### PR TITLE
Bug fix for Material.add_nuclide with unrecognized nuclides

### DIFF
--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -358,7 +358,12 @@ def zam(name):
         symbol, A, state = _GND_NAME_RE.match(name).groups()
     except AttributeError:
         raise ValueError("'{}' does not appear to be a nuclide name in GND "
-                         "format.".format(name))
+                         "format".format(name))
+
+    if symbol not in ATOMIC_NUMBER:
+        raise ValueError("'{}' is not a recognized element symbol"
+                         .format(symbol))
+
     metastable = int(state[2:]) if state else 0
     return (ATOMIC_NUMBER[symbol], int(A), metastable)
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -413,6 +413,8 @@ class Material(IDManagerMixin):
             Z, _, _ = openmc.data.zam(nuclide)
         except ValueError as e:
             warnings.warn(str(e))
+        except KeyError as e:
+            warnings.warn(repr(e))
         else:
             # For actinides, have the material be depletable by default
             if Z >= 89:

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -413,8 +413,6 @@ class Material(IDManagerMixin):
             Z, _, _ = openmc.data.zam(nuclide)
         except ValueError as e:
             warnings.warn(str(e))
-        except KeyError as e:
-            warnings.warn(repr(e))
         else:
             # For actinides, have the material be depletable by default
             if Z >= 89:

--- a/tests/unit_tests/test_pin.py
+++ b/tests/unit_tests/test_pin.py
@@ -2,7 +2,7 @@
 Tests for constructing Pin universes
 """
 
-import numpy
+import numpy as np
 import pytest
 
 import openmc
@@ -98,8 +98,8 @@ def test_subdivide(pin_mats, good_radii, surf_type):
     # check volumes of new rings
     radii = get_pin_radii(div0)
     bounds = [0] + radii[:N]
-    sqrs = numpy.square(bounds)
-    assert sqrs[1:] - sqrs[:-1] == pytest.approx(good_radii[0] ** 2 / N)
+    sqrs = np.square(bounds)
+    assert np.all(sqrs[1:] - sqrs[:-1] == pytest.approx(good_radii[0] ** 2 / N))
 
     # subdivide non-inner most region
     new_pin = pin(surfs, pin_mats, {1: N})
@@ -112,6 +112,6 @@ def test_subdivide(pin_mats, good_radii, surf_type):
 
     # check volumes of new rings
     radii = get_pin_radii(new_pin)
-    sqrs = numpy.square(radii[:N + 1])
-    assert sqrs[1:] - sqrs[:-1] == pytest.approx(
-        (good_radii[1] ** 2 - good_radii[0] ** 2) / N)
+    sqrs = np.square(radii[:N + 1])
+    assert np.all(sqrs[1:] - sqrs[:-1] == pytest.approx(
+        (good_radii[1] ** 2 - good_radii[0] ** 2) / N))


### PR DESCRIPTION
I found this bug when I added a custom nuclide with the fake name 'Abs' to my cross section library. Everything works fine with this fake nuclide except that the Python API tries to look up its Z number to make it depletable by default. This PR fixes that by expanding an already existing try/catch.

I also made some small changes to the test_pin unit test. I had to add a pair of `np.all`s to make it pass in my environment. I hope you don't mind that I aliased `numpy` to `np` to keep one of the lines under 80 columns wide.