### PR TITLE
Let MGXS be used in externally linked programs

### DIFF
--- a/include/openmc/hdf5_interface.h
+++ b/include/openmc/hdf5_interface.h
@@ -345,7 +345,7 @@ read_dataset(hid_t obj_id, const char* name, Position& r, bool indep=false)
 }
 
 template <typename T, std::size_t N>
-void read_dataset_as_shape(hid_t obj_id, const char* name,
+inline void read_dataset_as_shape(hid_t obj_id, const char* name,
                            xt::xtensor<T, N>& arr, bool indep=false)
 {
   hid_t dset = open_dataset(obj_id, name);
@@ -367,7 +367,7 @@ void read_dataset_as_shape(hid_t obj_id, const char* name,
 
 
 template <typename T, std::size_t N>
-void read_nd_vector(hid_t obj_id, const char* name, xt::xtensor<T, N>& result,
+inline void read_nd_vector(hid_t obj_id, const char* name, xt::xtensor<T, N>& result,
      bool must_have=false)
 {
   if (object_exists(obj_id, name)) {

--- a/include/openmc/mgxs.h
+++ b/include/openmc/mgxs.h
@@ -110,7 +110,10 @@ class Mgxs {
     //!
     //! @param xs_id HDF5 group id for the cross section data.
     //! @param temperature Temperatures to read.
-    Mgxs(hid_t xs_id, const std::vector<double>& temperature);
+    //! @param num_group number of energy groups
+    //! @param num_delay number of delayed groups
+    Mgxs(hid_t xs_id, const std::vector<double>& temperature,
+        int num_group, int num_delay);
 
     //! \brief Constructor that initializes and populates all data to build a
     //!   macroscopic cross section from microscopic cross section.
@@ -119,8 +122,11 @@ class Mgxs {
     //! @param mat_kTs temperatures (in units of eV) that data is needed.
     //! @param micros Microscopic objects to combine.
     //! @param atom_densities Atom densities of those microscopic quantities.
+    //! @param num_group number of energy groups
+    //! @param num_delay number of delayed groups
     Mgxs(const std::string& in_name, const std::vector<double>& mat_kTs,
-         const std::vector<Mgxs*>& micros, const std::vector<double>& atom_densities);
+         const std::vector<Mgxs*>& micros, const std::vector<double>& atom_densities,
+         int num_group, int num_delay);
 
     //! \brief Provides a cross section value given certain parameters
     //!

--- a/include/openmc/mgxs_interface.h
+++ b/include/openmc/mgxs_interface.h
@@ -20,6 +20,14 @@ struct MgxsInterface
   int num_energy_groups;
   int num_delayed_groups;
 
+  // List of available names in the HDF5 file
+  std::vector<std::string> xs_names;
+  std::vector<std::string> xs_to_read;
+  std::vector<std::vector<double>> xs_temps_to_read;
+
+  // Name of the HDF5 file which contains mgxs
+  std::string cross_sections_path;
+
   std::vector<Mgxs> nuclides_MG;
   std::vector<Mgxs> macro_xs;
 
@@ -27,12 +35,20 @@ struct MgxsInterface
   std::vector<double> energy_bin_avg;
   std::vector<double> rev_energy_bins;
 
+  // temperatues of each available nuclide
+  std::vector<std::vector<double>> nuc_temps;
+
   MgxsInterface() = default;
 
-  // Construct from path to cross sections file
-  MgxsInterface(const std::string& path_cross_sections);
+  // Construct from path to cross sections file, as well as a list
+  // of XS to read and the corresponding temperatures for each XS
+  MgxsInterface(const std::string& path_cross_sections,
+                const std::vector<std::string> xs_to_read,
+                const std::vector<std::vector<double>> xs_temps);
+  void setNuclidesToRead(std::vector<std::string> arg_xs_to_read);
+  void setNuclideTemperaturesToRead(std::vector<std::vector<double>> xs_temps);
 
-  void init(const std::string& path_cross_sections);
+  void init();
 
   void add_mgxs(hid_t file_id, const std::string& name,
          const std::vector<double>& temperature);
@@ -41,12 +57,26 @@ struct MgxsInterface
 
   std::vector<std::vector<double>> get_mat_kTs();
 
-  void read_mg_cross_sections_header();
+  // Reads just the header of the cross sections file, to find
+  // min & max energies as well as the available XS
+  void readHeader(const std::string& path_cross_sections);
 };
 
 namespace data {
   extern MgxsInterface mgInterface;
 }
+
+// Puts available XS in MGXS file to globals so that when
+// materials are read, the MGXS specified in a material can
+// be ensured to be present in the available data.
+void putMgxsHeaderDataToGlobals();
+
+// Set which nuclides and temperatures are to be read on
+// mgInterface through global data
+void setMgInterfaceNuclidesAndTemps();
+
+// After macro XS have been read, materials can be marked as fissionable
+void markFissionableMgxsMaterials();
 
 //==============================================================================
 // Mgxs tracking/transport/tallying interface methods

--- a/include/openmc/mgxs_interface.h
+++ b/include/openmc/mgxs_interface.h
@@ -45,8 +45,8 @@ struct MgxsInterface
   MgxsInterface(const std::string& path_cross_sections,
                 const std::vector<std::string> xs_to_read,
                 const std::vector<std::vector<double>> xs_temps);
-  void setNuclidesToRead(std::vector<std::string> arg_xs_to_read);
-  void setNuclideTemperaturesToRead(std::vector<std::vector<double>> xs_temps);
+  void set_nuclides_to_read(std::vector<std::string> arg_xs_to_read);
+  void set_nuclide_temperatures_to_read(std::vector<std::vector<double>> xs_temps);
 
   void init();
 
@@ -59,7 +59,7 @@ struct MgxsInterface
 
   // Reads just the header of the cross sections file, to find
   // min & max energies as well as the available XS
-  void readHeader(const std::string& path_cross_sections);
+  void read_header(const std::string& path_cross_sections);
 };
 
 namespace data {
@@ -69,14 +69,14 @@ namespace data {
 // Puts available XS in MGXS file to globals so that when
 // materials are read, the MGXS specified in a material can
 // be ensured to be present in the available data.
-void putMgxsHeaderDataToGlobals();
+void put_mgxs_header_data_to_globals();
 
 // Set which nuclides and temperatures are to be read on
 // mgInterface through global data
-void setMgInterfaceNuclidesAndTemps();
+void set_mg_interface_nuclides_and_temps();
 
 // After macro XS have been read, materials can be marked as fissionable
-void markFissionableMgxsMaterials();
+void mark_fissionable_mgxs_materials();
 
 //==============================================================================
 // Mgxs tracking/transport/tallying interface methods

--- a/include/openmc/mgxs_interface.h
+++ b/include/openmc/mgxs_interface.h
@@ -45,8 +45,8 @@ struct MgxsInterface
   MgxsInterface(const std::string& path_cross_sections,
                 const std::vector<std::string> xs_to_read,
                 const std::vector<std::vector<double>> xs_temps);
-  void set_nuclides_to_read(std::vector<std::string> arg_xs_to_read);
-  void set_nuclide_temperatures_to_read(std::vector<std::vector<double>> xs_temps);
+  void set_nuclides_and_temperatures(std::vector<std::string> arg_xs_to_read,
+                                     std::vector<std::vector<double>> xs_temps);
 
   void init();
 

--- a/include/openmc/mgxs_interface.h
+++ b/include/openmc/mgxs_interface.h
@@ -15,28 +15,8 @@ namespace openmc {
 // Global MGXS data container structure
 //==============================================================================
 
-struct MgxsInterface
-{
-  int num_energy_groups;
-  int num_delayed_groups;
-
-  // List of available names in the HDF5 file
-  std::vector<std::string> xs_names;
-  std::vector<std::string> xs_to_read;
-  std::vector<std::vector<double>> xs_temps_to_read;
-
-  // Name of the HDF5 file which contains mgxs
-  std::string cross_sections_path;
-
-  std::vector<Mgxs> nuclides_MG;
-  std::vector<Mgxs> macro_xs;
-
-  std::vector<double> energy_bins;
-  std::vector<double> energy_bin_avg;
-  std::vector<double> rev_energy_bins;
-
-  // temperatues of each available nuclide
-  std::vector<std::vector<double>> nuc_temps;
+struct MgxsInterface {
+public:
 
   MgxsInterface() = default;
 
@@ -45,25 +25,45 @@ struct MgxsInterface
   MgxsInterface(const std::string& path_cross_sections,
                 const std::vector<std::string> xs_to_read,
                 const std::vector<std::vector<double>> xs_temps);
-  void set_nuclides_and_temperatures(std::vector<std::string> arg_xs_to_read,
-                                     std::vector<std::vector<double>> xs_temps);
 
+  // Does things to construct after the nuclides and temperatures to
+  // read have been specified.
   void init();
 
+  // Set which nuclides and temperatures are to be read
+  void set_nuclides_and_temperatures(std::vector<std::string> xs_to_read,
+                                     std::vector<std::vector<double>> xs_temps);
+
+  // Add an Mgxs object to be managed
   void add_mgxs(hid_t file_id, const std::string& name,
          const std::vector<double>& temperature);
-
-  void create_macro_xs();
-
-  std::vector<std::vector<double>> get_mat_kTs();
 
   // Reads just the header of the cross sections file, to find
   // min & max energies as well as the available XS
   void read_header(const std::string& path_cross_sections);
+
+  // Calculate microscopic cross sections from nuclide macro XS
+  void create_macro_xs();
+
+  // Get the kT values which are used in the OpenMC model
+  std::vector<std::vector<double>> get_mat_kTs();
+
+  int num_energy_groups_;
+  int num_delayed_groups_;
+  std::vector<std::string> xs_names_; // available names in HDF5 file
+  std::vector<std::string> xs_to_read_; // XS which appear in materials
+  std::vector<std::vector<double>> xs_temps_to_read_; // temperatures used
+  std::string cross_sections_path_; // path to MGXS h5 file
+  std::vector<Mgxs> nuclides_;
+  std::vector<Mgxs> macro_xs_;
+  std::vector<double> energy_bins_;
+  std::vector<double> energy_bin_avg_;
+  std::vector<double> rev_energy_bins_;
+  std::vector<std::vector<double>> nuc_temps_; // all available temperatures
 };
 
 namespace data {
-  extern MgxsInterface mgInterface;
+  extern MgxsInterface mg;
 }
 
 // Puts available XS in MGXS file to globals so that when
@@ -72,7 +72,7 @@ namespace data {
 void put_mgxs_header_data_to_globals();
 
 // Set which nuclides and temperatures are to be read on
-// mgInterface through global data
+// mg through global data
 void set_mg_interface_nuclides_and_temps();
 
 // After macro XS have been read, materials can be marked as fissionable

--- a/include/openmc/mgxs_interface.h
+++ b/include/openmc/mgxs_interface.h
@@ -12,36 +12,41 @@
 namespace openmc {
 
 //==============================================================================
-// Global variables
+// Global MGXS data container structure
 //==============================================================================
+
+struct MgxsInterface
+{
+  int num_energy_groups;
+  int num_delayed_groups;
+
+  std::vector<Mgxs> nuclides_MG;
+  std::vector<Mgxs> macro_xs;
+
+  std::vector<double> energy_bins;
+  std::vector<double> energy_bin_avg;
+  std::vector<double> rev_energy_bins;
+
+  MgxsInterface() = default;
+
+  // Construct from path to cross sections file
+  MgxsInterface(const std::string& path_cross_sections);
+
+  void init(const std::string& path_cross_sections);
+
+  void add_mgxs(hid_t file_id, const std::string& name,
+         const std::vector<double>& temperature);
+
+  void create_macro_xs();
+
+  std::vector<std::vector<double>> get_mat_kTs();
+
+  void read_mg_cross_sections_header();
+};
 
 namespace data {
-
-extern std::vector<Mgxs> nuclides_MG;
-extern std::vector<Mgxs> macro_xs;
-extern int num_energy_groups;
-extern int num_delayed_groups;
-extern std::vector<double> energy_bins;
-extern std::vector<double> energy_bin_avg;
-extern std::vector<double> rev_energy_bins;
-
-} // namespace data
-
-//==============================================================================
-// Mgxs data loading interface methods
-//==============================================================================
-
-void read_mgxs();
-
-void
-add_mgxs(hid_t file_id, const std::string& name,
-     const std::vector<double>& temperature);
-
-void create_macro_xs();
-
-std::vector<std::vector<double>> get_mat_kTs();
-
-void read_mg_cross_sections_header();
+  extern MgxsInterface mgInterface;
+}
 
 //==============================================================================
 // Mgxs tracking/transport/tallying interface methods

--- a/include/openmc/mgxs_interface.h
+++ b/include/openmc/mgxs_interface.h
@@ -15,7 +15,7 @@ namespace openmc {
 // Global MGXS data container structure
 //==============================================================================
 
-struct MgxsInterface {
+class MgxsInterface {
 public:
 
   MgxsInterface() = default;

--- a/include/openmc/xsdata.h
+++ b/include/openmc/xsdata.h
@@ -22,8 +22,6 @@ namespace openmc {
 class XsData {
 
   private:
-    //! Number of energy and delayed neutron groups
-    size_t n_g, n_dg;
 
     //! \brief Reads scattering data from the HDF5 file
     void
@@ -63,6 +61,9 @@ class XsData {
     //  the HDF5 file when no delayed data is provided.
     void
     fission_matrix_no_delayed_from_hdf5(hid_t xsdata_grp, size_t n_ang);
+
+    //! Number of energy and delayed neutron groups
+    size_t n_g_, n_dg_;
 
   public:
 

--- a/include/openmc/xsdata.h
+++ b/include/openmc/xsdata.h
@@ -22,6 +22,9 @@ namespace openmc {
 class XsData {
 
   private:
+    //! Number of energy and delayed neutron groups
+    size_t n_g, n_dg;
+
     //! \brief Reads scattering data from the HDF5 file
     void
     scatter_from_hdf5(hid_t xsdata_grp, size_t n_ang,
@@ -98,7 +101,10 @@ class XsData {
     //! @param scatter_format The scattering representation of the file.
     //! @param n_pol Number of polar angles.
     //! @param n_azi Number of azimuthal angles.
-    XsData(bool fissionable, int scatter_format, int n_pol, int n_azi);
+    //! @param n_groups Number of energy groups.
+    //! @param n_d_groups Number of delayed neutron groups.
+    XsData(bool fissionable, int scatter_format, int n_pol, int n_azi,
+           size_t n_groups, size_t n_d_groups);
 
     //! \brief Loads the XsData object from the HDF5 file
     //!

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -155,7 +155,7 @@ void read_cross_sections_xml()
   if (settings::run_CE) {
     read_ce_cross_sections_xml();
   } else {
-    read_mg_cross_sections_header();
+    data::mgInterface.read_mg_cross_sections_header();
   }
 
   // Establish mapping between (type, material) and index in libraries

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -155,7 +155,7 @@ void read_cross_sections_xml()
   if (settings::run_CE) {
     read_ce_cross_sections_xml();
   } else {
-    data::mgInterface.read_header(settings::path_cross_sections);
+    data::mg.read_header(settings::path_cross_sections);
     put_mgxs_header_data_to_globals();
   }
 

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -155,7 +155,8 @@ void read_cross_sections_xml()
   if (settings::run_CE) {
     read_ce_cross_sections_xml();
   } else {
-    data::mgInterface.read_mg_cross_sections_header();
+    data::mgInterface.readHeader(settings::path_cross_sections);
+    putMgxsHeaderDataToGlobals();
   }
 
   // Establish mapping between (type, material) and index in libraries

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -155,8 +155,8 @@ void read_cross_sections_xml()
   if (settings::run_CE) {
     read_ce_cross_sections_xml();
   } else {
-    data::mgInterface.readHeader(settings::path_cross_sections);
-    putMgxsHeaderDataToGlobals();
+    data::mgInterface.read_header(settings::path_cross_sections);
+    put_mgxs_header_data_to_globals();
   }
 
   // Establish mapping between (type, material) and index in libraries

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -260,9 +260,9 @@ void read_input_xml()
       read_ce_cross_sections(nuc_temps, thermal_temps);
     } else {
       // Create material macroscopic data for MGXS
-      setMgInterfaceNuclidesAndTemps();
+      set_mg_interface_nuclides_and_temps();
       data::mgInterface.init();
-      markFissionableMgxsMaterials();
+      mark_fissionable_mgxs_materials();
     }
     simulation::time_read_xs.stop();
   }

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -260,8 +260,9 @@ void read_input_xml()
       read_ce_cross_sections(nuc_temps, thermal_temps);
     } else {
       // Create material macroscopic data for MGXS
-      data::mgInterface.init(settings::path_cross_sections);
-      data::mgInterface.create_macro_xs();
+      setMgInterfaceNuclidesAndTemps();
+      data::mgInterface.init();
+      markFissionableMgxsMaterials();
     }
     simulation::time_read_xs.stop();
   }

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -261,7 +261,7 @@ void read_input_xml()
     } else {
       // Create material macroscopic data for MGXS
       set_mg_interface_nuclides_and_temps();
-      data::mgInterface.init();
+      data::mg.init();
       mark_fissionable_mgxs_materials();
     }
     simulation::time_read_xs.stop();

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -260,8 +260,8 @@ void read_input_xml()
       read_ce_cross_sections(nuc_temps, thermal_temps);
     } else {
       // Create material macroscopic data for MGXS
-      read_mgxs();
-      create_macro_xs();
+      data::mgInterface.init(settings::path_cross_sections);
+      data::mgInterface.create_macro_xs();
     }
     simulation::time_read_xs.stop();
   }

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -368,7 +368,7 @@ void Material::normalize_density()
     // determine atomic weight ratio
     int i_nuc = nuclide_[i];
     double awr = settings::run_CE ?
-      data::nuclides[i_nuc]->awr_ : data::mgInterface.nuclides_MG[i_nuc].awr;
+      data::nuclides[i_nuc]->awr_ : data::mg.nuclides_[i_nuc].awr;
 
     // if given weight percent, convert all values so that they are divided
     // by awr. thus, when a sum is done over the values, it's actually
@@ -388,7 +388,7 @@ void Material::normalize_density()
     for (int i = 0; i < nuclide_.size(); ++i) {
       int i_nuc = nuclide_[i];
       double awr = settings::run_CE ?
-        data::nuclides[i_nuc]->awr_ : data::mgInterface.nuclides_MG[i_nuc].awr;
+        data::nuclides[i_nuc]->awr_ : data::mg.nuclides_[i_nuc].awr;
       sum_percent += atom_density_(i)*awr;
     }
     sum_percent = 1.0 / sum_percent;
@@ -726,7 +726,7 @@ void Material::init_bremsstrahlung()
 void Material::init_nuclide_index()
 {
   int n = settings::run_CE ?
-    data::nuclides.size() : data::mgInterface.nuclides_MG.size();
+    data::nuclides.size() : data::mg.nuclides_.size();
   mat_nuclide_index_.resize(n);
   std::fill(mat_nuclide_index_.begin(), mat_nuclide_index_.end(), C_NONE);
   for (int i = 0; i < nuclide_.size(); ++i) {
@@ -994,11 +994,11 @@ void Material::to_hdf5(hid_t group) const
   } else {
     for (int i = 0; i < nuclide_.size(); ++i) {
       int i_nuc = nuclide_[i];
-      if (data::mgInterface.nuclides_MG[i_nuc].awr != MACROSCOPIC_AWR) {
-        nuc_names.push_back(data::mgInterface.nuclides_MG[i_nuc].name);
+      if (data::mg.nuclides_[i_nuc].awr != MACROSCOPIC_AWR) {
+        nuc_names.push_back(data::mg.nuclides_[i_nuc].name);
         nuc_densities.push_back(atom_density_(i));
       } else {
-        macro_names.push_back(data::mgInterface.nuclides_MG[i_nuc].name);
+        macro_names.push_back(data::mg.nuclides_[i_nuc].name);
       }
     }
   }

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -368,7 +368,7 @@ void Material::normalize_density()
     // determine atomic weight ratio
     int i_nuc = nuclide_[i];
     double awr = settings::run_CE ?
-      data::nuclides[i_nuc]->awr_ : data::nuclides_MG[i_nuc].awr;
+      data::nuclides[i_nuc]->awr_ : data::mgInterface.nuclides_MG[i_nuc].awr;
 
     // if given weight percent, convert all values so that they are divided
     // by awr. thus, when a sum is done over the values, it's actually
@@ -388,7 +388,7 @@ void Material::normalize_density()
     for (int i = 0; i < nuclide_.size(); ++i) {
       int i_nuc = nuclide_[i];
       double awr = settings::run_CE ?
-        data::nuclides[i_nuc]->awr_ : data::nuclides_MG[i_nuc].awr;
+        data::nuclides[i_nuc]->awr_ : data::mgInterface.nuclides_MG[i_nuc].awr;
       sum_percent += atom_density_(i)*awr;
     }
     sum_percent = 1.0 / sum_percent;
@@ -726,7 +726,7 @@ void Material::init_bremsstrahlung()
 void Material::init_nuclide_index()
 {
   int n = settings::run_CE ?
-    data::nuclides.size() : data::nuclides_MG.size();
+    data::nuclides.size() : data::mgInterface.nuclides_MG.size();
   mat_nuclide_index_.resize(n);
   std::fill(mat_nuclide_index_.begin(), mat_nuclide_index_.end(), C_NONE);
   for (int i = 0; i < nuclide_.size(); ++i) {
@@ -994,11 +994,11 @@ void Material::to_hdf5(hid_t group) const
   } else {
     for (int i = 0; i < nuclide_.size(); ++i) {
       int i_nuc = nuclide_[i];
-      if (data::nuclides_MG[i_nuc].awr != MACROSCOPIC_AWR) {
-        nuc_names.push_back(data::nuclides_MG[i_nuc].name);
+      if (data::mgInterface.nuclides_MG[i_nuc].awr != MACROSCOPIC_AWR) {
+        nuc_names.push_back(data::mgInterface.nuclides_MG[i_nuc].name);
         nuc_densities.push_back(atom_density_(i));
       } else {
-        macro_names.push_back(data::nuclides_MG[i_nuc].name);
+        macro_names.push_back(data::mgInterface.nuclides_MG[i_nuc].name);
       }
     }
   }

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -25,18 +25,6 @@
 namespace openmc {
 
 //==============================================================================
-// Global variables
-//==============================================================================
-
-namespace data {
-
-// Storage for the MGXS data
-std::vector<Mgxs> nuclides_MG;
-std::vector<Mgxs> macro_xs;
-
-} // namespace data
-
-//==============================================================================
 // Mgxs base-class methods
 //==============================================================================
 
@@ -53,8 +41,6 @@ Mgxs::init(const std::string& in_name, double in_awr,
   kTs = xt::adapt(in_kTs);
   fissionable = in_fissionable;
   scatter_format = in_scatter_format;
-  num_groups = data::num_energy_groups;
-  num_delayed_groups = data::num_delayed_groups;
   xs.resize(in_kTs.size());
   is_isotropic = in_is_isotropic;
   n_pol = in_polar.size();
@@ -284,7 +270,10 @@ Mgxs::metadata_from_hdf5(hid_t xs_id, const std::vector<double>& temperature,
 
 //==============================================================================
 
-Mgxs::Mgxs(hid_t xs_id, const std::vector<double>& temperature)
+Mgxs::Mgxs(hid_t xs_id, const std::vector<double>& temperature,
+    int num_group, int num_delay) :
+  num_groups(num_group),
+  num_delayed_groups(num_delay)
 {
   // Call generic data gathering routine (will populate the metadata)
   int order_data;
@@ -317,7 +306,10 @@ Mgxs::Mgxs(hid_t xs_id, const std::vector<double>& temperature)
 //==============================================================================
 
 Mgxs::Mgxs(const std::string& in_name, const std::vector<double>& mat_kTs,
-     const std::vector<Mgxs*>& micros, const std::vector<double>& atom_densities)
+     const std::vector<Mgxs*>& micros, const std::vector<double>& atom_densities,
+     int num_group, int num_delay) :
+  num_groups(num_group),
+  num_delayed_groups(num_delay)
 {
   // Get the minimum data needed to initialize:
   // Dont need awr, but lets just initialize it anyways

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -288,7 +288,8 @@ Mgxs::Mgxs(hid_t xs_id, const std::vector<double>& temperature,
 
   // Load the more specific XsData information
   for (int t = 0; t < temps_to_read.size(); t++) {
-    xs[t] = XsData(fissionable, final_scatter_format, n_pol, n_azi);
+    xs[t] = XsData(fissionable, final_scatter_format, n_pol, n_azi,
+                   num_groups, num_delayed_groups);
     // Get the temperature as a string and then open the HDF5 group
     std::string temp_str = std::to_string(temps_to_read[t]) + "K";
     hid_t xsdata_grp = open_group(xs_id, temp_str.c_str());
@@ -332,7 +333,7 @@ Mgxs::Mgxs(const std::string& in_name, const std::vector<double>& mat_kTs,
   // Create the xs data for each temperature
   for (int t = 0; t < mat_kTs.size(); t++) {
     xs[t] = XsData(in_fissionable, in_scatter_format, in_polar.size(),
-      in_azimuthal.size());
+      in_azimuthal.size(), num_groups, num_delayed_groups);
 
     // Find the right temperature index to use
     double temp_desired = mat_kTs[t];

--- a/src/mgxs_interface.cpp
+++ b/src/mgxs_interface.cpp
@@ -112,7 +112,7 @@ MgxsInterface::add_mgxs(hid_t file_id, const std::string& name,
                 + "provided MGXS Library");
   }
 
-  nuclides_MG.emplace_back(xsgavin.keith.ridley@gmail.com_grp, temperature, num_energy_groups,
+  nuclides_MG.emplace_back(xs_grp, temperature, num_energy_groups,
       num_delayed_groups);
   close_group(xs_grp);
 }

--- a/src/mgxs_interface.cpp
+++ b/src/mgxs_interface.cpp
@@ -31,19 +31,16 @@ MgxsInterface::MgxsInterface(const std::string& path_cross_sections,
                              const std::vector<std::vector<double>> xs_temps)
 {
   read_header(path_cross_sections);
-  set_nuclides_to_read(xs_to_read);
-  set_nuclide_temperatures_to_read(xs_temps);
+  set_nuclides_and_temperatures(xs_to_read, xs_temps);
   init();
 }
 
-// Should these perhaps unnecessary setters be lumped into one?
-void MgxsInterface::set_nuclides_to_read(std::vector<std::string> arg_xs_to_read)
+void MgxsInterface::set_nuclides_and_temperatures(
+    std::vector<std::string> arg_xs_to_read,
+    std::vector<std::vector<double>> xs_temps)
 { 
   // Check to remove all duplicates
   xs_to_read = arg_xs_to_read;
-}
-void MgxsInterface::set_nuclide_temperatures_to_read(std::vector<std::vector<double>> xs_temps)
-{
   xs_temps_to_read = xs_temps;
   if (xs_to_read.size() != xs_temps.size())
     fatal_error("The list of macro XS temperatures to read does not "
@@ -264,7 +261,7 @@ void set_mg_interface_nuclides_and_temps()
 
   std::unordered_set<std::string> already_read;
 
-  // Loop over all files
+  // Loop over materials to find xs and temperature to be read
   for (const auto& mat : model::materials) {
     for (int i_nuc : mat->nuclide_) {
       std::string& name = nuclide_names[i_nuc];
@@ -272,8 +269,6 @@ void set_mg_interface_nuclides_and_temps()
       if (already_read.find(name) == already_read.end()) {
         data::mgInterface.xs_to_read.push_back(name);
         data::mgInterface.xs_temps_to_read.push_back(these_nuc_temps[i_nuc]);
-        // DBG
-        std::cout << these_nuc_temps[i_nuc][0] << std::endl;
         already_read.insert(name);
       }
     }

--- a/src/mgxs_interface.cpp
+++ b/src/mgxs_interface.cpp
@@ -30,19 +30,19 @@ MgxsInterface::MgxsInterface(const std::string& path_cross_sections,
                              const std::vector<std::string> xs_to_read,
                              const std::vector<std::vector<double>> xs_temps)
 {
-  readHeader(path_cross_sections);
-  setNuclidesToRead(xs_to_read);
-  setNuclideTemperaturesToRead(xs_temps);
+  read_header(path_cross_sections);
+  set_nuclides_to_read(xs_to_read);
+  set_nuclide_temperatures_to_read(xs_temps);
   init();
 }
 
 // Should these perhaps unnecessary setters be lumped into one?
-void MgxsInterface::setNuclidesToRead(std::vector<std::string> arg_xs_to_read)
+void MgxsInterface::set_nuclides_to_read(std::vector<std::string> arg_xs_to_read)
 { 
   // Check to remove all duplicates
   xs_to_read = arg_xs_to_read;
 }
-void MgxsInterface::setNuclideTemperaturesToRead(std::vector<std::vector<double>> xs_temps)
+void MgxsInterface::set_nuclide_temperatures_to_read(std::vector<std::vector<double>> xs_temps)
 {
   xs_temps_to_read = xs_temps;
   if (xs_to_read.size() != xs_temps.size())
@@ -182,7 +182,7 @@ std::vector<std::vector<double>> MgxsInterface::get_mat_kTs()
 
 //==============================================================================
 
-void MgxsInterface::readHeader(const std::string& path_cross_sections)
+void MgxsInterface::read_header(const std::string& path_cross_sections)
 {
   // Save name of HDF5 file to be read to struct data
   cross_sections_path = path_cross_sections;
@@ -231,7 +231,7 @@ void MgxsInterface::readHeader(const std::string& path_cross_sections)
   file_close(file_id);
 }
 
-void putMgxsHeaderDataToGlobals()
+void put_mgxs_header_data_to_globals()
 {
   // Get the minimum and maximum energies
   int neutron = static_cast<int>(Particle::Type::neutron);
@@ -249,7 +249,7 @@ void putMgxsHeaderDataToGlobals()
   }
 }
 
-void setMgInterfaceNuclidesAndTemps()
+void set_mg_interface_nuclides_and_temps()
 {
   // Get temperatures from global data
   std::vector<std::vector<double>> these_nuc_temps(data::nuclide_map.size());
@@ -280,7 +280,7 @@ void setMgInterfaceNuclidesAndTemps()
   }
 }
 
-void markFissionableMgxsMaterials()
+void mark_fissionable_mgxs_materials()
 {
   // Loop over all files
   for (const auto& mat : model::materials) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -710,7 +710,7 @@ write_tallies()
               << data::nuclides[i_nuclide]->name_ << "\n";
           } else {
             tallies_out << std::string(indent+1, ' ')
-              << data::mgInterface.nuclides_MG[i_nuclide].name << "\n";
+              << data::mg.nuclides_[i_nuclide].name << "\n";
           }
         }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -710,7 +710,7 @@ write_tallies()
               << data::nuclides[i_nuclide]->name_ << "\n";
           } else {
             tallies_out << std::string(indent+1, ' ')
-              << data::nuclides_MG[i_nuclide].name << "\n";
+              << data::mgInterface.nuclides_MG[i_nuclide].name << "\n";
           }
         }
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -123,7 +123,7 @@ Particle::from_source(const Bank* src)
   } else {
     g_ = static_cast<int>(src->E);
     g_last_ = static_cast<int>(src->E);
-    E_ = data::energy_bin_avg[g_ - 1];
+    E_ = data::mgInterface.energy_bin_avg[g_ - 1];
   }
   E_last_ = E_;
 }

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -123,7 +123,7 @@ Particle::from_source(const Bank* src)
   } else {
     g_ = static_cast<int>(src->E);
     g_last_ = static_cast<int>(src->E);
-    E_ = data::mgInterface.energy_bin_avg[g_ - 1];
+    E_ = data::mg.energy_bin_avg_[g_ - 1];
   }
   E_last_ = E_;
 }

--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -52,7 +52,7 @@ void read_particle_restart(Particle& p, int& previous_run_mode)
   // Set energy group and average energy in multi-group mode
   if (!settings::run_CE) {
     p.g_ = p.E_;
-    p.E_ = data::mgInterface.energy_bin_avg[p.g_ - 1];
+    p.E_ = data::mg.energy_bin_avg_[p.g_ - 1];
   }
 
   // Set particle last attributes

--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -52,7 +52,7 @@ void read_particle_restart(Particle& p, int& previous_run_mode)
   // Set energy group and average energy in multi-group mode
   if (!settings::run_CE) {
     p.g_ = p.E_;
-    p.E_ = data::energy_bin_avg[p.g_ - 1];
+    p.E_ = data::mgInterface.energy_bin_avg[p.g_ - 1];
   }
 
   // Set particle last attributes

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -82,7 +82,7 @@ scatter(Particle* p)
   int gin = p->g_last_ - 1;
   int gout = p->g_ - 1;
   int i_mat = p->material_;
-  data::macro_xs[i_mat].sample_scatter(gin, gout, p->mu_, p->wgt_);
+  data::mgInterface.macro_xs[i_mat].sample_scatter(gin, gout, p->mu_, p->wgt_);
 
   // Adjust return value for fortran indexing
   // TODO: Remove when no longer needed
@@ -92,7 +92,7 @@ scatter(Particle* p)
   p->u() = rotate_angle(p->u(), p->mu_, nullptr);
 
   // Update energy value for downstream compatability (in tallying)
-  p->E_ = data::energy_bin_avg[gout];
+  p->E_ = data::mgInterface.energy_bin_avg[gout];
 
   // Set event component
   p->event_ = EVENT_SCATTER;
@@ -148,7 +148,7 @@ create_fission_sites(Particle* p, std::vector<Particle::Bank>& bank)
     // the energy in the fission bank
     int dg;
     int gout;
-    data::macro_xs[p->material_].sample_fission_energy(p->g_ - 1, dg, gout);
+    data::mgInterface.macro_xs[p->material_].sample_fission_energy(p->g_ - 1, dg, gout);
     site.E = gout + 1;
     site.delayed_group = dg + 1;
 

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -82,7 +82,7 @@ scatter(Particle* p)
   int gin = p->g_last_ - 1;
   int gout = p->g_ - 1;
   int i_mat = p->material_;
-  data::mgInterface.macro_xs[i_mat].sample_scatter(gin, gout, p->mu_, p->wgt_);
+  data::mg.macro_xs_[i_mat].sample_scatter(gin, gout, p->mu_, p->wgt_);
 
   // Adjust return value for fortran indexing
   // TODO: Remove when no longer needed
@@ -92,7 +92,7 @@ scatter(Particle* p)
   p->u() = rotate_angle(p->u(), p->mu_, nullptr);
 
   // Update energy value for downstream compatability (in tallying)
-  p->E_ = data::mgInterface.energy_bin_avg[gout];
+  p->E_ = data::mg.energy_bin_avg_[gout];
 
   // Set event component
   p->event_ = EVENT_SCATTER;
@@ -148,7 +148,7 @@ create_fission_sites(Particle* p, std::vector<Particle::Bank>& bank)
     // the energy in the fission bank
     int dg;
     int gout;
-    data::mgInterface.macro_xs[p->material_].sample_fission_energy(p->g_ - 1, dg, gout);
+    data::mg.macro_xs_[p->material_].sample_fission_energy(p->g_ - 1, dg, gout);
     site.E = gout + 1;
     site.delayed_group = dg + 1;
 

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -311,9 +311,9 @@ Particle::Bank sample_external_source()
 
   // If running in MG, convert site % E to group
   if (!settings::run_CE) {
-    site.E = lower_bound_index(data::mgInterface.rev_energy_bins.begin(),
-      data::mgInterface.rev_energy_bins.end(), site.E);
-    site.E = data::mgInterface.num_energy_groups - site.E;
+    site.E = lower_bound_index(data::mg.rev_energy_bins_.begin(),
+      data::mg.rev_energy_bins_.end(), site.E);
+    site.E = data::mg.num_energy_groups_ - site.E;
   }
 
   // Set the random number generator back to the tracking stream.

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -311,9 +311,9 @@ Particle::Bank sample_external_source()
 
   // If running in MG, convert site % E to group
   if (!settings::run_CE) {
-    site.E = lower_bound_index(data::rev_energy_bins.begin(),
-      data::rev_energy_bins.end(), site.E);
-    site.E = data::num_energy_groups - site.E;
+    site.E = lower_bound_index(data::mgInterface.rev_energy_bins.begin(),
+      data::mgInterface.rev_energy_bins.end(), site.E);
+    site.E = data::mgInterface.num_energy_groups - site.E;
   }
 
   // Set the random number generator back to the tracking stream.

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -208,7 +208,7 @@ openmc_statepoint_write(const char* filename, bool* write_source)
             if (settings::run_CE) {
               nuclides.push_back(data::nuclides[i_nuclide]->name_);
             } else {
-              nuclides.push_back(data::mgInterface.nuclides_MG[i_nuclide].name);
+              nuclides.push_back(data::mg.nuclides_[i_nuclide].name);
             }
           }
         }

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -208,7 +208,7 @@ openmc_statepoint_write(const char* filename, bool* write_source)
             if (settings::run_CE) {
               nuclides.push_back(data::nuclides[i_nuclide]->name_);
             } else {
-              nuclides.push_back(data::nuclides_MG[i_nuclide].name);
+              nuclides.push_back(data::mgInterface.nuclides_MG[i_nuclide].name);
             }
           }
         }

--- a/src/summary.cpp
+++ b/src/summary.cpp
@@ -57,7 +57,7 @@ void write_nuclides(hid_t file)
       nuc_names.push_back(nuc->name_);
       awrs.push_back(nuc->awr_);
     } else {
-      const auto& nuc {data::nuclides_MG[i]};
+      const auto& nuc {data::mgInterface.nuclides_MG[i]};
       if (nuc.awr != MACROSCOPIC_AWR) {
         nuc_names.push_back(nuc.name);
         awrs.push_back(nuc.awr);

--- a/src/summary.cpp
+++ b/src/summary.cpp
@@ -57,7 +57,7 @@ void write_nuclides(hid_t file)
       nuc_names.push_back(nuc->name_);
       awrs.push_back(nuc->awr_);
     } else {
-      const auto& nuc {data::mgInterface.nuclides_MG[i]};
+      const auto& nuc {data::mg.nuclides_[i]};
       if (nuc.awr != MACROSCOPIC_AWR) {
         nuc_names.push_back(nuc.name);
         awrs.push_back(nuc.awr);

--- a/src/tallies/filter_energy.cpp
+++ b/src/tallies/filter_energy.cpp
@@ -43,10 +43,10 @@ EnergyFilter::set_bins(gsl::span<const double> bins)
   // (after flipping for the different ordering of the library and tallying
   // systems).
   if (!settings::run_CE) {
-    if (n_bins_ == data::num_energy_groups) {
+    if (n_bins_ == data::mgInterface.num_energy_groups) {
       matches_transport_groups_ = true;
       for (gsl::index i = 0; i < n_bins_ + 1; ++i) {
-        if (data::rev_energy_bins[i] != bins_[i]) {
+        if (data::mgInterface.rev_energy_bins[i] != bins_[i]) {
           matches_transport_groups_ = false;
           break;
         }
@@ -61,9 +61,9 @@ const
 {
   if (p->g_ != F90_NONE && matches_transport_groups_) {
     if (estimator == ESTIMATOR_TRACKLENGTH) {
-      match.bins_.push_back(data::num_energy_groups - p->g_);
+      match.bins_.push_back(data::mgInterface.num_energy_groups - p->g_);
     } else {
-      match.bins_.push_back(data::num_energy_groups - p->g_last_);
+      match.bins_.push_back(data::mgInterface.num_energy_groups - p->g_last_);
     }
     match.weights_.push_back(1.0);
 
@@ -104,7 +104,7 @@ EnergyoutFilter::get_all_bins(const Particle* p, int estimator,
                               FilterMatch& match) const
 {
   if (p->g_ != F90_NONE && matches_transport_groups_) {
-    match.bins_.push_back(data::num_energy_groups - p->g_);
+    match.bins_.push_back(data::mgInterface.num_energy_groups - p->g_);
     match.weights_.push_back(1.0);
 
   } else {

--- a/src/tallies/filter_energy.cpp
+++ b/src/tallies/filter_energy.cpp
@@ -43,10 +43,10 @@ EnergyFilter::set_bins(gsl::span<const double> bins)
   // (after flipping for the different ordering of the library and tallying
   // systems).
   if (!settings::run_CE) {
-    if (n_bins_ == data::mgInterface.num_energy_groups) {
+    if (n_bins_ == data::mg.num_energy_groups_) {
       matches_transport_groups_ = true;
       for (gsl::index i = 0; i < n_bins_ + 1; ++i) {
-        if (data::mgInterface.rev_energy_bins[i] != bins_[i]) {
+        if (data::mg.rev_energy_bins_[i] != bins_[i]) {
           matches_transport_groups_ = false;
           break;
         }
@@ -61,9 +61,9 @@ const
 {
   if (p->g_ != F90_NONE && matches_transport_groups_) {
     if (estimator == ESTIMATOR_TRACKLENGTH) {
-      match.bins_.push_back(data::mgInterface.num_energy_groups - p->g_);
+      match.bins_.push_back(data::mg.num_energy_groups_ - p->g_);
     } else {
-      match.bins_.push_back(data::mgInterface.num_energy_groups - p->g_last_);
+      match.bins_.push_back(data::mg.num_energy_groups_ - p->g_last_);
     }
     match.weights_.push_back(1.0);
 
@@ -104,7 +104,7 @@ EnergyoutFilter::get_all_bins(const Particle* p, int estimator,
                               FilterMatch& match) const
 {
   if (p->g_ != F90_NONE && matches_transport_groups_) {
-    match.bins_.push_back(data::mgInterface.num_energy_groups - p->g_);
+    match.bins_.push_back(data::mg.num_energy_groups_ - p->g_);
     match.weights_.push_back(1.0);
 
   } else {

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -361,7 +361,7 @@ score_fission_eout(const Particle* p, int i_tally, int i_score, int score_bin)
       if (settings::run_CE) {
         E_out = bank.E;
       } else {
-        E_out = data::energy_bin_avg[static_cast<int>(bank.E)];
+        E_out = data::mgInterface.energy_bin_avg[static_cast<int>(bank.E)];
       }
 
       // Set EnergyoutFilter bin index
@@ -1376,13 +1376,13 @@ score_general_mg(const Particle* p, int i_tally, int start_index,
 
   // To significantly reduce de-referencing, point matxs to the macroscopic
   // Mgxs for the material of interest
-  data::macro_xs[p->material_].set_angle_index(p_u);
+  data::mgInterface.macro_xs[p->material_].set_angle_index(p_u);
 
   // Do same for nucxs, point it to the microscopic nuclide data of interest
   if (i_nuclide >= 0) {
     // And since we haven't calculated this temperature index yet, do so now
-    data::nuclides_MG[i_nuclide].set_temperature_index(p->sqrtkT_);
-    data::nuclides_MG[i_nuclide].set_angle_index(p_u);
+    data::mgInterface.nuclides_MG[i_nuclide].set_temperature_index(p->sqrtkT_);
+    data::mgInterface.nuclides_MG[i_nuclide].set_angle_index(p_u);
   }
 
   for (auto i = 0; i < tally.scores_.size(); ++i) {
@@ -1869,7 +1869,7 @@ score_general_mg(const Particle* p, int i_tally, int start_index,
               // delayed-nu-fission xs to the absorption xs for all delayed
               // groups
               score = 0.;
-              for (auto d = 0; d < data::num_delayed_groups; ++d) {
+              for (auto d = 0; d < data::mgInterface.num_delayed_groups; ++d) {
                 if (i_nuclide >= 0) {
                   score += p->wgt_absorb_ * flux
                     * get_nuclide_xs(i_nuclide, MG_GET_XS_DECAY_RATE,
@@ -1960,7 +1960,7 @@ score_general_mg(const Particle* p, int i_tally, int start_index,
           continue;
         } else {
           score = 0.;
-          for (auto d = 0; d < data::num_delayed_groups; ++d) {
+          for (auto d = 0; d < data::mgInterface.num_delayed_groups; ++d) {
             if (i_nuclide >= 0) {
               score += atom_density * flux
                 * get_nuclide_xs(i_nuclide, MG_GET_XS_DECAY_RATE,

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -361,7 +361,7 @@ score_fission_eout(const Particle* p, int i_tally, int i_score, int score_bin)
       if (settings::run_CE) {
         E_out = bank.E;
       } else {
-        E_out = data::mgInterface.energy_bin_avg[static_cast<int>(bank.E)];
+        E_out = data::mg.energy_bin_avg_[static_cast<int>(bank.E)];
       }
 
       // Set EnergyoutFilter bin index
@@ -1376,13 +1376,13 @@ score_general_mg(const Particle* p, int i_tally, int start_index,
 
   // To significantly reduce de-referencing, point matxs to the macroscopic
   // Mgxs for the material of interest
-  data::mgInterface.macro_xs[p->material_].set_angle_index(p_u);
+  data::mg.macro_xs_[p->material_].set_angle_index(p_u);
 
   // Do same for nucxs, point it to the microscopic nuclide data of interest
   if (i_nuclide >= 0) {
     // And since we haven't calculated this temperature index yet, do so now
-    data::mgInterface.nuclides_MG[i_nuclide].set_temperature_index(p->sqrtkT_);
-    data::mgInterface.nuclides_MG[i_nuclide].set_angle_index(p_u);
+    data::mg.nuclides_[i_nuclide].set_temperature_index(p->sqrtkT_);
+    data::mg.nuclides_[i_nuclide].set_angle_index(p_u);
   }
 
   for (auto i = 0; i < tally.scores_.size(); ++i) {
@@ -1869,7 +1869,7 @@ score_general_mg(const Particle* p, int i_tally, int start_index,
               // delayed-nu-fission xs to the absorption xs for all delayed
               // groups
               score = 0.;
-              for (auto d = 0; d < data::mgInterface.num_delayed_groups; ++d) {
+              for (auto d = 0; d < data::mg.num_delayed_groups_; ++d) {
                 if (i_nuclide >= 0) {
                   score += p->wgt_absorb_ * flux
                     * get_nuclide_xs(i_nuclide, MG_GET_XS_DECAY_RATE,
@@ -1960,7 +1960,7 @@ score_general_mg(const Particle* p, int i_tally, int start_index,
           continue;
         } else {
           score = 0.;
-          for (auto d = 0; d < data::mgInterface.num_delayed_groups; ++d) {
+          for (auto d = 0; d < data::mg.num_delayed_groups_; ++d) {
             if (i_nuclide >= 0) {
               score += atom_density * flux
                 * get_nuclide_xs(i_nuclide, MG_GET_XS_DECAY_RATE,

--- a/src/xsdata.cpp
+++ b/src/xsdata.cpp
@@ -26,8 +26,8 @@ namespace openmc {
 
 XsData::XsData(bool fissionable, int scatter_format, int n_pol, int n_azi,
                size_t n_groups, size_t n_d_groups) :
-  n_g(n_groups),
-  n_dg(n_d_groups)
+  n_g_(n_groups),
+  n_dg_(n_d_groups)
 {
   size_t n_ang = n_pol * n_azi;
 
@@ -37,7 +37,7 @@ XsData::XsData(bool fissionable, int scatter_format, int n_pol, int n_azi,
     fatal_error("Invalid scatter_format!");
   }
   // allocate all [temperature][angle][in group] quantities
-  std::vector<size_t> shape {n_ang, n_g};
+  std::vector<size_t> shape {n_ang, n_g_};
   total = xt::zeros<double>(shape);
   absorption = xt::zeros<double>(shape);
   inverse_velocity = xt::zeros<double>(shape);
@@ -49,20 +49,20 @@ XsData::XsData(bool fissionable, int scatter_format, int n_pol, int n_azi,
   }
 
   // allocate decay_rate; [temperature][angle][delayed group]
-  shape[1] = n_dg;
+  shape[1] = n_dg_;
   decay_rate = xt::zeros<double>(shape);
 
   if (fissionable) {
-    shape = {n_ang, n_dg, n_g};
+    shape = {n_ang, n_dg_, n_g_};
     // allocate delayed_nu_fission; [temperature][angle][delay group][in group]
     delayed_nu_fission = xt::zeros<double>(shape);
 
     // chi_prompt; [temperature][angle][in group][out group]
-    shape = {n_ang, n_g, n_g};
+    shape = {n_ang, n_g_, n_g_};
     chi_prompt = xt::zeros<double>(shape);
 
     // chi_delayed; [temperature][angle][delay group][in group][out group]
-    shape = {n_ang, n_dg, n_g, n_g};
+    shape = {n_ang, n_dg_, n_g_, n_g_};
     chi_delayed = xt::zeros<double>(shape);
   }
 
@@ -129,7 +129,7 @@ XsData::fission_vector_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang,
   // Data is provided as nu-fission and chi with a beta for delayed info
 
   // Get chi
-  xt::xtensor<double, 2> temp_chi({n_ang, n_g}, 0.);
+  xt::xtensor<double, 2> temp_chi({n_ang, n_g_}, 0.);
   read_nd_vector(xsdata_grp, "chi", temp_chi, true);
 
   // Normalize chi by summing over the outgoing groups for each incoming angle
@@ -142,7 +142,7 @@ XsData::fission_vector_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang,
                          xt::all());
 
   // Get nu-fission
-  xt::xtensor<double, 2> temp_nufiss({n_ang, n_g}, 0.);
+  xt::xtensor<double, 2> temp_nufiss({n_ang, n_g_}, 0.);
   read_nd_vector(xsdata_grp, "nu-fission", temp_nufiss, true);
 
   // Get beta (strategy will depend upon the number of dimensions in beta)
@@ -152,7 +152,7 @@ XsData::fission_vector_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang,
   int ndim_target = 1;
   if (!is_isotropic) ndim_target += 2;
   if (beta_ndims == ndim_target) {
-    xt::xtensor<double, 2> temp_beta({n_ang, n_dg}, 0.);
+    xt::xtensor<double, 2> temp_beta({n_ang, n_dg_}, 0.);
     read_nd_vector(xsdata_grp, "beta", temp_beta, true);
 
     // Set prompt_nu_fission = (1. - beta_total)*nu_fission
@@ -163,7 +163,7 @@ XsData::fission_vector_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang,
          xt::view(temp_beta, xt::all(), xt::all(), xt::newaxis()) *
          xt::view(temp_nufiss, xt::all(), xt::newaxis(), xt::all());
   } else if (beta_ndims == ndim_target + 1) {
-    xt::xtensor<double, 3> temp_beta({n_ang, n_dg, n_g}, 0.);
+    xt::xtensor<double, 3> temp_beta({n_ang, n_dg_, n_g_}, 0.);
     read_nd_vector(xsdata_grp, "beta", temp_beta, true);
 
     // Set prompt_nu_fission = (1. - beta_total)*nu_fission
@@ -181,14 +181,14 @@ XsData::fission_vector_no_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang)
   // Data is provided separately as prompt + delayed nu-fission and chi
 
   // Get chi-prompt
-  xt::xtensor<double, 2> temp_chi_p({n_ang, n_g}, 0.);
+  xt::xtensor<double, 2> temp_chi_p({n_ang, n_g_}, 0.);
   read_nd_vector(xsdata_grp, "chi-prompt", temp_chi_p, true);
 
   // Normalize chi by summing over the outgoing groups for each incoming angle
   temp_chi_p /= xt::view(xt::sum(temp_chi_p, {1}), xt::all(), xt::newaxis());
 
   // Get chi-delayed
-  xt::xtensor<double, 3> temp_chi_d({n_ang, n_dg, n_g}, 0.);
+  xt::xtensor<double, 3> temp_chi_d({n_ang, n_dg_, n_g_}, 0.);
   read_nd_vector(xsdata_grp, "chi-delayed", temp_chi_d, true);
 
   // Normalize chi by summing over the outgoing groups for each incoming angle
@@ -214,7 +214,7 @@ XsData::fission_vector_no_delayed_from_hdf5(hid_t xsdata_grp, size_t n_ang)
   // Therefore, the code only considers the data as prompt.
 
   // Get chi
-  xt::xtensor<double, 2> temp_chi({n_ang, n_g}, 0.);
+  xt::xtensor<double, 2> temp_chi({n_ang, n_g_}, 0.);
   read_nd_vector(xsdata_grp, "chi", temp_chi, true);
 
   // Normalize chi by summing over the outgoing groups for each incoming angle
@@ -235,7 +235,7 @@ XsData::fission_matrix_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang, bool is_is
   // Data is provided as nu-fission and chi with a beta for delayed info
 
   // Get nu-fission matrix
-  xt::xtensor<double, 3> temp_matrix({n_ang, n_g, n_g}, 0.);
+  xt::xtensor<double, 3> temp_matrix({n_ang, n_g_, n_g_}, 0.);
   read_nd_vector(xsdata_grp, "nu-fission", temp_matrix, true);
 
   // Get beta (strategy will depend upon the number of dimensions in beta)
@@ -245,7 +245,7 @@ XsData::fission_matrix_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang, bool is_is
   int ndim_target = 1;
   if (!is_isotropic) ndim_target += 2;
   if (beta_ndims == ndim_target) {
-    xt::xtensor<double, 2> temp_beta({n_ang, n_dg}, 0.);
+    xt::xtensor<double, 2> temp_beta({n_ang, n_dg_}, 0.);
     read_nd_vector(xsdata_grp, "beta", temp_beta, true);
 
     xt::xtensor<double, 1> temp_beta_sum({n_ang}, 0.);
@@ -271,10 +271,10 @@ XsData::fission_matrix_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang, bool is_is
          xt::view(temp_matrix, xt::all(), xt::newaxis(), xt::all(), xt::all());
 
   } else if (beta_ndims == ndim_target + 1) {
-    xt::xtensor<double, 3> temp_beta({n_ang, n_dg, n_g}, 0.);
+    xt::xtensor<double, 3> temp_beta({n_ang, n_dg_, n_g_}, 0.);
     read_nd_vector(xsdata_grp, "beta", temp_beta, true);
 
-    xt::xtensor<double, 2> temp_beta_sum({n_ang, n_g}, 0.);
+    xt::xtensor<double, 2> temp_beta_sum({n_ang, n_g_}, 0.);
     temp_beta_sum = xt::sum(temp_beta, {1});
 
     // prompt_nu_fission is the sum of this matrix over outgoing groups and
@@ -310,7 +310,7 @@ XsData::fission_matrix_no_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang)
   // Data is provided separately as prompt + delayed nu-fission and chi
 
   // Get the prompt nu-fission matrix
-  xt::xtensor<double, 3> temp_matrix_p({n_ang, n_g, n_g}, 0.);
+  xt::xtensor<double, 3> temp_matrix_p({n_ang, n_g_, n_g_}, 0.);
   read_nd_vector(xsdata_grp, "prompt-nu-fission", temp_matrix_p, true);
 
   // prompt_nu_fission is the sum over outgoing groups
@@ -322,7 +322,7 @@ XsData::fission_matrix_no_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang)
        xt::view(prompt_nu_fission, xt::all(), xt::all(), xt::newaxis());
 
   // Get the delayed nu-fission matrix
-  xt::xtensor<double, 4> temp_matrix_d({n_ang, n_dg, n_g, n_g}, 0.);
+  xt::xtensor<double, 4> temp_matrix_d({n_ang, n_dg_, n_g_, n_g_}, 0.);
   read_nd_vector(xsdata_grp, "delayed-nu-fission", temp_matrix_d, true);
 
   // delayed_nu_fission is the sum over outgoing groups
@@ -341,7 +341,7 @@ XsData::fission_matrix_no_delayed_from_hdf5(hid_t xsdata_grp, size_t n_ang)
   // Therefore, the code only considers the data as prompt.
 
   // Get nu-fission matrix
-  xt::xtensor<double, 3> temp_matrix({n_ang, n_g, n_g}, 0.);
+  xt::xtensor<double, 3> temp_matrix({n_ang, n_g_, n_g_}, 0.);
   read_nd_vector(xsdata_grp, "nu-fission", temp_matrix, true);
 
   // prompt_nu_fission is the sum over outgoing groups
@@ -366,7 +366,7 @@ XsData::fission_from_hdf5(hid_t xsdata_grp, size_t n_ang, bool is_isotropic)
   // as a nu-fission matrix or a set of chi and nu-fission vectors
   if (object_exists(xsdata_grp, "chi") ||
       object_exists(xsdata_grp, "chi-prompt")) {
-    if (n_dg == 0) {
+    if (n_dg_ == 0) {
       fission_vector_no_delayed_from_hdf5(xsdata_grp, n_ang);
     } else {
       if (object_exists(xsdata_grp, "beta")) {
@@ -376,7 +376,7 @@ XsData::fission_from_hdf5(hid_t xsdata_grp, size_t n_ang, bool is_isotropic)
       }
     }
   } else {
-    if (n_dg == 0) {
+    if (n_dg_ == 0) {
       fission_matrix_no_delayed_from_hdf5(xsdata_grp, n_ang);
     } else {
       if (object_exists(xsdata_grp, "beta")) {
@@ -388,7 +388,7 @@ XsData::fission_from_hdf5(hid_t xsdata_grp, size_t n_ang, bool is_isotropic)
   }
 
   // Combine prompt_nu_fission and delayed_nu_fission into nu_fission
-  if (n_dg == 0) {
+  if (n_dg_ == 0) {
     nu_fission = prompt_nu_fission;
   } else {
     nu_fission = prompt_nu_fission + xt::sum(delayed_nu_fission, {1});
@@ -407,9 +407,9 @@ XsData::scatter_from_hdf5(hid_t xsdata_grp, size_t n_ang,
   hid_t scatt_grp = open_group(xsdata_grp, "scatter_data");
 
   // Get the outgoing group boundary indices
-  xt::xtensor<int, 2> gmin({n_ang, n_g}, 0.);
+  xt::xtensor<int, 2> gmin({n_ang, n_g_}, 0.);
   read_nd_vector(scatt_grp, "g_min", gmin, true);
-  xt::xtensor<int, 2> gmax({n_ang, n_g}, 0.);
+  xt::xtensor<int, 2> gmax({n_ang, n_g_}, 0.);
   read_nd_vector(scatt_grp, "g_max", gmax, true);
 
   // Make gmin and gmax start from 0 vice 1 as they do in the library
@@ -420,7 +420,7 @@ XsData::scatter_from_hdf5(hid_t xsdata_grp, size_t n_ang,
   // data.
   size_t length = order_data * xt::sum(gmax - gmin + 1)();
 
-  double_4dvec input_scatt(n_ang, double_3dvec(n_g));
+  double_4dvec input_scatt(n_ang, double_3dvec(n_g_));
   xt::xtensor<double, 1> temp_arr({length}, 0.);
   read_nd_vector(scatt_grp, "scatter_matrix", temp_arr, true);
 
@@ -437,7 +437,7 @@ XsData::scatter_from_hdf5(hid_t xsdata_grp, size_t n_ang,
   // scatt data
   size_t temp_idx = 0;
   for (size_t a = 0; a < n_ang; a++) {
-    for (size_t gin = 0; gin < n_g; gin++) {
+    for (size_t gin = 0; gin < n_g_; gin++) {
       input_scatt[a][gin].resize(gmax(a, gin) - gmin(a, gin) + 1);
       for (size_t i_gout = 0; i_gout < input_scatt[a][gin].size(); i_gout++) {
         input_scatt[a][gin][i_gout].resize(order_dim);
@@ -451,7 +451,7 @@ XsData::scatter_from_hdf5(hid_t xsdata_grp, size_t n_ang,
   }
 
   // Get multiplication matrix
-  double_3dvec temp_mult(n_ang, double_2dvec(n_g));
+  double_3dvec temp_mult(n_ang, double_2dvec(n_g_));
   if (object_exists(scatt_grp, "multiplicity_matrix")) {
     temp_arr.resize({length / order_data});
     read_nd_vector(scatt_grp, "multiplicity_matrix", temp_arr);
@@ -459,7 +459,7 @@ XsData::scatter_from_hdf5(hid_t xsdata_grp, size_t n_ang,
     // convert the flat temp_arr to a jagged array for passing to scatt data
     size_t temp_idx = 0;
     for (size_t a = 0; a < n_ang; a++) {
-      for (size_t gin = 0; gin < n_g; gin++) {
+      for (size_t gin = 0; gin < n_g_; gin++) {
         temp_mult[a][gin].resize(gmax(a, gin) - gmin(a, gin) + 1);
         for (size_t i_gout = 0; i_gout < temp_mult[a][gin].size(); i_gout++) {
           temp_mult[a][gin][i_gout] = temp_arr[temp_idx++];
@@ -469,7 +469,7 @@ XsData::scatter_from_hdf5(hid_t xsdata_grp, size_t n_ang,
   } else {
     // Use a default: multiplicities are 1.0.
     for (size_t a = 0; a < n_ang; a++) {
-      for (size_t gin = 0; gin < n_g; gin++) {
+      for (size_t gin = 0; gin < n_g_; gin++) {
         temp_mult[a][gin].resize(gmax(a, gin) - gmin(a, gin) + 1);
         for (size_t i_gout = 0; i_gout < temp_mult[a][gin].size(); i_gout++) {
           temp_mult[a][gin][i_gout] = 1.;

--- a/src/xsdata.cpp
+++ b/src/xsdata.cpp
@@ -27,8 +27,8 @@ namespace openmc {
 XsData::XsData(bool fissionable, int scatter_format, int n_pol, int n_azi)
 {
   size_t n_ang = n_pol * n_azi;
-  size_t n_dg = data::num_delayed_groups;
-  size_t n_g = data::num_energy_groups;
+  size_t n_dg = data::mgInterface.num_delayed_groups;
+  size_t n_g = data::mgInterface.num_energy_groups;
 
   // check to make sure scatter format is OK before we allocate
   if (scatter_format != ANGLE_HISTOGRAM && scatter_format != ANGLE_TABULAR &&
@@ -127,8 +127,8 @@ XsData::fission_vector_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang,
 {
   // Data is provided as nu-fission and chi with a beta for delayed info
 
-  size_t n_g = data::num_energy_groups;
-  size_t n_dg = data::num_delayed_groups;
+  size_t n_g = data::mgInterface.num_energy_groups;
+  size_t n_dg = data::mgInterface.num_delayed_groups;
 
   // Get chi
   xt::xtensor<double, 2> temp_chi({n_ang, n_g}, 0.);
@@ -182,8 +182,8 @@ XsData::fission_vector_no_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang)
 {
   // Data is provided separately as prompt + delayed nu-fission and chi
 
-  size_t n_g = data::num_energy_groups;
-  size_t n_dg = data::num_delayed_groups;
+  size_t n_g = data::mgInterface.num_energy_groups;
+  size_t n_dg = data::mgInterface.num_delayed_groups;
 
   // Get chi-prompt
   xt::xtensor<double, 2> temp_chi_p({n_ang, n_g}, 0.);
@@ -218,7 +218,7 @@ XsData::fission_vector_no_delayed_from_hdf5(hid_t xsdata_grp, size_t n_ang)
   // No beta is provided and there is no prompt/delay distinction.
   // Therefore, the code only considers the data as prompt.
 
-  size_t n_g = data::num_energy_groups;
+  size_t n_g = data::mgInterface.num_energy_groups;
 
   // Get chi
   xt::xtensor<double, 2> temp_chi({n_ang, n_g}, 0.);
@@ -241,8 +241,8 @@ XsData::fission_matrix_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang, bool is_is
 {
   // Data is provided as nu-fission and chi with a beta for delayed info
 
-  size_t n_g = data::num_energy_groups;
-  size_t n_dg = data::num_delayed_groups;
+  size_t n_g = data::mgInterface.num_energy_groups;
+  size_t n_dg = data::mgInterface.num_delayed_groups;
 
   // Get nu-fission matrix
   xt::xtensor<double, 3> temp_matrix({n_ang, n_g, n_g}, 0.);
@@ -319,8 +319,8 @@ XsData::fission_matrix_no_beta_from_hdf5(hid_t xsdata_grp, size_t n_ang)
 {
   // Data is provided separately as prompt + delayed nu-fission and chi
 
-  size_t n_g = data::num_energy_groups;
-  size_t n_dg = data::num_delayed_groups;
+  size_t n_g = data::mgInterface.num_energy_groups;
+  size_t n_dg = data::mgInterface.num_delayed_groups;
 
   // Get the prompt nu-fission matrix
   xt::xtensor<double, 3> temp_matrix_p({n_ang, n_g, n_g}, 0.);
@@ -353,7 +353,7 @@ XsData::fission_matrix_no_delayed_from_hdf5(hid_t xsdata_grp, size_t n_ang)
   // No beta is provided and there is no prompt/delay distinction.
   // Therefore, the code only considers the data as prompt.
 
-  size_t n_g = data::num_energy_groups;
+  size_t n_g = data::mgInterface.num_energy_groups;
 
   // Get nu-fission matrix
   xt::xtensor<double, 3> temp_matrix({n_ang, n_g, n_g}, 0.);
@@ -381,7 +381,7 @@ XsData::fission_from_hdf5(hid_t xsdata_grp, size_t n_ang, bool is_isotropic)
   // as a nu-fission matrix or a set of chi and nu-fission vectors
   if (object_exists(xsdata_grp, "chi") ||
       object_exists(xsdata_grp, "chi-prompt")) {
-    if (data::num_delayed_groups == 0) {
+    if (data::mgInterface.num_delayed_groups == 0) {
       fission_vector_no_delayed_from_hdf5(xsdata_grp, n_ang);
     } else {
       if (object_exists(xsdata_grp, "beta")) {
@@ -391,7 +391,7 @@ XsData::fission_from_hdf5(hid_t xsdata_grp, size_t n_ang, bool is_isotropic)
       }
     }
   } else {
-    if (data::num_delayed_groups == 0) {
+    if (data::mgInterface.num_delayed_groups == 0) {
       fission_matrix_no_delayed_from_hdf5(xsdata_grp, n_ang);
     } else {
       if (object_exists(xsdata_grp, "beta")) {
@@ -403,7 +403,7 @@ XsData::fission_from_hdf5(hid_t xsdata_grp, size_t n_ang, bool is_isotropic)
   }
 
   // Combine prompt_nu_fission and delayed_nu_fission into nu_fission
-  if (data::num_delayed_groups == 0) {
+  if (data::mgInterface.num_delayed_groups == 0) {
     nu_fission = prompt_nu_fission;
   } else {
     nu_fission = prompt_nu_fission + xt::sum(delayed_nu_fission, {1});
@@ -422,7 +422,7 @@ XsData::scatter_from_hdf5(hid_t xsdata_grp, size_t n_ang,
   hid_t scatt_grp = open_group(xsdata_grp, "scatter_data");
 
   // Get the outgoing group boundary indices
-  size_t n_g = data::num_energy_groups;
+  size_t n_g = data::mgInterface.num_energy_groups;
   xt::xtensor<int, 2> gmin({n_ang, n_g}, 0.);
   read_nd_vector(scatt_grp, "g_min", gmin, true);
   xt::xtensor<int, 2> gmax({n_ang, n_g}, 0.);


### PR DESCRIPTION
Hi all,

So, for my research, I can save a solid amount of work by leveraging code inside OpenMC. Unfortunately, there is much stuff that's tied to global variables and only works correctly when the proper sequence of OpenMC initialization routines have been called beforehand.

This PR (in my opinion) cleans up mgxs_interface a good bit, and removes the preponderance of global variables, leaving only a single MgxsInterface in OpenMC global scope. This is nice, because now, I can compile simple programs like this:

```cpp
#include "openmc/mgxs_interface.h"
#include "openmc/constants.h"

#include <iostream>
using namespace std;

int main()
{
  openmc::MgxsInterface mgxs("mgxs.h5", {"UO2"}, {{294.0}});

  // Now print some info about the first entry in the mgxs.h5 file:
  cout << mgxs.nuclides_MG.size() << endl;
  cout << "The first entry in mgxs.h5 is named " << mgxs.nuclides_MG[0].name << endl;
  cout << "Its total cross section in group 1 is "
       << mgxs.nuclides_MG[0].get_xs(openmc::MG_GET_XS_TOTAL, 1, nullptr, nullptr, nullptr)
       << endl;
}
```

Compiled like:

```
h5c++ test2.C -I/home/gavin/code/openmc/include -L/home/gavin/code/openmc/build/lib -lopenmc
```

And take advantage of previous work done in OpenMC, which can really save me some time. I hope the maintainers find this to be a useful contribution, and am happy to make as many changes to make this palatable for incorporation as are required.

Ideally, I'd like to keep adding some changes like this which allow OpenMC to be used as a general C++ library for doing Monte Carlo, which would be amazing for research. Opinions?