### PR TITLE
Get rid of MPI_REAL8 in state_point.cpp

### DIFF
--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -742,7 +742,7 @@ void write_tally_results_nr(hid_t file_id)
     } else {
       // Receive buffer not significant at other processors
 #ifdef OPENMC_MPI
-      MPI_Reduce(values.data(), nullptr, values.size(), MPI_REAL8, MPI_SUM,
+      MPI_Reduce(values.data(), nullptr, values.size(), MPI_DOUBLE, MPI_SUM,
             0, mpi::intracomm);
 #endif
     }


### PR DESCRIPTION
Thanks to Cliff Dugal from CNL who pointed out that we have one instance of MPI_REAL8 in state_point.cpp that will prevent OpenMC from compiling if the MPI implementation was built without Fortran support.