### PR TITLE
Exposing write summary.h5 settings option to CAPI.

### DIFF
--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -31,7 +31,7 @@ extern "C" bool cmfd_run;             //!< is a CMFD run?
 extern "C" bool dagmc;                //!< indicator of DAGMC geometry
 extern "C" bool entropy_on;           //!< calculate Shannon entropy?
 extern bool legendre_to_tabular;      //!< convert Legendre distributions to tabular?
-extern bool output_summary;           //!< write summary.h5?
+extern "C" bool output_summary;       //!< write summary.h5?
 extern bool output_tallies;           //!< write tallies.out?
 extern bool particle_restart_run;     //!< particle restart run?
 extern "C" bool photon_transport;     //!< photon transport turned on?

--- a/openmc/lib/settings.py
+++ b/openmc/lib/settings.py
@@ -26,6 +26,7 @@ class _Settings(object):
     restart_run = _DLLGlobal(c_bool, 'restart_run')
     run_CE = _DLLGlobal(c_bool, 'run_CE')
     verbosity = _DLLGlobal(c_int, 'verbosity')
+    output_summary = _DLLGlobal(c_bool, 'output_summary')
 
     @property
     def run_mode(self):


### PR DESCRIPTION
Exposing this symbol in the CAPI so the OpenMC plotter can avoid writing it during a model reload. 

While developing tally visualization in the plotter GUI, having an open statepoint file used to access tally information at the same time as a model reload will cause an error as HDF5 won't allow writing to an open file ID. And because the plotter now relies entirely on the CAPI, we need to have it availble here. Additionally, that application probably shouldn't be overwriting files if it isn't necessary.