### PR TITLE
Add ID map function to the capi

### DIFF
--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -70,6 +70,7 @@ extern "C" {
   int openmc_next_batch(int* status);
   int openmc_nuclide_name(int index, const char** name);
   int openmc_plot_geometry();
+  int openmc_id_map(void* slice, int32_t *data_out);
   int openmc_reset();
   int openmc_run();
   void openmc_set_seed(int64_t new_seed);

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -70,7 +70,7 @@ extern "C" {
   int openmc_next_batch(int* status);
   int openmc_nuclide_name(int index, const char** name);
   int openmc_plot_geometry();
-  int openmc_id_map(const void* slice, int32_t *data_out);
+  int openmc_id_map(const void* slice, int32_t* data_out);
   int openmc_reset();
   int openmc_run();
   void openmc_set_seed(int64_t new_seed);

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -70,7 +70,7 @@ extern "C" {
   int openmc_next_batch(int* status);
   int openmc_nuclide_name(int index, const char** name);
   int openmc_plot_geometry();
-  int openmc_id_map(void* slice, int32_t *data_out);
+  int openmc_id_map(const void* slice, int32_t *data_out);
   int openmc_reset();
   int openmc_run();
   void openmc_set_seed(int64_t new_seed);

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -52,7 +52,7 @@ struct RGBColor {
 };
 
 typedef xt::xtensor<RGBColor, 2> ImageData;
-typedef xt::xtensor<int32_t, 3>  IDData;
+typedef xt::xtensor<int32_t, 3>  IdData;
 
 enum class PlotType {
   slice = 1,

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -20,6 +20,7 @@ namespace openmc {
 //===============================================================================
 
 class Plot;
+class PlotC;
 
 namespace model {
 
@@ -52,6 +53,7 @@ struct RGBColor {
 };
 
 typedef xt::xtensor<RGBColor, 2> ImageData;
+typedef xt::xtensor<int32_t, 3>  IDData;
 
 enum class PlotType {
   slice = 1,
@@ -73,7 +75,27 @@ enum class PlotColorBy {
 // Plot class
 //===============================================================================
 
-class Plot
+
+// plot class for interaction with external code
+class CPlot {
+
+public:
+  int id_; //!< Plot ID
+  PlotType type_; //!< Plot type (Slice/Voxel)
+  PlotColorBy color_by_; //!< Plot coloring (cell/material)
+  Position origin_; //!< Plot origin in geometry
+  Position width_; //!< Plot width in geometry
+  PlotBasis basis_; //!< Plot basis (XY/XZ/YZ)
+  std::array<int, 3> pixels_; //!< Plot size in pixels
+  int meshlines_width_; //!< Width of lines added to the plot
+  int level_; //!< Plot universe level
+  int index_meshlines_mesh_; //!< Index of the mesh to draw on the plot
+  RGBColor meshlines_color_; //!< Color of meshlines on the plot
+  RGBColor not_found_; //!< Plot background color
+};
+
+
+class Plot : public CPlot
 {
 
 public:
@@ -95,20 +117,8 @@ private:
   void set_meshlines(pugi::xml_node plot_node);
   void set_mask(pugi::xml_node plot_node);
 
-  // Members
+// Members
 public:
-  int id_; //!< Plot ID
-  PlotType type_; //!< Plot type (Slice/Voxel)
-  PlotColorBy color_by_; //!< Plot coloring (cell/material)
-  Position origin_; //!< Plot origin in geometry
-  Position width_; //!< Plot width in geometry
-  PlotBasis basis_; //!< Plot basis (XY/XZ/YZ)
-  std::array<int, 3> pixels_; //!< Plot size in pixels
-  int meshlines_width_; //!< Width of lines added to the plot
-  int level_; //!< Plot universe level
-  int index_meshlines_mesh_; //!< Index of the mesh to draw on the plot
-  RGBColor meshlines_color_; //!< Color of meshlines on the plot
-  RGBColor not_found_; //!< Plot background color
   std::vector<RGBColor> colors_; //!< Plot colors
   std::string path_plot_; //!< Plot output filename
 };

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -20,7 +20,7 @@ namespace openmc {
 //===============================================================================
 
 class Plot;
-class PlotC;
+
 
 namespace model {
 
@@ -74,21 +74,16 @@ enum class PlotColorBy {
 //===============================================================================
 // Plot class
 //===============================================================================
-
-
-// plot class for interaction with external code
-class CPlot {
-
-public:
+struct Slice {
+  // Members
   Position origin_; //!< Plot origin in geometry
   Position width_; //!< Plot width in geometry
   PlotBasis basis_; //!< Plot basis (XY/XZ/YZ)
-  std::array<int, 3> pixels_; //!< Plot size in pixels
+  int pixels_[3]; //!< Plot size in pixels
   int level_; //!< Plot universe level
 };
 
-
-class Plot : public CPlot
+class Plot : public Slice
 {
 
 public:

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -78,7 +78,7 @@ struct Slice {
   Position origin_; //!< Plot origin in geometry
   Position width_; //!< Plot width in geometry
   PlotBasis basis_; //!< Plot basis (XY/XZ/YZ)
-  int pixels_[3]; //!< Plot size in pixels
+  std::array<int, 3> pixels_; //!< Plot size in pixels
   int level_; //!< Plot universe level
 };
 

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -80,18 +80,11 @@ enum class PlotColorBy {
 class CPlot {
 
 public:
-  int id_; //!< Plot ID
-  PlotType type_; //!< Plot type (Slice/Voxel)
-  PlotColorBy color_by_; //!< Plot coloring (cell/material)
   Position origin_; //!< Plot origin in geometry
   Position width_; //!< Plot width in geometry
   PlotBasis basis_; //!< Plot basis (XY/XZ/YZ)
   std::array<int, 3> pixels_; //!< Plot size in pixels
-  int meshlines_width_; //!< Width of lines added to the plot
   int level_; //!< Plot universe level
-  int index_meshlines_mesh_; //!< Index of the mesh to draw on the plot
-  RGBColor meshlines_color_; //!< Color of meshlines on the plot
-  RGBColor not_found_; //!< Plot background color
 };
 
 
@@ -119,6 +112,13 @@ private:
 
 // Members
 public:
+  int id_; //!< Plot ID
+  PlotType type_; //!< Plot type (Slice/Voxel)
+  PlotColorBy color_by_; //!< Plot coloring (cell/material)
+  int meshlines_width_; //!< Width of lines added to the plot
+  int index_meshlines_mesh_; //!< Index of the mesh to draw on the plot
+  RGBColor meshlines_color_; //!< Color of meshlines on the plot
+  RGBColor not_found_; //!< Plot background color
   std::vector<RGBColor> colors_; //!< Plot colors
   std::string path_plot_; //!< Plot output filename
 };

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -73,7 +73,7 @@ enum class PlotColorBy {
 //===============================================================================
 // Plot class
 //===============================================================================
-struct Slice {
+struct PlotBase {
   // Members
   Position origin_; //!< Plot origin in geometry
   Position width_; //!< Plot width in geometry
@@ -82,7 +82,7 @@ struct Slice {
   int level_; //!< Plot universe level
 };
 
-class Plot : public Slice
+class Plot : public PlotBase
 {
 
 public:

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -21,7 +21,6 @@ namespace openmc {
 
 class Plot;
 
-
 namespace model {
 
 extern std::vector<Plot> plots; //!< Plot instance container

--- a/openmc/capi/__init__.py
+++ b/openmc/capi/__init__.py
@@ -12,8 +12,7 @@ objects in the :mod:`openmc.capi` subpackage, for example:
 
 """
 
-from ctypes import CDLL, c_bool, c_int
-import numpy as np
+from ctypes import CDLL, c_bool
 import os
 import sys
 

--- a/openmc/capi/__init__.py
+++ b/openmc/capi/__init__.py
@@ -12,7 +12,8 @@ objects in the :mod:`openmc.capi` subpackage, for example:
 
 """
 
-from ctypes import CDLL, c_bool
+from ctypes import CDLL, c_bool, c_int
+import numpy as np
 import os
 import sys
 
@@ -42,7 +43,6 @@ else:
 def _dagmc_enabled():
     return c_bool.in_dll(_dll, "dagmc_enabled").value
 
-
 from .error import *
 from .core import *
 from .nuclide import *
@@ -53,3 +53,4 @@ from .filter import *
 from .tally import *
 from .settings import settings
 from .math import *
+from .plot import *

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -23,15 +23,25 @@ class _Position(Structure):
                 ('y', c_double),
                 ('z', c_double)]
 
-    def __getitem__(self, key):
-        if key == 0:
+    def __getitem__(self, idx):
+        if idx == 0:
             return self.x
-        elif key == 1:
+        elif idx == 1:
             return self.y
-        elif key == 2:
+        elif idx == 2:
             return self.z
 
-        raise ValueError("{} index is invalid for _Position".format(key))
+        raise ValueError("{} index is invalid for _Position".format(idx))
+
+    def __setitem__(self, idx, val):
+        if idx == 0:
+            self.x = val
+        elif idx == 1:
+            self.y = val
+        elif idx == 2:
+            self.z = val
+
+        raise ValueError("{} index is invalid for _Position".format(idx))
 
     def __repr__(self):
         return "({}, {}, {})".format(self.x, self.y, self.z)

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -64,8 +64,8 @@ class _Position(Structure):
         return "Position: ({}, {}, {})".format(self.x, self.y, self.z)
 
 
-class _Slice(Structure):
-    """A structure defining a 2-D slice with underlying c-types
+class _PlotBase(Structure):
+    """A structure defining a 2-D geometry slice with underlying c-types
 
     C-Type Attributes
     -----------------
@@ -212,20 +212,20 @@ class _Slice(Structure):
         return self.__repr__()
 
 
-_dll.openmc_id_map.argtypes = [POINTER(_Slice), POINTER(c_int32)]
+_dll.openmc_id_map.argtypes = [POINTER(_PlotBase), POINTER(c_int32)]
 _dll.openmc_id_map.restype = c_int
 _dll.openmc_id_map.errcheck = _error_handler
 
 
-def id_map(slice_view):
+def id_map(plot):
     """
     Generate a 2-D map of (cell_id, material_id). Used for in-memory image
          generation.
 
     Parameters
     ----------
-    plot : An openmc.capi.plot._Slice object describing the slice of the model
-           to be generated
+    plot : An openmc.capi.plot._PlotBase object describing the slice of the
+           model to be generated
 
     Returns
     -------
@@ -233,8 +233,8 @@ def id_map(slice_view):
              of OpenMC property ids with dtype int32
 
     """
-    img_data = np.zeros((slice_view.vRes, slice_view.hRes, 2),
+    img_data = np.zeros((plot.vRes, plot.hRes, 2),
                         dtype=np.dtype('int32'))
-    _dll.openmc_id_map(POINTER(_Slice)(slice_view),
+    _dll.openmc_id_map(POINTER(_PlotBase)(plot),
                        img_data.ctypes.data_as(POINTER(c_int32)))
     return img_data

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -23,46 +23,11 @@ class _Position(Structure):
                 ('y', c_double),
                 ('z', c_double)]
 
-    def __init__(self, vals=None):
-        if vals:
-            x = vals[0]
-            y = vals[1]
-            z = vals[2]
-        else:
-            x = 0.0
-            y = 0.0
-            z = 0.0
-
-    @property
-    def x(self):
-        return self.x
-
-    @property
-    def y(self):
-        return self.y
-
-    @property
-    def z(self):
-        return self.z
-
-    @x.setter
-    def x(self, x_val):
-        assert(isinstance(x_val, float))
-        self.x = x_val
-
-    @y.setter
-    def y(self, y_val):
-        assert(isinstance(y_val, float))
-        self.y = y_val
-
-    @z.setter
-    def z(self, z_val):
-        assert(isinstance(z_val, float))
-        self.z = z_val
+    def __repr__(self):
+        return "({}, {}, {})".format(self.x, self.y, self.z)
 
     def __str__(self):
-        return "Position: ({}, {}, {})".format(self.x, self.y, self.z)
-
+        return self.__repr__()
 
 class _PlotBase(Structure):
     """A structure defining a 2-D geometry slice with underlying c-types
@@ -91,9 +56,9 @@ class _PlotBase(Structure):
     basis : string
         One of {'xy', 'xz', 'yz'} indicating the horizontal and vertical
         axes of the plot.
-    hRes : float
+    h_res : float
         The horizontal resolution of the plot in pixels
-    vRes : float
+    v_res : float
         The vertical resolution of the plot in pixels
     level : int
         The universe level for the plot (default: -1 -> all universes shown)
@@ -132,11 +97,11 @@ class _PlotBase(Structure):
         raise ValueError("Plot basis {} is invalid".format(basis_))
 
     @property
-    def hRes(self):
+    def h_res(self):
         return self.pixels_[0]
 
     @property
-    def vRes(self):
+    def v_res(self):
         return self.pixels_[1]
 
     @property
@@ -183,30 +148,30 @@ class _PlotBase(Structure):
         raise ValueError("{} of type {} is an"
                          " invalid plot basis".format(basis, type(basis)))
 
-    @hRes.setter
-    def hRes(self, hRes):
-        self.pixels_[0] = hRes
+    @h_res.setter
+    def h_res(self, h_res):
+        self.pixels_[0] = h_res
 
-    @vRes.setter
-    def vRes(self, vRes):
-        self.pixels_[1] = vRes
+    @v_res.setter
+    def v_res(self, v_res):
+        self.pixels_[1] = v_res
 
     @level.setter
     def level(self, level):
         self.level_ = level
 
     def __repr__(self):
-        out_str = "-----\n"
-        out_str += "Plot:\n"
-        out_str += "-----\n"
-        out_str += "Origin: {}\n".format(self.origin)
-        out_str += "Width: {}\n".format(self.width)
-        out_str += "Height: {}\n".format(self.height)
-        out_str += "Basis: {}\n".format(self.basis)
-        out_str += "HRes: {}\n".format(self.hRes)
-        out_str += "VRes: {}\n".format(self.vRes)
-        out_str += "Level: {}\n".format(self.level)
-        return out_str
+        out_str = ["-----",
+                   "Plot:",
+                   "-----",
+                   "Origin: {}".format(self.origin),
+                   "Width: {}".format(self.width),
+                   "Height: {}".format(self.height),
+                   "Basis: {}".format(self.basis),
+                   "HRes: {}".format(self.h_res),
+                   "VRes: {}".format(self.v_res),
+                   "Level: {}".format(self.level)]
+        return '\n'.join(output)
 
     def __str__(self):
         return self.__repr__()
@@ -220,20 +185,21 @@ _dll.openmc_id_map.errcheck = _error_handler
 def id_map(plot):
     """
     Generate a 2-D map of (cell_id, material_id). Used for in-memory image
-         generation.
+    generation.
 
     Parameters
     ----------
-    plot : An openmc.capi.plot._PlotBase object describing the slice of the
-           model to be generated
+    plot : An openmc.capi.plot._PlotBase
+        Object describing the slice of the model to be generated
 
     Returns
     -------
-    id_map : a NumPy array with shape (vertical pixels, horizontal pixels, 2)
-             of OpenMC property ids with dtype int32
+    id_map : numpy.ndarray
+        A NumPy array with shape (vertical pixels, horizontal pixels, 2) of
+        OpenMC property ids with dtype int32
 
     """
-    img_data = np.zeros((plot.vRes, plot.hRes, 2),
+    img_data = np.zeros((plot.v_res, plot.h_res, 2),
                         dtype=np.dtype('int32'))
     _dll.openmc_id_map(POINTER(_PlotBase)(plot),
                        img_data.ctypes.data_as(POINTER(c_int32)))

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -41,7 +41,5 @@ _dll.openmc_id_map.restype = c_int
 
 def image_data_for_plot(plot):
     img_data = np.zeros((plot.pixels_[0], plot.pixels_[1], 2), dtype=np.dtype('int32'))
-    print(img_data[0,0])
     out = _dll.openmc_id_map(POINTER(_Plot)(plot), img_data.ctypes.data_as(POINTER(c_int32)))
-    print(img_data[0,0])
     return img_data

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -22,18 +22,11 @@ _RGBColor._fields_ = [('red', c_ushort),
 class _Plot(Structure):
     pass
 
-_Plot._fields_ = [('id_', c_int),
-                  ('type_', c_int),
-                  ('color_by_', c_int),
-                  ('origin_', _Position),
+_Plot._fields_ = [('origin_', _Position),
                   ('width_', _Position),
                   ('basis_', c_int),
                   ('pixels_', c_int*3),
-                  ('meshlines_width_', c_int),
-                  ('level_', c_int),
-                  ('index_meshlines_mesh_', c_int),
-                  ('meshlines_color_', _RGBColor),
-                  ('not_found_', _RGBColor)]
+                  ('level_', c_int)]
 
 
 _dll.openmc_id_map.argtypes= [POINTER(_Plot),]

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -178,6 +178,6 @@ _dll.openmc_id_map.restype = c_int
 _dll.openmc_id_map.errcheck = _error_handler
 
 def id_map(plot):
-    img_data = np.zeros((plot.pixels_[0], plot.pixels_[1], 2), dtype=np.dtype('int32'))
+    img_data = np.zeros((plot.pixels_[1], plot.pixels_[0], 2), dtype=np.dtype('int32'))
     out = _dll.openmc_id_map(POINTER(_Plot)(plot), img_data.ctypes.data_as(POINTER(c_int32)))
     return img_data

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -2,35 +2,177 @@ from ctypes import c_int, c_int32, c_double, c_ushort, POINTER, Structure
 
 from . import _dll
 from .core import _DLLGlobal
+from .error import _error_handler
 
 import numpy as np
 
+class _IntThree():
+    type_ = c_int*3
+    val_ = None
+    def __init__(self, vals=None):
+        if vals and iterable(vals) and all(vals == int):
+            self.val_ = type_(vals[0], vals[1], vals[2])
+        else:
+            raise ValueError("{} is not a valid object to construct IntThree.".format(vals))
+
+    def __str__(self):
+        return "({}, {}, {})".format(self.val_[0], self.val_[1], self.val_[2])
+
 class _Position(Structure):
-    pass
+    _fields_ = [('x', c_double),
+                ('y', c_double),
+                ('z', c_double)]
 
-_Position._fields_ = [('x', c_double),
-                      ('y', c_double),
-                      ('z', c_double)]
+    def __init__(self, vals=None):
+        if vals:
+            x = vals[0]
+            y = vals[1]
+            z = vals[2]
+        else:
+            x = 0.0
+            y = 0.0
+            z = 0.0
 
-class _RGBColor(Structure):
-    pass
+    @property
+    def x(self):
+        return self.x
 
-_RGBColor._fields_ = [('red', c_ushort),
-                      ('green', c_ushort),
-                      ('blue', c_ushort)]
+    @property
+    def y(self):
+        return self.y
+
+    @property
+    def z(self):
+        return self.z
+
+    @x.setter
+    def x(self, x_val):
+        assert(isinstance(x_val, float))
+        self.x = x_val
+
+    @y.setter
+    def y(self, y_val):
+        assert(isinstance(y_val, float))
+        self.y = y_val
+
+    @z.setter
+    def z(self, z_val):
+        assert(isinstance(z_val, float))
+        self.z = z_val
+
+    def __str__(self):
+        return "({}, {}, {})".format(self.x, self.y, self.z)
 
 class _Plot(Structure):
-    pass
+    _fields_ = [('origin_', _Position),
+                ('width_', _Position),
+                ('basis_', c_int),
+                ('pixels_', c_int*3),
+                ('level_', c_int)]
 
-_Plot._fields_ = [('origin_', _Position),
-                  ('width_', _Position),
-                  ('basis_', c_int),
-                  ('pixels_', c_int*3),
-                  ('level_', c_int)]
+    @property
+    def origin(self):
+        out = [self.origin_.x, self.origin_.y, self.origin_.z]
+        return [float(val) for val in out]
+
+    @property
+    def width(self):
+        return float(self.width_.x)
+
+    @property
+    def height(self):
+        return float(self.width_.y)
+
+    @property
+    def basis(self):
+        if self.basis_ == 1:
+            return 'xy'
+        elif self.basis_ == 2:
+            return 'xz'
+        elif self.basis_ == 3:
+            return 'yz'
+
+        raise ValueError("Plot basis {} is invalid".format(basis_))
+
+    @property
+    def hRes(self):
+        return self.pixels_[0]
+
+    @property
+    def vRes(self):
+        return self.pixels_[1]
+
+    @property
+    def level(self):
+        return int(self.level_)
+
+    @origin.setter
+    def origin(self, origin):
+        self.origin_.x = origin[0]
+        self.origin_.y = origin[1]
+        self.origin_.z = origin[2]
+
+    @width.setter
+    def width(self, width):
+        self.width_.x = width
+
+    @height.setter
+    def height(self, height):
+        self.width_.y = height
+
+    @basis.setter
+    def basis(self, basis):
+        if isinstance(basis, str):
+            valid_bases = ('xy', 'xz', 'yz')
+            if basis not in valid_bases:
+                raise ValueError("{} is not a valid plot basis.".format(basis))
+
+            if basis == 'xy':
+                self.basis_ = 1
+            elif basis == 'xz':
+                self.basis_ = 2
+            elif basis == 'yz':
+                self.basis_ = 3
+            return
+
+        if isinstance(basis, int):
+            valid_bases = (1, 2, 3)
+            if basis not in valid_bases:
+                raise ValueError("{} is not a valid plot basis.".format(basis))
+            self.basis_ = basis
+            return
+
+        raise ValueError("{} of type {} is an invalid plot basis".format(basis, type(basis)))
+
+    @hRes.setter
+    def hRes(self, hRes):
+        self.pixels_[0] = hRes
+
+    @vRes.setter
+    def vRes(self, vRes):
+        self.pixels_[1] = vRes
+
+    @level.setter
+    def level(self, level):
+        self.level_ = level
+
+    def __str__(self):
+        out_str = "-------"
+        out_str += "Plot:\n"
+        out_str += "-------"
+        out_str += "Origin: " + str(self.origin) + "\n"
+        out_str += "Width: " + str(self.width) + "\n"
+        out_str += "Height: " + str(self.height) + "\n"
+        out_str += "Basis: " + str(self.basis) + "\n"
+        out_str += "HRes: " + str(self.hRes) + "\n"
+        out_str += "VRes: " + str(self.vRes) + "\n"
+        out_str += "Level: " + str(self.level) + "\n"
+        return out_str
 
 
 _dll.openmc_id_map.argtypes= [POINTER(_Plot),]
 _dll.openmc_id_map.restype = c_int
+_dll.openmc_id_map.errcheck = _error_handler
 
 def image_data_for_plot(plot):
     img_data = np.zeros((plot.pixels_[0], plot.pixels_[1], 2), dtype=np.dtype('int32'))

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -1,14 +1,9 @@
-from ctypes import c_int, c_double, c_ushort, POINTER, Structure
+from ctypes import c_int, c_int32, c_double, c_ushort, POINTER, Structure
 
 from . import _dll
 from .core import _DLLGlobal
 
 import numpy as np
-
-_dll.openmc_get_image_data.argtypes = [c_int, c_int, c_int, c_int, c_int,
-                                       POINTER(c_double*3), c_double,
-                                       c_double, POINTER(c_double)]
-_dll.openmc_get_image_data.restype = c_double
 
 class _Position(Structure):
     pass
@@ -38,25 +33,15 @@ _Plot._fields_ = [('id_', c_int),
                   ('level_', c_int),
                   ('index_meshlines_mesh_', c_int),
                   ('meshlines_color_', _RGBColor),
-                  ('not_found_', _RGBColor),
-                  ('colors_', POINTER(_RGBColor))]
+                  ('not_found_', _RGBColor)]
 
 
-_dll.image_for_plot.argtypes= [POINTER(_Plot),]
-_dll.image_for_plot.restype = c_int
-
-def get_image_data():
-    origin = np.array([0.0, 0.0, 0.0])
-
-    val = np.array(1.0)
-
-    out = _dll.openmc_get_image_data(0, 0, 0, 0, 0, origin.ctypes.data_as(POINTER(c_double*3)), 0.0, 0.0, val.ctypes.data_as(POINTER(c_double)))
-    print(val)
-    return out
-
+_dll.openmc_id_map.argtypes= [POINTER(_Plot),]
+_dll.openmc_id_map.restype = c_int
 
 def image_data_for_plot(plot):
-    img_data = np.zeros((plot.pixels_[0], plot.pixels_[1], 3), dtype = float)
-
-    out = _dll.image_for_plot(POINTER(_Plot)(plot), img_data.ctypes.data_as(POINTER(c_double)))
+    img_data = np.zeros((plot.pixels_[0], plot.pixels_[1], 2), dtype=np.dtype('int32'))
+    print(img_data[0,0])
+    out = _dll.openmc_id_map(POINTER(_Plot)(plot), img_data.ctypes.data_as(POINTER(c_int32)))
+    print(img_data[0,0])
     return img_data

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -31,7 +31,7 @@ class _Position(Structure):
         elif idx == 2:
             return self.z
         else:
-            raise ValueError("{} index is invalid for _Position".format(idx))
+            raise IndexError("{} index is invalid for _Position".format(key))
 
     def __setitem__(self, idx, val):
         if idx == 0:
@@ -41,7 +41,7 @@ class _Position(Structure):
         elif idx == 2:
             self.z = val
         else:
-            raise ValueError("{} index is invalid for _Position".format(idx))
+            raise IndexError("{} index is invalid for _Position".format(idx))
 
     def __repr__(self):
         return "({}, {}, {})".format(self.x, self.y, self.z)

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -30,8 +30,8 @@ class _Position(Structure):
             return self.y
         elif idx == 2:
             return self.z
-
-        raise ValueError("{} index is invalid for _Position".format(idx))
+        else:
+            raise ValueError("{} index is invalid for _Position".format(idx))
 
     def __setitem__(self, idx, val):
         if idx == 0:
@@ -40,8 +40,8 @@ class _Position(Structure):
             self.y = val
         elif idx == 2:
             self.z = val
-
-        raise ValueError("{} index is invalid for _Position".format(idx))
+        else:
+            raise ValueError("{} index is invalid for _Position".format(idx))
 
     def __repr__(self):
         return "({}, {}, {})".format(self.x, self.y, self.z)

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -1,0 +1,62 @@
+from ctypes import c_int, c_double, c_ushort, POINTER, Structure
+
+from . import _dll
+from .core import _DLLGlobal
+
+import numpy as np
+
+_dll.openmc_get_image_data.argtypes = [c_int, c_int, c_int, c_int, c_int,
+                                       POINTER(c_double*3), c_double,
+                                       c_double, POINTER(c_double)]
+_dll.openmc_get_image_data.restype = c_double
+
+class _Position(Structure):
+    pass
+
+_Position._fields_ = [('x', c_double),
+                      ('y', c_double),
+                      ('z', c_double)]
+
+class _RGBColor(Structure):
+    pass
+
+_RGBColor._fields_ = [('red', c_ushort),
+                      ('green', c_ushort),
+                      ('blue', c_ushort)]
+
+class _Plot(Structure):
+    pass
+
+_Plot._fields_ = [('id_', c_int),
+                  ('type_', c_int),
+                  ('color_by_', c_int),
+                  ('origin_', _Position),
+                  ('width_', _Position),
+                  ('basis_', c_int),
+                  ('pixels_', c_int*3),
+                  ('meshlines_width_', c_int),
+                  ('level_', c_int),
+                  ('index_meshlines_mesh_', c_int),
+                  ('meshlines_color_', _RGBColor),
+                  ('not_found_', _RGBColor),
+                  ('colors_', POINTER(_RGBColor))]
+
+
+_dll.image_for_plot.argtypes= [POINTER(_Plot),]
+_dll.image_for_plot.restype = c_int
+
+def get_image_data():
+    origin = np.array([0.0, 0.0, 0.0])
+
+    val = np.array(1.0)
+
+    out = _dll.openmc_get_image_data(0, 0, 0, 0, 0, origin.ctypes.data_as(POINTER(c_double*3)), 0.0, 0.0, val.ctypes.data_as(POINTER(c_double)))
+    print(val)
+    return out
+
+
+def image_data_for_plot(plot):
+    img_data = np.zeros((plot.pixels_[0], plot.pixels_[1], 3), dtype = float)
+
+    out = _dll.image_for_plot(POINTER(_Plot)(plot), img_data.ctypes.data_as(POINTER(c_double)))
+    return img_data

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -70,6 +70,9 @@ class _Plot(Structure):
                 ('pixels_', c_int*3),
                 ('level_', c_int)]
 
+    def __init__(self):
+        self.level_ = -1
+
     @property
     def origin(self):
         out = [self.origin_.x, self.origin_.y, self.origin_.z]

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -210,7 +210,7 @@ class _Plot(Structure):
         return self.__repr__()
 
 
-_dll.openmc_id_map.argtypes= [POINTER(_Plot),]
+_dll.openmc_id_map.argtypes= [POINTER(_Plot),POINTER(c_int32)]
 _dll.openmc_id_map.restype = c_int
 _dll.openmc_id_map.errcheck = _error_handler
 
@@ -231,5 +231,6 @@ def id_map(plot):
 
     """
     img_data = np.zeros((plot.vRes, plot.hRes, 2), dtype=np.dtype('int32'))
+    print("Calling openmc id map")
     _dll.openmc_id_map(POINTER(_Plot)(plot), img_data.ctypes.data_as(POINTER(c_int32)))
     return img_data

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -177,7 +177,7 @@ _dll.openmc_id_map.argtypes= [POINTER(_Plot),]
 _dll.openmc_id_map.restype = c_int
 _dll.openmc_id_map.errcheck = _error_handler
 
-def image_data_for_plot(plot):
+def id_map(plot):
     img_data = np.zeros((plot.pixels_[0], plot.pixels_[1], 2), dtype=np.dtype('int32'))
     out = _dll.openmc_id_map(POINTER(_Plot)(plot), img_data.ctypes.data_as(POINTER(c_int32)))
     return img_data

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -26,8 +26,6 @@ class _Position(Structure):
     def __repr__(self):
         return "({}, {}, {})".format(self.x, self.y, self.z)
 
-    def __str__(self):
-        return self.__repr__()
 
 class _PlotBase(Structure):
     """A structure defining a 2-D geometry slice with underlying c-types
@@ -74,16 +72,15 @@ class _PlotBase(Structure):
 
     @property
     def origin(self):
-        out = [self.origin_.x, self.origin_.y, self.origin_.z]
-        return [float(val) for val in out]
+        return self.origin_
 
     @property
     def width(self):
-        return float(self.width_.x)
+        return self.width_.x
 
     @property
     def height(self):
-        return float(self.width_.y)
+        return self.width_.y
 
     @property
     def basis(self):
@@ -94,7 +91,7 @@ class _PlotBase(Structure):
         elif self.basis_ == 3:
             return 'yz'
 
-        raise ValueError("Plot basis {} is invalid".format(basis_))
+        raise ValueError("Plot basis {} is invalid".format(self.basis_))
 
     @property
     def h_res(self):
@@ -171,10 +168,7 @@ class _PlotBase(Structure):
                    "HRes: {}".format(self.h_res),
                    "VRes: {}".format(self.v_res),
                    "Level: {}".format(self.level)]
-        return '\n'.join(output)
-
-    def __str__(self):
-        return self.__repr__()
+        return '\n'.join(out_str)
 
 
 _dll.openmc_id_map.argtypes = [POINTER(_PlotBase), POINTER(c_int32)]
@@ -189,7 +183,7 @@ def id_map(plot):
 
     Parameters
     ----------
-    plot : An openmc.capi.plot._PlotBase
+    plot : openmc.capi.plot._PlotBase
         Object describing the slice of the model to be generated
 
     Returns

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -6,6 +6,7 @@ from .error import _error_handler
 
 import numpy as np
 
+
 class _Position(Structure):
     """Definition of an xyz location in space with underlying c-types
 
@@ -179,7 +180,8 @@ class _Slice(Structure):
             self.basis_ = basis
             return
 
-        raise ValueError("{} of type {} is an invalid plot basis".format(basis, type(basis)))
+        raise ValueError("{} of type {} is an"
+                         " invalid plot basis".format(basis, type(basis)))
 
     @hRes.setter
     def hRes(self, hRes):
@@ -194,7 +196,7 @@ class _Slice(Structure):
         self.level_ = level
 
     def __repr__(self):
-        out_str  = "-----\n"
+        out_str = "-----\n"
         out_str += "Plot:\n"
         out_str += "-----\n"
         out_str += "Origin: {}\n".format(self.origin)
@@ -210,19 +212,20 @@ class _Slice(Structure):
         return self.__repr__()
 
 
-_dll.openmc_id_map.argtypes= [POINTER(_Slice),POINTER(c_int32)]
+_dll.openmc_id_map.argtypes = [POINTER(_Slice), POINTER(c_int32)]
 _dll.openmc_id_map.restype = c_int
 _dll.openmc_id_map.errcheck = _error_handler
 
 
 def id_map(slice_view):
     """
-    Generate a 2-D map of (cell_id, material_id). Used for in-memory image generation.
+    Generate a 2-D map of (cell_id, material_id). Used for in-memory image
+         generation.
 
     Parameters
     ----------
-    plot : An openmc.capi.plot._Slice object describing the slice of the model to
-           be generated
+    plot : An openmc.capi.plot._Slice object describing the slice of the model
+           to be generated
 
     Returns
     -------
@@ -230,7 +233,8 @@ def id_map(slice_view):
              of OpenMC property ids with dtype int32
 
     """
-    img_data = np.zeros((slice_view.vRes, slice_view.hRes, 2), dtype=np.dtype('int32'))
-    print("Calling openmc id map")
-    _dll.openmc_id_map(POINTER(_Slice)(slice_view), img_data.ctypes.data_as(POINTER(c_int32)))
+    img_data = np.zeros((slice_view.vRes, slice_view.hRes, 2),
+                        dtype=np.dtype('int32'))
+    _dll.openmc_id_map(POINTER(_Slice)(slice_view),
+                       img_data.ctypes.data_as(POINTER(c_int32)))
     return img_data

--- a/openmc/capi/plot.py
+++ b/openmc/capi/plot.py
@@ -23,6 +23,16 @@ class _Position(Structure):
                 ('y', c_double),
                 ('z', c_double)]
 
+    def __getitem__(self, key):
+        if key == 0:
+            return self.x
+        elif key == 1:
+            return self.y
+        elif key == 2:
+            return self.z
+
+        raise ValueError("{} index is invalid for _Position".format(key))
+
     def __repr__(self):
         return "({}, {}, {})".format(self.x, self.y, self.z)
 

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -88,6 +88,19 @@ void read_plots_xml()
   }
 }
 
+void write_ids(xt::xtensor<int,2> ids) {
+
+  // create a binary file with ID information
+  std::string fname = "plot_ids.binary";
+  std::ofstream of;
+
+  of.open(fname);
+
+  for (auto id : ids) { of << id; }
+
+  of.close();
+}
+
 //==============================================================================
 // CREATE_PPM creates an image based on user input from a plots.xml <plot>
 // specification in the portable pixmap format (PPM)
@@ -104,6 +117,8 @@ void create_ppm(Plot pl)
 
   ImageData data;
   data.resize({width, height});
+  xt::xtensor<int, 2> ids;
+  ids.resize({width, height});
 
   int in_i, out_i;
   Position r;
@@ -150,6 +165,7 @@ void create_ppm(Plot pl)
       p.r()[in_i] = r[in_i] + in_pixel * x;
       position_rgb(p, pl, rgb, id);
       data(x,y) = rgb;
+      ids(x,y) = id;
     }
   }
 }
@@ -158,6 +174,9 @@ void create_ppm(Plot pl)
 
   // write ppm data to file
   output_ppm(pl, data);
+
+  // write ids to binary file
+  write_ids(ids);
 }
 
 void

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -988,7 +988,7 @@ extern "C" int openmc_id_map(const CPlot& pl, int* data_out) {
   double out_pixel = (pl.width_[1])/static_cast<double>(height);
 
   IDData data;
-  data.resize({width, height, 2});
+  data.resize({height, width, 2});
 
   int in_i, out_i;
   double xyz[3];
@@ -1039,15 +1039,15 @@ extern "C" int openmc_id_map(const CPlot& pl, int* data_out) {
       j = p.n_coord - 1;
       if (level >=0) {j = level + 1;}
       if (!found_cell) {
-        data(x,y,0) = -1;
-        data(x,y,1) = -1;
+        data(y,x,0) = -1;
+        data(y,x,1) = -1;
       } else {
         Cell *c = model::cells[p.coord[j].cell];
-        data(x,y,0) = c->id_;
+        data(y,x,0) = c->id_;
         if (c->type_ == FILL_UNIVERSE || p.material == MATERIAL_VOID) {
-          data(x,y,1) = -1;
+          data(y,x,1) = -1;
         } else {
-          data(x,y,1) = model::materials[p.material - 1]->id_;
+          data(y,x,1) = model::materials[p.material - 1]->id_;
         }
       }
     }

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -968,7 +968,7 @@ extern "C" int openmc_id_map(void* plot, int32_t* data_out) {
   double out_pixel = (plt->width_[1])/static_cast<double>(height);
 
   // size data array
-  IDData data;
+  IdData data;
   data.resize({height, width, 2});
 
   // setup basis indices and initial position centered on pixel

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -952,20 +952,20 @@ RGBColor random_color() {
   return {int(prn()*255), int(prn()*255), int(prn()*255)};
 }
 
-extern "C" int openmc_id_map(void* slice, int32_t* data_out) {
+extern "C" int openmc_id_map(void* plot, int32_t* data_out) {
 
-  auto sl = reinterpret_cast<Slice*>(slice);
-  if (!sl) {
+  auto plt = reinterpret_cast<PlotBase*>(plot);
+  if (!plt) {
     set_errmsg("Invalid slice pointer passed to openmc_id_map");
     return OPENMC_E_INVALID_ARGUMENT;
   }
 
-  size_t width = sl->pixels_[0];
-  size_t height = sl->pixels_[1];
+  size_t width = plt->pixels_[0];
+  size_t height = plt->pixels_[1];
 
   // get pixel size
-  double in_pixel = (sl->width_[0])/static_cast<double>(width);
-  double out_pixel = (sl->width_[1])/static_cast<double>(height);
+  double in_pixel = (plt->width_[0])/static_cast<double>(width);
+  double out_pixel = (plt->width_[1])/static_cast<double>(height);
 
   // size data array
   IDData data;
@@ -974,27 +974,27 @@ extern "C" int openmc_id_map(void* slice, int32_t* data_out) {
   // setup basis indices and initial position centered on pixel
   int in_i, out_i;
   double xyz[3];
-  switch(sl->basis_) {
+  switch(plt->basis_) {
   case PlotBasis::xy :
     in_i = 0;
     out_i = 1;
-    xyz[0] = sl->origin_[0] - sl->width_[0] / 2. + in_pixel / 2.;
-    xyz[1] = sl->origin_[1] + sl->width_[1] / 2. - out_pixel / 2.;
-    xyz[2] = sl->origin_[2];
+    xyz[0] = plt->origin_[0] - plt->width_[0] / 2. + in_pixel / 2.;
+    xyz[1] = plt->origin_[1] + plt->width_[1] / 2. - out_pixel / 2.;
+    xyz[2] = plt->origin_[2];
     break;
   case PlotBasis::xz :
     in_i = 0;
     out_i = 2;
-    xyz[0] = sl->origin_[0] - sl->width_[0] / 2. + in_pixel / 2.;
-    xyz[1] = sl->origin_[1];
-    xyz[2] = sl->origin_[2] + sl->width_[1] / 2. - out_pixel / 2.;
+    xyz[0] = plt->origin_[0] - plt->width_[0] / 2. + in_pixel / 2.;
+    xyz[1] = plt->origin_[1];
+    xyz[2] = plt->origin_[2] + plt->width_[1] / 2. - out_pixel / 2.;
     break;
   case PlotBasis::yz :
     in_i = 1;
     out_i = 2;
-    xyz[0] = sl->origin_[0];
-    xyz[1] = sl->origin_[1] - sl->width_[0] / 2. + in_pixel / 2.;
-    xyz[2] = sl->origin_[2] + sl->width_[1] / 2. - out_pixel / 2.;
+    xyz[0] = plt->origin_[0];
+    xyz[1] = plt->origin_[1] - plt->width_[0] / 2. + in_pixel / 2.;
+    xyz[2] = plt->origin_[2] + plt->width_[1] / 2. - out_pixel / 2.;
     break;
   }
 
@@ -1007,7 +1007,7 @@ extern "C" int openmc_id_map(void* slice, int32_t* data_out) {
   p.r() = xyz;
   p.u() = dir;
   p.coord_[0].universe = model::root_universe;
-  int level = sl->level_;
+  int level = plt->level_;
   int j{};
 
 #pragma omp for

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -1018,7 +1018,7 @@ extern "C" int openmc_id_map(const CPlot& pl, int* data_out) {
 
   double dir[3] = {0.5, 0.5, 0.5};
 
-  //#pragma omp parallel
+#pragma omp parallel
 {
   Particle p;
   p.initialize();
@@ -1028,7 +1028,7 @@ extern "C" int openmc_id_map(const CPlot& pl, int* data_out) {
   int level = pl.level_;
   int j{};
 
-  //#pragma omp for
+#pragma omp for
   for (int y = 0; y < height; y++) {
     p.coord[0].xyz[out_i] = xyz[out_i] - out_pixel * y;
     p.n_coord = 1;

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -954,7 +954,8 @@ RGBColor random_color() {
   return {int(prn()*255), int(prn()*255), int(prn()*255)};
 }
 
-extern "C" int openmc_id_map(const void* plot, int32_t* data_out) {
+extern "C" int openmc_id_map(const void* plot, int32_t* data_out)
+{
 
   auto plt = reinterpret_cast<const PlotBase*>(plot);
   if (!plt) {

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -88,15 +88,23 @@ void read_plots_xml()
   }
 }
 
-void write_ids(xt::xtensor<int,2> ids) {
+void
+write_ids(const Plot& pl, xt::xtensor<int,2> ids) {
 
   // create a binary file with ID information
   std::string fname = "plot_ids.binary";
   std::ofstream of;
 
-  of.open(fname);
-
-  for (auto id : ids) { of << id; }
+  of.open(fname, std::ios::binary);
+  of.write((char*) &(pl.pixels_[0]), sizeof(int));
+  of.write((char*) &(pl.pixels_[1]), sizeof(int));
+  of.write((char*) &(pl.width_[0]), sizeof(double));
+  of.write((char*) &(pl.width_[1]), sizeof(double));
+  for (int y = 0; y < pl.pixels_[1]; y++) {
+    for (int x = 0; x < pl.pixels_[0]; x++) {
+      of.write((char*) &(ids(x,y)), sizeof(int));
+    }
+  }
 
   of.close();
 }
@@ -176,7 +184,7 @@ void create_ppm(Plot pl)
   output_ppm(pl, data);
 
   // write ids to binary file
-  write_ids(ids);
+  write_ids(pl, ids);
 }
 
 void

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -408,7 +408,7 @@ def test_id_map(capi_init):
                              [(3, 3), (2, 2), (3, 3)]], dtype='int32')
 
     # create a plot object
-    s = openmc.capi.plot._Slice()
+    s = openmc.capi.plot._PlotBase()
     s.width = 1.26
     s.height = 1.26
     s.vRes = 3

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -403,9 +403,9 @@ def test_load_nuclide(capi_init):
 
 
 def test_id_map(capi_init):
-    expected_ids = np.array([[(3,3), (2,2), (3,3)],
-                             [(2,2), (1,1), (2,2)],
-                             [(3,3), (2,2), (3,3)]], dtype = 'int32')
+    expected_ids = np.array([[(3, 3), (2, 2), (3, 3)],
+                             [(2, 2), (1, 1), (2, 2)],
+                             [(3, 3), (2, 2), (3, 3)]], dtype='int32')
 
     # create a plot object
     s = openmc.capi.plot._Slice()
@@ -413,7 +413,7 @@ def test_id_map(capi_init):
     s.height = 1.26
     s.vRes = 3
     s.hRes = 3
-    s.origin = (0,0,0)
+    s.origin = (0.0, 0.0, 0.0)
     s.basis = 'xy'
     s.level = -1
 

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -400,3 +400,24 @@ def test_load_nuclide(capi_init):
     # load non-existent nuclide
     with pytest.raises(exc.DataError):
         openmc.capi.load_nuclide('Pu3')
+
+
+def test_id_map(capi_init):
+    expected_ids = np.array([[(3,3), (2,2), (3,3)],
+                             [(2,2), (1,1), (2,2)],
+                             [(3,3), (2,2), (3,3)]], dtype = 'int32')
+
+    # create a plot object
+    p = openmc.capi.plot._Plot()
+
+    p.width = 1.26
+    p.height = 1.26
+    p.vRes = 3
+    p.hRes = 3
+    p.origin = (0,0,0)
+    p.basis = 'xy'
+    p.level = -1
+
+    ids = openmc.capi.plot.id_map(p)
+    print(ids)
+    assert np.array_equal(expected_ids, ids)

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -411,8 +411,8 @@ def test_id_map(capi_init):
     s = openmc.capi.plot._PlotBase()
     s.width = 1.26
     s.height = 1.26
-    s.vRes = 3
-    s.hRes = 3
+    s.v_res = 3
+    s.h_res = 3
     s.origin = (0.0, 0.0, 0.0)
     s.basis = 'xy'
     s.level = -1

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -408,16 +408,14 @@ def test_id_map(capi_init):
                              [(3,3), (2,2), (3,3)]], dtype = 'int32')
 
     # create a plot object
-    p = openmc.capi.plot._Plot()
+    s = openmc.capi.plot._Slice()
+    s.width = 1.26
+    s.height = 1.26
+    s.vRes = 3
+    s.hRes = 3
+    s.origin = (0,0,0)
+    s.basis = 'xy'
+    s.level = -1
 
-    p.width = 1.26
-    p.height = 1.26
-    p.vRes = 3
-    p.hRes = 3
-    p.origin = (0,0,0)
-    p.basis = 'xy'
-    p.level = -1
-
-    ids = openmc.capi.plot.id_map(p)
-    print(ids)
+    ids = openmc.capi.plot.id_map(s)
     assert np.array_equal(expected_ids, ids)


### PR DESCRIPTION
This PR introduces a new function to the CAPI for returning a (N,M,2) array of cell and material ids, respectively, for a given slice through the geometry.

The motivation for this addition is an enhancement for the [OpenMC Plot GUI](https://youtu.be/zRsGYX6iKc8)  (created by @landonjmitchell) to add in-memory generation of geometry images, rather than a file read/write. Once this PR is in, the plot GUI will be moved to the openmc-dev org for further work.
