### PR TITLE
Fix bug when loading nuclides with openmc.capi

### DIFF
--- a/src/nuclide_header.F90
+++ b/src/nuclide_header.F90
@@ -703,15 +703,13 @@ contains
   end function openmc_nuclide_name
 
   subroutine extend_nuclides() bind(C)
-    integer :: n
     type(Nuclide), allocatable :: new_nuclides(:)
 
     ! allocate extra space in nuclides array
-    n = n_nuclides
-    allocate(new_nuclides(n + 1))
-    new_nuclides(1:n) = nuclides(:)
+    allocate(new_nuclides(n_nuclides + 1))
+    new_nuclides(1:n_nuclides) = nuclides(:)
     call move_alloc(FROM=new_nuclides, TO=nuclides)
-    n = n + 1
+    n_nuclides = n_nuclides + 1
   end subroutine
 
 end module nuclide_header

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -130,13 +130,6 @@ def test_nuclide_mapping(capi_init):
         assert name == nuc.name
 
 
-def test_load_nuclide(capi_init):
-    openmc.capi.load_nuclide('H3')
-    openmc.capi.load_nuclide('Pu239')
-    with pytest.raises(exc.DataError):
-        openmc.capi.load_nuclide('Pu3')
-
-
 def test_settings(capi_init):
     settings = openmc.capi.settings
     assert settings.batches == 10
@@ -394,3 +387,10 @@ def test_restart(capi_init):
 
     # Compare the keff values.
     assert keff0 == pytest.approx(keff1)
+
+
+def test_load_nuclide(capi_init):
+    openmc.capi.load_nuclide('H3')
+    openmc.capi.load_nuclide('Pu239')
+    with pytest.raises(exc.DataError):
+        openmc.capi.load_nuclide('Pu3')

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -131,6 +131,7 @@ def test_nuclide_mapping(capi_init):
 
 
 def test_load_nuclide(capi_init):
+    openmc.capi.load_nuclide('H3')
     openmc.capi.load_nuclide('Pu239')
     with pytest.raises(exc.DataError):
         openmc.capi.load_nuclide('Pu3')


### PR DESCRIPTION
Current develop branch results in segment fault in depletion calculation. The bug is found to be the invalid updating of the nuclide index `n_nuclides` in function `extend_nuclides()`. The unit test `test_load_nuclide()` is updated to make sure the loading of multiple nuclides works well.