### PR TITLE
Use coveralls parallel build webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,14 @@ env:
     - OPENMC_MULTIPOLE_LIBRARY=$HOME/multipole_lib
     - PATH=$PATH:$HOME/NJOY2016/build
     - DISPLAY=:99.0
+    - COVERALLS_PARALLEL=true
   matrix:
     - OMP=n MPI=n PHDF5=n
     - OMP=y MPI=n PHDF5=n
     - OMP=n MPI=y PHDF5=n
     - OMP=n MPI=y PHDF5=y
+notifications:
+  webhooks: https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN
 install:
   - ./tools/ci/travis-install.sh
 before_script:


### PR DESCRIPTION
It looks like the reason we are sometimes (often) seeing weird coverage results from our CI jobs is that we are not using Coveralls [parallel build webhook](https://docs.coveralls.io/parallel-build-webhook) (see [issue here](https://github.com/lemurheavy/coveralls-public/issues/1173#issuecomment-414794064)). This two-line change should hopefully fix these problems.