### PR TITLE
Fix tally mesh bug for very short tracks

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -523,6 +523,14 @@ void RegularMesh::bins_crossed(const Particle* p, std::vector<int>& bins,
   }
   r1 = r;
 
+  // The TINY_BIT offsets above mean that the preceding logic cannot always find
+  // the correct ijk0 and ijk1 indices. For tracks shorter than 2*TINY_BIT, just
+  // assume the track lies in only one mesh bin. These tracks are very short so
+  // any error caused by this assumption will be small.
+  if (total_distance < 2*TINY_BIT) {
+    for (int i = 0; i < n; ++i) ijk0[i] = ijk1[i];
+  }
+
   // ========================================================================
   // Find which mesh cells are traversed and the length of each traversal.
 
@@ -897,6 +905,14 @@ void RectilinearMesh::bins_crossed(const Particle* p, std::vector<int>& bins,
     if (!intersects(r0, r1, ijk0)) return;
   }
   r1 = r;
+
+  // The TINY_BIT offsets above mean that the preceding logic cannot always find
+  // the correct ijk0 and ijk1 indices. For tracks shorter than 2*TINY_BIT, just
+  // assume the track lies in only one mesh bin. These tracks are very short so
+  // any error caused by this assumption will be small.
+  if (total_distance < 2*TINY_BIT) {
+    for (int i = 0; i < 3; ++i) ijk0[i] = ijk1[i];
+  }
 
   // ========================================================================
   // Find which mesh cells are traversed and the length of each traversal.


### PR DESCRIPTION
I dug up a bug where `Mesh::bins_crossed` would give the wrong results for tracks that are shorter than `2 * TINY_BIT`. It's a pretty rare bug. I only found it when running 100's of millions of neutrons on 3D assembly problems. I probably wouldn't have known it was cropping up except that it can make OpenMC output non-zero fission rates for mesh cells with no fissionable material.

In the `Mesh::bins_crossed` logic, we first determine which mesh cells, `ijk0` and `ijk1`, contain the start and end points for the particle track. While determining `ijk0` and `ijk1` we nudge the starting and ending coordinates closer together by a `TINY_BIT` on both ends. (I'm not sure why we do that; it's some sort of finite-precision fix.) If the track is right next to a mesh boundary and shorter than `2*TINY_BIT` then this code will actually pick an `ijk1` that is in the wrong direction from `ijk0`. I think what happens then is that the code starts from `ijk0` and marches all the way through the mesh since it never hits the `ijk == ijk1` condition.

For the fix, I just check for these very short tracks and set `ijk0` and `ijk1` to the same value. In other words, it forces the whole contribution from that track to just lie in one of the mesh cells. This could add some small bias versus actually trying to precisely divide up the track among the two mesh cells, but in practice I expect it won't matter because `2*TINY_BIT` is 20 nanometers so the tally contribution will be very very small anyway.