### PR TITLE
stop division by zero in keff trigger if no trigger given

### DIFF
--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -111,7 +111,7 @@ check_tally_triggers(double& ratio, int& tally_id, int& score)
 double
 check_keff_trigger()
 {
-  if (settings::run_mode != RUN_MODE_EIGENVALUE) return 0.;
+  if (settings::run_mode != RUN_MODE_EIGENVALUE) return 0.0;
 
   double k_combined[2];
   openmc_get_keff(k_combined);
@@ -127,8 +127,10 @@ check_keff_trigger()
   case TriggerMetric::relative_error:
     uncertainty = k_combined[1] / k_combined[0];
     break;
-  case TriggerMetric::not_active:
-    break;
+  default:
+    // If it's an unrecognized TriggerMetric or no keff trigger is on,
+    // return 0 to stop division by zero where "ratio" is calculated.
+    return 0.0;
   }
 
   double ratio = uncertainty / settings::keff_trigger.threshold;


### PR DESCRIPTION
Hi all,

I'm excited to work with OpenMC this fall. To introduce myself, I'm a graduate from UT Knoxville coming to CRPG, and according to Dr. Forget, I'm going to be working on CUDA Monte Carlo implemented in OpenMC, first with something similar to what Shift developers have accomplished then hopefully moving on to investigating some new algorithms.

Anyways, I have been playing with OpenMC on the dev branch and found a small bug that occurs if a keff trigger isn't set. If no trigger is set, division by zero occurs in check_keff_trigger() in tallies/trigger.cpp. This gets passed back to check_triggers(), which incorrectly interprets NaN as signalling that more power iterations should be done.

This can be reproduced by running examples/python/lattice/simple from the current develop branch. I think any case without a keff trigger will do it though. In fact, this case gives output that says a negative amount more power iterations is required after inactive cycles finish.

This PR fixes that with one extra line!