### PR TITLE
modifications to allow one sided cones to live alongside dual sided cones

### DIFF
--- a/include/openmc/surface.h
+++ b/include/openmc/surface.h
@@ -341,6 +341,9 @@ public:
 
 class SurfaceXCone : public CSGSurface
 {
+  double x0_, y0_, z0_, radius_sq_;
+  double up_ = 0; // +1 up , -1 down ; dual sheet
+
 public:
   explicit SurfaceXCone(pugi::xml_node surf_node);
   double evaluate(Position r) const;
@@ -360,6 +363,9 @@ public:
 
 class SurfaceYCone : public CSGSurface
 {
+  double x0_, y0_, z0_, radius_sq_;
+  double up_ = 0; // +1 up , -1 down ; dual sheet
+
 public:
   explicit SurfaceYCone(pugi::xml_node surf_node);
   double evaluate(Position r) const;
@@ -379,6 +385,8 @@ public:
 
 class SurfaceZCone : public CSGSurface
 {
+  double x0_, y0_, z0_, radius_sq_;
+  double up_ = 0; // +1 up , -1 down ; dual sheet
 public:
   explicit SurfaceZCone(pugi::xml_node surf_node);
   double evaluate(Position r) const;


### PR DESCRIPTION
Hi all, again consider this a draft. This is what im thinking about cones, this hasnt really changed a lot for a few months. These changes allow MCNP likes cones to be supported, ie you can add an additional sign term +1/-1 to inside if one wants the up or down part of the sheet cone. 