### PR TITLE
Add openmc_cell_get_temperature method. 

### DIFF
--- a/docs/source/capi/index.rst
+++ b/docs/source/capi/index.rst
@@ -73,6 +73,17 @@ Functions
    :return: Return status (negative if an error occurred)
    :rtype: int
 
+.. c:function:: int openmc_cell_get_temperature(int32_t index, const int32_t* instance, double* T)
+
+   Get the temperature of a cell
+
+   :param int32_t index: Index in the cells array
+   :param int32_t* instance: Which instance of the cell. If a null pointer is passed, the temperature
+                             of the first instance is returned.
+   :param double* T: temperature of the cell
+   :return: Return status (negative if an error occurred)
+   :rtype: int
+
 .. c:function:: int openmc_cell_set_fill(int32_t index, int type, int32_t n, const int32_t* indices)
 
    Set the fill for a cell

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -13,6 +13,7 @@ extern "C" {
   int openmc_cell_filter_get_bins(int32_t index, int32_t** cells, int32_t* n);
   int openmc_cell_get_fill(int32_t index, int* type, int32_t** indices, int32_t* n);
   int openmc_cell_get_id(int32_t index, int32_t* id);
+  int openmc_cell_get_temperature(int32_t index, const int32_t* instance, double* T);
   int openmc_cell_set_fill(int32_t index, int type, int32_t n, const int32_t* indices);
   int openmc_cell_set_id(int32_t index, int32_t id);
   int openmc_cell_set_temperature(int32_t index, double T, const int32_t* instance);

--- a/openmc/capi/cell.py
+++ b/openmc/capi/cell.py
@@ -24,6 +24,10 @@ _dll.openmc_cell_get_fill.argtypes = [
     c_int32, POINTER(c_int), POINTER(POINTER(c_int32)), POINTER(c_int32)]
 _dll.openmc_cell_get_fill.restype = c_int
 _dll.openmc_cell_get_fill.errcheck = _error_handler
+_dll.openmc_cell_get_temperature.argtypes = [
+    c_int32, POINTER(c_int32), POINTER(c_double)]
+_dll.openmc_cell_get_temperature.restype = c_int
+_dll.openmc_cell_get_temperature.errcheck = _error_handler
 _dll.openmc_cell_set_fill.argtypes = [
     c_int32, c_int, c_int32, POINTER(c_int32)]
 _dll.openmc_cell_set_fill.restype = c_int
@@ -127,6 +131,23 @@ class Cell(_FortranObjectWithID):
         elif fill is None:
             indices = (c_int32*1)(-1)
             _dll.openmc_cell_set_fill(self._index, 1, 1, indices)
+
+    def get_temperature(self, instance=None):
+        """Get the temperature of a cell
+
+        Parameters
+        ----------
+        instance: int or None
+            Which instance of the cell
+
+        """
+
+        if instance is not None:
+          instance = c_int32(instance)
+
+        T = c_double()
+        _dll.openmc_cell_get_temperature(self._index, instance, T)
+        return T.value
 
     def set_temperature(self, T, instance=None):
         """Set the temperature of a cell

--- a/openmc/capi/cell.py
+++ b/openmc/capi/cell.py
@@ -143,7 +143,7 @@ class Cell(_FortranObjectWithID):
         """
 
         if instance is not None:
-          instance = c_int32(instance)
+            instance = c_int32(instance)
 
         T = c_double()
         _dll.openmc_cell_get_temperature(self._index, instance, T)
@@ -160,7 +160,11 @@ class Cell(_FortranObjectWithID):
             Which instance of the cell
 
         """
-        _dll.openmc_cell_set_temperature(self._index, T, c_int32(instance))
+
+        if instance is not None:
+            instance = c_int32(instance)
+
+        _dll.openmc_cell_set_temperature(self._index, T, instance)
 
 
 class _CellMapping(Mapping):

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -922,6 +922,36 @@ openmc_cell_set_temperature(int32_t index, double T, const int32_t* instance)
   return 0;
 }
 
+extern "C" int
+openmc_cell_get_temperature(int32_t index, const int32_t* instance, double* T)
+{
+  if (index < 0 || index >= model::cells.size()) {
+    strcpy(openmc_err_msg, "Index in cells array is out of bounds.");
+    return OPENMC_E_OUT_OF_BOUNDS;
+  }
+
+  Cell& c {*model::cells[index]};
+
+  if (c.sqrtkT_.size() < 1) {
+    strcpy(openmc_err_msg, "Cell temperature has not yet been set.");
+    return OPENMC_E_UNASSIGNED;
+  }
+
+  if (instance) {
+    if (*instance >= 0 && *instance < c.n_instances_) {
+      double sqrtkT = c.sqrtkT_.size() == 1 ? c.sqrtkT_[0] : c.sqrtkT_[*instance];
+      *T = sqrtkT * sqrtkT / K_BOLTZMANN;
+    } else {
+      strcpy(openmc_err_msg, "Distribcell instance is out of bounds.");
+      return OPENMC_E_OUT_OF_BOUNDS;
+    }
+  } else {
+    *T = c.sqrtkT_[0] * c.sqrtkT_[0] / K_BOLTZMANN;
+  }
+
+  return 0;
+}
+
 //! Return the index in the cells array of a cell with a given ID
 extern "C" int
 openmc_get_cell_index(int32_t id, int32_t* index)

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -75,6 +75,14 @@ def test_cell(capi_init):
     assert str(cell) == 'Cell[0]'
 
 
+def test_cell_temperature(capi_init):
+    cell = openmc.capi.cells[1]
+    cell.set_temperature(100.0, 0)
+    assert cell.get_temperature(0) == 100.0
+    cell.set_temperature(200)
+    assert cell.get_temperature() == 200.0
+
+
 def test_new_cell(capi_init):
     with pytest.raises(exc.AllocationError):
         openmc.capi.Cell(1)


### PR DESCRIPTION
Added method to query cell's temperature to inform multiphysics drivers of the initial temperature used in an OpenMC simulation.

I'm fairly new to the python API inner workings, so I more or less followed the pattern in `capi/cell.py`. Apologies if I missed anything!

Refs #1223