### PR TITLE
Export CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,11 @@ endif()
 #===============================================================================
 
 add_library(pugixml vendor/pugixml/pugixml.cpp)
-target_include_directories(pugixml PUBLIC vendor/pugixml/)
+target_include_directories(pugixml
+  PUBLIC
+    $<INSTALL_INTERFACE:include/pugixml>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/pugixml>
+)
 
 #===============================================================================
 # xtensor header-only library
@@ -134,7 +138,11 @@ target_link_libraries(xtensor INTERFACE xtl)
 #===============================================================================
 
 add_library(gsl INTERFACE)
-target_include_directories(gsl INTERFACE vendor/gsl/include)
+target_include_directories(gsl
+  INTERFACE
+    $<INSTALL_INTERFACE:include/gsl/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/gsl/include>
+)
 
 # Make sure contract violations throw exceptions
 target_compile_definitions(gsl INTERFACE GSL_THROW_ON_CONTRACT_VIOLATION)
@@ -172,7 +180,11 @@ endif()
 #===============================================================================
 
 add_library(faddeeva STATIC vendor/faddeeva/Faddeeva.cc)
-target_include_directories(faddeeva PUBLIC vendor/faddeeva/)
+target_include_directories(faddeeva
+  PUBLIC
+    $<INSTALL_INTERFACE:include/faddeeva>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/faddeeva>
+)
 target_compile_options(faddeeva PRIVATE ${cxxflags})
 
 #===============================================================================
@@ -283,7 +295,11 @@ set_target_properties(libopenmc PROPERTIES
   OUTPUT_NAME openmc)
 
 target_include_directories(libopenmc
-  PUBLIC include ${HDF5_INCLUDE_DIRS})
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    ${HDF5_INCLUDE_DIRS}
+)
 
 # Set compile flags
 target_compile_options(libopenmc PRIVATE ${cxxflags})
@@ -343,12 +359,28 @@ add_custom_command(TARGET libopenmc POST_BUILD
 # Install executable, scripts, manpage, license
 #===============================================================================
 
-install(TARGETS openmc libopenmc
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  )
-install(DIRECTORY src/relaxng DESTINATION share/openmc)
-install(FILES man/man1/openmc.1 DESTINATION share/man/man1)
-install(FILES LICENSE DESTINATION "share/doc/openmc" RENAME copyright)
-install(DIRECTORY include/ DESTINATION include)
+include(GNUInstallDirs)
+set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/OpenMC)
+install(TARGETS openmc libopenmc pugixml faddeeva gsl
+  EXPORT openmc-targets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(EXPORT openmc-targets
+  FILE OpenMCTargets.cmake
+  NAMESPACE OpenMC::
+  DESTINATION ${INSTALL_CONFIGDIR})
+
+install(DIRECTORY src/relaxng DESTINATION ${CMAKE_INSTALL_DATADIR}/openmc)
+install(FILES cmake/OpenMCConfig.cmake DESTINATION ${INSTALL_CONFIGDIR})
+install(FILES man/man1/openmc.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+install(FILES LICENSE DESTINATION "${CMAKE_INSTALL_DOCDIR}" RENAME copyright)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# Copy headers for vendored dependencies (note that xtensor/xtl are handled
+# separately since they are managed by CMake)
+install(DIRECTORY vendor/pugixml DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING PATTERN "*.hpp")
+install(DIRECTORY vendor/gsl DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY vendor/faddeeva DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/cmake/OpenMCConfig.cmake
+++ b/cmake/OpenMCConfig.cmake
@@ -1,0 +1,8 @@
+get_filename_component(OpenMC_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
+
+find_package(xtl REQUIRED HINTS ${OpenMC_CMAKE_DIR}/../xtl)
+find_package(xtensor REQUIRED HINTS ${OpenMC_CMAKE_DIR}/../xtensor)
+
+if(NOT TARGET OpenMC::libopenmc)
+  include("${OpenMC_CMAKE_DIR}/OpenMCTargets.cmake")
+endif()


### PR DESCRIPTION
This PR changes up our CMakeLists.txt file a bit to export targets properly. This makes it so that a downstream project could do something like:
```cmake
find_package(OpenMC REQUIRED)
target_link_libraries(foo OpenMC::libopenmc)
```
And all the transitive dependencies, includes, etc. are handled automatically by the imported target.