### PR TITLE
Process non-fission heating from njoy

### DIFF
--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -813,9 +813,8 @@ class IncidentNeutron(EqualityMixin):
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             # Run NJOY to create an ACE library
-            kwargs.setdefault('ace', os.path.join(tmpdir, 'ace'))
-            kwargs.setdefault('xsdir', os.path.join(tmpdir, 'xsdir'))
-            kwargs.setdefault('pendf', os.path.join(tmpdir, 'pendf'))
+            for key in ["ace", "xsdir", "pendf", "heatr"]:
+                kwargs.setdefault(key, os.path.join(tmpdir, key))
             kwargs['evaluation'] = evaluation
             make_ace(filename, temperatures, **kwargs)
 

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -553,7 +553,7 @@ class IncidentNeutron(EqualityMixin):
             fer_group = group['fission_energy_release']
             data.fission_energy = FissionEnergyRelease.from_hdf5(fer_group)
 
-        # Rebuild fission-less heating
+        # Rebuild non-fission heating
         total_heating = data.reactions.get(301)
         fission_heating = data.reactions.get(318)
         if total_heating is not None and fission_heating is not None:
@@ -564,9 +564,7 @@ class IncidentNeutron(EqualityMixin):
                 if fission is None:
                     continue
                 non_fission_heating.xs[strT] = Tabulated1D(
-                    total.x, total.y - fission(total.x),
-                    breakpoints=total.breakpoints,
-                    interpolation=total.interpolation)
+                    total.x, total.y - fission(total.x))
             data.reactions[999] = non_fission_heating
 
         return data

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -453,7 +453,7 @@ class IncidentNeutron(EqualityMixin):
             if rx.redundant:
                 photon_rx = any(p.particle == 'photon' for p in rx.products)
                 keep_mts = (4, 16, 103, 104, 105, 106, 107,
-                            203, 204, 205, 206, 207, 301, 444)
+                            203, 204, 205, 206, 207, 301, 444, 999)
                 if not (photon_rx or rx.mt in keep_mts):
                     continue
 

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -815,14 +815,13 @@ class IncidentNeutron(EqualityMixin):
         with tempfile.TemporaryDirectory() as tmpdir:
             # Run NJOY to create an ACE library
             kwargs.setdefault("output_dir", tmpdir)
-            for key in ("ace", "xsdir", "pendf", "heatr", "broadr",
-                        "gaspr", "purr"):
+            for key in ("acer", "pendf", "heatr", "broadr", "gaspr", "purr"):
                 kwargs.setdefault(key, os.path.join(kwargs["output_dir"], key))
             kwargs['evaluation'] = evaluation
             make_ace(filename, temperatures, **kwargs)
 
             # Create instance from ACE tables within library
-            lib = Library(kwargs['ace'])
+            lib = Library(kwargs['acer'])
             data = cls.from_ace(lib.tables[0])
             for table in lib.tables[1:]:
                 data.add_temperature_from_ace(table)

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -633,6 +633,18 @@ class IncidentNeutron(EqualityMixin):
             rx = Reaction.from_ace(ace, i)
             data.reactions[rx.mt] = rx
 
+        # If present, use fission xs to compute "fission heating" coefficient
+        fission_reaction = data.reactions.get(18)
+        if fission_reaction is not None:
+            fission_xs = fission_reaction.xs[strT].y
+
+            # Compute "fission-less" heating coefficient
+            no_fission_heating = Reaction(999)
+            no_fission_heating.xs[strT] = Tabulated1D(
+                energy, heating_number * (total_xs - fission_xs))
+            no_fission_heating.redundant = True
+            data.reactions[999] = no_fission_heating
+
         # Some photon production reactions may be assigned to MTs that don't
         # exist, usually MT=4. In this case, we create a new reaction and add
         # them

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -815,8 +815,10 @@ class IncidentNeutron(EqualityMixin):
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             # Run NJOY to create an ACE library
-            for key in ["ace", "xsdir", "pendf", "heatr"]:
-                kwargs.setdefault(key, os.path.join(tmpdir, key))
+            kwargs.setdefault("output_dir", tmpdir)
+            for key in ("ace", "xsdir", "pendf", "heatr", "broadr",
+                        "gaspr", "purr"):
+                kwargs.setdefault(key, os.path.join(kwargs["output_dir"], key))
             kwargs['evaluation'] = evaluation
             make_ace(filename, temperatures, **kwargs)
 

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -556,17 +556,17 @@ class IncidentNeutron(EqualityMixin):
         total_heating = data.reactions.get(301)
         fission_heating = data.reactions.get(318)
         if total_heating is not None and fission_heating is not None:
