### PR TITLE
Use MT301,901 for energy deposition for depletion

### DIFF
--- a/docs/source/methods/energy_deposition.rst
+++ b/docs/source/methods/energy_deposition.rst
@@ -1,0 +1,134 @@
+.. _methods_heating:
+
+=============================
+Heating and Energy Deposition
+=============================
+
+As particles traverse a problem, some portion of their energy is deposited at 
+collision sites. There are a variety of mechanisms that contribute to the
+energy deposition, including down-scattering from higher to lower energies,
+fission events, and reactions with positive Q-values. The information describing
+how much energy is deposited for a specific reaction is referred to as 
+"heating numbers" and can be computed using a program like NJOY with the
+``heatr`` module.
+
+These heating numbers are the product of reaction-specific coefficients and
+a reaction cross section
+
+.. math::
+
+    H(E) = \phi(E)\sum_i\rho_i\sum_rk_{i, r}
+
+and has units energy per time, typically eV / s.
+Here, :math:`k_{i, r}` are the KERMA [Kinetic Energy Release in Materials]
+coefficients for reaction :math:`r` of isotope :math:`i`.
+The KERMA coefficients have units energy :math:`\times` cross-section, e.g.
+eV-barn, and can be used much like a reaction cross section for the purpose
+of tallying energy deposition.
+
+KERMA coefficients can be computed using the energy-balance method with
+a nuclear data processing code like NJOY, which performs the following
+iteration over all reactions :math:`r` for all isotopes :math:`i`
+requested
+
+.. math::
+
+    k_{i, r}(E) = \left(E + Q_{i, r} - \bar{E}_{i, r, n} - \bar{E}_{i, r, \gamma}\right)\sigma_{i, r}(E)
+
+removing the energy of secondary neutrons and photons from the sum of
+incident neutron energy, :math:`E`, and the reaction :math:`Q` value.
+
+---------------------------
+The Special Case of Fission
+---------------------------
+
+During a fission event, there are potentially many secondary particles, and all
+must be considered. The total energy released in a fission event is typically
+broken up into the following categories:
+
+- :math:`E_{fr}` - kinetic energy of fission fragments
+- :math:`E_{n,p}` - energy of prompt fission neutrons
+- :math:`E_{n,d}` - energy of delayed fission neutrons
+- :math:`E_{\gamma,p}` - energy of prompt fission photons
+- :math:`E_{\gamma,d}` - energy of delayed fission photons
+- :math:`E_{\beta}` - energy of released :math:`\beta` particles
+- :math:`E_{\nu}` - energy of neutrinos
+
+These components are defined in MT=458 data in a standard ENDF/B-VII file.
+All these quantities have some energy dependence, but this dependence is not shown to
+make the following demonstrations cleaner.
+As neutrinos scarcely interact with matter, the recoverable energy from fission is defined as
+
+.. math::
+
+    E_r\equiv E_{fr} + E_{n,p} + E_{n, d} + E_{\gamma, p} + E_{\gamma, d} + E_{\beta}
+
+Furthermore, the energy of the secondary neutrons and photons is given as
+:math:`E_{n, p}` and :math:`E_{\gamma, p}`, respectively.
+
+NJOY computes the fission KERMA coefficient using this energy-balance method to be
+
+.. math::
+
+    k_{i, f}(E) = \left[E + Q(E) - \bar{E}(E)\right]\sigma_{i, f}(E)
+    = \left[E_{fr} + E_{\gamma, p}\right]\sigma_{i, j}(E)
+
+.. note::
+
+    The energy from delayed neutrons and photons and beta particles are intentionally
+    left out from the NJOY calculations
+
+---------------------
+OpenMC Implementation
+---------------------
+
+For fissile isotopes, OpenMC makes modifications to the heating reaction to include
+all relevant components of fission energy release. These modifications are made to
+the total heating reaction, MT=301. Breaking the total heating number into
+a fission and non-fission section, one can write
+
+.. math::
+
+    H_i(E) = H_{i, nf}(E) + \left[E_{fr}(E) + E_{\gamma, p}\right]\sigma_{i, f}(E)
+
+OpenMC seeks to modify the total heating data to include energy from :math:`\beta` particles
+and, conditionally, delayed photons. This conditional inclusion depends on the simulation
+mode: neutron transport, or coupled neutron-photon transport. The heating due to fission
+is removed using MT=318 data, and then re-built using the desired components of fission
+energy release from MT=458 data.
+
+Neutron Transport
+-----------------
+
+For this case, OpenMC instructs ``heatr`` to produce heating coefficients assuming
+that energy from photons, :math:`E_{\gamma, p}` and :math:`E_{\gamma, d}`,
+is deposited at the fission site.
+Let :math:`N901` represent the total heating number returned from this ``heatr`` 
+run with :math:`N918` reflecting fission heating computed from NJOY.
+:math:`M901` represent the following modification
+
+.. math::
+
+    M901_{i}(E)\equiv N901_{i}(E) - N918_{i}(E)
+      + \left[E_{i, fr} + E_{i, \beta} + E_{i, \gamma, p}
+      + E_{i, \gamma, d}\right]\sigma_{i, f}(E).
+
+This modified heating data is stored as the MT=901 reaction and will be scored
+if ``901`` is included in :attr:`openmc.Tally.scores`.
+
+Coupled neutron-photon transport
+--------------------------------
+
+Here, OpenMC instructs ``heatr`` to remove the assumption of local photon energy.
+However, the definitions provided in the NJOY manual indicate that, regardless of
+this mode, the prompt photon energy is still included in :math:`k_{i, f}`, 
+and therefore must be manually removed. Let :math:`N301` represent the total
+heating number returned from this ``heatr`` run and :math:`M301` be
+
+.. math::
+
+    M301_{i}(E)\equiv N301_{i}(E) - N318_{i}(E)
+      + \left[E_{i, fr}(E) + E_{i, \beta}(E)\right]\sigma_{i, f}(E).
+
+This modified heating data is stored as the MT=301 reaction and will be scored
+if ``301`` is included in :attr:`openmc.Tally.scores`.

