### PR TITLE
Add a litle tolerance for capture branching ratios

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -484,14 +484,9 @@ class Chain(object):
     def set_capture_branches(self, branch_ratios, strict=True):
         """Set the capture branching ratios
 
-        ``branch_ratios`` may be modified in place, only to
-        insert missing ground state reactions. These will be
-        inserted only if:
-
-            1) There is no branch directly to a ground state
-               target, and
-            2) The sum of all ratios on this branch does not
-               equal 1.
+        To provide a buffer around floating point precisions,
+        the sum of all branching ratios from a single parent
+        cannot be greater than 1.00001.
 
         Parameters
         ----------
@@ -568,7 +563,7 @@ class Chain(object):
             capt_ix_map[parent] = indexes
 
             this_sum = sum(sub.values())
-            check_less_than(parent + " ratios", this_sum, 1.0, True)
+            check_less_than(parent + " ratios", this_sum, 1.00001)
             sums[parent] = this_sum
 
         if len(missing_parents) > 0:


### PR DESCRIPTION
When adding capture branching ratios to a ``Chain``, the sum of ratios for a given parent nuclide was allowed to be no greater than 1.0. This limit is very tight, and does not allow
for minor floating point precision differences, like 1.0000000002.

The maximum value the sum of branching ratios from a single parent is now 1.00001, with no equality check. This has been added to the method docstring for transparency.

Some content was removed from the docstring that implied that ``branch_ratios`` would be modified in place. This is not the case, and thus the content was removed.