### PR TITLE
Check that hdf5 has MPI if performing depletion with MPI

### DIFF
--- a/openmc/deplete/__init__.py
+++ b/openmc/deplete/__init__.py
@@ -4,6 +4,9 @@ openmc.deplete
 
 A depletion front-end tool.
 """
+from sys import exit
+
+from h5py import get_config
 
 from .dummy_comm import DummyCommunicator
 
@@ -12,17 +15,14 @@ try:
 
     comm = MPI.COMM_WORLD
     have_mpi = True
-    # check if running with MPI and if hdf5 is MPI-enabled
-    from h5py import get_config
+    # check if running with MPI and if using parallel HDF5
 
     if not get_config().mpi and comm.size > 1:
         # Raise exception only on process 0
         if comm.rank:
-            from sys import exit
-
             exit()
         raise RuntimeError(
-            "Need MPI-enabled HDF5 install to perform depletion with MPI"
+            "Need parallel HDF5 installed to perform depletion with MPI"
         )
 except ImportError:
     comm = DummyCommunicator()

--- a/openmc/deplete/__init__.py
+++ b/openmc/deplete/__init__.py
@@ -6,10 +6,24 @@ A depletion front-end tool.
 """
 
 from .dummy_comm import DummyCommunicator
+
 try:
     from mpi4py import MPI
+
     comm = MPI.COMM_WORLD
     have_mpi = True
+    # check if running with MPI and if hdf5 is MPI-enabled
+    from h5py import get_config
+
+    if not get_config().mpi and comm.size > 1:
+        # Raise exception only on process 0
+        if comm.rank:
+            from sys import exit
+
+            exit()
+        raise RuntimeError(
+            "Need MPI-enabled HDF5 install to perform depletion with MPI"
+        )
 except ImportError:
     comm = DummyCommunicator()
     have_mpi = False


### PR DESCRIPTION
Check added in `openmc/depletion/__init__.py`. Without this check, the exporting of the `Results` to hdf5 will hang, as the second process attempts to write to a file that has already been opened on another process.

This error is only raised after a full transport calculation has been run. The check raises a more helpful error directly at the import from `openmc.deplete`, prior to transport calculations.