### PR TITLE
Fix cross section download/cache on Travis

### DIFF
--- a/tools/ci/download-xs.sh
+++ b/tools/ci/download-xs.sh
@@ -3,17 +3,17 @@ set -ex
 
 # Download NNDC HDF5 data
 if [[ ! -e $HOME/nndc_hdf5/cross_sections.xml ]]; then
-    wget https://anl.box.com/shared/static/a0eflty17atnpd0pp7460exagr3nuhm7.xz -O - | tar -C $HOME -xvJ
+    wget -q -O - https://anl.box.com/shared/static/a0eflty17atnpd0pp7460exagr3nuhm7.xz | tar -C $HOME -xJ
 fi
 
 # Download ENDF/B-VII.1 distribution
 ENDF=$HOME/endf-b-vii.1/
 if [[ ! -d $ENDF/neutrons || ! -d $ENDF/photoat || ! -d $ENDF/atomic_relax ]]; then
-    wget https://anl.box.com/shared/static/4kd2gxnf4gtk4w1c8eua5fsua22kvgjb.xz -O - | tar -C $HOME -xvJ
+    wget -q -O - https://anl.box.com/shared/static/4kd2gxnf4gtk4w1c8eua5fsua22kvgjb.xz | tar -C $HOME -xJ
 fi
 
 # Download multipole library
 if [[ ! -e $HOME/WMP_Library/092235.h5 ]]; then
-    wget https://github.com/mit-crpg/WMP_Library/releases/download/v1.0/WMP_Library_v1.0.tar.gz
-    tar -C $HOME -xzvf WMP_Library_v1.0.tar.gz
+    wget -q https://github.com/mit-crpg/WMP_Library/releases/download/v1.0/WMP_Library_v1.0.tar.gz
+    tar -C $HOME -xzf WMP_Library_v1.0.tar.gz
 fi

--- a/tools/ci/travis-before-script.sh
+++ b/tools/ci/travis-before-script.sh
@@ -6,4 +6,4 @@ set -ex
 sh -e /etc/init.d/xvfb start
 
 # Download NNDC HDF5 data, ENDF/B-VII.1 distribution, multipole library
-sh ./tools/ci/download-xs.sh
+source tools/ci/download-xs.sh


### PR DESCRIPTION
#1077 seems to have broken the cross sections cache on Travis because the download-xs.sh script uses bash-isms (`[[`) but is called using `sh`. This PR should fix that and also makes the output less verbose to shorten the Travis logs.