### PR TITLE
Speed up find_cell searches for geometries with many z-planes

### DIFF
--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -210,44 +210,9 @@ public:
   explicit UniversePartitioner(const Universe& univ);
 
   //! Return the list of cells that could contain the given coordinates.
-  const std::vector<int32_t>& get_cells(Position r, Direction u) const
-  {return get_cells(r, u, 0, surfs_.size()-1, (surfs_.size()-1)/2);}
+  const std::vector<int32_t>& get_cells(Position r, Direction u) const;
 
 private:
-  //! Perform a binary search for the given coordinates.
-  //
-  //! \param left The lower search bound of the `surfs_` vector
-  //! \param right The upper search bound of the `surfs_` vector
-  //! \param middle The index of the `Surface` to test against
-  const std::vector<int32_t>&
-    get_cells(Position r, Direction u, int left, int right, int middle) const
-  {
-    // Check the sense of the coordinates for the current surface.
-    auto i_surf = surfs_[middle];
-    const auto& surf = *model::surfaces[i_surf];
-    if (surf.sense(r, u)) {
-      // The coordinates lie in the positive halfspace.  Recurse if there are
-      // more surfaces to check.  Otherwise, return the cells on the positive
-      // side of this surface.
-      int right_leaf = right - (right - middle) / 2;
-      if (right_leaf != middle) {
-        return get_cells(r, u, middle+1, right, right_leaf);
-      } else {
-        return partitions_[middle+1];
-      }
-    } else {
-      // The coordinates lie in the negative halfspace.  Recurse if there are
-      // more surfaces to check.  Otherwise, return the cells on the negative
-      // side of this surface.
-      int left_leaf = left + (middle - left) / 2;
-      if (left_leaf != middle) {
-        return get_cells(r, u, left, middle-1, left_leaf);
-      } else {
-        return partitions_[middle];
-      }
-    }
-  }
-
   //! A sorted vector of indices to surfaces that partition the universe
   std::vector<int32_t> surfs_;
 

