### PR TITLE
Write statepoints with source banks from openmc.capi

### DIFF
--- a/openmc/capi/core.py
+++ b/openmc/capi/core.py
@@ -52,7 +52,7 @@ _dll.openmc_simulation_init.restype = c_int
 _dll.openmc_simulation_init.errcheck = _error_handler
 _dll.openmc_simulation_finalize.restype = c_int
 _dll.openmc_simulation_finalize.errcheck = _error_handler
-_dll.openmc_statepoint_write.argtypes = [POINTER(c_char_p)]
+_dll.openmc_statepoint_write.argtypes = [POINTER(c_char_p), POINTER(c_int)]
 _dll.openmc_statepoint_write.restype = c_int
 _dll.openmc_statepoint_write.errcheck = _error_handler
 
@@ -269,7 +269,7 @@ def source_bank():
     return as_array(ptr, (n.value,)).view(bank_dtype)
 
 
-def statepoint_write(filename=None):
+def statepoint_write(filename=None, write_source=False):
     """Write a statepoint file.
 
     Parameters
@@ -277,11 +277,13 @@ def statepoint_write(filename=None):
     filename : str or None
         Path to the statepoint to write. If None is passed, a default name that
         contains the current batch will be written.
+    write_source : bool
+        Whether or not to include the source bank in the statepoint.
 
     """
     if filename is not None:
         filename = c_char_p(filename.encode())
-    _dll.openmc_statepoint_write(filename)
+    _dll.openmc_statepoint_write(filename, c_int(write_source))
 
 
 @contextmanager

--- a/openmc/capi/core.py
+++ b/openmc/capi/core.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
-from ctypes import (CDLL, c_int, c_int32, c_int64, c_double, c_char_p, c_char,
-                    POINTER, Structure, c_void_p, create_string_buffer)
+from ctypes import (CDLL, c_bool, c_int, c_int32, c_int64, c_double, c_char_p,
+                    c_char, POINTER, Structure, c_void_p, create_string_buffer)
 from warnings import warn
 
 import numpy as np
@@ -52,7 +52,7 @@ _dll.openmc_simulation_init.restype = c_int
 _dll.openmc_simulation_init.errcheck = _error_handler
 _dll.openmc_simulation_finalize.restype = c_int
 _dll.openmc_simulation_finalize.errcheck = _error_handler
-_dll.openmc_statepoint_write.argtypes = [POINTER(c_char_p), POINTER(c_int)]
+_dll.openmc_statepoint_write.argtypes = [POINTER(c_char_p), POINTER(c_bool)]
 _dll.openmc_statepoint_write.restype = c_int
 _dll.openmc_statepoint_write.errcheck = _error_handler
 
@@ -269,7 +269,7 @@ def source_bank():
     return as_array(ptr, (n.value,)).view(bank_dtype)
 
 
-def statepoint_write(filename=None, write_source=False):
+def statepoint_write(filename=None, write_source=True):
     """Write a statepoint file.
 
     Parameters
@@ -283,7 +283,7 @@ def statepoint_write(filename=None, write_source=False):
     """
     if filename is not None:
         filename = c_char_p(filename.encode())
-    _dll.openmc_statepoint_write(filename, c_int(write_source))
+    _dll.openmc_statepoint_write(filename, c_bool(write_source))
 
 
 @contextmanager

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -352,9 +352,9 @@ contains
     if (statepoint_batch % contains(current_batch)) then
       if (sourcepoint_batch % contains(current_batch) .and. source_write &
            .and. .not. source_separate) then
-        err = openmc_statepoint_write(write_source=1)
+        err = openmc_statepoint_write(write_source=.true._C_BOOL)
       else
-        err = openmc_statepoint_write(write_source=0)
+        err = openmc_statepoint_write(write_source=.false._C_BOOL)
       end if
     end if
 

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -317,6 +317,7 @@ contains
 #ifdef OPENMC_MPI
     integer :: mpi_err ! MPI error code
 #endif
+    character(MAX_FILE_LEN) :: filename
 
     ! Reduce tallies onto master process and accumulate
     call time_tallies % start()
@@ -349,14 +350,29 @@ contains
 
     ! Write out state point if it's been specified for this batch
     if (statepoint_batch % contains(current_batch)) then
-      err = openmc_statepoint_write()
+      if (sourcepoint_batch % contains(current_batch) .and. source_write &
+           .and. .not. source_separate) then
+        err = openmc_statepoint_write(write_source=1)
+      else
+        err = openmc_statepoint_write(write_source=0)
+      end if
+    end if
+
+    ! Write out a separate source point if it's been specified for this batch
+    if (sourcepoint_batch % contains(current_batch) .and. source_write &
+         .and. source_separate) call write_source_point()
+
+    ! Write a continously-overwritten source point if requested.
+    if (source_latest) then
+      filename = trim(path_output) // 'source' // '.h5'
+      call write_source_point(filename)
     end if
 
     ! Write out source point if it's been specified for this batch
