### PR TITLE
Added additional check for negative values in URR probability tables

### DIFF
--- a/src/cross_section.F90
+++ b/src/cross_section.F90
@@ -393,7 +393,8 @@ contains
 
       ! Calculate elastic cross section/factor
       elastic = ZERO
-      if (urr % prob(i_energy, URR_ELASTIC, i_table) > ZERO) then
+      if (urr % prob(i_energy, URR_ELASTIC, i_table) > ZERO .and. &
+          urr % prob(i_energy + 1, URR_ELASTIC, i_table) > ZERO) then
         elastic = exp((ONE - f) * log(urr % prob(i_energy, URR_ELASTIC, &
              i_table)) + f * log(urr % prob(i_energy + 1, URR_ELASTIC, &
              i_table)))
@@ -401,7 +402,8 @@ contains
 
       ! Calculate fission cross section/factor
       fission = ZERO
-      if (urr % prob(i_energy, URR_FISSION, i_table) > ZERO) then
+      if (urr % prob(i_energy, URR_FISSION, i_table) > ZERO .and. &
+          urr % prob(i_energy + 1, URR_FISSION, i_table) > ZERO) then
         fission = exp((ONE - f) * log(urr % prob(i_energy, URR_FISSION, &
              i_table)) + f * log(urr % prob(i_energy + 1, URR_FISSION, &
              i_table)))
@@ -409,7 +411,8 @@ contains
 
       ! Calculate capture cross section/factor
       capture = ZERO
-      if (urr % prob(i_energy, URR_N_GAMMA, i_table) > ZERO) then
+      if (urr % prob(i_energy, URR_N_GAMMA, i_table) > ZERO .and. &
+          urr % prob(i_energy + 1, URR_N_GAMMA, i_table) > ZERO) then
         capture = exp((ONE - f) * log(urr % prob(i_energy, URR_N_GAMMA, &
              i_table)) + f * log(urr % prob(i_energy + 1, URR_N_GAMMA, &
              i_table)))


### PR DESCRIPTION
When running some test problems with the NNDC cross sections, I found several nuclides that have negative values in the URR probability tables:

 WARNING: Negative value(s) found on probability table for nuclide  11022.71c
 WARNING: Negative value(s) found on probability table for nuclide  18036.71c
 WARNING: Negative value(s) found on probability table for nuclide  34079.71c
 WARNING: Negative value(s) found on probability table for nuclide  41094.71c
 WARNING: Negative value(s) found on probability table for nuclide  41095.71c
 WARNING: Negative value(s) found on probability table for nuclide  42099.71c
 WARNING: Negative value(s) found on probability table for nuclide  48106.71c
 WARNING: Negative value(s) found on probability table for nuclide  50123.71c
 WARNING: Negative value(s) found on probability table for nuclide  53131.71c
 WARNING: Negative value(s) found on probability table for nuclide  55136.71c
 WARNING: Negative value(s) found on probability table for nuclide  63156.71c

This led to NaNs and an un-handled segfault.  This PR eliminates those NaNs at the expense of an additional comparison to make sure we're not taking the log of a negative number.