--- a/include/openmc/geometry_aux.h
+++ b/include/openmc/geometry_aux.h
@@ -10,11 +10,6 @@
 
 namespace openmc {
 
-extern int search_numerator1;
-extern int search_denominator1;
-extern int search_numerator2;
-extern int search_denominator2;
-
 void read_geometry_xml();
 
 //==============================================================================

--- a/include/openmc/geometry_aux.h
+++ b/include/openmc/geometry_aux.h
@@ -10,6 +10,11 @@
 
 namespace openmc {
 
+extern int search_numerator1;
+extern int search_denominator1;
+extern int search_numerator2;
+extern int search_denominator2;
+
 void read_geometry_xml();
 
 //==============================================================================

--- a/include/openmc/surface.h
+++ b/include/openmc/surface.h
@@ -220,8 +220,8 @@ public:
 
 class SurfaceZPlane : public PeriodicSurface
 {
-  double z0_;
 public:
+  double z0_;
   explicit SurfaceZPlane(pugi::xml_node surf_node);
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;

--- a/include/openmc/surface.h
+++ b/include/openmc/surface.h
@@ -180,7 +180,6 @@ public:
 
 class SurfaceXPlane : public PeriodicSurface
 {
-  double x0_;
 public:
   explicit SurfaceXPlane(pugi::xml_node surf_node);
   double evaluate(Position r) const;
@@ -190,6 +189,8 @@ public:
   bool periodic_translate(const PeriodicSurface* other, Position& r,
                           Direction& u) const;
   BoundingBox bounding_box() const;
+
+  double x0_;
 };
 
 //==============================================================================
@@ -200,7 +201,6 @@ public:
 
 class SurfaceYPlane : public PeriodicSurface
 {
-  double y0_;
 public:
   explicit SurfaceYPlane(pugi::xml_node surf_node);
   double evaluate(Position r) const;
@@ -210,6 +210,8 @@ public:
   bool periodic_translate(const PeriodicSurface* other, Position& r,
                           Direction& u) const;
   BoundingBox bounding_box() const;
+
+  double y0_;
 };
 
 //==============================================================================
@@ -221,7 +223,6 @@ public:
 class SurfaceZPlane : public PeriodicSurface
 {
 public:
-  double z0_;
   explicit SurfaceZPlane(pugi::xml_node surf_node);
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
@@ -230,6 +231,8 @@ public:
   bool periodic_translate(const PeriodicSurface* other, Position& r,
                           Direction& u) const;
   BoundingBox bounding_box() const;
+
+  double z0_;
 };
 
 //==============================================================================
@@ -240,7 +243,6 @@ public:
 
 class SurfacePlane : public PeriodicSurface
 {
-  double A_, B_, C_, D_;
 public:
   explicit SurfacePlane(pugi::xml_node surf_node);
   double evaluate(Position r) const;
@@ -250,6 +252,8 @@ public:
   bool periodic_translate(const PeriodicSurface* other, Position& r,
                           Direction& u) const;
   BoundingBox bounding_box() const;
+
+  double A_, B_, C_, D_;
 };
 
 //==============================================================================
@@ -261,13 +265,14 @@ public:
 
 class SurfaceXCylinder : public CSGSurface
 {
-  double y0_, z0_, radius_;
 public:
   explicit SurfaceXCylinder(pugi::xml_node surf_node);
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
+
+  double y0_, z0_, radius_;
 };
 
 //==============================================================================
@@ -279,13 +284,14 @@ public:
 
 class SurfaceYCylinder : public CSGSurface
 {
-  double x0_, z0_, radius_;
 public:
   explicit SurfaceYCylinder(pugi::xml_node surf_node);
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
+
+  double x0_, z0_, radius_;
 };
 
 //==============================================================================
@@ -297,13 +303,14 @@ public:
 
 class SurfaceZCylinder : public CSGSurface
 {
-  double x0_, y0_, radius_;
 public:
   explicit SurfaceZCylinder(pugi::xml_node surf_node);
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
+
+  double x0_, y0_, radius_;
 };
 
 //==============================================================================
@@ -315,13 +322,14 @@ public:
 
 class SurfaceSphere : public CSGSurface
 {
-  double x0_, y0_, z0_, radius_;
 public:
   explicit SurfaceSphere(pugi::xml_node surf_node);
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
+
+  double x0_, y0_, z0_, radius_;
 };
 
 //==============================================================================
@@ -333,13 +341,14 @@ public:
 
 class SurfaceXCone : public CSGSurface
 {
-  double x0_, y0_, z0_, radius_sq_;
 public:
   explicit SurfaceXCone(pugi::xml_node surf_node);
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
+
+  double x0_, y0_, z0_, radius_sq_;
 };
 
 //==============================================================================
@@ -351,13 +360,14 @@ public:
 
 class SurfaceYCone : public CSGSurface
 {
-  double x0_, y0_, z0_, radius_sq_;
 public:
   explicit SurfaceYCone(pugi::xml_node surf_node);
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
+
+  double x0_, y0_, z0_, radius_sq_;
 };
 
 //==============================================================================
@@ -369,13 +379,14 @@ public:
 
 class SurfaceZCone : public CSGSurface
 {
-  double x0_, y0_, z0_, radius_sq_;
 public:
   explicit SurfaceZCone(pugi::xml_node surf_node);
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
+
+  double x0_, y0_, z0_, radius_sq_;
 };
 
 //==============================================================================
@@ -386,14 +397,15 @@ public:
 
 class SurfaceQuadric : public CSGSurface
 {
-  // Ax^2 + By^2 + Cz^2 + Dxy + Eyz + Fxz + Gx + Hy + Jz + K = 0
-  double A_, B_, C_, D_, E_, F_, G_, H_, J_, K_;
 public:
   explicit SurfaceQuadric(pugi::xml_node surf_node);
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
   void to_hdf5_inner(hid_t group_id) const;
+
+  // Ax^2 + By^2 + Cz^2 + Dxy + Eyz + Fxz + Gx + Hy + Jz + K = 0
+  double A_, B_, C_, D_, E_, F_, G_, H_, J_, K_;
 };
 
 //==============================================================================

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -11,6 +11,8 @@
 #include "openmc/simulation.h"
 #include "openmc/surface.h"
 
+#include "openmc/geometry_aux.h"
+
 
 namespace openmc {
 
@@ -69,6 +71,7 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
   bool found = false;
   int32_t i_cell;
   if (neighbor_list) {
+    ++search_numerator1;
     for (auto it = neighbor_list->cbegin(); it != neighbor_list->cend(); ++it) {
       i_cell = *it;
 
@@ -80,6 +83,7 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
       Position r {p->r_local()};
       Direction u {p->u_local()};
       auto surf = p->surface_;
+      ++search_denominator1;
       if (model::cells[i_cell]->contains(r, u, surf)) {
         p->coord_[p->n_coord_-1].cell = i_cell;
         found = true;
@@ -88,8 +92,15 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
     }
 
   } else {
+    ++search_numerator2;
     int i_universe = p->coord_[p->n_coord_-1].universe;
-    const auto& cells {model::universes[i_universe]->cells_};
+    //const auto& cells {model::universes[i_universe]->cells_};
+    const auto& univ {*model::universes[i_universe]};
+    const auto& cells {
+      !univ.partitioner_ ?
+      model::universes[i_universe]->cells_
+      : univ.partitioner_->get_cells(p->r_local(), p->u_local())
+    };
     for (auto it = cells.cbegin(); it != cells.cend(); it++) {
       i_cell = *it;
 
@@ -101,6 +112,7 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
       Position r {p->r_local()};
       Direction u {p->u_local()};
       auto surf = p->surface_;
+      ++search_denominator2;
       if (model::cells[i_cell]->contains(r, u, surf)) {
         p->coord_[p->n_coord_-1].cell = i_cell;
         found = true;

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -11,8 +11,6 @@
 #include "openmc/simulation.h"
 #include "openmc/surface.h"
 
-#include "openmc/geometry_aux.h"
-
 
 namespace openmc {
 
@@ -71,7 +69,6 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
   bool found = false;
   int32_t i_cell;
   if (neighbor_list) {
-    ++search_numerator1;
     for (auto it = neighbor_list->cbegin(); it != neighbor_list->cend(); ++it) {
       i_cell = *it;
 
@@ -83,7 +80,6 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
       Position r {p->r_local()};
       Direction u {p->u_local()};
       auto surf = p->surface_;
-      ++search_denominator1;
       if (model::cells[i_cell]->contains(r, u, surf)) {
         p->coord_[p->n_coord_-1].cell = i_cell;
         found = true;
@@ -92,13 +88,11 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
     }
 
   } else {
-    ++search_numerator2;
     int i_universe = p->coord_[p->n_coord_-1].universe;
-    //const auto& cells {model::universes[i_universe]->cells_};
     const auto& univ {*model::universes[i_universe]};
     const auto& cells {
-      !univ.partitioner_ ?
-      model::universes[i_universe]->cells_
+      !univ.partitioner_
+      ? model::universes[i_universe]->cells_
       : univ.partitioner_->get_cells(p->r_local(), p->u_local())
     };
     for (auto it = cells.cbegin(); it != cells.cend(); it++) {
@@ -112,7 +106,6 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
       Position r {p->r_local()};
       Direction u {p->u_local()};
       auto surf = p->surface_;
-      ++search_denominator2;
       if (model::cells[i_cell]->contains(r, u, surf)) {
         p->coord_[p->n_coord_-1].cell = i_cell;
         found = true;

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -139,14 +139,13 @@ partition_universes()
       }
 
       // Partition the universe if there are more than 5 z-planes.  (Fewer than
-      // five is likely no worth it.)
+      // 5 is likely not worth it.)
       int n_zplanes = 0;
       for (auto i_surf : surf_inds) {
         if (dynamic_cast<const SurfaceZPlane*>(model::surfaces[i_surf].get())) {
           ++n_zplanes;
           if (n_zplanes > 5) {
-            univ->partitioner_ = std::make_unique<UniversePartitioner>(
-              UniversePartitioner(*univ));
+            univ->partitioner_ = std::make_unique<UniversePartitioner>(*univ);
             break;
           }
         }

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -23,11 +23,6 @@
 
 namespace openmc {
 
-int search_denominator1 {0};
-int search_numerator1 {0};
-int search_denominator2 {0};
-int search_numerator2 {0};
-
 void read_geometry_xml()
 {
 #ifdef DAGMC
@@ -126,6 +121,41 @@ adjust_indices()
 }
 
 //==============================================================================
+//! Partition some universes with many z-planes for faster find_cell searches.
+
+void
+partition_universes()
+{
+  // Iterate over universes with more than 10 cells.  (Fewer than 10 is likely
+  // not worth partitioning.)
+  for (const auto& univ : model::universes) {
+    if (univ->cells_.size() > 10) {
+      // Collect the set of surfaces in this universe.
+      std::unordered_set<int32_t> surf_inds;
+      for (auto i_cell : univ->cells_) {
+        for (auto token : model::cells[i_cell]->rpn_) {
+          if (token < OP_UNION) surf_inds.insert(std::abs(token) - 1);
+        }
+      }
+
+      // Partition the universe if there are more than 5 z-planes.  (Fewer than
+      // five is likely no worth it.)
+      int n_zplanes = 0;
+      for (auto i_surf : surf_inds) {
+        if (dynamic_cast<const SurfaceZPlane*>(model::surfaces[i_surf].get())) {
+          ++n_zplanes;
+          if (n_zplanes > 5) {
+            univ->partitioner_ = std::make_unique<UniversePartitioner>(
+              UniversePartitioner(*univ));
+            break;
+          }
+        }
+      }
+    }
+  }
+}
+
+//==============================================================================
 
 void
 assign_temperatures()
@@ -215,6 +245,7 @@ void finalize_geometry(std::vector<std::vector<double>>& nuc_temps,
   // Perform some final operations to set up the geometry
   adjust_indices();
   count_cell_instances(model::root_universe);
+  partition_universes();
 
   // Assign temperatures to cells that don't have temperatures already assigned
   assign_temperatures();
@@ -224,28 +255,6 @@ void finalize_geometry(std::vector<std::vector<double>>& nuc_temps,
 
   // Determine number of nested coordinate levels in the geometry
   model::n_coord_levels = maximum_levels(model::root_universe);
-
-  for (const auto& univ : model::universes) {
-    if (univ->cells_.size() > 10) {
-      std::unordered_set<int32_t> surf_inds;
-      for (auto i_cell : univ->cells_) {
-        for (auto token : model::cells[i_cell]->rpn_) {
-          if (token < OP_UNION) surf_inds.insert(std::abs(token) - 1);
-        }
-      }
-      int n_zplanes = 0;
-      for (auto i_surf : surf_inds) {
-        if (dynamic_cast<const SurfaceZPlane*>(model::surfaces[i_surf].get())) {
-          ++n_zplanes;
-          if (n_zplanes > 5) {
-            univ->partitioner_ = std::make_unique<UniversePartitioner>(
-              UniversePartitioner(*univ));
-            break;
-          }
-        }
-      }
-    }
-  }
 }
 
 //==============================================================================
@@ -546,8 +555,6 @@ maximum_levels(int32_t univ)
 void
 free_memory_geometry()
 {
-  std::cout << "SEARCH EFFICIENCY = " << static_cast<double>(search_numerator1) / search_denominator1 << "\n";
-  std::cout << "SEARCH EFFICIENCY = " << static_cast<double>(search_numerator2) / search_denominator2 << "\n";
   model::cells.clear();
   model::cell_map.clear();
 


### PR DESCRIPTION
This PR is aimed at speeding up multiphysics calculations that typically cut the geometry up with a bunch of z-planes.  Neighbor lists cannot be used when crossing lattice and universe boundaries which results in a very expensive search with finely discretized models.  This PR cuts down the cost of those `find_cell`s by performing a binary search on the z-planes.  After the binary search, the code can just check the small list of cells that can be found between the two bounding planes.

I did a timing test on my quarter-assembly multiphysics model with 37 axial regions.  When combined with #1208, I see a 60% increase in the neutrons per second.

There is also a ton of improvements we can make later to build off of this PR.
* Right now it only considers z-planes, but it is natural to extend the work to the other planes, cylinders, and spheres.
* This code can be further optimized by better handling cells that do not contain z-planes.  Currently those cells are added to all of the possible search outputs, e.g. the code doesn't check to see if a spherical cell is contained between a subset of the z-planes.
* In the future, we could also potentially have the code automatically detect universes with many cells (such as TRISO compacts) and add fake surfaces that aren't used in any region specifications but accelerate the searches.