### PR TITLE
Complex Cell Bounding Box Fix

### DIFF
--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -213,7 +213,7 @@ protected:
   BoundingBox bounding_box_simple() const;
   static BoundingBox bounding_box_complex(std::vector<int32_t> rpn);
   static void apply_demorgan(std::vector<int32_t>::iterator start,
-                               std::vector<int32_t>::iterator end);
+                             std::vector<int32_t>::iterator stop);
 };
 
 //==============================================================================

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -214,6 +214,10 @@ protected:
   static BoundingBox bounding_box_complex(std::vector<int32_t> rpn);
   static void apply_demorgan(std::vector<int32_t>::iterator start,
                              std::vector<int32_t>::iterator stop);
+  static void remove_complements(std::vector<int32_t>& rpn);
+  static std::vector<int32_t>::iterator
+  find_left_parenthesis(std::vector<int32_t>::iterator start,
+                        const std::vector<int32_t>& rpn);
 };
 
 //==============================================================================

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -214,15 +214,20 @@ protected:
   static BoundingBox bounding_box_complex(std::vector<int32_t> rpn);
 
   //! Applies DeMorgan's laws to a section of the RPN
+  //! \param start Starting point for token modification
+  //! \param stop Stopping point for token modification
   static void apply_demorgan(std::vector<int32_t>::iterator start,
                              std::vector<int32_t>::iterator stop);
 
   //! Removes complement operators from the RPN
+  //! \param rpn The rpn to remove complement operators from.
   static void remove_complement_ops(std::vector<int32_t>& rpn);
 
   //! Returns the beginning position of a parenthesis block (immediately before
   //! two surface tokens) in the RPN given a starting position at the end of
   //! that block (immediately after two surface tokens)
+  //! \param start Starting position of the search
+  //! \param rpn The rpn being searched
   static std::vector<int32_t>::iterator
   find_left_parenthesis(std::vector<int32_t>::iterator start,
                         const std::vector<int32_t>& rpn);
@@ -230,6 +235,8 @@ protected:
   //! Returns the ending position of a parenthesis block (immediately after two
   //! operator tokens) in the RPN given a starting position at the beginning of
   //! that block (immediately before two surface tokens)
+  //! \param start Starting position of the search
+  //! \param rpn The rpn being searched
   static std::vector<int32_t>::iterator
   find_right_parenthesis(std::vector<int32_t>::iterator start,
                         const std::vector<int32_t>& rpn);

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -212,12 +212,24 @@ protected:
   bool contains_complex(Position r, Direction u, int32_t on_surface) const;
   BoundingBox bounding_box_simple() const;
   static BoundingBox bounding_box_complex(std::vector<int32_t> rpn);
+
+  //! Applies DeMorgan's laws to a section of the RPN
   static void apply_demorgan(std::vector<int32_t>::iterator start,
                              std::vector<int32_t>::iterator stop);
+
+  //! Removes complement operators from the RPN
   static void remove_complement_ops(std::vector<int32_t>& rpn);
+
+  //! Returns the beginning position of a parenthesis block (immediately before
+  //! two surface tokens) in the RPN given a starting position at the end of
+  //! that block (immediately after two surface tokens)
   static std::vector<int32_t>::iterator
   find_left_parenthesis(std::vector<int32_t>::iterator start,
                         const std::vector<int32_t>& rpn);
+
+  //! Returns the ending position of a parenthesis block (immediately after two
+  //! operator tokens) in the RPN given a starting position at the beginning of
+  //! that block (immediately before two surface tokens)
   static std::vector<int32_t>::iterator
   find_right_parenthesis(std::vector<int32_t>::iterator start,
                         const std::vector<int32_t>& rpn);

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -218,6 +218,10 @@ protected:
   static std::vector<int32_t>::iterator
   find_left_parenthesis(std::vector<int32_t>::iterator start,
                         const std::vector<int32_t>& rpn);
+  static std::vector<int32_t>::iterator
+  find_right_parenthesis(std::vector<int32_t>::iterator start,
+                        const std::vector<int32_t>& rpn);
+
 };
 
 //==============================================================================

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -212,7 +212,8 @@ protected:
   bool contains_complex(Position r, Direction u, int32_t on_surface) const;
   BoundingBox bounding_box_simple() const;
   static BoundingBox bounding_box_complex(std::vector<int32_t> rpn);
-  static void apply_demorgan(std::vector<int32_t>& rpn);
+  static void apply_demorgan(std::vector<int32_t>::iterator start,
+                               std::vector<int32_t>::iterator end);
 };
 
 //==============================================================================

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -214,7 +214,7 @@ protected:
   static BoundingBox bounding_box_complex(std::vector<int32_t> rpn);
   static void apply_demorgan(std::vector<int32_t>::iterator start,
                              std::vector<int32_t>::iterator stop);
-  static void remove_complements(std::vector<int32_t>& rpn);
+  static void remove_complement_ops(std::vector<int32_t>& rpn);
   static std::vector<int32_t>::iterator
   find_left_parenthesis(std::vector<int32_t>::iterator start,
                         const std::vector<int32_t>& rpn);

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -232,15 +232,6 @@ protected:
   find_left_parenthesis(std::vector<int32_t>::iterator start,
                         const std::vector<int32_t>& rpn);
 
