### PR TITLE
Expose cells_size() to C-API.

### DIFF
--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -9,6 +9,7 @@
 extern "C" {
 #endif
 
+  int cells_size();
   int openmc_calculate_volumes();
   int openmc_cell_filter_get_bins(int32_t index, const int32_t** cells, int32_t* n);
   int openmc_cell_get_fill(int32_t index, int* type, int32_t** indices, int32_t* n);


### PR DESCRIPTION
To be able to loop over all OpenMC cells and check that all fissionable cells are accounted for in a T/H coupling mapping, we need to be able to access the `cells_size()` method from Enrico. Correct me if I'm wrong, but I think this needs to be added to do that?