### PR TITLE
Fix error in summary:write_nuclides and write_materials

### DIFF
--- a/src/summary.F90
+++ b/src/summary.F90
@@ -84,7 +84,7 @@ contains
     integer :: i
     character(kind=C_CHAR, len=20), allocatable :: nuc_names(:)
     character(kind=C_CHAR, len=20), allocatable :: macro_names(:)
-    real(8), allocatable :: awrs(:)
+    real(C_DOUBLE), allocatable :: awrs(:)
     integer :: num_nuclides
     integer :: num_macros
     integer :: j

--- a/src/summary.F90
+++ b/src/summary.F90
@@ -82,8 +82,8 @@ contains
     integer(HID_T) :: nuclide_group
     integer(HID_T) :: macro_group
     integer :: i
-    character(12), allocatable :: nuc_names(:)
-    character(12), allocatable :: macro_names(:)
+    character(kind=C_CHAR, len=20), allocatable :: nuc_names(:)
+    character(kind=C_CHAR, len=20), allocatable :: macro_names(:)
     real(8), allocatable :: awrs(:)
     integer :: num_nuclides
     integer :: num_macros
@@ -172,8 +172,8 @@ contains
     integer :: k
     integer :: n
     integer :: err
-    character(20), allocatable :: nuc_names(:)
-    character(20), allocatable :: macro_names(:)
+    character(kind=C_CHAR, len=20), allocatable :: nuc_names(:)
+    character(kind=C_CHAR, len=20), allocatable :: macro_names(:)
     real(8) :: volume
     real(8), allocatable :: nuc_densities(:)
     integer :: num_nuclides


### PR DESCRIPTION
This PR fixes the bug identified in #1074 wherein the example problems would crash while writing the summary file (this error would also have affected other MG problems which use macroscopic data and write summary files).

The problem was caused by not using C_CHAR for a Fortran character-array type when that variable accepts a C-string from a c-routine.  Whoops.