### PR TITLE
Depletion example notebook

### DIFF
--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -24,6 +24,7 @@ General Usage
     nuclear-data
     nuclear-data-resonance-covariance
     cad-geom
+    pincell-depletion
 
 --------
 Geometry

--- a/docs/source/examples/pincell-depletion.rst
+++ b/docs/source/examples/pincell-depletion.rst
@@ -1,0 +1,14 @@
+.. _notebook_depletion:
+
+=================
+Pincell Depletion
+=================
+
+
+.. only:: html
+
+    .. notebook:: ../../../examples/jupyter/pincell_depletion.ipynb
+
+.. only:: latex
+
+    IPython notebooks must be viewed in the online HTML documentation.

--- a/docs/source/usersguide/depletion.rst
+++ b/docs/source/usersguide/depletion.rst
@@ -29,8 +29,8 @@ operator class requires a :class:`openmc.Geometry` instance and a
     op = openmc.deplete.Operator(geom, settings)
 
 :mod:`openmc.deplete` supports multiple time-integration methods for determining
-material compositions over time. Each method appears as a different function.
-For example, :func:`openmc.deplete.integrator.cecm` runs a depletion calculation
+material compositions over time. Each method appears as a different class.
+For example, :class:`openmc.deplete.CECMIntegrator` runs a depletion calculation
 using the CE/CM algorithm (deplete over a timestep using the middle-of-step
 reaction rates). An instance of :class:`openmc.deplete.Operator` is passed to
 one of these functions along with the power level and timesteps::
@@ -38,7 +38,7 @@ one of these functions along with the power level and timesteps::
     power = 1200.0e6
     days = 24*60*60
     timesteps = [10.0*days, 10.0*days, 10.0*days]
-    openmc.deplete.cecm(op, power, timesteps)
+    openmc.deplete.CECMIntegrator(op, power, timesteps).integrate()
 
 The coupled transport-depletion problem is executed, and once it is done a
 ``depletion_results.h5`` file is written. The results can be analyzed using the
@@ -46,7 +46,7 @@ The coupled transport-depletion problem is executed, and once it is done a
 easy retrieval of k-effective, nuclide concentrations, and reaction rates over
 time::
 
-    results = openmc.deplete.ResultsList("depletion_results.h5")
+    results = openmc.deplete.ResultsList.from_hdf5("depletion_results.h5")
     time, keff = results.get_eigenvalue()
 
 Note that the coupling between the transport solver and the transmutation solver

--- a/examples/jupyter/pincell_depletion.ipynb
+++ b/examples/jupyter/pincell_depletion.ipynb
@@ -339,7 +339,10 @@
     "* A fission event for U-235 produces fission products like Xe135 according to a distribution\n",
     "* For thermal problems, Am241 will produce metastable Am242 about 8% of the time during an $(n,\\gamma)$ reaction. The other 92% of capture reactions will produce ground state Am242\n",
     "\n",
-    "These data are often distributed with other nuclear data, like incident neutron cross sections with ENDF/B-VII. The `openmc.deplete.Chain` object is responsible for representing this information. Two executables, `openmc-make-depletion-chain` and `openmc-make-depletion-chain-casl` will read in nuclear data using the `OPENMC_ENDF_DATA` environment variable and produce two depletion chain files. The first is a more detailed file containing every reaction and fission product possible, while the second uses data from CASL [Specification for the VERA Depletion Benchmark Suite](https://doi.org/10.2172/1256820) report to reduce the number of isotopes.\n",
+    "These data are often distributed with other nuclear data, like incident neutron cross sections with ENDF/B-VII.\n",
+    "OpenMC uses the [`openmc.deplete.Chain`](https://docs.openmc.org/en/latest/pythonapi/generated/openmc.deplete.Chain.html#openmc.deplete.Chain) to collect represent the various decay and transmutation pathways in a single object.\n",
+    "While a complete `Chain` can be created using nuclear data files, users may prefer to download pre-generated XML-representations instead.\n",
+    "Such files can be found at https://openmc.org/depletion-chains/ and include full and compressed chains, with capture branching ratios derived using PWR- or SFR-spectra.\n",
     "\n",
     "For this problem, we will be using a much smaller depletion chain that contains very few nuclides. In a realistic problem, over 1000 isotopes may be included in the depletion chain."
    ]

--- a/examples/jupyter/pincell_depletion.ipynb
+++ b/examples/jupyter/pincell_depletion.ipynb
@@ -18,6 +18,7 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
+    "import math\n",
     "import openmc"
    ]
   },
@@ -167,7 +168,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7fedf1eace90>"
+       "<matplotlib.image.AxesImage at 0x7f9aea1a50d0>"
       ]
      },
      "execution_count": 13,
@@ -176,7 +177,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQIAAAD4CAYAAAAHMeibAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAPzUlEQVR4nO3dXYwdd3nH8e+T2ICjjSVHTXbFhRsCQkWyEgVcxYBCUSKVqFYvgrDzwkVAVSyVCyqgUglviYqg1Bep1AYh+YrkIq5pkIEbgqXSpIFQhEUM+KoFqQVZJK1fJFaJBSZ+euE50Xp93mfOnHn5fqTVjs8czz4+5z+/feY/4zORmUjqt6uWXYCk5TMIJBkEkgwCSRgEkjAIJAFbll3AwLZrrsrt269edhlSZ/3mN69y/pWLMWxdY4Jg+/arue+BHcsuQ+qsw4+fG7nOQwNJBoEkg0ASBoEkDAJJGASSMAgkYRBIokEXFKk5PnDdxyvd3lNnH610e6qeQdBTVe/s8/4sQ6IZDIKOq3OHn8eo+gyIehkEHdP0HX9am/8dBsNiGQQt15UdfxKDYbEMghbqy84/zsbXwFAozyBoiTp3/iePnKx0e/ffs6vS7W1mKJTndQSS7AiablGdQNW/9ef9WVV3C4PXy85gNnMHQURsAR4Gfgy8DfhSZl7c9JyngL/OzP8uU2QfVRkAde70sxpWWxXhYCDMpkxH8CBwKjOPRsQasA84MlgZEXcDry9ZX69UtfM3ecefxub6ywSD8wfTKRMEe4CvFMsngL+kCIKIuBX4FXBm3AYi4gBwAODa7f2drqgiANq+84+z8d9WRSgYCFcqEwRrwHqxvA6sAkTEDuAtmfkvEUM/MPU1mXkIOASwura1d3djLRMAXd7xx6miWzAQrlQmCM4AK8XyCnC6WN4L7IuIDwJvB94YER/OzFMlflanGADVGbweBkI5Me9t0SPiQ8DrMvNQ0eL/Fvh2Zv7vhud8FXhkmsnC1bWt2YePM58nBNz5ZzNPKPQhDA4/fo6XXrxQ+X0NngD+NiL2AzuBo8BjwP4S2+wsA6A+83QJfe8O5u4IqtbVjmDWAHDnX4xZQqGrYbCojkBjGADNMkuX0MdTjv09Z7dAhkBzzfpa9+U/eBkEkjw0qJKdQDvMOpnYh4lEg6Ais4SAAdAM8wRCV8PAQ4MKGALtNst70tU5AzuCkqYdGAZAs816VqFrnYFBMCcDoJuePHJyplOMXQkEDw3mYAh025NHTk793nXlUMGOYAYGQL9Me7jQhe7AjmBKhkB/9aE7MAimYAio62FgEExgCGigy2FgEIxhCGizroaBQSDJIBjFbkCjdLErMAiGMAQ0SdfCwCCYkyGgLo0Bg2CTaRK8SwNA5UwzFtrQFXhl4QaT3jADQMNMcwVi0/+jkh1BwRBQWZPGSJM7A4MAQ0DVaWsYGAQTGAKaVRvHTK+D4APXfXxsQrfxDVUzjBs7k8bdMvQ2CJr2Rqh/mjQGexsEk9gNqKw2jaFeBoGTg6pLWyYPexkEki7XuyCwG1Dd2tAV9C4IJF2pV0FgN6BlaXpX0JsgMAS0bE0Og94EgaTRehEEdgNqiqZ2Bb0IAknjzR0EEbElIj4fEXdHxKci4qoN6+6NiO9HxM8j4l3VlDqfSf+XwG5AdZs07pbRFZTpCB4ETmXmUeAcsA8gIrYBr2bmu4HPAZ8tXeUCGABatiaNwTJBsAc4USyfAPYWyxeArxfLLwBnSvyMUpZ9SkaaV91jt0wQrAHrxfI6sAqQmb/PzIvF4+8BDo7aQEQciIjjEXH8/PmLo55WuSYlsfqtKWOxTBCcAVaK5RXg9MaVEXET8MvM/OmoDWTmoczcnZm7t21z3lJaljJ73zHglmL5ZuBYRNwAUHz/o8z8dkS8YfB4nTwsUNvVOYbLBMETwM6I2A/sBE4Cj0XENcA3gYMRcRL4EXC2dKUVaUorJg00YUzO/XHmxTzAZ4o/fq34vr/4/s4yRZVlN6CuqOtj0Ht1YN6E5JWGWfbY7NQNTuwE1EWDcb3IzqBXHYGk4XoTBMtuvaRJljlGOxMEHhao6xY5xjsTBOPYDagtljVWexEEksbrRBB4WKC+WNRY70QQSCqn80Hg/IDaZhljtvNBIGmy1geB8wPqm0WM+dYHwTgeFqit6h67nQ4CSdMxCCS1OwicH1BfVT32Wx0E4zg/oLarcwx3NggkTc8gkGQQSDIIJNHiIJh0c1OpC+q6WWprg0BSdQwCSQaBJINAEgaBJAwCSbT0lmejTpt42lBdNBjX99+z64p1Vd0k1Y5AkkEgySCQhEEgCYNAEgaBJAwCSZS4jiAitgAPAz8G3gZ8KTMvFuvuAHYBAfxHZv6wglolLUiZC4oeBE5l5tGIWAP2AUci4mrgIPDHxfP+FbijXJmSFqnMocEe4ESxfALYWyzvBE5nAbgQETcN20BEHIiI4xFx/Pz5iyVKkVRGmSBYA9aL5XVgdcjjm9ddJjMPZebuzNy9bZvTFdKylNn7zgArxfIKcHrI45vXSWqgMkFwDLilWL4ZOBYRN2TmfwLXRgFYycz/KluopMUpEwRPADsjYj+X5gVOAo8V6x4CPlF8PVSqQkkLN/dZg+JU4WeKP36t+L6/WPcc8Fy50iTVxRk6SQaBJINAEgaBJFr6mYVPnX106OcWDj7Tzc8uVJcM+6zCgSo+rxDsCCRhEEjCIJCEQSAJg0ASBoEkWhwE406bjDvdIrVJHacOocVBIKk6BoEkg0CSQSCJDgeBE4ZquzrHcKuDoMpZU6lNqh77rQ4CSdUwCCR1OwicJ1Bb1T12Wx8EzhOobxYx5lsfBJLK63wQeHigtlnGmO18EEiarBNB4DyB+mJRY70TQSCpnF4EgfMEaotljdXOBIGHB+q6RY7xzgTBJHYFarpljtHeBIGk0Vp5y7NRBq3TsNuhSW1Vx2FvrzoCDw/UVMsem50MAicO1RV1jeVOBsE4y05eabMmjMm5gyAitkfEFyLi7oj42JD1H42I4xHxs4h4a7kyZ2dXoLarcwyX6Qg+DTyXmUeBtYi4bbAiInYCP8nM3cBh4IqgkNQcZYJgD3CiWD4B7N2w7sXMfLZYfgE4U+LnVK4JrZgEzRmLZYJgDVgvlteB1cGKzPzdhue9A/jysA1ExIHi8OH4+fMXS5QynIcHaqu6x+7EIIiIuyLimc1fwHZgpXjaCnB6yN+9FfhuZv562LYz81Bm7s7M3du21Ttv2ZQkVn81aQxOvKAoM58Gnt78eEQ8AtwCHANuBr4TEa8DVjLzbES8uVh+LiKuB17OzFcqrX4KT519dOQFRoM34skjJ+ssST03KQCW0cmWubLwIPBwROwA1jPz2Yj4c+C9EXEQ+BaQEQHwUmbeWb5cSYsQmbnsGgBYXdua9z2wY2Hbn3TZsV2B6rDMbuDw4+d46cULMWxd7y4oknSl3gTBpKRt0sSNuqmJcwMDvQkCMAy0PE0OAehZEEgarndBYFegujW9G4AeBgEYBqpPG0IAehoEki5nEIxgV6Cy2jSGehsETWnJ1F9NGoO9DQK49EaMezPalOhqlnFjZ9K4W4ZeB8E0DAPNqo1jxiDAswiqTlvOEmxmEBQMA5XV1hCAjt3gpKxxn10Afn6Bhpvml0STQwDsCK4wzRtmd6CBLoQAGARzMwzUpTFgEAwxbYJ3aSBoNtO+923oBsAgGMkw0ChdCwEwCCRhEIxlV6DNutgNgEEwkWGgga6GABgEUzEM1OUQAINgaoZBf3U9BMArC2cyeKMn3SPBKxC7oQ8BMGBHMAe7g267/55dvQoBsCOYm91BN/UtAAYMgpIm/UelAQOh2Wbp3roWAuChQSVmGRgeLjRP30MA7AgqM21nAHYHTTFrKHc1BMAgqNS08wYDBsJyGABX8tBAkkGwCLP+BnHeoD52A8N5aLAgHiY0ixOC4xkECzZvIIChUNY8nVYfQwAMgtrMGghglzAvA2B2BkHNZjnNOGCXMFmZeZa+hwCUCIKI2A78DXAcuDEz/2HIc7YC/56Z75y/xO6ZpzsYsEu4nAFQjTIdwaeBf8vMpyPi7yPitsz84abn3Fti+51XRSAM9CUYqjjDYgBcqUwQ7AEGXcAJYC/wWhBExB3A88BfjNpARBwADgBcu72/ZzLLBMJAlw8fqjq9agCMViYI1oD1YnkdWB2siIg3AVsy8xcRMXIDmXkIOASwurY1S9TSCRsHalWhAO0Lhiqvq3Dnn87EIIiIu4BPDlm1HVgBXi6+n96w7v3A7RHxEWBXRHwD2JeZF8qX3A9VdAkDw3aspoTDoi6mMgBmE5nz/SKOiEeA5zPzWER8EfgO8ANgJTPPbnjeM5n53knbW13bmvc9sGOuWvqgikCYVtUhUeeVkwbAaIcfP8dLL14Y2qKXOTA/CNwZEfcA65n5LPA+Lk0iSmqRuTuCqtkRTK/O7qAN7AKmM64j8IKiFqpqUrHN3PmrZRC03OYdoqvB4I6/WAZBx3QlGNzx62UQdNyoHaopAeEO3wwGQU+N2wGrDgl39uYzCHQFd9z+6e8F/pJeYxBIMggkGQSSMAgkYRBIwiCQhEEgCYNAEgaBJBr0wSQR8X/A/1S82T/g8s9SbLo21dumWqFd9S6q1j/MzOuHrWhMECxCRBzPzN3LrmNabaq3TbVCu+pdRq0eGkgyCCR1PwgOLbuAGbWp3jbVCu2qt/ZaOz1HIGk6Xe8IJE3BIJDUvSCIiO0R8YWIuDsiPjbiOVsj4gd11zbMpHoj4qMRcTwifhYRb11CfVsi4vNFfZ+KiKs2rLujqO+vIuK2umsbZkK990bE9yPi5xHxrmXWWdQzstYNz3kqIm5cdC2dCwIu3XLtucw8CqyNGKD31lzTOCPrjYidwE+Kc8qHgaHBtmAPAqeK+s4B+4rarubSbe/+CfhH4O+WUNswo+rdBryame8GPgd8dnklvmZorQMRcTfw+joK6WIQ7AFOFMsngL0bV0bEHcDzwG9rrmuUcfW+WNxTEuAF4EydhRVG1bcTOJ0F4EJE3LSE+jYbVe8F4OvF8rJey81GvvcRcSvwK2qqs4tBsAasF8vrwOpgRUS8CdiSmb9YRmEjjKw3M3+34XnvAL5cY10Do+rb+Pjmdcs0tN7M/H1mXiwefw+XupllG1prROwA3pKZx+sqpLUfZx4RdwGfHLJqO7ACvFx833jN9vuB2yPiI8CuiPgGsC8zLzS03sHfvRX4bmb+eqFFDneGS3XB5fVtfHzzumUaVS8ARdfyy8z8ad2FDTGq1r3Avoj4IPB24I0R8eHMPLWwSjKzU1/AI8CfFstfBP4EeB1w3abnPbPsWqepF3gzcHuxfD1wTc31fQg4UCwfAB4Abij+/D0giq/vLfu1nKLeG4A/K5bfMHi8ibVueM5XgRsXXUsXDw0OAndGxD3Ael46xn4flyblmmhkvRGxCnwL+EpEnAT+OTNfqbm+J4CdEbGfS/MCJ4HHinUPAZ8ovh6qua5RhtYbEdcA3wQOFq/lj4CzyysTGP/a1sorCyV1siOQNCODQJJBIMkgkIRBIAmDQBIGgSQMAknA/wOE2BVcgIOLGwAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQIAAAD4CAYAAAAHMeibAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAP10lEQVR4nO3dX4wdd3nG8e/jLDEkW0OaJl5h44aAUImixAFXMUGhyJFKVKsXRrKJhKKCUByVCypElWLzJ1ERDt2bSm0Qiq9QuKBQkIEbgqW6CQYDYkUWsHJBQQISC9p6Q6WVkYwTv73YOdHx2Tl/Z878+c3zkVY7PnM8+/qc3zx+5zezcxQRmFm3bam7ADOrn4PAzBwEZuYgMDMcBGaGg8DMgIW6C+i56vprY+F1r6m7DLNkvfjc//HS2gXlrWtMECy87jXsPPVg3WWYJev5fY8PXedDAzNzEJiZg8DMcBCYGQ4CM8NBYGY4CMwMB4GZ0aALiqw5vvDomVK3d/+Ru0rdnpXPQdBRZe/ss/4sh0QzOAgSV+UOP4th9TkgquUgSEzTd/xJDf47HAzz5SBouVR2/HEcDPPlIGihruz8o/S/Bg6F4hwELVHlzn/L8rFSt/fsQ0dL3d4gh0Jxvo7AzNwRNN28OoGy/9ef9WeV3S30Xi93BtOZOQgkLQAPAz8C3gx8JiIuDzznK8DfR8QvixTZRWUGQJU7/bTyaisjHBwI0ynSETwAnIuIE5KWgIPAl3orJR0Athasr1PK2vmbvONPYrD+IsHg+YPJFAmCvcDnsuVV4G/JgkDSHcBzwNqoDUg6DBwGWNj56gKltFsZAdD2nX+U/n9bGaHgQNisSBAsAevZ8jqwHUDSdcAbI+Lfpdwbpr4sIo4DxwG27t7RuU9jLRIAKe/4o5TRLTgQNisSBGvAYra8CJzPlvcDByW9F3gL8FpJ74+IcwV+VlIcAOXpvR4OhGI068eiS3ofcHVEHM9a/IvANyPif/qe83ngkUkmC7fu3hFduJ35LCHgnX86s4RCF8Lg+X2Pc3H1XOmfa/AE8I+SDgG7gBPAY8ChAttMlgOgOrN0CV3vDmbuCMqWakcwbQB455+PaUIh1TCYV0dgIzgAmmWaLqGLpxx9ifEcOASaa9rXuiu/4OUgMDMfGpTJnUA7TDuZ2IWJRAdBSaYJAQdAM8wSCKmGgQ8NSuAQaLdp3pNU5wzcERQ06cBwADTbtGcVUusMHAQzcgCk6ZblY1OdYkwlEHxoMAOHQNpuWT428XuXyqGCO4IpOAC6ZdLDhRS6A3cEE3IIdFcXugMHwQQcApZ6GDgIxnAIWE/KYeAgGMEhYINSDQMHgZk5CIZxN2DDpNgVOAhyOARsnNTCwEEwI4eApTQGHAQDJknwlAaAFTPJWGhDV+ArC/uMe8McAJZnkisQm/6LSu4IMg4BK2rcGGlyZ+AgwCFg5WlrGDgIxnAI2LTaOGY6HQRfePTMyIRu4xtqzTBq7Iwbd3XobBA07Y2w7mnSGOxsEIzjbsCKatMY6mQQeHLQqtKWycNOBoGZXalzQeBuwKrWhq6gc0FgZpt1KgjcDVhdmt4VdCYIHAJWtyaHQWeCwMyG60QQuBuwpmhqV9CJIDCz0WYOAkkLkj4l6YCko5K29K27T9J3Jf1cUq2/hD3udwncDVjVxo27OrqCIh3BA8C5iDgB/A44CCDpVcBLEfF24JPAJwpXOQcOAKtbk8ZgkSDYC6xmy6vA/mz5EvDVbPkZYK3Azyik7lMyZrOqeuwWCYIlYD1bXge2A0TEixFxOXv8HcDysA1IOixpRdLK5bULBUqZTpOS2LqtKWOxSBCsAYvZ8iJwvn+lpJuBX0fET4ZtICKOR8SeiNiz5fprC5RiZkUUCYKTwO3Z8m3ASUk3AmTf/ywivinplb3Hq+TDAmu7KsdwkSB4Atgl6RCwCzgLPCbpGuDrwLKks8APgRcKV1qSprRiZj1NGJMz3848mwf4ePbHL2ffD2Xf31akqKLcDVgqqroNeqcuKGpC8prlqXtsJvUBJ+4ELEW9cT3PzqBTHYGZ5etMENTdepmNU+cYTSYIfFhgqZvnGE8mCEZxN2BtUddY7UQQmNloSQSBDwusK+Y11pMIAjMrJvkg8PyAtU0dYzb5IDCz8VofBJ4fsK6Zx5hvfRCM4sMCa6uqx27SQWBmk3EQmFm7g8DzA9ZVZY/9VgfBKJ4fsLarcgwnGwRmNjkHgZk5CMzMQWBmtDgIxn24qVkKqvqw1NYGgZmVx0FgZg4CM3MQmBkOAjPDQWBmtPQjz4adNvFpQ0tRb1w/+9DRTevK+pBUdwRm5iAwMweBmeEgMDMcBGaGg8DMcBCYGQWuI5C0ADwM/Ah4M/CZiLicrdsH3AoI+H5E/KCEWs1sTopcUPQAcC4iTkhaAg4CX5J0FbAM/Hn2vP8A9hUr08zmqcihwV5gNVteBfZny7uA85EBLkm6OW8Dkg5LWpG0cnntQoFSzKyIIkGwBKxny+vA9pzHB9ddISKOR8SeiNiz5fprC5RiZkUUCYI1YDFbXgTO5zw+uM7MGqhIEJwEbs+WbwNOSroxIn4G/JEywGJE/FfRQs1sfooEwRPALkmH2JgXOAs8lq07Anwk+zpSqEIzm7uZzxpkpwo/nv3xy9n3Q9m608DpYqWZWVV8QZGZOQjMzEFgZjgIzIyW3rPw/iN35d63sHdPN9+70FKSd6/CnjLuVwjuCMwMB4GZ4SAwMxwEZoaDwMxwEJgZLQ6CUadNRp1uMWuTKk4dQouDwMzK4yAwMweBmTkIzIyEg8AThtZ2VY7hVgdBmbOmZm1S9thvdRCYWTkcBGaWdhB4nsDaquqx2/og8DyBdc08xnzrg8DMiks+CHx4YG1Tx5hNPgjMbLwkgsDzBNYV8xrrSQSBmRXTiSDwPIG1RV1jNZkg8OGBpW6eYzyZIBjHXYE1XZ1jtDNBYGbDtfIjz4bptU55H4dm1lZVHPZ2qiPw4YE1Vd1jM8kg8MShpaKqsZxkEIxSd/KaDWrCmJw5CCRtk/RpSQckfThn/YckrUj6qaQ3FStzeu4KrO2qHMNFOoKPAacj4gSwJOnO3gpJu4AfR8Qe4IvApqAws+YoEgR7gdVseRXY37futxHxdLb8DLBW4OeUrgmtmBk0ZywWCYIlYD1bXge291ZExB/6nvdW4LN5G5B0ODt8WLm8dqFAKfl8eGBtVfXYHRsEku6V9NTgF7ANWMyetgicz/m7dwCnIuI3eduOiOMRsSci9my5/trZ/xUzaEoSW3c1aQyOvaAoIp4Enhx8XNIjwO3ASeA24FuSrgYWI+IFSW/Ilk9LugG4EBG/L7X6Cdx/5K6hFxj13ohblo9VWZJ13LgAqKOTLXJl4TLwsKTrgPWIeFrSXwPvlLQMfAMISQD/HRH3FC/XzOZBEVF3DQBs3b0jdp56cG7bH3fZsbsCq0Kd3cDz+x7n4uo55a3r3AVFZrZZZ4JgXNI2aeLG0tTEuYGezgQBOAysPk0OAehYEJhZvs4FgbsCq1rTuwHoYBCAw8Cq04YQgI4GgZldyUEwhLsCK6pNY6izQdCUlsy6q0ljsLNBABtvxKg3o02Jbs0yauyMG3d16HQQTMJhYNNq45hxEOCzCFaetpwlGOQgyDgMrKi2hgAk9gEnRY26dwH4/gWWb5L/JJocAuCOYJNJ3jB3B9aTQgiAg2BmDgNLaQw4CHJMmuApDQSbzqTvfRu6AXAQDOUwsGFSCwFwEJgZDoKR3BXYoBS7AXAQjOUwsJ5UQwAcBBNxGFjKIQAOgok5DLor9RAAX1k4ld4bPe4zEnwFYhq6EAA97ghm4O4gbc8+dLRTIQDuCGbm7iBNXQuAHgdBQeN+UanHgdBs03RvqYUA+NCgFNMMDB8uNE/XQwDcEZRm0s4A3B00xbShnGoIgIOgVJPOG/Q4EOrhANjMhwZm5iCYh2n/B/G8QXXcDeTzocGc+DChWTwhOJqDYM5mDQRwKBQ1S6fVxRAAB0Flpg0EcJcwKwfA9BwEFZvmNGOPu4TxisyzdD0EoEAQSNoG/AOwAtwUEf+c85xXAN+OiLfNXmJ6ZukOetwlXMkBUI4iHcHHgP+MiCcl/ZOkOyPiBwPPua/A9pNXRiD0dCUYyjjD4gDYrEgQ7AV6XcAqsB94OQgk7QPOAB8YtgFJh4HDAAs7X12glHYrEgg9KR8+lHV61QEwXJEgWALWs+V1YHtvhaTXAwsR8QtJQzcQEceB4wBbd++IArUkoX+glhUK0L5gKPO6Cu/8kxkbBJLuBT6as2obsAhcyL6f71v3buBuSR8EbpX0NeBgRFwqXnI3lNEl9OTtWE0Jh3ldTOUAmI4iZvuPWNIjwJmIOCnpGPAt4HvAYkS80Pe8pyLineO2t3X3jth56sGZaumCMgJhUmWHRJVXTjoAhnt+3+NcXD2X26IXucR4GbhH0nuA9Yh4GngXG5OIZtYiM3cEZXNHMLkqu4M2cBcwmVEdgS8oaqGyJhXbzDt/uRwELTe4Q6QaDN7x58tBkJhUgsE7frUcBIkbtkM1JSC8wzeDg6CjRu2AZYeEd/bmcxDYJt5xu8e3KjMzB4GZOQjMDAeBmeEgMDMcBGaGg8DMcBCYGQ4CM8NBYGY06MYkkv4X+FXJm/0TrryXYtO1qd421Qrtqndetf5pRNyQt6IxQTAPklYiYk/ddUyqTfW2qVZoV7111OpDAzNzEJhZ+kFwvO4CptSmettUK7Sr3sprTXqOwMwmk3pHYGYTcBCYWXpBIGmbpE9LOiDpw0Oe8wpJ36u6tjzj6pX0IUkrkn4q6U011Lcg6VNZfUclbelbty+r7+8k3Vl1bXnG1HufpO9K+rmk2u/HNqrWvud8RdJN864luSBg4yPXTkfECWBpyAC9r+KaRhlar6RdwI+zc8pfBHKDbc4eAM5l9f0OOJjVdhUbH3v3r8C/AI/WUFueYfW+CngpIt4OfBL4RH0lviy31h5JB4CtVRSSYhDsBVaz5VVgf/9KSfuAM8DFiusaZlS9v80+UxLgGWCtysIyw+rbBZyPDHBJ0s011DdoWL2XgK9my3W9loOGvveS7gCeo6I6UwyCJWA9W14HtvdWSHo9sBARv6ijsCGG1hsRf+h73luBz1ZYV8+w+vofH1xXp9x6I+LFiLicPf4ONrqZuuXWKuk64I0RsVJVIa29nbmke4GP5qzaBiwCF7Lv/ddsvxu4W9IHgVslfQ04GBGXGlpv7+/eAZyKiN/Mtch8a2zUBVfW1//44Lo6DasXgKxr+XVE/KTqwnIMq3U/cFDSe4G3AK+V9P6IODe3SiIiqS/gEeAvs+VjwF8AVwN/PPC8p+qudZJ6gTcAd2fLNwDXVFzf+4DD2fJh4G+AG7M/fwdQ9vWdul/LCeq9EfirbPmVvcebWGvfcz4P3DTvWlI8NFgG7pH0HmA9No6x38XGpFwTDa1X0nbgG8DnJJ0F/i0ifl9xfU8AuyQdYmNe4CzwWLbuCPCR7OtIxXUNk1uvpGuArwPL2Wv5Q+CF+soERr+2lfKVhWaWZEdgZlNyEJiZg8DMHARmhoPAzHAQmBkOAjPDQWBmwP8Dc3ITQlYJ4pYAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -281,63 +282,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before we write the material file, we must add one bit of information: the volume of our fuel. In order to translate the reaction rates obtained by `openmc` to meaningful units for depletion, we have to normalize them to a correct power. This requires us to know, or be able to calculate, how much fuel is in our problem. Correctly setting the volumes is a critical step, and incorrect answers, as the fuel is over- or under-depleted due to poor normalization.\n",
+    "Before we write the material file, we must add one bit of information: the volume of our fuel. In order to translate the reaction rates obtained by `openmc` to meaningful units for depletion, we have to normalize them to a correct power. This requires us to know, or be able to calculate, how much fuel is in our problem. Correctly setting the volumes is a critical step, and can lead to incorrect answers, as the fuel is over- or under-depleted due to poor normalization.\n",
     "\n",
     "For our problem, we can assign the \"volume\" to be the cross-sectional area of our fuel. This is identical to modeling our fuel pin inside a box with height of 1 cm."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
