### PR TITLE
Fix array IndexOutofbounds crash when a input material is never used for MG mode

### DIFF
--- a/src/mgxs_data.F90
+++ b/src/mgxs_data.F90
@@ -126,13 +126,9 @@ contains
 
       name = trim(mat % name) // C_NULL_CHAR
 
-      ! Do not read materials which we do not actually use in the problem to
-      ! reduce storage
-      if (allocated(kTs(i_mat) % data)) then
-        call create_macro_xs_c(name, mat % n_nuclides, mat % nuclide, &
-             kTs(i_mat) % size(), kTs(i_mat) % data, mat % atom_density, &
-             temperature_tolerance, temperature_method)
-      end if
+      call create_macro_xs_c(name, mat % n_nuclides, mat % nuclide, &
+           kTs(i_mat) % size(), kTs(i_mat) % data, mat % atom_density, &
+           temperature_tolerance, temperature_method)
     end do
 
   end subroutine create_macro_xs


### PR DESCRIPTION
@wuwenbin2006 reported this bug. Since #1016, we use `push_back` instead of `allocate` to initialize the `macro_xs` array. However, the array length should be equal to the number of materials, though we do not need to load the materials which we do not actually use in the problem.