-  //! Returns the ending position of a parenthesis block (immediately after two
-  //! operator tokens) in the RPN given a starting position at the beginning of
-  //! that block (immediately before two surface tokens)
-  //! \param start Starting position of the search
-  //! \param rpn The rpn being searched
-  static std::vector<int32_t>::iterator
-  find_right_parenthesis(std::vector<int32_t>::iterator start,
-                        const std::vector<int32_t>& rpn);
-
 };
 
 //==============================================================================

--- a/include/openmc/surface.h
+++ b/include/openmc/surface.h
@@ -83,6 +83,13 @@ struct BoundingBox
     return *this;
   }
 
+  inline bool is_valid() {
+    return xmin <= xmax &&
+           ymin <= ymax &&
+           zmin <= zmax;
+  }
+
+
 };
 
 //==============================================================================

--- a/include/openmc/surface.h
+++ b/include/openmc/surface.h
@@ -83,13 +83,6 @@ struct BoundingBox
     return *this;
   }
 
-  inline bool is_valid() {
-    return xmin <= xmax &&
-           ymin <= ymax &&
-           zmin <= zmax;
-  }
-
-
 };
 
 //==============================================================================

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -642,6 +642,40 @@ CSGCell::find_left_parenthesis(std::vector<int32_t>::iterator start,
   return it;
 }
 