-    "fuel.volume = 3.14159 * radii[0] ** 2"
+    "fuel.volume = math.pi * radii[0] ** 2"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<?xml version='1.0' encoding='utf-8'?>\r\n",
-      "<materials>\r\n",
-      "  <material depletable=\"true\" id=\"1\" name=\"uo2\" volume=\"0.5541764759999999\">\r\n",
-      "    <density units=\"g/cc\" value=\"10.4\" />\r\n",
-      "    <nuclide ao=\"0.0003845183882296898\" name=\"U234\" />\r\n",
-      "    <nuclide ao=\"0.04301995213827323\" name=\"U235\" />\r\n",
-      "    <nuclide ao=\"0.9563984774295304\" name=\"U238\" />\r\n",
-      "    <nuclide ao=\"0.000197052043966672\" name=\"U236\" />\r\n",
-      "    <nuclide ao=\"1.999242\" name=\"O16\" />\r\n",
-      "    <nuclide ao=\"0.000758\" name=\"O17\" />\r\n",
-      "  </material>\r\n",
-      "  <material id=\"2\" name=\"clad\">\r\n",
-      "    <density units=\"g/cc\" value=\"6\" />\r\n",
-      "    <nuclide ao=\"0.5145\" name=\"Zr90\" />\r\n",
-      "    <nuclide ao=\"0.1122\" name=\"Zr91\" />\r\n",
-      "    <nuclide ao=\"0.1715\" name=\"Zr92\" />\r\n",
-      "    <nuclide ao=\"0.1738\" name=\"Zr94\" />\r\n",
-      "    <nuclide ao=\"0.028\" name=\"Zr96\" />\r\n",
-      "  </material>\r\n",
-      "  <material id=\"3\" name=\"water\">\r\n",
-      "    <density units=\"g/cc\" value=\"1.0\" />\r\n",
-      "    <nuclide ao=\"0.999621\" name=\"O16\" />\r\n",
-      "    <nuclide ao=\"0.000379\" name=\"O17\" />\r\n",
-      "    <nuclide ao=\"1.99968852\" name=\"H1\" />\r\n",
-      "    <nuclide ao=\"0.00031148\" name=\"H2\" />\r\n",
-      "    <sab name=\"c_H_in_H2O\" />\r\n",
-      "  </material>\r\n",
-      "</materials>\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "materials.export_to_xml()\n",
-    "!cat materials.xml"
+    "materials.export_to_xml()"
    ]
   },
   {
@@ -351,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -407,7 +372,7 @@
        "             ('U238', 8)])"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -432,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +413,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -459,12 +424,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For this problem, we will take depletion step sizes of 30 days, and instruct OpenMC to re-run a transport simulation every 30 days until we have modeled the problem over a six month cycle. The depletion interface expects the time to be given in seconds, so we will have to convert. Note that these values are not cummulative."
+    "For this problem, we will take depletion step sizes of 30 days, and instruct OpenMC to re-run a transport simulation every 30 days until we have modeled the problem over a six month cycle. The depletion interface expects the time to be given in seconds, so we will have to convert. Note that these values are not cumulative."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -480,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -514,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -541,7 +506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,7 +515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -559,7 +524,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -568,22 +533,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "array([[0.76882937, 0.00982155],\n",
-       "       [0.75724032, 0.00827689],\n",
-       "       [0.75532241, 0.01031746],\n",
-       "       [0.74796854, 0.00919769],\n",
-       "       [0.74066559, 0.01157708],\n",
-       "       [0.7318449 , 0.00971503],\n",
-       "       [0.72072927, 0.00703074]])"
+       "       [0.75724033, 0.00827689],\n",
+       "       [0.75532242, 0.01031746],\n",
+       "       [0.74796855, 0.00919769],\n",
+       "       [0.74066561, 0.01157708],\n",
+       "       [0.73184492, 0.00971504],\n",
+       "       [0.7207293 , 0.00703074]])"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -601,7 +566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -610,7 +575,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -646,7 +611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -656,7 +621,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -678,7 +643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -707,7 +672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -716,7 +681,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -742,9 +707,9 @@
    "source": [
     "# Helpful tips\n",
     "\n",
-    "Depletion is a tricky task to get correct. Too short of time steps and you may never get your results due to running many transport simulations. Too long of time steps and you may get incorrect answers. Take the plot of xenon from above. Xenon is a fission product with a thermal absorption cross section on the order of millions of barns, but has a half life of ~9 hours. Taking smaller time steps at the beginning of your simulation to build up some equilibrium in your fission products is highly recommended.\n",
+    "Depletion is a tricky task to get correct. Use too short of time steps and you may never get your results due to running many transport simulations. Use long of time steps and you may get incorrect answers. Consider the xenon plot from above. Xenon-135 is a fission product with a thermal absorption cross section on the order of millions of barns, but has a half life of ~9 hours. Taking smaller time steps at the beginning of your simulation to build up some equilibrium in your fission products is highly recommended.\n",
     "\n",
-    "When possible, differentiate materials that reappear in multiple places. If we had built an entire core with the single `fuel` material, every pin would be depleted using the same averaged spectrum and reaction rates which is incorrect. The `Operator` can differentiate these materials using the `diff_burnable_mats` argument, but not that the volumes will be copied from the original material.\n",
+    "When possible, differentiate materials that reappear in multiple places. If we had built an entire core with the single `fuel` material, every pin would be depleted using the same averaged spectrum and reaction rates which is incorrect. The `Operator` can differentiate these materials using the `diff_burnable_mats` argument, but note that the volumes will be copied from the original material.\n",
     "\n",
     "Using higher-order integrators, like the `CECMIntegrator`, `EPCRK4Integrator` with a fourth order Runge-Kutta, or the `LEQIIntegrator`, can improve the accuracy of a simulation, or at least allow you to take longer depletion steps between transport simulations with similar accuracy.\n",
     "\n",
@@ -753,7 +718,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -763,22 +728,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7fede8277b50>"
+       "<matplotlib.image.AxesImage at 0x7f9ae8572a90>"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQ0AAAD8CAYAAABtq/EAAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO2df+wtZXngPw+/1Ovlqhe4ghAEila6IG7AoNvtyrJoTdnuYjZebBcTaHZxSQjJxtZbtC6F/YHc2DRhqZjbRJpKo2BYqOgu3lgKe1uXu4AVMVHALdaVpdnA1YWCCnKf/ePMwNz5njMz7895Z87zSb653ztnvmfemTPzOc/zvu/MI6qKYRjGUA4auwGGYUwLk4ZhGE6YNAzDcMKkYRiGEyYNwzCcMGkYhuFEsDRE5DQROThGYwzDKJ9DQv5YRM4C7gKOAF5sLD8HOBUQ4F5V3btsWci2DcMYBwmd3CUi3wPeoqo/qf5/MLAXeHu1yp8B724vU9VzgjZsGMYopOjTOB54UiuAF4AT2stE5KQE2zYMIzFB6ckKjgaeafz/GWDbkmWvB/66/ccicglwCcArXnXYGUe/8agETTSabPnZ82M3YSlPH3LY2E2YPU898UOe+dGz4vI3KaTxFLC58f/NwL4ly55c9sequgvYBXDCKcfplTdenqCJ68u5+x4buwlBfHXriWM3YVZcdfF1zn8TTRoichBwpKo+IiKHi0htr82q+vCSZY/G2raxmqlLok17f0wi+QkdPTkTOAp4D/B94KPAduAK4MPValc0/m0vMyIyN0EMYdk+m0jSEiQNVb0feHVj0fZq+R5gT2vdDcuMcHKK4ob9O6K8z6UHXRvlfVbRPCYmkPjYjFDDMJxI0RFqZCBFhBErkgjdTsxIpD5OFnHEw6QxIWKJIpccfFnVvhCZWMoSD5NG4cQQRemSGEp7P3wlYgIJw6RRIKGimIsk+oghEROIOyaNggiRxbqIoovmMQgRiMmjG5NGAfjKIqUo/ubs9yR772W88e7dUd8vRCAmj25MGiPjKoyYosgthi662hIqFF+BnLvvMRPHEkwaIzCWKEqShAvtdodIxFUgFnVsxKSRkTFkMVVRdNHcpxgCcZEHmEBMGplwEUaILOYoiS5iRCEu8gBLW0waickhi7FEcdMjHxy03oVv/mzilrxMSBTiE3msozzs3hPDMJywSCMRqSOMlNHF0Agi9vvFjkh8ow6LOLoxaSRgqDDGlkVsOYSyqj0xZFIft5TyWBdxmDQiM0QYrrKIJYrSJDGUdrtDJOITfdywf4eJo4FJIxKlymKqouiiuU8xBDJEHkPnd6xDumLSCCRFKhIiizlKoosYUYhr6jIk8pizPEaRhohsUdWnx9h2TGJHF76yWDdRdBEShfhEHkPkMTdxeEtDRA4BrgS+DpwCfEJV91dPHH8A2F+t+hpVfZOIHAF8DTgY+Bzw8aCWj0wJwkgti4f23ZL0/WtO27o9yfvWx8dHHrGjjjmJIyTS+NfA46p6m4gcDbwfuBk4DniPqj4pIpuBq6v1Lwb+uap+J6jFIxM7HSlBFrnk4Lr9WDLxkYdr1LFO6UqINN4B3FD9/g3gUuBmVf3fjXXOA+6sfj8K+JKI/AD4F6r6VMC2R2Hs6CKWLMaWxFDa7QyViK88LF05kBBpNMsv1mUW25wDXAagqjtE5KPA7wFX1cvbNMsyHnH0awOaF5dYwjBR+NPchxCBuPZ7uAzTrkO6EiKNZvnFDWUWReQwAFV9oV6mqi+KyNXAH61603ZZxoD2RWMMYcSQxRxEsYrYAhkafQyJPOYujpB7T3YDp1e/vxXYLSLbGq+fC9xV/0dEXlH9ug24N2C7hmGMiKj6fZlXtVuvBr7JQhq3ATtUdXv1+h8AV6jq0yJyInAHiwjieeBGVf1p3zZKKADdF2WUlJLMObJwwTfycB1lGdLX0RdxjB1tXHXxdXzv2z9wqhrvLY0cjC2N3MKYmizOu+yMQet9+foHErdkOTnkMXVxmDQi0iWM2MOpJcpiqBBikVIsqeUxdE5HlzzGEodJIwJTiC5iyiK3HFyJKRMfecw96jBpBFK6MGLJonRRrCKWQFzlMWdxmDQCyCUME0UcShbIlMRh0vBkrsKYmyhWESqQdRaHjzTs1vge+oSRorMzRBbrIoomzX32EUh9vIfK46ZHPtgrjiH3rgx9uE9prP2DhUPqp5YkjPMuO2MthdEm5Di4HPuhn2nIs1FCC4GnYq3Tk5C0JHY6EiKL1ByzfVOS933ilueSvG8T39TFJWUJTVfGTFOsT8OBqQsjlSxSCWIoqUTiI491EIePNNY+PTEMw421jDRCZnuOHWXEjjDGjiz6iB15uEYcOaMNyD9r1CKNQHIJ46F9t7z040IsYRyzfdNLP6UTu62ux9Dlcxry2fedQzGKfqdm7SKNVVFGTmG4EFMUcyJWBJIi8kgZccSONizS6MF3CGvKwphKROFKrP3yiTz6iBFxrKKEYdi1mdwV467VZQztv3ARRqgs5iiJVTT31Tf6qI/30KjjoX239EYcvk9Cr+ma+DX2U7/WKtJYRkhaUpow5hpVDCV0/12OfYx+jqn2b8w+0kg9UtJHDmGMJYoL7jm9fyXg5nc9mLglB1IfD5/I47zLzogacfTR98zRVRHHmCURZi8NX/qEEbsPw0cYqWUxVAqh75NKKr7yiC2OvntVXIozlUDy9EREtqTexirG7MeYojAuuOf0A35ykXq7PscqdqoS8nT5rnN1jI7RkAcLLy3LWL12QAlGVf24iJwDnAoIcK+q7u3bRsiQq68wSo8wYsoipxhCiBmJuEYdLkOyMYZjfaea+6YpuYdcXyrLCPyQRVnGmroE48mVMA4GdgL/GbgOuCZgu8lYF2HkjiRCidle12OYO+KI0Y+WmhBpvINFOUaqf89rvFaXYLy7ijqOB57UCuAFETkpYNudpEpL+hgqDNfbt2ONikxNFm1itd/1eKYYVfGhlDQlRBoryzKq6g7g51nI5KrWuhvWbyIil4jI/SJy/9/96NmA5hmGkYIQaXSWZVTVF1kUUzq+te7S9Rt/t0tVz1TVMze/9tUBzdtI6r6MIViEEc4YEUfMhxyFpCglzN1IUpaxXYJRVR8BDpcKYLOqPhqw7ZX4hGm5+jJchRHK3GTRJqY8hjLkMxyrbyNXihK9LGP1s6EEo4j8EnBW9ed7VXVP3zZcR09SjJj0fbgu/RhDCRHGnCUxhJCRFpeRlaGjKn0jKl2jKTlGUrKOnqjqflX9HVW9pfr3AVXdrqqPqeqpqnqdqn66rtmqqntU9ZPVT68wchHSW23CKI+QY5CiczSkY7TUkZTZ3Brvc8t7aFpSSkoypiwev+kjna8fe+HOTC3ZiG/UETviCIk2wC/iGBptWAmDjKyTMPrE4Pu3qYVywT2ne4njmO2bBotjyJTzGPeolMQsIo3cUUYJwkgpixBJhJBSIj7yyBlxjBVtWKQRgVhDq0MpQRhjSaJNux0xJeITdbhEHKGEPn8jJ7N9nkZoCYJVxIwyxhbG4zd9pBhhLCN2+3yOncs8jj5SdYrmnrsxeWnEHJvO3fHpSixhlC6LNjHbmzKtiyGOmJFuqnkbs0xPUkUZsXCNMGLKYsrU7Q9NW+rjOTRdyZmmdNH13I2cdWEnH2kYhpGXSUtjiqmJRRnhjJGqDL1PZR1SlElLYxljpSalCmNq/RdDibVfrsc4ljh8KaFDdHbS8CHW/SUxiSWMuTOGOGKQM9qIzWSl4Rp2pYoyht4y7RJlhJ7Ec40uVhFjf11TlT5i3krfxvVcjp2iTFYay/AJz3JEGblKDKybLNrk3P8Yn2mKaCNHijI5aZy777EiStNBmtzVN8pYZ1m08T0WKdKUlP0bLsS8bmY5T6NJjmdldJEjLRlbGBefv2vp8htvvyRzS17m8Zs+4jWfw2W6eYz5G303s62qmVKf12PUS5mNNHJPpS3lGySnMFbJwXX9XDLxFUdsXIovxSD1RK9JSSNnWjKFKCOHMFxF4fqeqQXiI47Soo2YxCgePSlpuBKjePMyYkcZpT1xK4UohmxrzHSmje+zOFYREm10lXUco6TjKB2hsUs1lvCE5japR0xSRBkXn78rqzBybT91RDZWAe4uUl4T3tIQkUNE5N+LyPtE5KPVg4br1z4gIn8pIt8VkX9QLTtCRB4Wke8CvxWh7YZhjED0sowi8irgRVX9ReDfAR+v1j+gVGPAdpPy0L5bOvszSkhNYn9zjh1htEnRHp9jFjtt7Dp3+s67kkhRlvEF4Nbq979iUSgJNpZqdCLmDNDUU3RThqsxhVGaLNrEbl/KNCV1itJ1zuaeIRq9LKOq/qyuHg/8IxaFn5eValyKa1nGEvszhjJmB2jJsmgzZltL66R2IdW1kawsY1Xg+fuq+s16WatU41JSlmXsoy88THEnqwuxvimnJIyaWG0eO9roO4emkKKkKsu4DXiLqv43EXmliGxrl2oM2G4vY6YmQ3AtJxjznoopCqMmpjhcjmcp0UbMFCWEEGn8MXC8iGxnETl8C7heRDYBfwrsFJFvAfcBrwEeEJHLgbOB33PZUCn3mkydKQujZg77UAIh11SKsozPqeo7q9KMp6rqaar66LJSjaHEzNlypSau31oWYWxkjFRlaHRYWoqSol9jcne5Gu7MSRg1c9ynqTA7aZTcnzFGlDHniyvGvrke47H7N0ro15idNFIw9qiJMS3Gfo5oaoqXRo5O0BKHuSzKGMYY0UYOcpyTvtdW8dIwDKMsJiuNqc0EzZkLlz49PDa593fsfg1XYl8rs36eRg6sL8NYRn1elFDOMTaTjTRcGXvkxIWQHHudIow2IfteYr/GKsY+l2cljRRDTlPu5TbKJsW5lWPYdVbS8CFHL/XUcmCjnxyfaYmjemDSmBXrnJrU2DFIT9HS2PKz58duQicpOkGnlFvPjRTHvvSOcp9rrGhpGIZRHpOTxg37d0xujkYOLCx/GTsWG4l53UxOGoZhjItJwzAMJ0wahmE4MXtp3PTIB71n0MWYfGNzNOZLjM/W9xwLOa9Dmb00poQNt46PfQb9mDRmgI0WbMSOSTq873IVkUOAK4GvA6cAn6iLJInIOcCpgAD3qureZctCG28YRn5Cbo1/qZariBzNopbrzSJyMIuqam+v1vszEXl3exlwTsC2DcMYiRS1XI8HntQKFrVdT2gvqyqwbaBZlnHf//txQPMMw0hB9FqureX1a9uWLHs9S2iWZdz6mlcFNM8wjBSkqOXaXF6/tm/JsgNqvxqGMQ2i13JV1UeAw6UC2KyqDy9Z9mhY042aG2+/ZOwmFIcdk3REr+VavXYF8OHq54qOZUaDYy/cOXYT1h77DPrxHj2phld/p/pv/Yih7dVre4A9rfU3LMvBhW/+LOD3XMUvX/9A8KzQm9/1oM0KnSk3v+vB4Pf48vUPeP1dfV6PgU3uMgzDCZOGYRhOmDQMw3BictK49KBrufSga8duRnHYaMHL2LHYSMzrZnLSMAxjXIqWxtOHHDZ2EzpJUXLPhvzGI8WxL70so881VrQ0DDcsLLdjkIO1l8ZpW7cn30aM8XyjLHJ8pjnOTR9mJY033r07+nv6Tr4xjD5SnFsproE2s5JGF2POoHMlJLde5/A8ZN+n1Jc09rkc8hAeg5c7ukovv2fkpfQO0BAmG2lMba5Gzn6NG2+/ZK0ijtz7O7U+qtjXymSlYRjGOBQvja9uPTH5NkrspY6RY69DtBFjH0vsz8hxTvpeW8VLowSG9HLPOYc13BhyLkx5VG520ugachq719k1F7Zoo5sxooyx+zO6zuEcw60wQ2kYG5mjOOa4T1Nh0tKI2Svcl0PGSlHGiDZgXhdZrH1xObY3v+vBQZ9djNQkZn9GilHG0aQhIluGrpujM3QdmIM45rAPJRByTXlLQ0S2iMh/FJH3ici/XfL65VXRo4dE5M3Vsl8Qkb8Wke8Cv+7d6h5K7teA4d9aNcdeuNMiDuJGGK5RRgmU0J8BYZHGx4A9qnobcLSInFW/ICLHAw+q6pnA54BaKr8O/KKqnqyqnw7YdhJypSi+rLM4xkhJXCktNUlFirKMAH+rqvdUv/8ViwJKAMcB94nIrSLyyoBtv8TUZoY2GfMbbEriGLOtpUQZPqS6NlKUZURVn2+sdwbwB9Xyi4A3AfuBy5a9abOW69/96NmXlrvmYGOmKFOINqD86eax2zd2lBFCzNQktI+wVxoi8l4Rubv9A2xheVnG5t/+feAuVX2iXqaqPwauYVFgaQPNWq6bX/tq9z0K5LSt2ztDxNiTcny+yWKf/KXJI0V7fI5Z7Cij69zpO+9KovcuV1W9E7izvVxEfpdFWcbdLMoyfkVEDmNRcnGfiPxc9fseETkKeA54oYpCtgH3xtsNwzByEZKe7AT+iYhcADxT9WH8MvAxEXk98EXgBhH5FvB5FoL5nyLyr4BjWXSQRqHEfo3U4WqKUHvsiCPV9lPfW1LiLQQpr4mQsozPATtay+4A7qj++/eW/NnbfLfnwxvv3s3fnP2epa9d+ObPepVqhDjlGpuUVrqxeeFefP6ubNsqiZypSR+lDLXWTOohPF/deiLn7nssy7ZO27qdh/bd0r9iB0/c8tzgh/P4iOPYC3fy+E0f8WnaYFIIJKcoUvdlxIgycvZlxJgoOSlpdHHpQddyw/4d/StGIna04UsOcdSsuthXyWTsKKKUW95z39GaOl2fjTRWUYdvy9KUvhRlCtEG5BXHMsaWwzJ8hVFalLEqNRkjLamZ3A1rX916YjH3oqT4BvHNpUv5Vi2BHMIYSinPzYh53UxOGl34hGV9E71i5Ju5etdj3qMyRXLu/5hRRhc5RhInK42YM0RD+PL1D0S/JyX0G2/d5BFjf2OnJUPPCx9yzwBtM1lpxCRHtOFKjFB5HcQRYx/HuL8kRZSRi9lJoys8S9l5lOIO2FjimKM8Yu2X6zEe+/mfXedwrkmOk5ZGzLArRrRRqjhgXlFHrH1xTUliCSNnlJFi0GDS0jAMIz+znKfRNdGra2p5LlxLOdbfiKFTzetv6DHndIQwRoQB5dxbUkJqAjOINKaYovgSM1WZUroSs70pOz3XITWBGUhjFak6RGOKw+cbLOZJX7o8YrfP59gN/YxiCKOLUqIMmGl6EkJtet87YF1xmWZeE/uu2PaFOVb6klJgKYURg5KHWNuIqo7dhpWccMpxeuWNlw9ad9Xdr103sfX1bXSJY8g9KS43tLmKoybHLfWpJJIjyvGNzFyEERpl9AnDJ8oYmppcdfF1fO/bP5BBK1dYpOHJkJvZXO6E9Yk4IM+zOLou7j6hjJn+TEEYU2Q2kQasjjZgdcSROtqAPBEH5Ik6pkBIv09sYUCaKKOrH8OlA9Qn0phtR+hQUneKgtuISkgePeXH7cdiSsLoY8zb37vIIg2XEowhdBnWt4d5yDBs7KHYUHG4VnCbOjH2OUVKkmp4NVaU4UvKsowbSjCKyAdE5DdE5Lerp5VHx+eg9Rl9yIdbkjhq5i6PWPs3Rh9GSOfnKnI9ZyZJWcaKA0owishW4EOq+hkWxZN+P2DbXoTM3Yg1JOYqDpPHRmLKwmUeRqyJeylGS3KSqiwjbCzBeDrwMICqPgOcLCKHBmx/JSnSlCG49HGYPNwZQxbgJvqUIyVjpyU1ScoywtISjM31YVE86cj2m64qy2gYRhkkLcvYKsH4VGN9gE3AviV/M1pZxlx9GzWu4W6sGYpTizhittf1GMaOMlL0ZeTGe55GVZbxa6q6W0T+E/AV4H+wEMMPgUNV9XkReS+wFfhT4HZVfbeIbAb+i6p2TpJwnafRxmfeRk3X/I0hU8xdnmLuUwohZD7HKkqZ55FCaD7CzSmMPlmkSk185mmESGMTcCXwdeAkVb1GRH4VOBu4FfgUcD2gwGdUVUXk/cDrgDcAn1fV73RtI1Qa4C+OkElfNVMUR5NcEkkd9ZQuDPDv/Azty8g6jXxAWcYNJRhV9Qu+28tN33M3hpR1dKmb4lN8yfW5HK70XcxDpTJWKuSbzpUkjBKZ/b0ntYmXRRx9VdliPLAntTggvTxWUWq/SEjfT+6REt+0ZMzaP2s/jbxvCLbrQx06dyNl52iTWEOzUyV0/1MII1U/xpjMPtKo6SoeHVIHdujzN1wjDvDr54ADv2lzRx+5iSFJV1HHSEn6KGVOxjLWKtLwPdhDcs7Yw7EQ59GBc40+Yu3XWMLw7ccYWxgws1vjh+LzwB7oH1GB+KMqTWJVqZ9q9BFLfj4yjpGO1JTUj2G3xgcS0r9RMzTiGHp3bJNY9z7U39JTiEBit9UnsihBGCWxlpEGdM/fgLA5HOD2jFGfyCNW1NFm7CgklchSRhcQLow+WaRKSyzSMAwjOWsbacD0ow1IF3E0SRV95EiPfFO6dYgyIPM08hyklgakFwfMRx5TohRZQLnCAEtPvAj5UIYOm7mM2fvOMoz5kJgpE3IccgujjxKGV5exNpO7fBky1Rz6o44h96rU1CevT9TRvGDWJfoIlaWrqGPNw5jCSMky1j49qQlJU2pi93OAf7rSZm4CiRVVlSqMXFGG9WkEkkscNSYQN0oWRc2UhAEmjSiULg6IJw8oXyAx+2l8+ovmLAwwaUQl5KlfNSlGV5rElEeb3DJJ2Ynr27kcu7OzxJvQTBqRmULUAWnl0cVQsYw1qpNaFjDN6KKJSSMBucUB05NHaeSQBUxfGDAxaYjIFlV9umudEqQB/eKAcqKOJusikRhP0ModXcD4woDMk7u6yjKKyOEi8t26fomI/Pdq+YZSjYZhTIuQyV0fA/5cVe8UkWtF5CxV3Vu9dhxwqqr+RETeBJxfLa9LNT4RsN3sdD31q2bI079cnjk69IlgXTS/gecWdcSqZDZGSgJlRBm+hEjjHbxcj7Uuy7gXQFW/3VjvfcDt1e91qca9wL9U1Z8EbD8rMcVRM0QgzZN63QVSsihq5i4MCJNGZ1nGBqeo6k5YlGoUkVcBf8yiVOMn2yuLyCXAJQBHHP3agObFZ6g4YFgfh+vTzmNEH7Dx4itVIrHrovo8tzPGcGqTqQsDBkijqpD220teqssyPsuKsowi8gbg/zSXqeqPReQa4KJl21PVXcAuWHSE9rUvN10lEZoMfVjx0HtXmsSSR82qizOXTFIWTYa0soD1iC6a9EpDVe8E7mwvr8oyng7sBt4KfEVEDgM2q2pdo/V84IvV+kJVqhHYBtwbYwfGIla6UuNTYyW2PNqkvphT4/tEcBNGNyHpyU7gShF5HfCMqt7TKMv44Wqds4Abqt/fCXxKRF4q1Riw7SJIka6A+7yOWP0ecyCkdEBsWcD8hAE2uSsaseZyNAmt7gbzl0hofRFwf+bFnKKLrLVcjQMZ0tfhEnWAf+TRZI5RSAxRgEUWvpg0IhM7ZQH3YdpVtC+2qUgkliTA70laJowDMWkkYIg4wF0eECf6qFl1MY4lk5hyaJNSFrA+wgCTRjKGDs1CmDwgjkCaDL14h8olpQy68H0+p8mim7V/sLBhGG5YpJGY1BEHpI06uhgrgugi5OnfFmEMw6SRiaH9HOAvD9h40eSUyBiESKLG9ang6ywMMGlkxSXqgDB51IwVhaQkhijAIgtfTBoj0DwBXdIWiCcQmI5EYkkCLKqIgUljZFzSFognEOi+GHMLJaYY2vgWJTJhLMekUQCuaUtNTIG0SXkR5yCkepnJohuTRkH4ygPSCmQqhJY5NFkMw6RRIK59Hm3aF89cJRKjFqqJwh2TRuGECgTmI5FYBZNNFGGYNCZEDIHA6ouvFJmkqKZuooiHSWOihPR/rKLvYo0llRRSWIXJIj5274lhGE5YpDFxYqUsQ8gZIYRg0UVagqUhIm9T1W/EaIwRxrKLJbVIxsYEkZ8gaYjIPwX+EDhmyWsfADaxePL4F1T1fy1bFrJ9o5/2RTV1iZgkxidIGqr6pao0wQGIyFbgQ6r6j0XkcOBPROSi9jLgn4Vs33BnStGICaJMUvVpnA48DKCqz4jIycAZ7WUicqiqvpCoDcZA+i7OVFIxKUyTVNJolmwEeA44csWyA4pBN8syAj/9jXfu+FaiNo7JkSypSDcD5rpfMN99+3nXPwgpy/ghVX14xZ89xaJUY80mYN+KZQfQLMsoIver6pl9bZwatl/TY677JiL3u/6Nd1nGFQ04jIUY/hL4rWrZZuAHwF8Av9lcpqo/dW2wYRjjEjp68ivA60Tk7ap6H/DLwNmq+mER2VWlGm8ALlfVZ9vLgltvGEZ2QkdP/ivwisb/7wDuqH7/wpL1NyzrYVdI+wrG9mt6zHXfnPer6FquhmGUh917YhiGE8VKQ0TeNnYbxkJEtozdBqObqX5GInKaiBwc8h5F3rDmOj09c/O8qE6yHcD9wAmq+vut138B+BKwH/gk8OnsjRyIiBwCXAl8HTgF+ISq7q9eOwc4FRDgXlXdO1pDPejZtyOArwEHA58DPj5WO30QkbOAu4AjgBcby90+M1Ut8gf42yXLtgJ/Xv1+OPDFsdvpsD/XAu9t/H5W6/X/ABwzdjsH7sulwL9p/H5B9fvBLKQo1c9dY7c11r5V//9N4C1jtzFw/74HvLLxf+fPrNj0ZAUHTE8HThaRQ8dt0mDeAdR3A38DOK/1+nHAfSJyq4i8MmvL3Fm1L8cDT2oF8IKInDRGAwPo+pyOAr4kIndXUccccP7MpiaNVdPTp0Cz7c8Ar2++qKoXAW9ikZ5clrVl7qzal/bns2E/J8DKz0lVd7CYdv0N4Kr8TUuC82c2Wp9G5OnpxdCxX1tYtP3Z6t8N9zGo6o9F5BrgopRtjEDzc2juS/vzWbqfhbNq3wBQ1RdF5GrgjzK3KxXOn9lo0tBI09O1sKnoq/ZLRH6XRXq1G3gr8JXGfv0QOFRVn2fRwXtvtgb7sZvFvuxlsS+7RWSbqj4iIoc3HpewWVUfHa2Vfqzat/8rIq+ozrcpfEadiMhBwJE+n1mRk7uq6em3Af9QVe8TkV/l5enp7wdex2Iq+udV9TtjtnUoIrKJl3vlT1LVa+r9Am4FPgVcDyjwGS3xg6moTrirgW+yuLBuA3ao6nYR+SXgrGrVvaq6Z6RmerFq36qfO1jMoO1g+6MAAABPSURBVHweuLG0L6w+RORM4B7g14DvAx/1+cyKlIZhGOUytY5QwzBGxqRhGIYTJg3DMJwwaRiG4YRJwzAMJ0wahmE4YdIwDMMJk4ZhGE78f6bUYnxQ0og4AAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQ0AAAD8CAYAAABtq/EAAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAf3UlEQVR4nO2df+xlZXngP88MX3/QgeqAw1CQCIUq7FhtwaDt7qbLVqRSW5sGsDQhdLPCuqhJ0RbRsqDbXdS1ki3SukOilqRaOrHYgi5OUqrL1mUWtKzLGmHc0lgI1AwDcYooX5mnf9xz4M793nvPec/7+9znk0zm+z33fu95z6/PfZ73fc95RFUxDMPoy6bcDTAMoy5MGoZhOGHSMAzDCZOGYRhOmDQMw3DCpGEYhhPe0hCRV4rI5hCNMQyjfA7z+WMRORO4AzgKeGZq+VnADkCAu1R1z7xlPus2DCMP4ju5S0T+DniFqn6/+X0zsAd4TfOWvwReP7tMVc/yWrFhGFmI0adxArBPG4B14GWzy0TkpAjrNgwjMl7pyQK2Awemfj8AbJuz7Bjgb2f/WEQuAS4B4HkvPP2wbS+L0ERjmmPX9uVuwlweWT86dxNGzzP7H+Hgk4+Ly9/EkMZjwJap37cA++csm3umqupOYCfA2ktP0xdd/ukITVxdrt5+Y+4mePH+R9+auwmj4omPXuj8N8GkISKbgKNV9QEROUJEWnttUdX75yzbG2rdxmJql8Qss9tjEkmP7+jJGcBLgLOBbwPvBc4HrgTe1bztyqn/Z5cZARmbIPowb5tNJHHxHj2JiaUn3aQUxYN7zwnyOSeecnuQz+mDCWQ5T3z0Qtb//htOfRo2I9QwDCdidIQaCYgRYYSKJHzXEzISafeTRRzhMGlURChRpJLDUBa1z0cm0/vOBOKHSaNwQoiidEn0ZXY7hkrEBOKHSaNAfEUxFkl0EUIiJhB3TBoF4SOLVRHFMqb3gY9ATB7LMWkUwFBZxBTFdy74zWifPY9tN18X9PN8BGLyWI7N08iMqzBCiiK1GIYSUiiuAhm7OIbM0zBpZCCXKGqRRBehJOIikLHKw6RRODlkMRZRLCKEQFY5+jBpFIyLMHxkMXZJdOEjkVWMPEwaBZJCFrlEcf1pP+z1vnd8I09/+1CBrJI87N4TwzCiY5FGJGJHGDGji74RRGhiRiRDoo5ViDgsPSmEvsLILYtccnAlpExiyqNGcZg0CqCPMFxlEUoUtUiii1AScRHIWMVh0shIqbIYiygWEUIgrtFHH4HUIg+TRgZipCI+shi7JLrwkcgqRh7VSENEjlTV73a9r3RphI4uhspi1UWxiKECCS2PksWRVBoichhwNfA14FTgg6p6sHni+FeBg81bf1RVTxGRo4CvAJuBz6jqVV3rKFkaJQgjtix2nXtZ1M9vOe/zN0T9/CHyWBVxpJbG2wBV1Y83P+9X1ZtF5KXAU6q6T0S2AB9Q1ctF5N3Abar6zb7rKFEaodOREmSRSg6uhJZJTHnUmq6klsYfAX+oqneJyOuAt6nqRTPvuQB4XFV3i8iHgF8FHgJ+VVUf61pHadLIHV2EkkWpkugilERc5THmqCO1NL4IXK6q/09EdgC/p6pvmHnPfwPerqrrze+bgd8DDlPVty/43GfLMm568bGnb73qC4PaF5pQwjBRhKFkgdQkjtTS+DTwX1V1j4i8FniHqv761OvPA65X1Utn/m4r8ClV/aWudZQSaeQQRghZjE0UiwghEBd5jEkcqe892Q28qvn5J4HdIrJt6vWfB+5ofxGR5zc/bgPu8livYRgZ8Yk0NgEfAL7ORBq3AFeo6vnN6zcAV6rqd0XkROBWJoWdnwY+qao/6FpHCZFGV5RRUkqyKpFFF0MjjxypSu5oo5p5Gn3JLY3UwqhNFsevn9frfQ+t7YrckvmkkEft4jBpBGSZMEIPp5Yoi75CCEVMscSWR4hh2VziMGkEoIboIqQsUsvBlZAyGSKPsUcdJg1PShdGKFmULopFhBKIqzzGLA6ThgephGGiCEPJAqlJHPa4v4GMVRjHr5/37L+xEWrbXPdxn2PY51zoOqdCFfuOgVVY66Dr4Mbo7PSRxRgF0cX0Ng+JQNr93TfquP60H3ZGHO15sSzqeHDvOYOLWOdk5SMNH6OXJIyxRhSu+OwHl33f95j6PBul1Ghjpfs0fNKS0OmIjyxic/b656J87u61N0f53GmG9n249HX49nPk7N+wjlAHahdGLFnEEkRfYolkiDxWQRzWEWoYRnRWMtLwme2ZO8oIHWHkjiy6CB15uEYcKaMNSD9rdEikYaMnU6QSRu7+i9JFMc10W0MI5Pj185zE4TKy0ndUpfYRlZWLNBZFGaUKYxVF0YdQEUiMyCNmxBE62rA+jQ6GDmHVLIyz1z83OmFAuO1y3cd9jmGoCWDzKGEYdmUijVj9GH37L1yE4SuLMUqiD77Rh0vU0bevY1nUUUL/hkUaAxiTMMYaVfTFd/td9n3fY7rsHOmKNobU+k3B6CONmCMloVOSocLIJYqj7lvv9b7HdqxFbsl8hkYeoSOOrj6OnBGHjZ4EpAZhxJZFXyn4fk4sqbT7x1UeLiMsu869rFMcXaMqXSMqpRE9PRGRI2OvYxEhnr41j7EK46j71g/5l4rY6x2yr0KnKj5Pl192ruboGA1elrF5bUMJRhE5C9gBCHCXqu7pWodPejJUGKVHGCFlkVIMPoSMRFyjjpJSlRhpSuqO0LcCD6vqLcDjwPTZ/xvAL6vqyY0wNgMfBq4Hfh+41mO90VgVYaSOJHwJ2V7XfZg64vC5KzYVPtJ4LXBv8/O9wLlTr70EuE1EvtREHScA+7QBWBeRkzzWvZRYaUkXfYXhevt2qFGR2mQxS6j2u+7PGKMqQyglTfGRxnbgQPPzAeCY9gVVvQJ4OROZvH/mvRveP42IXCIi94jIPQeffMKjeYZhxMBHGo8BW5qftwD7pl9U1WeYFFM6Yea9c98/9Xc7VfUMVT1j04+8yKN5G4ndl9EHizD8yRFxhHzIkU+KUsLcjShlGWdLMKrqA8AR0gBsUdW9HuteyJAwLVVfhqswfBmbLGYJKY++9DmGufo2UqUoPtK4CThBRM5nEk3cB3ysKcH4VRF5J/BzTKrEA1wJvKv5d6XHehcSoy+j6+DuOveyooSRY8g0NyG2OYY4us6LodFr7r6NwdJQ1YOq+juq+qfN/19V1fNV9UFV3aGqv6+qH29rtqrqnar6kebfneE2wQ+f3mqXjs+++Apj1SlJHODXMVrqSMpoZoQOueU9RT9GCmHklMXDF+1f+vpxN21N1JLnaPfHkPkdZ69/rvdcDtdnc8xj6GzR9ryeN3fj6u03Rn2u6GikkZpSUpIUwugSw9C/jS2Uo+5bL0Icfaaa18QoblhLHWWUIIyYsvCRhA8xJTJEHi6zR/tEHMvEEWOmaJ9ow25YC0CoodW+lCCMXJKYZbYdISUyJOpwiTh8ac87l7qxuRjt8zR8SxAsImSUkVsYD1+0vxhhzCN0+4bsO5d5HF3E6hRNPXejemmEHGLqM7zaRcziRaGEUbosZgnZ3phpXQhxhIx0Yw2/Vi+NecSKMkLhOtMz1LyL2mQxS6j2u+7PUp6GVkq0MUppGIYRj6qlUWNq4vqtFTIlGQs5UpW+0eEqpChVS2MeuVKTUoVRe0qyiJCpiguhxDGUElKU0UljCCGijNCEEsbYySGOEKSMNkJTrTRcw65YUUbfW6ZdOz59GGt0sYgQ2xu6YzTkrfSzuJ7LoVOUaqUxjyHhWYooI1Xv+6rJYpaU2x/imMaINlKkKNVJ4+rtNxZRmg7i5K5Do4xVlsUsQ/dFjDQlZv+GCyGvm/LnrHriUyEtdZRRqzDeeM2tc5d/4Zo3JW7Jczx80f5B09BdppuHmGbedTPbortg2/M6R72U0Ugj9VTaUr5BUgpjkRxc359KJkPFEZoQt9C78ODec5aWO/ClqvQkZVpSQ5SRQhhvvObWZ/+V/JmLGLKPUs8WTTk6F+IaGk2kMY8QxZvnETrKKO2JWyku5nnrypnOzDL0WRyL8Ik2lj2oJ0dJxyyRRuhSjSU8oXmW2CMmMaKMVN/+qdcfOyIr5d6UaWJeE4OlISKHich/FJFfEZH3isimqdfeIiJ/LSLfEpGfaZYdJSL3i8i3gN8K0HbDMDLgk548W5ZRRLYzKct4s4i8EHhGVX9WRC4ErgJ+gedKNX7Tu9UR6covS0hNQn9z5owu5tG2J2S6MqRTNGWK0p53NTwWMEZZxnXgs83Pf8OkUBJsLNXoRMgZoLGn6MYMV0MKI3c60kXo9sVMU2KnKMvO2dQzRIOXZVTVH7bV44F/yaTw87xSjXNxLctYYn9GX3J2gJYsi1lytrW0TmoXYl0b0coyNgWev62qX2+XzZRqnEvMsoxdhEhNaogyahJGS6g25442us6hHDdHuhKrLOM24BWq+t9F5AUism22VKPHejvJmZr0wfXJUSHvqahRGC0hxeGyP0uJNkKmKD7EKMt4OPDnwIdF5D7gbuBHmV+qsRel3GtSOzULo2UM21ACPtdUjLKM31PV1zWlGXeo6itVde+8Uo2+hMzZUqUmrt9aFmFsJEeq0jc6LC1FidGvUdU0cmMYYxJGyxi3qRZGJ42S+zNyRBljvrhCbJvrPs7dv1FCv8bopBGD3KMmRl3kfo5obIqXRopO0BKHuSzK6EeOaCMFKc7JoddW8dIwDKMsqr01vraZoClz4VWIMKaJca/KMkLfkxKb0A/lqVYapWB9GcY82vMiVdX5lKxMepJ75MQFnxx71aKMaXy2vcR+jUXkPpdHJY0YQ04193IbZRPj3Eox7DoqaQwhRS917rF9IzwpjmmJo3pg0hgVq5yatNg+iE/R0jh2bV/3mzISoxO0ptx6bMTY96V3lA+5xoqWhmEY5VGdNB7ce051czRSYGH5c9i+2EjI66Y6aRiGkReThmEYTpg0DMNwYvTSuP60Hw6eQRdi8o3N0RgvIY7t0HPM57z2ZfTSqAkbbs2PHYNuTBojwEYLNmL7JB6D73IVkcOAq4GvAacCH2yLJInIWcAOQIC7VHXPvGW+jTcMIz0xarluZlJV7TXN+/5SRF4/uww4y2PdhmFkIkYt1xOAfdrApLbry2aXNRXYNjBdlvEfDzzl0TzDMGIQvJbrzPL2tW1zlh3DHKbLMm454oUezTMMIwYxarlOL29f2z9nWdl3oxmGMZfgtVxV9QHgCGkAtqjq/XOW7fVrutGS6tmYNWH7JB7Ba7k2r10JvKv5d+WSZcYUx920NXcTVh47Bt0MHj1phld/p/n1T5v/z29euxO4c+b9G5al4B3fmGzikNlzD63t8p4V+tiONZsVOlJCPJH8obVdg/6uPa9zYJO7DMNwwqRhGIYTJg3DMJyoThonnnJ70GpRY8FGC57D9sVGQl431UnDMIy8FC2NR9aPzt2EpcQouWdDfvmIse9LL8s45BorWhqGGxaW2z5IwcpL47zP3xB9HTVVGDf6keKYpjg3hzAqaWy7+brgnzl08o1hdBHj3IpxDcwyKmksI+cMOld8cutVDs99tr2mvqTc53I9V1KhtB1dpZffM9JSegeoD9VK48RTbq+q0lrKe1Dab9xVeU5m6uiqtj6q0POaViY9MQwjDMVL4/2PvjX6OkrspQ6RY69C/0aIbSyxPyPFOTn02ipeGiXQp5d7zDms4Uafc6HmUbnRSWPZkFPuXmfXXNiijeXkiDJy92csO4dTDLfCCKVhbGSM4hjjNtVC1dII2SvclUOGSlFyRBswross1La47NvHdqz1OnYhUpOQ/Rkx7gjPJg0RObLve1N0hq4CYxDHGLahBHyuqcHSEJEjReQ/iciviMhvznn9nU3Ro/8rIj/RLDtNRP5WRL4FXDi41R2U3K8B/b+1Wo67aatFHISNMFyjjBIooT8D/CKN9wF3quotwHYRObN9QUROAP6Pqp4BfAZopXIh8LOqerKqftxj3VFIlaIMZZXFkSMlcaW01CQWMcoyAjyqql9ufv4bJgWUAI4H7haRz4rICzzW/Sw1P8Ur5zdYTeLI2dZSoowhxLo2YpRlRFWfnnrf6cANzfKLgVOAg8Db533odC3Xg08+8exy1xwsZ4pSQ7QBk4uxZHmEbl/uKMOHkKmJbx9h59UjIucA75nz0pFMyis+yYIyiyLyU8AdqvpIu0xVnxKRa4GL561PVXcCOwHWXnqadm9CWNrwcNe5l819PUQtlGmG3JNy3E1befii/cHaUNq9KjFENkQYoaOMZalJDWlJS6c0VPV2YEOcIyLXMCnLuJtJWcYvisjzmJRc3C8iP978fKeIvAT4HrDeRCHbgLvCbYZhGKnwSU8+DPxrEbkAOND0YbwBeJ+IHAP8BfCHInIf8CdMBPO/ReTfAscx6SANQon9GrHD1Rihdu50Jdb6Y99bUuItBDGvCZ+yjN8DrphZdivQxrj/bM6fvXro+oaw7ebr+M4FG0aDgUmOOKRUI5SRosRk+sKNnbKU2qeSMjXpopSh1paqZoSmnOQVIsd0+QYacpKmuDuz/fYPeXHH+MxFxO7LCBFlpOzPCHEN5Z/pFIjUD+UJHW0MJXSn6DIWXeSLopHcUUQpt7ynvqM1dro+Gmksog3f5qUpXSnKeZ+/YeEoSl92r72596MAh6YpKcUxj9xymMdQYZQWZSxKTXKkJS1VpScwCa9KuRclxjfI0Fy6lG/VEkghjL6U8tyMkNdNddJYxpCwrGuiV+q+DR9C3qNSIym3P2eUsYwUI4nVSiPkDFEfHlrbFfyeFN9vvFWTR4jtDZ2W9D0vhpB6Bugs1UojJCmiDVdChMqrII4Q25jj/pIYUUYqRieNZeFZzM6jGHfAhhLHGOURartc93Hu538uO4dTTXKsWhohw64Q0Uap4oBxRR2htsU1JQkljJRRRoxBg6qlYRhGekYpjVwpSl/6fmu1uD7paxG1pyohU5LU8zFCUEJqAiOQRo0pylBCpio1ySNke2N2eq5CagIjkMYiYkUbIcUx5Bss5ElfujxCt2/Ivut7jEIIYxmlRBmwAtPIXWlNP/QOWFdcppm3hL4rdvbCzDUlPabAYgojBCUPsc4iqskfjtWbtZeepi+6/NO93nv19hvnLl92E9ui2+Zblomjzz0pLje0uYqjJcUt9bEkkiLKGRqZuQjDN8roEsaQKKNvavLERy9k/e+/Ib3e3FCP3gqjz81sLnfCDok4IM2zOJZd3F1CyZn+1CCMGhlNpAGLow1YHHHEjjYgTcQBaaKOGvDp9wktDIgTZSzrx3DpAB0SaYy2I7QvsTtFwW1ExSePrvlx+6GoSRhdlDA9YB5JpOFSgtGHZYYd2sPcZxg29FCsrzhCzeuohRDbHCMliTW8GirKGErMsowbSjCKyFtE5N+IyHuap5UHZ8hO6zJ6n4Nbkjhaxi6PUNuXow/Dp/NzEameMxOlLGPDISUYRWQrcKmqfoJJ8aTksZfP3I1QQ2Ku4jB5bCSkLFzmYYSauBdjtCQlscoywsYSjK8C7gdQ1QPAySIS5UyOkab0waWPw+ThTg5ZgJvoY46U5E5LWqKUZYS5JRin3w+T4klHz37oorKMhmGUQac0ROQcEfnS7D+eK8sIC8oyqupTwLXACUyKQG+ZevlwYMMgv6ruVNUzVPWMTT/yIucN8iFV30aLa7gbaoZibRFHyPa67sPQUUaMvozUDJ6n0ZRl/Iqq7haR/wx8EfhfTMTwOLCmqk83tWC3An8OfE5VXy8iW4A/U9Wzl63DdZ7GLEPmbbQsm7/RZ4q5y1PMh5RC8JnPsYhS5nnEENoQ4aYURpcsYqUmqedpLCzLCLyOmRKMqvoksFNELgHeDbzTY929iNW3kTvigDj3RUwPXaaMRGKvt3RhdFFKX0bLqGaEziNWtAFlRBwQJ+roQ9/IJFcqNFSspaUkMaUxJNIYvTRahtzQBv5pCqQRB+STR2n4RGExRkpipCWhIgybRj6ArjRl2UHtG3LGTlVaQg3N1orv9tcijNysTKQBw1OVrjQFwqcq4Bd1tIw9+gghSVdRh+rDGDqJK2Q/hkUaHQzd2X2GwUJ3jkKYRweONfoItV0lCmMZJZQkXalIoyVG/0ZLjIijJVSV+lqjj1DyGyLjEOlIS+5+jGnsITyenHjK7UvFse3m6zrF0VWJHg49AV0E4vJQn2VMX3ylCyR0lBQjsmiJKYySWMlIA5b3b0CaPo6WIZFHqKhjltwSiZVKxYwuIG4fBsRLS6xPwzCM6KxspAH1RxsQL+KYJlb0kaKDdmhn8ipEGWCTuwYRWxwwHnnURCmygHKFAZaeDMLnoPQdNnO572Do8xhCPiSmZnz2Q2phdFHC8Oo8bPSkgz4jKtAddfQZVWlpT94hUcf0BbMq0YevLF1FHWoeRg0jJfNY+UgDuo3e5+CGmgA2je9ToNpv3TFGIKG2rVRhlBplgPVpHIJP/0ZL334OcC/9OLS/Y5ZaI5BQ8oshipbahGEdoQEoXRwQTh5QvkBCRklDIrcxCwNMGkHxeQ5HS4zRlWlCymOW1DKJmUINTfNCd3aW9jAdMGkEp4aoA+LKYxl9xZKrTyW2LKDO6GIak0YEUosD6pNHaaSQBdQvDKhMGiJypKp+d9l7SpAGdIsDyok6plkViYSoNZI6uoD8woDEk7uWlWUUkSNE5Ftt/RIR+R/N8g2lGg3DqAufEgYfAv5KVW9vfv4zVd3TvHYq8KCqfl9ETgHerKr/RUR+F7hBVR/ps45SIg3IE21AmIgDxhd1hKpkliMlgTKiDEicnojIl4ELVPVREfk14FRV/Q9z3vfbTOqdPCAinwJ+HtgD/Lqqfn/ZOkqSBoQTR4sJxI2SRdFSkzAgvTTuB35aVZ8UkV8E3qSql8553ydV9Temfn8hcBOwR1U/Muf9lwCXAGx68bGnb73qC4PaF4s+4oDww7LThJJHS6kSCV0XdUjtkRDDqdOUJAyIJI2mQtp75rz0cuDVqvoPIvIW4JWq+r6Zv/0x4LI5y38auFhVlxZMKi3SmCZ31AHh5TFLKpnELJoMcWUB9UUX06SONK5hQVlGVd3fvOffA19V1T0iIsyUalTVpUYoWRpQhjggvjxqZWhVs1URBqSXxuHA1cDXgJNU9VoReRPwc6r6ruY9f8QkolAR+RngD4CPAQp8QjtWXro0IHy6AsPlASYQn/KHoWUBZQsDKpun0YcapNESOuoAP3m0jF0iPpJocX3mRe3RxTQmjQIoVR4wHoGEEAWsZmQxi0mjEGKkLC2hBAL1SCSUJGDYk7TGKgwwaRRFX3FAfnnMkksmIeUwS0xZQJ3CAJNGkcSWB8QVyDL6yiWmDJYx9PmcqyCLFnuwsGEY0bFIIxEpIg7IF3WUgs/Tv1cpwmix9KRwXMQBfvJoGbtEfCTR4vpU8LEIA0wa1ZBDHjAegYQQBaxmZDGLSaNCcgkE6pFIKEnAakcV8zBpVIqrOFpCCmSW1EIJKYZZhhYlGrswwKRRPUPlAXEFUiM+1ctWQRYtQ6RhZRkLoj1Zh8hj+iJZVYH4ljlcJVn4YNIokOmT11cgMF6JhKiFaqJwx6RROL4CgfFIJFTBZBOFHyaNigghEFh88ZUikxjV1E0U4TBpVIpP/8ciui7WUFKJIYVFmCzCY/eeGIbhhEUalRMqZelDygjBB4su4uItDRF5tareG6Ixhh/zLpbYIsmNCSI9XtJo6p3cCBw757W3AIcD24Bdqvr/5y3zWb/RzexFVbtETBL58ZKGqt7WlCY4BBHZClyqqv9KRI4A/lhELp5dBvySz/oNd2qKRkwQZRKrT+NVwP0AqnpARE4GTp9dJiJrqroeqQ1GT7ouzlhSMSnUSSxpbAcOTP3+PeDoBcsOKQY9XZYR+MG+y3/qvkhtzMnRwL7cjejLO/q/1XG7/sC5LRmp6pg58HLXP+iUxpKyjJeq6v0L/uwxYMvU74cD+xcsOwRV3QnsbNZ9j6qe0dXG2rDtqo+xbpuI3OP6N53SUNXbgV5jbSLyPCZi+Gvgt5plW4CHgP8JvHt6mar+wLXBhmHkxXf05I3Ai0XkNap6N/AGmrKMIrKzSTV+DHhnU13+kGXerTcMIzm+oydfAJ4/9futwK3Nz7vmvH/Dsg52+rSvYGy76mOs2+a8XUU/hMcwjPKwe08Mw3CiWGmIyKtztyEXInJk7jYYy6n1GInIK0Vks89nFHnDmuv09MTNG0Rzkl0B3AO8TFWvm3n9NOA24CDwEeDjyRvZExE5DLga+BpwKvBBVT3YvHYWsAMQ4C5V3ZOtoQPo2LajgK8Am4HPAFflaucQRORM4A7gKOCZqeVux0xVi/wHPDpn2Vbgr5qfjwD+Inc7HbbnQ8A5Uz+fOfP67wLH5m5nz215G/Dvpn6+oPl5MxMpSvPvjtxtDbVtze/vBl6Ru42e2/d3wAumfnc+ZsWmJws4ZHo6cLKIrOVtUm9eC7R3A98LnDvz+vHA3SLyWRF5QdKWubNoW04A9mkDsC4iJ+VooAfLjtNLgNtE5EtN1DEGnI9ZbdJYND29BqbbfgA4ZvpFVb0YOIVJevL2pC1zZ9G2zB6fDdtZAQuPk6pewWTa9b3A+9M3LQrOxyxbn0bg6enFsGS7jmTS9ieb/zfcx6CqT4nItcDFMdsYgOnjML0ts8dn7nYWzqJtA0BVnxGRDwCfStyuWDgfs2zS0EDT07WwqeiLtktErmGSXu0GfhL44tR2PQ6sqerTTDp470rW4GHsZrIte5hsy24R2aaqD4jIEVOPS9iiqnuztXIYi7btOyLy/OZ8q+EYLUVENgFHDzlmRU7uaqan3wL8c1W9W0TexHPT088DXsxkKvqfqOo3c7a1LyJyOM/1yp+kqte22wV8lsktnx8DFPiElnhgGpoT7gPA15lcWLcAV6jq+SLyL4Azm7fuUdU7MzVzEIu2rfl3K5MZlE8DnyztC6sLETkD+DLwa8C3gfcOOWZFSsMwjHKprSPUMIzMmDQMw3DCpGEYhhMmDcMwnDBpGIbhhEnDMAwnTBqGYThh0jAMw4l/AucVBtn6j9yMAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -809,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -818,7 +783,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -827,7 +792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -836,7 +801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -863,31 +828,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
     "new_op = openmc.deplete.Operator(geometry, settings)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 51,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3820"
-      ]
-     },
-     "execution_count": 51,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "len(new_op.chain.nuclide_dict)"
    ]
   },
   {
@@ -898,10 +843,30 @@
     {
      "data": {
       "text/plain": [
-       "['H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'H7', 'He3', 'He4', 'He5']"
+       "3820"
       ]
      },
      "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(new_op.chain.nuclide_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'H7', 'He3', 'He4', 'He5']"
+      ]
+     },
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -912,7 +877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
@@ -930,7 +895,7 @@
        " 'Rg272']"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -952,16 +917,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "5.080334904405777"
