### PR TITLE
added context as an argument for downloading

### DIFF
--- a/openmc/_utils.py
+++ b/openmc/_utils.py
@@ -7,7 +7,7 @@ from urllib.request import urlopen
 _BLOCK_SIZE = 16384
 
 
-def download(url, checksum=None):
+def download(url, checksum=None, context=None):
     """Download file from a URL
 
     Parameters
@@ -16,6 +16,8 @@ def download(url, checksum=None):
         URL from which to download
     checksum : str or None
         MD5 checksum to check against
+    context : ssl.SSLContext instance or None
+        For example ssl._create_unverified_context()
 
     Returns
     -------
@@ -23,7 +25,7 @@ def download(url, checksum=None):
         Name of file written locally
 
     """
-    req = urlopen(url)
+    req = urlopen(url, context=context)
 
     # Get file size from header
     file_size = req.length

--- a/openmc/_utils.py
+++ b/openmc/_utils.py
@@ -29,7 +29,6 @@ def download(url, checksum=None, **kwargs):
 
     """
     req = urlopen(url, **kwargs)
-    print(kwargs)
     # Get file size from header
     file_size = req.length
 

--- a/openmc/_utils.py
+++ b/openmc/_utils.py
@@ -17,10 +17,7 @@ def download(url, checksum=None, **kwargs):
     checksum : str or None
         MD5 checksum to check against
     **kwargs : dict
-        Optional arguements passed to urlopen()
-        context: ssl.SSLContext object
-            Describes the various SSL options,
-            e.g. context=ssl._create_unverified_context()
+        Keyword arguments passed to :func:urllib.request.urlopen
 
     Returns
     -------

--- a/openmc/_utils.py
+++ b/openmc/_utils.py
@@ -7,7 +7,7 @@ from urllib.request import urlopen
 _BLOCK_SIZE = 16384
 
 
-def download(url, checksum=None, context=None):
+def download(url, checksum=None, **kwargs):
     """Download file from a URL
 
     Parameters
@@ -16,8 +16,11 @@ def download(url, checksum=None, context=None):
         URL from which to download
     checksum : str or None
         MD5 checksum to check against
-    context : ssl.SSLContext instance or None
-        For example ssl._create_unverified_context()
+    **kwargs : dict
+        Optional arguements passed to urlopen()
+        context: ssl.SSLContext object
+            Describes the various SSL options,
+            e.g. context=ssl._create_unverified_context()
 
     Returns
     -------
@@ -25,8 +28,8 @@ def download(url, checksum=None, context=None):
         Name of file written locally
 
     """
-    req = urlopen(url, context=context)
-
+    req = urlopen(url, **kwargs)
+    print(kwargs)
     # Get file size from header
     file_size = req.length
 

--- a/openmc/_utils.py
+++ b/openmc/_utils.py
@@ -16,8 +16,7 @@ def download(url, checksum=None, **kwargs):
         URL from which to download
     checksum : str or None
         MD5 checksum to check against
-    **kwargs : dict
-        Keyword arguments passed to :func:urllib.request.urlopen
+    Keyword arguments passed to :func:urllib.request.urlopen
 
     Returns
     -------


### PR DESCRIPTION
This minor tweak to the _utils.py code allows downloads to use the script in more cases

Currently the download function does not offer users the chance to specify context settings so some urls will refuse the download request.

This change adds an optional argument to the download function that allows context to be passed and retains the default settings when context is not passed.
