### PR TITLE
Get test suite to work with OpenMPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,11 @@ target_include_directories(pugixml PUBLIC vendor/pugixml/)
 # xtensor header-only library
 #===============================================================================
 
+# CMake 3.13+ will complain about policy CMP0079 unless it is set explicitly
+if (NOT (CMAKE_VERSION VERSION_LESS 3.13))
+  cmake_policy(SET CMP0079 NEW)
+endif()
+
 add_subdirectory(vendor/xtl)
 add_subdirectory(vendor/xtensor)
 target_link_libraries(xtensor INTERFACE xtl)

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -127,7 +127,9 @@ int openmc_finalize()
 
   // Free all MPI types
 #ifdef OPENMC_MPI
-  MPI_Type_free(&mpi::bank);
+  int init_called;
+  MPI_Initialized(&init_called);
+  if (init_called) MPI_Type_free(&mpi::bank);
 #endif
 
   return 0;

--- a/src/message_passing.cpp
+++ b/src/message_passing.cpp
@@ -8,8 +8,8 @@ int n_procs {1};
 bool master {true};
 
 #ifdef OPENMC_MPI
-MPI_Comm intracomm;
-MPI_Datatype bank;
+MPI_Comm intracomm {MPI_COMM_NULL};
+MPI_Datatype bank {MPI_DATATYPE_NULL};
 #endif
 
 extern "C" bool openmc_master() { return mpi::master; }

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,6 +1,17 @@
 import openmc
 import pytest
 
+from tests.regression_tests import config
+
+
+@pytest.fixture(scope='module')
+def mpi_intracomm():
+    if config['mpi']:
+        from mpi4py import MPI
+        return MPI.COMM_WORLD
+    else:
+        return None
+
 
 @pytest.fixture(scope='module')
 def uo2():

--- a/tests/unit_tests/test_capi.py
+++ b/tests/unit_tests/test_capi.py
@@ -50,8 +50,8 @@ def pincell_model():
 
 
 @pytest.fixture(scope='module')
-def capi_init(pincell_model):
-    openmc.capi.init()
+def capi_init(pincell_model, mpi_intracomm):
+    openmc.capi.init(intracomm=mpi_intracomm)
     yield
     openmc.capi.finalize()
 
@@ -408,11 +408,11 @@ def test_mesh(capi_init):
     assert msf.mesh == mesh
 
 
-def test_restart(capi_init):
+def test_restart(capi_init, mpi_intracomm):
     # Finalize and re-init to make internal state consistent with XML.
     openmc.capi.hard_reset()
     openmc.capi.finalize()
-    openmc.capi.init()
+    openmc.capi.init(intracomm=mpi_intracomm)
     openmc.capi.simulation_init()
 
     # Run for 7 batches then write a statepoint.

--- a/tests/unit_tests/test_complex_cell_capi.py
+++ b/tests/unit_tests/test_complex_cell_capi.py
@@ -3,7 +3,7 @@ import openmc.capi
 import pytest
 
 @pytest.fixture(autouse=True)
-def complex_cell(run_in_tmpdir):
+def complex_cell(run_in_tmpdir, mpi_intracomm):
 
     openmc.reset_auto_ids()
 
@@ -74,7 +74,7 @@ def complex_cell(run_in_tmpdir):
     model.export_to_xml()
 
     openmc.capi.finalize()
-    openmc.capi.init()
+    openmc.capi.init(intracomm=mpi_intracomm)
 
     yield
 


### PR DESCRIPTION
A [user reported](https://groups.google.com/forum/#!topic/openmc-users/wGCDL4YgvPU) seeing test failures when using OpenMPI to build OpenMC. I was able to reproduce this and it turns out there are a few issues, which I've fixed in this PR:

1. In some cases, a unit test may call `capi.finalize()` before `capi.init()`, which causes problems because the underlying C++ function has a call to `MPI_Type_free`. I've added a check for whether MPI was initialized before calling `MPI_Type_free` to prevent issues in this case.
2. Calling `openmc.capi.init` does not work with OpenMPI unless you explicitly pass a communicator. With MPICH, it just happened to work by luck, so our test suite didn't show any issues on Travis CI (where we're using MPICH). I've changed it so that when you run tests with `pytest --mpi`, we get the communicator from `mpi4py` and pass it to `capi.init()`.

There is also an unrelated fix in this PR for newer versions of CMake, which will complain about policy CMP0079.

I think it would be worth adding a new job on Travis that specifically builds/tests against OpenMPI, but that will require a little more work so I'm going to leave that for another time.