### PR TITLE
Fix broken docbuild on RTD

### DIFF
--- a/openmc/polynomial.py
+++ b/openmc/polynomial.py
@@ -1,6 +1,5 @@
 import numpy as np
 import openmc
-import openmc.capi as capi
 from collections.abc import Iterable
 
 
@@ -74,6 +73,7 @@ class ZernikeRadial(Polynomial):
         return self._order
 
     def __call__(self, r):
+        import openmc.capi as capi
         if isinstance(r, Iterable):
             return [np.sum(self._norm_coef * capi.calc_zn_rad(self.order, r_i))
                     for r_i in r]

--- a/scripts/openmc-plot-mesh-tally
+++ b/scripts/openmc-plot-mesh-tally
@@ -11,8 +11,10 @@ import tkinter.font as font
 import tkinter.messagebox as messagebox
 import tkinter.ttk as ttk
 
+import matplotlib
+matplotlib.use("TkAgg")
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-from matplotlib.backends.backend_tkagg import NavigationToolbar2TkAgg
+from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 import numpy as np
@@ -56,7 +58,7 @@ class MeshPlotter(tk.Frame):
         self.canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH, expand=1)
 
         # Create the navigation toolbar, tied to the canvas
-        self.mpl_toolbar = NavigationToolbar2TkAgg(self.canvas, figureFrame)
+        self.mpl_toolbar = NavigationToolbar2Tk(self.canvas, figureFrame)
         self.mpl_toolbar.update()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=1)
 

--- a/tests/regression_tests/dagmc/test.py
+++ b/tests/regression_tests/dagmc/test.py
@@ -1,7 +1,7 @@
 from tests.testing_harness import TestHarness
 import os
 import pytest
-import openmc
+import openmc.capi
 
 pytestmark = pytest.mark.skipif(
     not openmc.capi.dagmc_enabled,
@@ -9,4 +9,4 @@ pytestmark = pytest.mark.skipif(
 
 def test_dagmc():
     harness = TestHarness('statepoint.5.h5')
-    harness.main()    
+    harness.main()


### PR DESCRIPTION
Our 'latest' docs on readthedocs are currently broken (can't view docs for Python API classes/functions). This is caused by `import openmc.capi` at the top level of polynomial.py. I've moved that import out of the top level so that doc builds will succeed without building OpenMC first.

I've also put in a fix for some issues with openmc-plot-mesh-tally that were [identified by a user recently](https://groups.google.com/forum/#!topic/openmc-users/qE5UwBcjrY4).