### PR TITLE
Speeding up import of transport corrected cross sections

### DIFF
--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -3926,7 +3926,7 @@ class ScatterMatrixXS(MatrixMGXS):
                         # to match scattering matrix shape for tally arithmetic
                         energy_filter = copy.deepcopy(energy_filter)
                         scatter_p1 = \
-                            scatter_p1.diagonalize_filter(energy_filter)
+                            scatter_p1.diagonalize_filter(energy_filter, 1)
 
                         self._rxn_rate_tally = scatter_p0 - scatter_p1
 
@@ -4022,7 +4022,7 @@ class ScatterMatrixXS(MatrixMGXS):
                     # to match scattering matrix shape for tally arithmetic
                     energy_filter = flux.find_filter(openmc.EnergyFilter)
                     energy_filter = copy.deepcopy(energy_filter)
-                    scatter_p1 = scatter_p1.diagonalize_filter(energy_filter)
+                    scatter_p1 = scatter_p1.diagonalize_filter(energy_filter, 1)
 
                     # Compute the trasnport correction term
                     correction = scatter_p1 / flux

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -2964,7 +2964,7 @@ class Tally(IDManagerMixin):
         tally_avg.sparse = self.sparse
         return tally_avg
 
-    def diagonalize_filter(self, new_filter):
+    def diagonalize_filter(self, new_filter, filter_position=-1):
         """Diagonalize the tally data array along a new axis of filter bins.
 
         This is a helper method for the tally arithmetic methods. This method
@@ -2979,6 +2979,9 @@ class Tally(IDManagerMixin):
         ----------
         new_filter : Filter
             The filter along which to diagonalize the data in the new
+        filter_position : int
+            Where to place the new filter in the Tally.filters list. Defaults
+            to last position.
 
         Returns
         -------
@@ -2988,6 +2991,7 @@ class Tally(IDManagerMixin):
         """
 
         cv.check_type('new_filter', new_filter, _FILTER_CLASSES)
+        cv.check_type('filter_position', filter_position, Integral)
 
         if new_filter in self.filters:
             msg = 'Unable to diagonalize Tally ID="{0}" which already ' \
@@ -2996,7 +3000,7 @@ class Tally(IDManagerMixin):
 
         # Add the new filter to a copy of this Tally
         new_tally = copy.deepcopy(self)
-        new_tally.filters.append(new_filter)
+        new_tally.filters.insert(filter_position, new_filter)
 
         # Determine "base" indices along the new "diagonal", and the factor
         # by which the "base" indices should be repeated to account for all


### PR DESCRIPTION
Currently, when performing the P0 transport correction, we're subtracting the correction tally from the scattering matrix tally 
The filter orders are :
Scattering matrix : Cell, Energy, Energy out, Legendre
Correction : Cell, Energy out, Legendre, adding Energy in last with diagonalize_filter
Which leads to a couple of calls to swap_filters when doing the substration (to get the same order in both tallies) which are rather slow. For 25 cells and 70 energy groups it takes like 100 seconds

This PR changes the order to Cell, Energy, Energy out, Legendre for the correction term, leading to much faster (~3-5 fold) loading of cross sections
