### PR TITLE
Convert whitespace to blanks when reading arrays from XML

### DIFF
--- a/src/xml_interface.F90
+++ b/src/xml_interface.F90
@@ -261,6 +261,7 @@ contains
 
     ! Get value of text node/attribute
     str = node_value_string(node, name)
+    call whitespace_to_blanks(str)
 
     ! Read numbers into array
     read(UNIT=str, FMT=*, IOSTAT=stat) array
@@ -283,6 +284,7 @@ contains
 
     ! Get value of text node/attribute
     str = node_value_string(node, name)
+    call whitespace_to_blanks(str)
 
     ! Read numbers into array
     read(UNIT=str, FMT=*, IOSTAT=stat) array
@@ -332,5 +334,22 @@ contains
       array(n) = str(start:len(str))
     end if
   end subroutine get_node_array_string
+
+!===============================================================================
+! WHITESPACE_TO_BLANKS converts all whitespace to blanks
+!===============================================================================
+
+  subroutine whitespace_to_blanks(str)
+    character(len=*, kind=C_CHAR), intent(inout) :: str
+
+    integer :: i
+
+    do i = 1, len(str)
+      select case (str(i:i))
+      case (C_NEW_LINE, C_HORIZONTAL_TAB, C_CARRIAGE_RETURN)
+        str(i:i) = ' '
+      end select
+    end do
+  end subroutine
 
 end module xml_interface


### PR DESCRIPTION
This PR fixes #1038 by explicitly converting newline (and other whitespace) characters to blanks so that an internal READ statement using list-directed I/O works correctly. This is relevant when you have something like:
```XML
<parameters>
   -1.0 -1.0 -1.0
    1.0  1.0  1.0
</parameters>
```
i.e., where OpenMC needs to read an array of data that is spread out over multiple lines. @cjosey I've confirmed that I can run the `examples/xml/pincell` problem with ifort 18.0.1.