### PR TITLE
Differentiate material internally and allow for power density in depletion

### DIFF
--- a/include/openmc/timer.h
+++ b/include/openmc/timer.h
@@ -37,7 +37,7 @@ public:
   Timer() {};
 
   //! Start running the timer
-  void start ();
+  void start();
 
   //! Get total elapsed time in seconds
   //! \return Elapsed time in [s]
@@ -52,7 +52,7 @@ public:
 private:
   bool running_ {false}; //!< is timer running?
   std::chrono::time_point<clock> start_; //!< starting point for clock
-  double elapsed_ {0.0}; //!< elasped time in [s]
+  double elapsed_ {0.0}; //!< elapsed time in [s]
 };
 
 //==============================================================================

--- a/openmc/deplete/integrator/cecm.py
+++ b/openmc/deplete/integrator/cecm.py
@@ -7,7 +7,7 @@ from .cram import deplete
 from ..results import Results
 
 
-def cecm(operator, timesteps, power, print_out=True):
+def cecm(operator, timesteps, power=None, power_density=None, print_out=True):
     r"""Deplete using the CE/CM algorithm.
 
     Implements the second order `CE/CM predictor-corrector algorithm
@@ -31,16 +31,29 @@ def cecm(operator, timesteps, power, print_out=True):
         The operator object to simulate on.
     timesteps : iterable of float
         Array of timesteps in units of [s]. Note that values are not cumulative.
-    power : float or iterable of float
+    power : float or iterable of float, optional
         Power of the reactor in [W]. A single value indicates that the power is
         constant over all timesteps. An iterable indicates potentially different
         power levels for each timestep. For a 2D problem, the power can be given
         in [W/cm] as long as the "volume" assigned to a depletion material is
-        actually an area in [cm^2].
+        actually an area in [cm^2]. Either `power` or `power_density` must be
+        specified.
+    power_density : float or iterable of float, optional
+        Power density of the reactor in [W/gHM]. It is multiplied by initial
+        heavy metal inventory to get total power if `power` is not speficied.
     print_out : bool, optional
         Whether or not to print out time.
 
     """
+    if power is None:
+        if power_density is None:
+            raise RuntimeError(
+                "Neither power nor power density was specified.")
+        if not isinstance(power_density, Iterable):
+            power = power_density*operator.heavy_metal
+        else:
+            power = [i*operator.heavy_metal for i in power_density]
+
     if not isinstance(power, Iterable):
         power = [power]*len(timesteps)
 

--- a/openmc/deplete/integrator/cecm.py
+++ b/openmc/deplete/integrator/cecm.py
@@ -47,7 +47,7 @@ def cecm(operator, timesteps, power=None, power_density=None, print_out=True):
     """
     if power is None:
         if power_density is None:
-            raise RuntimeError(
+            raise ValueError(
                 "Neither power nor power density was specified.")
         if not isinstance(power_density, Iterable):
             power = power_density*operator.heavy_metal

--- a/openmc/deplete/integrator/predictor.py
+++ b/openmc/deplete/integrator/predictor.py
@@ -43,7 +43,7 @@ def predictor(operator, timesteps, power=None, power_density=None,
     """
     if power is None:
         if power_density is None:
