### PR TITLE
Energy deposition score and application to depletion

### DIFF
--- a/docs/source/pythonapi/deplete.rst
+++ b/docs/source/pythonapi/deplete.rst
@@ -95,6 +95,7 @@ total system energy.
    helpers.ChainFissionHelper
    helpers.ConstantFissionYieldHelper
    helpers.DirectReactionRateHelper
+   helpers.EnergyScoreHelper
    helpers.FissionYieldCutoffHelper
 
 The following classes are abstract classes that can be used to extend the

--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -371,6 +371,7 @@ constexpr int SCORE_FISS_Q_PROMPT      {-14}; // prompt fission Q-value
 constexpr int SCORE_FISS_Q_RECOV       {-15}; // recoverable fission Q-value
 constexpr int SCORE_DECAY_RATE         {-16}; // delayed neutron precursor decay rate
 constexpr int SCORE_HEATING            {-17}; // nuclear heating (neutron or photon)
+constexpr int SCORE_ENERGY_DEPOSITION  {-18}; // energy deposition
 
 // Tally map bin finding
 constexpr int NO_BIN_FOUND {-1};

--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -233,6 +233,7 @@ constexpr int N_XT    {205};
 constexpr int N_X3HE  {206};
 constexpr int N_XA    {207};
 constexpr int NEUTRON_HEATING {301};
+constexpr int FISSION_HEATING {318};
 constexpr int DAMAGE_ENERGY {444};
 constexpr int COHERENT {502};
 constexpr int INCOHERENT {504};

--- a/include/openmc/endf.h
+++ b/include/openmc/endf.h
@@ -81,6 +81,12 @@ public:
   //! \param[in] dset Dataset containing tabulated data
   explicit Tabulated1D(hid_t dset);
 
+  //! Construct using x and y data
+  //! \param[in] x independent variable
+  //! \param[in] y dependent variable to be interpolated
+  //! Assumes no breakpoints with linear interpolation
+  Tabulated1D(std::vector<double> x, std::vector<double> y);
+
   //! Evaluate the tabulated function
   //! \param[in] x independent variable
   //! \return Function evaluated at x

--- a/include/openmc/endf.h
+++ b/include/openmc/endf.h
@@ -54,10 +54,17 @@ public:
   //! \param[in] dset Dataset containing coefficients
   explicit Polynomial(hid_t dset);
 
+  //! Construct polynomial using coefficients
+  //! \param[in] c Coefficients in order of increasing order
+  Polynomial(std::vector<double> c) : coef_{c} {};
+
   //! Evaluate the polynomials
   //! \param[in] x independent variable
   //! \return Polynomial evaluated at x
   double operator()(double x) const override;
+
+  // Accessor
+  const std::vector<double>&coeffs() const { return coef_; }
 private:
   std::vector<double> coef_; //!< Polynomial coefficients
 };

--- a/include/openmc/endf.h
+++ b/include/openmc/endf.h
@@ -64,7 +64,7 @@ public:
   double operator()(double x) const override;
 
   // Accessor
-  const std::vector<double>&coeffs() const { return coef_; }
+  const std::vector<double>& coeffs() const { return coef_; }
 private:
   std::vector<double> coef_; //!< Polynomial coefficients
 };

--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -80,6 +80,8 @@ public:
   std::unique_ptr<Function1D> total_nu_; //!< Total neutron yield
   std::unique_ptr<Function1D> fission_q_prompt_; //!< Prompt fission energy release
   std::unique_ptr<Function1D> fission_q_recov_; //!< Recoverable fission energy release
+  //! Fission energy release without prompt neutrons
+  std::unique_ptr<Function1D> modified_fission_q_;
 
   // Resonance scattering information
   bool resonant_ {false};

