### PR TITLE
Fix CI failures due to coverage version clash

### DIFF
--- a/tools/ci/travis-install.sh
+++ b/tools/ci/travis-install.sh
@@ -22,4 +22,4 @@ python tools/ci/travis-install.py
 pip install -e .[test]
 
 # For uploading to coveralls
-pip install python-coveralls
+pip install coveralls


### PR DESCRIPTION
`pytest-cov` recently (2 days ago) dropped support for coverage < 4.4, and `python-coveralls` (which we use to upload coverage results to coveralls) requires coverage 4.0.4. This has led to our CI jobs failing because there is no version of coverage that satisfies both constraints (==4.0.4 and >=4.4). An easy fix implemented here changes from using the `python-coveralls` module to `coveralls-python`, which evidently is more actively maintained and works with recent versions of coverage. Once this is merged, other PRs (like #1065) should pass once we restart them.