### PR TITLE
C++ Cell and Universe Level Counting

### DIFF
--- a/include/openmc/geometry_aux.h
+++ b/include/openmc/geometry_aux.h
@@ -10,78 +10,10 @@
 #include <map>
 
 namespace openmc {
-  struct  UniverseCellCounter {
-  private:
-    UniverseCellCounter() {}
-    UniverseCellCounter(UniverseCellCounter& c) {}
-    UniverseCellCounter(const UniverseCellCounter& c) {}
 
-    static UniverseCellCounter* instance_;
+  extern std::map<int32_t, std::map<int32_t, int32_t>> universe_cell_counts;
+  extern std::map<int32_t, int32_t> universe_level_counts;
 
-  public:
-
-  // Methods
-    static UniverseCellCounter* instance() {
-      if (instance_ == nullptr)
-        instance_ = new UniverseCellCounter;
-
-      return instance_;
-    }
-
-    void clear();
-
-    void set_cell_count_for_univ(int32_t univ, int32_t cell, int count);
-
-    void increment_count_for_univ(int32_t univ, int32_t cell);
-
-    bool has_count(int32_t univ, int32_t cell);
-
-    bool has_count(int32_t univ);
-
-    void absorb_b_into_a(int32_t a, int32_t b);
-
-    auto get_count(int32_t univ);
-
-  // Members
-    std::map<int32_t, std::map<int32_t, int>> counts_;
-  };
-
-  struct  UniverseLevelCounter {
-  private:
-    UniverseLevelCounter() {}
-    UniverseLevelCounter(UniverseLevelCounter& c) {}
-    UniverseLevelCounter(const UniverseLevelCounter& c) {}
-
-    static UniverseLevelCounter* instance_;
-
-  public:
-
-  //Methods
-
-    static UniverseLevelCounter* instance() {
-      if (instance_ == nullptr)
-        instance_ = new UniverseLevelCounter;
-
-      return instance_;
-    }
-
-    void clear();
-
-    void set_cell_count_for_univ(int32_t univ, int count);
-
-    void increment_count_for_univ(int32_t univ);
-
-    bool has_count(int32_t univ);
-
-    void absorb_b_into_a(int32_t a, int32_t b);
-
-    void set_count(int32_t univ, int count);
-
-    int get_count(int32_t univ);
-
-  // Members
-    std::map<int32_t, int> counts_;
-  };
 
 void read_geometry_xml();
 

--- a/include/openmc/geometry_aux.h
+++ b/include/openmc/geometry_aux.h
@@ -7,8 +7,78 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <map>
 
 namespace openmc {
+  struct  CellCountStorage {
+  private:
+    CellCountStorage() {}
+    CellCountStorage(CellCountStorage& c) {}
+    CellCountStorage(const CellCountStorage& c) {}
+
+    static CellCountStorage* instance_;
+
+    std::map<int32_t, std::map<int32_t, int>> counts;
+
+  public:
+
+    static CellCountStorage* instance() {
+      if (instance_ == nullptr)
+        instance_ = new CellCountStorage;
+
+      return instance_;
+    }
+
+
+
+    void clear();
+
+    void set_cell_count_for_univ(int32_t univ, int32_t cell, int count);
+
+    void increment_count_for_univ(int32_t univ, int32_t cell);
+
+    bool has_count(int32_t univ, int32_t cell);
+
+    bool has_count(int32_t univ);
+
+    void absorb_b_into_a(int32_t a, int32_t b);
+
+    auto get_count(int32_t univ);
+  };
+
+  struct  LevelCountStorage {
+  private:
+    LevelCountStorage() {}
+    LevelCountStorage(LevelCountStorage& c) {}
+    LevelCountStorage(const LevelCountStorage& c) {}
+
+    static LevelCountStorage* instance_;
+
+    std::map<int32_t, int> counts;
+
+  public:
+
+    static LevelCountStorage* instance() {
+      if (instance_ == nullptr)
+        instance_ = new LevelCountStorage;
+
+      return instance_;
+    }
+
+    void clear();
+
+    void set_cell_count_for_univ(int32_t univ, int count);
+
+    void increment_count_for_univ(int32_t univ);
+
+    bool has_count(int32_t univ);
+
+    void absorb_b_into_a(int32_t a, int32_t b);
+
+    void set_count(int32_t univ, int count);
+
+    int get_count(int32_t univ);
+  };
 
 void read_geometry_xml();
 

--- a/include/openmc/geometry_aux.h
+++ b/include/openmc/geometry_aux.h
@@ -10,21 +10,21 @@
 #include <map>
 
 namespace openmc {
-  struct  CellCountStorage {
+  struct  UniverseCellCounter {
   private:
-    CellCountStorage() {}
-    CellCountStorage(CellCountStorage& c) {}
-    CellCountStorage(const CellCountStorage& c) {}
+    UniverseCellCounter() {}
+    UniverseCellCounter(UniverseCellCounter& c) {}
+    UniverseCellCounter(const UniverseCellCounter& c) {}
 
-    static CellCountStorage* instance_;
+    static UniverseCellCounter* instance_;
 
     std::map<int32_t, std::map<int32_t, int>> counts;
 
   public:
 
-    static CellCountStorage* instance() {
+    static UniverseCellCounter* instance() {
       if (instance_ == nullptr)
-        instance_ = new CellCountStorage;
+        instance_ = new UniverseCellCounter;
 
       return instance_;
     }

--- a/include/openmc/geometry_aux.h
+++ b/include/openmc/geometry_aux.h
@@ -11,9 +11,10 @@
 
 namespace openmc {
 
+namespace model {
   extern std::map<int32_t, std::map<int32_t, int32_t>> universe_cell_counts;
   extern std::map<int32_t, int32_t> universe_level_counts;
-
+} // namespace model
 
 void read_geometry_xml();
 

--- a/include/openmc/geometry_aux.h
+++ b/include/openmc/geometry_aux.h
@@ -18,18 +18,15 @@ namespace openmc {
 
     static UniverseCellCounter* instance_;
 
-    std::map<int32_t, std::map<int32_t, int>> counts;
-
   public:
 
+  // Methods
     static UniverseCellCounter* instance() {
       if (instance_ == nullptr)
         instance_ = new UniverseCellCounter;
 
       return instance_;
     }
-
-
 
     void clear();
 
@@ -44,6 +41,9 @@ namespace openmc {
     void absorb_b_into_a(int32_t a, int32_t b);
 
     auto get_count(int32_t univ);
+
+  // Members
+    std::map<int32_t, std::map<int32_t, int>> counts_;
   };
 
   struct  UniverseLevelCounter {
@@ -54,9 +54,9 @@ namespace openmc {
 
     static UniverseLevelCounter* instance_;
 
-    std::map<int32_t, int> counts;
-
   public:
+
+  //Methods
 
     static UniverseLevelCounter* instance() {
       if (instance_ == nullptr)
@@ -78,6 +78,9 @@ namespace openmc {
     void set_count(int32_t univ, int count);
 
     int get_count(int32_t univ);
+
+  // Members
+    std::map<int32_t, int> counts_;
   };
 
 void read_geometry_xml();

--- a/include/openmc/geometry_aux.h
+++ b/include/openmc/geometry_aux.h
@@ -7,13 +7,13 @@
 #include <cstdint>
 #include <string>
 #include <vector>
-#include <map>
+#include <unordered_map>
 
 namespace openmc {
 
 namespace model {
-  extern std::map<int32_t, std::map<int32_t, int32_t>> universe_cell_counts;
-  extern std::map<int32_t, int32_t> universe_level_counts;
+  extern std::unordered_map<int32_t, std::unordered_map<int32_t, int32_t>> universe_cell_counts;
+  extern std::unordered_map<int32_t, int32_t> universe_level_counts;
 } // namespace model
 
 void read_geometry_xml();

--- a/include/openmc/geometry_aux.h
+++ b/include/openmc/geometry_aux.h
@@ -46,21 +46,21 @@ namespace openmc {
     auto get_count(int32_t univ);
   };
 
-  struct  LevelCountStorage {
+  struct  UniverseLevelCounter {
   private:
-    LevelCountStorage() {}
-    LevelCountStorage(LevelCountStorage& c) {}
-    LevelCountStorage(const LevelCountStorage& c) {}
+    UniverseLevelCounter() {}
+    UniverseLevelCounter(UniverseLevelCounter& c) {}
+    UniverseLevelCounter(const UniverseLevelCounter& c) {}
 
-    static LevelCountStorage* instance_;
+    static UniverseLevelCounter* instance_;
 
     std::map<int32_t, int> counts;
 
   public:
 
-    static LevelCountStorage* instance() {
+    static UniverseLevelCounter* instance() {
       if (instance_ == nullptr)
-        instance_ = new LevelCountStorage;
+        instance_ = new UniverseLevelCounter;
 
       return instance_;
     }

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -136,7 +136,7 @@ int openmc_finalize()
 int openmc_reset()
 {
 
-  CellCountStorage::instance()->clear();
+  UniverseCellCounter::instance()->clear();
   LevelCountStorage::instance()->clear();
 
   for (auto& t : model::tallies) {

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -137,7 +137,7 @@ int openmc_reset()
 {
 
   UniverseCellCounter::instance()->clear();
-  LevelCountStorage::instance()->clear();
+  UniverseLevelCounter::instance()->clear();
 
   for (auto& t : model::tallies) {
     t->reset();

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -136,8 +136,8 @@ int openmc_finalize()
 int openmc_reset()
 {
 
-  universe_cell_counts.clear();
-  universe_level_counts.clear();
+  model::universe_cell_counts.clear();
+  model::universe_level_counts.clear();
 
   for (auto& t : model::tallies) {
     t->reset();

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -135,6 +135,10 @@ int openmc_finalize()
 
 int openmc_reset()
 {
+
+  CellCountStorage::instance()->clear();
+  LevelCountStorage::instance()->clear();
+
   for (auto& t : model::tallies) {
     t->reset();
   }

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -136,8 +136,8 @@ int openmc_finalize()
 int openmc_reset()
 {
 
-  UniverseCellCounter::instance()->clear();
-  UniverseLevelCounter::instance()->clear();
+  universe_cell_counts.clear();
+  universe_level_counts.clear();
 
   for (auto& t : model::tallies) {
     t->reset();

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -23,6 +23,91 @@
 
 namespace openmc {
 
+void UniverseCellCounter::clear() {
+  if (instance_ != nullptr) {
+    delete instance_;
+    instance_ = nullptr;
+  }
+}
+
+void UniverseCellCounter::set_cell_count_for_univ(int32_t univ, int32_t cell, int count) {
+    counts_[univ][cell] = count;
+}
+
+  void UniverseCellCounter::increment_count_for_univ(int32_t univ, int32_t cell) {
+    if (has_count(univ,cell)) {
+      counts_[univ][cell] += 1;
+    } else {
+      counts_[univ][cell] = 1;
+    }
+  }
+
+bool UniverseCellCounter::has_count(int32_t univ, int32_t cell) {
+  return counts_.count(univ) && counts_[univ].count(cell);
+}
+
+bool UniverseCellCounter::has_count(int32_t univ) {
+  return counts_.count(univ);
+}
+
+void UniverseCellCounter::absorb_b_into_a(int32_t a, int32_t b) {
+  std::map<int32_t, int> b_map = counts_[b];
+
+  for (auto it : b_map) {
+    if (has_count(a, it.first)) {
+      counts_[a][it.first] += it.second;
+    } else {
+      counts_[a][it.first] = it.second;
+      }
+  }
+}
+
+auto UniverseCellCounter::get_count(int32_t univ) {
+    return counts_[univ];
+}
+
+void UniverseLevelCounter::clear() {
+  if (instance_ != nullptr) {
+    delete instance_;
+    instance_ = nullptr;
+    }
+}
+
+void UniverseLevelCounter::set_cell_count_for_univ(int32_t univ, int count) {
+  counts_[univ] = count;
+}
+
+void UniverseLevelCounter::increment_count_for_univ(int32_t univ) {
+  if (has_count(univ)) {
+    counts_[univ] += 1;
+  } else {
+    counts_[univ] = 1;
+  }
+}
+
+bool UniverseLevelCounter::has_count(int32_t univ) {
+  return counts_.count(univ);
+}
+
+void UniverseLevelCounter::absorb_b_into_a(int32_t a, int32_t b) {
+  if (has_count(a)) {
+    counts_[a] += counts_[b];
+  } else {
+    counts_[a] = counts_[b];
+  }
+}
+
+void UniverseLevelCounter::set_count(int32_t univ, int count) {
+  counts_[univ] = count;
+}
+
+int UniverseLevelCounter::get_count(int32_t univ) {
+  return counts_[univ];
+}
+
+UniverseCellCounter* UniverseCellCounter::instance_ = nullptr;
+UniverseLevelCounter* UniverseLevelCounter::instance_ = nullptr;
+
 void read_geometry_xml()
 {
 #ifdef DAGMC
@@ -59,91 +144,6 @@ void read_geometry_xml()
   // Allocate universes, universe cell arrays, and assign base universe
   model::root_universe = find_root_universe();
 }
-
-void UniverseCellCounter::clear() {
-  if (instance_ != nullptr) {
-    delete instance_;
-    instance_ = nullptr;
-  }
-}
-
-void UniverseCellCounter::set_cell_count_for_univ(int32_t univ, int32_t cell, int count) {
-    counts[univ][cell] = count;
-}
-
-  void UniverseCellCounter::increment_count_for_univ(int32_t univ, int32_t cell) {
-    if (has_count(univ,cell)) {
-      counts[univ][cell] += 1;
-    } else {
-      counts[univ][cell] = 1;
-    }
-  }
-
-bool UniverseCellCounter::has_count(int32_t univ, int32_t cell) {
-  return counts.count(univ) && counts[univ].count(cell);
-}
-
-bool UniverseCellCounter::has_count(int32_t univ) {
-  return counts.count(univ);
-}
-
-void UniverseCellCounter::absorb_b_into_a(int32_t a, int32_t b) {
-  std::map<int32_t, int> b_map = counts[b];
-
-  for (auto it : b_map) {
-    if (has_count(a, it.first)) {
-      counts[a][it.first] += it.second;
-    } else {
-      counts[a][it.first] = it.second;
-      }
-  }
-}
-
-auto UniverseCellCounter::get_count(int32_t univ) {
-    return counts[univ];
-}
-
-void UniverseLevelCounter::clear() {
-  if (instance_ != nullptr) {
-    delete instance_;
-    instance_ = nullptr;
-    }
-}
-
-void UniverseLevelCounter::set_cell_count_for_univ(int32_t univ, int count) {
-  counts[univ] = count;
-}
-
-void UniverseLevelCounter::increment_count_for_univ(int32_t univ) {
-  if (has_count(univ)) {
-    counts[univ] += 1;
-  } else {
-    counts[univ] = 1;
-  }
-}
-
-bool UniverseLevelCounter::has_count(int32_t univ) {
-  return counts.count(univ);
-}
-
-void UniverseLevelCounter::absorb_b_into_a(int32_t a, int32_t b) {
-  if (has_count(a)) {
-    counts[a] += counts[b];
-  } else {
-    counts[a] = counts[b];
-  }
-}
-
-void UniverseLevelCounter::set_count(int32_t univ, int count) {
-  counts[univ] = count;
-}
-
-int UniverseLevelCounter::get_count(int32_t univ) {
-  return counts[univ];
-}
-
-UniverseCellCounter* UniverseCellCounter::instance_ = nullptr;
-UniverseLevelCounter* UniverseLevelCounter::instance_ = nullptr;
 
 //==============================================================================
 

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -60,6 +60,91 @@ void read_geometry_xml()
   model::root_universe = find_root_universe();
 }
 
+void CellCountStorage::clear() {
+  if (instance_ != nullptr) {
+    delete instance_;
+    instance_ = nullptr;
+  }
+}
+
+void CellCountStorage::set_cell_count_for_univ(int32_t univ, int32_t cell, int count) {
+    counts[univ][cell] = count;
+}
+
+  void CellCountStorage::increment_count_for_univ(int32_t univ, int32_t cell) {
+    if (has_count(univ,cell)) {
+      counts[univ][cell] += 1;
+    } else {
+      counts[univ][cell] = 1;
+    }
+  }
+
+bool CellCountStorage::has_count(int32_t univ, int32_t cell) {
+  return counts.count(univ) && counts[univ].count(cell);
+}
+
+bool CellCountStorage::has_count(int32_t univ) {
+  return counts.count(univ);
+}
+
+void CellCountStorage::absorb_b_into_a(int32_t a, int32_t b) {
+  std::map<int32_t, int> b_map = counts[b];
+
+  for (auto it : b_map) {
+    if (has_count(a, it.first)) {
+      counts[a][it.first] += it.second;
+    } else {
+      counts[a][it.first] = it.second;
+      }
+  }
+}
+
+auto CellCountStorage::get_count(int32_t univ) {
+    return counts[univ];
+}
+
+void LevelCountStorage::clear() {
+  if (instance_ != nullptr) {
+    delete instance_;
+    instance_ = nullptr;
+    }
+}
+
+void LevelCountStorage::set_cell_count_for_univ(int32_t univ, int count) {
+  counts[univ] = count;
+}
+
+void LevelCountStorage::increment_count_for_univ(int32_t univ) {
+  if (has_count(univ)) {
+    counts[univ] += 1;
+  } else {
+    counts[univ] = 1;
+  }
+}
+
+bool LevelCountStorage::has_count(int32_t univ) {
+  return counts.count(univ);
+}
+
+void LevelCountStorage::absorb_b_into_a(int32_t a, int32_t b) {
+  if (has_count(a)) {
+    counts[a] += counts[b];
+  } else {
+    counts[a] = counts[b];
+  }
+}
+
+void LevelCountStorage::set_count(int32_t univ, int count) {
+  counts[univ] = count;
+}
+
+int LevelCountStorage::get_count(int32_t univ) {
+  return counts[univ];
+}
+
+CellCountStorage* CellCountStorage::instance_ = nullptr;
+LevelCountStorage* LevelCountStorage::instance_ = nullptr;
+
 //==============================================================================
 
 void
@@ -395,19 +480,31 @@ prepare_distribcell()
 void
 count_cell_instances(int32_t univ_indx)
 {
-  for (int32_t cell_indx : model::universes[univ_indx]->cells_) {
-    Cell& c = *model::cells[cell_indx];
-    ++c.n_instances_;
+  CellCountStorage* counter = CellCountStorage::instance();
 
-    if (c.type_ == FILL_UNIVERSE) {
-      // This cell contains another universe.  Recurse into that universe.
-      count_cell_instances(c.fill_);
+  if (counter->has_count(univ_indx)) {
+    std::map<int32_t, int> univ_counts = counter->get_count(univ_indx);
+    for(auto it : univ_counts) {
+      Cell& c = *model::cells[it.first];
+      c.n_instances_ += it.second;
+    }
+  } else {
+    for (int32_t cell_indx : model::universes[univ_indx]->cells_) {
+      Cell& c = *model::cells[cell_indx];
+      ++c.n_instances_;
+      counter->increment_count_for_univ(univ_indx, cell_indx);
 
-    } else if (c.type_ == FILL_LATTICE) {
-      // This cell contains a lattice.  Recurse into the lattice universes.
-      Lattice& lat = *model::lattices[c.fill_];
-      for (auto it = lat.begin(); it != lat.end(); ++it) {
-        count_cell_instances(*it);
+      if (c.type_ == FILL_UNIVERSE) {
+        // This cell contains another universe.  Recurse into that universe.
+        count_cell_instances(c.fill_);
+        counter->absorb_b_into_a(univ_indx, c.fill_);
+      } else if (c.type_ == FILL_LATTICE) {
+        // This cell contains a lattice.  Recurse into the lattice universes.
+        Lattice& lat = *model::lattices[c.fill_];
+        for (auto it = lat.begin(); it != lat.end(); ++it) {
+          count_cell_instances(*it);
+          counter->absorb_b_into_a(univ_indx, *it);
+        }
       }
     }
   }
@@ -529,6 +626,12 @@ distribcell_path(int32_t target_cell, int32_t map, int32_t target_offset)
 int
 maximum_levels(int32_t univ)
 {
+  LevelCountStorage* counter = LevelCountStorage::instance();
+
+  if (counter->has_count(univ)) {
+    return counter->get_count(univ);
+  }
+
   int levels_below {0};
 
   for (int32_t cell_indx : model::universes[univ]->cells_) {
@@ -546,6 +649,7 @@ maximum_levels(int32_t univ)
   }
 
   ++levels_below;
+  counter->set_count(univ, levels_below);
   return levels_below;
 }
 

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -23,21 +23,22 @@
 
 namespace openmc {
 
-std::map<int32_t, std::map<int32_t, int32_t>> universe_cell_counts;
-std::map<int32_t, int32_t> universe_level_counts;
-
+namespace model {
+  std::map<int32_t, std::map<int32_t, int32_t>> universe_cell_counts;
+  std::map<int32_t, int32_t> universe_level_counts;
+} // namespace model
 
 void update_universe_cell_count(int32_t a, int32_t b) {
-  auto& universe_a_counts = universe_cell_counts[a];
-  const auto& universe_b_counts = universe_cell_counts[b];
+  auto& universe_a_counts = model::universe_cell_counts[a];
+  const auto& universe_b_counts = model::universe_cell_counts[b];
   for (auto it : universe_b_counts) {
     universe_a_counts[it.first] += it.second;
   }
 }
 
 void update_universe_level_count(int32_t a, int32_t b) {
-  auto& universe_a_count = universe_level_counts[a];
-  const auto& universe_b_count = universe_level_counts[b];
+  auto& universe_a_count = model::universe_level_counts[a];
+  const auto& universe_b_count = model::universe_level_counts[b];
   universe_a_count += universe_b_count;
 }
 
@@ -414,8 +415,8 @@ void
 count_cell_instances(int32_t univ_indx)
 {
 
-  if (universe_cell_counts.count(univ_indx)) {
-    std::map<int32_t, int> univ_counts = universe_cell_counts[univ_indx];
+  if (model::universe_cell_counts.count(univ_indx)) {
+    std::map<int32_t, int> univ_counts = model::universe_cell_counts[univ_indx];
     for(auto it : univ_counts) {
       Cell& c = *model::cells[it.first];
       c.n_instances_ += it.second;
@@ -424,7 +425,7 @@ count_cell_instances(int32_t univ_indx)
     for (int32_t cell_indx : model::universes[univ_indx]->cells_) {
       Cell& c = *model::cells[cell_indx];
       ++c.n_instances_;
-      universe_cell_counts[univ_indx][cell_indx] += 1;
+      model::universe_cell_counts[univ_indx][cell_indx] += 1;
 
       if (c.type_ == FILL_UNIVERSE) {
         // This cell contains another universe.  Recurse into that universe.
@@ -559,8 +560,8 @@ int
 maximum_levels(int32_t univ)
 {
 
-  if (universe_level_counts.count(univ)) {
-    return universe_level_counts[univ];
+  if (model::universe_level_counts.count(univ)) {
+    return model::universe_level_counts[univ];
   }
 
   int levels_below {0};
@@ -580,7 +581,7 @@ maximum_levels(int32_t univ)
   }
 
   ++levels_below;
-  universe_level_counts[univ] = levels_below;
+  model::universe_level_counts[univ] = levels_below;
   return levels_below;
 }
 

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -24,23 +24,16 @@
 namespace openmc {
 
 void UniverseCellCounter::clear() {
-  if (instance_ != nullptr) {
-    delete instance_;
-    instance_ = nullptr;
-  }
+  instance_->counts_.clear();
 }
 
 void UniverseCellCounter::set_cell_count_for_univ(int32_t univ, int32_t cell, int count) {
     counts_[univ][cell] = count;
 }
 
-  void UniverseCellCounter::increment_count_for_univ(int32_t univ, int32_t cell) {
-    if (has_count(univ,cell)) {
-      counts_[univ][cell] += 1;
-    } else {
-      counts_[univ][cell] = 1;
-    }
-  }
+void UniverseCellCounter::increment_count_for_univ(int32_t univ, int32_t cell) {
+    counts_[univ][cell] += 1;
+}
 
 bool UniverseCellCounter::has_count(int32_t univ, int32_t cell) {
   return counts_.count(univ) && counts_[univ].count(cell);
@@ -52,14 +45,7 @@ bool UniverseCellCounter::has_count(int32_t univ) {
 
 void UniverseCellCounter::absorb_b_into_a(int32_t a, int32_t b) {
   std::map<int32_t, int> b_map = counts_[b];
-
-  for (auto it : b_map) {
-    if (has_count(a, it.first)) {
-      counts_[a][it.first] += it.second;
-    } else {
-      counts_[a][it.first] = it.second;
-      }
-  }
+  for (auto it : b_map) { counts_[a][it.first] += it.second; }
 }
 
 auto UniverseCellCounter::get_count(int32_t univ) {
@@ -67,10 +53,7 @@ auto UniverseCellCounter::get_count(int32_t univ) {
 }
 
 void UniverseLevelCounter::clear() {
-  if (instance_ != nullptr) {
-    delete instance_;
-    instance_ = nullptr;
-    }
+  instance_->counts_.clear();
 }
 
 void UniverseLevelCounter::set_cell_count_for_univ(int32_t univ, int count) {
@@ -78,11 +61,7 @@ void UniverseLevelCounter::set_cell_count_for_univ(int32_t univ, int count) {
 }
 
 void UniverseLevelCounter::increment_count_for_univ(int32_t univ) {
-  if (has_count(univ)) {
     counts_[univ] += 1;
-  } else {
-    counts_[univ] = 1;
-  }
 }
 
 bool UniverseLevelCounter::has_count(int32_t univ) {
@@ -90,11 +69,7 @@ bool UniverseLevelCounter::has_count(int32_t univ) {
 }
 
 void UniverseLevelCounter::absorb_b_into_a(int32_t a, int32_t b) {
-  if (has_count(a)) {
     counts_[a] += counts_[b];
-  } else {
-    counts_[a] = counts_[b];
-  }
 }
 
 void UniverseLevelCounter::set_count(int32_t univ, int count) {

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -24,22 +24,18 @@
 namespace openmc {
 
 namespace model {
-  std::map<int32_t, std::map<int32_t, int32_t>> universe_cell_counts;
-  std::map<int32_t, int32_t> universe_level_counts;
+  std::unordered_map<int32_t, std::unordered_map<int32_t, int32_t>> universe_cell_counts;
+  std::unordered_map<int32_t, int32_t> universe_level_counts;
 } // namespace model
 
+
+// adds the cell counts of universe b to universe a
 void update_universe_cell_count(int32_t a, int32_t b) {
   auto& universe_a_counts = model::universe_cell_counts[a];
   const auto& universe_b_counts = model::universe_cell_counts[b];
-  for (auto it : universe_b_counts) {
+  for (const auto& it : universe_b_counts) {
     universe_a_counts[it.first] += it.second;
   }
-}
-
-void update_universe_level_count(int32_t a, int32_t b) {
-  auto& universe_a_count = model::universe_level_counts[a];
-  const auto& universe_b_count = model::universe_level_counts[b];
-  universe_a_count += universe_b_count;
 }
 
 void read_geometry_xml()
@@ -415,11 +411,10 @@ void
 count_cell_instances(int32_t univ_indx)
 {
 
-  if (model::universe_cell_counts.count(univ_indx)) {
-    std::map<int32_t, int> univ_counts = model::universe_cell_counts[univ_indx];
-    for(auto it : univ_counts) {
-      Cell& c = *model::cells[it.first];
-      c.n_instances_ += it.second;
+  const auto univ_counts = model::universe_cell_counts.find(univ_indx);
+  if (univ_counts != model::universe_cell_counts.end()) {
+    for (const auto& it : univ_counts->second) {
+      model::cells[it.first]->n_instances_ += it.second;
     }
   } else {
     for (int32_t cell_indx : model::universes[univ_indx]->cells_) {
@@ -560,8 +555,9 @@ int
 maximum_levels(int32_t univ)
 {
 
-  if (model::universe_level_counts.count(univ)) {
-    return model::universe_level_counts[univ];
+  const auto level_count = model::universe_level_counts.find(univ);
+  if (level_count != model::universe_level_counts.end()) {
+    return level_count->second;
   }
 
   int levels_below {0};

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -60,18 +60,18 @@ void read_geometry_xml()
   model::root_universe = find_root_universe();
 }
 
-void CellCountStorage::clear() {
+void UniverseCellCounter::clear() {
   if (instance_ != nullptr) {
     delete instance_;
     instance_ = nullptr;
   }
 }
 
-void CellCountStorage::set_cell_count_for_univ(int32_t univ, int32_t cell, int count) {
+void UniverseCellCounter::set_cell_count_for_univ(int32_t univ, int32_t cell, int count) {
     counts[univ][cell] = count;
 }
 
-  void CellCountStorage::increment_count_for_univ(int32_t univ, int32_t cell) {
+  void UniverseCellCounter::increment_count_for_univ(int32_t univ, int32_t cell) {
     if (has_count(univ,cell)) {
       counts[univ][cell] += 1;
     } else {
@@ -79,15 +79,15 @@ void CellCountStorage::set_cell_count_for_univ(int32_t univ, int32_t cell, int c
     }
   }
 
-bool CellCountStorage::has_count(int32_t univ, int32_t cell) {
+bool UniverseCellCounter::has_count(int32_t univ, int32_t cell) {
   return counts.count(univ) && counts[univ].count(cell);
 }
 
-bool CellCountStorage::has_count(int32_t univ) {
+bool UniverseCellCounter::has_count(int32_t univ) {
   return counts.count(univ);
 }
 
-void CellCountStorage::absorb_b_into_a(int32_t a, int32_t b) {
+void UniverseCellCounter::absorb_b_into_a(int32_t a, int32_t b) {
   std::map<int32_t, int> b_map = counts[b];
 
   for (auto it : b_map) {
@@ -99,7 +99,7 @@ void CellCountStorage::absorb_b_into_a(int32_t a, int32_t b) {
   }
 }
 
-auto CellCountStorage::get_count(int32_t univ) {
+auto UniverseCellCounter::get_count(int32_t univ) {
     return counts[univ];
 }
 
@@ -142,7 +142,7 @@ int LevelCountStorage::get_count(int32_t univ) {
   return counts[univ];
 }
 
-CellCountStorage* CellCountStorage::instance_ = nullptr;
+UniverseCellCounter* UniverseCellCounter::instance_ = nullptr;
 LevelCountStorage* LevelCountStorage::instance_ = nullptr;
 
 //==============================================================================
@@ -480,7 +480,7 @@ prepare_distribcell()
 void
 count_cell_instances(int32_t univ_indx)
 {
-  CellCountStorage* counter = CellCountStorage::instance();
+  UniverseCellCounter* counter = UniverseCellCounter::instance();
 
   if (counter->has_count(univ_indx)) {
     std::map<int32_t, int> univ_counts = counter->get_count(univ_indx);

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -103,18 +103,18 @@ auto UniverseCellCounter::get_count(int32_t univ) {
     return counts[univ];
 }
 
-void LevelCountStorage::clear() {
+void UniverseLevelCounter::clear() {
   if (instance_ != nullptr) {
     delete instance_;
     instance_ = nullptr;
     }
 }
 
-void LevelCountStorage::set_cell_count_for_univ(int32_t univ, int count) {
+void UniverseLevelCounter::set_cell_count_for_univ(int32_t univ, int count) {
   counts[univ] = count;
 }
 
-void LevelCountStorage::increment_count_for_univ(int32_t univ) {
+void UniverseLevelCounter::increment_count_for_univ(int32_t univ) {
   if (has_count(univ)) {
     counts[univ] += 1;
   } else {
@@ -122,11 +122,11 @@ void LevelCountStorage::increment_count_for_univ(int32_t univ) {
   }
 }
 
-bool LevelCountStorage::has_count(int32_t univ) {
+bool UniverseLevelCounter::has_count(int32_t univ) {
   return counts.count(univ);
 }
 
-void LevelCountStorage::absorb_b_into_a(int32_t a, int32_t b) {
+void UniverseLevelCounter::absorb_b_into_a(int32_t a, int32_t b) {
   if (has_count(a)) {
     counts[a] += counts[b];
   } else {
@@ -134,16 +134,16 @@ void LevelCountStorage::absorb_b_into_a(int32_t a, int32_t b) {
   }
 }
 
-void LevelCountStorage::set_count(int32_t univ, int count) {
+void UniverseLevelCounter::set_count(int32_t univ, int count) {
   counts[univ] = count;
 }
 
-int LevelCountStorage::get_count(int32_t univ) {
+int UniverseLevelCounter::get_count(int32_t univ) {
   return counts[univ];
 }
 
 UniverseCellCounter* UniverseCellCounter::instance_ = nullptr;
-LevelCountStorage* LevelCountStorage::instance_ = nullptr;
+UniverseLevelCounter* UniverseLevelCounter::instance_ = nullptr;
 
 //==============================================================================
 
@@ -626,7 +626,7 @@ distribcell_path(int32_t target_cell, int32_t map, int32_t target_offset)
 int
 maximum_levels(int32_t univ)
 {
-  LevelCountStorage* counter = LevelCountStorage::instance();
+  UniverseLevelCounter* counter = UniverseLevelCounter::instance();
 
   if (counter->has_count(univ)) {
     return counter->get_count(univ);


### PR DESCRIPTION
This soft of a partner PR to #1393 and #1181 in that it addresses an issue related to long runtimes when working with models containing TRISO particles.

Here, a lot of time is spent counting how many cells are contained in each universe. The recursive nature of this call causes us to spend a lot of time re-visiting universes, which is a common problem if we're in a lattice structure and can get really bad when working models using TRISO particles as the number of universes and cells can be in the millions.

In #1181, I used a couple of singleton classes to track counts and cache these counts for quick returns if we're visiting a universe more than once. Here, those classes have been replaced by a couple of maps for simplicity and because it'd probably be best to avoid singletons if we can help it.
