### PR TITLE
Material.add_material(...) method

### DIFF
--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -43,6 +43,32 @@ _THERMAL_NAMES = {'al': 'c_Al27', 'al27': 'c_Al27',
                   'uuo2': 'c_U_in_UO2', 'u-o2': 'c_U_in_UO2', 'u/o2': 'c_U_in_UO2',
                   'zrzrh': 'c_Zr_in_ZrH', 'zr-h': 'c_Zr_in_ZrH', 'zr/h': 'c_Zr_in_ZrH'}
 
+_THERMAL_NUCLIDES = {'c_Al27': ['Al27'],
+                     'c_Be': ['Be9'],
+                     'c_BeO': ['Be9'],
+                     'c_Be_in_BeO': ['Be9'],
+                     'c_Benzine': ['C12', 'H1'],
+                     'c_Ca_in_CaH2': ['Ca40'],
+                     'c_D_in_D2O': ['H2'],
+                     'c_Fe56': ['Fe56'],
+                     'c_Graphite': ['C12'],
+                     'c_H_in_CaH2': ['H1'],
+                     'c_H_in_CH2': ['H1'],
+                     'c_H_in_H2O': ['H1'],
+                     'c_H_in_ZrH': ['H1'],
+                     'c_liquid_CH4': ['H1'],
+                     'c_Mg24': ['Mg24'],
+                     'c_O_in_BeO': ['O16']
+                     'c_ortho_D': ['H2'],
+                     'c_ortho_H': ['H1'],
+                     'c_O_in_UO2': ['O16'],
+                     'c_SiO2': ['O16'],
+                     'c_para_D': ['H2'],
+                     'c_para_H': ['H1'],
+                     'c_solid_CH4': ['H1']
+                     'c_U_in_UO2': ['U238'],
+                     'c_Zr_in_ZrH': ['Zr90']}
+
 
 def get_thermal_name(name):
     """Get proper S(a,b) table name, e.g. 'HH2O' -> 'c_H_in_H2O'"""
@@ -63,6 +89,10 @@ def get_thermal_name(name):
             # OK, we give up. Just use the ACE name.
             return 'c_' + name
 
+def get_thermal_nuclides(name):
+    """Get the nuclides treated in this S(a,b) table"""
+
+    return _THERMAL_NUCLIDES[get_thermal_name(name)]
 
 class CoherentElastic(EqualityMixin):
     r"""Coherent elastic scattering data from a crystalline material

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -58,14 +58,14 @@ _THERMAL_NUCLIDES = {'c_Al27': ['Al27'],
                      'c_H_in_ZrH': ['H1'],
                      'c_liquid_CH4': ['H1'],
                      'c_Mg24': ['Mg24'],
-                     'c_O_in_BeO': ['O16']
+                     'c_O_in_BeO': ['O16'],
                      'c_ortho_D': ['H2'],
                      'c_ortho_H': ['H1'],
                      'c_O_in_UO2': ['O16'],
                      'c_SiO2': ['O16'],
                      'c_para_D': ['H2'],
                      'c_para_H': ['H1'],
-                     'c_solid_CH4': ['H1']
+                     'c_solid_CH4': ['H1'],
                      'c_U_in_UO2': ['U238'],
                      'c_Zr_in_ZrH': ['Zr90']}
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -68,6 +68,8 @@ class Material(object):
         The average molar mass of nuclides in the material in units of grams per
         mol.  For example, UO2 with 3 nuclides will have an average molar mass
         of 270 / 3 = 90 g / mol.
+    sab : list of str
+        List of the s(a,b) tables
 
     """
 
@@ -219,6 +221,10 @@ class Material(object):
         # Compute and return the molar mass
         return mass / moles
 
+    @property
+    def sab(self):
+        return self._sab
+
     @id.setter
     def id(self, material_id):
 
@@ -234,7 +240,7 @@ class Material(object):
     @name.setter
     def name(self, name):
         if name is not None:
