### PR TITLE
Add from_xml() classmethods on Geometry and Materials

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -936,14 +936,6 @@ class Material(IDManagerMixin):
             elif 'wo' in nuclide.attrib:
                 mat.add_nuclide(name, float(nuclide.attrib['wo']), 'wo')
 
-        # Get each element
-        for element in elem.findall('element'):
-            name = element.attrib['name']
-            if 'ao' in element.attrib:
-                mat.add_element(name, float(element.attrib['ao']))
-            elif 'wo' in element.attrib:
-                mat.add_element(name, float(element.attrib['wo']), 'wo')
-
         # Get each S(a,b) table
         for sab in elem.findall('sab'):
             fraction = float(sab.get('fraction', 1.0))

--- a/tests/regression_tests/lattice_hex/geometry.xml
+++ b/tests/regression_tests/lattice_hex/geometry.xml
@@ -7,42 +7,42 @@
 <geometry>
 
   <!-- Universe 011: Fuel pellet -->
-  <surface id="011" type="z-cylinder" coeffs="0.0 0.0 0.06"/>
-  <surface id="012" type="z-cylinder" coeffs="0.0 0.0 0.378"/>
-  <surface id="013" type="z-cylinder" coeffs="0.0 0.0 0.3865"/>
-  <surface id="014" type="z-cylinder" coeffs="0.0 0.0 0.455"/>
-  <surface id="015" type="sphere" coeffs="0.0 0.0 -2.5639 2.0"/>
-  <surface id="016" type="sphere" coeffs="0.0 0.0 2.5639 2.0"/>
+  <surface id="11" type="z-cylinder" coeffs="0.0 0.0 0.06"/>
+  <surface id="12" type="z-cylinder" coeffs="0.0 0.0 0.378"/>
+  <surface id="13" type="z-cylinder" coeffs="0.0 0.0 0.3865"/>
+  <surface id="14" type="z-cylinder" coeffs="0.0 0.0 0.455"/>
+  <surface id="15" type="sphere" coeffs="0.0 0.0 -2.5639 2.0"/>
+  <surface id="16" type="sphere" coeffs="0.0 0.0 2.5639 2.0"/>
 
-  <cell id="011" universe="011" material="void" region="-011"/>
-  <cell id="012" universe="011" material="13" region="011 -012 015 016"/>
-  <cell id="013" universe="011" material="void" region="011 -012 -015"/>
-  <cell id="014" universe="011" material="void" region="011 -012 -016"/>
-  <cell id="015" universe="011" material="void" region="012 -013"/>
-  <cell id="016" universe="011" material="21" region="013 -014"/>
-  <cell id="017" universe="011" material="01" region="014"/>
+  <cell id="11" universe="11" material="void" region="-11"/>
+  <cell id="12" universe="11" material="13" region="11 -12 15 16"/>
+  <cell id="13" universe="11" material="void" region="11 -12 -15"/>
+  <cell id="14" universe="11" material="void" region="11 -12 -16"/>
+  <cell id="15" universe="11" material="void" region="12 -13"/>
+  <cell id="16" universe="11" material="21" region="13 -14"/>
+  <cell id="17" universe="11" material="1" region="14"/>
 
 
   <!-- Universe 051: Central guide tube -->
-    <surface id="051" type="z-cylinder" coeffs="0.0 0.0 0.44"/>
-    <surface id="052" type="z-cylinder" coeffs="0.0 0.0 0.515"/>
-    <cell id="051" universe="051" material="01" region="-051"/>
-    <cell id="052" universe="051" material="21" region="051 -052"/>
-    <cell id="053" universe="051" material="01" region="052"/>
+    <surface id="51" type="z-cylinder" coeffs="0.0 0.0 0.44"/>
+    <surface id="52" type="z-cylinder" coeffs="0.0 0.0 0.515"/>
+    <cell id="51" universe="51" material="1" region="-51"/>
+    <cell id="52" universe="51" material="21" region="51 -52"/>
+    <cell id="53" universe="51" material="1" region="52"/>
 
 
   <!-- Universe 055: Cluster tube -->
     <surface id="155" type="z-cylinder" coeffs="0.0 0.0 0.55"/>
     <surface id="156" type="z-cylinder" coeffs="0.0 0.0 0.63"/>
-    <cell id="155" universe="055" material="01" region="-155"/>
-    <cell id="156" universe="055" material="22" region="155 -156"/>
-    <cell id="157" universe="055" material="01" region="156"/>
+    <cell id="155" universe="55" material="1" region="-155"/>
+    <cell id="156" universe="55" material="22" region="155 -156"/>
+    <cell id="157" universe="55" material="1" region="156"/>
 
 
 
 
   <!-- Lattice 101: Fuel assembly pins -->
-  <cell id="100" universe="100" material="01"/>
+  <cell id="100" universe="100" material="1"/>
   <hex_lattice id="101" outer="100" n_rings="11" n_axial="3"
       center="0.0 0.0 0.0" pitch="1.265 1.2">
     <universes>

--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -244,3 +244,14 @@ def test_determine_paths(cell_with_lattice):
     for i in range(4):
         assert geom.get_instances(cells[0].paths[i]) == i
         assert geom.get_instances(mats[-1].paths[i]) == i
+
+def test_from_xml(run_in_tmpdir, mixed_lattice_model):
+    # Export model
+    mixed_lattice_model.export_to_xml()
+
+    # Import geometry
+    geom = openmc.Geometry.from_xml()
+    assert isinstance(geom, openmc.Geometry)
+    ll, ur = geom.bounding_box
+    assert ll == pytest.approx((-6.0, -6.0, -np.inf))
+    assert ur == pytest.approx((6.0, 6.0, np.inf))


### PR DESCRIPTION
This PR adds nifty `from_xml()` methods that can generate `Geometry` and `Materials` instances from XML files that were previously exported. I haven't dealt with settings or tallies yet as I don't have an immediate need for such a capability. However, if others want such a capability, it should be pretty straightforward to implement.