### PR TITLE
Changed fox URL to a public URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/xml/fox"]
 	path = src/xml/fox
-	url = git@github.com:mit-crpg/fox
+	url = https://github.com/mit-crpg/fox.git


### PR DESCRIPTION
If the fox submodule is not already installed, a "make" command will raise the following error:

```
-- Initializing/Updating FoX XML submodule...
Cloning into 'src/xml/fox'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Clone of 'git@github.com:mit-crpg/fox' into submodule path 'src/xml/fox' failed
```

A quick Google search found the solution here: http://stackoverflow.com/questions/8197089/fatal-error-when-updating-submodule-using-git
