### PR TITLE
Clarify documentation on Operator diff_burnable_mats

### DIFF
--- a/docs/source/usersguide/depletion.rst
+++ b/docs/source/usersguide/depletion.rst
@@ -127,7 +127,9 @@ of the same material as a unique material definition with::
 For our example problem, this would deplete fuel on the outer region of the problem
 with different reaction rates than those in the center. Materials will be depleted
 corresponding to their local neutron spectra, and have unique compositions at each
-transport step.
+transport step.  The volume of the original ``fuel_3`` material must represent
+the volume of **all** the ``fuel_3`` in the problem. When creating the unique
+materials, this volume will be equally distributed across all material instances.
 
 
 .. note::

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -82,6 +82,7 @@ class Operator(TransportOperator):
         in the previous results.
     diff_burnable_mats : bool, optional
         Whether to differentiate burnable materials with multiple instances.
+        Volumes are divided equally from the original material volume.
         Default: False.
     energy_mode : {"energy-deposition", "fission-q"}
         Indicator for computing system energy. ``"energy-deposition"`` will


### PR DESCRIPTION
In PR #1392, it was revealed that the distribution of material volumes with ``diff_burnable_mats`` was not clear. In that PR, the Operator now divides the volume of the shared material equally across all identical and newly created instances. This commit adds some clarifying language into the Operator
docstring and depletion users guide on the handling of volumes across repeated materials.