### PR TITLE
Fixed volume allocation in openmc.deplete.Operator._differentiate_burnable_mats

### DIFF
--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -309,7 +309,12 @@ class Operator(TransportOperator):
             # Assign distribmats to cells
             for cell in self.geometry.get_all_material_cells().values():
                 if cell.fill in distribmats and cell.num_instances > 1:
-                    cell.fill = [cell.fill.clone()
+                    mat = cell.fill
+                    if mat.volume is None:
+                        raise RuntimeError("Volume not specified for depletable "
+                                           "material with ID={}.".format(mat.id))
+                    mat.volume /= mat.num_instances
+                    cell.fill = [mat.clone()
                                  for i in range(cell.num_instances)]
 
     def _get_burnable_mats(self):
@@ -341,7 +346,7 @@ class Operator(TransportOperator):
                 if mat.volume is None:
                     raise RuntimeError("Volume not specified for depletable "
                                        "material with ID={}.".format(mat.id))
-                volume[str(mat.id)] = mat.volume/mat.num_instances
+                volume[str(mat.id)] = mat.volume
                 self.heavy_metal += mat.fissionable_mass
 
         # Make sure there are burnable materials

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -341,7 +341,7 @@ class Operator(TransportOperator):
                 if mat.volume is None:
                     raise RuntimeError("Volume not specified for depletable "
                                        "material with ID={}.".format(mat.id))
-                volume[str(mat.id)] = mat.volume
+                volume[str(mat.id)] = mat.volume/mat.num_instances
                 self.heavy_metal += mat.fissionable_mass
 
         # Make sure there are burnable materials


### PR DESCRIPTION
When the variable `diff_burnable_mats=True` was specified when calling `openmc.deplete.Operator()`, the volume of each material instance was specified as the same as the non-differentiated burnable materials, e.g, if the given burnable material had 3 instances:
``` 
<material depletable="true" id="10001" name="fuel" volume="435">
...
  </material>
```

The `diff_burnable_mats=True` would produce differentiated burnable materials:

```
<material depletable="true" id="1" name="fuel" volume="435">
...</material>

<material depletable="true" id="2" name="fuel" volume="435">
...</material>

<material depletable="true" id="3" name="fuel" volume="435">
...</material>
```

This changed the material instance creation such that the sum of the differentiated material volumes is the same as the original undifferentiated material volume.