### PR TITLE
added more attributes to nuclide

### DIFF
--- a/openmc/nuclide.py
+++ b/openmc/nuclide.py
@@ -1,7 +1,7 @@
 import warnings
 
 import openmc.checkvalue as cv
-
+from openmc.data import ATOMIC_NUMBER, ATOMIC_SYMBOL, zam
 
 class Nuclide(str):
     """A nuclide that can be used in a material.
@@ -15,7 +15,14 @@ class Nuclide(str):
     ----------
     name : str
         Name of the nuclide, e.g. 'U235'
-
+    element_name : str
+        Name of the element, e.g. 'U'
+    protons : int
+        Number of the protons, e.g. 92
+    nucleons : int
+        Number of the nucleons, e.g. 235
+    neutrons : int
+        Number of neutrons, e.g. 143
     """
 
     def __new__(cls, name):
@@ -37,3 +44,19 @@ class Nuclide(str):
     @property
     def name(self):
         return self
+
+    @property
+    def element_name(self):
+        return ATOMIC_SYMBOL[zam(self)[0]]
+
+    @property
+    def protons(self):
+        return ATOMIC_NUMBER[self.element_name]
+
+    @property
+    def nucleons(self):
+        return zam(self)[1]
+
+    @property
+    def neutrons(self):
+        return zam(self)[1]-zam(self)[0]

--- a/openmc/nuclide.py
+++ b/openmc/nuclide.py
@@ -59,4 +59,4 @@ class Nuclide(str):
 
     @property
     def neutrons(self):
-        return zam(self)[1]-zam(self)[0]
+        return self.nucleons-self.protons

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -10,6 +10,25 @@ def test_attributes(uo2):
     assert uo2.id == 100
     assert uo2.depletable
 
+def test_nuclide_attributes():
+    test_nuclide = openmc.Nuclide('Li7')
+    assert test_nuclide.element_name == 'Li'
+    assert test_nuclide.name == 'Li7'
+    assert test_nuclide.nucleons == 7
+    assert test_nuclide.neutrons == 4
+    assert test_nuclide.protons == 3
+    test_nuclide = openmc.Nuclide('Co60m')
+    assert test_nuclide.element_name == 'Co'
+    assert test_nuclide.name == 'Co60m'
+    assert test_nuclide.nucleons == 60
+    assert test_nuclide.neutrons == 33
+    assert test_nuclide.protons == 27
+    test_nuclide = openmc.Nuclide('Ta180m')
+    assert test_nuclide.element_name == 'Ta'
+    assert test_nuclide.name == 'Ta180m'
+    assert test_nuclide.nucleons == 180
+    assert test_nuclide.neutrons == 107
+    assert test_nuclide.protons == 73
 
 def test_nuclides(uo2):
     """Test adding/removing nuclides."""


### PR DESCRIPTION
While I was having a look around the internal structure of openmc I noticed that there is some nice attributes in the openmc.data.py file. This PR is aimed at accessing some of these attributes through the openmc.Nuclide class.

Openmc.Nuclide can be created with a string such as 'U235' and currently has just a single attribute that returns the name. I was wondering if adding some additional attributes might be nice as they allow users to conveniently access information on the nuclide such as number of protons, neutrons, nucleons and the element name.

Thanks for considering this small PR, if the idea is welcome I am happy to add some more attributes to the openmc.element class in another PR.

I also added a few unit tests to check the expected attributes are returned.

Thanks

 