+       "5.080339195584719"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -972,7 +937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -981,7 +946,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {

--- a/examples/jupyter/pincell_depletion.ipynb
+++ b/examples/jupyter/pincell_depletion.ipynb
@@ -1,0 +1,1028 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook is intended to introduce the reader to the depletion interface contained in OpenMC. It is recommended that you are moderately familiar with building models using the OpenMC Python API. The earlier examples are excellent starting points, as this notebook will not focus heavily on model building.\n",
+    "\n",
+    "If you have a real power reactor, the fuel composition is constantly changing as fission events produce energy, remove some fissile isotopes, and produce fission products. Other reactions, like $(n, \\alpha)$ and $(n, \\gamma)$ will alter the composition as well. Furthermore, some nuclides undergo spontaneous decay with widely ranging frequencies. Depletion is the process of modeling this behavior.\n",
+    "\n",
+    "In this notebook, we will model a simple fuel pin in an infinite lattice using the Python API. We will then build and examine some of the necessary components for performing depletion analysis. Then, we will use the depletion interface in OpenMC to simulate the fuel pin producing power over several months. Lastly, we will wrap up with some helpful tips to improve the fidelity of depletion simulations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import openmc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Build the Geometry\n",
+    "\n",
+    "Much of this section is borrowed from the \"Modeling a Pin-Cell\" example. If you find yourself not understanding some aspects of this section, feel free to refer to that example, as some details may be glossed over for brevity.\n",
+    "\n",
+    "First, we will create our fuel, cladding, and water materials to represent a typical PWR."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fuel = openmc.Material(name=\"uo2\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fuel.add_element(\"U\", 1, percent_type=\"ao\", enrichment=4.25)\n",
+    "fuel.add_element(\"O\", 2)\n",
+    "fuel.set_density(\"g/cc\", 10.4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clad = openmc.Material(name=\"clad\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clad.add_element(\"Zr\", 1)\n",
+    "clad.set_density(\"g/cc\", 6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "water = openmc.Material(name=\"water\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "water.add_element(\"O\", 1)\n",
+    "water.add_element(\"H\", 2)\n",
+    "water.set_density(\"g/cc\", 1.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "water.add_s_alpha_beta(\"c_H_in_H2O\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "materials = openmc.Materials([fuel, clad, water])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, we are going to use the `openmc.model.pin` function to build our pin cell. The `pin` function anticipates concentric cylinders and materials to fill the inner regions. One additional material is needed than the number of cylinders to cover the domain outside the final ring. \n",
+    "\n",
+    "To do this, we define two radii for the outer radius of our fuel pin, and the outer radius of the cladding."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radii = [0.42, 0.45]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using these radii, we define concentric `ZCylinder` objects. So long as the cylinders are concentric and increasing in radius, any orientation can be used. We also take advantage of the fact that the `openmc.Materials` object is a subclass of the `list` object to assign materials to the regions defined by the surfaces."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pin_surfaces = [openmc.ZCylinder(r=r) for r in radii]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pin_univ = openmc.model.pin(pin_surfaces, materials)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first material, in our case `fuel`, is placed inside the first cylinder in the inner-most region. The second material, `clad`, fills the space between our cylinders, while `water` is placed outside the last ring. The `pin` function returns an `openmc.Universe` object, and has some additional features we will mention later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7fedf1eace90>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQIAAAD4CAYAAAAHMeibAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAPzUlEQVR4nO3dXYwdd3nH8e+T2ICjjSVHTXbFhRsCQkWyEgVcxYBCUSKVqFYvgrDzwkVAVSyVCyqgUglviYqg1Bep1AYh+YrkIq5pkIEbgqXSpIFQhEUM+KoFqQVZJK1fJFaJBSZ+euE50Xp93mfOnHn5fqTVjs8czz4+5z+/feY/4zORmUjqt6uWXYCk5TMIJBkEkgwCSRgEkjAIJAFbll3AwLZrrsrt269edhlSZ/3mN69y/pWLMWxdY4Jg+/arue+BHcsuQ+qsw4+fG7nOQwNJBoEkg0ASBoEkDAJJGASSMAgkYRBIokEXFKk5PnDdxyvd3lNnH610e6qeQdBTVe/s8/4sQ6IZDIKOq3OHn8eo+gyIehkEHdP0HX9am/8dBsNiGQQt15UdfxKDYbEMghbqy84/zsbXwFAozyBoiTp3/iePnKx0e/ffs6vS7W1mKJTndQSS7AiablGdQNW/9ef9WVV3C4PXy85gNnMHQURsAR4Gfgy8DfhSZl7c9JyngL/OzP8uU2QfVRkAde70sxpWWxXhYCDMpkxH8CBwKjOPRsQasA84MlgZEXcDry9ZX69UtfM3ecefxub6ywSD8wfTKRMEe4CvFMsngL+kCIKIuBX4FXBm3AYi4gBwAODa7f2drqgiANq+84+z8d9WRSgYCFcqEwRrwHqxvA6sAkTEDuAtmfkvEUM/MPU1mXkIOASwura1d3djLRMAXd7xx6miWzAQrlQmCM4AK8XyCnC6WN4L7IuIDwJvB94YER/OzFMlflanGADVGbweBkI5Me9t0SPiQ8DrMvNQ0eL/Fvh2Zv7vhud8FXhkmsnC1bWt2YePM58nBNz5ZzNPKPQhDA4/fo6XXrxQ+X0NngD+NiL2AzuBo8BjwP4S2+wsA6A+83QJfe8O5u4IqtbVjmDWAHDnX4xZQqGrYbCojkBjGADNMkuX0MdTjv09Z7dAhkBzzfpa9+U/eBkEkjw0qJKdQDvMOpnYh4lEg6Ais4SAAdAM8wRCV8PAQ4MKGALtNst70tU5AzuCkqYdGAZAs816VqFrnYFBMCcDoJuePHJyplOMXQkEDw3mYAh025NHTk793nXlUMGOYAYGQL9Me7jQhe7AjmBKhkB/9aE7MAimYAio62FgEExgCGigy2FgEIxhCGizroaBQSDJIBjFbkCjdLErMAiGMAQ0SdfCwCCYkyGgLo0Bg2CTaRK8SwNA5UwzFtrQFXhl4QaT3jADQMNMcwVi0/+jkh1BwRBQWZPGSJM7A4MAQ0DVaWsYGAQTGAKaVRvHTK+D4APXfXxsQrfxDVUzjBs7k8bdMvQ2CJr2Rqh/mjQGexsEk9gNqKw2jaFeBoGTg6pLWyYPexkEki7XuyCwG1Dd2tAV9C4IJF2pV0FgN6BlaXpX0JsgMAS0bE0Og94EgaTRehEEdgNqiqZ2Bb0IAknjzR0EEbElIj4fEXdHxKci4qoN6+6NiO9HxM8j4l3VlDqfSf+XwG5AdZs07pbRFZTpCB4ETmXmUeAcsA8gIrYBr2bmu4HPAZ8tXeUCGABatiaNwTJBsAc4USyfAPYWyxeArxfLLwBnSvyMUpZ9SkaaV91jt0wQrAHrxfI6sAqQmb/PzIvF4+8BDo7aQEQciIjjEXH8/PmLo55WuSYlsfqtKWOxTBCcAVaK5RXg9MaVEXET8MvM/OmoDWTmoczcnZm7t21z3lJaljJ73zHglmL5ZuBYRNwAUHz/o8z8dkS8YfB4nTwsUNvVOYbLBMETwM6I2A/sBE4Cj0XENcA3gYMRcRL4EXC2dKUVaUorJg00YUzO/XHmxTzAZ4o/fq34vr/4/s4yRZVlN6CuqOtj0Ht1YN6E5JWGWfbY7NQNTuwE1EWDcb3IzqBXHYGk4XoTBMtuvaRJljlGOxMEHhao6xY5xjsTBOPYDagtljVWexEEksbrRBB4WKC+WNRY70QQSCqn80Hg/IDaZhljtvNBIGmy1geB8wPqm0WM+dYHwTgeFqit6h67nQ4CSdMxCCS1OwicH1BfVT32Wx0E4zg/oLarcwx3NggkTc8gkGQQSDIIJNHiIJh0c1OpC+q6WWprg0BSdQwCSQaBJINAEgaBJAwCSbT0lmejTpt42lBdNBjX99+z64p1Vd0k1Y5AkkEgySCQhEEgCYNAEgaBJAwCSZS4jiAitgAPAz8G3gZ8KTMvFuvuAHYBAfxHZv6wglolLUiZC4oeBE5l5tGIWAP2AUci4mrgIPDHxfP+FbijXJmSFqnMocEe4ESxfALYWyzvBE5nAbgQETcN20BEHIiI4xFx/Pz5iyVKkVRGmSBYA9aL5XVgdcjjm9ddJjMPZebuzNy9bZvTFdKylNn7zgArxfIKcHrI45vXSWqgMkFwDLilWL4ZOBYRN2TmfwLXRgFYycz/KluopMUpEwRPADsjYj+X5gVOAo8V6x4CPlF8PVSqQkkLN/dZg+JU4WeKP36t+L6/WPcc8Fy50iTVxRk6SQaBJINAEgaBJFr6mYVPnX106OcWDj7Tzc8uVJcM+6zCgSo+rxDsCCRhEEjCIJCEQSAJg0ASBoEkWhwE406bjDvdIrVJHacOocVBIKk6BoEkg0CSQSCJDgeBE4ZquzrHcKuDoMpZU6lNqh77rQ4CSdUwCCR1OwicJ1Bb1T12Wx8EzhOobxYx5lsfBJLK63wQeHigtlnGmO18EEiarBNB4DyB+mJRY70TQSCpnF4EgfMEaotljdXOBIGHB+q6RY7xzgTBJHYFarpljtHeBIGk0Vp5y7NRBq3TsNuhSW1Vx2FvrzoCDw/UVMsem50MAicO1RV1jeVOBsE4y05eabMmjMm5gyAitkfEFyLi7oj42JD1H42I4xHxs4h4a7kyZ2dXoLarcwyX6Qg+DTyXmUeBtYi4bbAiInYCP8nM3cBh4IqgkNQcZYJgD3CiWD4B7N2w7sXMfLZYfgE4U+LnVK4JrZgEzRmLZYJgDVgvlteB1cGKzPzdhue9A/jysA1ExIHi8OH4+fMXS5QynIcHaqu6x+7EIIiIuyLimc1fwHZgpXjaCnB6yN+9FfhuZv562LYz81Bm7s7M3du21Ttv2ZQkVn81aQxOvKAoM58Gnt78eEQ8AtwCHANuBr4TEa8DVjLzbES8uVh+LiKuB17OzFcqrX4KT519dOQFRoM34skjJ+ssST03KQCW0cmWubLwIPBwROwA1jPz2Yj4c+C9EXEQ+BaQEQHwUmbeWb5cSYsQmbnsGgBYXdua9z2wY2Hbn3TZsV2B6rDMbuDw4+d46cULMWxd7y4oknSl3gTBpKRt0sSNuqmJcwMDvQkCMAy0PE0OAehZEEgarndBYFegujW9G4AeBgEYBqpPG0IAehoEki5nEIxgV6Cy2jSGehsETWnJ1F9NGoO9DQK49EaMezPalOhqlnFjZ9K4W4ZeB8E0DAPNqo1jxiDAswiqTlvOEmxmEBQMA5XV1hCAjt3gpKxxn10Afn6Bhpvml0STQwDsCK4wzRtmd6CBLoQAGARzMwzUpTFgEAwxbYJ3aSBoNtO+923oBsAgGMkw0ChdCwEwCCRhEIxlV6DNutgNgEEwkWGgga6GABgEUzEM1OUQAINgaoZBf3U9BMArC2cyeKMn3SPBKxC7oQ8BMGBHMAe7g267/55dvQoBsCOYm91BN/UtAAYMgpIm/UelAQOh2Wbp3roWAuChQSVmGRgeLjRP30MA7AgqM21nAHYHTTFrKHc1BMAgqNS08wYDBsJyGABX8tBAkkGwCLP+BnHeoD52A8N5aLAgHiY0ixOC4xkECzZvIIChUNY8nVYfQwAMgtrMGghglzAvA2B2BkHNZjnNOGCXMFmZeZa+hwCUCIKI2A78DXAcuDEz/2HIc7YC/56Z75y/xO6ZpzsYsEu4nAFQjTIdwaeBf8vMpyPi7yPitsz84abn3Fti+51XRSAM9CUYqjjDYgBcqUwQ7AEGXcAJYC/wWhBExB3A88BfjNpARBwADgBcu72/ZzLLBMJAlw8fqjq9agCMViYI1oD1YnkdWB2siIg3AVsy8xcRMXIDmXkIOASwurY1S9TSCRsHalWhAO0Lhiqvq3Dnn87EIIiIu4BPDlm1HVgBXi6+n96w7v3A7RHxEWBXRHwD2JeZF8qX3A9VdAkDw3aspoTDoi6mMgBmE5nz/SKOiEeA5zPzWER8EfgO8ANgJTPPbnjeM5n53knbW13bmvc9sGOuWvqgikCYVtUhUeeVkwbAaIcfP8dLL14Y2qKXOTA/CNwZEfcA65n5LPA+Lk0iSmqRuTuCqtkRTK/O7qAN7AKmM64j8IKiFqpqUrHN3PmrZRC03OYdoqvB4I6/WAZBx3QlGNzx62UQdNyoHaopAeEO3wwGQU+N2wGrDgl39uYzCHQFd9z+6e8F/pJeYxBIMggkGQSSMAgkYRBIwiCQhEEgCYNAEgaBJBr0wSQR8X/A/1S82T/g8s9SbLo21dumWqFd9S6q1j/MzOuHrWhMECxCRBzPzN3LrmNabaq3TbVCu+pdRq0eGkgyCCR1PwgOLbuAGbWp3jbVCu2qt/ZaOz1HIGk6Xe8IJE3BIJDUvSCIiO0R8YWIuDsiPjbiOVsj4gd11zbMpHoj4qMRcTwifhYRb11CfVsi4vNFfZ+KiKs2rLujqO+vIuK2umsbZkK990bE9yPi5xHxrmXWWdQzstYNz3kqIm5cdC2dCwIu3XLtucw8CqyNGKD31lzTOCPrjYidwE+Kc8qHgaHBtmAPAqeK+s4B+4rarubSbe/+CfhH4O+WUNswo+rdBryame8GPgd8dnklvmZorQMRcTfw+joK6WIQ7AFOFMsngL0bV0bEHcDzwG9rrmuUcfW+WNxTEuAF4EydhRVG1bcTOJ0F4EJE3LSE+jYbVe8F4OvF8rJey81GvvcRcSvwK2qqs4tBsAasF8vrwOpgRUS8CdiSmb9YRmEjjKw3M3+34XnvAL5cY10Do+rb+Pjmdcs0tN7M/H1mXiwefw+XupllG1prROwA3pKZx+sqpLUfZx4RdwGfHLJqO7ACvFx833jN9vuB2yPiI8CuiPgGsC8zLzS03sHfvRX4bmb+eqFFDneGS3XB5fVtfHzzumUaVS8ARdfyy8z8ad2FDTGq1r3Avoj4IPB24I0R8eHMPLWwSjKzU1/AI8CfFstfBP4EeB1w3abnPbPsWqepF3gzcHuxfD1wTc31fQg4UCwfAB4Abij+/D0giq/vLfu1nKLeG4A/K5bfMHi8ibVueM5XgRsXXUsXDw0OAndGxD3Ael46xn4flyblmmhkvRGxCnwL+EpEnAT+OTNfqbm+J4CdEbGfS/MCJ4HHinUPAZ8ovh6qua5RhtYbEdcA3wQOFq/lj4CzyysTGP/a1sorCyV1siOQNCODQJJBIMkgkIRBIAmDQBIGgSQMAknA/wOE2BVcgIOLGwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pin_univ.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bound_box = openmc.rectangular_prism(0.62, 0.62, boundary_type=\"reflective\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "root_cell = openmc.Cell(fill=pin_univ, region=bound_box)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "root_univ = openmc.Universe(cells=[root_cell])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geometry = openmc.Geometry(root_univ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lastly we construct our settings. For the sake of time, a relatively low number of particles will be used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "settings = openmc.Settings()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "settings.particles = 100\n",
+    "settings.inactive = 10\n",
+    "settings.batches = 50"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The depletion interface relies on `OpenMC` to perform the transport simulation and obtain reaction rates and other important information. We then have to create the `xml` input files that `openmc` expects, specifically `geometry.xml`, `settings.xml`, and `materials.xml`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geometry.export_to_xml()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "settings.export_to_xml()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before we write the material file, we must add one bit of information: the volume of our fuel. In order to translate the reaction rates obtained by `openmc` to meaningful units for depletion, we have to normalize them to a correct power. This requires us to know, or be able to calculate, how much fuel is in our problem. Correctly setting the volumes is a critical step, and incorrect answers, as the fuel is over- or under-depleted due to poor normalization.\n",
+    "\n",
+    "For our problem, we can assign the \"volume\" to be the cross-sectional area of our fuel. This is identical to modeling our fuel pin inside a box with height of 1 cm."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fuel.volume = 3.14159 * radii[0] ** 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<?xml version='1.0' encoding='utf-8'?>\r\n",
+      "<materials>\r\n",
+      "  <material depletable=\"true\" id=\"1\" name=\"uo2\" volume=\"0.5541764759999999\">\r\n",
+      "    <density units=\"g/cc\" value=\"10.4\" />\r\n",
+      "    <nuclide ao=\"0.0003845183882296898\" name=\"U234\" />\r\n",
+      "    <nuclide ao=\"0.04301995213827323\" name=\"U235\" />\r\n",
+      "    <nuclide ao=\"0.9563984774295304\" name=\"U238\" />\r\n",
+      "    <nuclide ao=\"0.000197052043966672\" name=\"U236\" />\r\n",
+      "    <nuclide ao=\"1.999242\" name=\"O16\" />\r\n",
+      "    <nuclide ao=\"0.000758\" name=\"O17\" />\r\n",
+      "  </material>\r\n",
+      "  <material id=\"2\" name=\"clad\">\r\n",
+      "    <density units=\"g/cc\" value=\"6\" />\r\n",
+      "    <nuclide ao=\"0.5145\" name=\"Zr90\" />\r\n",
+      "    <nuclide ao=\"0.1122\" name=\"Zr91\" />\r\n",
+      "    <nuclide ao=\"0.1715\" name=\"Zr92\" />\r\n",
+      "    <nuclide ao=\"0.1738\" name=\"Zr94\" />\r\n",
+      "    <nuclide ao=\"0.028\" name=\"Zr96\" />\r\n",
+      "  </material>\r\n",
+      "  <material id=\"3\" name=\"water\">\r\n",
+      "    <density units=\"g/cc\" value=\"1.0\" />\r\n",
+      "    <nuclide ao=\"0.999621\" name=\"O16\" />\r\n",
+      "    <nuclide ao=\"0.000379\" name=\"O17\" />\r\n",
+      "    <nuclide ao=\"1.99968852\" name=\"H1\" />\r\n",
+      "    <nuclide ao=\"0.00031148\" name=\"H2\" />\r\n",
+      "    <sab name=\"c_H_in_H2O\" />\r\n",
+      "  </material>\r\n",
+      "</materials>\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "materials.export_to_xml()\n",
+    "!cat materials.xml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Setting up for depletion\n",
+    "\n",
+    "The OpenMC depletion interface can be accessed from the `openmc.deplete` module, and has a variety of classes that will help us."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openmc.deplete"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to run the depletion calculation we need the following information:\n",
+    "\n",
+    "1. Nuclide decay, fission yield, and reaction data\n",
+    "2. Operational power or power density\n",
+    "3. Desired depletion schedule\n",
+    "4. Desired time integration scheme\n",
+    "\n",
+    "The first item is necessary to determine the paths by which nuclides transmute over the depletion simulation. This includes spontaneous decay, fission product yield distributions, and nuclides produced through neutron-reactions. For example,\n",
+    "* Te129 decays to I129 with a half life of ~70 minutes\n",
+    "* A fission event for U-235 produces fission products like Xe135 according to a distribution\n",
+    "* For thermal problems, Am241 will produce metastable Am242 about 8% of the time during an $(n,\\gamma)$ reaction. The other 92% of capture reactions will produce ground state Am242\n",
+    "\n",
+    "These data are often distributed with other nuclear data, like incident neutron cross sections with ENDF/B-VII. The `openmc.deplete.Chain` object is responsible for representing this information. Two executables, `openmc-make-depletion-chain` and `openmc-make-depletion-chain-casl` will read in nuclear data using the `OPENMC_ENDF_DATA` environment variable and produce two depletion chain files. The first is a more detailed file containing every reaction and fission product possible, while the second uses data from CASL [Specification for the VERA Depletion Benchmark Suite](https://doi.org/10.2172/1256820) report to reduce the number of isotopes.\n",
+    "\n",
+    "For this problem, we will be using a much smaller depletion chain that contains very few nuclides. In a realistic problem, over 1000 isotopes may be included in the depletion chain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chain = openmc.deplete.Chain.from_xml(\"./chain_simple.xml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OrderedDict([('I135', 0),\n",
+       "             ('Xe135', 1),\n",
+       "             ('Xe136', 2),\n",
+       "             ('Cs135', 3),\n",
+       "             ('Gd157', 4),\n",
+       "             ('Gd156', 5),\n",
+       "             ('U234', 6),\n",
+       "             ('U235', 7),\n",
+       "             ('U238', 8)])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.nuclide_dict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The primary entry point for depletion is the `openmc.deplete.Operator`. It relies on the `openmc.deplete.Chain` and helper classes to run `openmc`, retrieve and normalize reaction rates, and other perform other tasks. For a thorough description, please see the full API documentation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will create our Operator using the geometry and settings from above, and our simple chain file. The materials are read in automatically using the `materials.xml` file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "operator = openmc.deplete.Operator(geometry, settings, \"./chain_simple.xml\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will then simulate our fuel pin operating at linear power of 174 W/cm, or 174 W given a unit height for our problem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "power = 174"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this problem, we will take depletion step sizes of 30 days, and instruct OpenMC to re-run a transport simulation every 30 days until we have modeled the problem over a six month cycle. The depletion interface expects the time to be given in seconds, so we will have to convert. Note that these values are not cummulative."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_steps = [30 * 24 * 60 * 60] * 6"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And lastly, we will use the basic predictor, or forward Euler, time integration scheme. Other, more advanced methods are provided to the user through `openmc.deplete`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "integrator = openmc.deplete.PredictorIntegrator(operator, time_steps, power)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To perform the simulation, we use the `integrate` method, and let `openmc` take care of the rest."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "integrator.integrate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Processing the outputs\n",
+    "\n",
+    "The depletion simulation produces a few output files. First, the statepoint files from each individual transport simulation are written to `openmc_simulation_n<N>.h5`, where `<N>` indicates the current depletion step. Any tallies that we defined in `tallies.xml` will be included in these files across our simulations. We have 7 such files, one for each our of 6 depletion steps and the initial state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c5g7.h5\t\t\t openmc_simulation_n2.h5  openmc_simulation_n6.h5\r\n",
+      "depletion_results.h5\t openmc_simulation_n3.h5  statepoint.50.h5\r\n",
+      "openmc_simulation_n0.h5  openmc_simulation_n4.h5  summary.h5\r\n",
+      "openmc_simulation_n1.h5  openmc_simulation_n5.h5\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls *.h5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `depletion_results.h5` file contains information that is aggregated over all time steps through depletion. This includes the multiplication factor, as well as concentrations. We can process this file using the `openmc.deplete.ResultsList` object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = openmc.deplete.ResultsList.from_hdf5(\"./depletion_results.h5\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time, k = results.get_eigenvalue()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time /= (24 * 60 * 60)  # convert back to days from seconds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0.76882937, 0.00982155],\n",
+       "       [0.75724032, 0.00827689],\n",
+       "       [0.75532241, 0.01031746],\n",
+       "       [0.74796854, 0.00919769],\n",
+       "       [0.74066559, 0.01157708],\n",
+       "       [0.7318449 , 0.00971503],\n",
+       "       [0.72072927, 0.00703074]])"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first column of `k` is the value of `k-combined` at each point in our simulation, while the second column contains the associated uncertainty. We can plot this using `matplotlib`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib import pyplot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYcAAAEGCAYAAACO8lkDAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3deXgV5dnH8e+djQQCCUJIgBACCgKyiEYhCIgUUYx9FRVwqwso2Fq3Wq1YW1vtW/dXrVoFd1wQXLBiBWllk0UgKApVqSCbLBpQMCIowv3+kYmEnAgEcpYkv8915cpznplzzp1hyC/PnHlmzN0REREpKy7aBYiISOxROIiISAiFg4iIhFA4iIhICIWDiIiEUDiIiEiIhGgXUFUaN27subm50S5DRKRaWbhw4UZ3zyjfX2PCITc3l8LCwmiXISJSrZjZqor6dVhJRERCRGzkYGYJwM3Au0B74HZ332VmBiwEdgWrprl7GzMbBmwGDgMWu/sbkapVRKS2i+TI4VJgrbtPAL4CBgX92UB/d88D+gATg/7z3f1l4GHglxGsU0Sk1otkOHQHFgXtRUABgLuvcfeNQX8BMDloF5nZdcA5wH0RrFNEpNaL5AfSWUBx0C4GMitYpy/w66B9BfDvYN3TKnpBMxsODAfIycmpylpFRGq1SI4cNgGpQTsV2Fh2oZklAbj7jqDrTqAb8AzwSEUv6O6j3T3P3fMyMkLOxBIRkQMUyXCYAnQJ2p2BKWbWpMzyfsDUMo+z3f1bd38YaByhGkVEhMiGwxggx8wGAznAEuDBMssLgEllHr9kZiPM7CLg3ohVKSIiWE252U9eXp4fyCS4IaPmAjBuRH5VlyQiEvPMbGFwtugeNAlORERCKBxERCSEwkFEREIoHEREJITCQUREQigcREQkhMJBRERCKBxERCSEwkFEREIoHEREJITCQUREQigcREQkhMJBRERCKBxERCSEwkFEREIoHEREJITCQUREQigcREQkhMJBRERCKBxERCSEwkFEREIoHEREJERCpN7IzBKAm4F3gfbA7e6+y8wMWAjsClZNA9qW73P3NpGqVUSktovkyOFSYK27TwC+AgYF/dlAf3fPA/oAE3+iT0REIiSS4dAdWBS0FwEFAO6+xt03Bv0FwOSK+iJYp4hIrRfJcMgCioN2MZBZwTp9gWn70QeAmQ03s0IzKywqKqqyQkVEartIhsMmIDVopwIbyy40syQAd9+xt76y3H20u+e5e15GRkZYihYRqY0iGQ5TgC5BuzMwxcyalFneD5ha7jkV9VWpnbscdw/nW4iIVDuRDIcxQI6ZDQZygCXAg2WWFwCTyj2nor4q4+58unErSz8vZsOW7eF6GxGRasdqyl/NeXl5XlhYWKnnuDsn3D2d1V9+S/3kRP53YEdO7dwsTBWKiMQeM1sYnBm6h1o9Cc7MyGyQTMfmaeQ2rsevn3+Pq194jy3bKvyIQ0Sk1qjV4VAqJTGely/L55p+bZn4wXpOvm8ms5dt3PcTRURqKIVDICE+jqv6teGVX/YgJTGe8x6bx62vf8j2HTujXZqISMQpHMrp0iKdf17ZiwvyW/L4rBX8/IFZLFm7JdpliYhElMKhAilJ8dxyWkeeuvgYtmzbwcC/z+bv05exc1fN+PBeRGRfFA570efwJrx5dW9O7JDJnZOXMmTUXFZv+jbaZYmIhJ3CYR8a1kvioXOP4t4hXVi6oZgB989k3ILVmjgnIjWawmE/mBkDu2Yz+ZredM5O53cvL2b4MwvZ+M130S5NRCQsFA6V0Dw9hecu6cZNBe2ZsbSIk++byb8//DzaZYmIVDmFQyXFxRmX9GrNxCt6klE/mUvGFDLylQ/Y+t0P0S6NIaPmMmTU3GiXcdBqys8hUp0pHA7Q4Vn1efXyHlx2/KG8sGANA+5/m4Wrvox2WSIiVULhcBDqJMRzw4B2jBuezy53Bj0yl7ve/Jjvf9i17yeLiMQwhUMVOLbVIUy6qhdnHZ3NQ9OWM/Dvs/nk8+J9P1FEJEYpHKpI/eRE7jyrC4+cfzTrt2zn1Adm8eTsFezSxDkRqYYUDlXs5I5ZTL66F8cd1pg/T/yQC56Yz/ot26JdlohIpSgcwqBJ/WQevzCPvw7sxMJVX3HSvTN57f110S5LRGS/KRzCxMw4t1sOk67qxaFNUrly7HtcMfY9tnyre0WISOxTOIRZbuN6vDgin2tPbMukxes56b6ZzPpE94oQkdimcIiAhPg4rvhZGyb86jjq1Ynn/Mfn8afX/qN7RYhIzFI4RFCn7DRev6IXF/XI5ak5KzlV94oQkRilcIiwlKR4/vQ/RzBm6LEUb9/B6Q/N5qFpy/hhpybOiUjsUDhESe+2Gbx5dW9O6pjFXW8uZfCouazatDXaZYmIADEeDmZWz8wuNrMTol1LOKTXTeLBc7py/9lH8skX3zDg/rcZO1/3ihCR6ItYOJhZgpndamYDzexGM4sL+s3M3jWzwuDrk6C/MTABmOru0yJVZ6SZGacd2Zw3r+7NkS3SGfnKYi55upCiYt0rQkSiJ5Ijh0uBte4+AfgKGBT0ZwP93T0P6ANMDPrvAZ5291URrDFqmqWn8Oywbvzh1A68vWwjJ983kyn/2RDtskSklopkOHQHFgXtRUABgLuvcffSE/8LgMlmlkhJeDQ1szFm9ucI1hk1cXHGsJ6teP2KnmQ2SGb4Mwv53Usf8E0M3CtCRGqXSIZDFlB6qdJiILOCdfoC04AMYKW73+3uFwBnmVl2+ZXNbHjp4aiioqJw1R1xbTPr8+rlx/GrPofy4sI1DLh/JgtW6l4RIhI5kQyHTUBq0E4F9pgmbGZJAO6+A9gMlJ0h9l+gWfkXdPfR7p7n7nkZGRlhKTpakhLiuP7kdowfkY9hDB41lzsm614RIhIZkQyHKUCXoN0ZmGJmTcos7wdMBXD3b4EiM6sfLEsBPolUobEkL/cQ3riqF0PyWvDw9OWc/tBs/qt7RYhImEUyHMYAOWY2GMgBlgAPllleAEwq8/h3wJ/N7FzgGXf/KhxFjRuRz7gR+eF46SqTWieB28/szKMX5PH51yX3injs7U91rwgRCZuESL2Ru+8Cbgoejg++Dy6z/PJy6y8AFkSmuurhxA6ZHNmiNyNf+YC//PMjpn78BXcP6kKz9JRolyYiNUxMT4KTUBn16/DoBXncfkYnFq3ZzEn3zeTV99Zq4pyIVKmIjRyk6pgZZx+bQ/6hjbhm3CKuHreIf330OT/s3EVCvPJeRA6ewqEaa9moHuNH5DNq5qfc+6//YgaN6tXhiVkraJaeTLP0FJqmpdA4NQkzi3a5IlKNKByquYT4OC4/4TCOb5vB2aPn8nnxdm55/cM91klKiKNpWjLN0lJomp5M8yA0dgdIMvWTE6P0E9RsQ0bNBYj5kx5EylM41BAdm6dxRLM03J1HfpHHus3bWLd5G+u3bC9pB9/fWb6JDV9vp/yJTvWTE2gWBEbT9JQgQErCo1laCllpySQl6JCVSG2hcKhhzIxD6iVxSL0kOjZPq3CdH3bu4ovi7/YIjfVl2u9/toUvt35f7nWhcWqdICyS9xh5lPY1Tq1DXJwOX4nUBAqHWighPu7HX+o/Zdv3O1m/ZRvrNm9n3ZZgFBK0//t5MdOXFrGt3G1OE+ONrODwVcnrl4RI8/SSw1nN0lNooMNXItWCwkEqlJIUT+uMVFpnpFa43N3Zsm1HSXhs3sb6LdtYu3l7ECjbmL/iSzZ8vZ2d5Y5fpdZJ2H24Kr30c5Dd7ay05Ej8eCKyDwoHOSBmRnrdJNLrJtGhWYMK19m5yykq/o61QXis37z9x/a6zdv5z7otbPzm+5DnJcQZyYnxPPPOKs48qjl1k7SbikSa/tdJ2MTHlRxmKhkNNKxwne07drKh3Ifmz7yziq3f/cAfXl3C3W8u5dxuOVyYn6tRhUgEKRwkqpIT48ltXI/cxvV+7Ju9bCPuznUnt+Pxt1cwasZyHp35KQWdmzKsZys6Z6dHsWKR2kHhIDHJzDgm9xCOyT2ENV9+y5OzVzK+cA3/WLSOvJYNGdazFf2PyCJeZ0eJhIVOXJeY1+KQuvzx5x2YO7IvNxW0Z8PX2/nlc+9y/F3TeOztTyneviPaJYrUOAoHqTbqJydySa/WzLjuBB4+7yiyGiTzl39+RP5tU7ll4oes+fLbaJcoUmPosJJUO/FxxoBOTRnQqSnvr9nME7NXMGbuSp6as4L+HbIY1qsVeS0b6npSIgdB4SDVWpcW6dx/dlduGNCOMXNX8fy81Uz+zwY6Z6cxrGcrTunUlERdqVak0vS/RmqEpmkp/O7kdswd2ZdbT+/IN9t/4KoXFtHrjmn8ffoyNn8bOp9CRH6awkFqlLpJCfyie0v+/ZvjeeKiPA5tUo87Jy8l/7ap3PTqYpYXfRPtEkWqBR1WkhopLs7o2y6Tvu0y+Wj91zwxawXjF3zGs++spm+7Jgzr2YoehzbS5xKVoMuP1y4aOUiN175pA+4a1IXZN/Tlqp+14f01mznvsXkMuP9txheuYXu5CwiKiMJBapGM+nW45sS2zL6hL3ee2RmA61/6gJ53TOXef/2XouLvolyhSOyoFoeVzKyBu38d7TqkZkhOjGfwMS0YlJfN7GWbeHzWp9z/1ic8PH05px3ZjGG9WtEuq+KLCYrUFhELBzNLAG4G3gXaA7e7+y4rOei7ENgVrJrm7m3MrBEwB4gHxgJ/iFStUjuYGT3bNKZnm8YsL/qGJ2ev4KWFn/Hiws847rBGDOvZij5tm+gGRlIrRXLkcCmw1t0nmFkWMAgYB2QD/d19o5mlArcE618MnObuH0ewRqmlDs1I5S+nd+K3/Q/n+fmrGTNnFUOfKqR1Rj0uPq6VLh0utc5+f+ZgZh0P8r26A4uC9iKgAMDd17j7xqC/AJgctDOA181sejCKEAm79LpJ/KrPYbz9uxO4/+wjSa2TwB9eXUL+bVO5Y/LHbNiyPdolikREZT6QHm9mjczsDDNrcgDvlQUUB+1iILOCdfoC0wDc/XfA4ZQEyZ8rekEzG25mhWZWWFRUdAAliVQsMT6O045szj8uP44XL8snv3UjRs1YTs87pnLVC+/xwWebo12iSFhVZpzcELgW2A6cb2b3uPvsSjx/E1B6z8lUYGPZhWaWBODuP15i0913mtktwFMVvaC7jwZGA+Tl5XlF64gcjL1dOvyY3JJLh5/YQZcOl5qnMuGwAvibu28AMLMhlXyvKUAXYB7QGZhiZk3c/YtgeT9gaunKZlbH3b8DmgDvVPK9RKpc6aXDrzmxDeMWrOGpOSu57Nl3aXFIChf1aMXgvGzqJydGu0yRKlGZw0o3AVPN7Hwza0vFh4X2ZgyQY2aDgRxgCfBgmeUFwCQAM2sFLDSzK4E+wD2VfK9aadyIfM1ejYDylw7PrJ/Mra9/qEuHS42y3yMHd59qZmcCv6LkTKPnKvNG7r6LkoABGB98H1xm+eVl2iuAg/0AXCSsyl86/PFZoZcOd3ddokOqpUqdm+fuHwFXhKkWkWqrS4t0/nZOV0ae0o6n56xi7PySS4fXS4onKy2ZHTt36dLhUq1Uam81s5/t7bFIbdc0LYUbBuy+dPhOd5YXbaXnHVN5aNoyvtqqS4dL9VDZP2Wu3cdjEWH3pcM7N0/j8MxU2mbW5643l5J/+1uMfGUxn3xevO8XEYmig53yqYOpInthZqTXTeKZYd1YuqGYJ2ev4OV3P2Ps/NX0bpvB0ONy6d0mQ5fokJizX+FgZpcCPYBOZvZE0P0SoLkFIvvp8Kz63H5mZ6476XDGzl/NmLmruOjJBRwaXKLjDF2iQ2LIfh1WcvdH3f1iYIm7Dw2+3ghzbSI1UqPUOvy6bxtm/a4v9w05krpJCdwUXKLj9kkfs37LtmiXKKLDSiLRkpQQx+ldm3Pakc0oXPUVT8xaweiZy3n07U85pVNThh6XS9echtEuU2qpyobD0/t4LCKVVP4SHWPmruSF+WuY+P46uuakM/S4VgzomEWCToWVCKrsPIcX9vZYRA5Oi0Pq8vuCDlzVry0vL/yMJ2ev4Iqx79EsLZkLeuRy9jEtSK+bFO0ypRao7DyHs4LvKeEpR0QAUuskcGGPXKZe24fHLsgjt3E9bp/0Mfm3TeWmVxez7Itvol2i1HCVPay01cxGAjvN7Gl3/zwcRUntputD7RYXZ/TrkEm/Dpl8tP5rnpy9gvGFn/HsO6vpc3gGw3q2oudhjXWJDqlylT2IWc/dbwM2AGeZ2UjNkhaJjPZNG3DnWV2Yc0NfrunXliVrv+YXj8+n/70zGTt/Ndt37Ix2iVKDVDYcSkcOWcBLQVA0rvqyROSnNE6tw1X92jD7hhO4Z1AXEuPjGPnKYvJve4u73tTd6qRqVPYD6UnApOCzhzPNLA2YH5bKRGSv6iTEc+bR2ZxxVHPmr/iSx2et4O/TlzNqxqcUdG7KsJ6t6JydHu0ypZo60HkO7Sm5P8P3QO+qK0dEKsvM6Na6Ed1aN2L1pm95as7uu9XltWzI0J6t6N8hU6fCSqUcaDh8SskNe+q5+7gqrEdEDkJOo913q3ux8DOemrOSXz33Ls3TU7iwR0uGHJNDWoruVif7tt9/SphZhzIP/wWcAxxb5RWJyEGrn5zI0J6tmPbbPoz+xdFkN0zhr298TP5tb3HzP5awYuPWaJcoMa4yI4cbzGyEu28Dvgbi3f2WMNUlIlUgPs7of0QW/Y/IYsnaLTw5eyVj569hzDur6Ht4E4b2bEWPQxvpVFgJsdeRg5n9xcwGm1k2MBzob2b3Am8BcyJRoIhUjY7N07hncBdm3XACV/Ztw6I1mznvsXkMuP9txi9Yo1NhZQ/7Gjl8DjQAbgZaAJuBJpTc5GdheEsTkXBoUj+Za05syy/7HMrE99fx+KwVXP/yB9wx+WPO65bD+d1b0qRBcrTLlCjbazi4+wNB8zEAM0un5L4OpwJ/BE4Ja3UiEjbJifEMymvBWUdnM/fTTTwxayUPTFvGwzOW8/POzRjasxUdm6dFu0yJksrOc9gMvBF8iUgNYGb0OLQxPQ5tzMqNW388FfaV99ZybKtDGHpcK07skBntMqvUkFFzAV2qZW902ykR+VFu43r86X+O4JoT2/Ji4RqenL2Sy55dSHbDFOLMyKhfJ9olSoREbFaMmSWY2a1mNtDMbjSzuKDfzOxdMysMvj4p97yXzCw3UnWKCKSlJHJJr9bMuK4Pj5x/FM3SUlj95be8v2Yzo2cu14fXtUAkp0xeCqx19wnAV8CgoD8b6O/ueUAfYGLpE8xsIKA/VUSiJCE+jpM7NmX8Zfkc0awB9eok8Nc3PqbPXdMZO381P+zcFe0SJUwiGQ7dgUVBexFQAODua9x9Y9BfAEwGMLOuwBpgUwRrFJGfkFongXZZ9Rl7aXeapicz8pXF9L93Jq9/sI5duzza5UkVi2Q4ZAHFQbsYqOgTrr7ANDNrCBzm7oV7e0EzG156OKqoqKhqqxWRCuUf2ohXftmDRy/IIzE+jl8//x4/f3AWM/5bhLtCoqaIZDhsAlKDdiqwsexCM0sCcPcdlIwgzjezVykJjNFm1rz8C7r7aHfPc/e8jIyMsBYvIruZGSd2yOSNq3rxf4O7sGXbDi58Yj7nPPoO767+KtrlSRWIZDhMAboE7c7AFDNrUmZ5P2AqgLs/6+6nufvpQd9wd18bwVpFZD/ExxlnHJXNW9cez5//5wiWffENZ/x9DpeOKWTphuJ9v4DErEiGwxggx8wGU3JF1yXAg2WWFwCTIliPSNiNG5FfK86lr5MQz4U9cplx3Qn8tn9b3lm+iZPvn8lvxi1izZffRrs8OQARm+fg7ruAm4KH44Pvg8ssv/wnnndReCsTkapSr04Cv+7bhvO6teSRGct5as5KJn6wjnOPzeHXfdtonkQ1ort/iEiVa1gviZGntGfGdSdw1tEteHbeao6/axp3v7mUr7fviHZ5sh8UDiISNllpydx2Rif+dU1v+rZrwoPTltH7zmmMmqGJdLFO4SAiYdc6I5UHzz2K16/oSZfsdG6bVDKR7vl5q9mhiXQxSeEgIhHTsXkaTw89lheGd6dZejI3TiiZSDfxfU2kizUKBxGJuO6tG/HyL3vw2AV5JMXHccXYkol005d+oYl0MULhICJRYWb0CybS3TukZCLdRU8u4OzR77BwlSbSRZvCQUSiKj7OGNg1m6nX9uGW045gedFWznx4Dpc8rYl00aRwEJGYkJQQxwX5ucy8vg/XnXQ481aUTKS7ZtwiVm/SRLpIUziISEypm5TA5SccxtvXn8Dw3q15Y/F6fvZ/0/njP5bwRfH2aJdXaygcRCQmpddNYuSAkol0g/Ja8Ny81Rx/53TuevNjtmzTRLpwUziISEzLSkvmrwM78e/fHE+/Dpk8NG05ve+cxiMzlrPte02kCxeFg4hUC60a1+OBc7ry+hU96ZqTzu2TPqbP3dN4bt4qTaQLA4WDiFQrHZun8dTFxzJueHeyG9bl9xOWcOL/zeA1TaSrUgoHEamWurVuxEuX5fP4hXkkJ8Zz5dj3OPWBWUzTRLoqoXAQkWrLzPhZ+0z+eWUv7htyJMXf7eDiJxcwZPQ7LFz1ZbTLq9YUDiJS7cXHGad3bc5bv+nDracdwadFWznz4bkMe2oBH63/OtrlVUsKBxGpMZIS4vhFmYl081d+ySl/e5urX3hPE+kqKWJ3ghMRiZTSiXTndcvhkRmf8tScFbz+wXrOOTaHK/oeFu3yqgWFg4jUWOl1k7hhQDsuPi6Xv731CWPnr+alhZ/RsG4iTdNTol1eTNNhJRGp8TIbJPO/wUS6Eztksm7LdhZ/toVZn2yMdmkxS+EgIrVGbuN6/O2crnRoWp+4ODj/8XmMfGUxxbqvdQiFg4jUOvWTE+nULI3hvVvzwoLVnHzf2xpFlBOxcDCzBDO71cwGmtmNZhYX9JuZvWtmhcHXJ0H/IDN72sxmmVnTSNUpIrVDXJxx4ynteemyHtRJiPtxFPHNdz9Eu7SYEMmRw6XAWnefAHwFDAr6s4H+7p4H9AEmmlk88Im7Xwi8BBwTwTpFpBY5umVD3riq14+jiJPunalRBJENh+7AoqC9CCgAcPc17l76L1EATHb3ne6+yMwSgAzgXxGsU0RqmeTE+JBRxI0TavcoIpLhkAWU3vOvGMisYJ2+wDQoOdwEXACcBZxd0Qua2fDSw1FFRUVVX7GI1CplRxFj59fuUUQkw2ETkBq0U4E9triZJQG4+47gu7v7E8CJlARECHcf7e557p6XkZERtsJFpPbQKKJEJMNhCtAlaHcGpphZkzLL+wFTK3je98CSMNcmIrKH2j6KiGQ4jAFyzGwwkEPJL/wHyywvACYBmFkjM3vfzC4ATgZujWCdIlKBcSPyGTciP9plRFRtHkVE7PIZ7r4LuCl4OD74PrjM8svLtDexe5QhIhJVpaOIe6Ys5bFZK5ixtIg7zuxMzzaNo11a2GgSnIjIfkhOjOf3BR146bL8WjGKUDiIiFTC0S0P4Y2renFpr1Y/fhYxe1nN+yxC4SAiUknlRxHnPTaP30dhFDFk1FyGjJobltdWOIiIHKCyo4jna9goQuEgInIQYmUUUdUUDiIiVaCmjSIUDiIiVaQmjSIUDiIiVawmjCIUDiIiYVDdRxEKBxGRMKpoFDGnGowiFA4iImFWfhRxbjUYRSgcREQipHQUcUnP2B9FKBxERCIoOTGem06N/VGEwkFEJApifRShcBARiZJYHkUoHEREoiwWRxEKBxGRGFDRKOKmVxezNUqjCIWDiEgMKTuKeG7eak66LzqjCIWDiEiMKTuKSIqPzigiYveQFhGJFeNG5Ee7hP1SOoq4+82lPD57BdOXFnHnmZ3pcVj4712tkYOISAwrHUW8OCKfxAiOIjRyEBGpBvJyD+GNK3txz5Tdo4jUOgmkpSSG5f0iNnIwswQzu9XMBprZjWYWF/Sbmb1rZoXB1ydB/9lmNtvMlplZj0jVKSISq1KS9hxFfLyhmBUbt4ZlFBHJw0qXAmvdfQLwFTAo6M8G+rt7HtAHmGhmKcBOdz8O+CPwhwjWKSIS00pHEVkNktn4zXd8/vX2Kn+PSIZDd2BR0F4EFAC4+xp3Lz1PqwCYDOwAXg763gM2RbBOEZGYl5IUT8tGdTmyRTqtM1Kr/PUjGQ5ZQHHQLgYyK1inLzDN3X9w911BX2/gzope0MyGlx6OKioqqvKCRURiXWJ8eH6NRzIcNgGl8ZYK7DGrw8ySANx9R5m+1sBqd/+gohd099HunufueRkZGeGpWkSkFopkOEwBugTtzsAUM2tSZnk/YGrpg2BZO3efZGbJ5dYVEZEwimQ4jAFyzGwwkAMsAR4ss7wAmARgZnWBfwB3mtkSYAHwZQRrFRGp1SI2zyH4DOGm4OH44PvgMssvL9P+FqgeUxhFRGogzZAWEZEQCgcREQmhcBARkRAKBxERCaFwEBGREAoHEREJoXAQEZEQCgcREQmhcBARkRAKBxERCaFwEBGREAoHEREJoXAQEZEQCgcREQmhcBARkRARu5+DiIhUrXEjwnfbG40cREQkhMJBRERCKBxERCSEwkFEREIoHEREJITCQUREQigcREQkhMJBRERCKBxERCSEuXu0a6gSZlYErDrApzcGNlZhOeFSXeqE6lOr6qxa1aVOqD61hrvOlu6eUb6zxoTDwTCzQnfPi3Yd+1Jd6oTqU6vqrFrVpU6oPrVGq04dVhIRkRAKBxERCaFwKDE62gXsp+pSJ1SfWlVn1aoudUL1qTUqdeozBxERCaGRQzVmZvWjXUNFYrWufYmVus2sk5nFR7uOfalMndHctj9VZ6z8e5cVS9u0VoeDmSWY2a1mNtDMbjSzmNoeZtbAzMaa2adm9pSVuNnMlpnZR0DM7Nzl6moYi9vVzC4ys/+YWaGZLTezS2Jte5pZN+AdILGi/TNW9tlydYbsp8E6Ud+2ZeusqKZY2Z7la61oX62o/nDWExP/aaPoUmCtu08AvgIGRbme8voDQ4H2wNFAbyAF6Oju7d19XTSLK2VmqZSpCyggNrfr++5+RHBa4PPAZGJse7r7PKAoeFjR/hkT+2y5Osvvp8eW3yeitW3L1sBkgjgAAAO8SURBVPkTNcXE9ixfK6H76uuR3qa1PRy6A4uC9iJKfqnFktfcfZu7fwd8CGwDjgTWmtnQ6Ja2h7bsWVdMbld3f6/Mw2ZAE2Jze5aqaDvG4rYtv59uInSfiAUV1RSL2zNkX3X3DUR4m9b2e0hnAcVBuxjIjGItIdz9ewAzSwY+c/f5wMlm1h54y8wmufv6qBYJuPu7ZesCFhPD29XMDgeWlq87VrZnGT+1f8bUtq1gP10WLIqpbVvRvzcx/jugdF+FiusP5zat7SOHTUBq0E4ldqfSDwFuLn3g7h8BLwFNo1ZRBcrUtZPY3q5nAP8ofRCr25OK989Y3mf32E8hNrdtuZpieXtCuX0VIrdNa3s4TAG6BO3OweOYYmanAG+4+zdm1rLMomRKhvBRF/zFWCoZeI3Y3q7t3H1pBXXHxPYso6L9Myb32fL7aSxu25+oKSa3Zxnt3H0p/GT9YVPbDyuNAW4xs8FADuX+6ok2MzsbuAvYEpzelmlmb1Hyy/dZd98e1QJ3+0sQXK8BzwKziNHtambZwNrg4R51x8L2NLM8IIOSD3kr2j+9gr6o1mlmddlzP30AaB0L27bc9uxdviYzi5nfAeVqfa3cvgoR3l81CU5ERELU9sNKIiJSAYWDiIiEUDiIiEgIhYOIiIRQOIiISAiFg0iMMbM6ZnahmbWNdi1Se9X2eQ4ie2VmU4A5QI+gazYl56GfALzp7icc5OtfBBwHPOTuiwDc/Tsz6wSsCq4SegHwvbv/6WDeS6QyFA4ie/e/7j7DzP4E4O5/NrMZ7v69mZ1cRe8xuzQYyvgmeL+Pg4DqU0XvJbJfdFhJZC/cfUYFfdPNLBf4LUBwL4B/m9l1ZjbHzH5uZnea2fPB8mPN7GIze9TMTv2p9zKzeDMbaWY/B7qF5ycS2T8KB5EDswG4Mmi/D6S7+13ADCDX3a8HegU3vrmWksutfwAcs5fXPBcocveJQGHYKhfZDzqsJHIAguvybAse7gJ+CNrfATuC9k6gDtDc3V/Yj5ftzu4Lv+2sqlpFDoRGDiLh1yj4gBkzG7iX9T5n98giDrBwFybyUxQOIvtgZk0p+aV9jJm1CPoOo+Re2cdScsnnJmbWDGgFHGFmOUA6JXfuuh6YYGYvA5/t5a0eAY43s7uBFkDXcP1MIvuiq7KKRFFwKqu5+5N7WacP0EenskokaeQgEl3LgWZmdnRFC82sA3AEJR9mi0SMRg4iIhJCIwcREQmhcBARkRAKBxERCaFwEBGREAoHEREJoXAQEZEQ/w/PBlt2EYARKQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pyplot.errorbar(time, k[:, 0], yerr=k[:, 1])\n",
+    "pyplot.xlabel(\"Time [d]\")\n",
+    "pyplot.ylabel(\"$k_{eff}\\pm \\sigma$\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Due to the low number of particles selected, we have not only a very high uncertainty, but likely a horrendously poor fission source. This pin cell should have $k>1$, but we can still see the decline over time due to fuel consumption."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then examine concentrations of atoms in each of our materials. This requires knowing the material ID, which can be obtained from the `materials.xml` file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_time, u5 = results.get_atoms(\"1\", \"U235\")\n",
+    "_time, xe135 = results.get_atoms(\"1\", \"Xe135\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX4AAAEQCAYAAAC3JB/WAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3dd3hUVf7H8fc3ISRA6B0BEZAiRZEgSAk2imDFii62XbGgIKy61nV31WXVnyBgw+6KZVUULFRRE4qgAZQiVaogGATpne/vjwy7EUMyQCZ3kvm8nifPk7l3Zu6H6/XL4dxzzzF3R0REYkdc0AFERKRgqfCLiMQYFX4RkRijwi8iEmNU+EVEYowKv4hIjCk0hd/MmplZfNA5REQKu0JR+M2sNTAdSDjM/ivNbKqZLTWztqFtZ5lZXzPrF/q8iIgAxYIOEA53n2FmmTntM7MSwH53b2dmVwEPmtl5wONAq9DbJgFnFUxaEZHoVigKf3ZmVgW4FKhIVv6HgZGh3bOBbkBtYIOHHks2s71mVtfdlwUQWUQkqhSKrp5D3A1sB5YADYED7n4gtC+VrJZ+NWBrts9sBaoWZEgRkWhV6Fr8QBPgb+6+DXjn4EYzqwuscvc5ZtYASM72mWRgQ8HGFBGJToWxxb8auBbAzNqbWaVQ908jdx9rZknAr0BpCwGS3X1JgJlFRKKGFYbZOc0sBUgDegLzyerT3wC8BnxA1s3b0qG3O9ACOB04OJpnhrtPLsDIIiJRq1AUfhERyT+FsatHRESOQdTf3K1UqZLXqVMn6BgiIoXKzJkzN7h75Zz2RX3hr1OnDhkZGUHHEBEpVMxs5eH2qatHRCTGqPCLiMQYFX4RkRijwi8iEmNU+EVEYowKv4hIjCnShf/AAT2VLCJyqCJb+Ndv2UWnwWmMm7cu6CgiIlGlyBb+bbv3kZQQz80jZtLnzVls2LY76EgiIlGhyBb+epWTGdWnHXd1acjE79fTaVAao79dgyalE5FYV2QLP0BCfBx9zqzPp33bc3zFUvR751tu/HcG6zbvCjqaiEhginThP+jEqqUZeUtbHujemClLN9BpcBr/+WaVWv8iEpNiovADxMcZf+pQl3H9Ujmpehn+MnIuvV7+mtUbdwQdTUSkQMVM4T+oTqVSvH1jGx6+qCmzV22iy1PpvD5thYZ+ikjMiLnCDxAXZ/Rqczzj+6eSUqcCD300nytfmM6yzG1BRxMRibgCKfxmVvow28sUxPEPp2b5krx+fSueuLQ5C9dt4dwhkxme9gP79h8IMpaISERFrPCb2UNmttTMFvC/hdAxs4pmtsjMlgJ3Rer44TIzLkupxWcDOpLaoDIDxy7kkuemsWjd1qCjiYhEREQKv5klAyWApu7e2N3XZtt9PXChu9d39wcjcfyjUaVMEi/0asmwni1YvWkn5w2bzNBJS9ir1r+IFDGRavE3AE4B1pjZDYfsqwx8YmZfmlnFCB3/qJgZ559cg4n9U+natDqDJi7mgqenMm/N5qCjiYjkG4vkWHYzawxMAlq6+0/ZtscDTwLF3P22HD7XG+gNULt27ZYrVx526ciImjB/HQ+Mmscv2/dwU2pd+p59IkkJ8YFkERE5EmY2091TctoX0Zu77r4AeB+ofsj2/cA/gNqH+dwL7p7i7imVK+e4SHyB6NykGhP7d6RHi+N49ssf6D50MjNXbgosj4hIfohUH39StpdJwEIzqxLalxjaXgWYHonj56eyJRN44rKTef2G09i19wCXPj+Nf3z8PTv27As6mojIUYlUi/8RM3vPzHoBI8jq83/azE4AZppZX+AMsrp7CoWODSozvn8qf2h9PK9MXU7XpyYz7YcNQccSETliEe3jzw8pKSmekZERdIzfmL7sF/4ycg4rf9nB1a1rc8+5jSidlBB0LBGR/wqsj7+oalO3IuP6pXJjhxN4++tVdBmczheLfg46lohIWFT4j1KJ4vHc3/0k3r+lLSUTi3H9q9/w53e/49cde4KOJiKSKxX+Y3Rq7fJ82rc9t51Zn1HfrqHT4HQt9ygiUU2FPx8kFovnzi4NGd2nHZWTE7OWe3xLyz2KSHRS4c9HTY8ry+jb2nFn5wZMnK/lHkUkOqnw57OE+DhuO+tEPunbntr/Xe5xJuu3aLlHEYkOKvwR0qBqaT4ILfc4eUkm5wxK491vVqv1LyKBU+GPoP8u93hHKo2rl+HukXO45pWv+XGTlnsUkeCo8BeAEyqV4p0b2/DwhU2YtXITXQan8++vtNyjiARDhb+AxMUZvU6vw/j+qZx6fHn+OjprucflG7YHHU1EYowKfwGrWb4k/77hNB6/tDkL1m2h61PpvJi+jP1q/YtIAVHhD4CZcXlouccOJ1bm0TEL6PHcNBav13KPIhJ5KvwBqlomiRevacnQni1YvXEH3YdOZpiWexSRCFPhD5iZcUFouccuTarxpJZ7FJEIU+GPEhWTE3n6qlMZ3qslG7bt5sJnpvLE+IXs2rs/6GgiUsSo8EeZLk2q8Vn/jlzc4jie+eIHzhs2hVmrtNyjiOQfFf4oVLZkAv8XWu5xx+59XPLcNB7+5Ht27lHrX0SOnQp/FDu43OPVrWvz8pTldB2SzvRlvwQdS0QKORX+KFc6KYFHLmrG2ze2wR2ufGE6D46ax7bdWuxdRI6OCn8hcXq9ioy7owM3tDuBETNW0mVwOpOXZAYdS0QKIRX+QqRk8WL89fyTeP/m00lMiKPXy1/zl/fnsHnn3qCjiUghosJfCLU8vgJj+nbg5o71eG/maroMTufzheuDjiUihYQKfyGVlBDPPec24sNb21G2RAI3vJZB//98y6btWuxdRHKnwl/InVyrHB/f3p6+Z5/Ix9+tDS32/lPQsUQkihVI4Tez0gVxnFhVvFgcAzo14KPb2lO1TCI3j5hFnze12LuI5Cxihd/MHjKzpWa2APhd4Tez982sTqSOH4tOqlGGUX3acVeXhkz8Xou9i0jOIlL4zSwZKAE0dffG7r72kP0XA4mROHasS4iPo8+Z9fm0b3uO12LvIpKDSLX4GwCnAGvM7IbsO8ysBbAa0COoEXRi1dKMvKUt93fLWuy906A03svQYu8iEqHC7+6z3L0r0B54xMyqA5hZeaC+u2fk9nkz621mGWaWkZmph5SOVnyccWNq1mLvjaqV4a7353Dtq9+w5tedQUcTkQBZpFuAZjYUeM3dZ5nZH4DLAAdOBRYC17v7msN9PiUlxTMycv17QsJw4IDzxvSVPDZuIXFm3NutET1b1SYuzoKOJiIRYGYz3T0lp32R6uNPyvYyCVhoZlXcfYS7X+juFwGfA71zK/qSf+LijGvb1mH8HamcXKss9384j6tfmsGqX3YEHU1EClik+vgfMbP3zKwXMIKsPv+nI3QsOQK1KpRkxB9bM7BHM+au2UyXp9J5depyDmixd5GYEfGunmOlrp7IWfvrTu77cC5fLsok5fjyPHZpc+pVTg46lojkgwLv6pHCoUa5Erx6XSsGXX4yS37eRrchkxme9gP7tNi7SJF22MJvZslmVi3b66pmdoqZFS+YaFIQzIwep9ZkYv9UOjaozMCxC7nkuWksWrc16GgiEiGHLfzuvg2YBGBm1wMzgeuAoWbWvkDSSYGpUiaJ4b1aMqxnC1Zv2sl5wyYzbNIS9qr1L1Lk5NXVUzzUwn8cOMfd73D3m4HjIx9NCpqZcf7JNZjYP5WuTavz5MTFXPj0VOat2Rx0NBHJR3kV/jeAvwMZ7r4w2/YLIhdJglYxOZFhPVswvFdLMrft5qJnpvLkhEXs3qfF3kWKgmK57XT3f5hZKbKGYwJgZonAqkgHk+B1aVKN1idU4OFPFjDs86WMm7eOJy47mVNqlQs6mogcgzxH9bj7dnefbWbFzawlUNLd7yqAbBIFypUszpOXn8yr17di2+599Hh2KgPHLGDXXrX+RQqrXAu/md1lZhPM7DKybu7eAtxvZmcVSDqJGmc2rML4/qlc0ao2w9OXce6QyXyzYmPQsUTkKOTV4u8EdAHWAjPc/U/ufieaUjkmlUlKYGCPZrz5p9bs3X+Ay4d/xd8+ms+OPfuCjiYiRyCvwv+9Z5kKPJpt+yURzCRRrl39Soy/I5VrT6/Da9NW0OWpdKYt3RB0LBEJU16F/yEzOwXA3Zdn2/5j5CJJYVAqsRh/u6AJ7950OsXi4rjqpRnc+8Fctu7aG3Q0EclDroXf3TcDCWZW9+A2M6sNrIt0MCkcTjuhAmP6dqB3al3+880qOg9O58tFPwcdS0RykdfN3VeAl4FHzewJMyvp7quA2wsknRQKJYrHc1+3xoy8pS3JicW47tVvuPO979i8Q61/kWiUV1dPRyDF3XsCDwCXmFklQGP55Hda1C7PJ33bc9uZ9flw9hrOGZzGhPn6x6FItMmr8M8ADMDdd7v7G0AroGykg0nhlFgsnju7NGR0n3ZUSk6k9xszuf3t2WzcvifoaCISklfhvwk4z8z++4Svu48F7o5oKin0mh5XltF92jGgUwPGzfuJToPS+GTOWi32LhIF8ir8Ke4+0t1/M1Db3f8TwUxSRBQvFkffs0/kk9s7cFz5Etz21mxuHjGTn7fuCjqaSEzLdQUuM5sFfEJWn76HfuKA1919RUEE1ApcRcO+/Qd4acpyBk1cTImEeO7v3pjLWtbETIu9i0RCbitw5VX467v70hy2/93dH8rHjIelwl+0/JC5jXtHzuXrFRtpV78i/7y4GcdXLBV0LJEi56iXXsyp6Ifo3+pyVOpVTuad3m145KKmfLc6a7H3F9K13KNIQcprHH/THLbFA00ilkiKvLg44w9tjuezAR1pX78y/xyzkIufncb8tVrwRaQg5HVzd6yZfZ7t5wvge2BsAWSTIq5a2SRevKYlz1x1Kj9t3skFT0/lsXELNeWzSITluhALWU/tfpHt9Q5gcWgqB5FjZmZ0b149q79/zAKe+/IHxs1bx8AezWhTt2LQ8USKpLxu7ia6++4CzPM7urkbW6Yu3cC9H8xl1cYd9DytFvec25iyJRKCjiVS6BzLzd18KfpmVjo/vkeKvoNTPmdN+raaToPSGDdP0z6I5Kc8l148Wmb2kJktNbMFQOls2y8zs9fNbIqZVY/U8aXwOjjp2+g+7amYnMjNI2Zy8xsz+XmLBpOJ5IcjKvxm9kCY70sGSgBN3b2xu68NbY8Hlrj7tcD7ZM37I5KjZjXL8tFt7bi7a0M+X/QzZw9K452vV2naB5FjdKQt/lPDfF8D4BRgjZndcHCju+93929Dc/9UBiYe4fElxiTEx3HrGfUZf0cqJ1Uvwz0fzKXni9NZsWF70NFECq0jLfxzwnmTu89y965Ae+CR7F06lvWM/jXApcCVOX3ezHqbWYaZZWRmZh5hRCmKTqhUirdvbMPAHs2Yv3YLXZ5K57kv9eCXyNHIdVRPvhzAbCjwmrvPOmR7beA5d++e2+c1qkcOtX7LLv46eh7j56+nSY0yPHZJc5oep5nCRbI76lE9x3DApGwvk4CFZlblkLftAeZF4vhStFUtk8TwXik8/4dT+Xnrbi58ZioDxyxg5x49+CUSjkiN6nnEzN4zs17ACLL6/J82s4pm9p2ZXQN0BR6O0PElBnRtWp3P+nfkspY1GZ6+jK5D0pm2dEPQsUSiXlhdPWb2MPAs0JqsYv2BZueUaDLthw3c98FcVvyyg8tTanJ/t5MoW1IPfknsyo+unq+BfcCTQBeylmQUiRpt61Vi3B2p3NyxHiNnreHsQWmMmfuThn6K5CDcwt8EGA3cCVQB/hyxRCJHKSkhnnvObcToPu2oWiaRW9+cRe83ZrJusx78EsnuqEb1mFlldy+QcZbq6pGjsW//AV4OrfhVPD6Oe7o1omer2sTFacUviQ3H3NVjZjeb2UQzm2ZmX6GuHolyxeLjuKljPcbfkUrT48py/4fzuPLF6fyQuS3oaCKBC7er50ygD9CTrIeubo9YIpF8VKdSKd66sTWPX9KchT9t4dwhk3nmi6Xs1YNfEsPCLfxvAwlAYuinRMQSieQzM+PyVrX4bEBHzmlchSfGL+L8YVOY8+OvQUcTCUS4wzk/BcoDB6dpruTuzSIZ7CD18Ut+Gz9/HQ+OmseGbbv5Y/sT6N+pASWL57UmkUjhklsff7hXe0b2cftmVjVfkokEoEuTarSpW5HHxi3kxcnLGTd/HQMvbk77EysFHU2kQITb4n8dWE/WWH6Aeu5+RSSDHaQWv0TS9GW/cO8Hc1m+YTuXtqzJA90bU65k8aBjiRyz/HiAayWwAFgU+lmVT9lEAtWmbkXG9uvArWfU48PZazhnUBoff7dWD35JkRZu4X8ImEtWi38WcHfEEokUsKSEeO7u2oiPb2tP9bIluP3t2dz47wx+2rwz6GgiERFu4f8r8HegKVnDOntHLJFIQE6qUYYPb23LA90bM2XpBjoNSueNr1Zw4IBa/1K0hFv417t7d3e/191vBn6OZCiRoBSLj+NPHeoy4Y6OnFKrHA+Ons/lw79i6c968EuKjnAL/38nOjezRsBZkYkjEh1qVyzJG388jScubc6Sn7fRbchkhk1awp59evBLCr9wC/8sM0s3s0zgVeClCGYSiQpmxmUpWQ9+dW5SlScnLub8YVOYvWpT0NFEjkm4hX+3u6e6e2V3Px0oHclQItGkculEnr7qVF68JoXNO/fS47lp/OPj79m+e1/eHxaJQrk+wGVmlYC+QDMzWxDaHAd0Bk6NcDaRqNLppKq0rluBx8ct5JWpyxk/fx3/7NGMjg0qBx1N5Ijk2uJ39w3AZ/xv/P4iYD5wXcSTiUShMkkJPHJRM967+XQSE+K49pWv+fO73/Hrjj1BRxMJW7hP7hpQA4gn6y+L67X0osS6XXv3M+zzJTyftozyJYvz8IVNOLdZ9aBjiQD5M1fPS0A5sh7g2gdszqdsIoVWUkI8d3VpRLdm1bn7/Tnc8uYsujapxj8ubEKVMklBxxM5rHBv7o5290uAt9z9alT4Rf6rSY2yjOrTjr90bcTni37mnEFpvJuxWtM+SNQKt/CfYmb9gC1mNhO4KIKZRAqdhPg4bjmjHmP7daBhtdLc/f4crnnla1Zv3BF0NJHfOeI1d82sJLDf3Xfn+eZ8oD5+KWwOHHDenLGSf41dyAGHu7s25JrT6xCv9X6lAOXH7Jz/5e47CqroixRGcXFGr9PrMGFAR047oQJ///h7Lnt+GkvWbw06mgiQR+E3s4vMTEsTiRyF48qV4LXrWzH4ipNZtmE73YdOYdikJVrvVwKXV4u/o7vvM7Mzsm8MPdgVNjPTk74Sk8yMi1vU5LMBHemUbdqHuT9qfIQEJ6/Cv9nM/gn0M7N/HvwBXsnri83sITNbGnrit3S27Vea2dTQvrbHFl+kcKiUnMgzV53K8F4t2bh9Dxc+M4WBYxewa+/+vD8sks/y6sb5F9CVrDH8i7JtL5Xbh8wsGSgBNHX3Xdm2lyDrxnA7M7sKeBA492iCixRGB9f7HThmAcPTljF+3jr+dUlz2tStGHQ0iSF5Tdmwy91HAfcC44GlwCfAX/L43gbAKcAaM7sh2/a9wMjQ77OBX3L6sJn1NrMMM8vIzMzM+08hUoiULZHAvy5pzpt/as1+d658YTr3fziXrbv2Bh1NYkS4Uzb0Bm4la93dEsDb7v6fMD7XGJgEtHT3nw7ZdxPwlbvPye07NJxTirIde/YxaMJiXpm6nKplknj04qac1ahq0LGkCMiP4ZwV3P0Ud+/p7hcBYQ3+d/cFwPvAbyYwMbO6wKq8ir5IUVeyeDEeOO8kRt7SluTEYtzwWgZ3vDObjds16ZtETriFf+XBX8ysLNAqtzebWfaJSpKAhWZWJbSvCtDI3ceaWdLB7SKxrEXt8nzStz39zj6RT+f+xDmD0vjou7Wa9kEiItzCv9HMJpvZfGAWMC6P9z9iZu+ZWS9gBFl9/k+HnvodDTxuZvOAb4CNR5ldpEhJLBZP/04N+Pj29tQqX4K+b8/mxn9nsG7zrrw/LHIEwp6yITQ1cyV3L9C7rerjl1i0/4DzypTlPDlxEQlxcdzbrTFXtqpFnKZ9kDDly5QNnkVDbEQKQHyccWNqXcb1S6XJcWW478O5XPXSdFZs2B50NCkCwir8ZlYu0kFE5PfqVCrF2ze2YWCPZsxfs4WuQ9J5MX0Z+w+o71+OXrgt/k+zvwg9iCUiBcDM6HlabSYO6Ej7+pV4dMwCejw7lYXrtgQdTQqpcAt/upn9JfRgVW/gyUiGEpHfq1Y2iRevSWFYzxb8uGkn5w2dwqCJi9m9T9M+yJEJt/AnACXJGo9fHagcsUQiclhmxvkn12DigI6c17w6Qyct4fxhU5i9alPQ0aQQCffJ3dJATXdfYGatgW+1EItI8D5fuJ77P5zHui27uKHdCfy5cwNKFtdM6pI/o3peAG4L/b4CeCAfconIMTqrUVUm9E/l6ta1eXnKcro8lc7UpRuCjiVRLtzC/wWQBuDu64HOEUskIkekdFICj1zUjHd6t6FYXBxXvzSDe0bOYfNOTfomOQu38BvQwsy6mdl/gPURzCQiR6FN3YqM7deBmzrW5d2M1XQalMaE+euCjiVRKKzC7+7DgSlAE+BD4NJIhhKRo5OUEM+95zZmVJ92VChVnN5vzKTPW7PI3KplsuV/wn2AKwXoC1wLnEW2FbVEJPo0r1mOj29vz52dGzBx/no6DU7jg1k/atI3AcLv6nkJGAy0AwYCV0cskYjki4T4OG4760TG9GtP3UqlGPDud1z/2jes+XVn0NEkYOEW/i/dfZy7b3b35Rxm5SwRiT71q5TmvZvb8rfzT+Lr5RvpPCiNN75awQFN+xCzDjuOP7RkYi+yFl0pT9YN3h2h3evd/eKCCKhx/CL5Z/XGHdz34VwmL9lAqzrl+dclzalXOTnoWBIBuY3jz63wn0ZWod+aw+5N7l4gE4Wo8IvkL3fn/Zk/8vAn37Nr3wHuOOdEbuxQl4T4sCfrlULgqAr/IV9wHHAGUCq0qam79823hLlQ4ReJjJ+37uKvo+Yzbv46mtQow2OXNKfpcWWDjiX5JD+e3B1F1lDOg3P1VMqnbCISkCqlk3i+V0ueu/pU1m/ZzYXPTGXg2AXs3KNJ34q6cCf1eNHdXzj4wsyqRSiPiBSwc5tVp229Sgwcu4DhacsYO3cdA3s0o119te+KqnBb/OXN7Bszm2ZmXwHTIhlKRApW2ZIJ/OuS5rx9Yxvi44yrX5rBXe99x6879gQdTSIg3BZ/S7LG7h98/K9hZOKISJBOr5c17cPQSUsYnr6MLxb9zEPnN+G85tXJWnZbioJwW/wzyPpLIjH0Uyr3t4tIYZWUEM/dXRvx8W3tqVGuBLe/PZs/vp6hB7+KkHBH9UwB9gMHQpuqu3ujSAY7SKN6RIKzb/8BXpu2gicnLCbO4O6ujfhDm+OJj1PrP9rlx3DOau6+LtvrSu5eIJN+q/CLBC/7g1+n1i7Hvy5pToOqmrIrmuVH4f/rIZsqaRy/SGxxd0Z9u4Z/fPw923bv45Yz6tPnzHokFosPOprkID/G8Vcjaw7+9cBmYOMRBih9yOviZtb4SL5DRIJlZlzcoiafDejIec1rMHTSEroNmUzGiiMqBxIFwi38t7v78NDPEKBOXh8ws4fMbKmZLSDbNM5mVg54lqwpnkWkkKmYnMjgK07htetbsWvvAS59/iseGDWXLbu04ldhEW7h/9HM1oZ+MoGSub3ZzJKBEmRN7dDY3dce3Ofuv5K1qIuIFGJnNKzChP6p/LH9Cbw1YxWdB6Vrxa9CItfCb2YH93d29xqhn8rufnke39sAOAVYE5rl84iYWW8zyzCzjMzMzCP9uIgUkFKJxXjwvJP44NZ2lCuZQO83ZnLrmzP5ecuuoKNJLnK9uWtm9wFvkjU182+4+6o8vzyrH38S0NLdf8q2/Tqgkbvfk9d36OauSOGwd/8BXkhfxpBJS0gsFsf93RpzRataevArIMdyc7c5cGbo5wzgz8Bi4LJwDuzuC4D3yZrYTUSKsIT4OPqcWZ9x/TpwUvUy3PPBXHq+OJ3lG7YHHU0OkVfhv8XdX3P318makbM7cKa7P5nbh8wsKdvLJGChmVU5tqgiUhjUrZzM2ze2YWCPZsxfu4UuT6XzzBdL2bv/QN4flgKRa+F3901mVsnMxgBnA63d/aswvvcRM3vPzHoBI8jq838awMzKAm2Bk82s6rHFF5FoFBdn9DytNpMGdOTsRlV4Yvwizh82he9W/xp0NCHvPv5zgFeA59x9YLbtdd19WQHkUx+/SBEwfv46/jp6Hplbd3N9uxP4c+cGlCwe7hyRcjSO+sldM9sGpAFf878bvMWBC929WX4HzYkKv0jRsGXXXh4bu5A3Z6yiZvkSPHpxMzo2qBx0rCLrWAp/d3f/NIftnd19Qj5mPCwVfpGi5evlG7nngzksy9zOxS2O48HzTqJCqeJBxypyjnpUT05FP7S9QIq+iBQ9p51QgTF9O9D3rPp8Mmct5wxKY9TsNYQzb5jkj3Cf3BURyTdJCfEM6NyQT27vQO0KJbnjP99y7avfsHrjjqCjxQQVfhEJTMNqpRl5S1v+dv5JzFyxkc6D03lp8jL2H1DrP5JU+EUkUPFxxnXtTmDCgI60qVuBRz5dQI9np7Lgpy1BRyuyVPhFJCocV64Er1zXiqE9W/Djpp2cP2wKj49byK69+4OOVuSo8ItI1DAzLji5Bp8N6MhFLY7j2S9/4Nwhk5m+7JegoxUpKvwiEnXKlyrO/112MiP+2Jr9B5wrX5jOPSPnsHmH5vzPDyr8IhK12p9YifF3pHJTal3ezVjNOYPTGDv3Jw39PEYq/CIS1UoUj+febo356Lb2VCmdyC1vzqL3GzNZt1lz/h8tFX4RKRSaHleW0X3ace+5jUhfnEmnQWmMmL6SAxr6ecRU+EWk0CgWH8dNHesxoX8qzWuV5YFR87jiha9Y+vPWoKMVKir8IlLoHF+xFCP+2JonLm3O4vXb6DZkCkMnLWHPPs35Hw4VfhEplMyMy1Jq8dmAjnRpWo1BExdz3rDJzFy5KehoUU+FX0QKtcqlExnWswUvX5vC1l37uPT5afzj4+/ZsWdf0NGiloJxWnsAAAptSURBVAq/iBQJZzeuysQBHflD6+N5Zepyuj41mWlLNwQdKyqp8ItIkZGcWIyHL2rKO73bEGdw1UszuPeDuWzZpQe/slPhF5Eip03dioztl0rv1Lr855tVdB6UzucL1wcdK2qo8ItIkVSieDz3dWvMB7e2o0yJYtzwWgZ3vDObTdv3BB0tcCr8IlKknVKrHB/f3p6+Z5/IJ3N+otPgND6dE9vTPqjwi0iRl1gsngGdGvDRbe2pXrYEfd6axc0jZvLz1tic9kGFX0Rixkk1yvDhrW35S9dGfLEok06D0nl/5o8x1/pX4ReRmFIsPo5bzqjH2H4dOLFKMne+9x3XvfoNa37dGXS0AlMghd/MShfEcUREwlWvcjLv3nQ6f7+gCd+s2EjnQWm8ESOTvkWs8JvZQ2a21MwWAKWzbT/LzPqaWT8zax2p44uI5CUuzri2bR3G35FKi9rleXDUPK58cTorNmwPOlpERaTwm1kyUAJo6u6N3X1taHs88DgwDBgKDIzE8UVEjkStCiV544+n8dglzVjw0xa6DknnxfRl7C+irf9ItfgbAKcAa8zshmzbawMbPATYa2Z1D/2wmfU2swwzy8jMzIxQRBGR/zEzrmhVm88GdKR9/co8OmYBPZ6bxuL1RW/K54gUfnef5e5dgfbAI2ZWPbSrGpD9LG4Fqubw+RfcPcXdUypXrhyJiCIiOapaJokXr2nJ0J4tWL1xB92HTmbIZ0VryueI3tx19wXA+8DBwv8LkJztLcmAZlESkahiZlxwcg0m9k+la9PqDP5sMRc8PYW5P24OOlq+iFQff1K2l0nAQjOr4u6LgdIWAiS7+5JIZBAROVYVk7OmfH7xmhQ2bt/DRc9O5bFxC9m1d3/Q0Y6JReLBBTP7P+B44CNgJbAFuM/dLzezDsDB0Twz3H1ybt+VkpLiGRkZ+Z5RRORIbN65l0c//Z53M36kbuVSPH5Jc1LqVAg61mGZ2Ux3T8lxX7Q/sabCLyLRZPKSTO4ZOZe1m3dy7el1uKtLQ0olFgs61u/kVvj15K6IyBHocGJlJvRP5drT6/D6Vyvo8lQ6U5YUrluVKvwiIkeoVGIx/nZBE9696XSKx8fxh5dn8Jf357B5Z+FY8EWFX0TkKLWqU4Ex/Tpwc8d6vDdzNZ0Hp/HZ99G/4IsKv4jIMUhKiOeecxsxqk87ypcszp/+nUHft2fzy7bdQUc7LBV+EZF80LxmOT66rT39z2nA2Hk/0WlwOh9/tzYqp3xW4RcRySfFi8XR75wT+eT2DtQqX4Lb355N7zdmsn5LdC34osIvIpLPGlYrzchb2nJft0akL87knEFpvPvN6qhp/avwi4hEQLH4OHqn1mPcHak0rlaGu0fO4ZpXvmb1xh1BR1PhFxGJpBMqleKd3m14+MImzFq5iS5PpfPvr1YEuuCLCr+ISITFxRm9Tq/D+P6ppNSpwF9Hz+fKF6azLHNbMHkCOaqISAyqWb4kr1/fiv+77GQWrtvCuUMm83zaD+zbX7BTPqvwi4gUIDPj0pY1+WxAR85oWJl/jV1Ij+emsXDdlgLLoMIvIhKAKmWSeP4PLXnmqlNZs2kn5w+bwuCJiwtkwRcVfhGRgJgZ3ZtXZ+KAjnRvVp0hk5ZwwdNT+G71rxE9rgq/iEjAKpQqzlNXtuDla1P4dcdeLn52KgPHLIjYgi8q/CIiUeLsxlWZMCCVK1rVYnj6Mnq/MTMix4m+1QNERGJYmaQEBvZozvnNa1AsPjJtcxV+EZEo1LZ+pYh9t7p6RERijAq/iEiMUeEXEYkxKvwiIjFGhV9EJMao8IuIxBgVfhGRGKPCLyISYyxa1oA8HDPLBFYew1dUAjbkU5xIUs78VVhyQuHJqpz5K9I5j3f3yjntiPrCf6zMLMPdU4LOkRflzF+FJScUnqzKmb+CzKmuHhGRGKPCLyISY2Kh8L8QdIAwKWf+Kiw5ofBkVc78FVjOIt/HLyIivxULLX4REclGhT8KmVnpoDPkJFpzhSMasptZMzOLDzpHOI4ka5Dn9nA5o+G/d3bRdj6LZOE3s2Jm9rCZXWxm95lZVP05zayMmb1tZsvM7DXL8pCZLTWzBUDUXLSH5CofrefVzK4zs/lmlmFmP5jZn6LpnJpZa2A6kJDT9RlN1+whWX93rYbeE/i5zZ4zp0zRck4POZ+/u05zyh7pTFHzP24+uxFY4+4fApuAywLOc6jOwA1AY6AlkAqUAJq6e2N3XxtkuIPMLJlsuYDuRO95/c7dm4TGRb8FjCOKzqm7zwAyQy9zuj6j5po9JOuh1+pph14XQZ3b7DkPkykqzukh5/PQ6/STIM5nUS38bYBvQ79/S1bBiiYfuftOd98NfA/sBE4B1pjZDcFG+40G/DZX1J5Xd5+d7WUNoArReU4h5/MYref20Gv1F35/XUSDnDJF3Tk99Dp193UEcD6L6pq71YCtod+3AlUDzPI77r4HwMySgB/d/Wugq5k1BiaZ2Vh3/ynQkIC7z8qeC5hLFJ9XADNrCCw6NHu0nNOQw12fUXduc7hWl4Z2RdW5zem/N1FcBw5ep5Bz9kifz6La4v8FSA79nkz0zttxBfDQwRfuvgB4H6geWKIcZMu1n+g/rz2A0QdfROk5zen6jPZr9jfXKkTnuT0kUzSf099cp1Cw57OoFv4JwMmh35uHXkcVM+sGjHH3bWZ2fLZdSWT9kzpwoVbeQUnAR0T5eQUaufuiHLJHxTkNyen6jNpr9tBrNRrP7WEyRe05JXSdwmGzR1RR7er5N/APM7scqM0hLZWgmdmVwBPA5tAQr6pmNomswjrC3XcFGvB/Hgn9pfQRMAKYQnSf15rAmtDL32QP+pyaWQpQmaybpTldn57DtsCzmllJfnutDgPqRsO5PeScph6aycyiog4ckvOjQ65TCOBa1ZO7IiIxpqh29YiIyGGo8IuIxBgVfhGRGKPCLyISY1T4RQqImSWa2bVm1iDoLBLbiupwTpFcmdkEYBrQNrRpKlnD7c4Exrv7mcf4/dcB7YBn3P1bAHffbWbNgJWhCcOuAfa4+9+O5VgiR0qFX2LVo+6eZmZ/A3D3v5tZmrvvMbOu+XSMqQeLfjbbQsdbGPrL54x8OpZI2NTVIzHJ3dNy2PalmdUB7gQITef7mZndZWbTzOx8M3vczN4K7T/NzK43sxfN7LzDHcvM4s3sXjM7H2gdmT+RSPhU+EV+ax3QN/T7d0A5d38CSAPquPvdQIfQvPR/Jmtm1TlAq1y+8yog090/BjIillwkTOrqEckm9Kj/ztDLA8C+0O+7gb2h3/cDicBx7v5OGF/bhv/NE7M/v7KKHC21+EWOXsXQzVrM7OJc3ree//2LIA6wSAcTyY0Kv8QsM6tOVkFuZWa1Qtvqk7XE5GlkzexYxcxqACcATcysNlCOrIUz7gY+NLORwI+5HOp5oKOZ/R9QC2gRqT+TSDg0SZtIBISGc5q7v5rLe84AztBwTiloavGLRMYPQA0za5nTTjM7CWhC1o1hkQKlFr+ISIxRi19EJMao8IuIxBgVfhGRGKPCLyISY1T4RURijAq/iEiM+X8CBwkJYh/+OAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pyplot.plot(time, u5, label=\"U235\")\n",
+    "pyplot.xlabel(\"Time [d]\")\n",
+    "pyplot.ylabel(\"Number of atoms - U235\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXYAAAEQCAYAAACk818iAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3deZgcd33n8fe3u+fSrZFGsmRZx8j4wDceWQdHDJv18sTL4WDASZ6AbUABsrCb5QxLYgzJhpDlybHHAyJseHgIkA1gcAghBh5iAj2SLR/YAdngHlm2ZFue6dE9mqv7u390jdwz6pnuGU11VVd/Xs8zz3RVV1d9plT+dvnb1b8yd0dERJIjFXUAERGZXyrsIiIJo8IuIpIwKuwiIgmjwi4ikjAq7CIiCROrwm5mV5hZeobnW83s0mmeWxJeMhGRxhGbwm5mW4HdQMs0zy8D/g/w1rJ5K8zscTN7AvhAXYKKiMRcJuoAE9x9j5n1z/D8UTP7MXBJ2ezbgNe5+2OhBxQRaRCxKezlzGwVcDOwAsi4+x3TLNoFfNvMDgJvcPd8vTKKiMRVbFoxU3wQOAX8ErjYzCrmdPcPARcDDwN31i+eiEh8xbWwXwZ83d2/6u63uHtxugXdvQB8HFhft3QiIjEW18L+NMGHpGb2MjNbWWkhM2sLHq6i9MGriEjTi01hN7MeSj3zG4A/Bd5hZt8HNrr7gJktBXYAV5nZajPbBDxgZu8Frgc+HVF0EZFYMQ3bKyKSLLE5YxcRkfkRi8sdV65c6Rs3bow6hohIQ3nggQcG3L1r6vxYFPaNGzeyd+/eqGOIiDQUMztQab5aMSIiCaPCLiKSMCrsIiIJE0phN7NbzexnZrbXzHJm9vYwtiMiImcL68PTn7r7ZQBm9gng2yFtR0REpgjljN3dHyqbXOvuz01dxsx2Bmf0e/v7px2tV0REZinUHruZXQw8Xuk5d9/l7j3u3tPVddZlmCIiMkdhX8f+68A3Qt5GInzr4UP88vBJHKfo4A6Ol377C/OKwRAQZ+aVL+9+5nWT5k1aPlhHsK5alp9Y79Tlz6xjyvIA7ZkUC1rTLGjNBL/TdJQ9npjfcWZ66rwMC1rSpFIWxT+HSOjGC0WGx4t0tKRJz/NxHnZhv8TdK56xywuODY3xX/7uYdwhnTIMSJmBQcrAMMxK8wwwAzMrPRf85swypeUnnistW2FesA0rW/8L6yzfVoXlg+dSKSNjL2QjWMaB4bECAydHOTU6xOnRAkOjBU6PFhgtTDsCc0XtLSkWtGboaJnuDWAWbx4tGRa0lR63Z6J/0ygWnbFikULRGSs444Ui40Uv/RSKpXnFIuOFCvOKXppfKDJWdArF4Lng+bHC2fPMjLZMitZ0itZM6act+D11Xlsmfdb8M8unU5gl9w13vFDk9FiB4bEiw2MFTo+Vjt3TweORM/Mmlis9f2bZsnnTrWd4rMBYoXQa9L3fewUvWr14Xv+G0Aq7ma0DDoW1/iTZvT+PO/z9O7ezZWNn1HFCNVYoninyQ6PjDAVFf2h0/MwbwNBYgaGR0nOnx8qWGyk9d3p0nOeOj5153cT6xouzG9DuzJtFW6noV/q/h9ZM6kzRLRSdsbICWwgK7FihVHwnCux4IZhXfKGoTpoXrGOWcWNlUsFPT3mTmDJvxjeJYP7k16YnT5ct05ZJ05Ixxsad4fHJBXe4rJBOLa4T05PnFRkeLUxaT3nBnY2UwYLWDO0tKdpb0nS0lE4o2lvSLO1oYfWStknzOsqW6VzYOu//PqEVdnc/CHwkrPUnSW8uT0dLmqvWLYs6Suha0imWdqRY2lHxnuXnZHS8OOnNouKbx1iBUyOlN4eJN5HTowVOjYwHbyIFjgyNcXp0nFOjBUbHi7SkjUwqRSZttKRTpFNGJlV6nEkbLakULekUHa3BvJSRKX9N8Ls0f5p5ZevLpM7eXqUMLWemS8+lp2TKpO3MvHTKcHdGC0VGx4OfQpGRseKZeSNl80vThUnLTixzZrnxIqOFQsX1jYwXOTE8Tn5ifvm6gnlzKaCzNVPBXdbRQseSdtpbUhULbtuk6Smvz0wu0i1pi9X/xcRirJhml80N0LNxOa0ZfV/sXJTO7lpZtiDqJPFUasWkacuko44ClFpRE28C5W8eEz8TbwYjU+aPFoqlN9IGLLj1osIesf4TI/zi8EluumZd1FFE6iqVMtpTpSIs80uniBHr7csDsGPzioiTiEhSqLBHrDeXZ3F7hsvWLok6iogkhAp7xHpzA2zdtIJMWv8UIjI/VE0idOjoaZ7MD7FdbRgRmUcq7BHqzam/LiLzT4U9QtncAJ0LW7l4nr91JiLNTYU9Iu7O7lye7d0rIv9qu4gkiwp7RA7kh3jm2DDb1IYRkXmmwh6RrPrrIhISFfaIZHMDrF7SRvfKhVFHEZGEUWGPgLuzuy/Pjs0rm3IcCxEJlwp7BH75/EkGTo7q+nURCYUKewSyTwwAsL1bhV1E5p8KewSyuTwXdHZwQafGlxWR+afCXmeFYtBf714ZdRQRSSgV9jrb9+xxjg+Ps+NCtWFEJBwq7HWWzam/LiLhUmGvs2wuz+auhaxa0h51FBFJqFALu5ltN7PfMLPzw9xOoxgrFLlv/yA7Nqu/LiLhCe2ep2b2u8B57v4HYW2j0Txy8ChDowUNIyAioQqlsJvZi4B3AVeGsf5GNTH++jb110UkRGG1Yt4EPA/8vpndY2abpy5gZjvNbK+Z7e3v7w8pRrxkc3levGYJyxe2Rh1FRBIsrMK+AfiMu/8x8Hngw1MXcPdd7t7j7j1dXV0hxYiP4bECew8c0TACIhK6sAr7EcCDx48BTf/h6YNPHWF0vKj+uoiELqzC/n3gmuDxcuCRkLbTMHpzedIp47pNnVFHEZGEC6Wwu/v3gFYzewuwA/hUGNtpJL25PFecv5TF7S1RRxGRhAvtckd3f39Y6240p0bGefjpo7zjFd1RRxGRJqBvntbB/U8OMl509ddFpC5U2OugN5enJW30bFB/XUTCp8JeB719ea5Zv5yO1nTUUUSkCaiwh+zY0Bj/duiY2jAiUjcq7CHbsz9P0TVMr4jUjwp7yLK5PO0tKa5evyzqKCLSJFTYQ9aby7NlYydtGfXXRaQ+VNhDNHByhMcPn9D4MCJSVyrsIdrdVxqmVzfWEJF6UmEPUTaXZ1FbhsvXLok6iog0ERX2EPXm8mzd1Ekmrd0sIvWjihOSZ4+dZv/AKfXXRaTuVNhDMnEbPPXXRaTeVNhDks3lWb6ghUvOWxx1FBFpMirsIXB3enN5tnWvIJWyqOOISJNRYQ/BU4NDHDp6WuPDiEgkpi3sZrbYzO4MHi83s78ys2+a2YfNTLcBmkE26K9vV39dRCIwbWF39xPAbwST3wDGgduAu4LfMo3eXJ5Vi9vY3LUw6igi0oSq3RqvaGYXAeuAV7m7A0fM7N+HH60xuTvZXJ6XXrgCM/XXRaT+qvXYdwCvAb4eFHXMrBX4ndlsxMya5tKQJ54/ycDJEfXXRSQyM56xu/sg8Okp80bN7DXVVmxmdwC/DYwB/w44cQ45G0ZW16+LSMRmLOxmthrYAnwPuAV4I/Ao8Ikqr1sEdACXu/vw/ERtDL25POuWd3BB54Koo4hIk6rWivl7oBv4A+DDwLuAvwBurvK6i4CrgUNmdvu5hmwUxaLT25dXG0ZEIlXtw9M+d/8rM0sDOXd/GsDMijO9yN0fBF5tZpcCPzCzf3L3Z8uXMbOdwE6A9evXz/kPiJOfP3ucY6fHND6MiESq2hn7t83sSncvuPvflM1/fy0rd/d9wNeANRWe2+XuPe7e09XVVXviGJsYH2Z7t/rrIhKdah+efs3MKhX/V830OjNrL+uttwM/n2O+hpLNDdDdtZDzlrZHHUVEmli1VgzuXqntUu0Gnn9kZhuAu4EvNcMHqGOFIvftH+Sml5wfdRQRaXLTFnYzuwR4yzRPXwXcON1r3b2mVk2SPHroGKdGC7rMUUQiN9MZew7oAn5c4Tl9OjjFRH99W7d2jYhEa9rC7u5jZvZ+dz829TkzuyvcWI0nmxvgkvMW07mwNeooItLkZrwqZpqi3unux8OL1HhGxgvsffKI2jAiEgs1jcduZh8zsy8Hk5ea2W+GmKnhPPTUUUbGi/pikojEQq032hgHvgng7j8Bbg0rUCPK5vKkDK7r7ow6iohI9csdA3mgzcwWUCrqyfhG0TzpzQ1wxflLWdKu+4+ISPRqPWP/GnBl8Psq4A2hJWowQ6PjPPTUUd0tSURio9rojlvdfY+79wMfKJv/q0Bf2OEawf1PHmG86Oqvi0hsVDtj/19mtqp8hpm9CfhKeJEaS28uT0va6Nm4POooIiJA9R77e4DbzewnwD7gM5SG4/2HsIM1it7cAFdfsIwFrbV+XCEiEq5q17HvdvdPUroT0mPAL4DLgHfXIVvsHTs9xqOHjqm/LiKxMmNhN7P3mdk3gGuAt1Ma/KujHsEawX37Byk66q+LSKxU6x/8CaW7J93s7kUzuwf4KKXx1W8LO1zc9ebytGVSXLN+WdRRRETOqPbh6Yfc/U8nhu519yF3/wjwfPjR4i+bG2DLxk7aMtVGMRYRqZ9qPfY/n+apO0LI0lDyJ0d47LkTug2eiMROrV9QmqQZbpxRze6+QQAVdhGJnTkVdim1YRa1Zbjy/KVRRxERmWRWhd3MPhpWkEbT25fnuk2dZNJ6bxSReJltVXpJKCkazHPHhunrP6XLHEUklmZb2B8JJUWD6e0bAHQbPBGJp1kVdnf/WEg5Gkr2iTxLO1p48ZolUUcRETlLqA1iM7vWzD4b5jaikM3l2d69glTKoo4iInKW0Aq7mS0DXgm0hbWNKDw9OMSho6fZcaHaMCIST7Xe8/QTZrbGzF5vZo+a2Z01vOxm4OszrHOnme01s739/f215o1cNlfqr+uDUxGJq1rP2O+jdN/TTwP/Adgz08JmdjNwF+DTLePuu9y9x917uroa50572VyersVtbO5aFHUUEZGKai3slwHfAt4PrALeV2X524DPA7uAV5lZteUbgruf6a+bqb8uIvFU090hgjHZPzkxbWa3VFn+xmC5jcDH3P3Tc48YH7n+k/SfGFEbRkRirabCbmbvpHQD64WAAauB7hBzxVJvLg/ADt1YQ0RirNb7ub0S+F1gJJi+vJYXufuTwK2zThVT2Vye85d1cEGn7jUiIvFVa4/9K0ALpUsX22jCuygVi05vX57tm9VfF5F4q/WM/R3Acl44Y18JfC2URDG177njHB0aU39dRGKv1sK+193P3FzDzFaHlCe2JvrrGn9dROKu1sK+0cw+ReladoDNwJvDiRRPvbk83SsXsmZp03WhRKTB1FrYDwD7gWIw3RJOnHgaLxTZs3+Q1169NuooIiJV1frh6R3Ao5TO2B8EPhhaohh69NAxTo6Mq78uIg2h1jP2PwSuozQe+8uBh4DEjdo4nWzQX9f46yLSCGot7Icnvk0KYGY3hZQnlnb35bnkvMWsXJSogSpFJKFqbcUUJh6Y2SXAq8KJEz8j4wXuf3JQV8OISMOo9Yz9QTP7EXAp8ATwzvAixcvDTx1leKzIdrVhRKRB1FrYR9z9FRMTZvaykPLETjaXJ2WwVYVdRBrEjIXdzFYC7wWuMLN9wewUcAPwkpCzxUJvLs/l5y9laUdTXeEpIg1sxsLu7gNm9n2gFXg8mF0Evhx2sDg4PVrgoaePcPvLNkUdRUSkZlVbMe7+IzP7V2AtkKZ0xn4bpUsfE23vgUHGCq5hekWkodTaY/9rYBmlLyiNA8dCSxQj2VyeTMro2bA86igiIjWr9XLHb7n7G4Avu/tv0USF/eoLlrGwrdb3PxGR6NVa2K82s/8MHDezB4DXh5gpFo4Pj/HowaMaRkBEGk6t9zz9+MRjM3s5ZV9YSqr79w9SdNiu/rqINJhZ9xjcfSiMIHGTzeVpzaS4Zv2yqKOIiMzKjK0YM3u9mTVlgzmby9OzYTntLemoo4iIzEq1HvuvuPu4mV1fPjP44tK0zGyZmf2lmX3fzBpuiN/BU6Pse/a4+usi0pCqnY0fM7P/DlxqZjeUzb8ceO0Mr+sGfi94fA/wqblHrL89fRO3wVN/XUQaT7XC/kng1ZSuYX+8bP7CmV7k7g/CmTFlPncuAaOQzeVZ2JrmynVLo44iIjJr1YYUGAa+aWY/BDoo3ev0MeDvqq3YzLopfUN1m5l9K1hX+fM7gZ0A69evn1v6kGRzA2zZ1ElLutarQUVE4qPWyvVm4LvAfwI+D7yu2gvcvc/d3wbsAa6o8Pwud+9x956urq5ZRA7X4ePD5PpPqb8uIg2r1iteOt396okJM3vTLLZxFOibVaoI9Qa3wdP4MCLSqGo9Yz8w8cDMlgJbZlrYzO40s/9rZjcC33H3/DlkrKveXJ6lHS1cumZJ1FFEROak1jP2wWCEx06gnaA3Ph13v+Ncg0Ul2zfAtu5O0imLOoqIyJzUOqTAP5vZPcBKd+8POVNknh4c4unB07ztpRp/XUQaV83fKnV3BxJb1KGsv36h+usi0rhq6rGbWVMMmJLNDbByUSsvWrUo6igiInNW64en/1g+YWYdIWSJlLvT25dn++aVmKm/LiKNq9ZWzI/M7EPAkWD6auDd4USKRt/AKQ4fH9H16yLS8Got7C3AAkpXxADE5xtF8yQb9Ne3d6uwi0hjq7Ww3wmsc/d9ZraV0hgyidKbG2Dt0nY2rFgQdRQRkXNSa499F6XhBACeBD4aSpqIFItOb079dRFJhloL+w+BewHc/TBww8yLN5bHD5/gyNCY+usikgi1tmIMuMbMTgJvBQ6HF6n+zvTXVdhFJAFqOmN3988CPwYuA+4Cbg4zVL315gbYuGIBa5cl7ipOEWlCtX5BqQd4L6Wz9VcBi8MMVU/jhSJ7+gZ1tyQRSYxae+x/Dfw58FLgT4DfCi1Rnf3smeOcGBlXf11EEqPWHvu/uPt3g8fHzKxhhuGtZqK/vk3Xr4tIQkxb2M3sduC3AQeWm9nDwFDw9GHgb8OPF75sboCLVi+ia3Fb1FFERObFTGfs/wa8BzhR4bkjFeY1nNHxIvc/OcgtW+J1z1URkXMxbWF39/smHpvZ+cD1wMJg1uWUPkxtaA8/fZThsaIucxSRRKm1x/5N4HvASDCdiEtIenN5zGDbJhV2EUmOWgv759x918SEmZ0XUp66yuYGuHztUpYuaIk6iojIvKm1sC83s/uBMUrfQl0NdIeWqg5OjxZ46Kmj3PrSjVFHERGZV7UW9mspXbs+0Yq5OJw49fPAgSOMFtRfF5HkqfULSnsovQm0BT8LZ1rYzJaY2VfMrM/MvmAxHDIxmxsgkzK2bOyMOoqIyLyq9Yz9JuC1QDGYXkNpzJjp3ADcHiy/F7iO0ptDbPT25bnqgmUsaqv5ft4iIg2h1qp2s7s/NzFhZtWuirnb3UeDZX8OnPVNVTPbCewEWL++vteRnxge45GDx3j39Zvrul0RkXqotbDvnNJNWckM17GXFfV24KC7P1FhmV2UbuBBT0+P1xp4Ptz/5CCFous2eCKSSLUW9vOAnwaP26m9N/9m4I7Zhgpb9ok8rZkUL9mwPOooIiLzrtbC/h53L0xMmNkXqr3AzH4N+I67nzSzDe5+YI4Z5102l+fa9ctpb0lHHUVEZN7VeuZ90MyeCX76gRnv+GxmtwCfBX5oZvuAG88x57w5cmqUfc8d1zC9IpJYM56xm1nK3YvADe7+aK0rdfevAl8913Bh2LM/j7tugyciyVWtFfNhM/tbSmOwT7p0xd2fCi9WeLK5PAta01y5blnUUUREQlGtsF8JPENpTHan9A3U3wH+G/DpcKOFI5vLs2VjJ62ZWrtQIiKNpVphf5e7HwEws/9KqVf+SnfvDT1ZCJ4/McwTz5/kjdeuizqKiEhoZizs7n4k+DLSFymdsW9194a9LV5vcBu8HbpxtYgk2Iz9CDP7VeBB4F/d/caJom5mDTmyY28uz5L2DC9euyTqKCIioanWivkmcC/QamZ/GMxrBV4HXBFmsDBkc3m2dq8gnYrdmGQiIvOmWmF/s7v/49SZZvajkPKE5uCRIZ4aHOI2jb8uIgk3YyumUlEP5t8TTpzwqL8uIs2iaa75683lWbGwlYtWL4o6iohIqJqisLs72VyebZtXEMN7foiIzKumKOz7B07x3PFhjQ8jIk2hKQp7Vv11EWkiTVHYe/vyrFnazsYVMw5KKSKSCIkv7MWiszuXZ7v66yLSJBJf2H/x/Anyp0Z1GzwRaRqJL+zZJ0r9dY2/LiLNIvmFPZdnw4oFrFuu/rqINIdEF/ZC0dmzP6/LHEWkqSS6sP/smWOcGB5nm/rrItJEEl3YJ65fV39dRJpJqIXdzK4ws3SY25hJNpfnRasWsWpxe1QRRETqLrTCbmZbgd1AS1jbmMnoeJG9Tw6qvy4iTSe0wu7ue4D+sNZfzSMHjzI0WmC7hhEQkSYTWY/dzHaa2V4z29vfP//1P5vLYwbbujvnfd0iInEWWWF3913u3uPuPV1dXfO+/mxugBevWcKyBa3zvm4RkThL5FUxw2MFHjxwVP11EWlKiSzsDx44wmihqGF6RaQphXlVTA/QBdwQ1jamk83lSaeMLZvUXxeR5pMJa8XuvhdYGNb6Z5LNDXDluqUsagvtzxMRia3EtWJOjozz04PH1F8XkaaVuMJ+//5BCkVXf11EmlbiCntvX57WdIprNyyPOoqISCQSV9izuQFesmEZ7S2RDVEjIhKpRBX2o0Oj/OyZ42zvVhtGRJpXogr77r5B3GHHhfrgVESaV6IKe29ugI6WNFetWxZ1FBGRyCSrsPfl2bKpk9ZMov4sEZFZSUwF7D8xwi8On2S7boMnIk0uMYW9t690Gzx9MUlEml1yCntugMXtGS5buyTqKCIikUpQYc+zddMKMunE/EkiInOSiCp46OhpnswPqQ0jIkJCCntvrtRf367CLiKSjMKezQ3QubCVi1cvjjqKiEjkGr6wuzu9uTzbu1eQSlnUcUREItfwhf1Afohnjw2rDSMiEmj4wp7N6fp1EZFyCSjsA6xe0samlZHchU9EJHYaurBP9Nd3bF6JmfrrIiIQUmE3s4yZfcLMbjKzj5hZKNv5xeGT5E+Nqr8uIlImrDP2dwCH3P0u4AjwxjA20psbANRfFxEpF1Zh3wY8HDx+GLgxjI1kc3nWdy5g3fIFYaxeRKQhZUJa73nAieDxCWD11AXMbCewE2D9+vVz2sjbXraJI0Ojc4woIpJMYRX2PLAoeLwIGJi6gLvvAnYB9PT0+Fw2slVjr4uInCWsVsw9wFXB4yuDaRERqYOwCvsXgfVm9iZgPfClkLYjIiJThNKKcfci8NFg8v+FsQ0REamsob+gJCIiZ1NhFxFJGBV2EZGEUWEXEUkYFXYRkYQx9zl9N2h+Q5j1Awfm+PKVVPgCVAw1Sk5onKzKOb8aJSc0Ttawc25w966pM2NR2M+Fme11956oc1TTKDmhcbIq5/xqlJzQOFmjyqlWjIhIwqiwi4gkTBIK+66oA9SoUXJC42RVzvnVKDmhcbJGkrPhe+wiIjJZEs7YRUSkjAp7RMxscdQZKolrrmriktvMrjCzdNQ5qplNzij37XQ54/LvXS5O+7RhC3u9bpg9V2a2xMy+YmZ9ZvYFK7nDzJ4ws31AbA7MKbmWx3G/mtmtZvYzM9trZjkze3vc9qeZbQV2Ay2Vjs+4HLNTcp51nAbLRL5vy3NWyhSX/Tk1a6VjtVL+MPPE4j/aOarLDbPPwQ3A7cClwLXAK4AO4HJ3v9Tdn4ky3AQzW0RZLkr3p43jfv2pu18WXBP8ZeC7xGx/uvseoD+YrHR8xuKYnZJz6nF63dRjIqp9W55zmkyx2J9Ts3L2sfrteu/TRi7sdblh9jm4291Pu/sI8HPgNHA1cMjMbo822iQXMTlXLPeruz9UNrkWWEU89+eESvsxjvt26nGa5+xjIg4qZYrj/jzrWHX356jzPg3rnqf1UPWG2VFy91EAM2sHDrr7fcCrzexS4Adm9k/u/mykIQF3f7A8F/AoMd6vZnYx8PjU3HHZn2WmOz5jtW8rHKdPBE/Fat9W+vcm5jVg4liFyvnD3KeNfMZe9YbZMfFm4I6JCXffB3wNWBNZogrKchWI9379deBbExNx3Z9UPj7jfMxOOk4hnvt2SqY470+YcqxC/fZpIxf22N8w28x+DfiOu580sw1lT7VT+t/eyAVnahPagbuJ9369xN0fr5A7FvuzTKXjM5bH7NTjNI77dppMsdyfZS5x98dh2vyhaeRWzBeBj5fdMPuOKsvXlZndAvwZcCy4BGq1mf2AUuH8krsPRxrwBX8UvOncTemm4z8mpvvVzNYBh4LJSbnjsD/NrAfoovSBZKXj0yvMizSnmS1g8nH6P4HuOOzbKfvzFVMzmVlsasCUrHdPOVahzservnkqIpIwjdyKERGRClTYRUQSRoVdRCRhVNhFRBJGhV1kHplZm5m91cwuijqLNK9GvtxRZEZmdg+QBXYEs35C6XK0VwL/7O6vPMf13wq8FPjf7v4wgLuPmNkVwIFgUKq3AKPu/rFz2ZbIbKiwS5L9sbvfa2YfA3D3O83sXncfNbNXz9M2fjJR1MucDLb3WPDmcv08bUukJmrFSGK5+70V5v2LmW0E3g8QDPn6fTP7gJllzew1ZvYpM/ty8Px1ZnabmX3OzP7jdNsys7SZ/b6ZvQbYGs5fJFIbFXZpRs8B7w0e/xRY5u5/BtwLbHT3DwIvD8Ymfx+lkTkfAbbMsM7fBPrd/R+AvaElF6mBWjHSdIKvo58OJovAePB4BBgLHheANuB8d/9qDavdxgtjlRTmK6vIXOiMXWRmK4IPQzGzm2ZY7jAvnNGnAAs7mMh0VNgl0cxsDaWCu8XMLgjmXUjpFoDXURodcJWZrQU2AZeZ2XpgGaUbI3wQuMvMvg4cnGFTnwF+xcz+B3ABcE1Yf5NINRoETGSOgssdzd3/ZoZlrgeu1+WOUk86YxeZuxyw1syurfSkmb0YuIzSB68idaMzdhGRhNEZu4hIwqiwi4gkjAq7iEjCqLCLiCSMCruISMKosIuIJMz/BwzPrmt6kpsAAAABSURBVJI2OY+AAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pyplot.plot(time, xe135, label=\"Xe135\")\n",
+    "pyplot.xlabel(\"Time [d]\")\n",
+    "pyplot.ylabel(\"Number of atoms - Xe135\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also examine reaction rates over time using the `ResultsList`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_time, u5_fission = results.get_reaction_rate(\"1\", \"U235\", \"fission\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYMAAAEQCAYAAABSlhj/AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3deXhV5bX48e/KPJJAphMIU5gzMCiKooKgJBLHqnVoa9Xa2uHWttah1/5uHXp7b2+pVu2gVltrZ9tqBWxBEBWctShhnsOYOYFMhMzr98c5sTGG5ARy5vV5njyc7H3O3ovN4azzvvt93yWqijHGmNAW5usAjDHG+J4lA2OMMZYMjDHGWDIwxhiDJQNjjDFYMjDGGEOAJwMRyReR8H72R4nING/GZIwxgShgk4GIzAHeBSJPsD8ZeAy4sce260TkLRHZIyJzvROpMcb4v4BNBqr6HlDdz/464M3u30UkFuhU1XOAe4HveTxIY4wJEBG+DmAoiEg6cDWQAkSo6n19PK0deN71eANQ5KXwjDHG7wVsy6CXu4FjwG5gioh84u+lqh2q2uX6dR6wxIvxGWOMXwuKlgGQC9yvqk3As/09UUSygYOquskrkRljTAAIlpbBIVw3ikXkXBFJ7etJru6kqaq6UkRiXL8bY0zIk0BdtVREZgPrgOuBrTjvB9QAz6jqH0QkCfgxMBq4CWgEXgESXYdQYJaqdng5dGOM8TsBmwyMMcYMnWDpJjLGGHMKAvIGcmpqqo4bN87XYRhjTED54IMPalQ1ra99AZkMxo0bx/r1630dhjHGBBQROXCifdZNZIwxxpKBMcYYSwbGGGOwZGCMMQZLBsYYY7BkYIwxBksGxhhjsGQQkOqa23hkzS6+/ZdiOjq7Bn6BMcYMICAnnYWqivoWfvVGCX96/yDNbZ0AXD07i7kT+lyk1Rhj3OaRloGIJIvIoyKyRkTu7rXvBhG5RkTuF5Hxrm1Wm7gf+2uOcc/fNzFvyWv85u39FOY6WPof5xATGcbKzRW+Ds8YEwQ81TLIBm53PV6Nq6qYiKQA16tqkYhkAr8Qkc/iqk0sIp/BWZt4sYfiCijbyxt4bO1e/rmpjIjwMK45I4svz5vA6BFxACyYks5LWyu4/7JcwsPEx9EaYwKZR5KBqn4IzkIzwFM9dk0E2lzPKReR03CzNrGI3ArcCjBmzBhPhO031u8/wmNr9/Lqjirio8L50rxsbjl3POmJMR97XlF+Jiu3VPDBgaOcOX6Ej6I1xgQDj90zcJWXvBk4S0SWqWoLUAJMF5FYoAOI7lVc5oS1iVX1SeBJgNmzZwddEQZV5fXdNfzitT28v+8II+KjuGPRZD5/9jiS4iL7fM2CqelER4SxYnO5JQNjzCnxWDJQ1RLgFhF5GsgH/qWq1SJyB/AD4DBwsPv5oVqbuLNLeWlLBY+t3cPWsgYyk2K495IcrjtzNHFR/f/zJERHMH9yGiu3lHPvJTmEWVeRMeYkeWM0UR1QIiLpqlqlqi8AL4jI93B90+9Rm3iFiMQAw1S1ygux+UxbRxdLN5TyxLq9lNQcIzs1niVXTeeKWaOIinD/vn5Rfiart1Wy4dBRTh9rrQNjzMnxSDIQkQdw1h5+Hljhevxd4BrX/uuABFX9tYjEAcuARBFZgqs2sSfi8gfNbR08+/4hnnqjhPL6FnJHDuMXnzmNi/IcJ3UTeOG0dKLCw1ixucKSgTHmpHnqBvJ9fWzuTgQXAdtU9VnXc5uBsz0Rhz+pb27nd+/s5zdv7+fIsTbOHD+C/7tqOvMmpSJy8t07w2IimTc5lZWby/mvi6ed0rGMMaHL65POVPUlb5/Tl6oaW/j1m/v447sHaWrtYOHUdL52/gRmjxu6b/GL8zJZs72KjYfrmTk6eciOa4wJHTYD2UMOHWnml6/v5a/rD9PR2cXF00fy1fkTyBk5bMjPdeG0DCLDhRWbyy0ZGGNOiiWDIbarspHH1+5l+cYywkW46vRRfHneBMalxnvsnElxkZwzMZUVm8u5Z/FU6yoyxgyaJYMh8uHBozz22l7WbK8kLiqcm+eO44vnZeNIihn4xUOgKC+Tu5/fxJbSBvKzkrxyTmNM8LBkcApUlbf21PKL1/bwTkktSbGRfOvCSdx49jiGx0d5NZaC3Ay++4KwYku5JQNjzKBZMjgJXV3K6m2VPLZ2D5sO15OeGM3/K5rG9XPGkBDtm0uaHBfF2RNSWLm5nLsLp1hXkTFmUCwZDEJ7ZxfLi8t4fN1e9lQ1MTYljh9emc+Vp40iOiLc1+FRlJ/JPX/fzLbyBnJHWuvAGOM+SwZuaGnv5K/rD/HLdSWU1h1nqiORn14/i6I8BxHh/lMfqCAng//3wmZWbq6wZGCMGRRLBv1oaGnn9+8c4Ddv7aOmqY3Txw7nv6/IZcGUdL/shklJiOas7BRWbC7njoLJfhmjMcY/WTLoQ01TK0+/uY/fv3OAxtYO5k1O4z/On8CZ40f4/QdsUX4m/7V0C7sqm5jiSPR1OMaYAGHJoIfDR5t56vUSnv3XIdo6uyjKy+Sr508gb1TgdLkU5jr43rItrNhcbsnAGOM2SwbAnqpGHl9bwrLiUgCuPG0UX54/gQlpCT6ObPDSEqM5c9wIVmwu5/ZFk30djjEmQIR0Mth0uI7HXtvLqm0VREeEccPZY/nSedmMTI71dWinpCg/k/uWb2V3ZSOTMqx1YIwZWMglA1XlnZJaHl+7lzd215AYE8HXF0zkprnjSEmI9nV4Q+KiPAf3v7iVlVsqLBkYY9wSUslgV2Uj33l+ExsO1pGaEM1/Lp7KZ+eMITGm77KSgSpjWAyzxw5nxeZyvnHBJF+HY4wJACGVDIbHRdHU0sF/X5HHp0/PIibS9xPFPGVxXibf/8c2SqqbyA7Aex/GGO/ynxlTXpCWGM3q2+dxw1ljgzoRgLOrCGDllgofR2KMCQQhlQwAv58nMFRGJscya0wyKzaX+zoUY0wACLlkEEqK8jLZWtbAgdpjvg7FGOPnLBkEscX51lVkjHGPJYMgljU8jhlZSay0riJjzAAsGQS5xfmZbDxcz6Ejzb4OxRjjxywZBLnFrlFFL1lXkTGmH5YMgtzYlHhyRw5jxRbrKjLGnJglgxBQlJ/JhoN1lNUd93Uoxhg/5ZFkICLJIvKoiKwRkbt77btBRK4RkftFZLxr20IR+YaIfFNE5ngiplBmXUXGmIF4qmWQDdwOFLh+ABCRFOB6Vf0r8EvgIREJB5YAPwN+CvzQQzGFrOy0BKY6Em0CmglJuyobeWHDYV+H4fc8kgxU9UNV7QLmAk/12DURaHM9pxw4DRgD1KgL0C4i2b2PKSK3ish6EVlfXV3tibCDWlF+JusPHKWivsXXoRjjVf+7Yjvf/utGappafR2KX/PYPQPXB/rNwL0iEuPaXAJMF5FYEYkEogEH0NjjpY1ARu/jqeqTqjpbVWenpaV5KuygVeSagLZqq3UVmdBR09TKG7trUIU12yp9HY5f81gyUNUSVb0FeA/Id22rBu4AfgB8HTgI1AI9l9VMAGo8FVeompieyOSMBOsqMiFlxeZyOruUxJgIVlsy6Jc3RhPVASUikg6gqi+o6h04P/SfVNVdQKK4AAmqutsLcYWcxXmZvL//CNWN1lw2oWFZcRlTHYlcM3s0b+6uoam1w9ch+S1PjSZ6QESeFpGLgRXAaODnPfZfh/ND/9euTffgbDHc4XpsPKAoPxNVeMm6ikwIOHSkmQ8OHOWymSMpyMmgrbOLdTvtfuOJeKS4jare18fmawBE5CJgm6o+2+P5bwBveCIW82+TMxLITotn5eZybjhrrK/DMcajlm8sA+CyGSPJTIplRHwUq7ZWcPH0TB9H5p+8PulMVV9S1U3ePq9x1nIoysvk3ZJaam1khQliqsrSDaWcMW44WcPjCA8TLpyWzms7qmjr6PJ1eH7JZiCHmKL8TLoUu5lmgtr28kZ2VzVx+cxRH20ryHHQ2NrBOyW1PozMf1kyCDHTMhMZlxJno4pMUFtWXEpEmFCU/+8uoXMnpRIXFc5qu2fWJ0sGIUZEWJyfydt7azl6rM3X4Rgz5Lq6lOUby5g/OY0R8VEfbY+JDGf+5DRe3lZJV5f6MEL/ZMkgBBXlZdLZpbxsXUUmCP1r/xHK61u4bObIT+wrzHVQ1dhK8eE6H0Tm3ywZhKC8UcPIGh5ry1qboLS0uIy4qHAW5XxiIQMWTEknIkxYvdW+CPVmySAEiQgX52fy1p4a6pvbfR2OMUOmraOLFZvLKcjJIC7qkyPnk+IiOXtCCqu3VuBcCs10s2QQohbnZ9LeqazZbt+QTPBYt6ua+uPtHxtF1FtBTgYlNcfYW93kxcj8nyWDEDUjK4mRSTE2qsgElWXFpYyIj+LcSaknfM6inO5FG+2LUE+WDEJU96iiN3bX0NBiXUUm8DW1drBmeyUX52cSGX7ijzZHUgwzRifbENNeLBmEsKJ8B22dXby6vcrXoRhzylZvraClvYvL+xhF1FtBTgYbD9dTXm+lYLtZMghhs0YPxzHMuopMcFhWXEbW8FhOHzt8wOcW5jq7imx49b9ZMghhYWHCRXkO1u6qtqV9TUCraWrlzT01XDZjJM6V8Ps3Md25aKMNMf03SwYhrig/k7aOLl7dYV1FJnD9c5OziM0Vs048iqi3wlwH75bU2vBqF0sGIe70scNJS4xmpXUVmQC2tLiUqY5EJmckuv2agpwMOrqUV3da6wAsGYS88DDholwHr+2sornNuopM4DlY28yGg3WDahUAzMhKJmNYNKu2WDIASwYGZ1dRS3sXa60KlAlAyzeWAnDpjIFHEfUUFiYsyslg3a5qWto7PRFaQLFkYDhz/AhS4qNsVJEJOKrK0uIyzhw3glHJsYN+fWGug+Ptnbyxu8YD0QWWQScDEckRkRhPBGN8IzxMKMxz8OqOKvuGZALKtvIG9lQ1cfmswbUKus0Zn0JiTIRNQMPNZCAivxaRTBF5AHgE+B/PhmW8rSgvk+a2TusqMgFlWXGZs4hN3snVNY6KCGPh1HTWbK+kozO0y2G62zL4O5AFXA1cAqzzWETGJ87KHsHwuEhW2rLWJkB0dSnLi8s4f0oaw3sUsRmswlwHR5vbWX/g6BBGF3jcTQbpwLeBK4Ec4NMei8j4RER4GIW5Dl7Zbl1FJjC8v/8IFQ0tXNbPCqXumD85jaiIsJCfgOZWMlDV36jq9aq6U1WLVfUGTwdmvG9xfiZNrR28aTfTTABYVlxKXFQ4F05LP6XjxEdHcN7EVFaFeI0DG01kPjJ3QgpJsZE2qsj4vdaOTlZsrqAw19FnEZvBKsjNoLTuONvKG4YgusDUbzIQkdO9FYjxvcjwMBblZPDy9kpaO6yryPivdTudRWz6qnN8Mi6clkGYhHaNg4FaBheIyN9E5EEROdvdg4pIsog8KiJrROTuXvtuEZGrROQ7IlJ0om3GN4ryHTS2dPD2nlpfh2LMCS3bWEZKfBTnTjxxEZvBSEmIZvbYESE9xLTfZKCqS1T108BPgbNF5DnXh/z8AY6bDdwOFLh+evqcqj4PPA58tZ9txgfOmZhKYkyEdRUZv9XY0s6abZVcPL3/IjaDVZCbwY6KRg7WNg/ZMQOJuzeQD6rqT1T1auBHwPQBnv+hqnYBc4Gneu2uFpG7gOtxzlk40TbjA9ER4SyalsHqbZW0h/i4a+OfVm+tpLWjq986xyejwFUOc/W20GwdDDqtqmqZqv5soOeJSDZwM3BvrxnLtwGfB24ENvWzrffxbhWR9SKyvrraJkZ50uL8TOqPt/P2XusqMv5n2UZnEZvTxiQP6XHHpMQx1ZEYskNMPTaaSFVLVPUW4D0gv8euJcAc4PfAE/1s6328J1V1tqrOTktL81TYBjhvUirxUeG2rLXxO9WNrby5u5rLZ7pXxGawCnMd/OvAEWqaWof82P7O3eUoznMtR5EpIktEZMEgzlEHlIhI92DgLFVtVtXHgdR+thkfiYkM54JpGazaWhHyU/SNf/nnpjK6FK4Y4i6ibgW5GajCK9tDr3XgbsvgHFUtB/4C7GCAewYi8oCIPC0iFwMrgNHAz127nxORL4vITcDD/WwzPlSUn8nR5nbe23fE16EY85GlxWVMyxzGpEEUsRmMnMxhZA2PDckhpu7O1mgTkQeBvar6tIj8Z39PVtX7+th8jWvf4308/xPbjG+dPyWNuKhwVmwu55whGr5nzKk4UHuM4kN13LN4qsfOISIU5Dj4w3sHaGrtICH61Ce0BQp3WwbPA68DXxSRmUCZ50Iy/iAmMpwFU9NZtbWCzq7QnaJv/MfyYufHzmCL2AxWYW4GbR1drAuxFXzdTQZtQCzwWZxdRP12E5ngUJSXSU1TG+9bV5HxMWcRm1LOHD+CkSdRxGYwZo8bwYj4qJAbYupuMliBc7TPtB4/JsgtmJpGTGSYLWttfG5rWQN7q4957MZxT+FhwoXT0nl1RxVtHaEzgMLdZPCMqn5bVe9R1XuAWz0ZlPEPcVERLJiSzsotFXRZV5HxoWXFpUSGC0X5Dq+cryDHuSzLuyWhM9fG3WRwsWvC19si8g7wpieDMv5jcX4m1Y2tfHAwtAt/GN/p7FKWbyxj/uR0kuNOvojNYJw7KZW4qPCQ6ipyNxn8BLgK53IR1wHf9FhExq8snJpOVESYrVVkfOb9fUeobGjl8iFaodQdMZHhzJ+cxuqtlSHTKnY3GXwI3A38Cvg68IbHIjJ+JSE6gvmT01i52bqKjG8sKy4lPiqcC6dlePW8BbkZVDW2svFwnVfP6yvuJoP/AdbiTAR/B77kqYCM/ynKd1DR0MKGQ6Hxn+JkNbV28MXfrg/J2aue4ixiU05hroPYqHCvnnvhlAwiwiRkJqC5mwxeVNW/ucpevgMc9GRQxr9cMC2DqPAwW6toAA8s38qa7ZV8b+kWKw40RNburKahpWPIitgMRlJcJGdlp4TMfQN3k8FUEblWRK4Wkf8D5nkyKONfhsVEct6kVFZuCe0asf3556Zy/vbBYeZPTqOsvoU/vWffl4bC8uKhLWIzWIW5GZRUH2NPVaNPzu9N7iaDR4F0YAGwH7uBHHIW52dSWnecTYfrfR2K3ymrO849f9/EjKwkfnXjbOZOSOEXr+3hWGuHr0MLaI0t7azZXskl0zOJGMIiNoOxyFXjIBS6ity9wvHAMpyFbVYAl3ssIuOXFk1z9p/aqKKP6+xSvv3XYjq6lEevm0VkeBh3Fk6hpqmNZ97e7+vwAtqq7iI2szw/0exEHEkxzBidHBLlMPtNBiLyuohEAjfgXJ/oGeC3OG8omxCSFBfJORNTWbGl3LqKenjy9RLeLTnC/ZflMi41HoDTxgznwmkZPLFuL/XN7T6OMHAtKy5l9IhYZo0e2iI2g1WQk8HGw/WU1x/3aRyeNlAN5Hmq2g78GThbVReq6gJgkVeiM37l4vxMDh05ztayBl+H4hc2H67nodU7Kcp38OnTsz62746CyTS1dvDL1/f6KLrAVtXYwlt7arh8xiiPFLEZjMJc55DWNduCu6towG4iEYnC+eEvIhLlKmH5FY9HZvzOopwMwq2rCIDmtg6++ewGUhOi+d9P5X/iA2ta5jAunT6S37y1n6rGFh9FGbj+uancWcRmlvdHEfU2MT2R7LT4oL9vMFA30XDgBZwFZ3YBO4GtOIvVmBAzPD6KuRNSWLHZuor++x/b2Vd7jJ9cO+OESyTcvmgybZ1dPPaatQ4Ga2lxGTmZw5iY7pkiNoNVkOPg3ZLaoO72G6ib6ChwGXC6qo53/UxQ1Ru8E57xN4vzMtlf28z28uAfanciq7ZW8Of3D3LrvGzmTjjxkMfxqfFcMzuLP753gMNHm70YYWDbX3OMjYfq/KJV0K0wN4OOLuXVncHbOhiwm0hVO4FbROQGABE5U0TO8Xhkxi8V5GYQJoTsstaVDS385/ObyBs1jDsWTRnw+bctnISI8Oia3V6ILjgs31iGiOeL2AzGjKxk0hOjWR3EXUXuDi1tAv4IoKrvA32VtTQhIDUhmjnjU/hnCHYVdXUpd/x1I8fbO3nk2llERQz832dkciw3nDWW5z88zJ6qJi9EGdi6i9jMGT+CzCTPFrEZjLAwoSA3g7U7q2lpD87Z5YNJBuEAIlKI3TMIaUXTMympPsbuEPtwe/qtfby5p4bvXZLDxPQEt1/3tfMnEBsZzsMv7/JgdMFha1kDJdXHuNwLRWwGqyDHwfH2Tt7cXePrUDzC3WTwd+AREVmLc/bx9R6LyPi9wtwMRAipUUVby+pZ8tJOFuVk8JkzxwzqtSkJ0dxy7nj+ubmcLaU2g7s/Szc4i9gszvNOEZvBOCs7hcSYiKBdq8jdZFAN/BC4Efga8CmPRWT8XnpiDGeMGxEyyeB4WyfffLaYpLhIfnTV9JMa9/7FedkkxUby4OqdHogwOHR2KS9uKuP8Kd4rYjMYURFhLJyazprtVXR0Bl85THeTwa+AR4AlOGcfp3ksIhMQivIc7KpsCokFvH64cjt7qpp46NMzGBF/ch9Sw2Ii+er5E1i7s5r39x0Z4giDw3sltV4vYjNYBTkOjhxr44MDwVf5z91ksExVrwb+pKqfBaytG+IuyssEYOXm4Gwyd3tleyW/e+cAt5w7nnmTT+070I1njyMtMZofr9oRcjff3bGsuMwnRWwGY/6UNKIiwoJyApq7yWCmiHwTaBCRD4ArhjoQEYkXkZtFZMFQH9sMPUdSDLPHDmfFluBNBtWNrdz93CamOhK5q3DgYaQDiY0K5xsLJ/Kv/UdZt6t6CCIMHq0dnazYUk5hnoOYSO8WsRmMhOgIzp2Yyuptwbecu1vJQFW/r6qPquprOO8XzOzv+SKSLCKPisgaEbm7175bROQqEfmOiBS5tqXinOn8quscJgAszs9ke3kD+2qO+TqUIaeq3PXcRppaO/jp9bOG7APq2jPGkDU8lh+v2mllRHt4bUc1jS0dfjmKqLfC3AwOHz3OtvLgWqPLrWQgIveLyJ9cv44GrhrgJdnA7UCB66enz6nq88DjwFdd2x4CfquqB9yK2viFi1wjPoLxRvJv397P2p3VfLdoGpMzhm5JhKiIMG6/cDJbyxp4KQSWRXbX8o2lpCZEcc6EFF+HMqALpjknXgbbBDR3u4k6gKUAqvoWcFN/T1bVD1W1C5gLPNVrd7WI3IVzeOojriWyPw1kisjvROSBQcRvfGhUciwzRycH3WzknRWN/O/KHSyYksbnzx475Me/YtYoJqYn8NDqnUE5KmWwGlraWbO9ikumj/RZEZvBSE2IZvbYEawKsmTu7pWvBaJFJE5EvoYbo4lEJBu4GbjXtdJpt9uAz+McprrJdaz9qvqgqn4euFpEsvo43q0isl5E1ldXW3+rvyjKd7CltIGDtcGx9k5LeyfffHYDw2IiWHL1DI8snxweJtxZMJm91cd4YUPpkB8/0KzaUkFbR5dfjyLqrSA3gx0VjUHzvgf3k8FzwPQefw7UTYSqlqjqLcB7QH6PXUuAOcDvgSeAOqDn/O5dwCfeFar6pKrOVtXZaWk2stVfLO4eVRQkrYMlL+1kR0UjP756BmmJ0R47T2Gug/xRSTyyZjetHcG5vIG7lm8sY2xKHDN9XMRmMApc5TCDaQKau8lguarepapFqvoVYDB9+3VAiYiku37PUtVmVX0cSFXVZpxdR90ds7GAreoVIEaPiGN6VlJQjCpat6uap9/ax41nj2XB1PSBX3AKRIS7CqdQWnecZ98/5NFz+bN/F7EZ6fMiNoMxJiWOqY7EoLpv4G4yeFFErhWRAhEpAO7p78ki8oCIPC0iF+OsmTwa+Llr93Mi8mURuQlnnQSA7wAPiMhngN+7ls42AWJxXiYbD9UF9DLNtU2t3Pm3jUxKT+CeomleOed5k1KZM34EP3t1D81tHV45p7/5x0ZnEZvLAqiLqFtBroP1B45Q09Tq61CGhLvJYCpQhPOm7/VAYX9PVtX7VPULqvpPVV2jqsWqeo1r3+Oq+ktVfUZVu29K/0tVv62qf1LVP57C38f4QPc6Mi8FaOtAVfnO85upb27n0euGbhjpQLpbBzVNrTzz9n6vnNPfLCsuJXek/xSxGYzC3Ay61DkxMRi4mwy+rqo3qurNqnozcKkngzKBZVxqPDmZwwJ2iOmf3j/Imu2V3H3RFHJGDvPquWePG8HCqek8sXYv9ceDt4pWX/bVHGPj4XquCIC5BX3JyRzGqOTYoOkqcnfSWUOv3+s8E44JVBdPz+TDg3WU1x/3dSiDsqeqkf/+xzbOm5TKF84Z75MY7iiYTENLB0+9XuKT8/vKsuJSvytiMxgiQmGugzf21NDUGvjdfP4/qNcEhEDsKmrt6OQbfy4mNjKcBz89g7Aw39zAzB2ZxCXTM3n6rX1UNwZH//NAVJXlxWWcNT4FR1LMwC/wUwW5GbR1dPF6ECwv4u4M5EzXDeTPu34e9HRgJrBkpyUw1ZEYUF1FP1m9i23lDfzoqulkDPPtB9K3F02mtaOLx9bu8Wkc3rKltIGSmmMBNbegL7PHDmdEfFRQTEBzt2WwAufcgGk9foz5mMV5maw/cJTKhhZfhzKgt/bU8MvXS/jMnDEU5Pq+kEp2WgJXn5bFH989SGldYHW1nYylxaVEhYd9NE8lUEWEh3HB1HRe3VFFW0dgzyZ3Nxk84xrtc4+q3gPc6smgTGAqynegit9/Szp6rI07/rqR7LR4/uti//le840LJwHw0zXBPc2ms0t5cWMZ509JIyku0tfhnLLCXAeNLR28t6/W16GcEneTwcWupSDeFpF3gDc9GZQJTJMyEpmUnuDXXUWqyndf2EztsVZ+et0s4qIifB3SR0Ylx/LZs8bw3IeH2VsdvPWl3y2ppaqxNSBWKHXHuZNSiY0M9/svQQNxNxn8BOcSFNcD1+Gsg2zMJyzOz+T9fUf89kbo39YfZuWWCu4omELeqCRfh/MJXzt/ItERYTz88i5fh+Ixy4pLSYiO4IJpnp3l7S0xkeHMn5zGy9sqA3pZcneTwYfA3TjLX34deMNjEZmAVpTvoMtPu4r21Rzj/he3cnZ2Creel+3rcPqUlhjNF84Zzz82lbO1LPgKCra0d7JySwWFuQW6pPkAABqASURBVP5dxGawCvMyqGxoZePhwB11724y+B9gLc5E8HfgS54KyAS2KRmJZKfG+93Cde2dXXzr2Q1Ehofx0DW+G0bqji/Ny2ZYTAQPrQ6+1sHanVU0tnRwxazAHkXU28IpGUSECau3Be4ENLfXJlLVv6nqTlV9BzjoyaBM4BIRFuc7eLfkCLV+tGbLI2t2sfFwPT+8Mp+RybG+DqdfSbGRfOX8Cby6o4r1+4/4Opwhtay4jNSEaM7O9v8iNoORFBfJWdkpftkidpfbaxO55hlcLSL/B8zzZFAmsBXlZ9LZpbzsJ9+S3iup5bG1e7lmdhZF+YExlPGmueNITYhmyaqdQVNrt6GlnVd2VHHJ9MyAKGIzWAW5GZRUH2NPVWDe/Hf3X+RRIB1YAOzHbiCbfuRkDmNsSpxfLGtdf7yd2/9SzNgRcdx3aa6vw3FbXFQEty2cyPv7jvDG7hpfhzMkXnIVsbliVnCMIuptUU4GELg1DtxNBvHAMuBHOCegXe6xiEzAExEW52Xy9p4a6prbfBaHqvL/XthMZWMrj1w3i/ho/xlG6o7rzhzNqORYHlwdHK2DZcWljE2JY0aW/43iGgqZSbHMyEpiVYAuXNdvMhCR1101im8AngeeAX6L84ayMSdUlO+go0t9ekPthQ2l/GNTObdfOCmgqmh1i44I51sXTmLT4fqA/YDpVtXQwtt7a7l85qiAKmIzWAW5DjYeqqOi3v9n4ffWbzJQ1Xmq2g78GThbVReq6gKc3UXGnFD+qCSyhsey0kcT0A7WNnPvsq2cMW44Xz1/ok9iGAqfmjWKCWnxPLR6J50BPIb9xU3lqMJlAbpCqbsKc51dRS8HYFeRu91EnwPSROQcEXkDuNaDMZkgICIU5Wfy5p4ar6/T39HZxbf+sgEBHr52JuF+PIx0IBHhYdxRMIXdVU0sKy71dTgnbVlxKXmjhjExPcHXoXjUhLQEslPjA3KIqbvJ4BDQAPwG+DIQWguvm5OyOM9Be6d6vRLUz17dw4cH6/jBp/LIGh7n1XN7wkW5DvJGDePhNbsCcjG0kuomNgVwEZvBEBEKch28s7eW+ubAKlbkbjKYBryIs2bxUZxLUhjTr5mjkxmZFOPVtYo+OHCEn726m0/NGhU0a9+EhQl3Fkzh0JHj/GX9IV+HM2jLissQgUumB3cXUbeC3Aw6upTXdlb5OpRBcTcZ/AC4UlUfBzqA//RcSCZYiAgX5WXy+q4aGls8/y2psaWdbz5bzKjhsXz/8sAZRuqO+ZPTOHPcCH72ym6Ot3X6Ohy3qSrLN5ZxdnZgF7EZjJlZyaQnRgfcBDR3k8EDQKyIXAG8CnzBcyGZYFKU76Cts4tXd3j+W9J9y7ZSVnecR66dSWJM4C+N3JOIcGfhFKoaW/ndO/t9HY7bNpfWsy8IitgMRliYsCgng3W7qmlpD5zE7W4yeB9ni+AhoBB4z2MRmaBy2pjhZAyL9nhX0bLiUv6+oZTbFk7i9LEjPHouXzlz/AjOn5LG4+v20uCFltZQWLqhjKjwMC4K8CI2g1WY66C5rZO39gTOhEF3k0Euzklnd+KciXyHxyIyQSUszDkBbe3Oao55qGj44aPN/NfSLcwak8xtCwN3GKk77iyYQl1zO796Y5+vQxlQZ5fy4qYyFkxNIyk2uFpqAzkrO4XEmIiA6ipyKxmo6v+p6lxVfUFVi4HLPByXCSKL8xy0dnimq6izS/n2XzbS1aU8eu2soFzzpqe8UUlcnJ/Jr98o8auFAPvyzt5aqoOoiM1gREWEsXBqOmu2VwXM/JCBZiAXuf4sFJF7u3+AX3slOhMUZo8bQWpCtEeWtX5i3V7e33+E71+ex5iUwB9G6o7bF03meHsnj6/d6+tQ+rWsuJTE6AgWTg2OIjaDVZDj4MixtoBZeXagr1F5IhIORAN1wAHXT5mnAzPBIzxMuCgvg9d2VNPcNnRdRcWH6nj45V1cMj2TK08LnW+fE9MTuOq0LH737gHK64/7Opw+tbR38tKWCgrzgquIzWDMn5JGVERYwExAGygZHANG4qxn8FNV/a2q/pYBhpaKSLKIPCoia0Tk7l77bhGRq0TkO90tjx77nhORcYP/axh/V5SfyfH2TtbtrB6S4x1r7eCbz24gPTGa/7kiP6jXu+nLNy+chKry01f2+DqUPr22o4rG1o6QmGh2IgnREZw7MZVVWysCYqHBgZJBhqoeAq4UkX+IyFQAVR1oKcps4HagwPXT0+dU9XngceCr3RtF5FM4WyAmCJ05bgQp8VFDtqz1Ay9u5eCRZh6+diZJcaF1cxIga3gcn50zlr+uP8T+mmO+DucTlhWXkZYYzdkTgquIzWAV5GRw+Ohxtpc3+jqUAQ2UDEoBXB/er6vqDncOqqofqmoXMBd4qtfuahG5C7geeARARGbhXPKi9kTHFJFbRWS9iKyvrh6ab5fGeyLCwyjIdfDK9spTHnu9YnM5f11/mK+dP4E5QVYxazC+tmACUeFhPLzGv8pj1h9v59UdVVw6fWRArws1FC7MyUDEP2uC9zZQMojq8fijNVl7d+/0RUSygZuBe0Wk59TD24DPAzcCm0RkODBRVdf3dzxVfVJVZ6vq7LS0tIFOb/xQUb5z7PW6XSefzMvrj3PP3zczPSuJb104eQijCzzpiTHcfM44lm8sY3t5g6/D+ciqLRW0dXaF1ESzE0lNiGb22OEBcd9goGTwqIh0ikgn8IjrcRfOdYr6paolqnoLzglq+T12LQHmAL8HngAuBj4nIkuBhcCTIhK6HY1B7KzsFJLjIk96Wesu1zDSto4uHr1uFpFBPozUHV+eN4GE6AgeWu0/rYOlxaWMS4ljepAWsRmswlwH28sbOHSk2deh9Gug/02XqGq46yes+0/g0kGcow4oEZHu8WVZqtrsWucoVVX/oKqXq2r3Uhe3qmrgrtVrTigyPIzCHAdrtlfR2jH4rqKn3ijhnZJa7r8sh/Gp8R6IMPAkxUXylfkTWLO9kg8PHvV1OFQ2tPBOSfAXsRmMghwH4P9dRQMVt1kxmO3dROQBEXlaRC7GWSZzNPBz1+7nROTLInITzlVQTQhZnO+gqbWDNwdZ13dLaT0Prt7JRbkOrpk92kPRBaab5o4jNSGKB1ft9HUovLixDFWsi6iHMSlxTHUk+n1XkUeKwqrqfX1svsa17/F+XneTJ+Ix/mPuhFSGxUSwYnMFF0zLcOs1zW0dfOPZDYyIj+KHV4beMNKBxEdH8B8LJvLAi9t4a08N50xM9Vksy4rLmJ6VRHZacBexGayCXAc/f3U3tU2tpCT456BJ63Q1XhUVEcaiHAcvb6twu1DLD/65nX01x/jJNTMZHh818AtC0GfmjGFkUgxLVu302Zj2vdVNbC6tD/rSliejICeDLoVXtvtvjQNLBsbrivIdNLR08NbegbuKVm+t4E/vHeTW87J9+o3X30VHhPOtCyez8VAdL/uoO6K7iM2llgw+IXfkMEYlx/r1fQNLBsbrzp2USmJ0xICjiqoaWvjO85vIHTmMbxeE9jBSd1x52iiyU+N5aPUury+OpqosLy5l7oQUMoaFRhGbwXCWw8zgjT01Hlu991RZMjBeFx0RzoU5GazeVkl7Z99dRV1dyh1/28jx9k4evW4m0RGhub7NYESEh/HtgsnsrGzkxY3eXT5s4+F69tc2c/kMGxV+IoW5Dto6uk5pno0nWTIwPrE4z0FdczvvlvQ96fw3b+/njd01/NfFOUxMT/RydIGrKC+TnMxh/OTlXSdMtJ6wrLiUqIgwLsp3eO2cgWb22OEMj4tktZ92FVkyMD4xb3Ia8VHhfVZA217ewI9W7uDCael8ds4YH0QXuMLChLsKp3DwSDN/XX/IK+fs7FJe3FjOwinpDAuycqNDKSI8jAunZfDKjiqvJmp3WTIwPhETGc7CaRms2lpJR4//GC3tnXzjzxsYFhvJj66absNIT8L5U9KYPXY4P31lt1dq8L69t4aaplaumGU3jgdSkOugsaXjhC1iX7JkYHzm4nxn8Y/39/27+McPV2xnd1UTD356ut+Ox/Z3Is7WQWVDK79/54DHz7esuIzE6AjOnxKaRWwG47xJqcRGhrN6q/9NQLNkYHxm/uR0YiPDWeGqgPbajip++84Bbj5nnH2wnKI52SnMm5zGY2v30NjS7rHzdBexuSiEi9gMRkxkOPMnp7F6WwVdflYO05KB8ZnYqHAWTk3npS2VVDW0cNdzG5nqSOQ7F031dWhB4c6CyRxtbufXb+7z2Dle3VFFU2sHV8yyUUTuKsjNoLKhlU2l9b4O5WMsGRifWpzvoKapleuefJeGlg4evW6WfcMcItOzkrko18Gv3tjHkWMD1aM6OcuKS0lPjOasEK4rMVgXTM0gPEz8bgKaJQPjUwumpBMdEUZJzTG+u3gqUxw2jHQo3VEwmWNtHTyxbu+QH7u+uZ3XdlRz6QwrYjMYSXGRnJU9wu+GmFoyMD4VHx3BZ+aM4bIZI7lx7jhfhxN0JmUk8qlZo/jt2/upqG8Z+AWD8NLWcitic5IKcx3srT7GnqomX4fyEUsGxufuuzSXn14/y4aResjtF06mS5Wfvbp7SI+7dEMZ41PjyR9lRWwGa1GOc8Xe1dv8p3VgycCYIDd6RBzXnTGGv/zrEAdqjw3JMSvqW3h3Xy2XzxxpSfwkZCbFMiMrya+GmFoyMCYE3LZwIhHhwiNrhqZ18I9N3UVsbBTRySrIdVB8qG7Iu+9OliUDY0JA+rAYbpw7jqXFpeysaDzl4y0tLmVGVpKVHz0FhbnOrqKXt/tH68CSgTEh4ivzJpAQFcFDq0+tPOaeqia2lDZwmbUKTsmEtASyU+P9ZlSRJQNjQsTw+Ci+NC+b1dsqKT5Ud9LHWV5cSpjApdMzhzC60CMiLMrN4J29tdQf99wscXdZMjAmhHzh3PGMiI/iwVUn1zpQVZZtLGPuhFTSrYjNKSvMddDRpby2w/flMC0ZGBNCEqIj+Nr5E3hzTw1v7xm47GhvxYfqOFDbzGU2t2BIzMxKJj0x2i+GmFoyMCbEfO6ssWQmxfDj1TtRHdxiacuKy5xFbPKsiM1QCAsTFuVksHZntVeWG+83Fp+e3RjjdTGR4XzjgklsOFjHK9vd757o6OziH5vKuWCqFbEZSgW5DprbOnnrJFpqQ8mSgTEh6OrTsxiXEseDq3e6vZTy23trqWlqtbkFQ+zs7BQSoyN8PgHNkoExISgyPIzbF01mR0UjL24qc+s1y4rLSIyJ4PwpaR6OLrRERYSxYGo6a7ZX0unDGgceSQYikiwij4rIGhG5u9e+W0TkKhH5jogUubZdJyJvicgeEZnriZiMMR936fSRTHUk8vDLuwasydvS3smqrRUstiI2HlGY66D2WBsfHDjqsxg81TLIBm4HClw/PX1OVZ8HHge+KiKxQKeqngPcC3zPQzEZY3oICxPuLJjC/tpmnvvgcL/PfWW7q4iNdRF5xPwpaUSFh/m0xoFHkoGqfqiqXcBc4Kleu6tF5C7geuARoB143rVvA9BnpWgRuVVE1ovI+urqak+EbUzIuWBaOrPGJPPomt39jmbpLmIzx4rYeERCdATnTExh9baKQY/wGioeu2cgItnAzcC9ItJzdsptwOeBG4FNqtrhShwA84AlfR1PVZ9U1dmqOjstzfosjRkKIsJdhVOoaGjhD+8e6PM59c3trN1ZzWVWxMajCnMdHDpynO3lp7521MnwWDJQ1RJVvQV4D8jvsWsJMAf4PfBE90ZX8jioqps8FZMx5pPmTkjl3ImpPL52L02tHZ/Yv3JLdxEb6yLypAumZSDiuxoH3hhNVAeUiEi66/csVW1W1ceBVADXvqmqulJEYno81xjjBXcWTqH2WBu/eXPfJ/YtLS4lOy2evFHDfBBZ6EhLjGb22OE+G2LqqdFED4jI0yJyMbACGA383LX7ORH5sojcBDwsInHAMmCJiGwB/gUc8URcxpi+zRydTEFOBk++XkJdc9tH28vrj/PeviNcPmOUFbHxgoIcB9vKGzh0pNnr5/bUDeT7VPULqvpPVV2jqsWqeo1r3+Oq+ktVfUZVl7paCWerap7rJ19VP9lWNcZ41B0FU2hq6+CJdSUfbXtxY3cRG1uLyBsKcrvLYXq/dWCTzowxAExxJHLFzFE88/Y+qhqc1beWFZcxY3Qy46yIjVeMTYlnqiPRJ0NMLRkYYz7yrQsn0dGp/Py1PeypamRrWQOXz7BWgTcV5DpYv/8ItU2tXj2vJQNjzEfGpsRz7Rmj+fP7B/nFa3sJE7hkhhWx8aaCnAy6lEEtIjgULBkYYz7mtoWTCBPhhQ2lnDMxlfREK2LjTbkjhzEqOdbrQ0wtGRhjPsaRFMONc8cBcJl1EXmdiFCQm8Hru2s41se8D0+xZGCM+YTbFk7kPxdP5VJLBj5RkOOgraOL13d5b+kdSwbGmE9IjInkK/Mn2AqlPnLGuOEMj4v06hBTSwbGGONnIsLDuGBaBq9srxxwefGhYsnAGGP8UGGug4aWDt4r8c6CDJYMjDHGD503KZXYyHCvTUCzZGCMMX4oJjKc+ZPTeHlbpdt1qk+FJQNjjPFTBbkZVDS0sKm03uPnsmRgjDF+auHUdMLDhNVe6CqyZGCMMX4qOS6Ks7JHeGWIqSUDY4zxYwU5DvZUNbG3usmj57FkYIwxfmxRjqvGgYcroFkyMMYYPzYyOZbpWUkeH2JqycAYY/xcYa6D4kN1VLqKDnmCJQNjjPFzBTmeL4dpycAYY/zcxPQEslPjPTrE1JKBMcb4ORFhUW4G7+ytpf54u0fOYcnAGGMCQEGOg44uZe1Oz5TDtGRgjDEBYNboZNISoz02xDTCI0c1xhgzpMLChAcuyyVjmGdqUlsyMMaYAFGUn+mxY3skGYhIMvAAkAusVtUlPfbdAtQBE4HNqrpCRBYCeYAA76rqe56IyxhjTN881TLIBm53PV4NLOmx73OqukBEhgF/FJFVrv1nuPa/Aiz0UFzGGGP64JFkoKofAojIucBTvXZXi8hdQAPwCDAGqFFVdb2mXUSyVbXEE7EZY4z5JI+NJhKRbOBm4F4R6XnH4zbg88CNwCbAATT22N8IZPRxvFtFZL2IrK+urvZU2MYYE5I8lgxUtURVbwHeA/J77FoCzAF+DzwB1AIJPfYnADV9HO9JVZ2tqrPT0tI8FbYxxoQkb8wzqANKRCTd9XuWqjar6uNAqqruAhLFBUhQ1d1eiMsYY4yLp0YTPQCMBp4HVrgefxe4BnhORL4MtAIPu15yD3BHj8fGGGO8SFz3bQPK7Nmzdf369b4OwxhjAoqIfKCqs/vcF4jJQESqgQOncIhU+rgv4YcszqEVKHFC4MRqcQ4tT8c5VlX7vOkakMngVInI+hNlR39icQ6tQIkTAidWi3No+TJOW6jOGGOMJQNjjDGhmwye9HUAbrI4h1agxAmBE6vFObR8FmdI3jMwxhjzcaHaMjDGGNODJYMAISKJvo6hL/4alzv8IXYRyReRcF/H4Y7BxOrLa3uiOP3h37snf7ueIZMMRCRCRP5bRD4lIt8VEb/6u4vIMBH5s4iUiMgzrtU57hORPSKyHfCbN3KvuIb763UVkZtEZKtrgcO9IvJFf7qmIjIHeBeI7Ov96U/v2V6xfuK96nqOz69tzzj7islfrmmv6/mJ92lfsXs6Jr/5j+sFXwJKVfUF4CjwaR/H01sB8AVgGnA6MA+IBfJUdZqqlvkyuG4ikkCPuICL8d/rulFVc13jtv8EvIQfXVNXEafuJXj7en/6zXu2V6y936tn9n5f+Ora9ozzBDH5xTXtdT17v0//4YvrGUrJ4Cyg2PW4GOeHmD9ZrqrHVbUV2AYcB2YCpSLyBd+G9jGT+XhcfntdVXVDj19HAun45zWFvq+jv17b3u/VWj75vvAHfcXkd9e09/tUVSvwwfUMpRrIPesm9FkzwZdUtQ3AVfvhsKq+D1wkItOAV0RkpaqW+zRIPipc9FFcwGb8+LoCiMgUYGfv2P3lmrqc6P3pd9e2j/fqHtcuv7q2ff1748efA93vU+g7dk9fz1BqGfSsm9BnzQQ/cS1wX/cvqrodeA7wXCXsk9Ajrk78/7peCSzr/sVPr2lf709/f89+7L0K/nlte8Xkz9f0Y+9T8O71DKVksBqY4Xo83fW7XxGRImCFqjaJyNgeu2JwNsd9Tj5etS4GWI6fX1dgqqru7CN2v7imLn29P/32Pdv7veqP1/YEMfntNcX1PoUTxu5RodRN9Dvg+yJyDc66y/cN8HyvEpHrgB8D9a7hZhki8grOD9s/qGqLTwP8tx+4EtVy4A/Am/j3dc0CSl2/fix2X19TEZkNpOG8IdvX+1P72ObzWEUkjo+/V38GZPvDte11Tef1jklE/OJzoFecy3u9T8EH71WbgWyMMSakuomMMcacgCUDY4wxlgyMMcZYMjDGGIMlA2N8SkSiReRGEZns61hMaAuloaXG9EtEVgNvA3Ndm97COfRvAbBKVRec4vFvAs4BfqGqxQCq2ioi+cAB16JpnwfaVPX+UzmXMYNlycCYf/sfVV0nIvcDqOoDIrJOVdtE5KIhOsdb3YmghybX+Xa4EtL5Q3QuY9xm3UTGuKjquj62rRWRccCdAK6lj9eIyF0i8raIXCoiS0TkT679Z4rIzSLylIhccqJziUi4iNwjIpcCczzzNzLGfZYMjBlYBfAN1+ONQLKq/hhYB4xT1buB81zr+t+Bc8XZTcAZ/RzzM0C1qr4IrPdY5Ma4ybqJjBmAaxmD465fu4AO1+NWoN31uBOIBkap6rNuHPYs/r0uTudQxWrMybKWgTFDK8V1QxgR+VQ/z6vk3y2HMEA8HZgx/bFkYEwPIpKJ80P6DBEZ7do2EWd5zzNxrniZLiIjgfFAroiMAZJxFiO5G3hBRJ4HDvdzqieA+SLyIDAamOWpv5Mx7rCF6ozxEtfQUlHV3/TznPOB821oqfE2axkY4z17gZEicnpfO0UkB8jFefPZGK+yloExxhhrGRhjjLFkYIwxBksGxhhjsGRgjDEGSwbGGGOwZGCMMQb4/94Z6Vd9Cux3AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pyplot.plot(time, u5_fission)\n",
+    "pyplot.xlabel(\"Time [d]\")\n",
+    "pyplot.ylabel(\"Fission reactions / s\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Helpful tips\n",
+    "\n",
+    "Depletion is a tricky task to get correct. Too short of time steps and you may never get your results due to running many transport simulations. Too long of time steps and you may get incorrect answers. Take the plot of xenon from above. Xenon is a fission product with a thermal absorption cross section on the order of millions of barns, but has a half life of ~9 hours. Taking smaller time steps at the beginning of your simulation to build up some equilibrium in your fission products is highly recommended.\n",
+    "\n",
+    "When possible, differentiate materials that reappear in multiple places. If we had built an entire core with the single `fuel` material, every pin would be depleted using the same averaged spectrum and reaction rates which is incorrect. The `Operator` can differentiate these materials using the `diff_burnable_mats` argument, but not that the volumes will be copied from the original material.\n",
+    "\n",
+    "Using higher-order integrators, like the `CECMIntegrator`, `EPCRK4Integrator` with a fourth order Runge-Kutta, or the `LEQIIntegrator`, can improve the accuracy of a simulation, or at least allow you to take longer depletion steps between transport simulations with similar accuracy.\n",
+    "\n",
+    "Fuel pins with integrated burnable absorbers, like gadolinia, experience strong flux gradients until the absorbers are mostly burned away. This means that the spectrum and magnitude of the flux at the edge of the fuel pin can be vastly different than that in the interior. The helper `pin` function can be used to subdivide regions into equal volume segments, as follows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "div_surfs_1 = [openmc.ZCylinder(r=1)]\n",
+    "div_1 = openmc.model.pin(div_surfs_1, [fuel, water], subdivisions={0: 10})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7fede8277b50>"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQ0AAAD8CAYAAABtq/EAAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO2df+wtZXngPw+/1Ovlqhe4ghAEila6IG7AoNvtyrJoTdnuYjZebBcTaHZxSQjJxtZbtC6F/YHc2DRhqZjbRJpKo2BYqOgu3lgKe1uXu4AVMVHALdaVpdnA1YWCCnKf/ePMwNz5njMz7895Z87zSb653ztnvmfemTPzOc/zvu/MI6qKYRjGUA4auwGGYUwLk4ZhGE6YNAzDcMKkYRiGEyYNwzCcMGkYhuFEsDRE5DQROThGYwzDKJ9DQv5YRM4C7gKOAF5sLD8HOBUQ4F5V3btsWci2DcMYBwmd3CUi3wPeoqo/qf5/MLAXeHu1yp8B724vU9VzgjZsGMYopOjTOB54UiuAF4AT2stE5KQE2zYMIzFB6ckKjgaeafz/GWDbkmWvB/66/ccicglwCcArXnXYGUe/8agETTSabPnZ82M3YSlPH3LY2E2YPU898UOe+dGz4vI3KaTxFLC58f/NwL4ly55c9sequgvYBXDCKcfplTdenqCJ68u5+x4buwlBfHXriWM3YVZcdfF1zn8TTRoichBwpKo+IiKHi0htr82q+vCSZY/G2raxmqlLok17f0wi+QkdPTkTOAp4D/B94KPAduAK4MPValc0/m0vMyIyN0EMYdk+m0jSEiQNVb0feHVj0fZq+R5gT2vdDcuMcHKK4ob9O6K8z6UHXRvlfVbRPCYmkPjYjFDDMJxI0RFqZCBFhBErkgjdTsxIpD5OFnHEw6QxIWKJIpccfFnVvhCZWMoSD5NG4cQQRemSGEp7P3wlYgIJw6RRIKGimIsk+oghEROIOyaNggiRxbqIoovmMQgRiMmjG5NGAfjKIqUo/ubs9yR772W88e7dUd8vRCAmj25MGiPjKoyYosgthi662hIqFF+BnLvvMRPHEkwaIzCWKEqShAvtdodIxFUgFnVsxKSRkTFkMVVRdNHcpxgCcZEHmEBMGplwEUaILOYoiS5iRCEu8gBLW0waickhi7FEcdMjHxy03oVv/mzilrxMSBTiE3msozzs3hPDMJywSCMRqSOMlNHF0Agi9vvFjkh8ow6LOLoxaSRgqDDGlkVsOYSyqj0xZFIft5TyWBdxmDQiM0QYrrKIJYrSJDGUdrtDJOITfdywf4eJo4FJIxKlymKqouiiuU8xBDJEHkPnd6xDumLSCCRFKhIiizlKoosYUYhr6jIk8pizPEaRhohsUdWnx9h2TGJHF76yWDdRdBEShfhEHkPkMTdxeEtDRA4BrgS+DpwCfEJV91dPHH8A2F+t+hpVfZOIHAF8DTgY+Bzw8aCWj0wJwkgti4f23ZL0/WtO27o9yfvWx8dHHrGjjjmJIyTS+NfA46p6m4gcDbwfuBk4DniPqj4pIpuBq6v1Lwb+uap+J6jFIxM7HSlBFrnk4Lr9WDLxkYdr1LFO6UqINN4B3FD9/g3gUuBmVf3fjXXOA+6sfj8K+JKI/AD4F6r6VMC2R2Hs6CKWLMaWxFDa7QyViK88LF05kBBpNMsv1mUW25wDXAagqjtE5KPA7wFX1cvbNMsyHnH0awOaF5dYwjBR+NPchxCBuPZ7uAzTrkO6EiKNZvnFDWUWReQwAFV9oV6mqi+KyNXAH61603ZZxoD2RWMMYcSQxRxEsYrYAhkafQyJPOYujpB7T3YDp1e/vxXYLSLbGq+fC9xV/0dEXlH9ug24N2C7hmGMiKj6fZlXtVuvBr7JQhq3ATtUdXv1+h8AV6jq0yJyInAHiwjieeBGVf1p3zZKKADdF2WUlJLMObJwwTfycB1lGdLX0RdxjB1tXHXxdXzv2z9wqhrvLY0cjC2N3MKYmizOu+yMQet9+foHErdkOTnkMXVxmDQi0iWM2MOpJcpiqBBikVIsqeUxdE5HlzzGEodJIwJTiC5iyiK3HFyJKRMfecw96jBpBFK6MGLJonRRrCKWQFzlMWdxmDQCyCUME0UcShbIlMRh0vBkrsKYmyhWESqQdRaHjzTs1vge+oSRorMzRBbrIoomzX32EUh9vIfK46ZHPtgrjiH3rgx9uE9prP2DhUPqp5YkjPMuO2MthdEm5Di4HPuhn2nIs1FCC4GnYq3Tk5C0JHY6EiKL1ByzfVOS933ilueSvG8T39TFJWUJTVfGTFOsT8OBqQsjlSxSCWIoqUTiI491EIePNNY+PTEMw421jDRCZnuOHWXEjjDGjiz6iB15uEYcOaMNyD9r1CKNQHIJ46F9t7z040IsYRyzfdNLP6UTu62ux9Dlcxry2fedQzGKfqdm7SKNVVFGTmG4EFMUcyJWBJIi8kgZccSONizS6MF3CGvKwphKROFKrP3yiTz6iBFxrKKEYdi1mdwV467VZQztv3ARRqgs5iiJVTT31Tf6qI/30KjjoX239EYcvk9Cr+ma+DX2U7/WKtJYRkhaUpow5hpVDCV0/12OfYx+jqn2b8w+0kg9UtJHDmGMJYoL7jm9fyXg5nc9mLglB1IfD5/I47zLzogacfTR98zRVRHHmCURZi8NX/qEEbsPw0cYqWUxVAqh75NKKr7yiC2OvntVXIozlUDy9EREtqTexirG7MeYojAuuOf0A35ykXq7PscqdqoS8nT5rnN1jI7RkAcLLy3LWL12QAlGVf24iJwDnAoIcK+q7u3bRsiQq68wSo8wYsoipxhCiBmJuEYdLkOyMYZjfaea+6YpuYdcXyrLCPyQRVnGmroE48mVMA4GdgL/GbgOuCZgu8lYF2HkjiRCidle12OYO+KI0Y+WmhBpvINFOUaqf89rvFaXYLy7ijqOB57UCuAFETkpYNudpEpL+hgqDNfbt2ONikxNFm1itd/1eKYYVfGhlDQlRBoryzKq6g7g51nI5KrWuhvWbyIil4jI/SJy/9/96NmA5hmGkYIQaXSWZVTVF1kUUzq+te7S9Rt/t0tVz1TVMze/9tUBzdtI6r6MIViEEc4YEUfMhxyFpCglzN1IUpaxXYJRVR8BDpcKYLOqPhqw7ZX4hGm5+jJchRHK3GTRJqY8hjLkMxyrbyNXihK9LGP1s6EEo4j8EnBW9ed7VXVP3zZcR09SjJj0fbgu/RhDCRHGnCUxhJCRFpeRlaGjKn0jKl2jKTlGUrKOnqjqflX9HVW9pfr3AVXdrqqPqeqpqnqdqn66rtmqqntU9ZPVT68wchHSW23CKI+QY5CiczSkY7TUkZTZ3Brvc8t7aFpSSkoypiwev+kjna8fe+HOTC3ZiG/UETviCIk2wC/iGBptWAmDjKyTMPrE4Pu3qYVywT2ne4njmO2bBotjyJTzGPeolMQsIo3cUUYJwkgpixBJhJBSIj7yyBlxjBVtWKQRgVhDq0MpQRhjSaJNux0xJeITdbhEHKGEPn8jJ7N9nkZoCYJVxIwyxhbG4zd9pBhhLCN2+3yOncs8jj5SdYrmnrsxeWnEHJvO3fHpSixhlC6LNjHbmzKtiyGOmJFuqnkbs0xPUkUZsXCNMGLKYsrU7Q9NW+rjOTRdyZmmdNH13I2cdWEnH2kYhpGXSUtjiqmJRRnhjJGqDL1PZR1SlElLYxljpSalCmNq/RdDibVfrsc4ljh8KaFDdHbS8CHW/SUxiSWMuTOGOGKQM9qIzWSl4Rp2pYoyht4y7RJlhJ7Ec40uVhFjf11TlT5i3krfxvVcjp2iTFYay/AJz3JEGblKDKybLNrk3P8Yn2mKaCNHijI5aZy777EiStNBmtzVN8pYZ1m08T0WKdKUlP0bLsS8bmY5T6NJjmdldJEjLRlbGBefv2vp8htvvyRzS17m8Zs+4jWfw2W6eYz5G303s62qmVKf12PUS5mNNHJPpS3lGySnMFbJwXX9XDLxFUdsXIovxSD1RK9JSSNnWjKFKCOHMFxF4fqeqQXiI47Soo2YxCgePSlpuBKjePMyYkcZpT1xK4UohmxrzHSmje+zOFYREm10lXUco6TjKB2hsUs1lvCE5japR0xSRBkXn78rqzBybT91RDZWAe4uUl4T3tIQkUNE5N+LyPtE5KPVg4br1z4gIn8pIt8VkX9QLTtCRB4Wke8CvxWh7YZhjED0sowi8irgRVX9ReDfAR+v1j+gVGPAdpPy0L5bOvszSkhNYn9zjh1htEnRHp9jFjtt7Dp3+s67kkhRlvEF4Nbq979iUSgJNpZqdCLmDNDUU3RThqsxhVGaLNrEbl/KNCV1itJ1zuaeIRq9LKOq/qyuHg/8IxaFn5eValyKa1nGEvszhjJmB2jJsmgzZltL66R2IdW1kawsY1Xg+fuq+s16WatU41JSlmXsoy88THEnqwuxvimnJIyaWG0eO9roO4emkKKkKsu4DXiLqv43EXmliGxrl2oM2G4vY6YmQ3AtJxjznoopCqMmpjhcjmcp0UbMFCWEEGn8MXC8iGxnETl8C7heRDYBfwrsFJFvAfcBrwEeEJHLgbOB33PZUCn3mkydKQujZg77UAIh11SKsozPqeo7q9KMp6rqaar66LJSjaHEzNlypSau31oWYWxkjFRlaHRYWoqSol9jcne5Gu7MSRg1c9ynqTA7aZTcnzFGlDHniyvGvrke47H7N0ro15idNFIw9qiJMS3Gfo5oaoqXRo5O0BKHuSzKGMYY0UYOcpyTvtdW8dIwDKMsJiuNqc0EzZkLlz49PDa593fsfg1XYl8rs36eRg6sL8NYRn1elFDOMTaTjTRcGXvkxIWQHHudIow2IfteYr/GKsY+l2cljRRDTlPu5TbKJsW5lWPYdVbS8CFHL/XUcmCjnxyfaYmjemDSmBXrnJrU2DFIT9HS2PKz58duQicpOkGnlFvPjRTHvvSOcp9rrGhpGIZRHpOTxg37d0xujkYOLCx/GTsWG4l53UxOGoZhjItJwzAMJ0wahmE4MXtp3PTIB71n0MWYfGNzNOZLjM/W9xwLOa9Dmb00poQNt46PfQb9mDRmgI0WbMSOSTq873IVkUOAK4GvA6cAn6iLJInIOcCpgAD3qureZctCG28YRn5Cbo1/qZariBzNopbrzSJyMIuqam+v1vszEXl3exlwTsC2DcMYiRS1XI8HntQKFrVdT2gvqyqwbaBZlnHf//txQPMMw0hB9FqureX1a9uWLHs9S2iWZdz6mlcFNM8wjBSkqOXaXF6/tm/JsgNqvxqGMQ2i13JV1UeAw6UC2KyqDy9Z9mhY042aG2+/ZOwmFIcdk3REr+VavXYF8OHq54qOZUaDYy/cOXYT1h77DPrxHj2phld/p/pv/Yih7dVre4A9rfU3LMvBhW/+LOD3XMUvX/9A8KzQm9/1oM0KnSk3v+vB4Pf48vUPeP1dfV6PgU3uMgzDCZOGYRhOmDQMw3BictK49KBrufSga8duRnHYaMHL2LHYSMzrZnLSMAxjXIqWxtOHHDZ2EzpJUXLPhvzGI8WxL70so881VrQ0DDcsLLdjkIO1l8ZpW7cn30aM8XyjLHJ8pjnOTR9mJY033r07+nv6Tr4xjD5SnFsproE2s5JGF2POoHMlJLde5/A8ZN+n1Jc09rkc8hAeg5c7ukovv2fkpfQO0BAmG2lMba5Gzn6NG2+/ZK0ijtz7O7U+qtjXymSlYRjGOBQvja9uPTH5NkrspY6RY69DtBFjH0vsz8hxTvpeW8VLowSG9HLPOYc13BhyLkx5VG520ugachq719k1F7Zoo5sxooyx+zO6zuEcw60wQ2kYG5mjOOa4T1Nh0tKI2Svcl0PGSlHGiDZgXhdZrH1xObY3v+vBQZ9djNQkZn9GilHG0aQhIluGrpujM3QdmIM45rAPJRByTXlLQ0S2iMh/FJH3ici/XfL65VXRo4dE5M3Vsl8Qkb8Wke8Cv+7d6h5K7teA4d9aNcdeuNMiDuJGGK5RRgmU0J8BYZHGx4A9qnobcLSInFW/ICLHAw+q6pnA54BaKr8O/KKqnqyqnw7YdhJypSi+rLM4xkhJXCktNUlFirKMAH+rqvdUv/8ViwJKAMcB94nIrSLyyoBtv8TUZoY2GfMbbEriGLOtpUQZPqS6NlKUZURVn2+sdwbwB9Xyi4A3AfuBy5a9abOW69/96NmXlrvmYGOmKFOINqD86eax2zd2lBFCzNQktI+wVxoi8l4Rubv9A2xheVnG5t/+feAuVX2iXqaqPwauYVFgaQPNWq6bX/tq9z0K5LSt2ztDxNiTcny+yWKf/KXJI0V7fI5Z7Cij69zpO+9KovcuV1W9E7izvVxEfpdFWcbdLMoyfkVEDmNRcnGfiPxc9fseETkKeA54oYpCtgH3xtsNwzByEZKe7AT+iYhcADxT9WH8MvAxEXk98EXgBhH5FvB5FoL5nyLyr4BjWXSQRqHEfo3U4WqKUHvsiCPV9lPfW1LiLQQpr4mQsozPATtay+4A7qj++/eW/NnbfLfnwxvv3s3fnP2epa9d+ObPepVqhDjlGpuUVrqxeeFefP6ubNsqiZypSR+lDLXWTOohPF/deiLn7nssy7ZO27qdh/bd0r9iB0/c8tzgh/P4iOPYC3fy+E0f8WnaYFIIJKcoUvdlxIgycvZlxJgoOSlpdHHpQddyw/4d/StGIna04UsOcdSsuthXyWTsKKKUW95z39GaOl2fjTRWUYdvy9KUvhRlCtEG5BXHMsaWwzJ8hVFalLEqNRkjLamZ3A1rX916YjH3oqT4BvHNpUv5Vi2BHMIYSinPzYh53UxOGl34hGV9E71i5Ju5etdj3qMyRXLu/5hRRhc5RhInK42YM0RD+PL1D0S/JyX0G2/d5BFjf2OnJUPPCx9yzwBtM1lpxCRHtOFKjFB5HcQRYx/HuL8kRZSRi9lJoys8S9l5lOIO2FjimKM8Yu2X6zEe+/mfXedwrkmOk5ZGzLArRrRRqjhgXlFHrH1xTUliCSNnlJFi0GDS0jAMIz+znKfRNdGra2p5LlxLOdbfiKFTzetv6DHndIQwRoQB5dxbUkJqAjOINKaYovgSM1WZUroSs70pOz3XITWBGUhjFak6RGOKw+cbLOZJX7o8YrfP59gN/YxiCKOLUqIMmGl6EkJtet87YF1xmWZeE/uu2PaFOVb6klJgKYURg5KHWNuIqo7dhpWccMpxeuWNlw9ad9Xdr103sfX1bXSJY8g9KS43tLmKoybHLfWpJJIjyvGNzFyEERpl9AnDJ8oYmppcdfF1fO/bP5BBK1dYpOHJkJvZXO6E9Yk4IM+zOLou7j6hjJn+TEEYU2Q2kQasjjZgdcSROtqAPBEH5Ik6pkBIv09sYUCaKKOrH8OlA9Qn0phtR+hQUneKgtuISkgePeXH7cdiSsLoY8zb37vIIg2XEowhdBnWt4d5yDBs7KHYUHG4VnCbOjH2OUVKkmp4NVaU4UvKsowbSjCKyAdE5DdE5Lerp5VHx+eg9Rl9yIdbkjhq5i6PWPs3Rh9GSOfnKnI9ZyZJWcaKA0owishW4EOq+hkWxZN+P2DbXoTM3Yg1JOYqDpPHRmLKwmUeRqyJeylGS3KSqiwjbCzBeDrwMICqPgOcLCKHBmx/JSnSlCG49HGYPNwZQxbgJvqUIyVjpyU1ScoywtISjM31YVE86cj2m64qy2gYRhkkLcvYKsH4VGN9gE3AviV/M1pZxlx9GzWu4W6sGYpTizhittf1GMaOMlL0ZeTGe55GVZbxa6q6W0T+E/AV4H+wEMMPgUNV9XkReS+wFfhT4HZVfbeIbAb+i6p2TpJwnafRxmfeRk3X/I0hU8xdnmLuUwohZD7HKkqZ55FCaD7CzSmMPlmkSk185mmESGMTcCXwdeAkVb1GRH4VOBu4FfgUcD2gwGdUVUXk/cDrgDcAn1fV73RtI1Qa4C+OkElfNVMUR5NcEkkd9ZQuDPDv/Azty8g6jXxAWcYNJRhV9Qu+28tN33M3hpR1dKmb4lN8yfW5HK70XcxDpTJWKuSbzpUkjBKZ/b0ntYmXRRx9VdliPLAntTggvTxWUWq/SEjfT+6REt+0ZMzaP2s/jbxvCLbrQx06dyNl52iTWEOzUyV0/1MII1U/xpjMPtKo6SoeHVIHdujzN1wjDvDr54ADv2lzRx+5iSFJV1HHSEn6KGVOxjLWKtLwPdhDcs7Yw7EQ59GBc40+Yu3XWMLw7ccYWxgws1vjh+LzwB7oH1GB+KMqTWJVqZ9q9BFLfj4yjpGO1JTUj2G3xgcS0r9RMzTiGHp3bJNY9z7U39JTiEBit9UnsihBGCWxlpEGdM/fgLA5HOD2jFGfyCNW1NFm7CgklchSRhcQLow+WaRKSyzSMAwjOWsbacD0ow1IF3E0SRV95EiPfFO6dYgyIPM08hyklgakFwfMRx5TohRZQLnCAEtPvAj5UIYOm7mM2fvOMoz5kJgpE3IccgujjxKGV5exNpO7fBky1Rz6o44h96rU1CevT9TRvGDWJfoIlaWrqGPNw5jCSMky1j49qQlJU2pi93OAf7rSZm4CiRVVlSqMXFGG9WkEkkscNSYQN0oWRc2UhAEmjSiULg6IJw8oXyAx+2l8+ovmLAwwaUQl5KlfNSlGV5rElEeb3DJJ2Ynr27kcu7OzxJvQTBqRmULUAWnl0cVQsYw1qpNaFjDN6KKJSSMBucUB05NHaeSQBUxfGDAxaYjIFlV9umudEqQB/eKAcqKOJusikRhP0ModXcD4woDMk7u6yjKKyOEi8t26fomI/Pdq+YZSjYZhTIuQyV0fA/5cVe8UkWtF5CxV3Vu9dhxwqqr+RETeBJxfLa9LNT4RsN3sdD31q2bI079cnjk69IlgXTS/gecWdcSqZDZGSgJlRBm+hEjjHbxcj7Uuy7gXQFW/3VjvfcDt1e91qca9wL9U1Z8EbD8rMcVRM0QgzZN63QVSsihq5i4MCJNGZ1nGBqeo6k5YlGoUkVcBf8yiVOMn2yuLyCXAJQBHHP3agObFZ6g4YFgfh+vTzmNEH7Dx4itVIrHrovo8tzPGcGqTqQsDBkijqpD220teqssyPsuKsowi8gbg/zSXqeqPReQa4KJl21PVXcAuWHSE9rUvN10lEZoMfVjx0HtXmsSSR82qizOXTFIWTYa0soD1iC6a9EpDVe8E7mwvr8oyng7sBt4KfEVEDgM2q2pdo/V84IvV+kJVqhHYBtwbYwfGIla6UuNTYyW2PNqkvphT4/tEcBNGNyHpyU7gShF5HfCMqt7TKMv44Wqds4Abqt/fCXxKRF4q1Riw7SJIka6A+7yOWP0ecyCkdEBsWcD8hAE2uSsaseZyNAmt7gbzl0hofRFwf+bFnKKLrLVcjQMZ0tfhEnWAf+TRZI5RSAxRgEUWvpg0IhM7ZQH3YdpVtC+2qUgkliTA70laJowDMWkkYIg4wF0eECf6qFl1MY4lk5hyaJNSFrA+wgCTRjKGDs1CmDwgjkCaDL14h8olpQy68H0+p8mim7V/sLBhGG5YpJGY1BEHpI06uhgrgugi5OnfFmEMw6SRiaH9HOAvD9h40eSUyBiESKLG9ang6ywMMGlkxSXqgDB51IwVhaQkhijAIgtfTBoj0DwBXdIWiCcQmI5EYkkCLKqIgUljZFzSFognEOi+GHMLJaYY2vgWJTJhLMekUQCuaUtNTIG0SXkR5yCkepnJohuTRkH4ygPSCmQqhJY5NFkMw6RRIK59Hm3aF89cJRKjFqqJwh2TRuGECgTmI5FYBZNNFGGYNCZEDIHA6ouvFJmkqKZuooiHSWOihPR/rKLvYo0llRRSWIXJIj5274lhGE5YpDFxYqUsQ8gZIYRg0UVagqUhIm9T1W/EaIwRxrKLJbVIxsYEkZ8gaYjIPwX+EDhmyWsfADaxePL4F1T1fy1bFrJ9o5/2RTV1iZgkxidIGqr6pao0wQGIyFbgQ6r6j0XkcOBPROSi9jLgn4Vs33BnStGICaJMUvVpnA48DKCqz4jIycAZ7WUicqiqvpCoDcZA+i7OVFIxKUyTVNJolmwEeA44csWyA4pBN8syAj/9jXfu+FaiNo7JkSypSDcD5rpfMN99+3nXPwgpy/ghVX14xZ89xaJUY80mYN+KZQfQLMsoIver6pl9bZwatl/TY677JiL3u/6Nd1nGFQ04jIUY/hL4rWrZZuAHwF8Av9lcpqo/dW2wYRjjEjp68ivA60Tk7ap6H/DLwNmq+mER2VWlGm8ALlfVZ9vLgltvGEZ2QkdP/ivwisb/7wDuqH7/wpL1NyzrYVdI+wrG9mt6zHXfnPer6FquhmGUh917YhiGE8VKQ0TeNnYbxkJEtozdBqObqX5GInKaiBwc8h5F3rDmOj09c/O8qE6yHcD9wAmq+vut138B+BKwH/gk8OnsjRyIiBwCXAl8HTgF+ISq7q9eOwc4FRDgXlXdO1pDPejZtyOArwEHA58DPj5WO30QkbOAu4AjgBcby90+M1Ut8gf42yXLtgJ/Xv1+OPDFsdvpsD/XAu9t/H5W6/X/ABwzdjsH7sulwL9p/H5B9fvBLKQo1c9dY7c11r5V//9N4C1jtzFw/74HvLLxf+fPrNj0ZAUHTE8HThaRQ8dt0mDeAdR3A38DOK/1+nHAfSJyq4i8MmvL3Fm1L8cDT2oF8IKInDRGAwPo+pyOAr4kIndXUccccP7MpiaNVdPTp0Cz7c8Ar2++qKoXAW9ikZ5clrVl7qzal/bns2E/J8DKz0lVd7CYdv0N4Kr8TUuC82c2Wp9G5OnpxdCxX1tYtP3Z6t8N9zGo6o9F5BrgopRtjEDzc2juS/vzWbqfhbNq3wBQ1RdF5GrgjzK3KxXOn9lo0tBI09O1sKnoq/ZLRH6XRXq1G3gr8JXGfv0QOFRVn2fRwXtvtgb7sZvFvuxlsS+7RWSbqj4iIoc3HpewWVUfHa2Vfqzat/8rIq+ozrcpfEadiMhBwJE+n1mRk7uq6em3Af9QVe8TkV/l5enp7wdex2Iq+udV9TtjtnUoIrKJl3vlT1LVa+r9Am4FPgVcDyjwGS3xg6moTrirgW+yuLBuA3ao6nYR+SXgrGrVvaq6Z6RmerFq36qfO1jMoO1g+6MAAABPSURBVHweuLG0L6w+RORM4B7g14DvAx/1+cyKlIZhGOUytY5QwzBGxqRhGIYTJg3DMJwwaRiG4YRJwzAMJ0wahmE4YdIwDMMJk4ZhGE78f6bUYnxQ0og4AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "div_1.plot(width=(2.0, 2.0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The innermost region has been divided into 10 equal volume regions. We can pass additional arguments to divide multiple regions, except for the region outside the last cylinder."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Register depletion chain\n",
+    "\n",
+    "The depletion chain we created can be registered into the OpenMC `cross_sections.xml` file, so we don't have to always pass the `chain_file` argument to the `Operator`. To do this, we create a `DataLibrary` using `openmc.data`. Without any arguments, the `from_xml` method will look for the file located at `OPENMC_CROSS_SECTIONS`. For this example, we will just create a bare library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_lib = openmc.data.DataLibrary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_lib.register_file(\"./chain_simple.xml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_lib.export_to_xml()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<?xml version='1.0' encoding='utf-8'?>\r\n",
+      "<cross_sections>\r\n",
+      "  <depletion_chain path=\"chain_simple.xml\" type=\"depletion_chain\" />\r\n",
+      "</cross_sections>\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!cat cross_sections.xml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This allows us to make an `Operator` simply with the geometry and settings arguments, provided we exported our library to `OPENMC_CROSS_SECTIONS`. For a problem where we built and registered a `Chain` using all the available nuclear data, we might see something like the following."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_op = openmc.deplete.Operator(geometry, settings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3820"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(new_op.chain.nuclide_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'H7', 'He3', 'He4', 'He5']"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[nuc.name for nuc in new_op.chain.nuclides[:10]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Ds268',\n",
+       " 'Ds269',\n",
+       " 'Ds270',\n",
+       " 'Ds270_m1',\n",
+       " 'Ds271',\n",
+       " 'Ds271_m1',\n",
+       " 'Ds272',\n",
+       " 'Ds273',\n",
+       " 'Ds279_m1',\n",
+       " 'Rg272']"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[nuc.name for nuc in new_op.chain.nuclides[-10:]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Choice of depletion step size\n",
+    "\n",
+    "A general rule of thumb is to use depletion step sizes around 2 MWd/kgHM, where kgHM is really the initial heavy metal mass in kg. If your problem includes integral burnable absorbers, these typically require shorter time steps at or below 1 MWd/kgHM. These are typically valid for the predictor scheme, as the point of recent schemes is to extend this step size. A good convergence study, where the step size is decreased until some convergence metric is satisfied, is a beneficial exercise.\n",
+    "\n",
+    "We can use the `Operator` to determine our maximum step size using this recommendation. The `heavy_metal` attribute returns the mass of initial heavy metal in g, which, using our power, can be used to compute this step size. $$\\frac{2\\,MWd}{kgHM} = \\frac{P\\times\\Delta}{hm_{op}}$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5.080334904405777"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "operator.heavy_metal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "max_step = 2 * operator.heavy_metal / power * 1E3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\"Maximum\" depletion step:  58.4 [d]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"\\\"Maximum\\\" depletion step: {:5.3} [d]\".format(max_step))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, if we were provided the power density of our problem, we can provide this directly with `openmc.deplete.PredictorIntegrator(operator, time_steps, power_density=pdens)`. The values of `power` and `power_density` do not have to be scalars. For problems with variable power, we can provide an iterable with the same number of elements as `time_steps`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/python/pincell_depletion/restart_depletion.py
+++ b/examples/python/pincell_depletion/restart_depletion.py
@@ -61,14 +61,15 @@ op = openmc.deplete.Operator(geometry, settings_file, chain_file,
                              previous_results)
 
 # Perform simulation using the predictor algorithm
-openmc.deplete.integrator.predictor(op, time_steps, power)
+integrator = openmc.deplete.PredictorIntegrator(op, time_steps, power)
+integrator.integrate()
 
 ###############################################################################
 #                    Read depletion calculation results
 ###############################################################################
 
 # Open results file
-results = openmc.deplete.ResultsList("depletion_results.h5")
+results = openmc.deplete.ResultsList.from_hdf5("depletion_results.h5")
 
 # Obtain K_eff as a function of time
 time, keff = results.get_eigenvalue()

--- a/examples/python/pincell_depletion/run_depletion.py
+++ b/examples/python/pincell_depletion/run_depletion.py
@@ -132,14 +132,15 @@ settings_file.entropy_mesh = entropy_mesh
 op = openmc.deplete.Operator(geometry, settings_file, chain_file)
 
 # Perform simulation using the predictor algorithm
-openmc.deplete.integrator.predictor(op, time_steps, power)
+integrator = openmc.deplete.PredictorIntegrator(op, time_steps, power)
+integrator.integrate()
 
 ###############################################################################
 #                    Read depletion calculation results
 ###############################################################################
 
 # Open results file
-results = openmc.deplete.ResultsList("depletion_results.h5")
+results = openmc.deplete.ResultsList.from_hdf5("depletion_results.h5")
 
 # Obtain K_eff as a function of time
 time, keff = results.get_eigenvalue()

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -128,7 +128,7 @@ class Operator(TransportOperator):
     burnable_mats : list of str
         All burnable material IDs
     heavy_metal : float
-        Initial heavy metal inventory
+        Initial heavy metal inventory [g]
     local_mats : list of str
         All burnable material IDs being managed by a single process
     prev_res : ResultsList or None


### PR DESCRIPTION
This PR provides an example notebook for performing depletion analysis. As the focus of the notebook is on depletion, less focus is placed on explaining the model building. This is done under the assumption that the user is modestly familiar with the Python API. Topics in the notebook include
- Purpose of the depletion `Chain` and how to generate and register them
- Using `openmc.model.pin` to create a pin quickly, and the purpose of subdivisions
- Constructing an operator and depleting a pin cell
- Depletion with the predictor, different argument types [scalar power, power density, variable power]
- Extracting and plotting important information
- The concept of an "ideal" step size of 2 MWd/kgU [citation needed?] and how to obtain that with the operator

The notebook is included in the documentation much like other notebooks.

Some changes were made to the pincell depletion python example and user's guide on depletion regarding class-based integration and `ResultsList.from_hdf5`