### PR TITLE
Add a missing virtual destructor on Mesh

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -33,9 +33,10 @@ extern std::unordered_map<int32_t, int32_t> mesh_map;
 class Mesh
 {
 public:
-  // Constructors
+  // Constructors and destructor
   Mesh() = default;
   Mesh(pugi::xml_node node);
+  virtual ~Mesh() = default;
 
   // Methods
 


### PR DESCRIPTION
Simple PR here -- clang complains a missing virtual destructor on Mesh, so I've added that in.