### PR TITLE
Cleaner depletion module documentation and namespace

### DIFF
--- a/docs/source/_templates/mycallable.rst
+++ b/docs/source/_templates/mycallable.rst
@@ -1,0 +1,9 @@
+{{ fullname }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+    :members:
+    :special-members: __call__
+    

--- a/docs/source/pythonapi/deplete.rst
+++ b/docs/source/pythonapi/deplete.rst
@@ -31,7 +31,7 @@ specific to OpenMC is available using the following class:
 .. autosummary::
    :toctree: generated
    :nosignatures:
-   :template: myclass.rst
+   :template: mycallable.rst
 
    Operator
 
@@ -82,6 +82,19 @@ data, such as number densities and reaction rates for each material.
    Results
    ResultsList
 
+The following functions are used to solve the depletion equations, with
+:func:`cram.CRAM48` being the default.
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+   :template: myfunction.rst
+
+   cram.CRAM16
+   cram.CRAM48
+   cram.deplete
+   cram.timed_deplete
+
 The following classes are used to help the :class:`openmc.deplete.Operator`
 compute quantities like effective fission yields, reaction rates, and
 total system energy.
@@ -119,16 +132,5 @@ base classes:
    :nosignatures:
    :template: myintegrator.rst
 
-   Integrator
-   SIIntegrator
-
-Each of the integrator classes also relies on a number of "helper" functions
-as follows:
-
-.. autosummary::
-   :toctree: generated
-   :nosignatures:
-   :template: myfunction.rst
-
-   cram.CRAM16
-   cram.CRAM48
+   abc.Integrator
+   abc.SIIntegrator

--- a/docs/source/pythonapi/deplete.rst
+++ b/docs/source/pythonapi/deplete.rst
@@ -51,14 +51,14 @@ specific to OpenMC is available using the following class:
    Operator
 
 The :class:`Operator` must also have some knowledge of how nuclides transmute
-and decay. This is handled by the :class:`Chain`
+and decay. This is handled by the :class:`Chain`.
 
 Minimal Example
 ---------------
 
 A minimal example for performing depletion would be:
 
-.. code:: Python
+.. code::
 
     >>> import openmc
     >>> import openmc.deplete
@@ -72,7 +72,7 @@ A minimal example for performing depletion would be:
 
     # Set up 5 time steps of one day each
     >>> dt = [24 * 60 * 60] * 5
-    >>> power = 1E6  # constant power of 1 MW
+    >>> power = 1e6  # constant power of 1 MW
 
     # Deplete using mid-point predictor-corrector
     >>> cecm = openmc.deplete.CECMIntegrator(

--- a/openmc/deplete/__init__.py
+++ b/openmc/deplete/__init__.py
@@ -35,7 +35,10 @@ from .nuclide import *
 from .chain import *
 from .operator import *
 from .reaction_rates import *
-from .abc import *
+from .atom_number import *
 from .results import *
 from .results_list import *
 from .integrators import *
+from . import abc
+from . import cram
+from . import helpers

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -24,6 +24,13 @@ from .results import Results
 from .chain import Chain
 from .results_list import ResultsList
 
+
+__all__ = [
+    "OperatorResult", "TransportOperator", "ReactionRateHelper",
+    "EnergyHelper", "FissionYieldHelper", "TalliedFissionYieldHelper",
+    "Integrator", "SIIntegrator"]
+
+
 OperatorResult = namedtuple('OperatorResult', ['k', 'rates'])
 OperatorResult.__doc__ = """\
 Result of applying transport operator

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -45,6 +45,8 @@ _REACTIONS = [
 ]
 
 
+__all__ = ["Chain"]
+
 def replace_missing(product, decay_data):
     """Replace missing product with suitable decay daughter.
 

--- a/openmc/deplete/cram.py
+++ b/openmc/deplete/cram.py
@@ -13,8 +13,6 @@ import scipy.sparse.linalg as sla
 
 from . import comm
 
-__all__ = ["deplete", "timed_deplete", "CRAM16", "CRAM48"]
-
 
 def deplete(chain, x, rates, dt, matrix_func=None):
     """Deplete materials using given reaction rates for a specified time

--- a/openmc/deplete/nuclide.py
+++ b/openmc/deplete/nuclide.py
@@ -17,6 +17,10 @@ from numpy import empty
 
 from openmc.checkvalue import check_type
 
+__all__ = [
+    "DecayTuple", "ReactionTuple", "Nuclide", "FissionYield",
+    "FissionYieldDistribution"]
+
 
 DecayTuple = namedtuple('DecayTuple', 'type target branching_ratio')
 DecayTuple.__doc__ = """\

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -30,6 +30,9 @@ from .helpers import (
     FissionYieldCutoffHelper, AveragedFissionYieldHelper)
 
 
+__all__ = ["Operator", "OperatorResult"]
+
+
 def _distribute(items):
     """Distribute items across MPI communicator
 

--- a/openmc/deplete/reaction_rates.py
+++ b/openmc/deplete/reaction_rates.py
@@ -7,6 +7,9 @@ from collections import OrderedDict
 import numpy as np
 
 
+__all__ = ["ReactionRates"]
+
+
 class ReactionRates(np.ndarray):
     """Reaction rates resulting from a transport operator call
 

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -16,6 +16,9 @@ from .reaction_rates import ReactionRates
 _VERSION_RESULTS = (1, 0)
 
 
+__all__ = ["Results"]
+
+
 class Results(object):
     """Output of a depletion run
 

--- a/openmc/deplete/results_list.py
+++ b/openmc/deplete/results_list.py
@@ -5,6 +5,9 @@ from .results import Results, _VERSION_RESULTS
 from openmc.checkvalue import check_filetype_version
 
 
+__all__ = ["ResultsList"]
+
+
 class ResultsList(list):
     """A list of openmc.deplete.Results objects
 


### PR DESCRIPTION
This PR does some tidying of the depletion module in two parts. First, the `openmc.deplete` namespace is de-cluttered by using `__all__` across most of the depletion files. Without this, the wildcard imports would also introduce all the supporting classes and modules, like `scipy.sparse as sp` into `openmc.deplete`. 

I've separated the API into a primary API that includes everything the average user will want and need to perform depletion [`Operator`, the concrete `Integrators`] and some of the useful helpers for passing around depletion data and results [`Chain`, `ResultsList`, `AtomNumber`, etc]. The three main submodules, `abc`, `cram`, and `helpers` are all imported separately and not included in the wildcard with
```
from . import abc
from . import cram
from . import helpers
```

Much of their content is already included by importing other modules, but this is consistent to how `ace` and `endf` modules are imported in `openmc.data`

https://github.com/openmc-dev/openmc/blob/5b132d05bfa76528b0b9858ff5fe4de2af517f6e/openmc/data/__init__.py#L17-L19

The depletion API documentation is also cleaned up a little bit. Similar separation into "Primary API", "Internal Classes and Functions" and "Abstract Base Classes" is presented, with a minimal example after the primary API. By reading first two sections, the average user should have all the information they need to run a depletion problem as they have been introduced to the Operator and Integrators.