### PR TITLE
Update URLs and copyright

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ openmc@anl.gov.
 
 ## Resources
 
-- [GitHub Repository](https://github.com/mit-crpg/openmc)
+- [GitHub Repository](https://github.com/openmc-dev/openmc)
 - [Documentation](http://openmc.readthedocs.io/en/latest)
 - [User's Mailing List](openmc-users@googlegroups.com)
 - [Developer's Mailing List](openmc-dev@googlegroups.com)
@@ -22,7 +22,7 @@ openmc@anl.gov.
 ## How to Report Bugs
 
 OpenMC is hosted on GitHub and all bugs are reported and tracked through the
-[Issues](https://github.com/mit-crpg/openmc/issues) listed on GitHub.
+[Issues](https://github.com/openmc-dev/openmc/issues) listed on GitHub.
 
 ## How to Suggest Enhancements
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2018 Massachusetts Institute of Technology
+Copyright (c) 2011-2018 Massachusetts Institute of Technology and OpenMC contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OpenMC Monte Carlo Particle Transport Code
 
-[![License](https://img.shields.io/github/license/mit-crpg/openmc.svg)](http://openmc.readthedocs.io/en/latest/license.html)
-[![Travis CI build status (Linux)](https://travis-ci.org/mit-crpg/openmc.svg?branch=develop)](https://travis-ci.org/mit-crpg/openmc)
-[![Code Coverage](https://coveralls.io/repos/github/mit-crpg/openmc/badge.svg?branch=develop)](https://coveralls.io/github/mit-crpg/openmc?branch=develop)
+[![License](https://img.shields.io/github/license/openmc-dev/openmc.svg)](http://openmc.readthedocs.io/en/latest/license.html)
+[![Travis CI build status (Linux)](https://travis-ci.org/openmc-dev/openmc.svg?branch=develop)](https://travis-ci.org/openmc-dev/openmc)
+[![Code Coverage](https://coveralls.io/repos/github/openmc-dev/openmc/badge.svg?branch=develop)](https://coveralls.io/github/openmc-dev/openmc?branch=develop)
 
 The OpenMC project aims to provide a fully-featured Monte Carlo particle
 transport code based on modern methods. It is a constructive solid geometry,
@@ -44,7 +44,7 @@ list](https://groups.google.com/forum/?fromgroups=#!forum/openmc-users).
 ## Reporting Bugs
 
 OpenMC is hosted on GitHub and all bugs are reported and tracked through the
-[Issues](https://github.com/mit-crpg/openmc/issues) feature on GitHub. However,
+[Issues](https://github.com/openmc-dev/openmc/issues) feature on GitHub. However,
 GitHub Issues should not be used for common troubleshooting purposes. If you are
 having trouble installing the code or getting your model to run properly, you
 should first send a message to the User's Group mailing list. If it turns out

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'OpenMC'
-copyright = u'2011-2018, Massachusetts Institute of Technology'
+copyright = u'2011-2018, Massachusetts Institute of Technology and OpenMC contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -208,7 +208,7 @@ htmlhelp_basename = 'openmcdoc'
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
   ('index', 'openmc.tex', u'OpenMC Documentation',
-   u'Massachusetts Institute of Technology', 'manual'),
+   u'OpenMC contributors', 'manual'),
 ]
 
 latex_elements = {

--- a/docs/source/devguide/user-input.rst
+++ b/docs/source/devguide/user-input.rst
@@ -65,8 +65,8 @@ developer or send a message to the `developers mailing list`_.
 .. _property attribute: https://docs.python.org/3.6/library/functions.html#property
 .. _XML Schema Part 2: http://www.w3.org/TR/xmlschema-2/
 .. _boolean: http://www.w3.org/TR/xmlschema-2/#boolean
-.. _xml_interface module: https://github.com/mit-crpg/openmc/blob/develop/src/xml_interface.F90
-.. _input_xml module: https://github.com/mit-crpg/openmc/blob/develop/src/input_xml.F90
+.. _xml_interface module: https://github.com/openmc-dev/openmc/blob/develop/src/xml_interface.F90
+.. _input_xml module: https://github.com/openmc-dev/openmc/blob/develop/src/input_xml.F90
 .. _RELAX NG: http://relaxng.org/
 .. _compact syntax: http://relaxng.org/compact-tutorial-20030326.html
 .. _trang: http://www.thaiopensource.com/relaxng/trang.html

--- a/docs/source/devguide/workflow.rst
+++ b/docs/source/devguide/workflow.rst
@@ -55,7 +55,7 @@ Now that you understand the basic development workflow, let's discuss how an
 individual to contribute to development. Note that this would apply to both new
 features and bug fixes. The general steps for contributing are as follows:
 
-1. Fork the main openmc repository from `mit-crpg/openmc`_. This will create a
+1. Fork the main openmc repository from `openmc-dev/openmc`_. This will create a
    repository with the same name under your personal account. As such, you can
    commit to it as you please without disrupting other developers.
 
@@ -74,7 +74,7 @@ features and bug fixes. The general steps for contributing are as follows:
    ensure that those changes are made on a different branch.
 
 4. Issue a pull request from GitHub and select the *develop* branch of
-   mit-crpg/openmc as the target.
+   openmc-dev/openmc as the target.
 
    .. image:: ../_images/pullrequest.png
 
@@ -87,7 +87,7 @@ features and bug fixes. The general steps for contributing are as follows:
    request page itself.
 
 6. After the pull request has been thoroughly vetted, it is merged back into the
-   *develop* branch of mit-crpg/openmc.
+   *develop* branch of openmc-dev/openmc.
 
 Private Development
 -------------------
@@ -99,7 +99,7 @@ create a complete copy of the OpenMC repository (not a fork from GitHub). The
 private repository can then either be stored just locally or in conjunction with
 a private repository on Github (this requires a `paid plan`_). Alternatively,
 `Bitbucket`_ offers private repositories for free. If you want to merge some
-changes you've made in your private repository back to mit-crpg/openmc
+changes you've made in your private repository back to openmc-dev/openmc
 repository, simply follow the steps above with an extra step of pulling a branch
 from your private repository into a public fork.
 
@@ -128,9 +128,9 @@ can interfere with virtual environments.
 .. _GitHub: https://github.com/
 .. _git flow: http://nvie.com/git-model
 .. _valgrind: http://valgrind.org/
-.. _style guide: http://mit-crpg.github.io/openmc/devguide/styleguide.html
+.. _style guide: http://openmc.readthedocs.io/en/latest/devguide/styleguide.html
 .. _pull request: https://help.github.com/articles/using-pull-requests
-.. _mit-crpg/openmc: https://github.com/mit-crpg/openmc
+.. _openmc-dev/openmc: https://github.com/openmc-dev/openmc
 .. _paid plan: https://github.com/plans
 .. _Bitbucket: https://bitbucket.org
 .. _ctest: http://www.cmake.org/cmake/help/v2.8.12/ctest.html

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -4,7 +4,7 @@
 License Agreement
 =================
 
-Copyright © 2011-2018 Massachusetts Institute of Technology
+Copyright © 2011-2018 Massachusetts Institute of Technology and OpenMC contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -83,7 +83,7 @@ Installing from Source on Linux or Mac OS X
 -------------------------------------------
 
 All OpenMC source code is hosted on `GitHub
-<https://github.com/mit-crpg/openmc>`_. If you have `git
+<https://github.com/openmc-dev/openmc>`_. If you have `git
 <https://git-scm.com>`_, the `gcc <https://gcc.gnu.org/>`_ compiler suite,
 `CMake <http://www.cmake.org>`_, and `HDF5 <https://www.hdfgroup.org/HDF5/>`_
 installed, you can download and install OpenMC be entering the following
@@ -91,7 +91,7 @@ commands in a terminal:
 
 .. code-block:: sh
 
-    git clone https://github.com/mit-crpg/openmc.git
+    git clone https://github.com/openmc-dev/openmc.git
     cd openmc
     mkdir build && cd build
     cmake ..

--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -71,14 +71,14 @@ Bug Fixes
 - 0c6915_: Bugfix for generating thermal scattering data
 - 61ecb4_: Fix bugs in Python multipole objects
 
-.. _937469: https://github.com/mit-crpg/openmc/commit/937469
-.. _a149ef: https://github.com/mit-crpg/openmc/commit/a149ef
-.. _2c9b21: https://github.com/mit-crpg/openmc/commit/2c9b21
-.. _8047f6: https://github.com/mit-crpg/openmc/commit/8047f6
-.. _0beb4c: https://github.com/mit-crpg/openmc/commit/0beb4c
-.. _f124be: https://github.com/mit-crpg/openmc/commit/f124be
-.. _0c6915: https://github.com/mit-crpg/openmc/commit/0c6915
-.. _61ecb4: https://github.com/mit-crpg/openmc/commit/61ecb4
+.. _937469: https://github.com/openmc-dev/openmc/commit/937469
+.. _a149ef: https://github.com/openmc-dev/openmc/commit/a149ef
+.. _2c9b21: https://github.com/openmc-dev/openmc/commit/2c9b21
+.. _8047f6: https://github.com/openmc-dev/openmc/commit/8047f6
+.. _0beb4c: https://github.com/openmc-dev/openmc/commit/0beb4c
+.. _f124be: https://github.com/openmc-dev/openmc/commit/f124be
+.. _0c6915: https://github.com/openmc-dev/openmc/commit/0c6915
+.. _61ecb4: https://github.com/openmc-dev/openmc/commit/61ecb4
 
 ------------
 Contributors

--- a/docs/source/usersguide/beginners.rst
+++ b/docs/source/usersguide/beginners.rst
@@ -153,9 +153,9 @@ and `Volume II`_. You may also find it helpful to review the following terms:
 .. _Reactor Concepts Manual: http://www.tayloredge.com/periodic/trivia/ReactorConcepts.pdf
 .. _Volume I: https://www.standards.doe.gov/standards-documents/1000/1019-bhdbk-1993-v1
 .. _Volume II: https://www.standards.doe.gov/standards-documents/1000/1019-bhdbk-1993-v2
-.. _OpenMC source code: https://github.com/mit-crpg/openmc
+.. _OpenMC source code: https://github.com/openmc-dev/openmc
 .. _GitHub: https://github.com/
-.. _bug reports: https://github.com/mit-crpg/openmc/issues
+.. _bug reports: https://github.com/openmc-dev/openmc/issues
 .. _Neutron cross section: http://en.wikipedia.org/wiki/Neutron_cross_section
 .. _Effective multiplication factor: https://en.wikipedia.org/wiki/Nuclear_chain_reaction#Effective_neutron_multiplication_factor
 .. _Flux: http://en.wikipedia.org/wiki/Neutron_flux

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -181,7 +181,7 @@ with GitHub since this involves setting up ssh_ keys. With git installed and
 setup, the following command will download the full source code from the GitHub
 repository::
 
-    git clone https://github.com/mit-crpg/openmc.git
+    git clone https://github.com/openmc-dev/openmc.git
 
 By default, the cloned repository will be set to the development branch. To
 switch to the source of the latest stable release, run the following commands::
@@ -189,7 +189,7 @@ switch to the source of the latest stable release, run the following commands::
     cd openmc
     git checkout master
 
-.. _GitHub: https://github.com/mit-crpg/openmc
+.. _GitHub: https://github.com/openmc-dev/openmc
 .. _git: https://git-scm.com
 .. _ssh: https://en.wikipedia.org/wiki/Secure_Shell
 

--- a/man/man1/openmc.1
+++ b/man/man1/openmc.1
@@ -79,7 +79,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 .SH REPORTING BUGS
 The OpenMC source code is hosted on GitHub at
-https://github.com/mit-crpg/openmc. With a github account, you can submit issues
+https://github.com/openmc-dev/openmc. With a github account, you can submit issues
 directly on the github repository that will then be reviewed by OpenMC
 developers. Alternatively, you can send a bug report to
 .I openmc-users@googlegroups.com\fP.

--- a/man/man1/openmc.1
+++ b/man/man1/openmc.1
@@ -59,7 +59,8 @@ Indicates the default path to a directory containing windowed multipole data if
 the user has not specified the <multipole_library> tag in
 .I materials.xml\fP.
 .SH LICENSE
-Copyright \(co 2011-2018 Massachusetts Institute of Technology.
+Copyright \(co 2011-2018 Massachusetts Institute of Technology and OpenMC
+contributors.
 .PP
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ kwargs = {
     'author': 'The OpenMC Development Team',
     'author_email': 'openmc-dev@googlegroups.com',
     'description': 'OpenMC',
-    'url': 'https://github.com/mit-crpg/openmc',
+    'url': 'https://github.com/openmc-dev/openmc',
     'classifiers': [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -228,7 +228,7 @@ contains
              &not exist! In order to run OpenMC, you first need a set of input &
              &files; at a minimum, this includes settings.xml, geometry.xml, &
              &and materials.xml. Please consult the user's guide at &
-             &http://mit-crpg.github.io/openmc for further information.")
+             &http://openmc.readthedocs.io for further information.")
       else
         ! The settings.xml file is optional if we just want to make a plot.
         return
@@ -1369,7 +1369,7 @@ contains
                  &materials.xml, settings.xml,  or in the OPENMC_CROSS_SECTIONS&
                  & environment variable. OpenMC needs such a file to identify &
                  &where to find ACE cross section libraries. Please consult the&
-                 & user's guide at http://mit-crpg.github.io/openmc for &
+                 & user's guide at http://openmc.readthedocs.io for &
                  &information on how to set up ACE cross section libraries.")
           else
             call warning("The CROSS_SECTIONS environment variable is &
@@ -1387,7 +1387,7 @@ contains
                &materials.xml or in the OPENMC_MG_CROSS_SECTIONS environment &
                &variable. OpenMC needs such a file to identify where to &
                &find MG cross section libraries. Please consult the user's &
-               &guide at http://mit-crpg.github.io/openmc for information on &
+               &guide at http://openmc.readthedocs.io for information on &
                &how to set up MG cross section libraries.")
         else if (len_trim(env_variable) /= 0) then
           path_cross_sections = trim(env_variable)

--- a/src/output.F90
+++ b/src/output.F90
@@ -76,7 +76,7 @@ contains
     write(UNIT=OUTPUT_UNIT, FMT=*) &
          '                  | The OpenMC Monte Carlo Code'
     write(UNIT=OUTPUT_UNIT, FMT=*) &
-         '        Copyright | 2011-2018 Massachusetts Institute of Technology'
+         '        Copyright | 2011-2018 MIT and OpenMC contributors'
     write(UNIT=OUTPUT_UNIT, FMT=*) &
          '          License | http://openmc.readthedocs.io/en/latest/license.html'
     write(UNIT=OUTPUT_UNIT, FMT='(11X,"Version | ",I1,".",I2,".",I1)') &
@@ -171,7 +171,7 @@ contains
       write(UNIT=OUTPUT_UNIT, FMT='(1X,A,A)') "Git SHA1: ", GIT_SHA1
 #endif
       write(UNIT=OUTPUT_UNIT, FMT=*) "Copyright (c) 2011-2018 &
-           &Massachusetts Institute of Technology"
+           &Massachusetts Institute of Technology and OpenMC contributors"
       write(UNIT=OUTPUT_UNIT, FMT=*) "MIT/X license at &
            &<http://openmc.readthedocs.io/en/latest/license.html>"
     end if

--- a/tools/ci/travis-install.sh
+++ b/tools/ci/travis-install.sh
@@ -4,6 +4,9 @@ set -ex
 # Install NJOY 2016
 ./tools/ci/travis-install-njoy.sh
 
+# Upgrade pip before doing anything else
+pip install --upgrade pip
+
 # Running OpenMC's setup.py requires numpy/cython already. NumPy float
 # formatting changed in version 1.14, so stick with a lower version until we can
 # handle it in our test suite


### PR DESCRIPTION
As you can see, I just moved OpenMC from the mit-crpg organization to our new openmc-dev org. I've updated all the relevant URLs in our source. I've also modified our copyright line to reflect the fact that people contributing to OpenMC retain copyright to their contributions (since we have no copyright assignment policy).