### PR TITLE
Fix warnings when compiling with Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ endif()
 # HDF5 for binary output
 #===============================================================================
 
+# Allow user to specify HDF5_ROOT
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 # Unfortunately FindHDF5.cmake will always prefer a serial HDF5 installation
 # over a parallel installation if both appear on the user's PATH. To get around
 # this, we check for the environment variable HDF5_ROOT and if it exists, use it

--- a/include/openmc/endf.h
+++ b/include/openmc/endf.h
@@ -29,6 +29,7 @@ bool is_fission(int MT);
 class Function1D {
 public:
   virtual double operator()(double x) const = 0;
+  virtual ~Function1D() = default;
 };
 
 //==============================================================================

--- a/include/openmc/position.h
+++ b/include/openmc/position.h
@@ -1,7 +1,8 @@
 #ifndef OPENMC_POSITION_H
 #define OPENMC_POSITION_H
 
-#include <cmath>
+#include <cmath> // for sqrt
+#include <stdexcept> // for out_of_range
 #include <vector>
 
 namespace openmc {
@@ -29,6 +30,8 @@ struct Position {
       case 0: return x;
       case 1: return y;
       case 2: return z;
+      default:
+        throw std::out_of_range{"Index in Position must be between 0 and 2."};
     }
   }
   double& operator[](int i) {
@@ -36,6 +39,8 @@ struct Position {
       case 0: return x;
       case 1: return y;
       case 2: return z;
+      default:
+        throw std::out_of_range{"Index in Position must be between 0 and 2."};
     }
   }
 

--- a/openmc/capi/core.py
+++ b/openmc/capi/core.py
@@ -112,7 +112,7 @@ def find_material(xyz):
     if isinstance(mats, openmc.capi.Material):
         return mats
     else:
-        return mats[instance]
+        return mats[instance.value]
 
 def hard_reset():
     """Reset tallies, timers, and pseudo-random number generator state."""

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -4,6 +4,7 @@
 #include <cmath>     // for sqrt, floor, max
 #include <iterator>  // for back_inserter
 #include <numeric>   // for accumulate
+#include <stdexcept> // for runtime_error
 #include <string>    // for string, stod
 
 #include "openmc/error.h"
@@ -44,7 +45,7 @@ double Discrete::sample() const
       c += p_[i];
       if (xi < c) return x_[i];
     }
-    // throw exception?
+    throw std::runtime_error{"Error when sampling probability mass function."};
   } else {
     return x_[0];
   }
@@ -248,19 +249,21 @@ UPtrDist distribution_from_xml(pugi::xml_node node)
   std::string type = get_node_value(node, "type", true, true);
 
   // Allocate extension of Distribution
+  UPtrDist dist;
   if (type == "uniform") {
-    return UPtrDist{new Uniform(node)};
+    dist = UPtrDist{new Uniform(node)};
   } else if (type == "maxwell") {
-    return UPtrDist{new Maxwell(node)};
+    dist = UPtrDist{new Maxwell(node)};
   } else if (type == "watt") {
-    return UPtrDist{new Watt(node)};
+    dist = UPtrDist{new Watt(node)};
   } else if (type == "discrete") {
-    return UPtrDist{new Discrete(node)};
+    dist = UPtrDist{new Discrete(node)};
   } else if (type == "tabular") {
-    return UPtrDist{new Tabular(node)};
+    dist = UPtrDist{new Tabular(node)};
   } else {
     openmc::fatal_error("Invalid distribution type: " + type);
   }
+  return dist;
 }
 
 } // namespace openmc

--- a/src/eigenvalue.cpp
+++ b/src/eigenvalue.cpp
@@ -146,7 +146,7 @@ extern "C" double entropy_c(int i)
   return entropy.at(i - 1);
 }
 
-extern "C" double entropy_clear()
+extern "C" void entropy_clear()
 {
   entropy.clear();
 }

--- a/src/endf.cpp
+++ b/src/endf.cpp
@@ -3,6 +3,7 @@
 #include <algorithm> // for copy
 #include <cmath>     // for log, exp
 #include <iterator>  // for back_inserter
+#include <stdexcept> // for runtime_error
 
 #include "xtensor/xarray.hpp"
 #include "xtensor/xview.hpp"
