### PR TITLE
added compatibility for comments without whitespace around content

### DIFF
--- a/src/xml-fortran/xmlparse.f90
+++ b/src/xml-fortran/xmlparse.f90
@@ -371,6 +371,7 @@ subroutine xml_get( info, tag, endtag, attribs, no_attribs, &
 
    integer         :: kspace
    integer         :: kend
+   integer         :: kcend
    integer         :: keq
    integer         :: kfirst
    integer         :: ksecond
@@ -405,6 +406,7 @@ subroutine xml_get( info, tag, endtag, attribs, no_attribs, &
    close_bracket = .false.
    kspace        = index( info%line, ' ' )
    kend          = index( info%line, '>' )
+   kcend         = index( info%line, '-->' )
    do while ( kend <= 0 )
       read( info%lun, '(a)', iostat = ierr ) nextline
       call xml_remove_tabs_(nextline)
@@ -423,6 +425,8 @@ subroutine xml_get( info, tag, endtag, attribs, no_attribs, &
    enddo
    if ( kend > kspace ) then
       kend = kspace
+   else if (info%line(1:4) == '<!--' .and. kend > kcend) then
+      kend = kcend-1
    else
       close_bracket = .true.
    endif


### PR DESCRIPTION
We had a few users run into an issue during the first workshop where comment tags were not surrounded by spaces (e.g. <!--UO2-->).  Since this appears to be a valid xml comment according to the standard (http://www.w3.org/TR/REC-xml/#sec-comments), I attempted to add the capability to handle this kind of comment to xml-fortran.
