### PR TITLE
Minor CMFD fixes for clarity and to work with GNU 4.7.2

### DIFF
--- a/src/cmfd_input.F90
+++ b/src/cmfd_input.F90
@@ -78,9 +78,13 @@ contains
       cmfd%egrid = (/0.0_8,20.0_8/)
       cmfd % indices(4) = 1 ! one energy group
     end if
-
+    
     ! set global albedo
-    cmfd % albedo = mesh_ % albedo
+    if (associated(mesh_ % albedo)) then
+      cmfd % albedo = mesh_ % albedo
+    else
+      cmfd % albedo = (/1.0, 1.0, 1.0, 1.0, 1.0, 1.0/)
+    end if
 
     ! get acceleration map
     if (associated(mesh_ % map)) then

--- a/src/cmfd_jacobian_operator.F90
+++ b/src/cmfd_jacobian_operator.F90
@@ -250,7 +250,7 @@ contains
       call MatGetRow(ctx%loss%M, irow, ncols, cols, vals, ierr)
 
       ! set that row to Jacobian matrix
-      call MatSetValues(jac_prec, 1, irow, ncols, cols(1:ncols), vals, &
+      call MatSetValues(jac_prec, 1, (/irow/), ncols, cols(1:ncols), vals, &
            INSERT_VALUES, ierr)
 
       ! restore the row
@@ -283,7 +283,7 @@ contains
     ! set values in last row of matrix
     if (rank == n_procs_cmfd - 1) then
       phi_tmp = -phi_tmp ! negate the transpose
-      call MatSetValues(jac_prec, 1, n, n, (/(k,k=0,n-1)/), phi_tmp, &
+      call MatSetValues(jac_prec, 1, (/n/), n, (/(k,k=0,n-1)/), phi_tmp, &
            INSERT_VALUES, ierr)
       call MatSetValue(jac_prec, n, n, ONE, INSERT_VALUES, ierr)
     end if


### PR DESCRIPTION
Two changes are included in this request:
1) The users manual says that the default value of the <mesh> Element's albedo attribute is an array of six 1.0s.  However, this wasnt reflected in the code.  The code is updated to reflect this change.

2) For some reason GNU 4.6.\* allows passing of a scalar where a 1-D array (with one value) is expected.  GNU 4.7.2 does not.  The use of MatSetValues in the CMFD portion of OpenMC therefore wouldn't compile with GNU 4.7.2, but it would with 4.6.*.  I fixed this by simply changing the scalar int to an array with the good old (/num/) strategy.  We are now in agreement with the PETSc manual for version 3.3 (and probably earlier).
