### PR TITLE
Read depletion_chain information from main cross section file

### DIFF
--- a/openmc/data/library.py
+++ b/openmc/data/library.py
@@ -1,5 +1,6 @@
 import os
 import xml.etree.ElementTree as ET
+import pathlib
 
 import h5py
 
@@ -48,19 +49,20 @@ class DataLibrary(EqualityMixin):
 
         Parameters
         ----------
-        filename : str
+        filename : str or Path
             Path to the file to be registered.
 
         """
-        # Support pathlib
-        # TODO: Remove when support is Python 3.6+ only
-        filename = str(filename)
+        if not isinstance(filename, pathlib.Path):
+            path = pathlib.Path(filename)
+        else:
+            path = filename
 
-        with h5py.File(filename, 'r') as h5file:
+        with h5py.File(path, 'r') as h5file:
             filetype = h5file.attrs['filetype'].decode()[5:]
             materials = list(h5file)
 
-        library = {'path': filename, 'type': filetype, 'materials': materials}
+        library = {'path': path.name, 'type': filetype, 'materials': materials}
         self.libraries.append(library)
 
     def export_to_xml(self, path='cross_sections.xml'):

--- a/openmc/data/library.py
+++ b/openmc/data/library.py
@@ -72,7 +72,7 @@ class DataLibrary(EqualityMixin):
                 "File type {} not supported by {}"
                 .format(path.name, self.__class__.__name__))
 
-        library = {'path': path.name, 'type': filetype, 'materials': materials}
+        library = {'path': str(path), 'type': filetype, 'materials': materials}
         self.libraries.append(library)
 
     def export_to_xml(self, path='cross_sections.xml'):
@@ -97,8 +97,10 @@ class DataLibrary(EqualityMixin):
             dir_element.text = os.path.realpath(common_dir)
 
         for library in self.libraries:
-            lib_element = ET.SubElement(root, "library")
-            if library['materials']:
+            if library['type'] == "depletion_chain":
+                lib_element = ET.SubElement(root, "depletion_chain")
+            else:
+                lib_element = ET.SubElement(root, "library")
                 lib_element.set('materials', ' '.join(library['materials']))
             lib_element.set('path', os.path.relpath(library['path'], common_dir))
             lib_element.set('type', library['type'])

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -80,7 +80,7 @@ class TransportOperator(metaclass=ABCMeta):
             else:
                 warn("Use of OPENMC_DEPLETE_CHAIN is deprecated in favor "
                      "of adding depletion_chain to OPENMC_CROSS_SECTIONS",
-                     DeprecationWarning)
+                     FutureWarning)
         self.chain = Chain.from_xml(chain_file)
 
     @abstractmethod

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -8,6 +8,8 @@ from collections import namedtuple
 import os
 from pathlib import Path
 from abc import ABCMeta, abstractmethod
+from xml.etree import ElementTree as ET
+from warnings import warn
 
 from .chain import Chain
 
@@ -43,8 +45,9 @@ class TransportOperator(metaclass=ABCMeta):
     Parameters
     ----------
     chain_file : str, optional
-        Path to the depletion chain XML file.  Defaults to the
-        :envvar:`OPENMC_DEPLETE_CHAIN` environment variable if it exists.
+        Path to the depletion chain XML file.  Defaults to the file
+        listed under ``depletion_chain`` in
+        :envvar:`OPENMC_CROSS_SECTIONS` environment variable.
 
     Attributes
     ----------
@@ -62,8 +65,23 @@ class TransportOperator(metaclass=ABCMeta):
         if chain_file is None:
             chain_file = os.environ.get("OPENMC_DEPLETE_CHAIN", None)
             if chain_file is None:
-                raise IOError("No chain specified, either manually or in "
-                              "environment variable OPENMC_DEPLETE_CHAIN.")
+                xs_file = os.environ.get("OPENMC_CROSS_SECTIONS", None)
+                if xs_file is None:
+                    raise IOError(
+                        "OPENMC_CROSS_SECTIONS environment variable "
+                        "not set.")
+                root = ET.parse(xs_file).getroot()
+                node = root.find("depletion_chain")
+                if node is None:
+                    raise IOError(
+                        "No chain specified, either manually or "
+                        "under depletion_chain in environment variable "
+                        "OPENMC_CROSS_SECTIONS.")
+                chain_file = node.get("path")
+            else:
+                warn("Use of OPENMC_DEPLETE_CHAIN is deprecated in favor "
+                     "of adding depletion_chain to OPENMC_CROSS_SECTIONS",
+                     DeprecationWarning)
         self.chain = Chain.from_xml(chain_file)
 
     @abstractmethod

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -68,7 +68,7 @@ class TransportOperator(metaclass=ABCMeta):
             if chain_file is None:
                 data = DataLibrary.from_xml()
                 # search for depletion_chain path from end of list
-                for lib in data.libraries[::-1]:
+                for lib in reversed(data.libraries):
                     if lib['type'] == 'depletion_chain':
                         break
                 else:

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -107,7 +107,8 @@ class Chain(object):
     yield sublibrary files. The depletion chain used during a depletion
     simulation is indicated by either an argument to
     :class:`openmc.deplete.Operator` or through the
-    :envvar:`OPENMC_DEPLETE_CHAIN` environment variable.
+    ``depletion_chain`` item in the :envvar:`OPENMC_CROSS_SECTIONS`
+    environment variable.
 
     Attributes
     ----------

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -64,8 +64,9 @@ class Operator(TransportOperator):
     settings : openmc.Settings
         OpenMC Settings object
     chain_file : str, optional
-        Path to the depletion chain XML file.  Defaults to the
-        :envvar:`OPENMC_DEPLETE_CHAIN` environment variable if it exists.
+        Path to the depletion chain XML file.  Defaults to the file
+        listed under ``depletion_chain`` in
+        :envvar:`OPENMC_CROSS_SECTIONS` environment variable.
     prev_results : ResultsList, optional
         Results from a previous depletion calculation. If this argument is
         specified, the depletion calculation will start from the latest state

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -135,7 +135,7 @@ class Model(object):
         chain_file : str, optional
             Path to the depletion chain XML file.  Defaults to the chain
             found under the ``depletion_chain`` in the
-            :envvar:`OPENMC_CROSS_SECITON` environment variable if it exists.
+            :envvar:`OPENMC_CROSS_SECTIONS` environment variable if it exists.
         method : str
              Integration method used for depletion (e.g., 'cecm', 'predictor')
         **kwargs

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -133,8 +133,9 @@ class Model(object):
             Array of timesteps in units of [s]. Note that values are not
             cumulative.
         chain_file : str, optional
-            Path to the depletion chain XML file.  Defaults to the
-            :envvar:`OPENMC_DEPLETE_CHAIN` environment variable if it exists.
+            Path to the depletion chain XML file.  Defaults to the chain
+            found under the ``depletion_chain`` in the
+            :envvar:`OPENMC_CROSS_SECITON` environment variable if it exists.
         method : str
              Integration method used for depletion (e.g., 'cecm', 'predictor')
         **kwargs

--- a/tests/unit_tests/test_deplete_operator.py
+++ b/tests/unit_tests/test_deplete_operator.py
@@ -1,0 +1,72 @@
+"""Basic unit tests for openmc.deplete.Operator instantiation
+
+Modifies and resets environment variable OPENMC_CROSS_SECTIONS
+to a custom file with new depletion_chain node
+"""
+
+from os import remove
+from os import environ
+from unittest import mock
+from pathlib import Path
+import pytest
+
+from openmc.deplete.abc import TransportOperator
+from openmc.deplete.chain import Chain
+
+BARE_XS_FILE = "bare_cross_sections.xml"
+CHAIN_PATH = Path().cwd() / "tests" / "chain_simple.xml"
+
+
+@pytest.fixture(scope="module")
+def bare_xs():
+    """Create a very basic cross_sections file, return simple Chain.
+
+    """
+
+    bare_xs_contents = """<?xml version="1.0"?>
+<cross_sections>
+  <depletion_chain path="{}" />
+</cross_sections>
+""".format(CHAIN_PATH)
+
+    with open(BARE_XS_FILE, "w") as out:
+        out.write(bare_xs_contents)
+
+    yield
+    remove(BARE_XS_FILE)
+
+
+class BareDepleteOperator(TransportOperator):
+    """Very basic class for testing the initialization."""
+
+    # declare abstract methods so object can be created
+    def __call__(self, *args, **kwargs):
+        pass
+
+    def initial_condition(self):
+        pass
+
+    def get_results_info(self):
+        pass
+
+
+@mock.patch.dict(environ, {"OPENMC_CROSS_SECTIONS": BARE_XS_FILE})
+def test_operator_init(bare_xs):
+    """The test will set and unset environment variable OPENMC_CROSS_SECTIONS
+    to point towards a temporary dummy file. This file will be removed
+    at the end of the test, and only contains a
+    depletion_chain node."""
+    # force operator to read from OPENMC_CROSS_SECTIONS
+    bare_op = BareDepleteOperator(chain_file=None)
+    act_chain = bare_op.chain
+    ref_chain = Chain.from_xml(CHAIN_PATH)
+    assert len(act_chain) == len(ref_chain)
+    for name in ref_chain.nuclide_dict:
+        # compare openmc.deplete.Nuclide objects
+        ref_nuc = ref_chain[name]
+        act_nuc = act_chain[name]
+        for prop in [
+                'name', 'half_life', 'decay_energy', 'reactions',
+                'decay_modes', 'yield_data', 'yield_energies',
+                ]:
+            assert getattr(act_nuc, prop) == getattr(ref_nuc, prop), prop

--- a/tests/unit_tests/test_deplete_operator.py
+++ b/tests/unit_tests/test_deplete_operator.py
@@ -4,21 +4,20 @@ Modifies and resets environment variable OPENMC_CROSS_SECTIONS
 to a custom file with new depletion_chain node
 """
 
