### PR TITLE
Simplified the binary search, making it faster.

### DIFF
--- a/src/search.F90
+++ b/src/search.F90
@@ -3,8 +3,6 @@ module search
   use error,     only: fatal_error
   use global,    only: message
 
-  integer, parameter :: MAX_ITERATION = 64
-
   interface binary_search
     module procedure binary_search_real, binary_search_int4, binary_search_int8
   end interface binary_search
@@ -69,7 +67,7 @@ contains
     do while (R > L)
       ! Find values at midpoint
       array_index = (R + L)/2
-      if (val >= array(array_index)) then
+      if (val > array(array_index)) then
         L = array_index + 1
       else
         R = array_index
@@ -100,8 +98,7 @@ contains
 
     do while (R > L)
       ! Find values at midpoint
-      array_index = L + (R + L)/2
-      testval = 
+      array_index = (R + L)/2
       if (val > array(array_index)) then
         L = array_index + 1
       else


### PR DESCRIPTION
I have simplified the binary search algorithm. The checks if `array(L) < val < array(L+1)` (and with `R`) consume more time than they save, so I've taken them out.
Also, with the new implementation, it is impossible for the loop to get trapped, rendering the check on `n_iteration` unnecessary. (Frankly, I'm not sure if it was possible before to end up there, but this way is definitely safe.)

The code change results in a notably faster binary search, yielding a total performance improvement in the order of one percent.
