### PR TITLE
can write track files in restart mode now

### DIFF
--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -79,6 +79,9 @@ void run_particle_restart()
   int previous_run_mode;
   read_particle_restart(p, previous_run_mode);
 
+  // write track if that was requested on command line
+  if (settings::write_all_tracks) p.write_track_ = true;
+
   // Set all tallies to 0 for now (just tracking errors)
   model::tallies.clear();
 


### PR DESCRIPTION
It seems that previously, when running openmc in particle restart mode, particle tracks would not be written even if -t was specified on the command line. With this tiny change, the -t option now gives the expected result in the presence of a -r. This is useful for debugging, and I'm using it to hopefully find a fix to #1383.