-from os import remove
 from os import environ
 from unittest import mock
 from pathlib import Path
-import pytest
 
+import pytest
 from openmc.deplete.abc import TransportOperator
 from openmc.deplete.chain import Chain
 
 BARE_XS_FILE = "bare_cross_sections.xml"
-CHAIN_PATH = Path().cwd() / "tests" / "chain_simple.xml"
+CHAIN_PATH = Path(__file__).parents[1] / "chain_simple.xml"
 
 
-@pytest.fixture(scope="module")
-def bare_xs():
+@pytest.fixture()
+def bare_xs(run_in_tmpdir):
     """Create a very basic cross_sections file, return simple Chain.
 
     """
@@ -33,7 +32,6 @@ def bare_xs():
         out.write(bare_xs_contents)
 
     yield
-    remove(BARE_XS_FILE)
 
 
 class BareDepleteOperator(TransportOperator):


### PR DESCRIPTION
This PR closes #1239 by replacing the environment variable `OPENMC_DEPLETE_CHAIN` in favor of a `depletion_chain` node in the main `OPENMC_CROSS_SECTION` file. Unless a `chain_file` argument is directly passed when constructing an `openmc.deplete.Operator` object, the chain is created using this new default file. A `DeprecationWarning` is raised alerting the user to the change in behavior.

A unit test was added that makes a dummy `cross_sections.xml` file with this node, swaps the `OPENMC_CROSS_SECTION` environment variable to use this file, and creates a `Operator`. The depletion chain on this operator is that from `chain_simple.xml`, and is compared to a `Chain` created directly from this file.