### PR TITLE
Fix tally_deriv_map memory leak

### DIFF
--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -1047,6 +1047,7 @@ free_memory_tally()
   {
     model::tally_derivs.clear();
   }
+  model::tally_deriv_map.clear();
 
   model::tally_filters.clear();
   model::filter_map.clear();


### PR DESCRIPTION
Looks like we missed the `tally_deriv_map` in our memory freeing routines.