### PR TITLE
Correction to `id_` attribute in Material/Filter classes

### DIFF
--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -120,7 +120,7 @@ public:
   //! Assign a unique ID to the material
   //! \param[in] Unique ID to assign. A value of -1 indicates that an ID
   //!   should be automatically assigned.
-  void set_id(int32_t id);
+  void set_id(int32_t id = -1);
 
   //! Get whether material is fissionable
   //! \return Whether material is fissionable
@@ -132,7 +132,7 @@ public:
 
   //----------------------------------------------------------------------------
   // Data
-  int32_t id_; //!< Unique ID
+  int32_t id_ {-1}; //!< Unique ID
   std::string name_; //!< Name of material
   std::vector<int> nuclide_; //!< Indices in nuclides vector
   std::vector<int> element_; //!< Indices in elements vector

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -120,7 +120,7 @@ public:
   //! Assign a unique ID to the material
   //! \param[in] Unique ID to assign. A value of -1 indicates that an ID
   //!   should be automatically assigned.
-  void set_id(int32_t id = -1);
+  void set_id(int32_t id);
 
   //! Get whether material is fissionable
   //! \return Whether material is fissionable

--- a/include/openmc/tallies/filter.h
+++ b/include/openmc/tallies/filter.h
@@ -104,7 +104,7 @@ public:
   //! Assign a unique ID to the filter
   //! \param[in]  Unique ID to assign. A value of -1 indicates that an ID should
   //!   be automatically assigned
-  void set_id(int32_t id = -1);
+  void set_id(int32_t id);
 
   //! Get number of bins
   //! \return Number of bins

--- a/include/openmc/tallies/filter.h
+++ b/include/openmc/tallies/filter.h
@@ -104,7 +104,7 @@ public:
   //! Assign a unique ID to the filter
   //! \param[in]  Unique ID to assign. A value of -1 indicates that an ID should
   //!   be automatically assigned
-  void set_id(int32_t id);
+  void set_id(int32_t id = -1);
 
   //! Get number of bins
   //! \return Number of bins

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -873,8 +873,8 @@ void Material::set_id(int32_t id)
   // If no ID specified, auto-assign next ID in sequence
   if (id == -1) {
     id = 0;
-    for (const auto& f : model::materials) {
-      id = std::max(id, f->id_);
+    for (const auto& m : model::materials) {
+      id = std::max(id, m->id_);
     }
     ++id;
   }


### PR DESCRIPTION
In #1362, an error was reported regarding `std::out_of_range` being thrown when initializing materials. It was thought that this had to do with the number of nuclides, but turned out to be a problem with a material ID set to zero.

I found the problem [here](https://github.com/openmc-dev/openmc/blob/a8d90844a38cb85eb3f051d74ec5e71dec613857/src/material.cpp#L863) in `material.cpp`. The `id_` attribute of material is uninitialized and by default will be `0` when the object is created. This method is used in the constructor of `Material` so we'll always enter that logical block and remove the entry with a key of zero from the `model::material_map`. I found a similar bug in our `Filter` class. 

The easy fix here is to initialize the `id_` attribute of these classes to `-1`, as expected by the `set_id` method, but the logic here seems inconsistent with what exists in the Python API where our automatic indexing begins at 1. Should we be updating one or the other to match?

There was also a block intending to set IDs automatically (as we do in the Python API), which wouldn't be accessed unless the user passes `-1` to `set_id`, so I added a default argument there.

