### PR TITLE
Add 'implicit none' to modules

### DIFF
--- a/src/eigenvalue.F90
+++ b/src/eigenvalue.F90
@@ -23,6 +23,7 @@ module eigenvalue
                           reset_result
   use tracking,     only: transport
 
+  implicit none
   private
   public :: run_eigenvalue
 

--- a/src/endf.F90
+++ b/src/endf.F90
@@ -3,6 +3,8 @@ module endf
   use constants
   use string, only: to_str
 
+  implicit none
+
 contains
 
 !===============================================================================

--- a/src/energy_grid.F90
+++ b/src/energy_grid.F90
@@ -5,6 +5,8 @@ module energy_grid
   use list_header,      only: ListReal
   use output,           only: write_message
 
+  implicit none
+
 contains
 
 !===============================================================================

--- a/src/fixed_source.F90
+++ b/src/fixed_source.F90
@@ -11,6 +11,8 @@ module fixed_source
   use tally,           only: synchronize_tallies, setup_active_usertallies
   use tracking,        only: transport
 
+  implicit none
+
 contains
 
   subroutine run_fixedsource()

--- a/src/search.F90
+++ b/src/search.F90
@@ -3,6 +3,8 @@ module search
   use constants
   use error,     only: fatal_error
 
+  implicit none
+
   integer, parameter :: MAX_ITERATION = 64
 
   interface binary_search

--- a/src/tracking.F90
+++ b/src/tracking.F90
@@ -16,6 +16,8 @@ module tracking
   use track_output,    only: initialize_particle_track, write_particle_track, &
                              finalize_particle_track
 
+  implicit none
+
 contains
 
 !===============================================================================


### PR DESCRIPTION
Some modules were missing 'implicit none' statements.  All the tests pass so hopefully we don't have any accidental implicits.
