### PR TITLE
Two small data-related fixues

### DIFF
--- a/scripts/openmc-get-nndc-data
+++ b/scripts/openmc-get-nndc-data
@@ -148,16 +148,11 @@ if not response or response.lower().startswith('y'):
 # get a list of all ACE files
 ace_files = sorted(glob.glob(os.path.join('nndc', '**', '*.ace*')))
 
-# Get path to fission energy release data
-data_dir = os.path.dirname(sys.modules['openmc.data'].__file__)
-fer_file = os.path.join(data_dir, 'fission_Q_data_endfb71.h5')
-
 # Call the ace-to-hdf5 conversion script
 pwd = os.path.dirname(os.path.realpath(__file__))
 ace2hdf5 = os.path.join(pwd, 'openmc-ace-to-hdf5')
 subprocess.call([ace2hdf5,
                  '-d', 'nndc_hdf5',
-                 '--fission_energy_release', fer_file,
                  '--libver', args.libver] + ace_files)
 
 # Generate photo interaction library files

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ kwargs = {
     # Data files and librarries
     'package_data': {
         'openmc.capi': ['libopenmc.{}'.format(suffix)],
-        'openmc.data': ['mass.mas12', '*.h5']
+        'openmc.data': ['mass.mas12', 'BREMX.DAT', '*.h5']
     },
 
     # Metadata
@@ -52,6 +52,7 @@ kwargs = {
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 
     # Required dependencies


### PR DESCRIPTION
Thanks to @wbinventor for pointing out two problems generating data, which are fixed by this PR:
1. `openmc-get-nndc-data` tries to call `openmc-ace-to-hdf5` with a `--fission_energy_release` flag, which doesn't exist after #1032.
2. BREMX.DAT (Bremsstrahlung photon spectra) is not listed in `package_data` in `setup.py` and thus doesn't get installed.