### PR TITLE
Fix distance-to-surface calculation for general plane surface

### DIFF
--- a/src/geometry.F90
+++ b/src/geometry.F90
@@ -892,7 +892,7 @@ contains
           if (on_surface .or. tmp == ZERO) then
             d = INFINITY
           else
-            d = -(A*x + B*y + C*w - D)/tmp
+            d = -(A*x + B*y + C*z - D)/tmp
             if (d < ZERO) d = INFINITY
           end if
 


### PR DESCRIPTION
There is currently a bug in the distance-to-surface calculation for a general plane of the form Ax + By + Cz = D, i.e. `<surface type="plane" ... />`. However, the bug does not affect the calculation if C=0. I don't know of any existing OpenMC models that use the general plane surface where C is non-zero. The correct formula for distance-to-surface for a plane can be found [here](http://mit-crpg.github.io/openmc/methods/geometry.html#generic-plane).

None of the models in the test suite are affected. Same for all of our [ICSBEP benchmark models](https://github.com/mit-crpg/benchmarks).