-            fission_less_heating = Reaction(999)
-            fission_less_heating.redundant = True
+            non_fission_heating = Reaction(999)
+            non_fission_heating.redundant = True
             for strT, total in total_heating.xs.items():
                 fission = fission_heating.xs.get(strT)
                 if fission is None:
                     continue
-                fission_less_heating.xs[strT] = Tabulated1D(
+                non_fission_heating.xs[strT] = Tabulated1D(
                     total.x, total.y - fission(total.x),
                     breakpoints=total.breakpoints,
                     interpolation=total.interpolation)
-            data.reactions[999] = fission_less_heating
+            data.reactions[999] = non_fission_heating
 
         return data
 
@@ -847,8 +847,8 @@ class IncidentNeutron(EqualityMixin):
                     interpolation=fission_kerma.interpolation)
 
                 fission_heating = Reaction(318)
-                fission_less_heating = Reaction(999)
-                fission_less_heating.redundant = True
+                non_fission_heating = Reaction(999)
+                non_fission_heating.redundant = True
 
                 for strT, fission_xs in data.reactions[18].xs.items():
                     total_heating = data.reactions[301].xs.get(strT)
@@ -859,14 +859,14 @@ class IncidentNeutron(EqualityMixin):
                         breakpoints=fission_xs.breakpoints,
                         interpolation=fission_xs.interpolation)
                     fission_heating.xs[strT] = heater_at_temp
