### PR TITLE
Introduce Position and Direction types for C++ code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,7 +386,6 @@ add_library(libopenmc SHARED
   src/cell.cpp
   src/initialize.cpp
   src/finalize.cpp
-  src/geometry.cpp
   src/geometry_aux.cpp
   src/hdf5_interface.cpp
   src/lattice.cpp
@@ -396,6 +395,7 @@ add_library(libopenmc SHARED
   src/mgxs_interface.cpp
   src/particle.cpp
   src/plot.cpp
+  src/position.cpp
   src/pugixml/pugixml_c.cpp
   src/random_lcg.cpp
   src/scattdata.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,7 @@ add_library(libopenmc SHARED
   src/cell.cpp
   src/initialize.cpp
   src/finalize.cpp
+  src/geometry.cpp
   src/geometry_aux.cpp
   src/hdf5_interface.cpp
   src/lattice.cpp

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -279,19 +279,19 @@ Cell::Cell(pugi::xml_node cell_node)
 //==============================================================================
 
 bool
-Cell::contains(Position r, Angle a, int32_t on_surface) const
+Cell::contains(Position r, Direction u, int32_t on_surface) const
 {
   if (simple) {
-    return contains_simple(r, a, on_surface);
+    return contains_simple(r, u, on_surface);
   } else {
-    return contains_complex(r, a, on_surface);
+    return contains_complex(r, u, on_surface);
   }
 }
 
 //==============================================================================
 
 std::pair<double, int32_t>
-Cell::distance(Position r, Angle a, int32_t on_surface) const
+Cell::distance(Position r, Direction u, int32_t on_surface) const
 {
   double min_dist {INFTY};
   int32_t i_surf {std::numeric_limits<int32_t>::max()};
@@ -303,7 +303,7 @@ Cell::distance(Position r, Angle a, int32_t on_surface) const
     // Calculate the distance to this surface.
     // Note the off-by-one indexing
     bool coincident {token == on_surface};
-    double d {surfaces_c[abs(token)-1]->distance(r, a, coincident)};
+    double d {surfaces_c[abs(token)-1]->distance(r, u, coincident)};
 
     // Check if this distance is the new minimum.
     if (d < min_dist) {
@@ -354,7 +354,7 @@ Cell::to_hdf5(hid_t cell_group) const
 //==============================================================================
 
 bool
-Cell::contains_simple(Position r, Angle a, int32_t on_surface) const
+Cell::contains_simple(Position r, Direction u, int32_t on_surface) const
 {
   for (int32_t token : rpn) {
     if (token < OP_UNION) {
@@ -367,7 +367,7 @@ Cell::contains_simple(Position r, Angle a, int32_t on_surface) const
         return false;
       } else {
         // Note the off-by-one indexing
-        bool sense = surfaces_c[abs(token)-1]->sense(r, a);
+        bool sense = surfaces_c[abs(token)-1]->sense(r, u);
         if (sense != (token > 0)) {return false;}
       }
     }
@@ -378,7 +378,7 @@ Cell::contains_simple(Position r, Angle a, int32_t on_surface) const
 //==============================================================================
 
 bool
-Cell::contains_complex(Position r, Angle a, int32_t on_surface) const
+Cell::contains_complex(Position r, Direction u, int32_t on_surface) const
 {
   // Make a stack of booleans.  We don't know how big it needs to be, but we do
   // know that rpn.size() is an upper-bound.
@@ -409,7 +409,7 @@ Cell::contains_complex(Position r, Angle a, int32_t on_surface) const
         stack[i_stack] = false;
       } else {
         // Note the off-by-one indexing
-        bool sense = surfaces_c[abs(token)-1]->sense(r, a);;
+        bool sense = surfaces_c[abs(token)-1]->sense(r, u);;
         stack[i_stack] = (sense == (token > 0));
       }
     }
@@ -492,16 +492,16 @@ extern "C" {
   bool cell_contains(Cell *c, double xyz[3], double uvw[3], int32_t on_surface)
   {
     Position r {xyz};
-    Angle a {uvw};
-    return c->contains(r, a, on_surface);
+    Direction u {uvw};
+    return c->contains(r, u, on_surface);
   }
 
   void cell_distance(Cell *c, double xyz[3], double uvw[3], int32_t on_surface,
                      double *min_dist, int32_t *i_surf)
   {
     Position r {xyz};
-    Angle a {uvw};
-    std::pair<double, int32_t> out = c->distance(r, a, on_surface);
+    Direction u {uvw};
+    std::pair<double, int32_t> out = c->distance(r, u, on_surface);
     *min_dist = out.first;
     *i_surf = out.second;
   }

--- a/src/cell.h
+++ b/src/cell.h
@@ -8,6 +8,7 @@
 
 #include "hdf5.h"
 #include "pugixml.hpp"
+#include "geometry.h"
 
 
 namespace openmc {
@@ -97,21 +98,19 @@ public:
   //!   known to be on.  This index takes precedence over surface sense
   //!   calculations.
   bool
-  contains(const double xyz[3], const double uvw[3], int32_t on_surface) const;
+  contains(Position r, Angle a, int32_t on_surface) const;
 
   //! Find the oncoming boundary of this cell.
   std::pair<double, int32_t>
-  distance(const double xyz[3], const double uvw[3], int32_t on_surface) const;
+  distance(Position r, Angle a, int32_t on_surface) const;
 
   //! \brief Write cell information to an HDF5 group.
   //! @param group_id An HDF5 group id.
   void to_hdf5(hid_t group_id) const;
 
 protected:
-  bool contains_simple(const double xyz[3], const double uvw[3],
-                       int32_t on_surface) const;
-  bool contains_complex(const double xyz[3], const double uvw[3],
-                        int32_t on_surface) const;
+  bool contains_simple(Position r, Angle a, int32_t on_surface) const;
+  bool contains_complex(Position r, Angle a, int32_t on_surface) const;
 };
 
 } // namespace openmc

--- a/src/cell.h
+++ b/src/cell.h
@@ -1,5 +1,5 @@
-#ifndef CELL_H
-#define CELL_H
+#ifndef OPENMC_CELL_H
+#define OPENMC_CELL_H
 
 #include <cstdint>
 #include <string>
@@ -92,10 +92,10 @@ public:
   //! provides a performance benefit for the common case. In
   //! contains_complex, we evaluate the RPN expression using a stack, similar to
   //! how a RPN calculator would work.
-  //! @param xyz[3] The 3D Cartesian coordinate to check.
-  //! @param uvw[3] A direction used to "break ties" the coordinates are very
+  //! \param r The 3D Cartesian coordinate to check.
+  //! \param u A direction used to "break ties" the coordinates are very
   //!   close to a surface.
-  //! @param on_surface The signed index of a surface that the coordinate is
+  //! \param on_surface The signed index of a surface that the coordinate is
   //!   known to be on.  This index takes precedence over surface sense
   //!   calculations.
   bool
@@ -106,7 +106,7 @@ public:
   distance(Position r, Direction u, int32_t on_surface) const;
 
   //! \brief Write cell information to an HDF5 group.
-  //! @param group_id An HDF5 group id.
+  //! \param group_id An HDF5 group id.
   void to_hdf5(hid_t group_id) const;
 
 protected:
@@ -115,4 +115,4 @@ protected:
 };
 
 } // namespace openmc
-#endif // CELL_H
+#endif // OPENMC_CELL_H

--- a/src/cell.h
+++ b/src/cell.h
@@ -8,7 +8,8 @@
 
 #include "hdf5.h"
 #include "pugixml.hpp"
-#include "geometry.h"
+
+#include "position.h"
 
 
 namespace openmc {
@@ -98,19 +99,19 @@ public:
   //!   known to be on.  This index takes precedence over surface sense
   //!   calculations.
   bool
-  contains(Position r, Angle a, int32_t on_surface) const;
+  contains(Position r, Direction u, int32_t on_surface) const;
 
   //! Find the oncoming boundary of this cell.
   std::pair<double, int32_t>
-  distance(Position r, Angle a, int32_t on_surface) const;
+  distance(Position r, Direction u, int32_t on_surface) const;
 
   //! \brief Write cell information to an HDF5 group.
   //! @param group_id An HDF5 group id.
   void to_hdf5(hid_t group_id) const;
 
 protected:
-  bool contains_simple(Position r, Angle a, int32_t on_surface) const;
-  bool contains_complex(Position r, Angle a, int32_t on_surface) const;
+  bool contains_simple(Position r, Direction u, int32_t on_surface) const;
+  bool contains_complex(Position r, Direction u, int32_t on_surface) const;
 };
 
 } // namespace openmc

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -1,0 +1,59 @@
+#include "geometry.h"
+
+namespace openmc {
+
+Position&
+Position::operator+=(Position other)
+{
+  x += other.x;
+  y += other.y;
+  z += other.z;
+  return *this;
+}
+
+Position&
+Position::operator+=(double v)
+{
+  x += v;
+  y += v;
+  z += v;
+  return *this;
+}
+
+Position&
+Position::operator-=(Position other)
+{
+  x -= other.x;
+  y -= other.y;
+  z -= other.z;
+  return *this;
+}
+
+Position&
+Position::operator-=(double v)
+{
+  x -= v;
+  y -= v;
+  z -= v;
+  return *this;
+}
+
+Position&
+Position::operator*=(Position other)
+{
+  x *= other.x;
+  y *= other.y;
+  z *= other.z;
+  return *this;
+}
+
+Position&
+Position::operator*=(double v)
+{
+  x *= v;
+  y *= v;
+  z *= v;
+  return *this;
+}
+
+} // namespace openmc

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -1,68 +1,10 @@
-#ifndef GEOMETRY_H
-#define GEOMETRY_H
+#ifndef OPENMC_GEOMETRY_H
+#define OPENMC_GEOMETRY_H
 
 namespace openmc {
 
 extern "C" int openmc_root_universe;
 
-struct Position {
-  double x = 0.;
-  double y = 0.;
-  double z = 0.;
-
-  Position() = default;
-  Position(double x_, double y_, double z_) : x{x_}, y{y_}, z{z_} { };
-  Position(const double xyz[]) : x{xyz[0]}, y{xyz[1]}, z{xyz[2]} { };
-
-  Position& operator+=(Position);
-  Position& operator+=(double);
-  Position& operator-=(Position);
-  Position& operator-=(double);
-  Position& operator*=(Position);
-  Position& operator*=(double);
-  const double& operator[](int i) const {
-    switch (i) {
-      case 0: return x;
-      case 1: return y;
-      case 2: return z;
-    }
-  }
-  double& operator[](int i) {
-    switch (i) {
-      case 0: return x;
-      case 1: return y;
-      case 2: return z;
-    }
-  }
-
-  inline double dot(Position other) {
-    return x*other.x + y*other.y + z*other.z;
-  }
-};
-
-inline Position operator+(Position a, Position b) { return a += b; }
-inline Position operator+(Position a, double b)   { return a += b; }
-inline Position operator+(double a, Position b)   { return b += a; }
-
-inline Position operator-(Position a, Position b) { return a -= b; }
-inline Position operator-(Position a, double b)   { return a -= b; }
-inline Position operator-(double a, Position b)   { return b -= a; }
-
-inline Position operator*(Position a, Position b) { return a *= b; }
-inline Position operator*(Position a, double b)   { return a *= b; }
-inline Position operator*(double a, Position b)   { return b *= a; }
-
-
-struct Angle : Position {
-  double& u() { return x; }
-  double& v() { return y; }
-  double& w() { return z; }
-  Angle() = default;
-  Angle(double u, double v, double w) : Position{u, v, w} { };
-  Angle(const double uvw[]) : Position{uvw} { };
-  Angle(Position r) : Position{r} { };
-};
-
 } // namespace openmc
 
-#endif // GEOMETRY_H
+#endif // OPENMC_GEOMETRY_H

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -1,6 +1,68 @@
 #ifndef GEOMETRY_H
 #define GEOMETRY_H
 
+namespace openmc {
+
 extern "C" int openmc_root_universe;
+
+struct Position {
+  double x = 0.;
+  double y = 0.;
+  double z = 0.;
+
+  Position() = default;
+  Position(double x_, double y_, double z_) : x{x_}, y{y_}, z{z_} { };
+  Position(double xyz[]) : x{xyz[0]}, y{xyz[1]}, z{xyz[2]} { };
+
+  Position& operator+=(Position);
+  Position& operator+=(double);
+  Position& operator-=(Position);
+  Position& operator-=(double);
+  Position& operator*=(Position);
+  Position& operator*=(double);
+  const double& operator[](int i) const {
+    switch (i) {
+      case 0: return x;
+      case 1: return y;
+      case 2: return z;
+    }
+  }
+  double& operator[](int i) {
+    switch (i) {
+      case 0: return x;
+      case 1: return y;
+      case 2: return z;
+    }
+  }
+
+  inline double dot(Position other) {
+    return x*other.x + y*other.y + z*other.z;
+  }
+};
+
+inline Position operator+(Position a, Position b) { return a += b; }
+inline Position operator+(Position a, double b)   { return a += b; }
+inline Position operator+(double a, Position b)   { return b += a; }
+
+inline Position operator-(Position a, Position b) { return a -= b; }
+inline Position operator-(Position a, double b)   { return a -= b; }
+inline Position operator-(double a, Position b)   { return b -= a; }
+
+inline Position operator*(Position a, Position b) { return a *= b; }
+inline Position operator*(Position a, double b)   { return a *= b; }
+inline Position operator*(double a, Position b)   { return b *= a; }
+
+
+struct Angle : Position {
+  double& u() { return x; }
+  double& v() { return y; }
+  double& w() { return z; }
+  Angle() = default;
+  Angle(double u, double v, double w) : Position{u, v, w} { };
+  Angle(double uvw[]) : Position{uvw} { };
+  Angle(Position r) : Position{r} { };
+};
+
+} // namespace openmc
 
 #endif // GEOMETRY_H

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -12,7 +12,7 @@ struct Position {
 
   Position() = default;
   Position(double x_, double y_, double z_) : x{x_}, y{y_}, z{z_} { };
-  Position(double xyz[]) : x{xyz[0]}, y{xyz[1]}, z{xyz[2]} { };
+  Position(const double xyz[]) : x{xyz[0]}, y{xyz[1]}, z{xyz[2]} { };
 
   Position& operator+=(Position);
   Position& operator+=(double);
@@ -59,7 +59,7 @@ struct Angle : Position {
   double& w() { return z; }
   Angle() = default;
   Angle(double u, double v, double w) : Position{u, v, w} { };
-  Angle(double uvw[]) : Position{uvw} { };
+  Angle(const double uvw[]) : Position{uvw} { };
   Angle(Position r) : Position{r} { };
 };
 

--- a/src/hdf5_interface.h
+++ b/src/hdf5_interface.h
@@ -183,8 +183,8 @@ write_dataset(hid_t obj_id, const char* name, const std::array<T, N>& buffer)
   write_dataset(obj_id, 1, dims, name, H5TypeMap<T>::type_id, buffer.data(), false);
 }
 
-template<> inline void
-write_dataset<Position>(hid_t obj_id, const char* name, Position r)
+inline void
+write_dataset(hid_t obj_id, const char* name, Position r)
 {
   std::array<double, 3> buffer {r.x, r.y, r.z};
   write_dataset(obj_id, name, buffer);

--- a/src/hdf5_interface.h
+++ b/src/hdf5_interface.h
@@ -11,6 +11,8 @@
 #include <vector>
 #include <complex.h>
 
+#include "geometry.h"
+
 
 namespace openmc {
 
@@ -179,6 +181,13 @@ write_dataset(hid_t obj_id, const char* name, const std::array<T, N>& buffer)
 {
   hsize_t dims[] {N};
   write_dataset(obj_id, 1, dims, name, H5TypeMap<T>::type_id, buffer.data(), false);
+}
+
+template<> inline void
+write_dataset<Position>(hid_t obj_id, const char* name, Position r)
+{
+  std::array<double, 3> buffer {r.x, r.y, r.z};
+  write_dataset(obj_id, name, buffer);
 }
 
 } // namespace openmc

--- a/src/hdf5_interface.h
+++ b/src/hdf5_interface.h
@@ -1,5 +1,5 @@
-#ifndef HDF5_INTERFACE_H
-#define HDF5_INTERFACE_H
+#ifndef OPENMC_HDF5_INTERFACE_H
+#define OPENMC_HDF5_INTERFACE_H
 
 #include "hdf5.h"
 #include "hdf5_hl.h"
@@ -191,4 +191,4 @@ write_dataset(hid_t obj_id, const char* name, Position r)
 }
 
 } // namespace openmc
-#endif //HDF5_INTERFACE_H
+#endif // OPENMC_HDF5_INTERFACE_H

--- a/src/hdf5_interface.h
+++ b/src/hdf5_interface.h
@@ -11,7 +11,7 @@
 #include <vector>
 #include <complex.h>
 
-#include "geometry.h"
+#include "position.h"
 
 
 namespace openmc {

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -223,25 +223,23 @@ RectLattice::are_valid_indices(const int i_xyz[3]) const
 //==============================================================================
 
 std::pair<double, std::array<int, 3>>
-RectLattice::distance(Position r, Angle a, const int i_xyz[3]) const
+RectLattice::distance(Position r, Direction u, const int i_xyz[3]) const
 {
   // Get short aliases to the coordinates.
   double x = r.x;
   double y = r.y;
   double z = r.z;
-  double u = a.u();
-  double v = a.v();
 
   // Determine the oncoming edge.
-  double x0 {copysign(0.5 * pitch[0], u)};
-  double y0 {copysign(0.5 * pitch[1], v)};
+  double x0 {copysign(0.5 * pitch[0], u.x)};
+  double y0 {copysign(0.5 * pitch[1], u.y)};
 
   // Left and right sides
   double d {INFTY};
   std::array<int, 3> lattice_trans;
-  if ((std::abs(x - x0) > FP_PRECISION) && u != 0) {
-    d = (x0 - x) / u;
-    if (u > 0) {
+  if ((std::abs(x - x0) > FP_PRECISION) && u.x != 0) {
+    d = (x0 - x) / u.x;
+    if (u.x > 0) {
       lattice_trans = {1, 0, 0};
     } else {
       lattice_trans = {-1, 0, 0};
@@ -249,11 +247,11 @@ RectLattice::distance(Position r, Angle a, const int i_xyz[3]) const
   }
 
   // Front and back sides
-  if ((std::abs(y - y0) > FP_PRECISION) && v != 0) {
-    double this_d = (y0 - y) / v;
+  if ((std::abs(y - y0) > FP_PRECISION) && u.y != 0) {
+    double this_d = (y0 - y) / u.y;
     if (this_d < d) {
       d = this_d;
-      if (v > 0) {
+      if (u.y > 0) {
         lattice_trans = {0, 1, 0};
       } else {
         lattice_trans = {0, -1, 0};
@@ -263,13 +261,12 @@ RectLattice::distance(Position r, Angle a, const int i_xyz[3]) const
 
   // Top and bottom sides
   if (is_3d) {
-    double w {a.w()};
-    double z0 {copysign(0.5 * pitch[2], w)};
-    if ((std::abs(z - z0) > FP_PRECISION) && w != 0) {
-      double this_d = (z0 - z) / w;
+    double z0 {copysign(0.5 * pitch[2], u.z)};
+    if ((std::abs(z - z0) > FP_PRECISION) && u.z != 0) {
+      double this_d = (z0 - z) / u.z;
       if (this_d < d) {
         d = this_d;
-        if (w > 0) {
+        if (u.z > 0) {
           lattice_trans = {0, 0, 1};
         } else {
           lattice_trans = {0, 0, -1};
@@ -579,11 +576,11 @@ HexLattice::are_valid_indices(const int i_xyz[3]) const
 //==============================================================================
 
 std::pair<double, std::array<int, 3>>
-HexLattice::distance(Position r, Angle a, const int i_xyz[3]) const
+HexLattice::distance(Position r, Direction u, const int i_xyz[3]) const
 {
   // Compute the direction on the hexagonal basis.
-  double beta_dir = a.u() * std::sqrt(3.0) / 2.0 + a.v() / 2.0;
-  double gamma_dir = a.u() * std::sqrt(3.0) / 2.0 - a.v() / 2.0;
+  double beta_dir = u.x * std::sqrt(3.0) / 2.0 + u.y / 2.0;
+  double gamma_dir = u.x * std::sqrt(3.0) / 2.0 - u.y / 2.0;
 
   // Note that hexagonal lattice distance calculations are performed
   // using the particle's coordinates relative to the neighbor lattice
@@ -636,18 +633,18 @@ HexLattice::distance(Position r, Angle a, const int i_xyz[3]) const
   }
 
   // Upper and lower sides.
-  edge = -copysign(0.5*pitch[0], a.v());
-  if (a.v() > 0) {
+  edge = -copysign(0.5*pitch[0], u.y);
+  if (u.y > 0) {
     const int i_xyz_t[3] {i_xyz[0], i_xyz[1]+1, i_xyz[2]};
     r_t = get_local_position(r, i_xyz_t);
   } else {
     const int i_xyz_t[3] {i_xyz[0], i_xyz[1]-1, i_xyz[2]};
     r_t = get_local_position(r, i_xyz_t);
   }
-  if ((std::abs(r_t.y - edge) > FP_PRECISION) && a.v() != 0) {
-    double this_d = (edge - r_t.y) / a.v();
+  if ((std::abs(r_t.y - edge) > FP_PRECISION) && u.y != 0) {
+    double this_d = (edge - r_t.y) / u.y;
     if (this_d < d) {
-      if (a.v() > 0) {
+      if (u.y > 0) {
         lattice_trans = {0, 1, 0};
       } else {
         lattice_trans = {0, -1, 0};
@@ -659,13 +656,12 @@ HexLattice::distance(Position r, Angle a, const int i_xyz[3]) const
   // Top and bottom sides
   if (is_3d) {
     double z = r.z;
-    double w = a.w();
-    double z0 {copysign(0.5 * pitch[1], w)};
-    if ((std::abs(z - z0) > FP_PRECISION) && w != 0) {
-      double this_d = (z0 - z) / w;
+    double z0 {copysign(0.5 * pitch[1], u.z)};
+    if ((std::abs(z - z0) > FP_PRECISION) && u.z != 0) {
+      double this_d = (z0 - z) / u.z;
       if (this_d < d) {
         d = this_d;
-        if (w > 0) {
+        if (u.z > 0) {
           lattice_trans = {0, 0, 1};
         } else {
           lattice_trans = {0, 0, -1};
@@ -897,8 +893,8 @@ extern "C" {
                         const int i_xyz[3], double *d, int lattice_trans[3])
   {
     Position r {xyz};
-    Angle a {uvw};
-    std::pair<double, std::array<int, 3>> ld {lat->distance(r, a, i_xyz)};
+    Direction u {uvw};
+    std::pair<double, std::array<int, 3>> ld {lat->distance(r, u, i_xyz)};
     *d = ld.first;
     lattice_trans[0] = ld.second[0];
     lattice_trans[1] = ld.second[1];

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -223,15 +223,14 @@ RectLattice::are_valid_indices(const int i_xyz[3]) const
 //==============================================================================
 
 std::pair<double, std::array<int, 3>>
-RectLattice::distance(const double xyz[3], const double uvw[3],
-                      const int i_xyz[3]) const
+RectLattice::distance(Position r, Angle a, const int i_xyz[3]) const
 {
   // Get short aliases to the coordinates.
-  double x {xyz[0]};
-  double y {xyz[1]};
-  double z {xyz[2]};
-  double u {uvw[0]};
-  double v {uvw[1]};
+  double x = r.x;
+  double y = r.y;
+  double z = r.z;
+  double u = a.u();
+  double v = a.v();
 
   // Determine the oncoming edge.
   double x0 {copysign(0.5 * pitch[0], u)};
@@ -264,7 +263,7 @@ RectLattice::distance(const double xyz[3], const double uvw[3],
 
   // Top and bottom sides
   if (is_3d) {
-    double w {uvw[2]};
+    double w {a.w()};
     double z0 {copysign(0.5 * pitch[2], w)};
     if ((std::abs(z - z0) > FP_PRECISION) && w != 0) {
       double this_d = (z0 - z) / w;
@@ -285,13 +284,13 @@ RectLattice::distance(const double xyz[3], const double uvw[3],
 //==============================================================================
 
 std::array<int, 3>
-RectLattice::get_indices(const double xyz[3]) const
+RectLattice::get_indices(Position r) const
 {
-  int ix {static_cast<int>(std::ceil((xyz[0] - lower_left[0]) / pitch[0]))-1};
-  int iy {static_cast<int>(std::ceil((xyz[1] - lower_left[1]) / pitch[1]))-1};
+  int ix {static_cast<int>(std::ceil((r.x - lower_left.x) / pitch.x))-1};
+  int iy {static_cast<int>(std::ceil((r.y - lower_left.y) / pitch.y))-1};
   int iz;
   if (is_3d) {
-    iz = static_cast<int>(std::ceil((xyz[2] - lower_left[2]) / pitch[2]))-1;
+    iz = static_cast<int>(std::ceil((r.z - lower_left.z) / pitch.z))-1;
   } else {
     iz = 0;
   }
@@ -300,18 +299,15 @@ RectLattice::get_indices(const double xyz[3]) const
 
 //==============================================================================
 
-std::array<double, 3>
-RectLattice::get_local_xyz(const double global_xyz[3], const int i_xyz[3]) const
+Position
+RectLattice::get_local_position(Position r, const int i_xyz[3]) const
 {
-  std::array<double, 3> local_xyz;
-  local_xyz[0] = global_xyz[0] - (lower_left[0] + (i_xyz[0] + 0.5)*pitch[0]);
-  local_xyz[1] = global_xyz[1] - (lower_left[1] + (i_xyz[1] + 0.5)*pitch[1]);
+  r.x -= (lower_left.x + (i_xyz[0] + 0.5)*pitch.x);
+  r.y -= (lower_left.y + (i_xyz[1] + 0.5)*pitch.y);
   if (is_3d) {
-    local_xyz[2] = global_xyz[2] - (lower_left[2] + (i_xyz[2] + 0.5)*pitch[2]);
-  } else {
-    local_xyz[2] = global_xyz[2];
+    r.z -= (lower_left.z + (i_xyz[2] + 0.5)*pitch.z);
   }
-  return local_xyz;
+  return r;
 }
 
 //==============================================================================
@@ -583,12 +579,11 @@ HexLattice::are_valid_indices(const int i_xyz[3]) const
 //==============================================================================
 
 std::pair<double, std::array<int, 3>>
-HexLattice::distance(const double xyz[3], const double uvw[3],
-                     const int i_xyz[3]) const
+HexLattice::distance(Position r, Angle a, const int i_xyz[3]) const
 {
   // Compute the direction on the hexagonal basis.
-  double beta_dir = uvw[0] * std::sqrt(3.0) / 2.0 + uvw[1] / 2.0;
-  double gamma_dir = uvw[0] * std::sqrt(3.0) / 2.0 - uvw[1] / 2.0;
+  double beta_dir = a.u() * std::sqrt(3.0) / 2.0 + a.v() / 2.0;
+  double gamma_dir = a.u() * std::sqrt(3.0) / 2.0 - a.v() / 2.0;
 
   // Note that hexagonal lattice distance calculations are performed
   // using the particle's coordinates relative to the neighbor lattice
@@ -600,15 +595,15 @@ HexLattice::distance(const double xyz[3], const double uvw[3],
   double d {INFTY};
   std::array<int, 3> lattice_trans;
   double edge = -copysign(0.5*pitch[0], beta_dir);  // Oncoming edge
-  std::array<double, 3> xyz_t;
+  Position r_t;
   if (beta_dir > 0) {
     const int i_xyz_t[3] {i_xyz[0]+1, i_xyz[1], i_xyz[2]};
-    xyz_t = get_local_xyz(xyz, i_xyz_t);
+    r_t = get_local_position(r, i_xyz_t);
   } else {
     const int i_xyz_t[3] {i_xyz[0]-1, i_xyz[1], i_xyz[2]};
-    xyz_t = get_local_xyz(xyz, i_xyz_t);
+    r_t = get_local_position(r, i_xyz_t);
   }
-  double beta = xyz_t[0] * std::sqrt(3.0) / 2.0 + xyz_t[1] / 2.0;
+  double beta = r_t.x * std::sqrt(3.0) / 2.0 + r_t.y / 2.0;
   if ((std::abs(beta - edge) > FP_PRECISION) && beta_dir != 0) {
     d = (edge - beta) / beta_dir;
     if (beta_dir > 0) {
@@ -622,12 +617,12 @@ HexLattice::distance(const double xyz[3], const double uvw[3],
   edge = -copysign(0.5*pitch[0], gamma_dir);
   if (gamma_dir > 0) {
     const int i_xyz_t[3] {i_xyz[0]+1, i_xyz[1]-1, i_xyz[2]};
-    xyz_t = get_local_xyz(xyz, i_xyz_t);
+    r_t = get_local_position(r, i_xyz_t);
   } else {
     const int i_xyz_t[3] {i_xyz[0]-1, i_xyz[1]+1, i_xyz[2]};
-    xyz_t = get_local_xyz(xyz, i_xyz_t);
+    r_t = get_local_position(r, i_xyz_t);
   }
-  double gamma = xyz_t[0] * std::sqrt(3.0) / 2.0 - xyz_t[1] / 2.0;
+  double gamma = r_t.x * std::sqrt(3.0) / 2.0 - r_t.y / 2.0;
   if ((std::abs(gamma - edge) > FP_PRECISION) && gamma_dir != 0) {
     double this_d = (edge - gamma) / gamma_dir;
     if (this_d < d) {
@@ -641,18 +636,18 @@ HexLattice::distance(const double xyz[3], const double uvw[3],
   }
 
   // Upper and lower sides.
-  edge = -copysign(0.5*pitch[0], uvw[1]);
-  if (uvw[1] > 0) {
+  edge = -copysign(0.5*pitch[0], a.v());
+  if (a.v() > 0) {
     const int i_xyz_t[3] {i_xyz[0], i_xyz[1]+1, i_xyz[2]};
-    xyz_t = get_local_xyz(xyz, i_xyz_t);
+    r_t = get_local_position(r, i_xyz_t);
   } else {
     const int i_xyz_t[3] {i_xyz[0], i_xyz[1]-1, i_xyz[2]};
-    xyz_t = get_local_xyz(xyz, i_xyz_t);
+    r_t = get_local_position(r, i_xyz_t);
   }
-  if ((std::abs(xyz_t[1] - edge) > FP_PRECISION) && uvw[1] != 0) {
-    double this_d = (edge - xyz_t[1]) / uvw[1];
+  if ((std::abs(r_t.y - edge) > FP_PRECISION) && a.v() != 0) {
+    double this_d = (edge - r_t.y) / a.v();
     if (this_d < d) {
-      if (uvw[1] > 0) {
+      if (a.v() > 0) {
         lattice_trans = {0, 1, 0};
       } else {
         lattice_trans = {0, -1, 0};
@@ -663,8 +658,8 @@ HexLattice::distance(const double xyz[3], const double uvw[3],
 
   // Top and bottom sides
   if (is_3d) {
-    double z {xyz[2]};
-    double w {uvw[2]};
+    double z = r.z;
+    double w = a.w();
     double z0 {copysign(0.5 * pitch[1], w)};
     if ((std::abs(z - z0) > FP_PRECISION) && w != 0) {
       double this_d = (z0 - z) / w;
@@ -686,24 +681,24 @@ HexLattice::distance(const double xyz[3], const double uvw[3],
 //==============================================================================
 
 std::array<int, 3>
-HexLattice::get_indices(const double xyz[3]) const
+HexLattice::get_indices(Position r) const
 {
   // Offset the xyz by the lattice center.
-  double xyz_o[3] {xyz[0] - center[0], xyz[1] - center[1], xyz[2]};
-  if (is_3d) {xyz_o[2] -= center[2];}
+  Position r_o {r.x - center.x, r.y - center.y, r.z};
+  if (is_3d) {r_o.z -= center.z;}
 
   // Index the z direction.
   std::array<int, 3> out;
   if (is_3d) {
-    out[2] = static_cast<int>(std::ceil(xyz_o[2] / pitch[1] + 0.5 * n_axial))-1;
+    out[2] = static_cast<int>(std::ceil(r_o.z / pitch[1] + 0.5 * n_axial))-1;
   } else {
     out[2] = 0;
   }
 
   // Convert coordinates into skewed bases.  The (x, alpha) basis is used to
   // find the index of the global coordinates to within 4 cells.
-  double alpha = xyz_o[1] - xyz_o[0] / std::sqrt(3.0);
-  out[0] = static_cast<int>(std::floor(xyz_o[0]
+  double alpha = r_o.y - r_o.x / std::sqrt(3.0);
+  out[0] = static_cast<int>(std::floor(r_o.x
                                        / (0.5*std::sqrt(3.0) * pitch[0])));
   out[1] = static_cast<int>(std::floor(alpha / pitch[0]));
 
@@ -725,8 +720,8 @@ HexLattice::get_indices(const double xyz[3]) const
   for (int i = 0; i < 2; i++) {
     for (int j = 0; j < 2; j++) {
       int i_xyz[3] {out[0] + j, out[1] + i, 0};
-      std::array<double, 3> xyz_t = get_local_xyz(xyz, i_xyz);
-      double d = xyz_t[0]*xyz_t[0] + xyz_t[1]*xyz_t[1];
+      Position r_t = get_local_position(r, i_xyz);
+      double d = r_t.x*r_t.x + r_t.y*r_t.y;
       if (d < d_min) {
         d_min = d;
         k_min = k;
@@ -751,26 +746,19 @@ HexLattice::get_indices(const double xyz[3]) const
 
 //==============================================================================
 
-std::array<double, 3>
-HexLattice::get_local_xyz(const double global_xyz[3], const int i_xyz[3]) const
+Position
+HexLattice::get_local_position(Position r, const int i_xyz[3]) const
 {
-  std::array<double, 3> local_xyz;
-
   // x_l = x_g - (center + pitch_x*cos(30)*index_x)
-  local_xyz[0] = global_xyz[0] - (center[0]
-       + std::sqrt(3.0)/2.0 * (i_xyz[0] - n_rings + 1) * pitch[0]);
+  r.x -= (center.x + std::sqrt(3.0)/2.0 * (i_xyz[0] - n_rings + 1) * pitch[0]);
   // y_l = y_g - (center + pitch_x*index_x + pitch_y*sin(30)*index_y)
-  local_xyz[1] = global_xyz[1] - (center[1]
-       + (i_xyz[1] - n_rings + 1) * pitch[0]
-       + (i_xyz[0] - n_rings + 1) * pitch[0] / 2.0);
+  r.y -= (center.y + (i_xyz[1] - n_rings + 1) * pitch[0]
+                   + (i_xyz[0] - n_rings + 1) * pitch[0] / 2.0);
   if (is_3d) {
-    local_xyz[2] = global_xyz[2] - center[2]
-         + (0.5 * n_axial - i_xyz[2] - 0.5) * pitch[1];
-  } else {
-    local_xyz[2] = global_xyz[2];
+    r.z -= center.z - (0.5 * n_axial - i_xyz[2] - 0.5) * pitch[1];
   }
 
-  return local_xyz;
+  return r;
 }
 
 //==============================================================================
@@ -908,7 +896,9 @@ extern "C" {
   void lattice_distance(Lattice *lat, const double xyz[3], const double uvw[3],
                         const int i_xyz[3], double *d, int lattice_trans[3])
   {
-    std::pair<double, std::array<int, 3>> ld {lat->distance(xyz, uvw, i_xyz)};
+    Position r {xyz};
+    Angle a {uvw};
+    std::pair<double, std::array<int, 3>> ld {lat->distance(r, a, i_xyz)};
     *d = ld.first;
     lattice_trans[0] = ld.second[0];
     lattice_trans[1] = ld.second[1];
@@ -917,7 +907,8 @@ extern "C" {
 
   void lattice_get_indices(Lattice *lat, const double xyz[3], int i_xyz[3])
   {
-    std::array<int, 3> inds = lat->get_indices(xyz);
+    Position r {xyz};
+    std::array<int, 3> inds = lat->get_indices(r);
     i_xyz[0] = inds[0];
     i_xyz[1] = inds[1];
     i_xyz[2] = inds[2];
@@ -926,10 +917,11 @@ extern "C" {
   void lattice_get_local_xyz(Lattice *lat, const double global_xyz[3],
                              const int i_xyz[3], double local_xyz[3])
   {
-    std::array<double, 3> xyz = lat->get_local_xyz(global_xyz, i_xyz);
-    local_xyz[0] = xyz[0];
-    local_xyz[1] = xyz[1];
-    local_xyz[2] = xyz[2];
+    Position global {global_xyz};
+    Position local = lat->get_local_position(global, i_xyz);
+    local_xyz[0] = local.x;
+    local_xyz[1] = local.y;
+    local_xyz[2] = local.z;
   }
 
   int32_t lattice_offset(Lattice *lat, int map, const int i_xyz[3])

--- a/src/lattice.h
+++ b/src/lattice.h
@@ -7,10 +7,11 @@
 #include <unordered_map>
 #include <vector>
 
-#include "constants.h"
-#include "geometry.h"
 #include "hdf5.h"
 #include "pugixml.hpp"
+
+#include "constants.h"
+#include "position.h"
 
 
 namespace openmc {
@@ -82,7 +83,7 @@ public:
   //! @return The distance to the next crossing and an array indicating how the
   //!   lattice indices would change after crossing that boundary.
   virtual std::pair<double, std::array<int, 3>>
-  distance(Position r, Angle a, const int i_xyz[3]) const
+  distance(Position r, Direction u, const int i_xyz[3]) const
   = 0;
 
   //! \brief Find the lattice tile indices for a given point.
@@ -194,7 +195,7 @@ public:
   bool are_valid_indices(const int i_xyz[3]) const;
 
   std::pair<double, std::array<int, 3>>
-  distance(Position r, Angle a, const int i_xyz[3]) const;
+  distance(Position r, Direction u, const int i_xyz[3]) const;
 
   std::array<int, 3> get_indices(Position r) const;
 
@@ -234,7 +235,7 @@ public:
   bool are_valid_indices(const int i_xyz[3]) const;
 
   std::pair<double, std::array<int, 3>>
-  distance(Position r, Angle a, const int i_xyz[3]) const;
+  distance(Position r, Direction u, const int i_xyz[3]) const;
 
   std::array<int, 3> get_indices(Position r) const;
 

--- a/src/lattice.h
+++ b/src/lattice.h
@@ -1,5 +1,5 @@
-#ifndef LATTICE_H
-#define LATTICE_H
+#ifndef OPENMC_LATTICE_H
+#define OPENMC_LATTICE_H
 
 #include <array>
 #include <cstdint>
@@ -71,54 +71,54 @@ public:
   int32_t fill_offset_table(int32_t offset, int32_t target_univ_id, int map);
 
   //! \brief Check lattice indices.
-  //! @param i_xyz[3] The indices for a lattice tile.
-  //! @return true if the given indices fit within the lattice bounds.  False
+  //! \param i_xyz[3] The indices for a lattice tile.
+  //! \return true if the given indices fit within the lattice bounds.  False
   //!   otherwise.
   virtual bool are_valid_indices(const int i_xyz[3]) const = 0;
 
   //! \brief Find the next lattice surface crossing
-  //! @param r A 3D Cartesian coordinate.
-  //! @param a A 3D Cartesian direction.
-  //! @param i_xyz[3] The indices for a lattice tile.
-  //! @return The distance to the next crossing and an array indicating how the
+  //! \param r A 3D Cartesian coordinate.
+  //! \param u A 3D Cartesian direction.
+  //! \param i_xyz[3] The indices for a lattice tile.
+  //! \return The distance to the next crossing and an array indicating how the
   //!   lattice indices would change after crossing that boundary.
   virtual std::pair<double, std::array<int, 3>>
   distance(Position r, Direction u, const int i_xyz[3]) const
   = 0;
 
   //! \brief Find the lattice tile indices for a given point.
-  //! @param r A 3D Cartesian coordinate.
-  //! @return An array containing the indices of a lattice tile.
+  //! \param r A 3D Cartesian coordinate.
+  //! \return An array containing the indices of a lattice tile.
   virtual std::array<int, 3> get_indices(Position r) const = 0;
 
   //! \brief Get coordinates local to a lattice tile.
-  //! @param r A 3D Cartesian coordinate.
-  //! @param i_xyz[3] The indices for a lattice tile.
-  //! @return Local 3D Cartesian coordinates.
+  //! \param r A 3D Cartesian coordinate.
+  //! \param i_xyz[3] The indices for a lattice tile.
+  //! \return Local 3D Cartesian coordinates.
   virtual Position
   get_local_position(Position r, const int i_xyz[3]) const = 0;
 
   //! \brief Check flattened lattice index.
-  //! @param indx The index for a lattice tile.
-  //! @return true if the given index fit within the lattice bounds.  False
+  //! \param indx The index for a lattice tile.
+  //! \return true if the given index fit within the lattice bounds.  False
   //!   otherwise.
   virtual bool is_valid_index(int indx) const
   {return (indx >= 0) && (indx < universes.size());}
 
   //! \brief Get the distribcell offset for a lattice tile.
-  //! @param The map index for the target cell.
-  //! @param i_xyz[3] The indices for a lattice tile.
-  //! @return Distribcell offset i.e. the largest instance number for the target
+  //! \param The map index for the target cell.
+  //! \param i_xyz[3] The indices for a lattice tile.
+  //! \return Distribcell offset i.e. the largest instance number for the target
   //!  cell found in the geometry tree under this lattice tile.
   virtual int32_t& offset(int map, const int i_xyz[3]) = 0;
 
   //! \brief Convert an array index to a useful human-readable string.
-  //! @param indx The index for a lattice tile.
-  //! @return A string representing the lattice tile.
+  //! \param indx The index for a lattice tile.
+  //! \return A string representing the lattice tile.
   virtual std::string index_to_string(int indx) const = 0;
 
   //! \brief Write lattice information to an HDF5 group.
-  //! @param group_id An HDF5 group id.
+  //! \param group_id An HDF5 group id.
   void to_hdf5(hid_t group_id) const;
 
 protected:
@@ -258,4 +258,4 @@ private:
 };
 
 } //  namespace openmc
-#endif // LATTICE_H
+#endif // OPENMC_LATTICE_H

--- a/src/lattice.h
+++ b/src/lattice.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "constants.h"
+#include "geometry.h"
 #include "hdf5.h"
 #include "pugixml.hpp"
 
@@ -75,26 +76,26 @@ public:
   virtual bool are_valid_indices(const int i_xyz[3]) const = 0;
 
   //! \brief Find the next lattice surface crossing
-  //! @param xyz[3] A 3D Cartesian coordinate.
-  //! @param uvw[3] A 3D Cartesian direction.
+  //! @param r A 3D Cartesian coordinate.
+  //! @param a A 3D Cartesian direction.
   //! @param i_xyz[3] The indices for a lattice tile.
   //! @return The distance to the next crossing and an array indicating how the
   //!   lattice indices would change after crossing that boundary.
   virtual std::pair<double, std::array<int, 3>>
-  distance(const double xyz[3], const double uvw[3], const int i_xyz[3]) const
+  distance(Position r, Angle a, const int i_xyz[3]) const
   = 0;
 
   //! \brief Find the lattice tile indices for a given point.
-  //! @param xyz[3] A 3D Cartesian coordinate.
+  //! @param r A 3D Cartesian coordinate.
   //! @return An array containing the indices of a lattice tile.
-  virtual std::array<int, 3> get_indices(const double xyz[3]) const = 0;
+  virtual std::array<int, 3> get_indices(Position r) const = 0;
 
   //! \brief Get coordinates local to a lattice tile.
-  //! @param global_xyz[3] A 3D Cartesian coordinate.
+  //! @param r A 3D Cartesian coordinate.
   //! @param i_xyz[3] The indices for a lattice tile.
   //! @return Local 3D Cartesian coordinates.
-  virtual std::array<double, 3>
-  get_local_xyz(const double global_xyz[3], const int i_xyz[3]) const = 0;
+  virtual Position
+  get_local_position(Position r, const int i_xyz[3]) const = 0;
 
   //! \brief Check flattened lattice index.
   //! @param indx The index for a lattice tile.
@@ -193,12 +194,12 @@ public:
   bool are_valid_indices(const int i_xyz[3]) const;
 
   std::pair<double, std::array<int, 3>>
-  distance(const double xyz[3], const double uvw[3], const int i_xyz[3]) const;
+  distance(Position r, Angle a, const int i_xyz[3]) const;
 
-  std::array<int, 3> get_indices(const double xyz[3]) const;
+  std::array<int, 3> get_indices(Position r) const;
 
-  std::array<double, 3>
-  get_local_xyz(const double global_xyz[3], const int i_xyz[3]) const;
+  Position
+  get_local_position(Position r, const int i_xyz[3]) const;
 
   int32_t& offset(int map, const int i_xyz[3]);
 
@@ -207,9 +208,9 @@ public:
   void to_hdf5_inner(hid_t group_id) const;
 
 private:
-  std::array<int, 3> n_cells;       //!< Number of cells along each axis
-  std::array<double, 3> lower_left; //!< Global lower-left corner of the lattice
-  std::array<double, 3> pitch;      //!< Lattice tile width along each axis
+  std::array<int, 3> n_cells;    //!< Number of cells along each axis
+  Position lower_left;           //!< Global lower-left corner of the lattice
+  Position pitch;                //!< Lattice tile width along each axis
 
   // Convenience aliases
   int &nx {n_cells[0]};
@@ -233,12 +234,12 @@ public:
   bool are_valid_indices(const int i_xyz[3]) const;
 
   std::pair<double, std::array<int, 3>>
-  distance(const double xyz[3], const double uvw[3], const int i_xyz[3]) const;
+  distance(Position r, Angle a, const int i_xyz[3]) const;
 
-  std::array<int, 3> get_indices(const double xyz[3]) const;
+  std::array<int, 3> get_indices(Position r) const;
 
-  std::array<double, 3>
-  get_local_xyz(const double global_xyz[3], const int i_xyz[3]) const;
+  Position
+  get_local_position(Position r, const int i_xyz[3]) const;
 
   bool is_valid_index(int indx) const;
 
@@ -251,7 +252,7 @@ public:
 private:
   int n_rings;                   //!< Number of radial tile positions
   int n_axial;                   //!< Number of axial tile positions
-  std::array<double, 3> center;  //!< Global center of lattice
+  Position center;               //!< Global center of lattice
   std::array<double, 2> pitch;   //!< Lattice tile width and height
 };
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1,6 +1,10 @@
-#include "geometry.h"
+#include "position.h"
 
 namespace openmc {
+
+//==============================================================================
+// Position implementation
+//==============================================================================
 
 Position&
 Position::operator+=(Position other)

--- a/src/position.h
+++ b/src/position.h
@@ -1,0 +1,74 @@
+#ifndef OPENMC_POSITION_H
+#define OPENMC_POSITION_H
+
+namespace openmc {
+
+//==============================================================================
+//! Type representing a position in Cartesian coordinates
+//==============================================================================
+
+struct Position {
+  // Constructors
+  Position() = default;
+  Position(double x_, double y_, double z_) : x{x_}, y{y_}, z{z_} { };
+  Position(const double xyz[]) : x{xyz[0]}, y{xyz[1]}, z{xyz[2]} { };
+
+  // Unary operators
+  Position& operator+=(Position);
+  Position& operator+=(double);
+  Position& operator-=(Position);
+  Position& operator-=(double);
+  Position& operator*=(Position);
+  Position& operator*=(double);
+  const double& operator[](int i) const {
+    switch (i) {
+      case 0: return x;
+      case 1: return y;
+      case 2: return z;
+    }
+  }
+  double& operator[](int i) {
+    switch (i) {
+      case 0: return x;
+      case 1: return y;
+      case 2: return z;
+    }
+  }
+
+  // Other member functions
+
+  //! Dot product of two vectors
+  //! \param[in] other Vector to take dot product with
+  //! \result Resulting dot product
+  inline double dot(Position other) {
+    return x*other.x + y*other.y + z*other.z;
+  }
+
+  // Data members
+  double x = 0.;
+  double y = 0.;
+  double z = 0.;
+};
+
+// Binary operators
+inline Position operator+(Position a, Position b) { return a += b; }
+inline Position operator+(Position a, double b)   { return a += b; }
+inline Position operator+(double a, Position b)   { return b += a; }
+
+inline Position operator-(Position a, Position b) { return a -= b; }
+inline Position operator-(Position a, double b)   { return a -= b; }
+inline Position operator-(double a, Position b)   { return b -= a; }
+
+inline Position operator*(Position a, Position b) { return a *= b; }
+inline Position operator*(Position a, double b)   { return a *= b; }
+inline Position operator*(double a, Position b)   { return b *= a; }
+
+//==============================================================================
+//! Type representing a vector direction in Cartesian coordinates
+//==============================================================================
+
+using Direction = Position;
+
+} // namespace openmc
+
+#endif // OPENMC_POSITION_H

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -582,18 +582,18 @@ axis_aligned_cylinder_normal(Position r, double offset1, double offset2)
 SurfaceXCylinder::SurfaceXCylinder(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, id, y0, z0, r);
+  read_coeffs(surf_node, id, y0, z0, radius);
 }
 
 double SurfaceXCylinder::evaluate(Position r) const
 {
-  return axis_aligned_cylinder_evaluate<1, 2>(r, y0, z0, this->r);
+  return axis_aligned_cylinder_evaluate<1, 2>(r, y0, z0, radius);
 }
 
 double SurfaceXCylinder::distance(Position r, Direction u, bool coincident) const
 {
   return axis_aligned_cylinder_distance<0, 1, 2>(r, u, coincident, y0, z0,
-                                                 this->r);
+                                                 radius);
 }
 
 Direction SurfaceXCylinder::normal(Position r) const
@@ -605,7 +605,7 @@ Direction SurfaceXCylinder::normal(Position r) const
 void SurfaceXCylinder::to_hdf5_inner(hid_t group_id) const
 {
   write_string(group_id, "type", "x-cylinder", false);
-  std::array<double, 3> coeffs {{y0, z0, r}};
+  std::array<double, 3> coeffs {{y0, z0, radius}};
   write_dataset(group_id, "coefficients", coeffs);
 }
 
@@ -616,18 +616,18 @@ void SurfaceXCylinder::to_hdf5_inner(hid_t group_id) const
 SurfaceYCylinder::SurfaceYCylinder(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, id, x0, z0, r);
+  read_coeffs(surf_node, id, x0, z0, radius);
 }
 
 double SurfaceYCylinder::evaluate(Position r) const
 {
-  return axis_aligned_cylinder_evaluate<0, 2>(r, x0, z0, this->r);
+  return axis_aligned_cylinder_evaluate<0, 2>(r, x0, z0, radius);
 }
 
 double SurfaceYCylinder::distance(Position r, Direction u, bool coincident) const
 {
   return axis_aligned_cylinder_distance<1, 0, 2>(r, u, coincident, x0, z0,
-                                                 this->r);
+                                                 radius);
 }
 
 Direction SurfaceYCylinder::normal(Position r) const
@@ -638,7 +638,7 @@ Direction SurfaceYCylinder::normal(Position r) const
 void SurfaceYCylinder::to_hdf5_inner(hid_t group_id) const
 {
   write_string(group_id, "type", "y-cylinder", false);
-  std::array<double, 3> coeffs {{x0, z0, r}};
+  std::array<double, 3> coeffs {{x0, z0, radius}};
   write_dataset(group_id, "coefficients", coeffs);
 }
 
@@ -649,18 +649,18 @@ void SurfaceYCylinder::to_hdf5_inner(hid_t group_id) const
 SurfaceZCylinder::SurfaceZCylinder(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, id, x0, y0, r);
+  read_coeffs(surf_node, id, x0, y0, radius);
 }
 
 double SurfaceZCylinder::evaluate(Position r) const
 {
-  return axis_aligned_cylinder_evaluate<0, 1>(r, x0, y0, this->r);
+  return axis_aligned_cylinder_evaluate<0, 1>(r, x0, y0, radius);
 }
 
 double SurfaceZCylinder::distance(Position r, Direction u, bool coincident) const
 {
   return axis_aligned_cylinder_distance<2, 0, 1>(r, u, coincident, x0, y0,
-                                                 this->r);
+                                                 radius);
 }
 
 Direction SurfaceZCylinder::normal(Position r) const
@@ -671,7 +671,7 @@ Direction SurfaceZCylinder::normal(Position r) const
 void SurfaceZCylinder::to_hdf5_inner(hid_t group_id) const
 {
   write_string(group_id, "type", "z-cylinder", false);
-  std::array<double, 3> coeffs {{x0, y0, r}};
+  std::array<double, 3> coeffs {{x0, y0, radius}};
   write_dataset(group_id, "coefficients", coeffs);
 }
 
@@ -682,7 +682,7 @@ void SurfaceZCylinder::to_hdf5_inner(hid_t group_id) const
 SurfaceSphere::SurfaceSphere(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, id, x0, y0, z0, r);
+  read_coeffs(surf_node, id, x0, y0, z0, radius);
 }
 
 double SurfaceSphere::evaluate(Position r) const
@@ -690,7 +690,7 @@ double SurfaceSphere::evaluate(Position r) const
   const double x = r.x - x0;
   const double y = r.y - y0;
   const double z = r.z - z0;
-  return x*x + y*y + z*z - this->r*this->r;
+  return x*x + y*y + z*z - radius*radius;
 }
 
 double SurfaceSphere::distance(Position r, Direction u, bool coincident) const
@@ -699,7 +699,7 @@ double SurfaceSphere::distance(Position r, Direction u, bool coincident) const
   const double y = r.y - y0;
   const double z = r.z - z0;
   const double k = x*u.x + y*u.y + z*u.z;
-  const double c = x*x + y*y + z*z - this->r*this->r;
+  const double c = x*x + y*y + z*z - radius*radius;
   const double quad = k*k - c;
 
   if (quad < 0.0) {
@@ -739,7 +739,7 @@ Direction SurfaceSphere::normal(Position r) const
 void SurfaceSphere::to_hdf5_inner(hid_t group_id) const
 {
   write_string(group_id, "type", "sphere", false);
-  std::array<double, 4> coeffs {{x0, y0, z0, r}};
+  std::array<double, 4> coeffs {{x0, y0, z0, radius}};
   write_dataset(group_id, "coefficients", coeffs);
 }
 
@@ -835,29 +835,29 @@ axis_aligned_cone_normal(Position r, double offset1, double offset2,
 SurfaceXCone::SurfaceXCone(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, id, x0, y0, z0, r_sq);
+  read_coeffs(surf_node, id, x0, y0, z0, radius_sq);
 }
 
 double SurfaceXCone::evaluate(Position r) const
 {
-  return axis_aligned_cone_evaluate<0, 1, 2>(r, x0, y0, z0, r_sq);
+  return axis_aligned_cone_evaluate<0, 1, 2>(r, x0, y0, z0, radius_sq);
 }
 
 double SurfaceXCone::distance(Position r, Direction u, bool coincident) const
 {
   return axis_aligned_cone_distance<0, 1, 2>(r, u, coincident, x0, y0, z0,
-                                             r_sq);
+                                             radius_sq);
 }
 
 Direction SurfaceXCone::normal(Position r) const
 {
-  return axis_aligned_cone_normal<0, 1, 2>(r, x0, y0, z0, r_sq);
+  return axis_aligned_cone_normal<0, 1, 2>(r, x0, y0, z0, radius_sq);
 }
 
 void SurfaceXCone::to_hdf5_inner(hid_t group_id) const
 {
   write_string(group_id, "type", "x-cone", false);
-  std::array<double, 4> coeffs {{x0, y0, z0, r_sq}};
+  std::array<double, 4> coeffs {{x0, y0, z0, radius_sq}};
   write_dataset(group_id, "coefficients", coeffs);
 }
 
@@ -868,29 +868,29 @@ void SurfaceXCone::to_hdf5_inner(hid_t group_id) const
 SurfaceYCone::SurfaceYCone(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, id, x0, y0, z0, r_sq);
+  read_coeffs(surf_node, id, x0, y0, z0, radius_sq);
 }
 
 double SurfaceYCone::evaluate(Position r) const
 {
-  return axis_aligned_cone_evaluate<1, 0, 2>(r, y0, x0, z0, r_sq);
+  return axis_aligned_cone_evaluate<1, 0, 2>(r, y0, x0, z0, radius_sq);
 }
 
 double SurfaceYCone::distance(Position r, Direction u, bool coincident) const
 {
   return axis_aligned_cone_distance<1, 0, 2>(r, u, coincident, y0, x0, z0,
-                                             r_sq);
+                                             radius_sq);
 }
 
 Direction SurfaceYCone::normal(Position r) const
 {
-  return axis_aligned_cone_normal<1, 0, 2>(r, y0, x0, z0, r_sq);
+  return axis_aligned_cone_normal<1, 0, 2>(r, y0, x0, z0, radius_sq);
 }
 
 void SurfaceYCone::to_hdf5_inner(hid_t group_id) const
 {
   write_string(group_id, "type", "y-cone", false);
-  std::array<double, 4> coeffs {{x0, y0, z0, r_sq}};
+  std::array<double, 4> coeffs {{x0, y0, z0, radius_sq}};
   write_dataset(group_id, "coefficients", coeffs);
 }
 
@@ -901,29 +901,29 @@ void SurfaceYCone::to_hdf5_inner(hid_t group_id) const
 SurfaceZCone::SurfaceZCone(pugi::xml_node surf_node)
   : Surface(surf_node)
 {
-  read_coeffs(surf_node, id, x0, y0, z0, r_sq);
+  read_coeffs(surf_node, id, x0, y0, z0, radius_sq);
 }
 
 double SurfaceZCone::evaluate(Position r) const
 {
-  return axis_aligned_cone_evaluate<2, 0, 1>(r, z0, x0, y0, r_sq);
+  return axis_aligned_cone_evaluate<2, 0, 1>(r, z0, x0, y0, radius_sq);
 }
 
 double SurfaceZCone::distance(Position r, Direction u, bool coincident) const
 {
   return axis_aligned_cone_distance<2, 0, 1>(r, u, coincident, z0, x0, y0,
-                                             r_sq);
+                                             radius_sq);
 }
 
 Direction SurfaceZCone::normal(Position r) const
 {
-  return axis_aligned_cone_normal<2, 0, 1>(r, z0, x0, y0, r_sq);
+  return axis_aligned_cone_normal<2, 0, 1>(r, z0, x0, y0, radius_sq);
 }
 
 void SurfaceZCone::to_hdf5_inner(hid_t group_id) const
 {
   write_string(group_id, "type", "z-cone", false);
-  std::array<double, 4> coeffs {{x0, y0, z0, r_sq}};
+  std::array<double, 4> coeffs {{x0, y0, z0, radius_sq}};
   write_dataset(group_id, "coefficients", coeffs);
 }
 

--- a/src/surface.h
+++ b/src/surface.h
@@ -1,5 +1,5 @@
-#ifndef SURFACE_H
-#define SURFACE_H
+#ifndef OPENMC_SURFACE_H
+#define OPENMC_SURFACE_H
 
 #include <map>
 #include <limits>  // For numeric_limits
@@ -66,16 +66,16 @@ public:
   virtual ~Surface() {}
 
   //! Determine which side of a surface a point lies on.
-  //! @param r The 3D Cartesian coordinate of a point.
-  //! @param o A direction used to "break ties" and pick a sense when the
+  //! \param r The 3D Cartesian coordinate of a point.
+  //! \param u A direction used to "break ties" and pick a sense when the
   //!   point is very close to the surface.
-  //! @return true if the point is on the "positive" side of the surface and
+  //! \return true if the point is on the "positive" side of the surface and
   //!   false otherwise.
   bool sense(Position r, Direction u) const;
 
   //! Determine the direction of a ray reflected from the surface.
-  //! @param r The point at which the ray is incident.
-  //! @param o A direction.  This is both an input and an output parameter.
+  //! \param r The point at which the ray is incident.
+  //! \param u A direction.  This is both an input and an output parameter.
   //!   It specifies the icident direction on input and the reflected direction
   //!   on output.
   Direction reflect(Position r, Direction u) const;
@@ -84,23 +84,23 @@ public:
   //!
   //! Surfaces can be described by some function f(x, y, z) = 0.  This member
   //! function evaluates that mathematical function.
-  //! @param r A 3D Cartesian coordinate.
+  //! \param r A 3D Cartesian coordinate.
   virtual double evaluate(Position r) const = 0;
 
   //! Compute the distance between a point and the surface along a ray.
-  //! @param r A 3D Cartesian coordinate.
-  //! @param o The direction of the ray.
-  //! @param coincident A hint to the code that the given point should lie
+  //! \param r A 3D Cartesian coordinate.
+  //! \param u The direction of the ray.
+  //! \param coincident A hint to the code that the given point should lie
   //!   exactly on the surface.
   virtual double distance(Position r, Direction u, bool coincident) const = 0;
 
   //! Compute the local outward normal direction of the surface.
-  //! @param r A 3D Cartesian coordinate.
-  //! @return Normal direction
+  //! \param r A 3D Cartesian coordinate.
+  //! \return Normal direction
   virtual Direction normal(Position r) const = 0;
 
   //! Write all information needed to reconstruct the surface to an HDF5 group.
-  //! @param group_id An HDF5 group id.
+  //! \param group_id An HDF5 group id.
   //TODO: this probably needs to include i_periodic for PeriodicSurface
   void to_hdf5(hid_t group_id) const;
 
@@ -124,12 +124,12 @@ public:
   explicit PeriodicSurface(pugi::xml_node surf_node);
 
   //! Translate a particle onto this surface from a periodic partner surface.
-  //! @param other A pointer to the partner surface in this periodic BC.
-  //! @param r A point on the partner surface that will be translated onto
+  //! \param other A pointer to the partner surface in this periodic BC.
+  //! \param r A point on the partner surface that will be translated onto
   //!   this surface.
-  //! @param a A direction that will be rotated for systems with rotational
+  //! \param u A direction that will be rotated for systems with rotational
   //!   periodicity.
-  //! @return true if this surface and its partner make a rotationally-periodic
+  //! \return true if this surface and its partner make a rotationally-periodic
   //!   boundary condition.
   virtual bool periodic_translate(const PeriodicSurface *other, Position& r,
                                   Direction& u) const = 0;
@@ -383,4 +383,4 @@ extern "C" {
 }
 
 } // namespace openmc
-#endif // SURFACE_H
+#endif // OPENMC_SURFACE_H

--- a/src/surface.h
+++ b/src/surface.h
@@ -74,10 +74,9 @@ public:
   bool sense(Position r, Direction u) const;
 
   //! Determine the direction of a ray reflected from the surface.
-  //! \param r The point at which the ray is incident.
-  //! \param u A direction.  This is both an input and an output parameter.
-  //!   It specifies the icident direction on input and the reflected direction
-  //!   on output.
+  //! \param[in] r The point at which the ray is incident.
+  //! \param[in] u Incident direction of the ray
+  //! \return Outgoing direction of the ray
   Direction reflect(Position r, Direction u) const;
 
   //! Evaluate the equation describing the surface.
@@ -227,7 +226,7 @@ public:
 
 class SurfaceXCylinder : public Surface
 {
-  double y0, z0, r;
+  double y0, z0, radius;
 public:
   explicit SurfaceXCylinder(pugi::xml_node surf_node);
   double evaluate(Position r) const;
@@ -245,7 +244,7 @@ public:
 
 class SurfaceYCylinder : public Surface
 {
-  double x0, z0, r;
+  double x0, z0, radius;
 public:
   explicit SurfaceYCylinder(pugi::xml_node surf_node);
   double evaluate(Position r) const;
@@ -263,7 +262,7 @@ public:
 
 class SurfaceZCylinder : public Surface
 {
-  double x0, y0, r;
+  double x0, y0, radius;
 public:
   explicit SurfaceZCylinder(pugi::xml_node surf_node);
   double evaluate(Position r) const;
@@ -281,7 +280,7 @@ public:
 
 class SurfaceSphere : public Surface
 {
-  double x0, y0, z0, r;
+  double x0, y0, z0, radius;
 public:
   explicit SurfaceSphere(pugi::xml_node surf_node);
   double evaluate(Position r) const;
@@ -299,7 +298,7 @@ public:
 
 class SurfaceXCone : public Surface
 {
-  double x0, y0, z0, r_sq;
+  double x0, y0, z0, radius_sq;
 public:
   explicit SurfaceXCone(pugi::xml_node surf_node);
   double evaluate(Position r) const;
@@ -317,7 +316,7 @@ public:
 
 class SurfaceYCone : public Surface
 {
-  double x0, y0, z0, r_sq;
+  double x0, y0, z0, radius_sq;
 public:
   explicit SurfaceYCone(pugi::xml_node surf_node);
   double evaluate(Position r) const;
@@ -335,7 +334,7 @@ public:
 
 class SurfaceZCone : public Surface
 {
-  double x0, y0, z0, r_sq;
+  double x0, y0, z0, radius_sq;
 public:
   explicit SurfaceZCone(pugi::xml_node surf_node);
   double evaluate(Position r) const;

--- a/src/surface.h
+++ b/src/surface.h
@@ -9,7 +9,7 @@
 #include "pugixml.hpp"
 
 #include "constants.h"
-#include "geometry.h"
+#include "position.h"
 
 
 namespace openmc {
@@ -71,14 +71,14 @@ public:
   //!   point is very close to the surface.
   //! @return true if the point is on the "positive" side of the surface and
   //!   false otherwise.
-  bool sense(Position r, Angle a) const;
+  bool sense(Position r, Direction u) const;
 
   //! Determine the direction of a ray reflected from the surface.
   //! @param r The point at which the ray is incident.
   //! @param o A direction.  This is both an input and an output parameter.
   //!   It specifies the icident direction on input and the reflected direction
   //!   on output.
-  Angle reflect(Position r, Angle a) const;
+  Direction reflect(Position r, Direction u) const;
 
   //! Evaluate the equation describing the surface.
   //!
@@ -92,12 +92,12 @@ public:
   //! @param o The direction of the ray.
   //! @param coincident A hint to the code that the given point should lie
   //!   exactly on the surface.
-  virtual double distance(Position r, Angle a, bool coincident) const = 0;
+  virtual double distance(Position r, Direction u, bool coincident) const = 0;
 
   //! Compute the local outward normal direction of the surface.
   //! @param r A 3D Cartesian coordinate.
   //! @return Normal direction
-  virtual Angle normal(Position r) const = 0;
+  virtual Direction normal(Position r) const = 0;
 
   //! Write all information needed to reconstruct the surface to an HDF5 group.
   //! @param group_id An HDF5 group id.
@@ -132,7 +132,7 @@ public:
   //! @return true if this surface and its partner make a rotationally-periodic
   //!   boundary condition.
   virtual bool periodic_translate(const PeriodicSurface *other, Position& r,
-                                  Angle& a) const = 0;
+                                  Direction& u) const = 0;
 
   //! Get the bounding box for this surface.
   virtual BoundingBox bounding_box() const = 0;
@@ -150,10 +150,10 @@ class SurfaceXPlane : public PeriodicSurface
 public:
   explicit SurfaceXPlane(pugi::xml_node surf_node);
   double evaluate(Position r) const;
-  double distance(Position r, Angle a, bool coincident) const;
-  Angle normal(Position r) const;
+  double distance(Position r, Direction u, bool coincident) const;
+  Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
-  bool periodic_translate(const PeriodicSurface *other, Position& r, Angle& a)
+  bool periodic_translate(const PeriodicSurface *other, Position& r, Direction& u)
        const;
   BoundingBox bounding_box() const;
 };
@@ -170,10 +170,10 @@ class SurfaceYPlane : public PeriodicSurface
 public:
   explicit SurfaceYPlane(pugi::xml_node surf_node);
   double evaluate(Position r) const;
-  double distance(Position r, Angle a, bool coincident) const;
-  Angle normal(Position r) const;
+  double distance(Position r, Direction u, bool coincident) const;
+  Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
-  bool periodic_translate(const PeriodicSurface *other, Position& r, Angle& a)
+  bool periodic_translate(const PeriodicSurface *other, Position& r, Direction& u)
        const;
   BoundingBox bounding_box() const;
 };
@@ -190,10 +190,10 @@ class SurfaceZPlane : public PeriodicSurface
 public:
   explicit SurfaceZPlane(pugi::xml_node surf_node);
   double evaluate(Position r) const;
-  double distance(Position r, Angle a, bool coincident) const;
-  Angle normal(Position r) const;
+  double distance(Position r, Direction u, bool coincident) const;
+  Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
-  bool periodic_translate(const PeriodicSurface *other, Position& r, Angle& a)
+  bool periodic_translate(const PeriodicSurface *other, Position& r, Direction& u)
        const;
   BoundingBox bounding_box() const;
 };
@@ -210,10 +210,10 @@ class SurfacePlane : public PeriodicSurface
 public:
   explicit SurfacePlane(pugi::xml_node surf_node);
   double evaluate(Position r) const;
-  double distance(Position r, Angle a, bool coincident) const;
-  Angle normal(Position r) const;
+  double distance(Position r, Direction u, bool coincident) const;
+  Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
-  bool periodic_translate(const PeriodicSurface *other, Position& r, Angle& a)
+  bool periodic_translate(const PeriodicSurface *other, Position& r, Direction& u)
        const;
   BoundingBox bounding_box() const;
 };
@@ -231,8 +231,8 @@ class SurfaceXCylinder : public Surface
 public:
   explicit SurfaceXCylinder(pugi::xml_node surf_node);
   double evaluate(Position r) const;
-  double distance(Position r, Angle a, bool coincident) const;
-  Angle normal(Position r) const;
+  double distance(Position r, Direction u, bool coincident) const;
+  Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
 };
 
@@ -249,8 +249,8 @@ class SurfaceYCylinder : public Surface
 public:
   explicit SurfaceYCylinder(pugi::xml_node surf_node);
   double evaluate(Position r) const;
-  double distance(Position r, Angle a, bool coincident) const;
-  Angle normal(Position r) const;
+  double distance(Position r, Direction u, bool coincident) const;
+  Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
 };
 
@@ -267,8 +267,8 @@ class SurfaceZCylinder : public Surface
 public:
   explicit SurfaceZCylinder(pugi::xml_node surf_node);
   double evaluate(Position r) const;
-  double distance(Position r, Angle a, bool coincident) const;
-  Angle normal(Position r) const;
+  double distance(Position r, Direction u, bool coincident) const;
+  Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
 };
 
@@ -285,8 +285,8 @@ class SurfaceSphere : public Surface
 public:
   explicit SurfaceSphere(pugi::xml_node surf_node);
   double evaluate(Position r) const;
-  double distance(Position r, Angle a, bool coincident) const;
-  Angle normal(Position r) const;
+  double distance(Position r, Direction u, bool coincident) const;
+  Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
 };
 
@@ -303,8 +303,8 @@ class SurfaceXCone : public Surface
 public:
   explicit SurfaceXCone(pugi::xml_node surf_node);
   double evaluate(Position r) const;
-  double distance(Position r, Angle a, bool coincident) const;
-  Angle normal(Position r) const;
+  double distance(Position r, Direction u, bool coincident) const;
+  Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
 };
 
@@ -321,8 +321,8 @@ class SurfaceYCone : public Surface
 public:
   explicit SurfaceYCone(pugi::xml_node surf_node);
   double evaluate(Position r) const;
-  double distance(Position r, Angle a, bool coincident) const;
-  Angle normal(Position r) const;
+  double distance(Position r, Direction u, bool coincident) const;
+  Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
 };
 
@@ -339,8 +339,8 @@ class SurfaceZCone : public Surface
 public:
   explicit SurfaceZCone(pugi::xml_node surf_node);
   double evaluate(Position r) const;
-  double distance(Position r, Angle a, bool coincident) const;
-  Angle normal(Position r) const;
+  double distance(Position r, Direction u, bool coincident) const;
+  Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
 };
 
@@ -357,8 +357,8 @@ class SurfaceQuadric : public Surface
 public:
   explicit SurfaceQuadric(pugi::xml_node surf_node);
   double evaluate(Position r) const;
-  double distance(Position r, Angle a, bool coincident) const;
-  Angle normal(Position r) const;
+  double distance(Position r, Direction u, bool coincident) const;
+  Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
 };
 
@@ -367,19 +367,19 @@ public:
 //==============================================================================
 
 extern "C" {
-    Surface* surface_pointer(int surf_ind);
-    int surface_id(Surface *surf);
-    int surface_bc(Surface *surf);
-    bool surface_sense(Surface *surf, double xyz[3], double uvw[3]);
-    void surface_reflect(Surface *surf, double xyz[3], double uvw[3]);
-    double surface_distance(Surface *surf, double xyz[3], double uvw[3],
-                            bool coincident);
-    void surface_normal(Surface *surf, double xyz[3], double uvw[3]);
-    void surface_to_hdf5(Surface *surf, hid_t group);
-    int surface_i_periodic(PeriodicSurface *surf);
-    bool surface_periodic(PeriodicSurface *surf, PeriodicSurface *other,
-                          double xyz[3], double uvw[3]);
-    void free_memory_surfaces_c();
+  Surface* surface_pointer(int surf_ind);
+  int surface_id(Surface *surf);
+  int surface_bc(Surface *surf);
+  bool surface_sense(Surface *surf, double xyz[3], double uvw[3]);
+  void surface_reflect(Surface *surf, double xyz[3], double uvw[3]);
+  double surface_distance(Surface *surf, double xyz[3], double uvw[3],
+                          bool coincident);
+  void surface_normal(Surface *surf, double xyz[3], double uvw[3]);
+  void surface_to_hdf5(Surface *surf, hid_t group);
+  int surface_i_periodic(PeriodicSurface *surf);
+  bool surface_periodic(PeriodicSurface *surf, PeriodicSurface *other,
+                        double xyz[3], double uvw[3]);
+  void free_memory_surfaces_c();
 }
 
 } // namespace openmc


### PR DESCRIPTION
This pull request introduces a `Position` type which is inteded to replace `double xyz[3]` that is used all over the place. The `Position` type is simply a struct with three data members `x, y, z`. I originally thought about having a separate type `Direction`, but it looked too similar to `Position` so what I ended up doing is just having `Direction` be an alias of `Position` for now. Later on, perhaps `Direction` might be defined separately, but at least having the alias means that function prototypes won't change. Function prototypes dealing with positions and angles are now much clearer. For example
```C++
bool Cell::contains(const double xyz[3], const double uvw[3], int32_t on_surface);
```
is now
```C++
bool Cell:contains(Position r, Direction u, int32_t on_surface);
```
As this example illustrates, I decided in this first pass to just pass positions/directions by value. The struct is 24 bytes, and that's within the range that most people considerable for passing by value. Later on when all the geometry has been moved over to C++, I'll do some performance testing and we can decide whether the pass-by-value semantics are ok of if pass-by-reference would be better.

Closes #1021. I've settled on the conventions `Position r` and `Direction u`, although I'm open to suggestions for changing if someone has a better idea.

It's clear from the diff, but worth mentioning here that this PR only affects C++ code. I haven't touched Fortran code, so `xyz` and `uvw` is still present there.