### PR TITLE
fixed bug with trigger, model and statepoint

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -218,10 +218,23 @@ class Model(object):
 
         openmc.run(**kwargs)
 
+        # in order to accomodate the fact that you may start with only 2
+        # batches but set max_batches to be 10000, the format that openmc
+        # actually writes would be in this case 00001
+        
         n = self.settings.batches
+        m = self.settings.trigger_max_batches
+               
         if self.settings.statepoint is not None:
             if 'batches' in self.settings.statepoint:
                 n = self.settings.statepoint['batches'][-1]
 
+
+        if self.settings.trigger_active:
+            if self.settings.trigger_max_batches is not None:
+                len_s_n = len(str(self.settings.batches))
+                n = str().zfill(len(str(self.settings.trigger_max_batches))-len_s_n)
+                n += str(self.settings.batches)
+                
         with openmc.StatePoint('statepoint.{}.h5'.format(n)) as sp:
             return sp.k_combined


### PR DESCRIPTION
Name of the statepoint file generated when using the trigger feature depends on the final number of batches needed to get a result with an error below the threshold defined with trigger and the number of digits of the maximum number of batches admissible.
If we define a maximum number of batches of 1000000, and 100 batches were needed, statepoint file name will follow like this: statepoint.0000100.h5

This is fine when we try to run the simulation without defining a model, but when a model is defined, the name of the expected statepoint file is: statepoint.100.h5.

This causes an error since model.py tries to read a file which doesn’t exist.

@makeclean