### PR TITLE
Fix bug in calculating distance to boundary in complex cells

### DIFF
--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -424,7 +424,7 @@ CSGCell::distance(Position r, Direction u, int32_t on_surface) const
 
     // Calculate the distance to this surface.
     // Note the off-by-one indexing
-    bool coincident {token == on_surface};
+    bool coincident {std::abs(token) == std::abs(on_surface)};
     double d {model::surfaces[abs(token)-1]->distance(r, u, coincident)};
 
     // Check if this distance is the new minimum.

--- a/tools/ci/travis-install.sh
+++ b/tools/ci/travis-install.sh
@@ -22,13 +22,8 @@ fi
 # Build and install OpenMC executable
 python tools/ci/travis-install.py
 
-if [[ $TRAVIS_PYTHON_VERSION == "3.7" ]]; then
-    # Install Python API in editable mode
-    pip install -e .[test]
-else
-    # Conditionally install vtk
-    pip install -e .[test,vtk]
-fi
+# Install Python API in editable mode
+pip install -e .[test,vtk]
 
 # For uploading to coveralls
 pip install coveralls


### PR DESCRIPTION
This PR addresses the behavior described in #1170. I traced the problem down to how surface coincidence is determine in `CSGCell::distance`. Because surface distance checks only care whether the particle is coincident (and not which halfspace it's headed into), the correct way to check coincidence is to take the absolute value of the current surface and compare with the absolute value of the halfspace in the region specification. This only becomes a problem for complex cells where both halfspaces of a surface might appear in the region specification for a single cell. In that case, it's possible to end up in an infinite loop where the particle enters the complex cell, determines the distance to the nearest boundary of the cell (which is zero without the bugfix), and then repeats.

I also noticed that Python 3.7 wheels are now available for vtk so I've removed a check in our install script to that effect.