-    if ((sourcepoint_batch % contains(current_batch) .or. source_latest) .and. &
-         source_write) then
-      call write_source_point()
-    end if
+    !if ((sourcepoint_batch % contains(current_batch) .or. source_latest) .and. &
+    !     source_write) then
+    !  call write_source_point()
+    !end if
 
   end subroutine finalize_batch
 

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -368,12 +368,6 @@ contains
       call write_source_point(filename)
     end if
 
-    ! Write out source point if it's been specified for this batch
-    !if ((sourcepoint_batch % contains(current_batch) .or. source_latest) .and. &
-    !     source_write) then
-    !  call write_source_point()
-    !end if
-
   end subroutine finalize_batch
 
 !===============================================================================

--- a/src/state_point.F90
+++ b/src/state_point.F90
@@ -140,6 +140,17 @@ contains
       ! Write out current batch number
       call write_dataset(file_id, "current_batch", current_batch)
 
+      ! Indicate whether source bank is stored in statepoint
+      if (present(write_source)) then
+        if (write_source /= 0) then
+          call write_attribute(file_id, "source_present", 1)
+        else
+          call write_attribute(file_id, "source_present", 0)
+        end if
+      else
+        call write_attribute(file_id, "source_present", 0)
+      end if
+
       ! Write out information for eigenvalue run
       if (run_mode == MODE_EIGENVALUE) then
         call write_dataset(file_id, "n_inactive", n_inactive)
@@ -442,13 +453,8 @@ contains
           file_id = file_open(filename_, 'a', parallel=.true.)
         end if
         call write_source_bank(file_id, work_index, source_bank)
-        call write_attribute(file_id, "source_present", 1)
         if (master .or. parallel) call file_close(file_id)
-      else
-        call write_attribute(file_id, "source_present", 0)
       end if
-    else
-      call write_attribute(file_id, "source_present", 0)
     end if
   end function openmc_statepoint_write
 

--- a/src/state_point.F90
+++ b/src/state_point.F90
@@ -70,6 +70,7 @@ contains
     integer(HID_T) :: cmfd_group, tallies_group, tally_group, meshes_group, &
                       filters_group, filter_group, derivs_group, &
                       deriv_group, runtime_group
+    integer(C_INT) :: ignored_err
     real(C_DOUBLE) :: k_combined(2)
     character(MAX_WORD_LEN), allocatable :: str_array(:)
     character(C_CHAR), pointer :: string(:)
@@ -151,7 +152,7 @@ contains
         call write_dataset(file_id, "k_col_abs", k_col_abs)
         call write_dataset(file_id, "k_col_tra", k_col_tra)
         call write_dataset(file_id, "k_abs_tra", k_abs_tra)
-        err = openmc_get_keff(k_combined)
+        ignored_err = openmc_get_keff(k_combined)
         call write_dataset(file_id, "k_combined", k_combined)
 
         ! Write out CMFD info

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -330,13 +330,13 @@ def test_restart(capi_init):
         openmc.capi.next_batch()
     keff0 = openmc.capi.keff()
 
-    # Restart the simulation from the statepoint and run all 10 batches.
+    # Restart the simulation from the statepoint and the 5 active batches.
     openmc.capi.simulation_finalize()
     openmc.capi.hard_reset()
     openmc.capi.finalize()
     openmc.capi.init(args=('-r', 'restart_test.h5'))
     openmc.capi.simulation_init()
-    for i in range(10):
+    for i in range(5):
         openmc.capi.next_batch()
     keff1 = openmc.capi.keff()
     openmc.capi.simulation_finalize()

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -311,3 +311,31 @@ def test_mesh(capi_init):
 
     msf = openmc.capi.MeshSurfaceFilter(mesh)
     assert msf.mesh == mesh
+
+
+def test_restart(pincell_model):
+    # Run for 7 batches then write a statepoint.
+    openmc.capi.init()
+    openmc.capi.simulation_init()
+    for i in range(7):
+        openmc.capi.next_batch()
+    openmc.capi.statepoint_write('restart_test.h5', True)
+
+    # Run 3 more batches and copy the keff.
+    for i in range(3):
+        openmc.capi.next_batch()
+    keff0 = openmc.capi.keff()
+    openmc.capi.simulation_finalize()
+    openmc.capi.finalize()
+
+    # Restart the simulation and run all 10 batches.
+    openmc.capi.init(args=('-r', 'restart_test.h5'))
+    openmc.capi.simulation_init()
+    for i in range(10):
+        openmc.capi.next_batch()
+    keff1 = openmc.capi.keff()
+    openmc.capi.simulation_finalize()
+    openmc.capi.finalize()
+
+    # Compare the keff values.
+    assert keff0 == pytest.approx(keff1)


### PR DESCRIPTION
Currently calls to `openmc.capi.statepoint_write` will create a statepoint without a source bank.  This PR adds an optional flag that will include the source bank.  I've also added a unit test that verifies restart capability from the capi using `openmc.capi.statepoint_write`.

I made some changes to the statepoint/sourcepoint logic in this PR.  I think it's more clear because now a call to `write_source_point` is guaranteed to write a sourcepoint (regardless of global variables), and it will never modify a statepoint file.