-            raise RuntimeError(
+            raise ValueError(
                 "Neither power nor power density was specified.")
         if not isinstance(power_density, Iterable):
             power = power_density*operator.heavy_metal

--- a/openmc/deplete/integrator/predictor.py
+++ b/openmc/deplete/integrator/predictor.py
@@ -7,7 +7,8 @@ from .cram import deplete
 from ..results import Results
 
 
-def predictor(operator, timesteps, power, print_out=True):
+def predictor(operator, timesteps, power=None, power_density=None,
+              print_out=True):
     r"""Deplete using a first-order predictor algorithm.
 
     Implements the first-order predictor algorithm. This algorithm is
@@ -26,16 +27,29 @@ def predictor(operator, timesteps, power, print_out=True):
         The operator object to simulate on.
     timesteps : iterable of float
         Array of timesteps in units of [s]. Note that values are not cumulative.
-    power : float or iterable of float
+    power : float or iterable of float, optional
         Power of the reactor in [W]. A single value indicates that the power is
         constant over all timesteps. An iterable indicates potentially different
         power levels for each timestep. For a 2D problem, the power can be given
         in [W/cm] as long as the "volume" assigned to a depletion material is
-        actually an area in [cm^2].
+        actually an area in [cm^2]. Either `power` or `power_density` must be
+        specified.
+    power_density : float or iterable of float, optional
+        Power density of the reactor in [W/gHM]. It is multiplied by initial
+        heavy metal inventory to get total power if `power` is not speficied.
     print_out : bool, optional
         Whether or not to print out time.
 
     """
+    if power is None:
+        if power_density is None:
+            raise RuntimeError(
+                "Neither power nor power density was specified.")
+        if not isinstance(power_density, Iterable):
+            power = power_density*operator.heavy_metal
+        else:
+            power = [i*operator.heavy_metal for i in power_density]
+
     if not isinstance(power, Iterable):
         power = [power]*len(timesteps)
 

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -109,7 +109,7 @@ class Operator(TransportOperator):
 
     """
     def __init__(self, geometry, settings, chain_file=None, prev_results=None,
-                 diff_burnable_mats=True):
+                 diff_burnable_mats=False):
         super().__init__(chain_file)
         self.round_number = False
         self.settings = settings

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -70,6 +70,8 @@ class Operator(TransportOperator):
         Results from a previous depletion calculation. If this argument is
         specified, the depletion calculation will start from the latest state
         in the previous results.
+    diff_burnable_mats : bool, optional
+        Whether to differentiate burnable materials with multiple instances
 
     Attributes
     ----------
@@ -102,13 +104,17 @@ class Operator(TransportOperator):
         All burnable material IDs being managed by a single process
     prev_res : ResultsList
         Results from a previous depletion calculation
+    diff_burnable_mats : bool
+        Whether to differentiate burnable materials with multiple instances
 
     """
-    def __init__(self, geometry, settings, chain_file=None, prev_results=None):
+    def __init__(self, geometry, settings, chain_file=None, prev_results=None,
+                 diff_burnable_mats=True):
         super().__init__(chain_file)
         self.round_number = False
         self.settings = settings
         self.geometry = geometry
+        self.diff_burnable_mats = diff_burnable_mats
 
         if prev_results != None:
             # Reload volumes into geometry
@@ -221,8 +227,9 @@ class Operator(TransportOperator):
 
         """
 
-        # Automatically distribute burnable materials
-        self._differentiate_burnable_mats()
+        if self.diff_burnable_mats:
+            # Automatically distribute burnable materials
+            self._differentiate_burnable_mats()
 
         burnable_mats = set()
         model_nuclides = set()

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -247,7 +247,7 @@ class Operator(TransportOperator):
                     raise RuntimeError("Volume not specified for depletable "
                                        "material with ID={}.".format(mat.id))
                 volume[str(mat.id)] = mat.volume
-                self.heavy_metal += mat.get_heavy_metal_mass()
+                self.heavy_metal += mat.fissionable_mass
 
         # Make sure there are burnable materials
         if not burnable_mats:

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -96,6 +96,8 @@ class Operator(TransportOperator):
         Reaction rates from the last operator step.
     burnable_mats : list of str
         All burnable material IDs
+    heavy_metal : float
+        Initial heavy metal inventory
     local_mats : list of str
         All burnable material IDs being managed by a single process
     prev_res : ResultsList
@@ -226,6 +228,8 @@ class Operator(TransportOperator):
         model_nuclides = set()
         volume = OrderedDict()
 
+        self.heavy_metal = 0.0
+
         # Iterate once through the geometry to get dictionaries
         for mat in self.geometry.get_all_materials().values():
             for nuclide in mat.get_nuclides():
@@ -236,6 +240,7 @@ class Operator(TransportOperator):
                     raise RuntimeError("Volume not specified for depletable "
                                        "material with ID={}.".format(mat.id))
                 volume[str(mat.id)] = mat.volume
+                self.heavy_metal += mat.get_heavy_metal_mass()
 
         # Make sure there are burnable materials
         if not burnable_mats:

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -758,7 +758,7 @@ class Material(IDManagerMixin):
         """
         mass = 0.0
         for nuc, _, _ in self._nuclides:
-            if openmc.data.zam(nuc)[0] > 90:
+            if openmc.data.zam(nuc)[0] >= 90:
                 mass += self.get_mass(nuc)
         return mass
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -747,6 +747,21 @@ class Material(IDManagerMixin):
             raise ValueError("Volume must be set in order to determine mass.")
         return self.volume*self.get_mass_density(nuclide)
 
+    def get_heavy_metal_mass(self):
+        """Return mass of heavy metal nuclides.
+
+        Returns
+        -------
+        float
+            Mass in [g]
+
+        """
+        mass = 0.0
+        for nuc, _, _ in self._nuclides:
+            if openmc.data.zam(nuc)[0] > 90:
+                mass += self.get_mass(nuc)
+        return mass
+
     def clone(self, memo=None):
         """Create a copy of this material with a new unique ID.
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -747,6 +747,7 @@ class Material(IDManagerMixin):
             raise ValueError("Volume must be set in order to determine mass.")
         return self.volume*self.get_mass_density(nuclide)
 
+    @property
     def get_heavy_metal_mass(self):
         """Return mass of heavy metal nuclides.
 

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -23,6 +23,10 @@ int openmc_finalize()
   // Clear results
   openmc_reset();
 
+  // Reset timers
+  reset_timers();
+  reset_timers_f();
+
   // Reset global variables
   settings::assume_separate = false;
   settings::check_overlaps = false;
@@ -115,10 +119,6 @@ int openmc_reset()
   simulation::k_abs_tra = 0.0;
   simulation::k_sum = {0.0, 0.0};
 
-  // Reset timers
-  reset_timers();
-  reset_timers_f();
-
   return 0;
 }
 
