### PR TITLE
Fix bug when reaction rate nuclides change through depletion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     - LD_LIBRARY_PATH=$HOME/MOAB/lib:$HOME/DAGMC/lib
     - PATH=$PATH:$HOME/NJOY2016/build
     - COVERALLS_PARALLEL=true
+    - NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=0
 matrix:
   include:
     - python: "3.5"

--- a/docs/source/pythonapi/deplete.rst
+++ b/docs/source/pythonapi/deplete.rst
@@ -87,7 +87,7 @@ The following classes are abstract classes that can be used to extend the
 :mod:`openmc.deplete` capabilities:
 
 .. autosummary::
-   :toctree:generated
+   :toctree: generated
    :nosignatures:
    :template: myclass.rst
 

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -177,9 +177,9 @@ class ReactionRateHelper(ABC):
     Parameters
     ----------
     n_nucs : int
+        Number of burnable nuclides tracked by :class:`openmc.deplete.Operator`
     n_react : int
-        Number of burnable nuclides and reactions tracked
-        by :class:`openmc.deplete.Operator`.
+        Number of reactions tracked by :class:`openmc.deplete.Operator`
 
     Attributes
     ----------

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -174,17 +174,23 @@ class ReactionRateHelper(ABC):
     Reaction rates are passed back to the operator for be used in
     an :class:`openmc.deplete.OperatorResult` instance
 
+    Parameters
+    ----------
+    n_nucs : int
+    n_react : int
+        Number of burnable nuclides and reactions tracked
+        by :class:`openmc.deplete.Operator`.
+
     Attributes
     ----------
     nuclides : list of str
-        All nuclides with desired reaction rates. Ordered to be
-        consistent with :class:`openmc.deplete.Operator`
+        All nuclides with desired reaction rates.
     """
 
-    def __init__(self):
+    def __init__(self, n_nucs, n_react):
         self._nuclides = None
         self._rate_tally = None
-        self._results_cache = None
+        self._results_cache = empty((n_nucs, n_react))
 
     @abstractmethod
     def generate_tallies(self, materials, scores):
@@ -200,17 +206,6 @@ class ReactionRateHelper(ABC):
         check_type("nuclides", nuclides, list, str)
         self._nuclides = nuclides
         self._rate_tally.nuclides = nuclides
-
-    def _get_results_cache(self, nnucs, nreact):
-        """Cache for results for a given material
-
-        Creates an empty array of shape ``(nnucs, nreact)``
-        if the shape does not match the current cache.
-        """
-        if (self._results_cache is None
-                or self._results_cache.shape != (nnucs, nreact)):
-            self._results_cache = empty((nnucs, nreact))
-        return self._results_cache
 
     @abstractmethod
     def get_material_rates(self, mat_id, nuc_index, react_index):
@@ -236,7 +231,6 @@ class ReactionRateHelper(ABC):
         ----------
         number : iterable of float
             Number density [atoms/b-cm] of each nuclide tracked in the calculation.
-            Ordered identically to :attr:`nuclides`
 
         Returns
         -------

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -16,11 +16,17 @@ from .abc import ReactionRateHelper, EnergyHelper
 class DirectReactionRateHelper(ReactionRateHelper):
     """Class that generates tallies for one-group rates
 
+    Parameters
+    ----------
+    n_nucs : int
+    n_react : int
+        Number of burnable nuclides and reactions tracked
+        by :class:`openmc.deplete.Operator`.
+
     Attributes
     ----------
     nuclides : list of str
-        All nuclides with desired reaction rates. Ordered to be
-        consistent with :class:`openmc.deplete.Operator`
+        All nuclides with desired reaction rates.
     """
 
     def generate_tallies(self, materials, scores):
@@ -61,14 +67,13 @@ class DirectReactionRateHelper(ReactionRateHelper):
             Array with shape ``(n_nuclides, n_rxns)`` with the
             reaction rates in this material
         """
-        results = self._get_results_cache(len(nuc_index), len(react_index))
-        results.fill(0.0)
+        self._results_cache.fill(0.0)
         full_tally_res = self._rate_tally.results[mat_id, :, 1]
         for i_tally, (i_nuc, i_react) in enumerate(
                 product(nuc_index, react_index)):
-            results[i_nuc, i_react] = full_tally_res[i_tally]
+            self._results_cache[i_nuc, i_react] = full_tally_res[i_tally]
 
-        return results
+        return self._results_cache
 
 
 # ----------------------------

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -19,9 +19,9 @@ class DirectReactionRateHelper(ReactionRateHelper):
     Parameters
     ----------
     n_nucs : int
+        Number of burnable nuclides tracked by :class:`openmc.deplete.Operator`
     n_react : int
-        Number of burnable nuclides and reactions tracked
-        by :class:`openmc.deplete.Operator`.
+        Number of reactions tracked by :class:`openmc.deplete.Operator`
 
     Attributes
     ----------

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -158,7 +158,8 @@ class Operator(TransportOperator):
             self.local_mats, self._burnable_nucs, self.chain.reactions)
 
         # Get classes to assist working with tallies
-        self._rate_helper = DirectReactionRateHelper()
+        self._rate_helper = DirectReactionRateHelper(
+            self.reaction_rates.n_nuc, self.reaction_rates.n_react)
         self._energy_helper = ChainFissionHelper()
 
     def __call__(self, vec, power, print_out=True):

--- a/openmc/model/funcs.py
+++ b/openmc/model/funcs.py
@@ -471,7 +471,7 @@ def pin(surfaces, items, subdivisions=None, divide_vols=True,
         to be divided. Will construct equal area rings
     divide_vols : bool
         If this evaluates to ``True``, then volumes of subdivided
-        :class:`openmc.Material`s will also be divided by the
+        :class:`openmc.Material` instances will also be divided by the
         number of divisions.  Otherwise the volume of the
         original material will not be modified before subdivision
     kwargs:


### PR DESCRIPTION
The size of the `Operator.reaction_rates` does not change through depletion, but the number of tallied nuclides for reaction rates may or may not. The `DirectReactionRateHelper` returns reaction rates according to the number of nuclides tallied, a potential subset of all nuclides designated as burnable by the `Operator`. This causes `IndexErrors` if a nuclide is not
tallied at a later step.

Example: 10 nuclides [0-9] are originally tracked by the `Operator` and tallied by `DirectReactionRateHelper`. The `Operator.reaction_rates` array will be of shape `(n_mat, 10, n_react)`. Initially, the `DirectReactionRateHelper` returns an array of size `(10, n_react)`
for each material. Then, if nuclide 5 is not in the list of nuclides passed to the `DirectReactionRateHelper` at the next step, [decayed to zero], `DirectReactionRateHelper` will return an array `(9, n_react)` and try to pass tally data for nuclide 9 into row 9 of the reaction rate
array, causing an `IndexError`. Even if the last index is removed and `get_material_rates` does not raise this Error, the resulting array will not be of compatible sizes with `Operator.reaction_rates`

This commit instructs requires two integers, `n_nucs and n_react`, to be passed to the initialization of any `ReactionRateHelper`, allocating a single array for storing material-reaction rates. The method get_material_rates uses this directly and does not re-allocate storage
if `len(nuc_index)` has changed [like if nuclide 9 has dropped out]. 