### PR TITLE
Allow user control over initial concentration for trace isotopes

### DIFF
--- a/docs/source/io_formats/depletion_results.rst
+++ b/docs/source/io_formats/depletion_results.rst
@@ -44,3 +44,10 @@ The current version of the depletion results file format is 1.0.
 **/reactions/<name>/**
 
 :Attributes: - **index** (*int*) -- Index user in results for this reaction
+
+.. note::
+
+    The reaction rates for some isotopes not originally present may
+    be non-zero, but should be negligible compared to other atoms.
+    This can be controlled by changing the
+    :class:`openmc.deplete.Operator` ``dilute_initial`` attribute.

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -76,6 +76,11 @@ class Operator(TransportOperator):
     fission_q : dict, optional
         Dictionary of nuclides and their fission Q values [eV]. If not given,
         values will be pulled from the ``chain_file``.
+    dilute_initial : float, optional
+        Initial atom density [atoms/cm^3] to add for nuclides that are zero
+        in initial condition to ensure they exist in the decay chain.
+        Only done for nuclides with reaction rates.
+        Defaults to 1.0e3.
 
     Attributes
     ----------
@@ -84,9 +89,9 @@ class Operator(TransportOperator):
     settings : openmc.Settings
         OpenMC settings object
     dilute_initial : float
-        Initial atom density to add for nuclides that are zero in initial
-        condition to ensure they exist in the decay chain. Only done for
-        nuclides with reaction rates. Defaults to 1.0e3.
+        Initial atom density [atoms/cm^3] to add for nuclides that
+        are zero in initial condition to ensure they exist in the decay
+        chain. Only done for nuclides with reaction rates.
     output_dir : pathlib.Path
         Path to output directory to save results.
     round_number : bool
@@ -110,11 +115,11 @@ class Operator(TransportOperator):
         Results from a previous depletion calculation
     diff_burnable_mats : bool
         Whether to differentiate burnable materials with multiple instances
-
     """
     def __init__(self, geometry, settings, chain_file=None, prev_results=None,
-                 diff_burnable_mats=False, fission_q=None):
-        super().__init__(chain_file, fission_q)
+                 diff_burnable_mats=False, fission_q=None,
+                 dilute_initial=1.0e3):
+        super().__init__(chain_file, fission_q, dilute_initial)
         self.round_number = False
         self.settings = settings
         self.geometry = geometry

--- a/openmc/deplete/results_list.py
+++ b/openmc/deplete/results_list.py
@@ -26,7 +26,15 @@ class ResultsList(list):
                 self.append(Results.from_hdf5(fh, i))
 
     def get_atoms(self, mat, nuc):
-        """Get nuclide concentration over time from a single material
+        """Get number of nuclides over time from a single material
+
+        .. note::
+
+            Initial values for some isotopes that do not appear in
+            initial concentrations may be non-zero, depending on the
+            value of :class:`openmc.deplete.Operator` ``dilute_initial``.
+            The :class:`openmc.deplete.Operator` adds isotopes according
+            to this setting, which can be set to zero.
 
         Parameters
         ----------
@@ -55,6 +63,14 @@ class ResultsList(list):
 
     def get_reaction_rate(self, mat, nuc, rx):
         """Get reaction rate in a single material/nuclide over time
+
+        .. note::
+
+            Initial values for some isotopes that do not appear in
+            initial concentrations may be non-zero, depending on the
+            value of :class:`openmc.deplete.Operator` ``dilute_initial``
+            The :class:`openmc.deplete.Operator` adds isotopes according
+            to this setting, which can be set to zero.
 
         Parameters
         ----------


### PR DESCRIPTION
Closes #1288 by allowing the user to specify the value of `dilute_initial`  when initializing an `Operator`. This value is allowed to be zero to instruct Openmc not to add any trace isotopes into the problem. The default value of 1000 atoms / cm^3 is left in place, but some documentation is added in the `ResultsList.get_atoms` methods and io format documentation about why some values may be non-zero for these trace isotopes. 

## Some discussion 

I ran some comparison tests on a quarter PWR assembly over the weekend without depletion, with the current dilution value of 1E-3 atoms/cm^3, and a value of zero initial trace concentration. The error in reactivity compared to the reference case at time zero was _slightly_ greater [8.56 pcm vs. 8.04 pcm] when using a dilution of 1E-3 atoms/cm. For comparison, the uncertainty from the steady state calculation was 18.8 pcm.

However, when you look at k over time, the presence of the trace isotopes makes a noticeable effect. The two figures below show how the system eigenvalue and Xe concentration change due to these settings.

![k-deplete](https://user-images.githubusercontent.com/19477741/61718798-4d150b80-ad29-11e9-929a-597d2c196d1f.png)

![xe](https://user-images.githubusercontent.com/19477741/61718814-54d4b000-ad29-11e9-85f9-4e4083a9dcab.png)

By adding the trace isotopes, we appear to be helping the xenon equilibrium, as the build up of initial xenon causes a sharp drop in k during the first depletion step. Once the system reaches or further approaches this equilibrium, we have good but not complete agreement. 

I bring this up to highlight the effect of the default setting, whatever it is. The operator is able to handle having a value of 0 for dilution, but I'm not sure how the xenon equilibrium feature [#1245] would fare. Looking over the methodology proposed in the M&C paper, one would have zero-valued xenon absorption cross section initially, but xenon is introduced during the equilibrium search anyway. I think openmc will cause errors if you construct a tally for a nuclide that doesn't exist in the problem.