-                    fission_less_heating.xs[strT] = Tabulated1D(
+                    non_fission_heating.xs[strT] = Tabulated1D(
                         total_heating.x,
                         total_heating.y - heater_at_temp(total_heating.x),
                         breakpoints=total_heating.breakpoints,
                         interpolation=total_heating.interpolation)
 
                 data.reactions[318] = fission_heating
-                data.reactions[999] = fission_less_heating
+                data.reactions[999] = non_fission_heating
 
             # Add 0K elastic scattering cross section
             if '0K' not in data.energy:

--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -1,10 +1,8 @@
-import argparse
 from collections import namedtuple
 from io import StringIO
 import os
 import shutil
 from subprocess import Popen, PIPE, STDOUT, CalledProcessError
-import sys
 import tempfile
 
 from . import endf
@@ -237,8 +235,9 @@ def make_ace(filename, temperatures=None, ace='ace', xsdir='xsdir', pendf=None,
         Fractional error tolerance for NJOY processing
     broadr : bool, optional
         Indicating whether to Doppler broaden XS when running NJOY
-    heatr : bool, optional
-        Indicating whether to add heating kerma when running NJOY
+    heatr : bool or str, optional
+        Indicating whether to add heating kerma when running NJOY. If string,
+        write the output tape to this file
     gaspr : bool, optional
         Indicating whether to add gas production data when running NJOY
     purr : bool, optional
@@ -292,6 +291,7 @@ def make_ace(filename, temperatures=None, ace='ace', xsdir='xsdir', pendf=None,
     if heatr:
         nheatr_in = nlast
         nheatr = nheatr_in + 1
+        tapeout[nheatr] = "heatr" if heatr is True else heatr
         commands += _TEMPLATE_HEATR
         nlast = nheatr
 

--- a/openmc/data/reaction.py
+++ b/openmc/data/reaction.py
@@ -54,6 +54,7 @@ REACTION_NAME = {1: '(n,total)', 2: '(n,elastic)', 4: '(n,level)',
                  198: '(n,n3p)', 199: '(n,3n2pa)', 200: '(n,5n2p)', 203: '(n,Xp)',
                  204: '(n,Xd)', 205: '(n,Xt)', 206: '(n,X3He)', 207: '(n,Xa)',
                  301: 'heating', 444: 'damage-energy',
+                 318: "fission-heating", 999: "non-fission-heating",
                  649: '(n,pc)', 699: '(n,dc)', 749: '(n,tc)', 799: '(n,3Hec)',
                  849: '(n,ac)', 891: '(n,2nc)'}
 REACTION_NAME.update({i: '(n,n{})'.format(i - 50) for i in range(50, 91)})

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -231,6 +231,10 @@ std::string reaction_name(int mt)
     return  "(n,Xa)";
   } else if (mt == 301) {
     return "heating";
+  } else if (mt == 318) {
+    return "fission-heating";
+  } else if (mt == 999) {
+    return "non-fission-heating";
   } else if (mt == 444) {
     return  "damage-energy";
   } else if (mt == COHERENT) {

--- a/tests/unit_tests/test_data_neutron.py
+++ b/tests/unit_tests/test_data_neutron.py
@@ -481,7 +481,7 @@ def test_ace_convert(run_in_tmpdir):
     filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-001_H_001.endf')
     ace_ascii = 'ace_ascii'
     ace_binary = 'ace_binary'
-    openmc.data.njoy.make_ace(filename, ace=ace_ascii)
+    openmc.data.njoy.make_ace(filename, acer=ace_ascii)
 
     # Convert to binary
     openmc.data.ace.ascii_to_binary(ace_ascii, ace_binary)

--- a/tests/unit_tests/test_data_neutron.py
+++ b/tests/unit_tests/test_data_neutron.py
@@ -206,7 +206,7 @@ def test_derived_products(am244):
 
 
 def test_heating(run_in_tmpdir, am244):
-    assert 999 in am244.reactions  # TBD
+    assert 999 in am244.reactions
     strT = min(am244.reactions[1].xs.keys())
     total_xs = am244.reactions[1].xs[strT].y
     fission_xs = am244.reactions[18].xs[strT].y
@@ -215,6 +215,12 @@ def test_heating(run_in_tmpdir, am244):
     heating_number = total_heating / total_xs
     assert no_fission_heating == pytest.approx(
         heating_number * (total_xs - fission_xs))
+    # Re-read to ensure data is written
+    am244.export_to_hdf5("Am244.h5")
+    new = openmc.data.IncidentNeutron.from_hdf5("Am244.h5")
+    assert 999 in new.reactions
+    new_rxn = new.reactions[999].xs[strT].y
+    assert (new_rxn == no_fission_heating).all()
 
 
 def test_urr(pu239):

--- a/tests/unit_tests/test_data_neutron.py
+++ b/tests/unit_tests/test_data_neutron.py
@@ -205,6 +205,18 @@ def test_derived_products(am244):
     assert total_neutron.yield_(6e6) == pytest.approx(4.2558)
 
 
+def test_heating(run_in_tmpdir, am244):
+    assert 999 in am244.reactions  # TBD
+    strT = min(am244.reactions[1].xs.keys())
+    total_xs = am244.reactions[1].xs[strT].y
+    fission_xs = am244.reactions[18].xs[strT].y
+    total_heating = am244.reactions[301].xs[strT].y
+    no_fission_heating = am244.reactions[999].xs[strT].y
+    heating_number = total_heating / total_xs
+    assert no_fission_heating == pytest.approx(
+        heating_number * (total_xs - fission_xs))
+
+
 def test_urr(pu239):
     for T, ptable in pu239.urr.items():
         assert T.endswith('K')


### PR DESCRIPTION
This PR is related to #1238 in that it provides a new "reaction" dubbed 999 that is the heating number without heating due to fission. The motivation for this is as follows. Total energy deposition can be attributed to two components: energy released from fission and neutron [and/or photon] heating. However, one cannot take the simple sum of the two, as the heating coefficients [sum of products of reaction heating numbers x reaction cross section] includes heating due to fission. This is included in the recoverable energy from fission, which also includes energy due to released neutrons and photons. In order to account for energy deposition outside the fission site, the recoverable fission energy from prompt and delayed neutrons and photons should be removed from the `fission-q-recoverable` score, as it is accounted for in the heating data. This overlap can lead to over-predicting the energy deposition, unless some steps are taken.

This PR takes the first step in removing the heating coefficient due to fission and creating the new fission-less heating coefficient. The partial PR #1272 includes logic for removing the recoverable fission energy due to neutrons. The new reaction is given the reaction number 999 to try and avoid conflicting with standard reaction numbers. I am willing to change this value if necessary.

I am making this a standalone PR aside from the energy deposition items linked here because new data is required to properly create the energy-deposition tally. It is my hope that this PR can be bundled into the data pipeline so that the fission-less heating data can be accessed with the recoverable fission energy data.