--- a/docs/source/methods/index.rst
+++ b/docs/source/methods/index.rst
@@ -18,3 +18,4 @@ Theory and Methodology
     eigenvalue
     parallelization
     cmfd
+    energy_deposition

--- a/docs/source/pythonapi/deplete.rst
+++ b/docs/source/pythonapi/deplete.rst
@@ -95,6 +95,7 @@ total system energy.
    helpers.ChainFissionHelper
    helpers.ConstantFissionYieldHelper
    helpers.DirectReactionRateHelper
+   helpers.EnergyScoreHelper
    helpers.FissionYieldCutoffHelper
 
 The following classes are abstract classes that can be used to extend the

--- a/docs/source/usersguide/tallies.rst
+++ b/docs/source/usersguide/tallies.rst
@@ -261,12 +261,13 @@ The following tables show all valid scores:
     |                      |produced by NJOY's HEATR module while for photons, |
     |                      |this is tallied from either direct photon energy   |
     |                      |deposition (analog estimator) or pre-generated     |
-    |                      |photon heating number.                             |
+    |                      |photon heating number. See :ref:`methods_heating`  |
     +----------------------+---------------------------------------------------+
     |heating-local         |Total nuclear heating in units of eV per source    |
     |                      |particle assuming energy from secondary photons is |
     |                      |deposited locally. Note that this score should only|
-    |                      |be used for incident neutrons.                     |
+    |                      |be used for incident neutrons. See                 |
+    |                      |:ref:`methods_heating`.                            |
     +----------------------+---------------------------------------------------+
     |kappa-fission         |The recoverable energy production rate due to      |
     |                      |fission. The recoverable energy is defined as the  |

--- a/openmc/deplete/dummy_comm.py
+++ b/openmc/deplete/dummy_comm.py
@@ -1,3 +1,5 @@
+import sys
+
 class DummyCommunicator(object):
     rank = 0
     size = 1
@@ -25,3 +27,6 @@ class DummyCommunicator(object):
 
     def scatter(self, sendobj, root=0):
         return sendobj[0]
+
+    def Abort(self, exit_code_or_msg):
+        sys.exit(exit_code_or_msg)

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -205,7 +205,7 @@ class EnergyScoreHelper(EnergyHelper):
         the number of MPI processes
         """
         super().reset()
-        if not comm.rank:
+        if comm.rank == 0:
             self._energy = self._tally.results[0, 0, 1]
 
 # ------------------------------------

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -10,7 +10,6 @@ from collections import defaultdict
 from numpy import dot, zeros, newaxis
 
 from . import comm
-import openmc.data
 from openmc.checkvalue import check_type, check_greater_than
 from openmc.lib import (
     Tally, MaterialFilter, EnergyFilter, EnergyFunctionFilter)
@@ -164,9 +163,9 @@ class EnergyScoreHelper(EnergyHelper):
 
     Parameters
     ----------
-    reaction_mt : int or None
-        Valid score to use when obtaining system energy from openmc.
-        Defaults to 901 [heating assuming local photons]
+    score : string
+        Valid score to use when obtaining system energy from OpenMC.
+        Defaults to "heating-local"
 
     Attributes
     ----------
@@ -177,27 +176,15 @@ class EnergyScoreHelper(EnergyHelper):
         System energy [eV] computed from the tally. Will be zero for
         all MPI processes that are not the "master" process to avoid
         artificially increasing the tallied energy.
-    score : int
-        MT reaction number that is scored.
+    score : str
+        Score used to obtain system energy
 
     """
 
