### PR TITLE
Check for energy-dependent multiplicity in ACE file

### DIFF
--- a/src/ace.F90
+++ b/src/ace.F90
@@ -657,6 +657,20 @@ contains
       rxn % multiplicity  = abs(nint(XSS(JXS5 + i - 1)))
       rxn % scatter_in_cm = (nint(XSS(JXS5 + i - 1)) < 0)
 
+      ! If multiplicity is energy-dependent (absolute value > 100), set it based
+      ! on the MT value
+      if (rxn % multiplicity > 100) then
+        if (any(rxn%MT == [11, 16, 24, 30, 41])) then
+          rxn % multiplicity = 2
+        elseif (any(rxn%MT == [17, 25, 42])) then
+          rxn % multiplicity = 3
+        elseif (rxn%MT == 37) then
+          rxn % multiplicity = 4
+        else
+          rxn % multiplicity = 1
+        end if
+      end if
+
       ! read starting energy index
       LOCA = int(XSS(LXS + i - 1))
       IE   = int(XSS(JXS7 + LOCA - 1))


### PR DESCRIPTION
This is a relatively simple pull request that checks for the presence of an energy-dependent multiplicity for a reaction other than fission. This is indicated in the ACE format by an entry in the TYR block with absolute value greater than 100 (see MCNP Manual, Volume III). The new check in the code sets the multiplicity based on the MT value if it sees that it's energy dependent.

I don't believe this situation occurs for any data being used by OpenMC users. The ENDF/B-VII.0 library does have a few instances of energy-dependent multiplicities for reactions other than fission: (n,2n) and (n,3n) in Am-242 and Am-242m. However, this is only indicated in the ACE file if it was produced with NJOY 2012. In ENDF/B-VII.1, the multiplicities for those reactions are no longer energy-dependent.

@nelsonag maybe you can review this since you are probably more familiar with the ACE format than anyone else on the dev team?
