### PR TITLE
Added a check for the name of the ACE data to be read.

### DIFF
--- a/src/ace.F90
+++ b/src/ace.F90
@@ -243,6 +243,15 @@ contains
 
       ! Read first line of header
       read(UNIT=in, FMT='(A10,2G12.0,1X,A10)') name, awr, kT, date_
+      
+      ! Check that correct xs was found 
+      ! (if XS listing (cross_sections.xml) is broken, this may not be the case)
+      
+      if( trim(adjustl(name)) /= trim(adjustl(listing % name)) ) then	  
+         message = "XS listing entry " // trim(listing % name) // " did not &
+         &match ACE data, " // trim(name) // " found instead."
+         call fatal_error()
+      end if	 
 
       ! Read more header and NXS and JXS
       read(UNIT=in, FMT=100) comment, mat, & 


### PR DESCRIPTION
Hi!
I got erroneous results (keff off by 300 pcm or so) when using OpenMC with my own cross section libraries. It turned out that the xs listing file for OpenMC (cross_sections.xml) was broken and, hence, OpenMC read the wrong S(a,b) data from the ACE file containing numerous entries for different moderators.

I generated the broken xs listing file using convert_xsdata.py, which does not seem to work properly in the case of S(a,b) data. I don't speak any python, so I could not fix the script, but instead I added a check to ace.F90 that ensures that the ACE data to be read in corresponds to the data requested in materials.xml. With the modification, this kind of ACE-reading errors should be avoided in the future.
Tuomas
