### PR TITLE
Use defaultdict when weighting fission yields

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -5,6 +5,7 @@ to run a full depletion simulation.
 """
 
 from collections import namedtuple
+from collections import defaultdict
 from collections.abc import Iterable
 import os
 from pathlib import Path
@@ -376,14 +377,17 @@ class FissionYieldHelper(ABC):
 
     Attributes
     ----------
-    constant_yields : dict of str to :class:`openmc.deplete.FissionYield`
+    constant_yields : collections.defaultdict
         Fission yields for all nuclides that only have one set of
-        fission yield data. Can be accessed as ``{parent: {product: yield}}``
+        fission yield data. Dictionary of form ``{str: {str: float}}``
+        representing yields for ``{parent: {product: yield}}``. Default
+        return object is an empty dictionary
+
     """
 
     def __init__(self, chain_nuclides):
         self._chain_nuclides = {}
-        self._constant_yields = {}
+        self._constant_yields = defaultdict(dict)
 
         # Get all nuclides with fission yield data
         for nuc in chain_nuclides:
@@ -407,14 +411,16 @@ class FissionYieldHelper(ABC):
         Parameters
         ----------
         local_mat_index : int
-            Index for material tracked on this process that
-            exists in :attr:`local_mat_index` and fits within
-            the first axis in :attr:`results`
+            Index for the material with requested fission yields.
+            Should correspond to the material represented in
+            ``mat_indexes[local_mat_index]`` during
+            :meth:`generate_tallies`.
 
         Returns
         -------
