### PR TITLE
Fix reading ASCII ACE table for Python 3

### DIFF
--- a/openmc/data/ace.py
+++ b/openmc/data/ace.py
@@ -191,7 +191,8 @@ def get_table(filename, name=None):
         if lib.tables:
             return lib.tables[0]
         else:
-            raise ValueError(f'Could not find ACE table with name: {name}')
+            raise ValueError('Could not find ACE table with name: {}'
+                             .format(name))
 
 
 class Library(EqualityMixin):


### PR DESCRIPTION
In Python 3, when `seek()` is used in a text file only the beginning of the file is allowed as a reference point, and any offset other than `f.tell()` causes undefined behavior. This PR fixes a couple instances of this.