@@ -126,6 +126,8 @@ int openmc_hard_reset()
 {
   // Reset all tallies and timers
   openmc_reset();
+  reset_timers();
+  reset_timers_f();
 
   // Reset total generations and keff guess
   simulation::keff = 1.0;

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -2258,7 +2258,7 @@ contains
           call write_message("Maximum neutron transport energy: " // &
                trim(to_str(energy_max(NEUTRON))) // " eV for " // &
                trim(adjustl(nuclides(i) % name)), 7)
-          if (master .and. energy_max(NEUTRON) < 20.E6) call warning("Maximum &
+          if (master .and. energy_max(NEUTRON) < 20.e6) call warning("Maximum &
                &neutron energy is below 20 MeV. This may bias the results.")
           exit
         end if

--- a/src/input_xml.F90
+++ b/src/input_xml.F90
@@ -2258,6 +2258,8 @@ contains
           call write_message("Maximum neutron transport energy: " // &
                trim(to_str(energy_max(NEUTRON))) // " eV for " // &
                trim(adjustl(nuclides(i) % name)), 7)
+          if (master .and. energy_max(NEUTRON) < 20.E6) call warning("Maximum &
+               &neutron energy is below 20 MeV. This may bias the results.")
           exit
         end if
       end if
@@ -2272,9 +2274,10 @@ contains
           exit
         end if
       end do
-      if (.not. mp_found) call warning("Windowed multipole functionality is &
-           &turned on, but no multipole libraries were found. Make sure that &
-           &windowed multipole data is present in your cross_sections.xml file.")
+      if (master .and. .not. mp_found) call warning("Windowed multipole &
+           &functionality is turned on, but no multipole libraries were found. &
+           &Make sure that windowed multipole data is present in your &
+           &cross_sections.xml file.")
     end if
 
     call already_read % clear()

--- a/src/nuclide_header.F90
+++ b/src/nuclide_header.F90
@@ -685,8 +685,8 @@ contains
 
   subroutine nuclide_init_grid(this, E_min, E_max, M)
     class(Nuclide), intent(inout) :: this
-    real(8), intent(in) :: E_min           ! Minimum energy in MeV
-    real(8), intent(in) :: E_max           ! Maximum energy in MeV
+    real(8), intent(in) :: E_min           ! Minimum energy in eV
+    real(8), intent(in) :: E_max           ! Maximum energy in eV
     integer, intent(in) :: M               ! Number of equally log-spaced bins
 
     integer :: i, j, k               ! Loop indices


### PR DESCRIPTION
This PR adds two enhancements to depletion based on user's feedbacks:
1. it is common to use one material for multiple regions, especially in a lattice geometry with fresh fuels. For depletion, users need to differentiate the materials and assign to cells as `distribmats` manually, otherwise, all the material instances are treated as one region. We now try to expand the burnable materials with multiple instances automatically.
2. power density in [W/gHM, or W/cm/gHM for 2D cases] can now  be used alternatively. It is internally multiplied by initial heavy metal inventory [Z>=90] to get total power if `power` is not speficied.