### PR TITLE
Hdf5 legacy fix

### DIFF
--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -17,8 +17,16 @@ Reaction::Reaction(hid_t group, const std::vector<int>& temperatures)
   int tmp;
   read_attribute(group, "center_of_mass", tmp);
   scatter_in_cm_ = (tmp == 1);
-  read_attribute(group, "redundant", tmp);
-  redundant_ = (tmp == 1);
+
+  // Checks if redudant attribute exists before loading
+  // (for compatibiltiy with legacy .h5 libraries)
+  htri_t exists = H5Aexists(group, "redundant");
+  if( exists ) {
+    read_attribute(group, "redundant", tmp);
+    redundant_ = (tmp == 1);
+  } else {
+    redundant_ = false;
+  }
 
   // Read cross section and threshold_idx data
   for (auto t : temperatures) {

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -20,8 +20,7 @@ Reaction::Reaction(hid_t group, const std::vector<int>& temperatures)
 
   // Checks if redudant attribute exists before loading
   // (for compatibiltiy with legacy .h5 libraries)
-  htri_t exists = H5Aexists(group, "redundant");
-  if( exists ) {
+  if (attribute_exists(group, "redundant")) {
     read_attribute(group, "redundant", tmp);
     redundant_ = (tmp == 1);
   } else {


### PR DESCRIPTION
Fix for Issue #1072, to add legacy support for hdf5 library files lacking the "redundant" attribute that were generated before #1068 was implemented.