### PR TITLE
Don't deactivate tallies in openmc_reset

### DIFF
--- a/src/api.F90
+++ b/src/api.F90
@@ -259,7 +259,6 @@ contains
     if (allocated(tallies)) then
       do i = 1, size(tallies)
         associate (t => tallies(i) % obj)
-          t % active = .false.
           t % n_realizations = 0
           if (allocated(t % results)) then
             t % results(:, :, :) = ZERO
@@ -277,14 +276,6 @@ contains
     k_col_tra = ZERO
     k_abs_tra = ZERO
     k_sum(:) = ZERO
-
-    ! Clear active tally lists
-    call active_analog_tallies % clear()
-    call active_tracklength_tallies % clear()
-    call active_meshsurf_tallies % clear()
-    call active_collision_tallies % clear()
-    call active_surface_tallies % clear()
-    call active_tallies % clear()
 
     ! Reset timers
     call time_total % reset()

--- a/src/cmfd_execute.F90
+++ b/src/cmfd_execute.F90
@@ -11,7 +11,7 @@ module cmfd_execute
 
   implicit none
   private
-  public :: execute_cmfd, cmfd_init_batch
+  public :: execute_cmfd, cmfd_init_batch, cmfd_tally_init
 
 contains
 
@@ -359,6 +359,19 @@ contains
     end if
 
   end function get_matrix_idx
+
+!===============================================================================
+! CMFD_TALLY_INIT
+!===============================================================================
+
+  subroutine cmfd_tally_init()
+    integer :: i
+    if (cmfd_run) then
+      do i = 1, size(cmfd_tallies)
+        cmfd_tallies(i) % obj % active = .true.
+      end do
+    end if
+  end subroutine cmfd_tally_init
 
 !===============================================================================
 ! CMFD_TALLY_RESET resets all cmfd tallies

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -573,6 +573,13 @@ contains
     ! Write tally results to tallies.out
     if (output_tallies .and. master) call write_tallies()
 
+    ! Deactivate all tallies
+    if (allocated(tallies)) then
+      do i = 1, n_tallies
+        tallies(i) % obj % active = .false.
+      end do
+    end if
+
     ! Stop timers and show timing statistics
     call time_finalize%stop()
     call time_total%stop()

--- a/src/simulation.F90
+++ b/src/simulation.F90
@@ -7,7 +7,7 @@ module simulation
 #endif
 
   use bank_header,     only: source_bank
-  use cmfd_execute,    only: cmfd_init_batch, execute_cmfd
+  use cmfd_execute,    only: cmfd_init_batch, cmfd_tally_init, execute_cmfd
   use cmfd_header,     only: cmfd_on
   use constants,       only: ZERO
   use eigenvalue,      only: count_source_for_ufs, calculate_average_keff, &
@@ -427,6 +427,9 @@ contains
 
     ! Allocate tally results arrays if they're not allocated yet
     call configure_tallies()
+
+    ! Activate the CMFD tallies
+    call cmfd_tally_init()
 
     ! Set up material nuclide index mapping
     do i = 1, n_materials

--- a/src/tallies/tally_header.F90
+++ b/src/tallies/tally_header.F90
@@ -388,7 +388,6 @@ contains
 
     do i = 1, n_tallies
       call tallies(i) % obj % allocate_results()
-      tallies(i) % obj % active = .false.
     end do
 
   end subroutine configure_tallies

--- a/src/tallies/tally_header.F90
+++ b/src/tallies/tally_header.F90
@@ -388,6 +388,7 @@ contains
 
     do i = 1, n_tallies
       call tallies(i) % obj % allocate_results()
+      tallies(i) % obj % active = .false.
     end do
 
   end subroutine configure_tallies

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -49,7 +49,13 @@ def capi_init(pincell_model):
 
 
 @pytest.fixture(scope='module')
-def capi_run(capi_init):
+def capi_simulation_init(pincell_model):
+    openmc.capi.simulation_init()
+    yield
+
+
+@pytest.fixture(scope='module')
+def capi_run(capi_simulation_init):
     openmc.capi.run()
 
 
@@ -173,10 +179,6 @@ def test_tally(capi_init):
     t.scores = new_scores
     assert t.scores == new_scores
 
-    assert not t.active
-    t.active = True
-    assert t.active
-
     t2 = openmc.capi.tallies[2]
     t2.id = 2
     assert len(t2.filters) == 2
@@ -194,6 +196,13 @@ def test_new_tally(capi_init):
     new_tally_with_id = openmc.capi.Tally(10)
     new_tally_with_id.scores = ['flux']
     assert len(openmc.capi.tallies) == 4
+
+
+def test_tally_activate(capi_simulation_init):
+    t = openmc.capi.tallies[1]
+    assert not t.active
+    t.active = True
+    assert t.active
 
 
 def test_tally_results(capi_run):


### PR DESCRIPTION
This PR makes it so that calls to `openmc_reset` do not deactivate the tallies, and it makes some other changes to when tallies are activated and deactivated.

My current use case for `openmc_reset` is to call it in between iterations of a multiphysics solver where I want to clear out the tallies but I still want them active for the next iteration.  This use case could be handled by adding an argument to `openmc_reset` that specifies whether the tallies should or should not be deactivated, but thinking about the overall structure of a run, I don't think `openmc_reset` should ever deactivate the tallies.  You probably only want to deactivate them if you're starting again from the inactive batches which means calling `openmc_simulation_init` so that's where I've moved the logic to deactivate tallies.

Two implications for that choice:
- The CMFD tallies now need to be activated by `openmc_simulation_init` (this might fix a case we don't currently test for where someone uses CMFD with the depletion solver).
- Setting a tally active before calling `openmc_simulation_init` will now have no effect.  This means you can't set a tally as active and then call `openmc_run` (which internally calls `openmc_simulation_init`), as was previously done by one of our test cases.  I think this is okay because I can't come up with a use case where someone would want to activate a tally for the inactive batches and then not use a batch-by-batch style of run which would require them to manually call `openmc_simulation_init` anyway.

Let me know if this re-ordering of the tally activation is fine, and I'll also add something to the test suite that tests a call to `openmc_reset` in the middle of a run.