### PR TITLE
Fix for latest pip version

### DIFF
--- a/tools/ci/travis-install.sh
+++ b/tools/ci/travis-install.sh
@@ -23,7 +23,7 @@ fi
 python tools/ci/travis-install.py
 
 # Install Python API in editable mode
-pip install -e .[test,vtk]
+pip install --no-use-pep517 -e .[test,vtk]
 
 # For uploading to coveralls
 pip install coveralls


### PR DESCRIPTION
The latest version of `pip` doesn't allow for editable installs for projects with a `pyproject.toml` file due to potential confusion over which build system should be used if it is present. More details in [PEP 517](https://www.python.org/dev/peps/pep-0517/). 

Adding the `--no-use-pep517` flag to the `pip install` command allows us to ignore the `pyproject.toml` file and install as usual. @paulromano is going to elaborate more generally on our editable install on CI shortly.

Update: Editable install explanation in #1226 