### PR TITLE
Fix bug for distributed temperatures without distributed materials

### DIFF
--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -167,16 +167,25 @@ get_temperatures(std::vector<std::vector<double>>& nuc_temps,
       int i_material = cell->material_[j];
       if (i_material == MATERIAL_VOID) continue;
 
-      // Get temperature of cell (rounding to nearest integer)
-      double sqrtkT = cell->sqrtkT_.size() == 1 ?
-        cell->sqrtkT_[j] : cell->sqrtkT_[0];
-      double temperature = sqrtkT*sqrtkT / K_BOLTZMANN;
+      // Get temperature(s) of cell (rounding to nearest integer)
+      std::vector<double> cell_temps;
+      if (cell->sqrtkT_.size() == 1) {
+        double sqrtkT = cell->sqrtkT_[0];
+        cell_temps.push_back(sqrtkT*sqrtkT / K_BOLTZMANN);
+      } else if (cell->sqrtkT_.size() == cell->material_.size()) {
+        double sqrtkT = cell->sqrtkT_[j];
+        cell_temps.push_back(sqrtkT*sqrtkT / K_BOLTZMANN);
+      } else {
+        for (double sqrtkT : cell->sqrtkT_)
+          cell_temps.push_back(sqrtkT*sqrtkT / K_BOLTZMANN);
+      }
 
       const auto& mat {model::materials[i_material]};
       for (const auto& i_nuc : mat->nuclide_) {
-        // Add temperature if it hasn't already been added
-        if (!contains(nuc_temps[i_nuc], temperature)) {
-          nuc_temps[i_nuc].push_back(temperature);
+        for (double temperature : cell_temps) {
+          // Add temperature if it hasn't already been added
+          if (!contains(nuc_temps[i_nuc], temperature))
+            nuc_temps[i_nuc].push_back(temperature);
         }
       }
 
@@ -184,9 +193,10 @@ get_temperatures(std::vector<std::vector<double>>& nuc_temps,
         // Get index in data::thermal_scatt array
         int i_sab = table.index_table;
 
-        // Add temperature if it hasn't already been added
-        if (!contains(thermal_temps[i_sab], temperature)) {
-          thermal_temps[i_sab].push_back(temperature);
+        for (double temperature : cell_temps) {
+          // Add temperature if it hasn't already been added
+          if (!contains(thermal_temps[i_sab], temperature))
+            thermal_temps[i_sab].push_back(temperature);
         }
       }
     }


### PR DESCRIPTION
When we call `get_temperatures` to find out what temps are assigned to each nuclide, there's a bug that occurs related to distributed temperatures.  We correctly account for the case where the cell has one temperature and many materials, or N temperatures and N materials, but we missed the case where it has many temperatures and only one material.