-            cv.check_type('name for Material ID="{0}"'.format(self._id),
+            cv.check_type('name for Material ID="{0}"'.format(self.id),
                           name, string_types)
             self._name = name
         else:
@@ -242,7 +248,7 @@ class Material(object):
 
     @temperature.setter
     def temperature(self, temperature):
-        cv.check_type('Temperature for Material ID="{0}"'.format(self._id),
+        cv.check_type('Temperature for Material ID="{0}"'.format(self.id),
                       temperature, (Real, type(None)))
         self._temperature = temperature
 
@@ -286,7 +292,7 @@ class Material(object):
 
         if not isinstance(filename, string_types) and filename is not None:
             msg = 'Unable to add OTF material file to Material ID="{0}" with a ' \
-                  'non-string name "{1}"'.format(self._id, filename)
+                  'non-string name "{1}"'.format(self.id, filename)
             raise ValueError(msg)
 
         self._distrib_otf_file = filename
@@ -315,22 +321,22 @@ class Material(object):
 
         if self._macroscopic is not None:
             msg = 'Unable to add a Nuclide to Material ID="{0}" as a ' \
-                  'macroscopic data-set has already been added'.format(self._id)
+                  'macroscopic data-set has already been added'.format(self.id)
             raise ValueError(msg)
 
         if not isinstance(nuclide, string_types + (openmc.Nuclide,)):
             msg = 'Unable to add a Nuclide to Material ID="{0}" with a ' \
-                  'non-Nuclide value "{1}"'.format(self._id, nuclide)
+                  'non-Nuclide value "{1}"'.format(self.id, nuclide)
             raise ValueError(msg)
 
         elif not isinstance(percent, Real):
             msg = 'Unable to add a Nuclide to Material ID="{0}" with a ' \
-                  'non-floating point value "{1}"'.format(self._id, percent)
+                  'non-floating point value "{1}"'.format(self.id, percent)
             raise ValueError(msg)
 
         elif percent_type not in ['ao', 'wo', 'at/g-cm']:
             msg = 'Unable to add a Nuclide to Material ID="{0}" with a ' \
-                  'percent type "{1}"'.format(self._id, percent_type)
+                  'percent type "{1}"'.format(self.id, percent_type)
             raise ValueError(msg)
 
         if isinstance(nuclide, openmc.Nuclide):
@@ -354,7 +360,7 @@ class Material(object):
 
         if not isinstance(nuclide, openmc.Nuclide):
             msg = 'Unable to remove a Nuclide "{0}" in Material ID="{1}" ' \
-                  'since it is not a Nuclide'.format(self._id, nuclide)
+                  'since it is not a Nuclide'.format(self.id, nuclide)
             raise ValueError(msg)
 
         # If the Material contains the Nuclide, delete it
@@ -380,12 +386,12 @@ class Material(object):
             msg = 'Unable to add a Macroscopic data set to Material ID="{0}" ' \
                   'with a macroscopic value "{1}" as an incompatible data ' \
                   'member (i.e., nuclide, element, or S(a,b) table) ' \
-                  'has already been added'.format(self._id, macroscopic)
+                  'has already been added'.format(self.id, macroscopic)
             raise ValueError(msg)
 
         if not isinstance(macroscopic, string_types + (openmc.Macroscopic,)):
             msg = 'Unable to add a Macroscopic to Material ID="{0}" with a ' \
-                  'non-Macroscopic value "{1}"'.format(self._id, macroscopic)
+                  'non-Macroscopic value "{1}"'.format(self.id, macroscopic)
             raise ValueError(msg)
 
         if isinstance(macroscopic, openmc.Macroscopic):
@@ -400,7 +406,7 @@ class Material(object):
         else:
             msg = 'Unable to add a Macroscopic to Material ID="{0}". ' \
                   'Only one Macroscopic allowed per ' \
-                  'Material.'.format(self._id)
+                  'Material.'.format(self.id)
             raise ValueError(msg)
 
         # Generally speaking, the density for a macroscopic object will
@@ -423,7 +429,7 @@ class Material(object):
 
         if not isinstance(macroscopic, openmc.Macroscopic):
             msg = 'Unable to remove a Macroscopic "{0}" in Material ID="{1}" ' \
-                  'since it is not a Macroscopic'.format(self._id, macroscopic)
+                  'since it is not a Macroscopic'.format(self.id, macroscopic)
             raise ValueError(msg)
 
         # If the Material contains the Macroscopic, delete it
@@ -451,22 +457,22 @@ class Material(object):
 
         if self._macroscopic is not None:
             msg = 'Unable to add an Element to Material ID="{0}" as a ' \
-                  'macroscopic data-set has already been added'.format(self._id)
+                  'macroscopic data-set has already been added'.format(self.id)
             raise ValueError(msg)
 
         if not isinstance(element, string_types + (openmc.Element,)):
             msg = 'Unable to add an Element to Material ID="{0}" with a ' \
-                  'non-Element value "{1}"'.format(self._id, element)
+                  'non-Element value "{1}"'.format(self.id, element)
             raise ValueError(msg)
 
         if not isinstance(percent, Real):
             msg = 'Unable to add an Element to Material ID="{0}" with a ' \
-                  'non-floating point value "{1}"'.format(self._id, percent)
+                  'non-floating point value "{1}"'.format(self.id, percent)
             raise ValueError(msg)
 
         if percent_type not in ['ao', 'wo']:
             msg = 'Unable to add an Element to Material ID="{0}" with a ' \
-                  'percent type "{1}"'.format(self._id, percent_type)
+                  'percent type "{1}"'.format(self.id, percent_type)
             raise ValueError(msg)
 
         # Copy this Element to separate it from same Element in other Materials
@@ -479,13 +485,13 @@ class Material(object):
             if not isinstance(enrichment, Real):
                 msg = 'Unable to add an Element to Material ID="{0}" with a ' \
                       'non-floating point enrichment value "{1}"'\
-                      .format(self._id, enrichment)
+                      .format(self.id, enrichment)
                 raise ValueError(msg)
 
             elif element.name != 'U':
                 msg = 'Unable to use enrichment for element {0} which is not ' \
                       'uranium for Material ID="{1}"'.format(element.name,
-                                                             self._id)
+                                                             self.id)
                 raise ValueError(msg)
 
             # Check that the enrichment is in the valid range
@@ -498,7 +504,7 @@ class Material(object):
                       'constant at 0.008, which is only valid at low ' \
                       'enrichments. Consider setting the isotopic ' \
                       'composition manually for enrichments over 5%.'.\
-                      format(enrichment, self._id)
+                      format(enrichment, self.id)
                 warnings.warn(msg)
 
         self._elements.append((element, percent, percent_type, enrichment))
@@ -524,7 +530,7 @@ class Material(object):
                 self._elements.remove(elm)
 
     def add_material(self, material, percent, percent_type='ao'):
-        """Add a material to the material
+        """Mix a material to the material
 
         Parameters
         ----------
@@ -539,37 +545,38 @@ class Material(object):
 
         if self._macroscopic is not None:
             msg = 'Unable to add a Material to Material ID="{0}" as a ' \
-                  'macroscopic data-set has already been added'.format(self._id)
+                  'macroscopic data-set has already been added'.format(self.id)
             raise ValueError(msg)
 
         if not isinstance(material, openmc.Material):
             msg = 'Unable to add a Material to Material ID="{0}" with a ' \
-                  'non-Material value "{1}"'.format(self._id, material)
+                  'non-Material value "{1}"'.format(self.id, material)
             raise ValueError(msg)
 
         elif not isinstance(percent, Real):
             msg = 'Unable to add a Material to Material ID="{0}" with a ' \
-                  'non-floating point value "{1}"'.format(self._id, percent)
+                  'non-floating point value "{1}"'.format(self.id, percent)
             raise ValueError(msg)
 
         elif self.temperature != material.temperature:
             msg = 'Unable to add a Material to Material ID="{0}" with a ' \
-                  'different temperature "{1}"'.format(self._id, temperature)
+                  'different temperature "{1}"'.format(self.id, temperature)
             raise ValueError(msg)
 
         elif percent_type not in ['ao', 'wo']:
             msg = 'Unable to add a Material to Material ID="{0}" with a ' \
-                  'percent type "{1}"'.format(self._id, percent_type)
+                  'percent type "{1}"'.format(self.id, percent_type)
             raise ValueError(msg)
 
         # Get the atom densities in the given material
         nuclides_densities = material.get_nuclide_atom_densities()
         nuclides = nuclides_densities.keys()
         densities = nuclides_densities.values()
+        new_nuclides = []
 
         # Compute the sum of the atom densities
         sum_densities = 0.
-        for nuclide,density in zip(nuclides,densities):
+        for nuclide, density in zip(nuclides, densities):
 
             # Make a local variable with the nuclide density
             density = density[1]
@@ -584,32 +591,16 @@ class Material(object):
                 amm = material.average_molar_mass
                 density *= atomic_mass / amm
 
+            new_nuclides.append([nuclide, density])
             sum_densities += density
 
-        # Add the nuclides of the given material to this material
-        for nuclide,density in zip(nuclides,densities):
-
-            # Make a local variable with the nuclide density
-            density = density[1]
-
-            # Convert to weight percent, if requested
-            if percent_type == 'wo':
-                if isinstance(nuclide, openmc.Nuclide):
-                    atomic_mass = openmc.data.atomic_mass(nuclide.name)
-                else:
-                    atomic_mass = openmc.data.atomic_mass(nuclide)
-
-                amm = material.average_molar_mass
-                density *= atomic_mass / amm
-
-            # Normalize the density to sum to 1.0
-            density /= sum_densities
-
-            # Add the nuclide to the material
-            self.add_nuclide(nuclide, density*percent, percent_type)
+        # Add the nuclide to the material
+        for nuclide in new_nuclides:
+            density = nuclide[1] / sum_densities
+            self.add_nuclide(nuclide[0], density*percent, percent_type)
 
         # Add the s(a,b) tables
-        for sab in material._sab:
+        for sab in material.sab:
             self.add_s_alpha_beta(sab)
 
     def add_s_alpha_beta(self, name):
@@ -624,12 +615,12 @@ class Material(object):
 
         if self._macroscopic is not None:
             msg = 'Unable to add an S(a,b) table to Material ID="{0}" as a ' \
-                  'macroscopic data-set has already been added'.format(self._id)
+                  'macroscopic data-set has already been added'.format(self.id)
             raise ValueError(msg)
 
         if not isinstance(name, string_types):
             msg = 'Unable to add an S(a,b) table to Material ID="{0}" with a ' \
-                        'non-string table name "{1}"'.format(self._id, name)
+                        'non-string table name "{1}"'.format(self.id, name)
             raise ValueError(msg)
 
         new_name = openmc.data.get_thermal_name(name)
@@ -842,7 +833,7 @@ class Material(object):
 
         # Create Material XML element
         element = ET.Element("material")
-        element.set("id", str(self._id))
+        element.set("id", str(self.id))
 
         if len(self._name) > 0:
             element.set("name", str(self._name))

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -639,6 +639,10 @@ class Material(object):
                   'Table "{}" is being renamed as "{}".'.format(name, new_name)
             warnings.warn(msg)
 
+        # Check whether sab has already been added to list of sab tables
+        if new_name in self._sab:
+            return
+
         # Check whether nuclides treated by this sab table are already treated
         # by another sab table
         new_nucs = openmc.data.get_thermal_nuclides(new_name)

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -570,34 +570,37 @@ class Material(object):
         # Compute the sum of the atom densities
         sum_densities = 0.
         for nuclide,density in zip(nuclides,densities):
+
+            # Make a local variable with the nuclide density
             density = density[1]
 
             # Convert to weight percent, if requested
             if percent_type == 'wo':
                 if isinstance(nuclide, openmc.Nuclide):
-                    awr = openmc.data.atomic_mass(nuclide.name)
+                    atomic_mass = openmc.data.atomic_mass(nuclide.name)
                 else:
-                    awr = openmc.data.atomic_mass(nuclide)
+                    atomic_mass = openmc.data.atomic_mass(nuclide)
 
                 amm = material.average_molar_mass
-                density *= awr / amm
+                density *= atomic_mass / amm
 
             sum_densities += density
 
         # Add the nuclides of the given material to this material
         for nuclide,density in zip(nuclides,densities):
 
+            # Make a local variable with the nuclide density
             density = density[1]
 
             # Convert to weight percent, if requested
             if percent_type == 'wo':
                 if isinstance(nuclide, openmc.Nuclide):
-                    awr = openmc.data.atomic_mass(nuclide.name)
+                    atomic_mass = openmc.data.atomic_mass(nuclide.name)
                 else:
-                    awr = openmc.data.atomic_mass(nuclide)
+                    atomic_mass = openmc.data.atomic_mass(nuclide)
 
                 amm = material.average_molar_mass
-                density *= awr / amm
+                density *= atomic_mass / amm
 
             # Normalize the density to sum to 1.0
             density /= sum_densities


### PR DESCRIPTION
This short PR adds an `add_material(...)` method to the Material object in the Python API. This method is useful when trying to homogenize multiple materials by atom percent (e.g. for the C5G7 benchmark or water/structural materials in BEAVRS) or weight percent (e.g. for the TREAT fuel/graphite blocks). The `add_material(...)` is structured such that it expands a given material into its constituent nuclides and adds the nuclides to the base material. 

While this method is handy, there are some caveats that haven't been addressed in this PR. Since the temperature is set by material or cell, a material can only be added to another material if they have the same temperature. Also, since s(a,b) are set on a material basis, there is the possibility of a material having multiple s(a,b) for the same nuclide. I'm not sure how OpenMC treats these cases, but it doesn't appear that an error is given.

Two materials can be homogenized as follows:

    fuel = openmc.Material()
    fuel.set_density('g/cm3', 10.0)
    fuel.add_element('U', 1.0, enrichment=2.5)
    fuel.add_element('O', 2.0)

    clad = openmc.Material()
    clad.set_density('g/cm3', 6.55)
    clad.add_element('Zr', 1.0)
 
    fuel_clad = openmc.Material()
    fuel_clad.add_material(fuel, 0.9, 'ao')
    fuel_clad.add_material(clad, 0.1, 'ao')

This PR builds on PR #771