### PR TITLE
Fix in MGXS get_xsdata

### DIFF
--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -986,7 +986,7 @@ class Library(object):
             xsdata.num_azimuthal = self.num_azimuthal
 
         if nuclide != 'total':
-            xsdata.atomic_weight_ratio = self._nuclides[nuclide][1]
+            xsdata.atomic_weight_ratio = self._nuclides[nuclide]
 
         if subdomain is None:
             subdomain = 'all'


### PR DESCRIPTION
In the MGXS `library.get_xsdata` method retrieving the cross-section for a specific nuclide, I think we're indexing the `library._nuclides` attribute incorrectly when getting values for a specific nuclide.

This attribute is really a `summary.nuclides` dictionary which contains nuclide names as keys and their atomic weight ratios as values ([generated here](https://github.com/openmc-dev/openmc/blob/4ba8568f0888f6b2f6895e7e300e4ef6dca26ee3/openmc/summary.py#L90)), so we shouldn't need to index that data structure any further to get the awr. 