### PR TITLE
Add temperature check when setting cell temperatures

### DIFF
--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -126,6 +126,12 @@ namespace data {
 extern std::array<double, 2> energy_min;
 extern std::array<double, 2> energy_max;
 
+//! Minimum temperature in [K] that nuclide data is available at
+extern double temperature_min;
+
+//! Maximum temperature in [K] that nuclide data is available at
+extern double temperature_max;
+
 extern std::vector<std::unique_ptr<Nuclide>> nuclides;
 extern std::unordered_map<std::string, int> nuclide_map;
 

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -357,6 +357,12 @@ read_ce_cross_sections(const std::vector<std::vector<double>>& nuc_temps,
     }
   }
 
+  // Show minimum/maximum temperature
+  write_message("Minimum neutron data temperature: " +
+    std::to_string(data::temperature_min) + " K");
+  write_message("Maximum neutron data temperature: " +
+    std::to_string(data::temperature_max) + " K");
+
   // If the user wants multipole, make sure we found a multipole library.
   if (settings::temperature_multipole) {
     bool mp_found = false;

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -117,6 +117,8 @@ int openmc_finalize()
 
   data::energy_max = {INFTY, INFTY};
   data::energy_min = {0.0, 0.0};
+  data::temperature_min = 0.0;
+  data::temperature_max = INFTY;
   model::root_universe = -1;
   openmc::openmc_set_seed(DEFAULT_SEED);
 

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -18,7 +18,7 @@
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xview.hpp"
 
-#include <algorithm> // for sort
+#include <algorithm> // for sort, min_element
 #include <string> // for to_string, stoi
 
 namespace openmc {
@@ -30,6 +30,8 @@ namespace openmc {
 namespace data {
 std::array<double, 2> energy_min {0.0, 0.0};
 std::array<double, 2> energy_max {INFTY, INFTY};
+double temperature_min {0.0};
+double temperature_max {INFTY};
 std::vector<std::unique_ptr<Nuclide>> nuclides;
 std::unordered_map<std::string, int> nuclide_map;
 } // namespace data
@@ -153,6 +155,12 @@ Nuclide::Nuclide(hid_t group, const std::vector<double>& temperature, int i_nucl
 
   // Sort temperatures to read
   std::sort(temps_to_read.begin(), temps_to_read.end());
+
+  double T_min_read = *std::min_element(temps_to_read.cbegin(), temps_to_read.cend());
+  double T_max_read = *std::max_element(temps_to_read.cbegin(), temps_to_read.cend());
+
+  data::temperature_min = std::max(data::temperature_min, T_min_read);
+  data::temperature_max = std::min(data::temperature_max, T_max_read);
 
   hid_t energy_group = open_group(group, "energy");
   for (const auto& T : temps_to_read) {


### PR DESCRIPTION
One issue we've run into with coupled OpenMC-TH simulations is that there is no check on the temperatures being passed to OpenMC. If the temperature being passed to OpenMC is outside the range of the available data, it happily accepts it but then eventually segfaults somewhere in the cross section lookup when a temperature index doesn't make sense. This branch keeps track of the min/max temperature that is available in the data and then uses that when `Cell::set_temperature` is called to make sure the data is within range. Note that even with multipole data, we still generally do temperature interpolation outside the resolved resonance range, so this check is still necessary.

There are no tests yet because our test data set only has a single temperature. Once #1227 is addressed, we can add a test for this.

Closes #1292