### PR TITLE
Allow tests to run when OPENMC_ENDF_DATA is not set

### DIFF
--- a/tests/unit_tests/test_data_decay.py
+++ b/tests/unit_tests/test_data_decay.py
@@ -10,9 +10,6 @@ from uncertainties import ufloat
 import openmc.data
 
 
-_ENDF_DATA = os.environ['OPENMC_ENDF_DATA']
-
-
 def ufloat_close(a, b):
     assert a.nominal_value == pytest.approx(b.nominal_value)
     assert a.std_dev == pytest.approx(b.std_dev)
@@ -21,14 +18,16 @@ def ufloat_close(a, b):
 @pytest.fixture(scope='module')
 def nb90():
     """Nb90 decay data."""
-    filename = os.path.join(_ENDF_DATA, 'decay', 'dec-041_Nb_090.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'decay', 'dec-041_Nb_090.endf')
     return openmc.data.Decay.from_endf(filename)
 
 
 @pytest.fixture(scope='module')
 def u235_yields():
     """U235 fission product yield data."""
-    filename = os.path.join(_ENDF_DATA, 'nfy', 'nfy-092_U_235.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'nfy', 'nfy-092_U_235.endf')
     return openmc.data.FissionProductYields.from_endf(filename)
 
 

--- a/tests/unit_tests/test_data_neutron.py
+++ b/tests/unit_tests/test_data_neutron.py
@@ -9,7 +9,6 @@ import openmc.data
 from . import needs_njoy
 
 _TEMPERATURES = [300., 600., 900.]
-_ENDF_DATA = os.environ['OPENMC_ENDF_DATA']
 
 
 @pytest.fixture(scope='module')
@@ -23,14 +22,16 @@ def pu239():
 @pytest.fixture(scope='module')
 def xe135():
     """Xe135 ENDF data (contains SLBW resonance range)"""
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-054_Xe_135.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-054_Xe_135.endf')
     return openmc.data.IncidentNeutron.from_endf(filename)
 
 
 @pytest.fixture(scope='module')
 def sm150():
     """Sm150 ENDF data (contains MLBW resonance range)"""
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-062_Sm_150.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-062_Sm_150.endf')
     return openmc.data.IncidentNeutron.from_endf(filename)
 
 
@@ -38,69 +39,79 @@ def sm150():
 def gd154():
     """Gd154 ENDF data (contains Reich Moore resonance range and reosnance
     covariance with LCOMP=1)."""
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-064_Gd_154.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-064_Gd_154.endf')
     return openmc.data.IncidentNeutron.from_endf(filename, covariance=True)
 
 
 @pytest.fixture(scope='module')
 def cl35():
     """Cl35 ENDF data (contains RML resonance range)"""
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-017_Cl_035.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-017_Cl_035.endf')
     return openmc.data.IncidentNeutron.from_endf(filename)
 
 
 @pytest.fixture(scope='module')
 def am241():
     """Am241 ENDF data (contains Madland-Nix fission energy distribution)."""
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-095_Am_241.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-095_Am_241.endf')
     return openmc.data.IncidentNeutron.from_endf(filename)
 
 
 @pytest.fixture(scope='module')
 def u233():
     """U233 ENDF data (contains Watt fission energy distribution)."""
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-092_U_233.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-092_U_233.endf')
     return openmc.data.IncidentNeutron.from_endf(filename)
 
 
 @pytest.fixture(scope='module')
 def u236():
     """U236 ENDF data (contains Watt fission energy distribution)."""
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-092_U_236.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-092_U_236.endf')
     return openmc.data.IncidentNeutron.from_endf(filename)
 
 
 @pytest.fixture(scope='module')
 def na22():
     """Na22 ENDF data (contains evaporation spectrum)."""
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-011_Na_022.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-011_Na_022.endf')
     return openmc.data.IncidentNeutron.from_endf(filename)
 
 
 @pytest.fixture(scope='module')
 def na23():
     """Na23 ENDF data (contains MLBW resonance covariance with LCOMP=0)."""
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-011_Na_023.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-011_Na_023.endf')
     return openmc.data.IncidentNeutron.from_endf(filename, covariance=True)
 
 
 @pytest.fixture(scope='module')
 def be9():
     """Be9 ENDF data (contains laboratory angle-energy distribution)."""
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-004_Be_009.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-004_Be_009.endf')
     return openmc.data.IncidentNeutron.from_endf(filename)
 
 
 @pytest.fixture(scope='module')
 def h2():
-    endf_file = os.path.join(_ENDF_DATA, 'neutrons', 'n-001_H_002.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    endf_file = os.path.join(endf_data, 'neutrons', 'n-001_H_002.endf')
     return openmc.data.IncidentNeutron.from_njoy(
         endf_file, temperatures=_TEMPERATURES)
 
 
 @pytest.fixture(scope='module')
 def am244():
-    endf_file = os.path.join(_ENDF_DATA, 'neutrons', 'n-095_Am_244.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    endf_file = os.path.join(endf_data, 'neutrons', 'n-095_Am_244.endf')
     return openmc.data.IncidentNeutron.from_njoy(endf_file)
 
 
@@ -108,21 +119,24 @@ def am244():
 def ti50():
     """Ti50 ENDF data (contains Multi-level Breit-Wigner resonance range and
        resonance covariance with LCOMP=1)."""
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-022_Ti_050.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-022_Ti_050.endf')
     return openmc.data.IncidentNeutron.from_endf(filename, covariance=True)
 
 
 @pytest.fixture(scope='module')
 def cf252():
     """Cf252 ENDF data (contains RM resonance covariance with LCOMP=0)."""
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-098_Cf_252.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-098_Cf_252.endf')
     return openmc.data.IncidentNeutron.from_endf(filename, covariance=True)
 
 
 @pytest.fixture(scope='module')
 def th232():
     """Th232 ENDF data (contains RM resonance covariance with LCOMP=2)."""
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-090_Th_232.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-090_Th_232.endf')
     return openmc.data.IncidentNeutron.from_endf(filename, covariance=True)
 
 
@@ -458,7 +472,8 @@ def test_laboratory(be9):
 
 @needs_njoy
 def test_correlated(tmpdir):
-    endf_file = os.path.join(_ENDF_DATA, 'neutrons', 'n-014_Si_030.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    endf_file = os.path.join(endf_data, 'neutrons', 'n-014_Si_030.endf')
     si30 = openmc.data.IncidentNeutron.from_njoy(endf_file, heatr=False)
 
     # Convert to HDF5 and read back
@@ -484,7 +499,8 @@ def test_nbody(tmpdir, h2):
 
 @needs_njoy
 def test_ace_convert(run_in_tmpdir):
-    filename = os.path.join(_ENDF_DATA, 'neutrons', 'n-001_H_001.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'neutrons', 'n-001_H_001.endf')
     ace_ascii = 'ace_ascii'
     ace_binary = 'ace_binary'
     openmc.data.njoy.make_ace(filename, acer=ace_ascii)

--- a/tests/unit_tests/test_data_photon.py
+++ b/tests/unit_tests/test_data_photon.py
@@ -9,19 +9,17 @@ import pytest
 import openmc.data
 
 
-_ENDF_DATA = os.environ['OPENMC_ENDF_DATA']
-
-
 @pytest.fixture(scope='module')
 def elements_endf():
     """Dictionary of element ENDF data indexed by atomic symbol."""
+    endf_data = os.environ['OPENMC_ENDF_DATA']
     elements = {'H': 1, 'O': 8, 'Al': 13, 'Cu': 29, 'Ag': 47, 'U': 92, 'Pu': 94}
     data = {}
     for symbol, Z in elements.items():
         p_file = 'photoat-{:03}_{}_000.endf'.format(Z, symbol)
-        p_path = os.path.join(_ENDF_DATA, 'photoat', p_file)
+        p_path = os.path.join(endf_data, 'photoat', p_file)
         a_file = 'atom-{:03}_{}_000.endf'.format(Z, symbol)
-        a_path = os.path.join(_ENDF_DATA, 'atomic_relax', a_file)
+        a_path = os.path.join(endf_data, 'atomic_relax', a_file)
         data[symbol] = openmc.data.IncidentPhoton.from_endf(p_path, a_path)
     return data
 

--- a/tests/unit_tests/test_data_thermal.py
+++ b/tests/unit_tests/test_data_thermal.py
@@ -10,9 +10,6 @@ import openmc.data
 from . import needs_njoy
 
 
-_ENDF_DATA = os.environ['OPENMC_ENDF_DATA']
-
-
 @pytest.fixture(scope='module')
 def h2o():
     """H in H2O thermal scattering data."""
@@ -32,8 +29,9 @@ def graphite():
 @pytest.fixture(scope='module')
 def h2o_njoy():
     """H in H2O generated using NJOY."""
-    path_h1 = os.path.join(_ENDF_DATA, 'neutrons', 'n-001_H_001.endf')
-    path_h2o = os.path.join(_ENDF_DATA, 'thermal_scatt', 'tsl-HinH2O.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    path_h1 = os.path.join(endf_data, 'neutrons', 'n-001_H_001.endf')
+    path_h2o = os.path.join(endf_data, 'thermal_scatt', 'tsl-HinH2O.endf')
     return openmc.data.ThermalScattering.from_njoy(
         path_h1, path_h2o, temperatures=[293.6, 500.0])
 
@@ -41,15 +39,17 @@ def h2o_njoy():
 @pytest.fixture(scope='module')
 def hzrh():
     """H in ZrH thermal scattering data."""
-    filename = os.path.join(_ENDF_DATA, 'thermal_scatt', 'tsl-HinZrH.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'thermal_scatt', 'tsl-HinZrH.endf')
     return openmc.data.ThermalScattering.from_endf(filename)
 
 
 @pytest.fixture(scope='module')
 def hzrh_njoy():
     """H in ZrH generated using NJOY."""
-    path_h1 = os.path.join(_ENDF_DATA, 'neutrons', 'n-001_H_001.endf')
-    path_hzrh = os.path.join(_ENDF_DATA, 'thermal_scatt', 'tsl-HinZrH.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    path_h1 = os.path.join(endf_data, 'neutrons', 'n-001_H_001.endf')
+    path_hzrh = os.path.join(endf_data, 'thermal_scatt', 'tsl-HinZrH.endf')
     with_endf_data = openmc.data.ThermalScattering.from_njoy(
         path_h1, path_hzrh, temperatures=[296.0], iwt=0
     )
@@ -62,7 +62,8 @@ def hzrh_njoy():
 @pytest.fixture(scope='module')
 def sio2():
     """SiO2 thermal scattering data."""
-    filename = os.path.join(_ENDF_DATA, 'thermal_scatt', 'tsl-SiO2.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'thermal_scatt', 'tsl-SiO2.endf')
     return openmc.data.ThermalScattering.from_endf(filename)
 
 
@@ -100,11 +101,11 @@ def test_graphite_xs(graphite):
     elastic = graphite.elastic.xs['296K']
     assert elastic([1e-3, 1.0]) == pytest.approx([0.0, 0.62586153])
 
-
 @needs_njoy
 def test_graphite_njoy():
-    path_c0 = os.path.join(_ENDF_DATA, 'neutrons', 'n-006_C_000.endf')
-    path_gr = os.path.join(_ENDF_DATA, 'thermal_scatt', 'tsl-graphite.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    path_c0 = os.path.join(endf_data, 'neutrons', 'n-006_C_000.endf')
+    path_gr = os.path.join(endf_data, 'thermal_scatt', 'tsl-graphite.endf')
     graphite = openmc.data.ThermalScattering.from_njoy(
         path_c0, path_gr, temperatures=[296.0])
     assert graphite.nuclides == ['C0', 'C12', 'C13']
@@ -141,7 +142,8 @@ def test_continuous_dist(h2o_njoy):
 
 
 def test_h2o_endf():
-    filename = os.path.join(_ENDF_DATA, 'thermal_scatt', 'tsl-HinH2O.endf')
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = os.path.join(endf_data, 'thermal_scatt', 'tsl-HinH2O.endf')
     h2o = openmc.data.ThermalScattering.from_endf(filename)
     assert not h2o.elastic
     assert h2o.atomic_weight_ratio == pytest.approx(0.99917)

--- a/tests/unit_tests/test_deplete_chain.py
+++ b/tests/unit_tests/test_deplete_chain.py
@@ -12,8 +12,6 @@ import pytest
 
 from tests import cdtemp
 
-_ENDF_DATA = Path(os.environ['OPENMC_ENDF_DATA'])
-
 _TEST_CHAIN = """\
 <depletion_chain>
   <nuclide name="A" half_life="23652.0" decay_modes="2" decay_energy="0.0" reactions="1">
@@ -67,9 +65,10 @@ def test_len():
 
 def test_from_endf():
     """Test depletion chain building from ENDF files"""
-    decay_data = (_ENDF_DATA / 'decay').glob('*.endf')
-    fpy_data = (_ENDF_DATA / 'nfy').glob('*.endf')
-    neutron_data = (_ENDF_DATA / 'neutrons').glob('*.endf')
+    endf_data = Path(os.environ['OPENMC_ENDF_DATA'])
+    decay_data = (endf_data / 'decay').glob('*.endf')
+    fpy_data = (endf_data / 'nfy').glob('*.endf')
+    neutron_data = (endf_data / 'neutrons').glob('*.endf')
     chain = Chain.from_endf(decay_data, fpy_data, neutron_data)
 
     assert len(chain) == len(chain.nuclides) == len(chain.nuclide_dict) == 3820


### PR DESCRIPTION
Currently you cannot run the test suite without first setting the `OPENMC_ENDF_DATA` environment variable. Without that environment variable set, pytest runs into some errors when searching for tests and then doesn't run any tests at all. Here's an example output from the failure:
```
_____________ ERROR collecting tests/unit_tests/test_data_decay.py _____________
test_data_decay.py:13: in <module>
    _ENDF_DATA = os.environ['OPENMC_ENDF_DATA']
/usr/lib/python3.6/os.py:669: in __getitem__
    raise KeyError(key) from None
E   KeyError: 'OPENMC_ENDF_DATA'
```
Obviously, `OPENMC_ENDF_DATA` must be set appropriately for all the tests to pass, but it's still nice to have the ability to do a blanket test suite run without first setting up the ENDF data and see that the other tests pass.

This PR moves the relevant code inspecting that environment variable into the test functions. Now pytest will run the whole suite and just fail the tests that require the ENDF data.