### PR TITLE
Make sure fission neutron energy is resampled if > max energy

### DIFF
--- a/openmc/capi/core.py
+++ b/openmc/capi/core.py
@@ -121,7 +121,7 @@ def find_material(xyz):
     _dll.openmc_find_cell((c_double*3)(*xyz), index, instance)
 
     mats = openmc.capi.Cell(index=index.value).fill
-    if isinstance(mats, openmc.capi.Material):
+    if isinstance(mats, (openmc.capi.Material, type(None))):
         return mats
     else:
         return mats[instance.value]

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -1057,7 +1057,8 @@ void sample_fission_neutron(int i_nuclide, const Reaction* rx, double E_in, Bank
       rx->products_[group].sample(E_in, site->E, mu);
 
       // resample if energy is greater than maximum neutron energy
-      constexpr int neutron = static_cast<int>(ParticleType::neutron);
+      // TODO: off-by-one
+      constexpr int neutron = static_cast<int>(ParticleType::neutron) - 1;
       if (site->E < data::energy_max[neutron]) break;
 
       // check for large number of resamples
@@ -1082,7 +1083,8 @@ void sample_fission_neutron(int i_nuclide, const Reaction* rx, double E_in, Bank
       rx->products_[0].sample(E_in, site->E, mu);
 
       // resample if energy is greater than maximum neutron energy
-      constexpr int neutron = static_cast<int>(ParticleType::neutron);
+      // TODO: off-by-one
+      constexpr int neutron = static_cast<int>(ParticleType::neutron) - 1;
       if (site->E < data::energy_max[neutron]) break;
 
       // check for large number of resamples

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -5,7 +5,9 @@
 #include <sstream>
 #include <string>
 
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 #include "openmc/capi.h"
 #include "openmc/constants.h"


### PR DESCRIPTION
The main bugfix in this PR is to make sure that the index used in `data::energy_max` is correct when sampling an energy for a fission neutron. There is an off-by-one error at present. There are two other small bugs that are also fixed:
- If `openmc.capi.find_material` finds a cell filled with a void, right now you'll just get an exception. `None` is returned properly with the fix
- We're missing an `#ifdef _OPENMP` in settings.cpp around `#include <omp.h>`. Usually that header is present, but there's no guarantee (thanks to @sphamil for finding this!)