### PR TITLE
Iterate over all libraries, not children, in Element.expand

### DIFF
--- a/openmc/element.py
+++ b/openmc/element.py
@@ -98,7 +98,7 @@ class Element(str):
             library_nuclides = set()
             tree = ET.parse(cross_sections)
             root = tree.getroot()
-            for child in root:
+            for child in root.findall('library'):
                 nuclide = child.attrib['materials']
                 if re.match(r'{}\d+'.format(self), nuclide) and \
                    '_m' not in nuclide:


### PR DESCRIPTION
After PR #1247, the cross section file is allowed to contain the depletion chain file. This is present as a new tag, of the form
```
   <depletion_chain path="path.xml" type="depletion_chain" />
```

The Element.expand method looked for `material` attributes in all children of the `OPENMC_CROSS_SECTION` file. This caused an error for the `depletion_chain` element, which does not have any `materials` attributes.

This error can be reproduced by removing the `chain_file` in `examples/python/pincell_depletion/run_depletion.py`

https://github.com/openmc-dev/openmc/blob/8555f914faad40097ce18cb5330006539e0d304d/examples/python/pincell_depletion/run_depletion.py#L132

triggering the change from #1247.

Now, only those children with the `library` tag are iterated over.