### PR TITLE
Fix for Mesh __repr__  methods

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -530,14 +530,24 @@ class RectilinearMesh(MeshBase):
         self._z_grid = grid
 
     def __repr__(self):
+        fmt = '{0: <16}{1}{2}\n'
         string = super().__repr__()
-        string += '{0: <16}{1}{2}\n'.format('\tDimensions', '=\t', self.n_dimension)
+        string += fmt.format('\tDimensions', '=\t', self.n_dimension)
         x_grid_str = str(self._x_grid) if not self._x_grid else len(self._x_grid)
+        string += fmt.format('\tN X pnts:', '=\t', x_grid_str)
+        if self._x_grid:
+            string += fmt.format('\tX Min:', '=\t', self._x_grid[0])
+            string += fmt.format('\tX Max:', '=\t', self._x_grid[-1])
         y_grid_str = str(self._y_grid) if not self._y_grid else len(self._y_grid)
+        string += fmt.format('\tN Y pnts:', '=\t', y_grid_str)
+        if self._y_grid:
+            string += fmt.format('\tY Min:', '=\t', self._y_grid[0])
+            string += fmt.format('\tY Max:', '=\t', self._y_grid[-1])
         z_grid_str = str(self._z_grid) if not self._z_grid else len(self._z_grid)
-        string += '{0: <16}{1}{2}\n'.format('\tx pnts:', '=\t', x_grid_str)
-        string += '{0: <16}{1}{2}\n'.format('\ty pnts:', '=\t', y_grid_str)
-        string += '{0: <16}{1}{2}\n'.format('\tz pnts:', '=\t', z_grid_str)
+        string += fmt.format('\tN Z pnts:', '=\t', z_grid_str)
+        if self._z_grid:
+            string += fmt.format('\tZ Min:', '=\t', self._z_grid[0])
+            string += fmt.format('\tZ Max:', '=\t', self._z_grid[-1])
         return string
 
     @classmethod

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -53,6 +53,12 @@ class MeshBase(IDManagerMixin, metaclass=ABCMeta):
         else:
             self._name = ''
 
+    def __repr__(self):
+        string = type(self).__name__ + '\n'
+        string += '{0: <16}{1}{2}\n'.format('\tID', '=\t', self._id)
+        string += '{0: <16}{1}{2}\n'.format('\tName', '=\t', self._name)
+        return string
+
     @classmethod
     def from_hdf5(cls, group):
         """Create mesh from HDF5 group
@@ -126,7 +132,10 @@ class RegularMesh(MeshBase):
 
     @property
     def n_dimension(self):
-        return len(self._dimension)
+        if self._dimension is not None:
+            return len(self._dimension)
+        else:
+            return None
 
     @property
     def lower_left(self):
@@ -187,11 +196,9 @@ class RegularMesh(MeshBase):
         self._width = width
 
     def __repr__(self):
-        string = 'RegularMesh\n'
-        string += '{0: <16}{1}{2}\n'.format('\tID', '=\t', self._id)
-        string += '{0: <16}{1}{2}\n'.format('\tName', '=\t', self._name)
-        string += '{0: <16}{1}{2}\n'.format('\tType', '=\t', self._type)
-        string += '{0: <16}{1}{2}\n'.format('\tBasis', '=\t', self._dimension)
+        string = super().__repr__()
+        string += '{0: <16}{1}{2}\n'.format('\tDimensions', '=\t', self.n_dimension)
+        string += '{0: <16}{1}{2}\n'.format('\tMesh Cells', '=\t', self._dimension)
         string += '{0: <16}{1}{2}\n'.format('\tWidth', '=\t', self._lower_left)
         string += '{0: <16}{1}{2}\n'.format('\tOrigin', '=\t', self._upper_right)
         string += '{0: <16}{1}{2}\n'.format('\tPixels', '=\t', self._width)
@@ -521,6 +528,17 @@ class RectilinearMesh(MeshBase):
     def z_grid(self, grid):
         cv.check_type('mesh z_grid', grid, Iterable, Real)
         self._z_grid = grid
+
+    def __repr__(self):
+        string = super().__repr__()
+        string += '{0: <16}{1}{2}\n'.format('\tDimensions', '=\t', self.n_dimension)
+        x_grid_str = str(self._x_grid) if not self._x_grid else len(self._x_grid)
+        y_grid_str = str(self._y_grid) if not self._y_grid else len(self._y_grid)
+        z_grid_str = str(self._z_grid) if not self._z_grid else len(self._z_grid)
+        string += '{0: <16}{1}{2}\n'.format('\tx pnts:', '=\t', x_grid_str)
+        string += '{0: <16}{1}{2}\n'.format('\ty pnts:', '=\t', y_grid_str)
+        string += '{0: <16}{1}{2}\n'.format('\tz pnts:', '=\t', z_grid_str)
+        return string
 
     @classmethod
     def from_hdf5(cls, group):


### PR DESCRIPTION
I noticed that the `Mesh` classes in our Python API were failing to generate their string representations due to a missing `_type` attribute. Even doing something like:

```python
import openmc

mesh = openmc.RegularMesh()

print(mesh)

mesh = openmc.RectilinearMesh()

print(mesh)

mesh.x_grid = (-1.0, 0.0, 0.5, 10.0)

print(mesh)
```

would fail with 

```python
Traceback (most recent call last):
  File "mesh_test.py", line 5, in <module>
    print(mesh)
  File "/home/shriwise/opt/openmc/src/openmc/mesh.py", line 193, in __repr__
    string += '{0: <16}{1}{2}\n'.format('\tType', '=\t', self._type)
AttributeError: 'RegularMesh' object has no attribute '_type'
```
I was a little stuck with what to do about reporting the x/y/z points for `RectilinearMesh`, so I settled for the number of points in each dimension and their extents. The output now looks like:

```bash
RegularMesh
	ID             =	1
	Name           =	
	Dimensions     =	None
	Mesh Cells     =	None
	Width          =	None
	Origin         =	None
	Pixels         =	None

RectilinearMesh
	ID             =	2
	Name           =	
	Dimensions     =	3
	N X pnts:      =	None
	N Y pnts:      =	None
	N Z pnts:      =	None

RectilinearMesh
	ID             =	2
	Name           =	
	Dimensions     =	3
	N X pnts:      =	4
	X Min:         =	-1.0
	X Max:         =	10.0
	N Y pnts:      =	None
	N Z pnts:      =	None
```

