### PR TITLE
Added method to get total material density. 

### DIFF
--- a/docs/source/capi/index.rst
+++ b/docs/source/capi/index.rst
@@ -335,6 +335,15 @@ Functions
    :return: Return status (negative if an error occurs)
    :rtype: int
 
+.. c:function:: int openmc_material_get_density(int32_t index, double* density)
+
+   Get density of a material.
+
+   :param int32_t index: Index in the materials array
+   :param double* denity: Pointer to a density
+   :return Return status (negative if an error occurs)
+   :rtype: int
+
 .. c:function:: int openmc_material_get_id(int32_t index, int32_t* id)
 
    Get the ID of a material

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -50,6 +50,7 @@ extern "C" {
   int openmc_material_get_densities(int32_t index, int** nuclides, double** densities, int* n);
   int openmc_material_get_id(int32_t index, int32_t* id);
   int openmc_material_get_fissionable(int32_t index, bool* fissionable);
+  int openmc_material_get_density(int32_t index, double* density);
   int openmc_material_get_volume(int32_t index, double* volume);
   int openmc_material_set_density(int32_t index, double density, const char* units);
   int openmc_material_set_densities(int32_t index, int n, const char** name, const double* density);

--- a/openmc/capi/material.py
+++ b/openmc/capi/material.py
@@ -32,6 +32,9 @@ _dll.openmc_material_get_densities.argtypes = [
     POINTER(c_int)]
 _dll.openmc_material_get_densities.restype = c_int
 _dll.openmc_material_get_densities.errcheck = _error_handler
+_dll.openmc_material_get_density.argtypes = [c_int32, POINTER(c_double)]
+_dll.openmc_material_get_density.restype = c_int
+_dll.openmc_material_get_density.errcheck = _error_handler
 _dll.openmc_material_get_volume.argtypes = [c_int32, POINTER(c_double)]
 _dll.openmc_material_get_volume.restype = c_int
 _dll.openmc_material_get_volume.errcheck = _error_handler
@@ -138,6 +141,15 @@ class Material(_FortranObjectWithID):
     def nuclides(self):
         return self._get_densities()[0]
         return nuclides
+
+    @property
+    def density(self):
+      density = c_double()
+      try:
+          _dll.openmc_material_get_density(self._index, density)
+      except OpenMCError:
+          return None
+      return density.value
 
     @property
     def densities(self):

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -1204,6 +1204,19 @@ openmc_material_get_densities(int32_t index, int** nuclides, double** densities,
 }
 
 extern "C" int
+openmc_material_get_density(int32_t index, double* density)
+{
+  if (index >= 0 && index < model::materials.size()) {
+    auto& mat = model::materials[index];
+    *density = mat->density_gpcc_;
+    return 0;
+  } else {
+    set_errmsg("Index in materials array is out of bounds.");
+    return OPENMC_E_OUT_OF_BOUNDS;
+  }
+}
+
+extern "C" int
 openmc_material_get_fissionable(int32_t index, bool* fissionable)
 {
   if (index >= 0 && index < model::materials.size()) {

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -120,6 +120,9 @@ def test_material(capi_init):
     m.set_density(rho)
     assert sum(m.densities) == pytest.approx(rho)
 
+    m.set_density(0.1, 'g/cm3')
+    assert m.density == pytest.approx(0.1)
+
 
 def test_new_material(capi_init):
     with pytest.raises(exc.AllocationError):


### PR DESCRIPTION
This MR adds `openmc_material_get_density` to get a cell's density in g/cm^3 so that a summation over the densities of its constituent nuclides can be hidden from a multiphysics driver than only needs to know the total density used.

Closes #1253