### PR TITLE
Fix export of atomic relaxation transition data for pandas 0.24.0

### DIFF
--- a/openmc/data/photon.py
+++ b/openmc/data/photon.py
@@ -735,7 +735,8 @@ class IncidentPhoton(EqualityMixin):
                         shell_values.insert(0, None)
                         df = relax.transitions[shell].replace(
                             shell_values, range(len(shell_values)))
-                        sub_group.create_dataset('transitions', data=df.values)
+                        sub_group.create_dataset(
+                            'transitions', data=df.values.astype(float))
 
                 # Determine threshold
                 threshold = rx.xs.x[0]


### PR DESCRIPTION
Evidently the latest version of pandas (0.24.0) breaks the export of incident photon data, specifically atomic relaxation transition data. This PR should fix it.

@pshriwise If you're wondering why your PR is failing, this is why.