--- a/openmc/capi/tally.py
+++ b/openmc/capi/tally.py
@@ -89,7 +89,8 @@ _SCORES = {
     -5: 'absorption', -6: 'fission', -7: 'nu-fission', -8: 'kappa-fission',
     -9: 'current', -10: 'events', -11: 'delayed-nu-fission',
     -12: 'prompt-nu-fission', -13: 'inverse-velocity', -14: 'fission-q-prompt',
-    -15: 'fission-q-recoverable', -16: 'decay-rate', -17: 'heating'
+    -15: 'fission-q-recoverable', -16: 'decay-rate', -17: 'heating',
+    -18: "energy-deposition",
 }
 _ESTIMATORS = {
     1: 'analog', 2: 'tracklength', 3: 'collision'

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -8,6 +8,7 @@ import bisect
 
 from numpy import dot, zeros, newaxis
 
+from . import comm
 from openmc.checkvalue import check_type, check_greater_than
 from openmc.capi import (
     Tally, MaterialFilter, EnergyFilter, EnergyFunctionFilter)
@@ -155,6 +156,47 @@ class ChainFissionHelper(EnergyHelper):
         """
         self._energy += dot(fission_rates, self._fission_q_vector)
 
+
+class EnergyScoreHelper(EnergyHelper):
+    """Class responsible for obtaining system energy via a tally score
+
+    Attributes
+    ----------
+    nuclides : list of str
+        List of nuclides with reaction rates. Not needed, but provided
+        for a consistent API across other :class:`EnergyHelper`
+    energy : float
+        System energy [eV] computed from the tally. Will be zero for
+        all MPI processes that are not the "master" process to avoid
+        artificially increasing the tallied energy.
+
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._tally = None
+
+    def prepare(self, *args, **kwargs):
+        """Create a tally for system energy production
+
+        Input arguments are not used, as the only information needed
+        is :attr:`score`
+
+        """
+        self._tally = Tally()
+        self._tally.scores = ["energy-deposition"]
+
+    def reset(self):
+        """Obtain system energy from tally
+
+        Only the master process, ``comm.rank == 0`` will
+        have a non-zero :attr:`energy` taken from the tally.
+        This avoids accidentally scaling the system power by
+        the number of MPI processes
+        """
+        super().reset()
+        if not comm.rank:
+            self._energy = self._tally.results[0, 0, 1]
 
 # ------------------------------------
 # Helper for collapsing fission yields

--- a/src/endf.cpp
+++ b/src/endf.cpp
@@ -151,6 +151,16 @@ Tabulated1D::Tabulated1D(hid_t dset)
   n_pairs_ = x_.size();
 }
 
