### PR TITLE
Addition of tally_conv.py to utils

### DIFF
--- a/src/utils/statepoint.py
+++ b/src/utils/statepoint.py
@@ -176,11 +176,12 @@ class StatePoint(BinaryFile):
             
             # Read nuclide bins
             n_nuclides = self._get_int()[0]
+            t.n_nuclides = n_nuclides
             t.nuclides = self._get_int(n_nuclides)
 
             # Read score bins
-            n_scores = self._get_int()[0]
-            t.scores = [score_types[j] for j in self._get_int(n_scores)]
+            t.n_scores = self._get_int()[0]
+            t.scores = [score_types[j] for j in self._get_int(t.n_scores)]
 
         # Set flag indicating metadata has already been read
         self._metadata = True


### PR DESCRIPTION
tally_conv.py is a python program to reduce the burden of extracting the values and uncertainties of all the tallys (and their filters/scores) stored in the statepoint binary files for plotting purposes.  This information, once extracted, can be plotted and displayed immediately using matplotlib with one tally/filter/score per axes, the same plots saved to a png file, the data written to a csv file for each tally, or any combination of the above.

It is likely that each user will want to display the information in their own way (with multiple tallies or scores on the same axes).  To limit the scope of this program I wrote tally_conv with the goal of providing the base capabilities and allowing the user to modify it as they see fit. 
