### PR TITLE
More fixes to make Valgrind happy

### DIFF
--- a/include/openmc/hdf5_interface.h
+++ b/include/openmc/hdf5_interface.h
@@ -162,8 +162,7 @@ void read_attribute(hid_t obj_id, const char* name, xt::xarray<T>& arr)
   std::size_t size = 1;
   for (const auto x : shape)
     size *= x;
-  std::vector<T> buffer;
-  buffer.resize(size);
+  std::vector<T> buffer(size);
 
   // Read data from attribute
   read_attr(obj_id, name, H5TypeMap<T>::type_id, buffer.data());
@@ -245,8 +244,7 @@ void read_dataset(hid_t dset, xt::xarray<T>& arr, bool indep=false)
   std::size_t size = 1;
   for (const auto x : shape)
     size *= x;
-  std::vector<T> buffer;
-  buffer.resize(size);
+  std::vector<T> buffer(size);
 
   // Read data from attribute
   read_dataset(dset, nullptr, H5TypeMap<T>::type_id, buffer.data(), indep);
@@ -275,8 +273,7 @@ void read_dataset_as_shape(hid_t obj_id, const char* name,
   std::size_t size = 1;
   for (const auto x : arr.shape())
     size *= x;
-  std::vector<T> buffer;
-  buffer.resize(size);
+  std::vector<T> buffer(size);
 
   // Read data from attribute
   read_dataset(dset, nullptr, H5TypeMap<T>::type_id, buffer.data(), indep);

--- a/include/openmc/hdf5_interface.h
+++ b/include/openmc/hdf5_interface.h
@@ -162,13 +162,14 @@ void read_attribute(hid_t obj_id, const char* name, xt::xarray<T>& arr)
   std::size_t size = 1;
   for (const auto x : shape)
     size *= x;
-  T* buffer = new T[size];
+  std::vector<T> buffer;
+  buffer.resize(size);
 
   // Read data from attribute
-  read_attr(obj_id, name, H5TypeMap<T>::type_id, buffer);
+  read_attr(obj_id, name, H5TypeMap<T>::type_id, buffer.data());
 
   // Adapt array into xarray
-  arr = xt::adapt(buffer, size, xt::acquire_ownership(), shape);
+  arr = xt::adapt(buffer, shape);
 }
 
 // overload for std::string
@@ -244,13 +245,14 @@ void read_dataset(hid_t dset, xt::xarray<T>& arr, bool indep=false)
   std::size_t size = 1;
   for (const auto x : shape)
     size *= x;
-  T* buffer = new T[size];
+  std::vector<T> buffer;
+  buffer.resize(size);
 
   // Read data from attribute
-  read_dataset(dset, nullptr, H5TypeMap<T>::type_id, buffer, indep);
+  read_dataset(dset, nullptr, H5TypeMap<T>::type_id, buffer.data(), indep);
 
   // Adapt into xarray
-  arr = xt::adapt(buffer, size, xt::acquire_ownership(), shape);
+  arr = xt::adapt(buffer, shape);
 }
 
 template <typename T>
@@ -273,13 +275,14 @@ void read_dataset_as_shape(hid_t obj_id, const char* name,
   std::size_t size = 1;
   for (const auto x : arr.shape())
     size *= x;
-  T* buffer = new T[size];
+  std::vector<T> buffer;
+  buffer.resize(size);
 
   // Read data from attribute
-  read_dataset(dset, nullptr, H5TypeMap<T>::type_id, buffer, indep);
+  read_dataset(dset, nullptr, H5TypeMap<T>::type_id, buffer.data(), indep);
 
   // Adapt into xarray
-  arr = xt::adapt(buffer, size, xt::acquire_ownership(), arr.shape());
+  arr = xt::adapt(buffer, arr.shape());
 
   close_dataset(dset);
 }

--- a/include/openmc/search.h
+++ b/include/openmc/search.h
@@ -14,6 +14,7 @@ template<class It, class T>
 typename std::iterator_traits<It>::difference_type
 lower_bound_index(It first, It last, const T& value)
 {
+  if (*first == value) return 0;
   It index = std::lower_bound(first, last, value) - 1;
   return (index == last) ? -1 : index - first;
 }

--- a/src/hdf5_interface.F90
+++ b/src/hdf5_interface.F90
@@ -675,6 +675,7 @@ contains
     ! If 'name' argument is passed, obj_id is interpreted to be a group and
     ! 'name' is the name of the dataset we should read from
     if (present(name)) then
+      allocate(name_(len_trim(name) + 1))
       name_ = to_c_string(name)
       call read_double_c(obj_id, c_loc(name_), buffer_, indep_)
     else
@@ -698,6 +699,7 @@ contains
     ! If 'name' argument is passed, obj_id is interpreted to be a group and
     ! 'name' is the name of the dataset we should read from
     if (present(name)) then