-    def __init__(self, score=None):
+    def __init__(self, score="heating-local"):
         super().__init__()
         self.score = score
         self._tally = None
-
-    @property
-    def score(self):
-        return self._score
-
-    @score.setter
-    def score(self, value):
-        if value is None:
-            self._score = 901
-        else:
-            check_type("score", value, int)
-            self._score = value
 
     def prepare(self, *args, **kwargs):
         """Create a tally for system energy production

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -221,9 +221,11 @@ class Operator(TransportOperator):
         # Get classes to assist working with tallies
         self._rate_helper = DirectReactionRateHelper(
             self.reaction_rates.n_nuc, self.reaction_rates.n_react)
-        self._energy_helper = (
-            ChainFissionHelper() if energy_mode == "fission-q"
-            else EnergyScoreHelper())
+        if energy_mode == "fission-q":
+            self._energy_helper = ChainFissionHelper()
+        else:
+            score = 301 if settings.photon_transport else 901
+            self._energy_helper = EnergyScoreHelper(score)
 
         # Select and create fission yield helper
         fission_helper = self._fission_helpers[fission_yield_mode]

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -225,7 +225,7 @@ class Operator(TransportOperator):
         if energy_mode == "fission-q":
             self._energy_helper = ChainFissionHelper()
         else:
-            score = 301 if settings.photon_transport else 901
+            score = "heating" if settings.photon_transport else "heating-local"
             self._energy_helper = EnergyScoreHelper(score)
 
         # Select and create fission yield helper

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -84,8 +84,7 @@ class Operator(TransportOperator):
         Indicator for computing system energy. ``"energy-deposition"`` will
         compute with a single energy deposition tally, taking fission energy
         release data and heating into consideration. ``"fission-q"`` will
-        use the fission Q values from the depletion chain, not taking
-        heating into consideration.
+        use the fission Q values from the depletion chain
     fission_q : dict, optional
         Dictionary of nuclides and their fission Q values [eV]. If not given,
         values will be pulled from the ``chain_file``. Only applicable
@@ -261,8 +260,6 @@ class Operator(TransportOperator):
         # Update status
         self.number.set_density(vec)
 
-        time_start = time.time()
-
         # Update material compositions and tally nuclides
         self._update_materials()
         nuclides = self._get_tally_nuclides()
@@ -273,8 +270,6 @@ class Operator(TransportOperator):
         # Run OpenMC
         openmc.lib.reset()
         openmc.lib.run()
-
-        time_openmc = time.time()
 
         # Extract results
         op_result = self._unpack_tallies_and_normalize(power)

--- a/openmc/deplete/results_list.py
+++ b/openmc/deplete/results_list.py
@@ -137,7 +137,7 @@ class ResultsList(list):
     def get_depletion_time(self):
         """Return an array of the average time to deplete a material
 
-        ..note::
+        .. note::
 
             Will have one fewer row than number of other methods,
             like :meth:`get_eigenvalues`, because no depletion
@@ -145,7 +145,6 @@ class ResultsList(list):
 
         Returns
         -------
-
         times : :class:`numpy.ndarray`
             Vector of average time to deplete a single material
             across all processes and materials.

--- a/openmc/lib/tally.py
+++ b/openmc/lib/tally.py
@@ -319,7 +319,7 @@ class Tally(_FortranObjectWithID):
     @scores.setter
     def scores(self, scores):
         scores_ = (c_char_p * len(scores))()
-        scores_[:] = [str(x).encode() for x in scores]
+        scores_[:] = [x.encode() for x in scores]
         _dll.openmc_tally_set_scores(self._index, len(scores), scores_)
 
     @property

--- a/openmc/lib/tally.py
+++ b/openmc/lib/tally.py
@@ -319,7 +319,7 @@ class Tally(_FortranObjectWithID):
     @scores.setter
     def scores(self, scores):
         scores_ = (c_char_p * len(scores))()
-        scores_[:] = [x.encode() for x in scores]
+        scores_[:] = [str(x).encode() for x in scores]
         _dll.openmc_tally_set_scores(self._index, len(scores), scores_)
 
     @property


### PR DESCRIPTION
This PR supersedes  #1342  and closes #1238 by using the newly modified heating and local heating (MT=301,901) heating numbers from #1344 to obtain the system energy. The MT score is passed directly on to the Tally object and requires no modifications to the C++ tally source code.

**NOTE** 
Without any MT901 data, the simulation will not fail until after the first transport simulation. The lack of MT901 data results in a zero-valued tally reflecting zero energy production. In this case, `Operator.__call__` will terminate the simulation after unpacking tallies and processing reaction rates but before
https://github.com/openmc-dev/openmc/blob/3dc0d1ad5dc4ce39466a8a95d2656a2c582c398d/openmc/deplete/operator.py#L635-L638