### PR TITLE
Fix complex cell geometry partitioning bug

### DIFF
--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -701,6 +701,13 @@ UniversePartitioner::UniversePartitioner(const Universe& univ)
   // Populate the partition lists.
   partitions_.resize(surfs_.size() + 1);
   for (auto i_cell : univ.cells_) {
+    // It is difficult to determine the bounds of a complex cell, so add complex
+    // cells to all partitions.
+    if (!model::cells[i_cell]->simple_) {
+      for (auto& p : partitions_) p.push_back(i_cell);
+      continue;
+    }
+
     // Find the tokens for bounding z-planes.
     int32_t lower_token = 0, upper_token = 0;
     double min_z, max_z;


### PR DESCRIPTION
I just realized that the #1210 changes will cause a bug for some complex cells.  When considering `~` and `|` operators and parenthetical groups it becomes much more difficult to determine the bounding z-planes of a region.  This PR avoids the bug by simply adding complex cells to all the partitions of a universe so that the complex cell is always checked in a `find_cell` search, regardless of it's z-planes.