### PR TITLE
Don't use VERSION_GREATER_EQUAL in order to support CMake 3.3+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 #===============================================================================
 
 # Allow user to specify HDF5_ROOT
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+if (NOT (CMAKE_VERSION VERSION_LESS 3.12))
   cmake_policy(SET CMP0074 NEW)
 endif()
 


### PR DESCRIPTION
The VERSION_GREATER_EQUAL check for an `if()` statement in CMake was apparently not supported until CMake 3.7. This pull request changes the check to `NOT (... VERSION_LESS ...)` so that running cmake still works with versions prior to 3.7.

Thanks to @bforget for reporting.