### PR TITLE
Make sure from_ace classmethods get correct type of ACE table

### DIFF
--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -588,6 +588,9 @@ class IncidentNeutron(EqualityMixin):
 
         # If mass number hasn't been specified, make an educated guess
         zaid, xs = ace.name.split('.')
+        if not xs.endswith('c'):
+            raise TypeError(
+                "{} is not a continuous-energy neutron ACE table.".format(ace))
         name, element, Z, mass_number, metastable = \
             get_metadata(int(zaid), metastable_scheme)
 

--- a/openmc/data/photon.py
+++ b/openmc/data/photon.py
@@ -549,7 +549,9 @@ class IncidentPhoton(EqualityMixin):
             ace = get_table(ace_or_filename)
 
         # Get atomic number based on name of ACE table
-        zaid = ace.name.split('.')[0]
+        zaid, xs = ace.name.split('.')
+        if not xs.endswith('p'):
+            raise TypeError("{} is not a photoatomic transport ACE table.".format(ace))
         Z = get_metadata(int(zaid))[2]
 
         # Read each reaction

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -600,6 +600,8 @@ class ThermalScattering(EqualityMixin):
 
         # Get new name that is GND-consistent
         ace_name, xs = ace.name.split('.')
+        if not xs.endswith('t'):
+            raise TypeError("{} is not a thermal scattering ACE table.".format(ace))
         name = get_thermal_name(ace_name)
 
         # Assign temperature to the running list


### PR DESCRIPTION
Right now if you call `from_ace` on one of our data classes with the wrong type of ACE table, you'll get a weird error, at some point. This PR simply adds a check up front that the suffix on the ACE table is correct for the class that it is being passed to (`c` for continuous-energy neutron, `t` for thermal scattering, `p` for photoatomic).

Credit to @Shimwell for identifying this.