### PR TITLE
Fixed the equality compare of MeshFilter class in PythonAPI

### DIFF
--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -610,11 +610,32 @@ class MeshFilter(Filter):
         self.mesh = mesh
         self.id = filter_id
 
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return False
+        elif len(self.bins) != len(other.bins):
+            return False
+        elif self.mesh.type != other.mesh.type:
+            return False
+        elif self.mesh.dimension != other.mesh.dimension:
+            return False
+        elif not np.allclose(self.mesh.lower_left, other.mesh.lower_left):
+            return False
+        elif not np.allclose(self.mesh.upper_right, other.mesh.upper_right):
+            return False   
+        else:
+            return True
+
     def __repr__(self):
         string = type(self).__name__ + '\n'
         string += '{: <16}=\t{}\n'.format('\tMesh ID', self.mesh.id)
         string += '{: <16}=\t{}\n'.format('\tID', self.id)
         return string
+
+    def __hash__(self):
+        string = type(self).__name__ + '\n'
+        string += '{: <16}=\t{}\n'.format('\tBins', self.mesh.lower_left)
+        return hash(string)            
 
     @classmethod
     def from_hdf5(cls, group, **kwargs):


### PR DESCRIPTION
For creating multiple MeshFilters , OpenMOC pythonAPI will take them the same if they have the same  mesh dimensions but different lower_left and upper_right. This is because the __eq__ is too simple in the base class Filter. And the wrong equality affects the _create_filter_subelements(tallies.py:3149) called by Tallies::export_to_xml().

Just override the __eq__ and __hash__ in class MeshFilter.