### PR TITLE
Make sure init is called in C-API unit test

### DIFF
--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -49,7 +49,7 @@ def capi_init(pincell_model):
 
 
 @pytest.fixture(scope='module')
-def capi_simulation_init(pincell_model):
+def capi_simulation_init(capi_init):
     openmc.capi.simulation_init()
     yield
 


### PR DESCRIPTION
The `capi_simulation_init` fixture currently doesn't depend on the `capi_init` fixture.  This can cause errors when calling pytest with a `-k` filter that picks up tests depending on `capi_simulation_init` but not `capi_init`.  In this case, the test will simply run without halting.