@@ -19,17 +20,23 @@ namespace openmc {
 
 Interpolation int2interp(int i)
 {
+  // TODO: We are ignoring specification of two-dimensional interpolation
+  // schemes (method of corresponding points and unit base interpolation). Those
+  // should be accounted for in the distribution classes somehow.
+
   switch (i) {
-  case 1:
+  case 1: case 11: case 21:
     return Interpolation::histogram;
-  case 2:
+  case 2: case 12: case 22:
     return Interpolation::lin_lin;
-  case 3:
+  case 3: case 13: case 23:
     return Interpolation::lin_log;
-  case 4:
+  case 4: case 14: case 24:
     return Interpolation::log_lin;
-  case 5:
+  case 5: case 15: case 25:
     return Interpolation::log_log;
+  default:
+    throw std::runtime_error{"Invalid interpolation code."};
   }
 }
 
@@ -142,6 +149,8 @@ double Tabulated1D::operator()(double x) const
   case Interpolation::log_log:
     r = log(x/x0)/log(x1/x0);
     return y0*exp(r*log(y1/y0));
+  default:
+    throw std::runtime_error{"Invalid interpolation scheme."};
   }
 }
 

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -389,6 +389,7 @@ distribcell_path_inner(int32_t target_cell, int32_t map, int32_t target_offset,
         return path.str();
       }
     }
+    throw std::runtime_error{"Error determining distribcell path."};
   }
 }
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -162,12 +162,15 @@ int RegularMesh::get_bin(Position r) const
 
 int RegularMesh::get_bin_from_indices(const int* ijk) const
 {
-  if (n_dimension_ == 1) {
-    return ijk[0];
-  } else if (n_dimension_ == 2) {
-    return (ijk[1] - 1)*shape_[0] + ijk[0];
-  } else if (n_dimension_ == 3) {
-    return ((ijk[2] - 1)*shape_[1] + (ijk[1] - 1))*shape_[0] + ijk[0];
+  switch (n_dimension_) {
+    case 1:
+      return ijk[0];
+    case 2:
+      return (ijk[1] - 1)*shape_[0] + ijk[0];
+    case 3:
+      return ((ijk[2] - 1)*shape_[1] + (ijk[1] - 1))*shape_[0] + ijk[0];
+    default:
+      throw std::runtime_error{"Invalid number of mesh dimensions"};
   }
 }
 
@@ -206,6 +209,8 @@ bool RegularMesh::intersects(Position r0, Position r1) const
       return intersects_2d(r0, r1);
     case 3:
       return intersects_3d(r0, r1);
+    default:
+      throw std::runtime_error{"Invalid number of mesh dimensions."};
   }
 }
 

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -1,7 +1,7 @@
 #include "openmc/thermal.h"
 
 #include <algorithm> // for sort, move, min, max, find
-#include <cmath>     // for round, sqrt, fabs
+#include <cmath>     // for round, sqrt, abs
 #include <sstream>   // for stringstream
 
 #include "xtensor/xarray.hpp"
@@ -80,7 +80,7 @@ ThermalScattering::ThermalScattering(hid_t group, const std::vector<double>& tem
 
       auto i_closest = xt::argmin(xt::abs(temps_available - T))[0];
       auto temp_actual = temps_available[i_closest];
-      if (std::fabs(temp_actual - T) < tolerance) {
+      if (std::abs(temp_actual - T) < tolerance) {
         if (std::find(temps_to_read.begin(), temps_to_read.end(), std::round(temp_actual))
             == temps_to_read.end()) {
           temps_to_read.push_back(std::round(temp_actual));
@@ -156,7 +156,7 @@ ThermalScattering::calculate_xs(double E, double sqrtkT, int* i_temp,
   if (settings::temperature_method == TEMPERATURE_NEAREST) {
     // If using nearest temperature, do linear search on temperature
     for (i = 0; i < kTs_.size(); ++i) {
-      if (abs(kTs_[i] - kT) < K_BOLTZMANN*settings::temperature_tolerance) {
+      if (std::abs(kTs_[i] - kT) < K_BOLTZMANN*settings::temperature_tolerance) {
         break;
       }
     }
@@ -574,7 +574,7 @@ ThermalData::sample(const NuclideMicroXS* micro_xs, double E,
   // Because of floating-point roundoff, it may be possible for mu to be
   // outside of the range [-1,1). In these cases, we just set mu to exactly
   // -1 or 1
-  if (std::fabs(*mu) > 1.0) *mu = std::copysign(1.0, *mu);
+  if (std::abs(*mu) > 1.0) *mu = std::copysign(1.0, *mu);
 
 }
 

--- a/src/xml_interface.cpp
+++ b/src/xml_interface.cpp
@@ -53,6 +53,7 @@ get_node_value_bool(pugi::xml_node node, const char* name)
             << node.name() << "\" XML node";
     fatal_error(err_msg);
   }
+  return false;
 }
 
 } // namespace openmc


### PR DESCRIPTION
Some of the warnings are real issues (`Function1D` not having a virtual destructor, for example) but most are just technicalities about potential paths in non-void functions with no return statement (usually when we call `fatal_error`). I've also addressed an issue that @jtramm ran into yesterday with the latest version of CMake complaining about a policy when the `HDF5_ROOT` environment variable is set.