### PR TITLE
Better conditional for call to MPI_Type_free

### DIFF
--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -127,9 +127,7 @@ int openmc_finalize()
 
   // Free all MPI types
 #ifdef OPENMC_MPI
-  int init_called;
-  MPI_Initialized(&init_called);
-  if (init_called) MPI_Type_free(&mpi::bank);
+  if (mpi::bank != MPI_DATATYPE_NULL) MPI_Type_free(&mpi::bank);
 #endif
 
   return 0;


### PR DESCRIPTION
Cliff Dugal (CNL) pointed out that checking whether MPI is initialized is not a great way to ensure that the call the `MPI_Type_free` in `openmc_finalize` is error-free. For example, if you call `openmc_finalize` twice, MPI will still appear as initialized on the second call. Explicitly comparing to `MPI_DATATYPE_NULL` is a better idea.