-        library : dict
-            Dictionary of ``{parent: {product: fyield}}``
+        library : collections.abc.Mapping
+            Dictionary-like object mapping ``{str: {str: float}``.
+            This reflects fission yields for ``{parent: {product: fyield}}``.
         """
 
     @staticmethod

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -412,7 +412,7 @@ class Chain(object):
             names of nuclides with yield data and ``f_yield``
             is a float for the fission yield.
         """
-        out = {}
+        out = defaultdict(dict)
         for nuc in self.nuclides:
             if nuc.yield_data is None:
                 continue

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -398,7 +398,7 @@ class Chain(object):
             clean_indentation(root_elem)
             tree.write(str(filename), encoding='utf-8')
 
-    def get_thermal_fission_yields(self):
+    def get_default_fission_yields(self):
         """Return fission yields at lowest incident neutron energy
 
         Used as the default set of fission yields for :meth:`form_matrix`
@@ -440,13 +440,13 @@ class Chain(object):
 
         See Also
         --------
-        :meth:`get_thermal_fission_yields`
+        :meth:`get_default_fission_yields`
         """
         matrix = defaultdict(float)
         reactions = set()
 
         if fission_yields is None:
-            fission_yields = self.get_thermal_fission_yields()
+            fission_yields = self.get_default_fission_yields()
 
         for i, nuc in enumerate(self.nuclides):
 
@@ -721,7 +721,7 @@ class Chain(object):
     @property
     def fission_yields(self):
         if self._fission_yields is None:
-            self._fission_yields = [self.get_thermal_fission_yields()]
+            self._fission_yields = [self.get_default_fission_yields()]
         return self._fission_yields
 
     @fission_yields.setter

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from itertools import product
 from numbers import Real
 import bisect
+from collections import defaultdict
 
 from numpy import dot, zeros, newaxis
 
@@ -179,9 +180,11 @@ class ConstantFissionYieldHelper(FissionYieldHelper):
 
     Attributes
     ----------
-    constant_yields : dict of str to :class:`openmc.deplete.FissionYield`
+    constant_yields : collections.defaultdict
         Fission yields for all nuclides that only have one set of
-        fission yield data. Can be accessed as ``{parent: {product: yield}}``
+        fission yield data. Dictionary of form ``{str: {str: float}}``
+        representing yields for ``{parent: {product: yield}}``. Default
+        return object is an empty dictionary
     energy : float
         Energy of fission yield libraries.
     """
@@ -237,7 +240,7 @@ class ConstantFissionYieldHelper(FissionYieldHelper):
 
         Returns
         -------
-        library : dict
+        library : collections.defaultdict
             Dictionary of ``{parent: {product: fyield}}``
         """
         return self.constant_yields
@@ -282,6 +285,11 @@ class FissionYieldCutoffHelper(TalliedFissionYieldHelper):
     fast_yields : dict
         Dictionary of the form ``{parent: {product: yield}}``
         with fast yields
+    constant_yields : collections.defaultdict
+        Fission yields for all nuclides that only have one set of
+        fission yield data. Dictionary of form ``{str: {str: float}}``
+        representing yields for ``{parent: {product: yield}}``. Default
+        return object is an empty dictionary
     results : numpy.ndarray
         Array of fission rate fractions with shape
         ``(n_mats, 2, n_nucs)``. ``results[:, 0]``
@@ -417,7 +425,7 @@ class FissionYieldCutoffHelper(TalliedFissionYieldHelper):
 
         Returns
         -------
-        library : dict
+        library : collections.defaultdict
             Dictionary of ``{parent: {product: fyield}}``
         """
         yields = self.constant_yields
@@ -469,9 +477,11 @@ class AveragedFissionYieldHelper(TalliedFissionYieldHelper):
 
     Attributes
     ----------
-    constant_yields : dict of str to :class:`openmc.deplete.FissionYield`
+    constant_yields : collections.defaultdict
         Fission yields for all nuclides that only have one set of
-        fission yield data. Can be accessed as ``{parent: {product: yield}}``
+        fission yield data. Dictionary of form ``{str: {str: float}}``
+        representing yields for ``{parent: {product: yield}}``. Default
+        return object is an empty dictionary
     results : None or numpy.ndarray
         If tallies have been generated and unpacked, then the array will
         have shape ``(n_mats, n_tnucs)``, where ``n_mats`` is the number
@@ -569,12 +579,13 @@ class AveragedFissionYieldHelper(TalliedFissionYieldHelper):
 
         Returns
         -------
-        library : dict
-            Dictionary of ``{parent: {product: fyield}}``
+        library : collections.defaultdict
+            Dictionary of ``{parent: {product: fyield}}``. Default return
+            value is an empty dictionary
         """
         if not self._tally_nucs:
             return self.constant_yields
-        mat_yields = {}
+        mat_yields = defaultdict(dict)
         average_energies = self.results[local_mat_index]
         for avg_e, nuc in zip(average_energies, self._tally_nucs):
             nuc_energies = nuc.yield_energies

--- a/tests/dummy_operator.py
+++ b/tests/dummy_operator.py
@@ -83,7 +83,7 @@ class TestChain(object):
     fission_yields = [None]
 
     @staticmethod
-    def get_thermal_fission_yields():
+    def get_default_fission_yields():
         return None
 
     def form_matrix(self, rates, _fission_yields=None):

--- a/tests/unit_tests/test_deplete_chain.py
+++ b/tests/unit_tests/test_deplete_chain.py
@@ -385,13 +385,13 @@ def test_set_alpha_branches():
 def test_simple_fission_yields(simple_chain):
     """Check the default fission yields that can be used to form the matrix
     """
-    fission_yields = simple_chain.get_thermal_fission_yields()
+    fission_yields = simple_chain.get_default_fission_yields()
     assert fission_yields == {"C": {"A": 0.0292737, "B": 0.002566345}}
 
 
 def test_fission_yield_attribute(simple_chain):
     """Test the fission_yields property"""
-    thermal_yields = simple_chain.get_thermal_fission_yields()
+    thermal_yields = simple_chain.get_default_fission_yields()
     # generate default with property
     assert simple_chain.fission_yields[0] == thermal_yields
     empty_chain = Chain()


### PR DESCRIPTION
The Chain.form_matrix method looks for information and fission yields for all isotopes with a fission reaction. However, the AveragedFissionYieldHelper and FissionYieldCutoffHelper
are not guaranteed to return yields to all isotopes with fission reactions. Instead, the union on two sets of yields are returned:
1) yields from isotopes with a single set of fission yields
2) weighted yields computed for isotopes with both multiple sets of fission yields **and** non-zero densities.

This later item can cause some isotopes that the Chain anticipates having fission yields, since they have a fission reaction, to not exist in the yields library. An isotope with multiple sets of yields but that is not physically present in the problem will not have reaction rates and also not have fission yields computed by these helpers. This will cause a KeyError during Chain.form_matrix when fission yields for these isotopes are requested.

https://github.com/openmc-dev/openmc/blob/0a14a5b7d8aaeed3b22917819dd960fcc148d544/openmc/deplete/chain.py#L490-L499

This PR changes the return type from weighted_yields on ConstantFissionYieldHelper, AveragedFissionYieldHelper, and FissionYieldCutoffHelper to be defaultdict(dict). This resolves the above issue by returning an "empty" set of yields for isotopes that potentially *should* have fission yields, but have zero density across the problem. These isotopes are not considered by the Operator either, since they have no density and therefore do not have tallied reaction rates nor fission yields. 