### PR TITLE
Don't read tallies.xml when OpenMC is run in plotting mode.

### DIFF
--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -33,10 +33,10 @@ contains
   subroutine read_input_xml()
 
     call read_settings_xml()
-    if ((run_mode /= MODE_PLOTTING)) call read_cross_sections_xml()
+    if (run_mode /= MODE_PLOTTING) call read_cross_sections_xml()
     call read_geometry_xml()
     call read_materials_xml()
-    call read_tallies_xml()
+    if (run_mode /= MODE_PLOTTING) call read_tallies_xml()
     if (cmfd_run) call configure_cmfd()
 
   end subroutine read_input_xml


### PR DESCRIPTION
As discussed in #310, if you try to generate a plot and your tallies.xml contains a tally with individual nuclides, it fails with an error message. This pull request fixes that behavior.
