### PR TITLE
Fix source.cpp indexing bug caused by distributed temperatures

### DIFF
--- a/src/source.cpp
+++ b/src/source.cpp
@@ -173,7 +173,8 @@ Bank SourceDistribution::sample() const
         if (space_box->only_fissionable()) {
           // Determine material
           auto c = model::cells[cell_index - 1];
-          int32_t mat_index = c->material_[instance];
+          auto mat_index = c->material_.size() == 1
+            ? c->material_[0] : c->material_[instance];
 
           if (mat_index == MATERIAL_VOID) {
             found = false;


### PR DESCRIPTION
When identifying the current material in source.cpp, we index into a cell's material array like `cell.material_[instance]` to account for distributed materials.  But this will cause an error when using distributed temperatures (this causes `instance` to be non-zero) without distributed materials (`cell.material_.size()` is 1).