### PR TITLE
Fission heating fixes - mark redundant, consistent energy grid

### DIFF
--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -842,15 +842,17 @@ class IncidentNeutron(EqualityMixin):
                     f318 = StringIO(heatr.section[3, 318])
                     get_head_record(f318)
                     _params, fission_kerma = get_tab1_record(f318)
-                    fission_heating.xs[temp] = fission_kerma
                     total_heating_xs = data.reactions[301].xs.get(temp)
                     if total_heating_xs is None:
+                        fission_heating.xs[temp] = fission_kerma
                         continue
+                    # Cast fission heating to same grid as total heating
+                    new_fission_heat_xs = fission_kerma(total_heating_xs.x)
+                    fission_heating.xs[temp] = Tabulated1D(
+                        total_heating_xs.x, new_fission_heat_xs)
                     non_fission_heating.xs[temp] = Tabulated1D(
-                        fission_kerma.x,
-                        total_heating_xs(fission_kerma.x) - fission_kerma.y,
-                        breakpoints=fission_kerma.breakpoints,
-                        interpolation=fission_kerma.interpolation)
+                        total_heating_xs.x,
+                        total_heating_xs.y - new_fission_heat_xs)
 
                 data.reactions[318] = fission_heating
                 data.reactions[999] = non_fission_heating

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -834,6 +834,7 @@ class IncidentNeutron(EqualityMixin):
                 non_fission_heating = Reaction(999)
                 non_fission_heating.redundant = True
                 fission_heating = Reaction(318)
+                fission_heating.redundant = True
 
                 heatr_evals = get_evaluations(kwargs["heatr"])
                 for heatr in heatr_evals:


### PR DESCRIPTION
This PR closes #1340 with two changes:
1. Fission heating cross section is marked as redundant.

This instructs openmc to not add fission heating to the total cross section. This would be very bad, as these values would reflect millions of barn cross sections. MT318 is included in the redundant cross sections to be written to hdf5.

2. The energy grid from total heating is used for fission and non-fission heating in `IncidentNeutron.from_njoy`. 

I found that the grids in MT=301 and MT=318 were different by about 20 values in the 0.01 - 10 eV range, and that the grid was one bin larger for fission heating. While these cross sections are not added to the total cross section and thus their grid maybe doesn't matter, I felt it wouldn't hurt to write the data with the identical grids.

Unrelated to the bug fix, but the breakpoints and interpolation schemes are removed from the non-fission heating, as these values are given as linearly interpolatable from NJOY already.