### PR TITLE
Using entity_by_index and correcting entries in surface map.

### DIFF
--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -182,6 +182,7 @@ class DAGCell : public Cell
 public:
   moab::DagMC* dagmc_ptr_;
   DAGCell();
+  int32_t dag_index_;
 
   bool contains(Position r, Direction u, int32_t on_surface) const;
 

--- a/include/openmc/surface.h
+++ b/include/openmc/surface.h
@@ -131,6 +131,8 @@ class DAGSurface : public Surface
 public:
   moab::DagMC* dagmc_ptr_;
   DAGSurface();
+  int32_t dag_index_;
+
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -601,7 +601,7 @@ std::pair<double, int32_t>
 DAGCell::distance(Position r, Direction u, int32_t on_surface) const
 {
   moab::ErrorCode rval;
-  moab::EntityHandle vol = dagmc_ptr_->entity_by_id(3, id_);
+  moab::EntityHandle vol = dagmc_ptr_->entity_by_index(3, model::cell_map[id_] + 1);
   moab::EntityHandle hit_surf;
   double dist;
   double pnt[3] = {r.x, r.y, r.z};
@@ -621,7 +621,7 @@ DAGCell::distance(Position r, Direction u, int32_t on_surface) const
 bool DAGCell::contains(Position r, Direction u, int32_t on_surface) const
 {
   moab::ErrorCode rval;
-  moab::EntityHandle vol = dagmc_ptr_->entity_by_id(3, id_);
+  moab::EntityHandle vol = dagmc_ptr_->entity_by_index(3, model::cell_map[id_] + 1);
 
   int result = 0;
   double pnt[3] = {r.x, r.y, r.z};
@@ -830,9 +830,9 @@ openmc_extend_cells(int32_t n, int32_t* index_start, int32_t* index_end)
 int32_t next_cell(DAGCell* cur_cell, DAGSurface* surf_xed)
 {
   moab::EntityHandle surf =
-    surf_xed->dagmc_ptr_->entity_by_id(2, surf_xed->id_);
+    surf_xed->dagmc_ptr_->entity_by_index(2, model::surface_map[surf_xed->id_] + 1);
   moab::EntityHandle vol =
-    cur_cell->dagmc_ptr_->entity_by_id(3, cur_cell->id_);
+    cur_cell->dagmc_ptr_->entity_by_index(3, model::cell_map[cur_cell->id_] + 1);
 
   moab::EntityHandle new_vol;
   cur_cell->dagmc_ptr_->next_vol(surf, vol, new_vol);

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -601,7 +601,7 @@ std::pair<double, int32_t>
 DAGCell::distance(Position r, Direction u, int32_t on_surface) const
 {
   moab::ErrorCode rval;
-  moab::EntityHandle vol = dagmc_ptr_->entity_by_index(3, model::cell_map[id_] + 1);
+  moab::EntityHandle vol = dagmc_ptr_->entity_by_index(3, dag_index_);
   moab::EntityHandle hit_surf;
   double dist;
   double pnt[3] = {r.x, r.y, r.z};
@@ -621,7 +621,7 @@ DAGCell::distance(Position r, Direction u, int32_t on_surface) const
 bool DAGCell::contains(Position r, Direction u, int32_t on_surface) const
 {
   moab::ErrorCode rval;
-  moab::EntityHandle vol = dagmc_ptr_->entity_by_index(3, model::cell_map[id_] + 1);
+  moab::EntityHandle vol = dagmc_ptr_->entity_by_index(3, dag_index_);
 
   int result = 0;
   double pnt[3] = {r.x, r.y, r.z};
@@ -830,9 +830,9 @@ openmc_extend_cells(int32_t n, int32_t* index_start, int32_t* index_end)
 int32_t next_cell(DAGCell* cur_cell, DAGSurface* surf_xed)
 {
   moab::EntityHandle surf =
-    surf_xed->dagmc_ptr_->entity_by_index(2, model::surface_map[surf_xed->id_] + 1);
+    surf_xed->dagmc_ptr_->entity_by_index(2, surf_xed->dag_index_);
   moab::EntityHandle vol =
-    cur_cell->dagmc_ptr_->entity_by_index(3, model::cell_map[cur_cell->id_] + 1);
+    cur_cell->dagmc_ptr_->entity_by_index(3, cur_cell->dag_index_);
 
   moab::EntityHandle new_vol;
   cur_cell->dagmc_ptr_->next_vol(surf, vol, new_vol);

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -138,7 +138,8 @@ void load_dagmc_geometry()
 
     // set cell ids using global IDs
     DAGCell* c = new DAGCell();
-    c->id_ = model::DAG->id_by_index(3, i+1);
+    c->dag_index_ = i+1;
+    c->id_ = model::DAG->id_by_index(3, c->dag_index_);
     c->dagmc_ptr_ = model::DAG;
     c->universe_ = dagmc_univ_id; // set to zero for now
     c->fill_ = C_NONE; // no fill, single universe
@@ -261,7 +262,8 @@ void load_dagmc_geometry()
 
     // set cell ids using global IDs
     DAGSurface* s = new DAGSurface();
-    s->id_ = model::DAG->id_by_index(2, i+1);
+    s->dag_index_ = i+1;
+    s->id_ = model::DAG->id_by_index(2, s->dag_index_);
     s->dagmc_ptr_ = model::DAG;
 
     // set BCs

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -303,7 +303,7 @@ void load_dagmc_geometry()
 
     // add to global array and map
     model::surfaces.emplace_back(s);
-    model::surface_map[s->id_] = s->id_;
+    model::surface_map[s->id_] = i;
   }
 
   return;

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -132,7 +132,7 @@ void create_ppm(Plot pl)
     break;
   }
 
-  Direction u {0.5, 0.5, 0.5};
+  Direction u {0.7071, 0.7071, 0.0};
 
   #pragma omp parallel
   {
@@ -837,7 +837,7 @@ void create_voxel(Plot pl)
   Position ll = pl.origin_ - pl.width_ / 2.;
 
   // allocate and initialize particle
-  Direction u {0.5, 0.5, 0.5};
+  Direction u {0.7071, 0.7071, 0.0};
   Particle p;
   p.r() = ll;
   p.u() = u;

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -241,7 +241,7 @@ double
 DAGSurface::distance(Position r, Direction u, bool coincident) const
 {
   moab::ErrorCode rval;
-  moab::EntityHandle surf = dagmc_ptr_->entity_by_id(2, id_);
+  moab::EntityHandle surf = dagmc_ptr_->entity_by_index(2, dag_index_);
   moab::EntityHandle hit_surf;
   double dist;
   double pnt[3] = {r.x, r.y, r.z};
@@ -256,7 +256,7 @@ Direction DAGSurface::normal(Position r) const
 {
   moab::ErrorCode rval;
   Direction u;
-  moab::EntityHandle surf = dagmc_ptr_->entity_by_id(2, id_);
+  moab::EntityHandle surf = dagmc_ptr_->entity_by_index(2, dag_index_);
   double pnt[3] = {r.x, r.y, r.z};
   double dir[3] = {u.x, u.y, u.z};
   rval = dagmc_ptr_->get_angle(surf, pnt, dir);
@@ -267,7 +267,7 @@ Direction DAGSurface::normal(Position r) const
 BoundingBox DAGSurface::bounding_box() const
 {
   moab::ErrorCode rval;
-  moab::EntityHandle surf = dagmc_ptr_->entity_by_id(2, id_);
+  moab::EntityHandle surf = dagmc_ptr_->entity_by_index(2, dag_index_);
   double min[3], max[3];
   rval = dagmc_ptr_->getobb(surf, min, max);
   MB_CHK_ERR_CONT(rval);


### PR DESCRIPTION
This PR updates uses `entity_by_index` lookups for volume handles in the DAGMC interface as they perform much better than the current `entity_by_id` lookups. I was going to use the `surface/cell_map`s to find these indices but I decided on adding an attribute to the `DAGMCSurface/Cell` classes to contain this 1-indexing to DAGMC-related code. @paulromano did just go through all the effort of removing those +1's after all...

I also replaced the direction values in `plot.cpp` with a normalized direction which was resulting in false negatives in DAGMC's `point_in_volume` method due to problems when trying to intersect that direction with triangles in the surface mesh.

Overall effects of this PR are significant improvement a significant improvement in tracking and plotting performance for CAD-based geometries and a fix to resulting images when plotting CAD-based geometries as well.