### PR TITLE
Allow voxel plots to be colored by material

### DIFF
--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -908,11 +908,13 @@ void create_voxel(Plot pl)
     // generate ids using plotbase
     IdData ids = pltbase.get_map<IdData>();
 
-    // select only cell ID data and flip the y-axis
-    xt::xtensor<int32_t, 2> data1 = xt::flip(xt::view(ids.data_, xt::all(), xt::all(), 0), 0);
+    // select only cell/material ID data and flip the y-axis
+    int idx = pl.color_by_ == PlotColorBy::cells ? 0 : 1;
+    xt::xtensor<int32_t, 2> data_slice = xt::view(ids.data_, xt::all(), xt::all(), idx);
+    xt::xtensor<int32_t, 2> data_flipped = xt::flip(data_slice, 0);
 
     // Write to HDF5 dataset
-    voxel_write_slice(z, dspace, dset, memspace, &(data1(0,0)));
+    voxel_write_slice(z, dspace, dset, memspace, data_flipped.data());
   }
 
   voxel_finalize(dspace, dset, memspace);


### PR DESCRIPTION
As [pointed out](https://groups.google.com/forum/#!topic/openmc-users/ZpHI4H7rp-I) by a user, currently the `Plot.color_by` option does not work for voxel plots. This PR fixes that.