### PR TITLE
Add coverage of c++ source files using cpp-coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,5 +53,5 @@ before_script:
 script:
   - ./tools/ci/travis-script.sh
 after_success:
-  - cpp-coveralls --exclude-pattern "/usr/*" --dump cpp_cov.json
+  - cpp-coveralls --exclude-pattern "/usr/*" -e "build" --dump cpp_cov.json
   - coveralls --merge=cpp_cov.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,5 +53,5 @@ before_script:
 script:
   - ./tools/ci/travis-script.sh
 after_success:
-  - cpp-coveralls --exclude-pattern "/usr/*" -e "build" --dump cpp_cov.json
+  - cpp-coveralls -i src -i include --exclude-pattern "/usr/*" --dump cpp_cov.json
   - coveralls --merge=cpp_cov.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,5 @@ before_script:
 script:
   - ./tools/ci/travis-script.sh
 after_success:
-  - coveralls
+  - cpp-coveralls --exclude-pattern "/usr/*" --dump cpp_cov.json
+  - coveralls --merge=cpp_cov.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,10 @@ if(optimize)
   list(REMOVE_ITEM cxxflags -O2)
   list(APPEND cxxflags -O3)
 endif()
+if(coverage)
+  list(APPEND cxxflags --coverage)
+  list(APPEND ldflags --coverage)
+endif()
 
 # Show flags being used
 message(STATUS "OpenMC C++ flags: ${cxxflags}")

--- a/tools/ci/travis-install.py
+++ b/tools/ci/travis-install.py
@@ -48,6 +48,9 @@ def install(omp=False, mpi=False, phdf5=False, dagmc=False):
     if dagmc:
         cmake_cmd.append('-Ddagmc=ON')
 
+    # Build in coverage mode for coverage testing
+    cmake_cmd.append('-Dcoverage=on')
+
     # Build and install
     cmake_cmd.append('..')
     print(' '.join(cmake_cmd))

--- a/tools/ci/travis-install.sh
+++ b/tools/ci/travis-install.sh
@@ -25,5 +25,8 @@ python tools/ci/travis-install.py
 # Install Python API in editable mode
 pip install -e .[test,vtk]
 
-# For uploading to coveralls
+# For coverage testing of the C++ source files
+pip install cpp-coveralls
+
+# For coverage testing of the Python source files
 pip install coveralls


### PR DESCRIPTION
Addresses issue #1229

This PR uses cpp-coveralls, [github repo](https://github.com/eddyxu/cpp-coveralls), an open source library for C++ code coverage, to generate a code coverage report than coveralls-python can read and merge into the Python coverage repo.

An alternate way of doing this is outlined in #1229