### PR TITLE
Make sure Shannon entropy mesh without dimension can be assigned

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -155,7 +155,8 @@ RegularMesh::RegularMesh(pugi::xml_node node)
     fatal_error("Must specify either <upper_right> and <width> on a mesh.");
   }
 
-  if (shape_.dimension() > 0) {
+  // TODO: Change to zero when xtensor is updated
+  if (shape_.size() > 1) {
     if (shape_.size() != lower_left_.size()) {
       fatal_error("Number of entries on <lower_left> must be the same "
         "as the number of entries on <dimension>.");

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -512,7 +512,8 @@ void read_settings_xml()
     if (!m) fatal_error("Only regular meshes can be used as an entropy mesh");
     simulation::entropy_mesh = m;
 
-    if (m->shape_.dimension() == 0) {
+    // TODO: Change to zero when xtensor is updated
+    if (m->shape_.size() == 1) {
       // If the user did not specify how many mesh cells are to be used in
       // each direction, we automatically determine an appropriate number of
       // cells


### PR DESCRIPTION
A user is supposed to be allowed to assign a regular mesh for Shannon entropy that doesn't have assigned dimensions. In this case, the code will automatically assign a number of dimensions based on the number of particles per batch (same heuristic that MCNP uses). I discovered that this was actually broken, as can be observed by trying to run [this model](https://github.com/mit-crpg/benchmarks/tree/master/icsbep/pu-sol-therm-018/openmc/case-1). This PR fixes that auto-assignment.