+std::vector<int32_t>::iterator
+CSGCell::find_right_parenthesis(std::vector<int32_t>::iterator start,
+                                const std::vector<int32_t>& rpn) {
+  // start search at zero
+  int level = 0;
+  auto it = start;
+  while (it != rpn.end()) {
+    // look at two tokens at a time
+    int32_t one = *it;
+    int32_t two = *(it + 1);
+
+    // decrement parenthesis level if there are two adjacent surfaces
+    if (one < OP_UNION && two < OP_UNION) {
+      level++;
+    // increment if there are two adjacent operators
+    } else if (one >= OP_UNION && two >= OP_UNION) {
+      level--;
+    }
+
+    // if the level gets to zero, return the position
+    if (level == 0) {
+      // move the iterator back one before leaving the loop
+      // so that all tokens in the parenthesis are included
+      it++;
+      break;
+    }
+
+    // continue loop, one token at a time
+    it++;
+  }
+  return it;
+}
+
+
 void CSGCell::remove_complement_ops(std::vector<int32_t>& rpn) {
   auto it = std::find(rpn.begin(), rpn.end(), OP_COMPLEMENT);
   while (it != rpn.end()) {
@@ -687,20 +721,17 @@ BoundingBox CSGCell::bounding_box_complex(std::vector<int32_t> rpn) {
       // add until last two tokens in the sub-rpn are operators
       // (indicates a right parenthesis)
       auto subrpn_start = it - 2; // include current tokens
-      auto subrpn_end = it;
-      while (!((*subrpn_end >= OP_UNION) && (*(subrpn_end + 1) >= OP_UNION))) {
-        subrpn_end++;
-      }
+      auto subrpn_end = find_right_parenthesis(subrpn_start, rpn);
 
       // create the subrpn, including the first of our current tokens
-      std::vector<int32_t> subrpn(subrpn_start, ++subrpn_end);
+      std::vector<int32_t> subrpn(subrpn_start, subrpn_end);
 
       // save the last operator, tells us how to combine this region
       // with our current bounding box
       int32_t op = *subrpn_end++;
       it = subrpn_end;
 
-      // get bounding box for the subrpn
+      // get bounding box for the sub-rpn
       BoundingBox sub_box = bounding_box_complex(subrpn);
       // combine the sub-rpn bounding box with our current cell box
       if (op == OP_UNION) {

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -601,7 +601,7 @@ BoundingBox CSGCell::bounding_box_simple() const {
 void CSGCell::apply_demorgan(std::vector<int32_t>::iterator start,
                              std::vector<int32_t>::iterator stop)
 {
-  while(start < stop) {
+  while (start < stop) {
     if (*start < OP_UNION) { *start *= -1; }
     else if (*start == OP_UNION) { *start = OP_INTERSECTION; }
     else if (*start == OP_INTERSECTION) { *start = OP_UNION; }

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -642,38 +642,6 @@ CSGCell::find_left_parenthesis(std::vector<int32_t>::iterator start,
   return it;
 }
 
-std::vector<int32_t>::iterator
-CSGCell::find_right_parenthesis(std::vector<int32_t>::iterator start,
-                                const std::vector<int32_t>& rpn) {
-  int parenthesis_level = 0;
-  auto it = start;
-  while (it != rpn.end()) {
-    // look at two tokens at a time
-    int32_t one = *it;
-    int32_t two = *(it + 1);
-
-    // increment parenthesis level if there are two adjacent surfaces
-    if (one < OP_UNION && two < OP_UNION) {
-      parenthesis_level++;
-    // decrement if there are two adjacent operators
-    } else if (one >= OP_UNION && two >= OP_UNION) {
-      parenthesis_level--;
-    }
-
-    // if the level gets to zero, return the position
-    if (parenthesis_level == 0) {
-      // move the iterator forward one before leaving the loop
-      // so that all tokens in the parenthesis block are included
-      it++;
-      break;
-    }
-
-    // continue loop, one token at a time
-    it++;
-  }
-  return it;
-}
-
 void CSGCell::remove_complement_ops(std::vector<int32_t>& rpn) {
   auto it = std::find(rpn.begin(), rpn.end(), OP_COMPLEMENT);
   while (it != rpn.end()) {
@@ -711,12 +679,8 @@ BoundingBox CSGCell::bounding_box_complex(std::vector<int32_t> rpn) {
     }
   }
 
-  if (i_stack == 0) {
-    return stack[i_stack];
-  } else {
-    return BoundingBox();
-  }
-
+  Ensures(i_stack == 0);
+  return stack.front();
 }
 
 BoundingBox CSGCell::bounding_box() const {

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -612,7 +612,7 @@ void CSGCell::apply_demorgan(std::vector<int32_t>::iterator start,
 std::vector<int32_t>::iterator
 CSGCell::find_left_parenthesis(std::vector<int32_t>::iterator start,
                                const std::vector<int32_t>& rpn) {
-
+  // start search at zero
   int level = 0;
   auto it = start;
   while (it != rpn.begin()) {
@@ -643,12 +643,7 @@ CSGCell::find_left_parenthesis(std::vector<int32_t>::iterator start,
 }
 
 void CSGCell::remove_complements(std::vector<int32_t>& rpn) {
-  if (rpn.back() == OP_COMPLEMENT) {
-    apply_demorgan(rpn.begin(), rpn.end());
-    rpn.pop_back();
-  }
-
-  std::vector<int32_t>::iterator it = std::find(rpn.begin(), rpn.end(), OP_COMPLEMENT);
+  auto it = std::find(rpn.begin(), rpn.end(), OP_COMPLEMENT);
   while (it != rpn.end()) {
     // find the opening parenthesis (if any)
     auto left = find_left_parenthesis(it, rpn);
@@ -663,13 +658,15 @@ void CSGCell::remove_complements(std::vector<int32_t>& rpn) {
 }
 
 BoundingBox CSGCell::bounding_box_complex(std::vector<int32_t> rpn) {
-
+  // remove complements by adjusting surface signs and operators
   remove_complements(rpn);
 
+  // use the first token to set the bounding box
   auto it = rpn.begin();
   BoundingBox current = model::surfaces[abs(*it) - 1]->bounding_box(*it > 0);
   it++;
 
+  // loop over tokens
   while (it < rpn.end()) {
     // move through the rpn in twos
     int32_t one = *it; it++;
@@ -713,7 +710,6 @@ BoundingBox CSGCell::bounding_box_complex(std::vector<int32_t> rpn) {
       }
     }
   }
-
   return current;
 }
 

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -642,7 +642,7 @@ CSGCell::find_left_parenthesis(std::vector<int32_t>::iterator start,
   return it;
 }
 
-void CSGCell::remove_complements(std::vector<int32_t>& rpn) {
+void CSGCell::remove_complement_ops(std::vector<int32_t>& rpn) {
   auto it = std::find(rpn.begin(), rpn.end(), OP_COMPLEMENT);
   while (it != rpn.end()) {
     // find the opening parenthesis (if any)
@@ -659,7 +659,7 @@ void CSGCell::remove_complements(std::vector<int32_t>& rpn) {
 
 BoundingBox CSGCell::bounding_box_complex(std::vector<int32_t> rpn) {
   // remove complements by adjusting surface signs and operators
-  remove_complements(rpn);
+  remove_complement_ops(rpn);
 
   // use the first token to set the bounding box
   auto it = rpn.begin();

--- a/tests/unit_tests/test_complex_cell_bb.py
+++ b/tests/unit_tests/test_complex_cell_bb.py
@@ -47,7 +47,7 @@ def complex_cell(run_in_tmpdir, mpi_intracomm):
     c1.region = ~(-s3 | +s4 | ~(+s13 & -s14))
 
     c2 = openmc.Cell(fill=u238)
-    c2.region = +s2 & -s5 & +s12 & -s15 & ~(+s3 & -s4 & +s13 & -s14)
+    c2.region =  ~(+s3 & -s4 & +s13 & -s14) & +s2 & -s5 & +s12 & -s15
 
     c3 = openmc.Cell(fill=zr90)
     c3.region = ((+s1 & -s7 & +s17 & -s16) | (+s7 & -s6 & +s11 & -s17)) \


### PR DESCRIPTION
This aims to address #529.

The `CSGCell::bounding_box_complex()` method now removes complement operators at the start rather than trying to address them as it moves through the cell's RPN. This avoids treating some of these complement operator placements as special cases and makes finding parenthesis artifacts in the RPN more straightforward both when removing the complement operators and creating the bounding box.

I've also started using iterators to move through the RPN. It makes creating sub-sets of the RPN cleaner and avoids eating up memory if some unforeseen case is hit in the while loops.