### PR TITLE
Updating MOAB version in CI

### DIFF
--- a/tools/ci/travis-install-dagmc.sh
+++ b/tools/ci/travis-install-dagmc.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # MOAB Variables
-MOAB_BRANCH='Version5.0'
+MOAB_BRANCH='Version5.1.0'
 MOAB_REPO='https://bitbucket.org/fathomteam/moab/'
 MOAB_INSTALL_DIR=$HOME/MOAB/
 


### PR DESCRIPTION
MOAB recently released a new version 5.1.0. DAGMC and related workflows are rapidly moving to this version. It's probably best to be using it for testing now.