### PR TITLE
Fix reading of Debye-Waller for incoherent elastic

### DIFF
--- a/include/openmc/thermal.h
+++ b/include/openmc/thermal.h
@@ -76,11 +76,6 @@ private:
     std::unique_ptr<AngleEnergy> distribution; //!< Secondary angle-energy distribution
   };
 
-  //! Upper threshold for incoherent inelastic scattering (usually ~4 eV)
-  double threshold_inelastic_;
-  //! Upper threshold for coherent/incoherent elastic scattering
-  double threshold_elastic_ {0.0};
-
   // Inelastic scattering data
   Reaction elastic_;
   Reaction inelastic_;

--- a/src/secondary_thermal.cpp
+++ b/src/secondary_thermal.cpp
@@ -61,7 +61,7 @@ CoherentElasticAE::sample(double E_in, double& E_out, double& mu) const
 
 IncoherentElasticAE::IncoherentElasticAE(hid_t group)
 {
-  read_attribute(group, "debye_waller", debye_waller_);
+  read_dataset(group, "debye_waller", debye_waller_);
 }
 
 void

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -210,22 +210,15 @@ ThermalData::ThermalData(hid_t group)
     if (temp == "coherent_elastic") {
       auto xs = dynamic_cast<CoherentElasticXS*>(elastic_.xs.get());
       elastic_.distribution = std::make_unique<CoherentElasticAE>(*xs);
-
-      // Set threshold energy
-      threshold_elastic_ = xs->bragg_edges().back();
-
     } else {
-      auto xs = dynamic_cast<Tabulated1D*>(elastic_.xs.get());
       if (temp == "incoherent_elastic") {
         elastic_.distribution = std::make_unique<IncoherentElasticAE>(dgroup);
       } else if (temp == "incoherent_elastic_discrete") {
+        auto xs = dynamic_cast<Tabulated1D*>(elastic_.xs.get());
         elastic_.distribution = std::make_unique<IncoherentElasticAEDiscrete>(
           dgroup, xs->x()
         );
       }
-
-      // Set threshold energy
-      threshold_elastic_ = xs->x().back();
     }
 
     close_group(elastic_group);
@@ -239,10 +232,6 @@ ThermalData::ThermalData(hid_t group)
     // Read inelastic cross section
     inelastic_.xs = read_function(inelastic_group, "xs");
 
-    // Set inelastic threshold
-    auto xs = dynamic_cast<Tabulated1D*>(inelastic_.xs.get());
-    threshold_inelastic_ = xs->x().back();
-
     // Read angle-energy distribution
     hid_t dgroup = open_group(inelastic_group, "distribution");
     std::string temp;
@@ -250,6 +239,7 @@ ThermalData::ThermalData(hid_t group)
     if (temp == "incoherent_inelastic") {
       inelastic_.distribution = std::make_unique<IncoherentInelasticAE>(dgroup);
     } else if (temp == "incoherent_inelastic_discrete") {
+      auto xs = dynamic_cast<Tabulated1D*>(inelastic_.xs.get());
       inelastic_.distribution = std::make_unique<IncoherentInelasticAEDiscrete>(
         dgroup, xs->x()
       );


### PR DESCRIPTION
The `IncoherentElasticAE` class which stores the Debye-Waller integral was not reading data out of the HDF5 group correctly (this class is not tested currently because our NNDC data doesn't have the right kind of S(a,b) data -- working on fixing that separately). That is now fixed. There are also two "threshold" data members that are unused, so I've removed them.