### PR TITLE
Fix bug related to incoherent inelastic thermal scattering

### DIFF
--- a/src/secondary_correlated.cpp
+++ b/src/secondary_correlated.cpp
@@ -124,6 +124,12 @@ CorrelatedAngleEnergy::CorrelatedAngleEnergy(hid_t group)
         m = mu.shape()[1] - offset_mu;
       }
 
+      // For incoherent inelastic thermal scattering, the angle distributions
+      // may be given as discrete mu values. In this case, interpolation values
+      // of zero appear in the HDF5 file. Here we change it to a 1 so that
+      // int2interp doesn't fail.
+      if (interp_mu == 0) interp_mu = 1;
+
       auto interp = int2interp(interp_mu);
       auto xs = xt::view(mu, 0, xt::range(offset_mu, offset_mu + m));
       auto ps = xt::view(mu, 1, xt::range(offset_mu, offset_mu + m));


### PR DESCRIPTION
@bforget recently noticed that trying to run a model with H2O using data from MCNP's ENDF/B-VII.1 data caused the following error:
```
 Reading c_H_in_H2O from /opt/data/hdf5/mcnp_endfb71/c_H_in_H2O.h5
terminate called after throwing an instance of 'std::runtime_error'
  what():  Invalid interpolation code
Aborted
```
The problem is that when continuous S(a,b) distributions appear in an ACE file, we internally convert them using `CorrelatedAngleEnergy`. The angle distributions are discrete however and as a result, it doesn't make sense to assign an interpolation scheme for a discrete distribution, so we just put a zero. With stricter checking recently adopted in `int2interp`, this caused the above error because 0 is not a valid interpolation code.

This PR allows the data to pass through by just assigning an interpolation value of one in this case. The value is actually not used in the thermal scattering routines, so it will make no difference.