### PR TITLE
Check for negative values when calculating cross sections from probability tables

### DIFF
--- a/src/cross_section.F90
+++ b/src/cross_section.F90
@@ -475,7 +475,7 @@ contains
       fission = fission * micro_xs(i_nuclide) % fission
     end if
 
-    ! Check for negative calues
+    ! Check for negative values
     if (elastic < ZERO) elastic = ZERO
     if (fission < ZERO) fission = ZERO
     if (capture < ZERO) capture = ZERO


### PR DESCRIPTION
This pull request adds a check when calculating cross sections in the unresolved resonance range from probability tables for negative values of the elastic, capture, and fission cross section and sets them to zero. A user recently [ran into a problem](https://groups.google.com/d/topic/openmc-users/ZzV77lt83G4/discussion) where an ACE file had negative probability tables that resulted in a negative total cross section. The present fix should guarantee that a negative total cross section is never encountered in the URR.
