### PR TITLE
Make sure find_cell returns false when no cell is found

### DIFF
--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -243,6 +243,8 @@ find_cell(Particle* p, int search_surf) {
       return find_cell(p, 0);
     }
   }
+
+  return found;
 }
 
 //==============================================================================


### PR DESCRIPTION
I ran into a segfault recently running a volume calculation where the bounding box extends beyond the boundary of the model and traced it to a bug in the new C++ implementation of `find_cell`. Notably, in the case that a cell is not found, there is actually no `return` statement. We evidently didn't run into this problem in debug mode because in that case, the compiler probably defaults to a false return value, but there's no guarantee of course and without debug=on it resulted a segfault.