### PR TITLE
Flush stdout when printing generation info

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -423,7 +423,7 @@ void print_batch_keff()
     std::cout << "   " << std::setw(8) << simulation::keff << " +/-"
       << std::setw(8) << simulation::keff_std;
   }
-  std::cout << '\n';
+  std::cout << std::endl;
 
   // Restore state of cout
   std::cout.flags(f);


### PR DESCRIPTION
With our move of output functionality to C++, our output of the generation-by-generation keff is now buffered.  This means that you'll have to wait several generations before you see any output.  This PR uses `std::endl` to flush the stdout