### PR TITLE
I/O Fixes

### DIFF
--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -97,16 +97,17 @@ class Summary(object):
                 self._macroscopics = name.decode()
 
     def _read_geometry(self):
-        if "dagmc" in self._f['geometry'].attrs.keys():
-            return
 
-        # Read in and initialize the Materials and Geometry
+        # Read in and initialize the Materials
         self._read_materials()
-        self._read_surfaces()
-        cell_fills = self._read_cells()
-        self._read_universes()
-        self._read_lattices()
-        self._finalize_geometry(cell_fills)
+
+        # Read native geometry only
+        if "dagmc" not in self._f['geometry'].attrs.keys():
+            self._read_surfaces()
+            cell_fills = self._read_cells()
+            self._read_universes()
+            self._read_lattices()
+            self._finalize_geometry(cell_fills)
 
     def _read_materials(self):
         for group in self._f['materials'].values():

--- a/openmc/volume.py
+++ b/openmc/volume.py
@@ -212,13 +212,12 @@ class VolumeCalculation(object):
                     ids.append(domain_id)
                     group = f[obj_name]
                     volume = ufloat(*group['volume'][()])
+                    volumes[domain_id] = volume
                     nucnames = group['nuclides'][()]
                     atoms_ = group['atoms'][()]
-
                     atom_dict = OrderedDict()
                     for name_i, atoms_i in zip(nucnames, atoms_):
                         atom_dict[name_i.decode()] = ufloat(*atoms_i)
-                    volumes[domain_id] = volume
                     atoms[domain_id] = atom_dict
 
         # Instantiate some throw-away domains that are used by the constructor

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -311,21 +311,19 @@ void VolumeCalculation::to_hdf5(const std::string& filename,
     // Create array of nuclide names from the vector
     auto n_nuc = result.nuclides.size();
 
-    if (!result.nuclides.empty()) {
-      std::vector<std::string> nucnames;
-      for (int i_nuc : result.nuclides) {
-        nucnames.push_back(data::nuclides[i_nuc]->name_);
-      }
-
-      // Create array of total # of atoms with uncertainty for each nuclide
-      xt::xtensor<double, 2> atom_data({n_nuc, 2});
-      xt::view(atom_data, xt::all(), 0) = xt::adapt(result.atoms);
-      xt::view(atom_data, xt::all(), 1) = xt::adapt(result.uncertainty);
-
-      // Write results
-      write_dataset(group_id, "nuclides", nucnames);
-      write_dataset(group_id, "atoms", atom_data);
+    std::vector<std::string> nucnames;
+    for (int i_nuc : result.nuclides) {
+      nucnames.push_back(data::nuclides[i_nuc]->name_);
     }
+
+    // Create array of total # of atoms with uncertainty for each nuclide
+    xt::xtensor<double, 2> atom_data({n_nuc, 2});
+    xt::view(atom_data, xt::all(), 0) = xt::adapt(result.atoms);
+    xt::view(atom_data, xt::all(), 1) = xt::adapt(result.uncertainty);
+
+    // Write results
+    write_dataset(group_id, "nuclides", nucnames);
+    write_dataset(group_id, "atoms", atom_data);
 
     close_group(group_id);
   }


### PR DESCRIPTION
This PR contains a few updates to file IO: 

  - Allow material reading if the statepoint file is from a DagMC run, only the is undefined there. The materials are still valid and can be used as usual.
  - Write empty groups for `atoms`, `nuclides` for domains with zero volume in a volume calculation (see #1360 for reference)

Another very small change is setting the volume value for the domain ID right after the volume value is extracted from the statepoint file, for clarity.