+Tabulated1D::Tabulated1D(std::vector<double> x, std::vector<double> y)
+{
+  x_ = x;
+  y_ = y;
+  n_pairs_ = x.size();
+  int_.push_back(Interpolation::lin_lin);
+  nbt_.push_back(x.size());
+  n_regions_ = 1;
+}
+
 double Tabulated1D::operator()(double x) const
 {
   // find which bin the abscissa is in -- if the abscissa is outside the

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -287,8 +287,8 @@ Nuclide::Nuclide(hid_t group, const std::vector<double>& temperature, int i_nucl
         throw std::runtime_error{"prompt_neutrons not Tabulated1D in " + 
           object_name(fer_group)};
       }
-      auto recov_data = tab_recov->y();
-      auto recov_x = tab_recov->x();
+      const auto& recov_data = tab_recov->y();
+      const auto& recov_x = tab_recov->x();
       int i=0;
       for (auto yit = recov_data.cbegin(); yit != recov_data.cend(); ++yit) {
         mod_data.push_back(*yit - (*neutrons)(recov_x[i]));
@@ -301,8 +301,8 @@ Nuclide::Nuclide(hid_t group, const std::vector<double>& temperature, int i_nucl
         throw std::runtime_error{"prompt_neutrons not Polynomial in " + 
           object_name(fer_group)};
       }
-      auto recov_data = poly_recov->coeffs();
-      auto neutron_data = neutrons->coeffs();
+      const auto& recov_data = poly_recov->coeffs();
+      const auto& neutron_data = neutrons->coeffs();
       int i=0;
       for (auto it = recov_data.cbegin(); it != recov_data.cend(); ++it) {
         mod_data.push_back(*it - neutron_data.at(i));

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -621,6 +621,7 @@ const std::unordered_map<int, const char*> score_names = {
   {SCORE_FISS_Q_RECOV,       "Recoverable fission power"},
   {SCORE_CURRENT,            "Current"},
   {SCORE_HEATING,            "Heating"},
+  {SCORE_ENERGY_DEPOSITION,  "Energy Deposition"},
 };
 
 //! Create an ASCII output file showing all tally results.

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -121,6 +121,8 @@ std::string reaction_name(int mt)
     return  "fission-q-recoverable";
   } else if (mt == SCORE_HEATING) {
     return  "heating";
+  } else if (mt == SCORE_ENERGY_DEPOSITION) {
+    return "energy-deposition";
 
   // Normal ENDF-based reactions
   } else if (mt == TOTAL_XS) {

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -113,6 +113,9 @@ score_str_to_int(std::string score_str)
   if (score_str == "heating")
     return SCORE_HEATING;
 
+  if (score_str == "energy-deposition")
+    return SCORE_ENERGY_DEPOSITION;
+
   if (score_str == "current")
     return SCORE_CURRENT;
 


### PR DESCRIPTION
This PR introduces two features: an energy deposition tally and a related energy helper for the operator

## Energy deposition tally score
Using the separated fission and heating scoring routines from #1329 and the inclusion of fission heating from #1322, the energy deposition score is implemented simply as
``total_heating - fission_heating + modified_fission_q``. Where ``modified_fission_q`` is the recoverable energy from fission minus energy from prompt neutrons. The idea behind this split is that removing the energy from prompt neutrons [and eventually prompt photons] from the recoverable fission energy, we avoid double counting when including the total heating. This allows the energy from neutrons [and eventually photons] to be distributed away from the fission site.

Some features were added to the `openmc::Tabulated1D` and `openmc::Polynomial` classes to make this process a little easier. It is not possible to construct these with `x` and `y` vectors for `Tabulated1D` and the coefficient vector for `Polynomial`. 

This also assumes that nearly all of the fission heating [MT=318] comes from energy that is contained in the recoverable fission energy [MT=458] and is included in the total heating [MT=301] information. 

Below is a table taken by scoring neutron heating, recoverable fission energy, and the new energy deposition quantity in a 2D PWR assembly. Cross section data was taken using the fixes in #1341. Scores have been divided by 1E6.

|material	| energy-deposition	| fission-q-recoverable	| heating |
|-|-|-|-|
fuel |179.1233756191688	| 94.01349137593269	|87.48114580138251
water |1.588209065664372	| 0.0 |1.588209065664372
cladding | 0.06933964196717787 |0.0 |0.06933964196717787

About 99% of the energy is deposited in the fuel. For non-fissile materials, the energy deposition score recovers the normal neutron heating. For the fuel, if you sum the `fission-q-recoverable` and `heating` columns, you get a value that is greater than the `energy-deposition` column. Interestingly, this difference is not equal to the energy deposited in water and clad, ``94.01 + 87.48 - 179.12 ~= 2.37``, ``1.588 + 0.069 ~= 1.65``

This feature supersedes #1272 and improves it with :arrow_down:

## Energy deposition model for depletion

Using this new score, getting the system energy for depletion is very straightforward. An `EnergyScoreHelper` is added that creates a tally that computes the `energy-deposition` score with no filters, e.g. across the entire problem. This value can be passed directly to the `Operator` to scale reaction rates accordingly. A special case is taken when running with multiple processes in that only the master process returns the tallied data. Since all processes share the same tally data, having each process return the energy produced by "this process" would result in scaling the system energy by the number of MPI processes
https://github.com/openmc-dev/openmc/blob/3df4f94fbf990f7b02b18738ca02ee8614273a03/openmc/deplete/operator.py#L633-L635

## TODO
- [ ] Add this score to the tally regression test [before / after #1338 ?]
- [ ] Remove prompt photon energy if we are in coupled neutron / photon transport