### PR TITLE
Add option in download() to appear as browser

### DIFF
--- a/openmc/_utils.py
+++ b/openmc/_utils.py
@@ -2,12 +2,12 @@ import hashlib
 import os.path
 from pathlib import Path
 from urllib.parse import urlparse
-from urllib.request import urlopen
+from urllib.request import urlopen, Request
 
 _BLOCK_SIZE = 16384
 
 
-def download(url, checksum=None, **kwargs):
+def download(url, checksum=None, as_browser=False, **kwargs):
     """Download file from a URL
 
     Parameters
@@ -16,7 +16,10 @@ def download(url, checksum=None, **kwargs):
         URL from which to download
     checksum : str or None
         MD5 checksum to check against
-    Keyword arguments passed to :func:urllib.request.urlopen
+    as_browser : bool
+        Change User-Agent header to appear as a browser
+    kwargs : dict
+        Keyword arguments passed to :func:urllib.request.urlopen
 
     Returns
     -------
@@ -24,7 +27,11 @@ def download(url, checksum=None, **kwargs):
         Name of file written locally
 
     """
-    req = urlopen(url, **kwargs)
+    if as_browser:
+        page = Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    else:
+        page = url
+    req = urlopen(page, **kwargs)
     # Get file size from header
     file_size = req.length
 


### PR DESCRIPTION
One of our data generation scripts need the ability to download from a URL with the request appearing as though it's coming from a browser (see https://github.com/openmc-dev/data/issues/6). This PR just adds an extra option to `download()` to allow that use case.