+      allocate(name_(len_trim(name) + 1))
       name_ = to_c_string(name)
       call read_double_c(obj_id, c_loc(name_), buffer, indep_)
     else
@@ -720,6 +722,7 @@ contains
     ! If 'name' argument is passed, obj_id is interpreted to be a group and
     ! 'name' is the name of the dataset we should read from
     if (present(name)) then
+      allocate(name_(len_trim(name) + 1))
       name_ = to_c_string(name)
       call read_double_c(obj_id, c_loc(name_), buffer, indep_)
     else
@@ -742,6 +745,7 @@ contains
     ! If 'name' argument is passed, obj_id is interpreted to be a group and
     ! 'name' is the name of the dataset we should read from
     if (present(name)) then
+      allocate(name_(len_trim(name) + 1))
       name_ = to_c_string(name)
       call read_double_c(obj_id, c_loc(name_), buffer, indep_)
     else
@@ -764,6 +768,7 @@ contains
     ! If 'name' argument is passed, obj_id is interpreted to be a group and
     ! 'name' is the name of the dataset we should read from
     if (present(name)) then
+      allocate(name_(len_trim(name) + 1))
       name_ = to_c_string(name)
       call read_double_c(obj_id, c_loc(name_), buffer, indep_)
     else
@@ -888,6 +893,7 @@ contains
     ! If 'name' argument is passed, obj_id is interpreted to be a group and
     ! 'name' is the name of the dataset we should read from
     if (present(name)) then
+      allocate(name_(len_trim(name) + 1))
       name_ = to_c_string(name)
       call read_int_c(obj_id, c_loc(name_), buffer_, indep_)
     else
@@ -911,6 +917,7 @@ contains
     ! If 'name' argument is passed, obj_id is interpreted to be a group and
     ! 'name' is the name of the dataset we should read from
     if (present(name)) then
+      allocate(name_(len_trim(name) + 1))
       name_ = to_c_string(name)
       call read_int_c(obj_id, c_loc(name_), buffer, indep_)
     else
@@ -933,6 +940,7 @@ contains
     ! If 'name' argument is passed, obj_id is interpreted to be a group and
     ! 'name' is the name of the dataset we should read from
     if (present(name)) then
+      allocate(name_(len_trim(name) + 1))
       name_ = to_c_string(name)
       call read_int_c(obj_id, c_loc(name_), buffer, indep_)
     else
@@ -955,6 +963,7 @@ contains
     ! If 'name' argument is passed, obj_id is interpreted to be a group and
     ! 'name' is the name of the dataset we should read from
     if (present(name)) then
+      allocate(name_(len_trim(name) + 1))
       name_ = to_c_string(name)
       call read_int_c(obj_id, c_loc(name_), buffer, indep_)
     else
@@ -977,6 +986,7 @@ contains
     ! If 'name' argument is passed, obj_id is interpreted to be a group and
     ! 'name' is the name of the dataset we should read from
     if (present(name)) then
+      allocate(name_(len_trim(name) + 1))
       name_ = to_c_string(name)
       call read_int_c(obj_id, c_loc(name_), buffer, indep_)
     else
@@ -1025,6 +1035,7 @@ contains
     ! If 'name' argument is passed, obj_id is interpreted to be a group and
     ! 'name' is the name of the dataset we should read from
     if (present(name)) then
+      allocate(name_(len_trim(name) + 1))
       name_ = to_c_string(name)
       call read_llong_c(obj_id, c_loc(name_), buffer_, indep_)
     else
@@ -1425,6 +1436,7 @@ contains
     ! If 'name' argument is passed, obj_id is interpreted to be a group and
     ! 'name' is the name of the dataset we should read from
     if (present(name)) then
+      allocate(name_(len_trim(name) + 1))
       name_ = to_c_string(name)
       call read_complex_c(obj_id, c_loc(name_), buffer, indep_)
     else


### PR DESCRIPTION
Four fixes here:

In hdf5_interface.h we had prepared buffers for xtensor arrays by using `T* buffer = new T[size]`.  xtensor then deallocates them with (I think) `allocator<double>::deallocate` which causes Valgrind to warn about mismatched free() / delete / delete [].  I've fixed that by using `std::vector` as the buffer.

When we called `read_attribute_string` from Fortran, the buffer was undersized by one byte.  (I assume we miscounted a null character somewhere).  That's fixed now.

When computing photon production cross sections, we were interpolating on a `Tabulated1D` with a value equal to the first grid point in that table.  In that case, our search returned an index of `-1` which we then indexed an array with.

You know all those `may be used uninitialized in this function` warnings we used to get with strings in hdf5_interface.F90?  Valgrind helped me figure out what that was about, and it's now fixed by making sure we allocate character arrays that are declared locally in hdf5_interface.F90 rather than those with inferred length returned by `to_c_string`.

There are still a few small Valgrind errors raised by calls inside the HDF5 library which probably means we've messed up a buffer or a type or something, but I'm not sure now how to track that down.