### PR TITLE
Fix for hexagonal prism convenience function

### DIFF
--- a/openmc/model/funcs.py
+++ b/openmc/model/funcs.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from collections.abc import Iterable
 from math import sqrt
 from numbers import Real
+from functools import partial
 
 from openmc import XPlane, YPlane, Plane, ZCylinder
 from openmc.checkvalue import check_type, check_value

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1,7 +1,6 @@
 from abc import ABCMeta
 from collections import OrderedDict
 from copy import deepcopy
-from functools import partial
 from numbers import Real, Integral
 from xml.etree import ElementTree as ET
 

--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -206,14 +206,25 @@ def test_get_by_name():
 def test_hex_prism():
     hex_prism = openmc.model.get_hexagonal_prism(edge_length=5.0,
                                                  origin=(0.0, 0.0),
-                                                 boundary_type='reflective',
-                                                 orientation='y',
-                                                 corner_radius=0.10)
-
-    hex_prism = openmc.model.get_hexagonal_prism(edge_length=5.0,
-                                                 origin=(0.0, 0.0),
-                                                 boundary_type='reflective',
                                                  orientation='y')
+    # clear checks
+    assert (0.0, 0.0, 0.0) in hex_prism
+    assert (10.0, 10.0, 10.0) not in hex_prism
+    # edge checks
+    assert (0.0, 5.01, 0.0) not in hex_prism
+    assert (0.0, 4.99, 0.0) in hex_prism
+
+    rounded_hex_prism = openmc.model.get_hexagonal_prism(edge_length=5.0,
+                                                         origin=(0.0, 0.0),
+                                                         orientation='y',
+                                                         corner_radius=1.0)
+
+    # clear checks
+    assert (0.0, 0.0, 0.0) in rounded_hex_prism
+    assert (10.0, 10.0, 10.0) not in rounded_hex_prism
+    # edge checks
+    assert (0.0, 5.01, 0.0) not in rounded_hex_prism
+    assert (0.0, 4.99, 0.0) not in rounded_hex_prism
 
 
 def test_get_lattice_by_name(cell_with_lattice):

--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -203,6 +203,19 @@ def test_get_by_name():
     assert not univs
 
 
+def test_hex_prism():
+    hex_prism = openmc.model.get_hexagonal_prism(edge_length=5.0,
+                                                 origin=(0.0, 0.0),
+                                                 boundary_type='reflective',
+                                                 orientation='y',
+                                                 corner_radius=0.10)
+
+    hex_prism = openmc.model.get_hexagonal_prism(edge_length=5.0,
+                                                 origin=(0.0, 0.0),
+                                                 boundary_type='reflective',
+                                                 orientation='y')
+
+
 def test_get_lattice_by_name(cell_with_lattice):
     cells, _, _, lattice = cell_with_lattice
     geom = openmc.Geometry([cells[-1]])
@@ -244,6 +257,7 @@ def test_determine_paths(cell_with_lattice):
     for i in range(4):
         assert geom.get_instances(cells[0].paths[i]) == i
         assert geom.get_instances(mats[-1].paths[i]) == i
+
 
 def test_from_xml(run_in_tmpdir, mixed_lattice_model):
     # Export model


### PR DESCRIPTION
When creating a hexagonal prism with rounded corners I encountered an error related to `partial` not being imported. I've added that import here and a couple of quick tests to cover this case. 

Also one line addition for PEP8 in `funcs.py`.