### PR TITLE
Make sure output is always verbosity-limited

### DIFF
--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -172,7 +172,7 @@ void load_dagmc_geometry()
 
   // notify user if UWUW materials are going to be used
   if (using_uwuw) {
-    std::cout << "Found UWUW Materials in the DAGMC geometry file.\n";
+    write_message("Found UWUW Materials in the DAGMC geometry file.", 6);
   }
 
   int32_t dagmc_univ_id = 0; // universe is always 0 for DAGMC runs

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -211,6 +211,7 @@ extern "C" void print_particle(Particle* p)
 void print_plot()
 {
   header("PLOTTING SUMMARY", 5);
+  if (settings::verbosity < 5) return;
 
   for (auto pl : model::plots) {
     // Plot id
@@ -453,6 +454,7 @@ void print_runtime()
 
   // display header block
   header("Timing Statistics", 6);
+  if (settings::verbosity < 6) return;
 
   // Save state of cout
   auto f {std::cout.flags()};
@@ -537,6 +539,7 @@ void print_results()
 
   // display header block for results
   header("Results", 4);
+  if (settings::verbosity < 4) return;
 
   // Calculate t-value for confidence intervals
   int n = simulation::n_realizations;


### PR DESCRIPTION
Continuing along the same lines as #1323, this PR makes sure that a few other outputs from the code can be inhibited by the user-selected verbosity.