### PR TITLE
Use level for neutron data temperature messages

### DIFF
--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -359,9 +359,9 @@ read_ce_cross_sections(const std::vector<std::vector<double>>& nuc_temps,
 
   // Show minimum/maximum temperature
   write_message("Minimum neutron data temperature: " +
-    std::to_string(data::temperature_min) + " K");
+    std::to_string(data::temperature_min) + " K", 4);
   write_message("Maximum neutron data temperature: " +
-    std::to_string(data::temperature_max) + " K");
+    std::to_string(data::temperature_max) + " K", 4);
 
   // If the user wants multipole, make sure we found a multipole library.
   if (settings::temperature_multipole) {


### PR DESCRIPTION
By setting a level, the messages will be printed only if the verbosity setting allows it. This reduces some of the noise printed in testing. Related output from travis:
https://travis-ci.org/openmc-dev/openmc/jobs/574867362#L1666-L1683

A level of 4 was chosen, indicating this should be printed with the OpenMC logo, headers, and results.