### PR TITLE
Fix pip editable install on Travis CI (again...)

### DIFF
--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -439,7 +439,7 @@ class Plot(IDManagerMixin):
         string += '{: <16}=\t{}\n'.format('\tBasis', self._basis)
         string += '{: <16}=\t{}\n'.format('\tWidth', self._width)
         string += '{: <16}=\t{}\n'.format('\tOrigin', self._origin)
-        string += '{: <16}=\t{}\n'.format('\tPixels', self._origin)
+        string += '{: <16}=\t{}\n'.format('\tPixels', self._pixels)
         string += '{: <16}=\t{}\n'.format('\tColor by', self._color_by)
         string += '{: <16}=\t{}\n'.format('\tBackground', self._background)
         string += '{: <16}=\t{}\n'.format('\tMask components',

--- a/tools/ci/travis-install.sh
+++ b/tools/ci/travis-install.sh
@@ -23,7 +23,7 @@ fi
 python tools/ci/travis-install.py
 
 # Install Python API in editable mode
-pip install --no-use-pep517 -e .[test,vtk]
+pip install -e .[test,vtk]
 
 # For uploading to coveralls
 pip install coveralls


### PR DESCRIPTION
Seems like the pip folks can't make up their minds. A new release came out yesterday that changed pip such that you don't need to specify `--no-use-pep517` when doing an editable install. So, I've reverted our travis install script to what it was before. I noticed this when I saw that that the tests on #1224 were failing.