### PR TITLE
Update xtensor, miscellaneous other fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ if (NOT (CMAKE_VERSION VERSION_LESS 3.13))
 endif()
 
 add_subdirectory(vendor/xtl)
+set(xtl_DIR ${CMAKE_CURRENT_BINARY_DIR}/vendor/xtl)
 add_subdirectory(vendor/xtensor)
 target_link_libraries(xtensor INTERFACE xtl)
 

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -142,6 +142,11 @@ Geometry and Visualization
 Miscellaneous
 -------------
 
+- Govatsa Acharya, "`Investigating the Application of Self-Actuated Passive
+  Shutdown System in a Small Lead-Cooled Reactor
+  <https://doi.org/10.13140/RG.2.2.26088.01281>`_," M.S. Thesis, KTH Royal
+  Institute of Technology (2019).
+
 - Shikhar Kumar, Benoit Forget, and Kord Smith, "Analysis of fission source
   convergence for a 3-D SMR core using functional expansion tallies," *Proc.
   M&C*, 937-947, Portland, Oregon, Aug. 25-29 (2019).

--- a/examples/jupyter/chain_simple.xml
+++ b/examples/jupyter/chain_simple.xml
@@ -1,1 +1,1 @@
-/home/romano/openmc/tests/chain_simple.xml
+../../tests/chain_simple.xml

--- a/scripts/openmc-update-inputs
+++ b/scripts/openmc-update-inputs
@@ -298,4 +298,4 @@ if __name__ == '__main__':
             move(fname, fname + '.original')
 
             # Write a new geometry file.
-            tree.write(fname)
+            tree.write(fname, xml_declaration=True)

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -307,6 +307,10 @@ CSGCell::CSGCell(pugi::xml_node cell_node)
 
   if (fill_present) {
     fill_ = std::stoi(get_node_value(cell_node, "fill"));
+    if (fill_ == universe_) {
+      fatal_error("Cell " + std::to_string(id_) +
+        " is filled with the same universe that it is contained in.");
+    }
   } else {
     fill_ = C_NONE;
   }

--- a/src/eigenvalue.cpp
+++ b/src/eigenvalue.cpp
@@ -572,8 +572,9 @@ void ufs_count_sites()
     // distributed so that effectively the production of fission sites is not
     // biased
 
-    auto s = xt::view(simulation::source_frac, xt::all());
-    s = simulation::ufs_mesh->volume_frac_;
+    std::size_t n = simulation::ufs_mesh->n_bins();
+    double vol_frac = simulation::ufs_mesh->volume_frac_;
+    simulation::source_frac = xt::xtensor<double, 1>({n}, vol_frac);
 
   } else {
     // count number of source sites in each ufs mesh cell

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -155,8 +155,8 @@ RegularMesh::RegularMesh(pugi::xml_node node)
     fatal_error("Must specify either <upper_right> and <width> on a mesh.");
   }
 
-  // TODO: Change to zero when xtensor is updated
-  if (shape_.size() > 1) {
+  // Make sure lower_left and dimension match
+  if (shape_.size() > 0) {
     if (shape_.size() != lower_left_.size()) {
       fatal_error("Number of entries on <lower_left> must be the same "
         "as the number of entries on <dimension>.");

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -149,8 +149,10 @@ RegularMesh::RegularMesh(pugi::xml_node node)
         "the <lower_left> coordinates on a tally mesh.");
     }
 
-    // Set width and upper right coordinate
-    width_ = xt::eval((upper_right_ - lower_left_) / shape_);
+    // Set width
+    if (shape_.size() > 0) {
+      width_ = xt::eval((upper_right_ - lower_left_) / shape_);
+    }
   } else {
     fatal_error("Must specify either <upper_right> and <width> on a mesh.");
   }

--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -180,7 +180,7 @@ PhotonInteraction::PhotonInteraction(hid_t group, int i_element)
   // Read Compton profiles
   read_dataset(rgroup, "J", profile_pdf_);
 
-  // Get Compton profile momentum grid. By deafult, an xtensor has a size of 1.
+  // Get Compton profile momentum grid
   if (data::compton_profile_pz.size() == 0) {
     read_dataset(rgroup, "pz", data::compton_profile_pz);
   }

--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -181,8 +181,7 @@ PhotonInteraction::PhotonInteraction(hid_t group, int i_element)
   read_dataset(rgroup, "J", profile_pdf_);
 
   // Get Compton profile momentum grid. By deafult, an xtensor has a size of 1.
-  // TODO: Change to zero when xtensor is updated
-  if (data::compton_profile_pz.size() == 1) {
+  if (data::compton_profile_pz.size() == 0) {
     read_dataset(rgroup, "pz", data::compton_profile_pz);
   }
   close_group(rgroup);
@@ -213,8 +212,7 @@ PhotonInteraction::PhotonInteraction(hid_t group, int i_element)
     // Get energy grids used for bremsstrahlung DCS and for stopping powers
     xt::xtensor<double, 1> electron_energy;
     read_dataset(rgroup, "electron_energy", electron_energy);
-    // TODO: Change to zero when xtensor is updated
-    if (data::ttb_k_grid.size() == 1) {
+    if (data::ttb_k_grid.size() == 0) {
       read_dataset(rgroup, "photon_energy", data::ttb_k_grid);
     }
 
@@ -255,8 +253,7 @@ PhotonInteraction::PhotonInteraction(hid_t group, int i_element)
     }
 
     // Set incident particle energy grid
-    // TODO: Change to zero when xtensor is updated
-    if (data::ttb_e_grid.size() == 1) {
+    if (data::ttb_e_grid.size() == 0) {
       data::ttb_e_grid = electron_energy;
     }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -512,8 +512,7 @@ void read_settings_xml()
     if (!m) fatal_error("Only regular meshes can be used as an entropy mesh");
     simulation::entropy_mesh = m;
 
-    // TODO: Change to zero when xtensor is updated
-    if (m->shape_.size() == 1) {
+    if (m->shape_.size() == 0) {
       // If the user did not specify how many mesh cells are to be used in
       // each direction, we automatically determine an appropriate number of
       // cells

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -810,8 +810,7 @@ void Tally::init_results()
 void Tally::reset()
 {
   n_realizations_ = 0;
-  // TODO: Change to zero when xtensor is updated
-  if (results_.size() != 1) {
+  if (results_.size() != 0) {
     xt::view(results_, xt::all()) = 0.0;
   }
 }
@@ -1399,8 +1398,7 @@ openmc_tally_results(int32_t index, double** results, size_t* shape)
   }
 
   const auto& t {model::tallies[index]};
-  // TODO: Change to zero when xtensor is updated
-  if (t->results_.size() == 1) {
+  if (t->results_.size() == 0) {
     set_errmsg("Tally results have not been allocated yet.");
     return OPENMC_E_ALLOCATE;
   }

--- a/vendor/vendor.txt
+++ b/vendor/vendor.txt
@@ -1,0 +1,4 @@
+gsl-lite==0.34.0
+pugixml==1.8
+xtensor==0.20.8
+xtl==0.6.5

--- a/vendor/xtensor/CMakeLists.txt
+++ b/vendor/xtensor/CMakeLists.txt
@@ -1,5 +1,6 @@
 ############################################################################
-# Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    #
+# Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          #
+# Copyright (c) QuantStack                                                 #
 #                                                                          #
 # Distributed under the terms of the BSD 3-Clause License.                 #
 #                                                                          #
@@ -28,16 +29,71 @@ message(STATUS "Building xtensor v${${PROJECT_NAME}_VERSION}")
 # Dependencies
 # ============
 
-#find_package(xtl 0.4.9 REQUIRED)
+set(xtl_REQUIRED_VERSION 0.6.7)
+find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)
+message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
 
-#message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
+find_package(nlohmann_json 3.1.1 QUIET)
 
-#find_package(nlohmann_json 3.1.1)
+# Optional dependencies
+# =====================
+
+OPTION(XTENSOR_USE_XSIMD "simd acceleration for xtensor" OFF)
+OPTION(XTENSOR_USE_TBB "enable parallelization using intel TBB" OFF)
+OPTION(XTENSOR_USE_OPENMP "enable parallelization using OpenMP" OFF)
+if(XTENSOR_USE_TBB AND XTENSOR_USE_OPENMP)
+    message(
+        FATAL 
+        "XTENSOR_USE_TBB and XTENSOR_USE_OPENMP cannot both be active at once"
+    )
+endif()
+
+if(XTENSOR_USE_XSIMD)
+    set(xsimd_REQUIRED_VERSION 7.4.0)
+    find_package(xsimd ${xsimd_REQUIRED_VERSION} REQUIRED)
+    message(STATUS "Found xsimd: ${xsimd_INCLUDE_DIRS}/xsimd")
+endif()
+
+if(XTENSOR_USE_TBB)
+    set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
+    find_package(TBB REQUIRED)
+    message(STATUS "Found intel TBB: ${TBB_INCLUDE_DIRS}")
+endif()
+
+if(XTENSOR_USE_OPENMP)
+    find_package(OpenMP REQUIRED)
+    if (OPENMP_FOUND)
+        # Set openmp variables now
+
+        # Create private target just for this lib
+        # https://cliutils.gitlab.io/modern-cmake/chapters/packages/OpenMP.html
+        # Probably not safe for cmake < 3.4 ..
+        find_package(Threads REQUIRED)
+        add_library(OpenMP::OpenMP_CXX_xtensor IMPORTED INTERFACE)
+        set_property(
+            TARGET 
+            OpenMP::OpenMP_CXX_xtensor
+            PROPERTY 
+            INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS}
+        )
+        # Only works if the same flag is passed to the linker; use CMake 3.9+ otherwise (Intel, AppleClang)
+        set_property(
+            TARGET 
+            OpenMP::OpenMP_CXX_xtensor
+            PROPERTY 
+            INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
+
+        message(STATUS "OpenMP Found")
+    else()
+        message(FATAL "Failed to locate OpenMP")
+    endif()
+endif()
 
 # Build
 # =====
 
 set(XTENSOR_HEADERS
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xaccessible.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xaccumulator.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xadapt.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xarray.hpp
@@ -47,16 +103,19 @@ set(XTENSOR_HEADERS
     ${XTENSOR_INCLUDE_DIR}/xtensor/xbuffer_adaptor.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xbuilder.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xcomplex.hpp
-    ${XTENSOR_INCLUDE_DIR}/xtensor/xconcepts.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xcontainer.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xcsv.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xdynamic_view.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xeval.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xexception.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xexpression.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xexpression_holder.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xexpression_traits.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xfixed.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xfunction.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xfunctor_view.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xgenerator.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xhistogram.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xindex_view.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xinfo.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xio.hpp
@@ -64,7 +123,10 @@ set(XTENSOR_HEADERS
     ${XTENSOR_INCLUDE_DIR}/xtensor/xiterator.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xjson.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xlayout.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xmanipulation.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xmasked_view.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xmath.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xmime.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xnoalias.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xnorm.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xnpy.hpp
@@ -74,6 +136,7 @@ set(XTENSOR_HEADERS
     ${XTENSOR_INCLUDE_DIR}/xtensor/xoptional_assembly.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xoptional_assembly_base.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xoptional_assembly_storage.hpp
+    ${XTENSOR_INCLUDE_DIR}/xtensor/xpad.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xrandom.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xreducer.hpp
     ${XTENSOR_INCLUDE_DIR}/xtensor/xscalar.hpp
@@ -102,13 +165,13 @@ target_link_libraries(xtensor INTERFACE xtl)
 
 OPTION(XTENSOR_ENABLE_ASSERT "xtensor bound check" OFF)
 OPTION(XTENSOR_CHECK_DIMENSION "xtensor dimension check" OFF)
-OPTION(XTENSOR_USE_XSIMD "simd acceleration for xtensor" OFF)
 OPTION(BUILD_TESTS "xtensor test suite" OFF)
 OPTION(BUILD_BENCHMARK "xtensor benchmark" OFF)
 OPTION(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
 OPTION(DOWNLOAD_GBENCHMARK "download google benchmark and build from source" ON)
 OPTION(DEFAULT_COLUMN_MAJOR "set default layout to column major" OFF)
 OPTION(DISABLE_VS2017 "disables the compilation of some test with Visual Studio 2017" OFF)
+OPTION(CPP17 "enables C++17" OFF)
 
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
     set(BUILD_TESTS ON)
@@ -120,13 +183,6 @@ endif()
 
 if(XTENSOR_CHECK_DIMENSION)
     add_definitions(-DXTENSOR_ENABLE_CHECK_DIMENSION)
-endif()
-
-if(XTENSOR_USE_XSIMD)
-    add_definitions(-DXTENSOR_USE_XSIMD)
-    find_package(xsimd 4.1.6 REQUIRED)
-    message(STATUS "Found xsimd: ${xsimd_INCLUDE_DIRS}/xsimd")
-    target_link_libraries(xtensor INTERFACE xsimd)
 endif()
 
 if(DEFAULT_COLUMN_MAJOR)
@@ -143,6 +199,11 @@ endif()
 
 if(BUILD_BENCHMARK)
     add_subdirectory(benchmark)
+endif()
+
+if(XTENSOR_USE_OPENMP)
+    # Link xtensor itself to OpenMP to propagate to user projects
+    target_link_libraries(xtensor INTERFACE OpenMP::OpenMP_CXX_xtensor)
 endif()
 
 # Installation

--- a/vendor/xtensor/include/xtensor/xaccessible.hpp
+++ b/vendor/xtensor/include/xtensor/xaccessible.hpp
@@ -1,0 +1,307 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_ACCESSIBLE_HPP
+#define XTENSOR_ACCESSIBLE_HPP
+
+#include "xexception.hpp"
+#include "xstrides.hpp"
+#include "xtensor_forward.hpp"
+
+namespace xt
+{
+    /**
+     * @class xconst_accessible
+     * @brief Base class for implementation of common expression constant access methods.
+     *
+     * The xaccessible class implements constant access methods common to all expressions.
+     *
+     * @tparam D The derived type, i.e. the inheriting class for which xconst_accessible
+     *      
+     *
+     */
+    template <class D>
+    class xconst_accessible
+    {
+    public:
+
+        using derived_type = D;
+        using inner_types = xcontainer_inner_types<D>;
+        using reference = typename inner_types::reference;
+        using const_reference = typename inner_types::const_reference;
+        using size_type = typename inner_types::size_type;
+
+        size_type size() const noexcept;
+        size_type dimension() const noexcept;
+        size_type shape(size_type index) const;
+
+        template <class... Args>
+        const_reference at(Args... args) const;
+
+        template <class S>
+        disable_integral_t<S, const_reference> operator[](const S& index) const;
+        template <class I>
+        const_reference operator[](std::initializer_list<I> index) const;
+        const_reference operator[](size_type i) const;
+
+        template <class... Args>
+        const_reference periodic(Args... args) const;
+
+        template <class... Args>
+        bool in_bounds(Args... args) const;
+
+    protected:
+
+        xconst_accessible() = default;
+        ~xconst_accessible() = default;
+
+        xconst_accessible(const xconst_accessible&) = default;
+        xconst_accessible& operator=(const xconst_accessible&) = default;
+
+        xconst_accessible(xconst_accessible&&) = default;
+        xconst_accessible& operator=(xconst_accessible&&) = default;
+
+    private:
+
+        const derived_type& derived_cast() const noexcept;
+    };
+
+    /**
+     * @class xaccessible
+     * @brief Base class for implementation of common expression access methods.
+     *
+     * The xaccessible class implements access methods common to all expressions.
+     *
+     * @tparam D The derived type, i.e. the inheriting class for which xaccessible
+     *           provides the interface.
+     */
+    template <class D>
+    class xaccessible : public xconst_accessible<D>
+    {
+    public:
+
+        using base_type = xconst_accessible<D>;
+        using derived_type = typename base_type::derived_type;
+        using reference = typename base_type::reference;
+        using size_type = typename base_type::size_type;
+
+        template <class... Args>
+        reference at(Args... args);
+
+        template <class S>
+        disable_integral_t<S, reference> operator[](const S& index);
+        template <class I>
+        reference operator[](std::initializer_list<I> index);
+        reference operator[](size_type i);
+
+        template <class... Args>
+        reference periodic(Args... args);
+
+        using base_type::at;
+        using base_type::operator[];
+        using base_type::periodic;
+
+    protected:
+
+        xaccessible() = default;
+        ~xaccessible() = default;
+
+        xaccessible(const xaccessible&) = default;
+        xaccessible& operator=(const xaccessible&) = default;
+
+        xaccessible(xaccessible&&) = default;
+        xaccessible& operator=(xaccessible&&) = default;
+
+    private:
+
+        derived_type& derived_cast() noexcept;
+    };
+
+    /************************************
+     * xconst_accessible implementation *
+     ************************************/
+    
+    /**
+     * Returns the size of the expression.
+     */
+    template <class D>
+    inline auto xconst_accessible<D>::size() const noexcept -> size_type
+    {
+        return compute_size(derived_cast().shape());
+    }
+
+    /**
+     * Returns the number of dimensions of the expression.
+     */
+    template <class D>
+    inline auto xconst_accessible<D>::dimension() const noexcept -> size_type
+    {
+        return derived_cast().shape().size();
+    }
+
+    /**
+     * Returns the i-th dimension of the expression.
+     */
+    template <class D>
+    inline auto xconst_accessible<D>::shape(size_type index) const -> size_type
+    {
+        return derived_cast().shape()[index];
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the expression,
+     * after dimension and bounds checking.
+     * @param args a list of indices specifying the position in the expression. Indices
+     * must be unsigned integers, the number of indices should be equal to the number of dimensions
+     * of the expression.
+     * @exception std::out_of_range if the number of argument is greater than the number of dimensions
+     * or if indices are out of bounds.
+     */
+    template <class D>
+    template <class... Args>
+    inline auto xconst_accessible<D>::at(Args... args) const -> const_reference
+    {
+        check_access(derived_cast().shape(), static_cast<size_type>(args)...);
+        return derived_cast().operator()(args...);
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the expression.
+     * @param index a sequence of indices specifying the position in the expression. Indices
+     * must be unsigned integers, the number of indices in the list should be equal or greater
+     * than the number of dimensions of the expression.
+     */
+    template <class D>
+    template <class S>
+    inline auto xconst_accessible<D>::operator[](const S& index) const
+        -> disable_integral_t<S, const_reference>
+    {
+        return derived_cast().element(index.cbegin(), index.cend());
+    }
+
+    template <class D>
+    template <class I>
+    inline auto xconst_accessible<D>::operator[](std::initializer_list<I> index) const -> const_reference
+    {
+        return derived_cast().element(index.begin(), index.end());
+    }
+
+    template <class D>
+    inline auto xconst_accessible<D>::operator[](size_type i) const -> const_reference
+    {
+        return derived_cast().operator()(i);
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the expression,
+     * after applying periodicity to the indices (negative and 'overflowing' indices are changed).
+     * @param args a list of indices specifying the position in the expression. Indices
+     * must be integers, the number of indices should be equal to the number of dimensions
+     * of the expression.
+     */
+    template <class D>
+    template <class... Args>
+    inline auto xconst_accessible<D>::periodic(Args... args) const -> const_reference
+    {
+        normalize_periodic(derived_cast().shape(), args...);
+        return derived_cast()(static_cast<size_type>(args)...);
+    }
+    
+    /**
+     * Returns ``true`` only if the the specified position is a valid entry in the expression.
+     * @param args a list of indices specifying the position in the expression.
+     * @return bool
+     */
+    template <class D>
+    template <class... Args>
+    inline bool xconst_accessible<D>::in_bounds(Args... args) const
+    {
+        return check_in_bounds(derived_cast().shape(), args...);
+    }
+
+    template <class D>
+    inline auto xconst_accessible<D>::derived_cast() const noexcept -> const derived_type&
+    {
+        return *static_cast<const derived_type*>(this);
+    }
+
+    /******************************
+     * xaccessible implementation *
+     ******************************/
+
+    /**
+     * Returns a reference to the element at the specified position in the expression,
+     * after dimension and bounds checking.
+     * @param args a list of indices specifying the position in the expression. Indices
+     * must be unsigned integers, the number of indices should be equal to the number of dimensions
+     * of the expression.
+     * @exception std::out_of_range if the number of argument is greater than the number of dimensions
+     * or if indices are out of bounds.
+     */
+    template <class D>
+    template <class... Args>
+    inline auto xaccessible<D>::at(Args... args) -> reference
+    {   
+        check_access(derived_cast().shape(), static_cast<size_type>(args)...);
+        return derived_cast().operator()(args...);
+    }
+
+    /**
+     * Returns a reference to the element at the specified position in the expression.
+     * @param index a sequence of indices specifying the position in the expression. Indices
+     * must be unsigned integers, the number of indices in the list should be equal or greater
+     * than the number of dimensions of the expression.
+     */
+    template <class D>
+    template <class S>
+    inline auto xaccessible<D>::operator[](const S& index)
+        -> disable_integral_t<S, reference>
+    {
+        return derived_cast().element(index.cbegin(), index.cend());
+    }
+
+    template <class D>
+    template <class I>
+    inline auto xaccessible<D>::operator[](std::initializer_list<I> index) -> reference
+    {
+        return derived_cast().element(index.begin(), index.end());
+    }
+
+    template <class D>
+    inline auto xaccessible<D>::operator[](size_type i) -> reference
+    {
+        return derived_cast().operator()(i);
+    }
+
+    /**
+     * Returns a reference to the element at the specified position in the expression,
+     * after applying periodicity to the indices (negative and 'overflowing' indices are changed).
+     * @param args a list of indices specifying the position in the expression. Indices
+     * must be integers, the number of indices should be equal to the number of dimensions
+     * of the expression.
+     */
+    template <class D>
+    template <class... Args>
+    inline auto xaccessible<D>::periodic(Args... args) -> reference
+    {
+        normalize_periodic(derived_cast().shape(), args...);
+        return derived_cast()(static_cast<size_type>(args)...);
+    }
+
+
+    template <class D>
+    inline auto xaccessible<D>::derived_cast() noexcept -> derived_type&
+    {
+        return *static_cast<derived_type*>(this);
+    }
+
+}
+
+#endif
+

--- a/vendor/xtensor/include/xtensor/xaccumulator.hpp
+++ b/vendor/xtensor/include/xtensor/xaccumulator.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -21,7 +22,7 @@
 namespace xt
 {
 
-#define DEFAULT_STRATEGY_ACCUMULATORS evaluation_strategy::immediate
+#define DEFAULT_STRATEGY_ACCUMULATORS evaluation_strategy::immediate_type
 
     /**************
      * accumulate *
@@ -73,13 +74,13 @@ namespace xt
         template <class F, class E, class EVS>
         xarray<typename std::decay_t<E>::value_type> accumulator_impl(F&&, E&&, std::size_t, EVS)
         {
-            static_assert(!std::is_same<evaluation_strategy::lazy, EVS>::value, "Lazy accumulators not yet implemented.");
+            static_assert(!std::is_same<evaluation_strategy::lazy_type, EVS>::value, "Lazy accumulators not yet implemented.");
         }
 
         template <class F, class E, class EVS>
         xarray<typename std::decay_t<E>::value_type> accumulator_impl(F&&, E&&, EVS)
         {
-            static_assert(!std::is_same<evaluation_strategy::lazy, EVS>::value, "Lazy accumulators not yet implemented.");
+            static_assert(!std::is_same<evaluation_strategy::lazy_type, EVS>::value, "Lazy accumulators not yet implemented.");
         }
 
         template <class T, class R>
@@ -88,14 +89,56 @@ namespace xt
             using type = xarray<R>;
         };
 
-        template <class T, std::size_t N, class R>
-        struct xaccumulator_return_type<xtensor<T, N>, R>
+        template <class T, layout_type L, class R>
+        struct xaccumulator_return_type<xarray<T, L>, R>
         {
-            using type = xtensor<R, N>;
+            using type = xarray<R, L>;
+        };
+
+        template <class T, std::size_t N, layout_type L, class R>
+        struct xaccumulator_return_type<xtensor<T, N, L>, R>
+        {
+            using type = xtensor<R, N, L>;
+        };
+
+        template <class T, std::size_t... I, layout_type L, class R>
+        struct xaccumulator_return_type<xtensor_fixed<T, xshape<I...>, L>, R>
+        {
+            using type = xtensor_fixed<R, xshape<I...>, L>;
         };
 
         template <class T, class R>
         using xaccumulator_return_type_t = typename xaccumulator_return_type<T, R>::type;
+
+        template <class T>
+        struct fixed_compute_size;
+
+        template <class T, class R>
+        struct xaccumulator_linear_return_type
+        {
+            using type = xtensor<R, 1>;
+        };
+
+        template <class T, layout_type L, class R>
+        struct xaccumulator_linear_return_type<xarray<T, L>, R>
+        {
+            using type = xtensor<R, 1, L>;
+        };
+
+        template <class T, std::size_t N, layout_type L, class R>
+        struct xaccumulator_linear_return_type<xtensor<T, N, L>, R>
+        {
+            using type = xtensor<R, 1, L>;
+        };
+
+        template <class T, std::size_t... I, layout_type L, class R>
+        struct xaccumulator_linear_return_type<xtensor_fixed<T, xshape<I...>, L>, R>
+        {
+            using type = xtensor_fixed<R, xshape<fixed_compute_size<xshape<I...>>::value>, L>;
+        };
+
+        template <class T, class R>
+        using xaccumulator_linear_return_type_t = typename xaccumulator_linear_return_type<T, R>::type;
 
         template <class F, class E>
         inline auto accumulator_init_with_f(F&& f, E& e, std::size_t axis)
@@ -104,7 +147,8 @@ namespace xt
             // e[:, 0, :, :, ...] = f(e[:, 0, :, :, ...])
             // so that all "first" values are initialized in a first pass
 
-            std::size_t outer_loop_size, inner_loop_size, outer_stride, inner_stride, pos = 0;
+            std::size_t outer_loop_size, inner_loop_size, pos = 0;
+            std::size_t outer_stride, inner_stride;
 
             auto set_loop_sizes = [&outer_loop_size, &inner_loop_size](auto first, auto last, std::ptrdiff_t ax) {
                 outer_loop_size = std::accumulate(first, first + ax,
@@ -113,9 +157,10 @@ namespace xt
                                                   std::size_t(1), std::multiplies<std::size_t>());
             };
 
+            // Note: add check that strides > 0
             auto set_loop_strides = [&outer_stride, &inner_stride](auto first, auto last, std::ptrdiff_t ax) {
-                outer_stride = ax == 0 ? 1 : *std::min_element(first, first + ax);
-                inner_stride = (ax == std::distance(first, last) - 1) ? 1 : *std::min_element(first + ax + 1, last);
+                outer_stride = static_cast<std::size_t>(ax == 0 ? 1 : *std::min_element(first, first + ax));
+                inner_stride = static_cast<std::size_t>((ax == std::distance(first, last) - 1) ? 1 : *std::min_element(first + ax + 1, last));
             };
 
             set_loop_sizes(e.shape().begin(), e.shape().end(), static_cast<std::ptrdiff_t>(axis));
@@ -140,9 +185,9 @@ namespace xt
         }
 
         template <class F, class E>
-        inline auto accumulator_impl(F&& f, E&& e, std::size_t axis, evaluation_strategy::immediate)
+        inline auto accumulator_impl(F&& f, E&& e, std::size_t axis, evaluation_strategy::immediate_type)
         {
-            using accumulate_functor = std::decay_t<decltype(std::get<0>(f))>;
+            using accumulate_functor = std::decay_t<decltype(xt::get<0>(f))>;
             using function_return_type = typename accumulate_functor::result_type;
             using result_type = xaccumulator_return_type_t<std::decay_t<E>, function_return_type>;
 
@@ -153,74 +198,80 @@ namespace xt
 
             result_type result = e;  // assign + make a copy, we need it anyways
 
-            std::size_t inner_stride = result.strides()[axis];
-            std::size_t outer_stride = 1;  // this is either going row- or column-wise (strides.back / strides.front)
-            std::size_t outer_loop_size = 0;
-            std::size_t inner_loop_size = 0;
-
-            auto set_loop_sizes = [&outer_loop_size, &inner_loop_size](auto first, auto last, std::ptrdiff_t ax) {
-                outer_loop_size = std::accumulate(first,
-                                                  first + ax,
-                                                  std::size_t(1), std::multiplies<std::size_t>());
-
-                inner_loop_size = std::accumulate(first + ax,
-                                                  last,
-                                                  std::size_t(1), std::multiplies<std::size_t>());
-            };
-
-            if (result_type::static_layout == layout_type::row_major)
+            if(result.shape(axis) != std::size_t(0))
             {
-                set_loop_sizes(result.shape().cbegin(), result.shape().cend(), static_cast<std::ptrdiff_t>(axis));
-            }
-            else
-            {
-                set_loop_sizes(result.shape().cbegin(), result.shape().cend(), static_cast<std::ptrdiff_t>(axis + 1));
-                std::swap(inner_loop_size, outer_loop_size);
-            }
+                std::size_t inner_stride = static_cast<std::size_t>(result.strides()[axis]);
+                std::size_t outer_stride = 1;  // this is either going row- or column-wise (strides.back / strides.front)
+                std::size_t outer_loop_size = 0;
+                std::size_t inner_loop_size = 0;
+                std::size_t init_size = e.shape()[axis] != std::size_t(1) ? std::size_t(1) : std::size_t(0);
 
-            std::size_t pos = 0;
+                auto set_loop_sizes = [&outer_loop_size, &inner_loop_size, init_size](auto first, auto last, std::ptrdiff_t ax) {
+                    outer_loop_size = std::accumulate(first,
+                                                      first + ax,
+                                                      init_size, std::multiplies<std::size_t>());
 
-            inner_loop_size = inner_loop_size - inner_stride;
+                    inner_loop_size = std::accumulate(first + ax,
+                                                      last,
+                                                      std::size_t(1), std::multiplies<std::size_t>());
+                };
 
-            // activate the init loop if we have an init function other than identity
-            if (!std::is_same<decltype(std::get<1>(f)), xtl::identity>::value)
-            {
-                accumulator_init_with_f(std::get<1>(f), result, axis);
-            }
-
-            pos = 0;
-            for (std::size_t i = 0; i < outer_loop_size; ++i)
-            {
-                for (std::size_t j = 0; j < inner_loop_size; ++j)
+                if (result_type::static_layout == layout_type::row_major)
                 {
-                    result.storage()[pos + inner_stride] = std::get<0>(f)(result.storage()[pos],
-                                                                       result.storage()[pos + inner_stride]);
-                    pos += outer_stride;
+                    set_loop_sizes(result.shape().cbegin(), result.shape().cend(), static_cast<std::ptrdiff_t>(axis));
                 }
-                pos += inner_stride;
+                else
+                {
+                    set_loop_sizes(result.shape().cbegin(), result.shape().cend(), static_cast<std::ptrdiff_t>(axis + 1));
+                    std::swap(inner_loop_size, outer_loop_size);
+                }
+
+                std::size_t pos = 0;
+
+                inner_loop_size = inner_loop_size - inner_stride;
+
+                // activate the init loop if we have an init function other than identity
+                if (!std::is_same<std::decay_t<decltype(xt::get<1>(f))>, xtl::identity>::value)
+                {
+                    accumulator_init_with_f(xt::get<1>(f), result, axis);
+                }
+
+                pos = 0;
+                for (std::size_t i = 0; i < outer_loop_size; ++i)
+                {
+                    for (std::size_t j = 0; j < inner_loop_size; ++j)
+                    {
+                        result.storage()[pos + inner_stride] = xt::get<0>(f)(result.storage()[pos],
+                                                                             result.storage()[pos + inner_stride]);
+                        pos += outer_stride;
+                    }
+                    pos += inner_stride;
+                }
             }
             return result;
         }
 
         template <class F, class E>
-        inline auto accumulator_impl(F&& f, E&& e, evaluation_strategy::immediate)
+        inline auto accumulator_impl(F&& f, E&& e, evaluation_strategy::immediate_type)
         {
-            using accumulate_functor = std::decay_t<decltype(std::get<0>(f))>;
+            using accumulate_functor = std::decay_t<decltype(xt::get<0>(f))>;
             using T = typename accumulate_functor::result_type;
 
-            using result_type = xtensor<T, 1>;
+            using result_type = xaccumulator_linear_return_type_t<std::decay_t<E>, T>;
             std::size_t sz = e.size();
             auto result = result_type::from_shape({sz});
 
-            auto it = e.template begin<XTENSOR_DEFAULT_LAYOUT>();
-
-            result.storage()[0] = std::get<1>(f)(*it);
-            ++it;
-
-            for (std::size_t idx = 0; it != e.template end<XTENSOR_DEFAULT_LAYOUT>(); ++it)
+            if(sz != std::size_t(0))
             {
-                result.storage()[idx + 1] = std::get<0>(f)(result.storage()[idx], *it);
-                ++idx;
+                auto it = e.template begin<XTENSOR_DEFAULT_TRAVERSAL>();
+                result.storage()[0] = xt::get<1>(f)(*it);
+                ++it;
+
+                for (std::size_t idx = 0; it != e.template end<XTENSOR_DEFAULT_TRAVERSAL>(); ++it)
+                {
+                    result.storage()[idx + 1] = xt::get<0>(f)(result.storage()[idx], *it);
+                    ++idx;
+                }
             }
             return result;
         }
@@ -237,7 +288,7 @@ namespace xt
      * @return returns xarray<T> filled with accumulated values
      */
     template <class F, class E, class EVS = DEFAULT_STRATEGY_ACCUMULATORS,
-              typename std::enable_if_t<!std::is_integral<EVS>::value, int> = 0>
+              XTL_REQUIRES(is_evaluation_strategy<EVS>)>
     inline auto accumulate(F&& f, E&& e, EVS evaluation_strategy = EVS())
     {
         // Note we need to check is_integral above in order to prohibit EVS = int, and not taking the std::size_t
@@ -257,9 +308,10 @@ namespace xt
      * @return returns xarray<T> filled with accumulated values
      */
     template <class F, class E, class EVS = DEFAULT_STRATEGY_ACCUMULATORS>
-    inline auto accumulate(F&& f, E&& e, std::size_t axis, EVS evaluation_strategy = EVS())
+    inline auto accumulate(F&& f, E&& e, std::ptrdiff_t axis, EVS evaluation_strategy = EVS())
     {
-        return detail::accumulator_impl(std::forward<F>(f), std::forward<E>(e), axis, evaluation_strategy);
+        std::size_t ax = normalize_axis(e.dimension(), axis);
+        return detail::accumulator_impl(std::forward<F>(f), std::forward<E>(e), ax, evaluation_strategy);
     }
 }
 

--- a/vendor/xtensor/include/xtensor/xadapt.hpp
+++ b/vendor/xtensor/include/xtensor/xadapt.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -18,6 +19,8 @@
 
 #include "xarray.hpp"
 #include "xtensor.hpp"
+#include "xfixed.hpp"
+#include "xbuffer_adaptor.hpp"
 
 namespace xt
 {
@@ -34,6 +37,24 @@ namespace xt
 
         template <class C>
         using array_size = array_size_impl<std::decay_t<C>>;
+
+        template <class P>
+        struct default_allocator_for_ptr
+        {
+            using type = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>;
+        };
+
+        template <class P>
+        using default_allocator_for_ptr_t = typename default_allocator_for_ptr<P>::type;
+
+        template <class T>
+        using not_an_array = xtl::negation<is_array<T>>;
+
+        template <class T>
+        using not_a_pointer = xtl::negation<std::is_pointer<T>>;
+
+        template <class T>
+        using not_a_layout = xtl::negation<std::is_same<layout_type,T>>;
     }
 
     /**************************
@@ -48,9 +69,31 @@ namespace xt
      * @param l the layout_type of the xarray_adaptor
      */
     template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class C, class SC,
-              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int> = 0>
-    xarray_adaptor<xtl::closure_type_t<C>, L, std::decay_t<SC>>
-    adapt(C&& container, const SC& shape, layout_type l = L);
+              XTL_REQUIRES(detail::not_an_array<std::decay_t<SC>>,
+                           detail::not_a_pointer<C>)>
+    inline xarray_adaptor<xtl::closure_type_t<C>, L, std::decay_t<SC>>
+    adapt(C&& container, const SC& shape, layout_type l = L)
+    {
+        using return_type = xarray_adaptor<xtl::closure_type_t<C>, L, std::decay_t<SC>>;
+        return return_type(std::forward<C>(container), shape, l);
+    }
+
+    /**
+     * Constructs an non-owning xarray_adaptor from a pointer with the specified shape and layout.
+     * @param pointer the container to adapt
+     * @param shape the shape of the xarray_adaptor
+     * @param l the layout_type of the xarray_adaptor
+     */
+    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class C, class SC,
+              XTL_REQUIRES(detail::not_an_array<std::decay_t<SC>>,
+                           std::is_pointer<C>)>
+    inline auto adapt(C&& pointer, const SC& shape, layout_type l = L)
+    {
+        using buffer_type = xbuffer_adaptor<C, xt::no_ownership, detail::default_allocator_for_ptr_t<C>>;
+        using return_type = xarray_adaptor<buffer_type, L, std::decay_t<SC>>;
+        std::size_t size = compute_size(shape);
+        return return_type(buffer_type(pointer, size), shape, l);
+    }
 
     /**
      * Constructs an xarray_adaptor of the given stl-like container,
@@ -60,10 +103,16 @@ namespace xt
      * @param strides the strides of the xarray_adaptor
      */
     template <class C, class SC, class SS,
-              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int> = 0,
-              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int> = 0>
-    xarray_adaptor<xtl::closure_type_t<C>, layout_type::dynamic, std::decay_t<SC>>
-    adapt(C&& container, SC&& shape, SS&& strides);
+              XTL_REQUIRES(detail::not_an_array<std::decay_t<SC>>,
+                           detail::not_a_layout<std::decay_t<SS>>)>
+    inline xarray_adaptor<xtl::closure_type_t<C>, layout_type::dynamic, std::decay_t<SC>>
+    adapt(C&& container, SC&& shape, SS&& strides)
+    {
+        using return_type = xarray_adaptor<xtl::closure_type_t<C>, layout_type::dynamic, std::decay_t<SC>>;
+        return return_type(std::forward<C>(container),
+                           xtl::forward_sequence<typename return_type::inner_shape_type, SC>(shape),
+                           xtl::forward_sequence<typename return_type::inner_strides_type, SS>(strides));
+    }
 
     /**
      * Constructs an xarray_adaptor of the given dynamically allocated C array,
@@ -71,32 +120,79 @@ namespace xt
      * @param pointer the pointer to the beginning of the dynamic array
      * @param size the size of the dynamic array
      * @param ownership indicates whether the adaptor takes ownership of the array.
-     *        Possible values are ``no_ownerhsip()`` or ``acquire_ownership()``
+     *        Possible values are ``no_ownership()`` or ``acquire_ownership()``
      * @param shape the shape of the xarray_adaptor
      * @param l the layout_type of the xarray_adaptor
      * @param alloc the allocator used for allocating / deallocating the dynamic array
      */
-    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class P, class O, class SC, class A = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>,
-              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int> = 0>
-    xarray_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, L, SC>
-    adapt(P&& pointer, typename A::size_type size, O ownership, const SC& shape, layout_type l = L, const A& alloc = A());
+    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class P, class O, class SC, class A = detail::default_allocator_for_ptr_t<P>,
+              XTL_REQUIRES(detail::not_an_array<std::decay_t<SC>>)>
+    inline xarray_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, L, SC>
+    adapt(P&& pointer, typename A::size_type size, O ownership, const SC& shape, layout_type l = L, const A& alloc = A())
+    {
+        (void)ownership;
+        using buffer_type = xbuffer_adaptor<xtl::closure_type_t<P>, O, A>;
+        using return_type = xarray_adaptor<buffer_type, L, SC>;
+        buffer_type buf(std::forward<P>(pointer), size, alloc);
+        return return_type(std::move(buf), shape, l);
+    }
 
     /**
      * Constructs an xarray_adaptor of the given dynamically allocated C array,
-     * with the specified shape and layout.
+     * with the specified shape and strides.
      * @param pointer the pointer to the beginning of the dynamic array
      * @param size the size of the dynamic array
      * @param ownership indicates whether the adaptor takes ownership of the array.
-     *        Possible values are ``no_ownerhsip()`` or ``acquire_ownership()``
+     *        Possible values are ``no_ownership()`` or ``acquire_ownership()``
      * @param shape the shape of the xarray_adaptor
      * @param strides the strides of the xarray_adaptor
      * @param alloc the allocator used for allocating / deallocating the dynamic array
      */
-    template <class P, class O, class SC, class SS, class A = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>,
-              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int> = 0,
-              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int> = 0>
-    xarray_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, layout_type::dynamic, std::decay_t<SC>>
-    adapt(P&& pointer, typename A::size_type size, O ownership, SC&& shape, SS&& strides, const A& alloc = A());
+    template <class P, class O, class SC, class SS, class A = detail::default_allocator_for_ptr_t<P>,
+              XTL_REQUIRES(detail::not_an_array<std::decay_t<SC>>,
+                           detail::not_a_layout<std::decay_t<SS>>)>
+    inline xarray_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, layout_type::dynamic, std::decay_t<SC>>
+    adapt(P&& pointer, typename A::size_type size, O ownership, SC&& shape, SS&& strides, const A& alloc = A())
+    {
+        (void)ownership;
+        using buffer_type = xbuffer_adaptor<xtl::closure_type_t<P>, O, A>;
+        using return_type = xarray_adaptor<buffer_type, layout_type::dynamic, std::decay_t<SC>>;
+        buffer_type buf(std::forward<P>(pointer), size, alloc);
+        return return_type(std::move(buf),
+                           xtl::forward_sequence<typename return_type::inner_shape_type, SC>(shape),
+                           xtl::forward_sequence<typename return_type::inner_strides_type, SS>(strides));
+    }
+
+    /**
+     * Contructs an xarray_adaptor of the given C array allocated on the stack, with the
+     * specified shape and layout.
+     * @param c_array the C array allocated on the stack
+     * @param shape the shape of the xarray_adaptor
+     * @param l the layout_type of the xarray_adaptor
+     */
+    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class T, std::size_t N, class SC,
+              XTL_REQUIRES(detail::not_an_array<std::decay_t<SC>>)>
+    inline auto adapt(T (&c_array)[N], const SC& shape, layout_type l = L)
+    {
+        return adapt(&c_array[0], N, xt::no_ownership(), shape, l);
+    }
+
+    /**
+     * Contructs an xarray_adaptor of the given C array allocated on the stack, with the
+     * specified shape and stirdes.
+     * @param c_array the C array allocated on the stack
+     * @param shape the shape of the xarray_adaptor
+     * @param strides the strides of the xarray_adaptor
+     */
+    template <class T, std::size_t N, class SC, class SS,
+             XTL_REQUIRES(detail::not_an_array<std::decay_t<SC>>,
+                          detail::not_a_layout<std::decay_t<SS>>)>
+    inline auto adapt(T (&c_array)[N], SC&& shape, SS&& strides)
+    {
+        return adapt(&c_array[0], N, xt::no_ownership(),
+                     std::forward<SC>(shape),
+                     std::forward<SS>(strides));
+    }
 
     /***************************
      * xtensor_adaptor builder *
@@ -109,8 +205,13 @@ namespace xt
      * @param l the layout_type of the xtensor_adaptor
      */
     template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class C>
-    xtensor_adaptor<C, 1, L>
-    adapt(C&& container, layout_type l = L);
+    inline xtensor_adaptor<C, 1, L>
+    adapt(C&& container, layout_type l = L)
+    {
+        const std::array<typename std::decay_t<C>::size_type, 1> shape{container.size()};
+        using return_type = xtensor_adaptor<xtl::closure_type_t<C>, 1, L>;
+        return return_type(std::forward<C>(container), shape, l);
+    }
 
     /**
      * Constructs an xtensor_adaptor of the given stl-like container,
@@ -120,9 +221,32 @@ namespace xt
      * @param l the layout_type of the xtensor_adaptor
      */
     template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class C, class SC,
-              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int> = 0>
-    xtensor_adaptor<C, detail::array_size<SC>::value, L>
-    adapt(C&& container, const SC& shape, layout_type l = L);
+              XTL_REQUIRES(detail::is_array<std::decay_t<SC>>,
+                           detail::not_a_pointer<C>)>
+    inline xtensor_adaptor<C, detail::array_size<SC>::value, L>
+    adapt(C&& container, const SC& shape, layout_type l = L)
+    {
+        constexpr std::size_t N = detail::array_size<SC>::value;
+        using return_type = xtensor_adaptor<xtl::closure_type_t<C>, N, L>;
+        return return_type(std::forward<C>(container), shape, l);
+    }
+
+    /**
+     * Constructs an non-owning xtensor_adaptor from a pointer with the specified shape and layout.
+     * @param pointer the pointer to adapt
+     * @param shape the shape of the xtensor_adaptor
+     * @param l the layout_type of the xtensor_adaptor
+     */
+    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class C, class SC,
+              XTL_REQUIRES(detail::is_array<std::decay_t<SC>>,
+                           std::is_pointer<C>)>
+    inline auto adapt(C&& pointer, const SC& shape, layout_type l = L)
+    {
+        using buffer_type = xbuffer_adaptor<C, xt::no_ownership, detail::default_allocator_for_ptr_t<C>>;
+        constexpr std::size_t N = detail::array_size<SC>::value;
+        using return_type = xtensor_adaptor<buffer_type, N, L>;
+        return return_type(buffer_type(pointer, compute_size(shape)), shape, l);
+    }
 
     /**
      * Constructs an xtensor_adaptor of the given stl-like container,
@@ -132,10 +256,17 @@ namespace xt
      * @param strides the strides of the xtensor_adaptor
      */
     template <class C, class SC, class SS,
-              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int> = 0,
-              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int> = 0>
-    xtensor_adaptor<C, detail::array_size<SC>::value, layout_type::dynamic>
-    adapt(C&& container, SC&& shape, SS&& strides);
+              XTL_REQUIRES(detail::is_array<std::decay_t<SC>>,
+                           detail::not_a_layout<std::decay_t<SS>>)>
+    inline xtensor_adaptor<C, detail::array_size<SC>::value, layout_type::dynamic>
+    adapt(C&& container, SC&& shape, SS&& strides)
+    {
+        constexpr std::size_t N = detail::array_size<SC>::value;
+        using return_type = xtensor_adaptor<xtl::closure_type_t<C>, N, layout_type::dynamic>;
+        return return_type(std::forward<C>(container),
+                           xtl::forward_sequence<typename return_type::inner_shape_type, SC>(shape),
+                           xtl::forward_sequence<typename return_type::inner_strides_type, SS>(strides));
+    }
 
     /**
      * Constructs a 1-D xtensor_adaptor of the given dynamically allocated C array,
@@ -143,145 +274,15 @@ namespace xt
      * @param pointer the pointer to the beginning of the dynamic array
      * @param size the size of the dynamic array
      * @param ownership indicates whether the adaptor takes ownership of the array.
-     *        Possible values are ``no_ownerhsip()`` or ``acquire_ownership()``
+     *        Possible values are ``no_ownership()`` or ``acquire_ownership()``
      * @param l the layout_type of the xtensor_adaptor
      * @param alloc the allocator used for allocating / deallocating the dynamic array
      */
-    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class P, class O, class A = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>>
-    xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, 1, L>
-    adapt(P&& pointer, typename A::size_type size, O ownership, layout_type l = L, const A& alloc = A());
-
-    /**
-     * Constructs an xtensor_adaptor of the given dynamically allocated C array,
-     * with the specified shape and layout.
-     * @param pointer the pointer to the beginning of the dynamic array
-     * @param size the size of the dynamic array
-     * @param ownership indicates whether the adaptor takes ownership of the array.
-     *        Possible values are ``no_ownerhsip()`` or ``acquire_ownership()``
-     * @param shape the shape of the xtensor_adaptor
-     * @param l the layout_type of the xtensor_adaptor
-     * @param alloc the allocator used for allocating / deallocating the dynamic array
-     */
-    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class P, class O, class SC, class A = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>,
-              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int> = 0>
-    xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, detail::array_size<SC>::value, L>
-    adapt(P&& pointer, typename A::size_type size, O ownership, const SC& shape, layout_type l = L, const A& alloc = A());
-
-    /**
-     * Constructs an xtensor_adaptor of the given dynamically allocated C array,
-     * with the specified shape and strides.
-     * @param pointer the pointer to the beginning of the dynamic array
-     * @param size the size of the dynamic array
-     * @param ownership indicates whether the adaptor takes ownership of the array.
-     *        Possible values are ``no_ownerhsip()`` or ``acquire_ownership()``
-     * @param shape the shape of the xtensor_adaptor
-     * @param strides the strides of the xtensor_adaptor
-     * @param alloc the allocator used for allocating / deallocating the dynamic array
-     */
-    template <class P, class O, class SC, class SS, class A = std::allocator<std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<P>>>>,
-              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int> = 0,
-              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int> = 0>
-    xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, detail::array_size<SC>::value, layout_type::dynamic>
-    adapt(P&& pointer, typename A::size_type size, O ownership, SC&& shape, SS&& strides, const A& alloc = A());
-
-    /*****************************************
-     * xarray_adaptor builder implementation *
-     *****************************************/
-
-    // shape only - container version
-    template <layout_type L, class C, class SC,
-              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int>>
-    inline xarray_adaptor<xtl::closure_type_t<C>, L, std::decay_t<SC>>
-    adapt(C&& container, const SC& shape, layout_type l)
-    {
-        using return_type = xarray_adaptor<xtl::closure_type_t<C>, L, std::decay_t<SC>>;
-        return return_type(std::forward<C>(container), shape, l);
-    }
-
-    // shape and strides - container version
-    template <class C, class SC, class SS,
-              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int>,
-              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int>>
-    inline xarray_adaptor<xtl::closure_type_t<C>, layout_type::dynamic, std::decay_t<SC>>
-    adapt(C&& container, SC&& shape, SS&& strides)
-    {
-        using return_type = xarray_adaptor<xtl::closure_type_t<C>, layout_type::dynamic, std::decay_t<SC>>;
-        return return_type(std::forward<C>(container),
-                           xtl::forward_sequence<typename return_type::inner_shape_type>(shape),
-                           xtl::forward_sequence<typename return_type::inner_strides_type>(strides));
-    }
-
-    // shape only - buffer version
-    template <layout_type L, class P, class O, class SC, class A,
-              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int>>
-    inline xarray_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, L, SC>
-    adapt(P&& pointer, typename A::size_type size, O, const SC& shape, layout_type l, const A& alloc)
-    {
-        using buffer_type = xbuffer_adaptor<xtl::closure_type_t<P>, O, A>;
-        using return_type = xarray_adaptor<buffer_type, L, SC>;
-        buffer_type buf(std::forward<P>(pointer), size, alloc);
-        return return_type(std::move(buf), shape, l);
-    }
-
-    // shape and strides - buffer version
-    template <class P, class O, class SC, class SS, class A,
-              typename std::enable_if_t<!detail::is_array<std::decay_t<SC>>::value, int>,
-              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int>>
-    inline xarray_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, layout_type::dynamic, std::decay_t<SC>>
-    adapt(P&& pointer, typename A::size_type size, O, SC&& shape, SS&& strides, const A& alloc)
-    {
-        using buffer_type = xbuffer_adaptor<xtl::closure_type_t<P>, O, A>;
-        using return_type = xarray_adaptor<buffer_type, layout_type::dynamic, std::decay_t<SC>>;
-        buffer_type buf(std::forward<P>(pointer), size, alloc);
-        return return_type(std::move(buf),
-                           xtl::forward_sequence<typename return_type::inner_shape_type>(shape),
-                           xtl::forward_sequence<typename return_type::inner_strides_type>(strides));
-    }
-
-    /******************************************
-     * xtensor_adaptor builder implementation *
-     ******************************************/
-
-    // 1-D case - container version
-    template <layout_type L, class C>
-    inline xtensor_adaptor<C, 1, L>
-    adapt(C&& container, layout_type l)
-    {
-        const std::array<typename std::decay_t<C>::size_type, 1> shape{container.size()};
-        using return_type = xtensor_adaptor<xtl::closure_type_t<C>, 1, L>;
-        return return_type(std::forward<C>(container), shape, l);
-    }
-
-    // shape only - container version
-    template <layout_type L, class C, class SC,
-              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int>>
-    inline xtensor_adaptor<C, detail::array_size<SC>::value, L>
-    adapt(C&& container, const SC& shape, layout_type l)
-    {
-        constexpr std::size_t N = detail::array_size<SC>::value;
-        using return_type = xtensor_adaptor<xtl::closure_type_t<C>, N, L>;
-        return return_type(std::forward<C>(container), shape, l);
-    }
-
-    // shape and strides - container version
-    template <class C, class SC, class SS,
-              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int>,
-              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int>>
-    inline xtensor_adaptor<C, detail::array_size<SC>::value, layout_type::dynamic>
-    adapt(C&& container, SC&& shape, SS&& strides)
-    {
-        constexpr std::size_t N = detail::array_size<SC>::value;
-        using return_type = xtensor_adaptor<xtl::closure_type_t<C>, N, layout_type::dynamic>;
-        return return_type(std::forward<C>(container),
-                           xtl::forward_sequence<typename return_type::inner_shape_type>(shape),
-                           xtl::forward_sequence<typename return_type::inner_strides_type>(strides));
-    }
-
-    // 1-D case - buffer version
-    template <layout_type L, class P, class O, class A>
+    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class P, class O, class A = detail::default_allocator_for_ptr_t<P>>
     inline xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, 1, L>
-    adapt(P&& pointer, typename A::size_type size, O, layout_type l, const A& alloc)
+    adapt(P&& pointer, typename A::size_type size, O ownership, layout_type l = L, const A& alloc = A())
     {
+        (void)ownership;
         using buffer_type = xbuffer_adaptor<xtl::closure_type_t<P>, O, A>;
         using return_type = xtensor_adaptor<buffer_type, 1, L>;
         buffer_type buf(std::forward<P>(pointer), size, alloc);
@@ -289,12 +290,23 @@ namespace xt
         return return_type(std::move(buf), shape, l);
     }
 
-    // shape only - buffer version
-    template <layout_type L, class P, class O, class SC, class A,
-              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int>>
+    /**
+     * Constructs an xtensor_adaptor of the given dynamically allocated C array,
+     * with the specified shape and layout.
+     * @param pointer the pointer to the beginning of the dynamic array
+     * @param size the size of the dynamic array
+     * @param ownership indicates whether the adaptor takes ownership of the array.
+     *        Possible values are ``no_ownership()`` or ``acquire_ownership()``
+     * @param shape the shape of the xtensor_adaptor
+     * @param l the layout_type of the xtensor_adaptor
+     * @param alloc the allocator used for allocating / deallocating the dynamic array
+     */
+    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class P, class O, class SC, class A = detail::default_allocator_for_ptr_t<P>,
+              XTL_REQUIRES(detail::is_array<std::decay_t<SC>>)>
     inline xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, detail::array_size<SC>::value, L>
-    adapt(P&& pointer, typename A::size_type size, O, const SC& shape, layout_type l, const A& alloc)
+    adapt(P&& pointer, typename A::size_type size, O ownership, const SC& shape, layout_type l = L, const A& alloc = A())
     {
+        (void)ownership;
         using buffer_type = xbuffer_adaptor<xtl::closure_type_t<P>, O, A>;
         constexpr std::size_t N = detail::array_size<SC>::value;
         using return_type = xtensor_adaptor<buffer_type, N, L>;
@@ -302,21 +314,185 @@ namespace xt
         return return_type(std::move(buf), shape, l);
     }
 
-    // shape and strides - buffer version
-    template <class P, class O, class SC, class SS, class A,
-              typename std::enable_if_t<detail::is_array<std::decay_t<SC>>::value, int>,
-              typename std::enable_if_t<!std::is_same<layout_type, std::decay_t<SS>>::value, int>>
+    /**
+     * Constructs an xtensor_adaptor of the given dynamically allocated C array,
+     * with the specified shape and strides.
+     * @param pointer the pointer to the beginning of the dynamic array
+     * @param size the size of the dynamic array
+     * @param ownership indicates whether the adaptor takes ownership of the array.
+     *        Possible values are ``no_ownership()`` or ``acquire_ownership()``
+     * @param shape the shape of the xtensor_adaptor
+     * @param strides the strides of the xtensor_adaptor
+     * @param alloc the allocator used for allocating / deallocating the dynamic array
+     */
+    template <class P, class O, class SC, class SS, class A = detail::default_allocator_for_ptr_t<P>,
+              XTL_REQUIRES(detail::is_array<std::decay_t<SC>>,
+                           detail::not_a_layout<std::decay_t<SS>>)>
     inline xtensor_adaptor<xbuffer_adaptor<xtl::closure_type_t<P>, O, A>, detail::array_size<SC>::value, layout_type::dynamic>
-    adapt(P&& pointer, typename A::size_type size, O, SC&& shape, SS&& strides, const A& alloc)
+    adapt(P&& pointer, typename A::size_type size, O ownership, SC&& shape, SS&& strides, const A& alloc = A())
     {
+        (void)ownership;
         using buffer_type = xbuffer_adaptor<xtl::closure_type_t<P>, O, A>;
         constexpr std::size_t N = detail::array_size<SC>::value;
         using return_type = xtensor_adaptor<buffer_type, N, layout_type::dynamic>;
         buffer_type buf(std::forward<P>(pointer), size, alloc);
         return return_type(std::move(buf),
-                           xtl::forward_sequence<typename return_type::inner_shape_type>(shape),
-                           xtl::forward_sequence<typename return_type::inner_strides_type>(strides));
+                           xtl::forward_sequence<typename return_type::inner_shape_type, SC>(shape),
+                           xtl::forward_sequence<typename return_type::inner_strides_type, SS>(strides));
     }
+    
+    /**
+     * Contructs an xtensor_adaptor of the given C array allocated on the stack, with the
+     * specified shape and layout.
+     * @param c_array the C array allocated on the stack
+     * @param shape the shape of the xarray_adaptor
+     * @param l the layout_type of the xarray_adaptor
+     */
+    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class T, std::size_t N, class SC,
+              XTL_REQUIRES(detail::is_array<std::decay_t<SC>>)>
+    inline auto adapt(T (&c_array)[N], const SC& shape, layout_type l = L)
+    {
+        return adapt(&c_array[0], N, xt::no_ownership(), shape, l);
+    }
+
+    /**
+     * Contructs an xtensor_adaptor of the given C array allocated on the stack, with the
+     * specified shape and stirdes.
+     * @param c_array the C array allocated on the stack
+     * @param shape the shape of the xarray_adaptor
+     * @param strides the strides of the xarray_adaptor
+     */
+    template <class T, std::size_t N, class SC, class SS,
+             XTL_REQUIRES(detail::is_array<std::decay_t<SC>>,
+                          detail::not_a_layout<std::decay_t<SS>>)>
+    inline auto adapt(T (&c_array)[N], SC&& shape, SS&& strides)
+    {
+        return adapt(&c_array[0], N, xt::no_ownership(),
+                     std::forward<SC>(shape),
+                     std::forward<SS>(strides));
+    }
+    /**
+     * Constructs an non-owning xtensor_fixed_adaptor from a pointer with the
+     * specified shape and layout.
+     * @param pointer the pointer to adapt
+     * @param shape the shape of the xtensor_fixed_adaptor
+     */
+    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class C, std::size_t... X,
+              XTL_REQUIRES(std::is_pointer<C>)>
+    inline auto adapt(C&& ptr, const fixed_shape<X...>& /*shape*/)
+    {
+        using buffer_type = xbuffer_adaptor<C, xt::no_ownership, detail::default_allocator_for_ptr_t<C>>;
+        using return_type = xfixed_adaptor<buffer_type, fixed_shape<X...>, L>;
+        return return_type(buffer_type(ptr, detail::fixed_compute_size<fixed_shape<X...>>::value));
+    }
+
+#ifndef X_OLD_CLANG
+    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class C, class T,  std::size_t N>
+    inline auto adapt(C&& ptr, const T(&shape)[N])
+    {
+        using shape_type = std::array<std::size_t, N>;
+        return adapt(std::forward<C>(ptr), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
+    }
+#else
+    template <layout_type L = XTENSOR_DEFAULT_LAYOUT, class C>
+    inline auto adapt(C&& ptr, std::initializer_list<std::size_t> shape)
+    {
+        using shape_type = xt::dynamic_shape<std::size_t>;
+        return adapt(std::forward<C>(ptr), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
+    }
+#endif
+
+#ifndef X_OLD_CLANG
+    /**
+     * Adapt a smart pointer to a typed memory block (unique_ptr or shared_ptr)
+     *
+     * \code{.cpp}
+     * #include <xtensor/xadapt.hpp>
+     * #include <xtensor/xio.hpp>
+     *
+     * std::shared_ptr<double> sptr(new double[8], std::default_delete<double[]>());
+     * sptr.get()[2] = 321.;
+     * auto xptr = adapt_smart_ptr(sptr, {4, 2});
+     * xptr(1, 3) = 123.;
+     * std::cout << xptr;
+     * \endcode
+     *
+     * @param smart_ptr a smart pointer to a memory block of T[]
+     * @param shape The desired shape
+     *
+     * @return xtensor_adaptor for memory
+     */
+    template <class P, class I, std::size_t N>
+    auto adapt_smart_ptr(P&& smart_ptr, const I(&shape)[N])
+    {
+        using buffer_adaptor = xbuffer_adaptor<decltype(smart_ptr.get()), smart_ownership,
+                                               std::decay_t<P>>;
+        std::array<std::size_t, N> fshape = xtl::forward_sequence<std::array<std::size_t, N>, decltype(shape)>(shape);
+        return xtensor_adaptor<buffer_adaptor, N>(
+            buffer_adaptor(smart_ptr.get(), compute_size(fshape),
+            std::forward<P>(smart_ptr)),
+            std::move(fshape)
+        );
+    }
+
+    /**
+     * Adapt a smart pointer (shared_ptr or unique_ptr)
+     *
+     * This function allows to automatically adapt a shared or unique pointer to
+     * a given shape and operate naturally on it. Memory will be automatically
+     * handled by the smart pointer implementation.
+     *
+     * \code{.cpp}
+     * #include <xtensor/xadapt.hpp>
+     * #include <xtensor/xio.hpp>
+     *
+     * struct Buffer {
+     *     Buffer(std::vector<double>& buf) : m_buf(buf) {}
+     *     ~Buffer() { std::cout << "deleted" << std::endl; }
+     *     std::vector<double> m_buf;
+     * };
+     *
+     * auto data = std::vector<double>{1,2,3,4,5,6,7,8};
+     * auto shared_buf = std::make_shared<Buffer>(data);
+     * auto unique_buf = std::make_unique<Buffer>(data);
+     *
+     * std::cout << shared_buf.use_count() << std::endl;
+     * {
+     *     auto obj = adapt_smart_ptr(shared_buf.get()->m_buf.data(),
+     *                                {2, 4}, shared_buf);
+     *     // Use count increased to 2
+     *     std::cout << shared_buf.use_count() << std::endl;
+     *     std::cout << obj << std::endl;
+     * }
+     * // Use count reset to 1
+     * std::cout << shared_buf.use_count() << std::endl;
+     *
+     * {
+     *     auto obj = adapt_smart_ptr(unique_buf.get()->m_buf.data(),
+     *                                {2, 4}, std::move(unique_buf));
+     *     std::cout << obj << std::endl;
+     * }
+     * \endcode
+     *
+     * @param data_ptr A pointer to a typed data block (e.g. double*)
+     * @param shape The desired shape
+     * @param smart_ptr A smart pointer to move or copy, in order to manage memory
+     *
+     * @return xtensor_adaptor on the memory
+     */
+    template <class P, class I, std::size_t N, class D>
+    auto adapt_smart_ptr(P&& data_ptr, const I(&shape)[N], D&& smart_ptr)
+    {
+        using buffer_adaptor = xbuffer_adaptor<P, smart_ownership,
+                                               std::decay_t<D>>;
+        std::array<std::size_t, N> fshape = xtl::forward_sequence<std::array<std::size_t, N>, decltype(shape)>(shape);
+
+        return xtensor_adaptor<buffer_adaptor, N>(
+            buffer_adaptor(data_ptr, compute_size(fshape), std::forward<D>(smart_ptr)),
+            std::move(fshape)
+        );
+    }
+#endif
 }
 
 #endif

--- a/vendor/xtensor/include/xtensor/xassign.hpp
+++ b/vendor/xtensor/include/xtensor/xassign.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -15,12 +16,16 @@
 
 #include <xtl/xsequence.hpp>
 
-#include "xconcepts.hpp"
 #include "xexpression.hpp"
 #include "xiterator.hpp"
 #include "xstrides.hpp"
 #include "xtensor_forward.hpp"
 #include "xutils.hpp"
+#include "xfunction.hpp"
+
+#if defined(XTENSOR_USE_TBB)
+#include <tbb/tbb.h>
+#endif
 
 namespace xt
 {
@@ -74,7 +79,7 @@ namespace xt
         using base_type = xexpression_assigner_base<Tag>;
 
         template <class E1, class E2>
-        static void assign_xexpression(xexpression<E1>& e1, const xexpression<E2>& e2);
+        static void assign_xexpression(E1& e1, const E2& e2);
 
         template <class E1, class E2>
         static void computed_assign(xexpression<E1>& e1, const xexpression<E2>& e2);
@@ -88,15 +93,19 @@ namespace xt
     private:
 
         template <class E1, class E2>
-        static bool resize(xexpression<E1>& e1, const xexpression<E2>& e2);
+        static bool resize(E1& e1, const E2& e2);
+
+        template <class E1, class F, class... CT>
+        static bool resize(E1& e1, const xfunction<F, CT...>& e2);
+
     };
 
-    /*****************
-     * data_assigner *
-     *****************/
+    /********************
+     * stepper_assigner *
+     ********************/
 
     template <class E1, class E2, layout_type L>
-    class data_assigner
+    class stepper_assigner
     {
     public:
 
@@ -107,7 +116,7 @@ namespace xt
         using size_type = typename lhs_iterator::size_type;
         using difference_type = typename lhs_iterator::difference_type;
 
-        data_assigner(E1& e1, const E2& e2);
+        stepper_assigner(E1& e1, const E2& e2);
 
         void run();
 
@@ -127,13 +136,45 @@ namespace xt
         index_type m_index;
     };
 
-    /********************
-     * trivial_assigner *
-     ********************/
+    /*******************
+     * linear_assigner *
+     *******************/
 
     template <bool simd_assign>
-    struct trivial_assigner
+    class linear_assigner
     {
+    public:
+
+        template <class E1, class E2>
+        static void run(E1& e1, const E2& e2);
+    };
+
+    template <>
+    class linear_assigner<false>
+    {
+    public:
+
+        template <class E1, class E2>
+        static void run(E1& e1, const E2& e2);
+
+    private:
+
+        template <class E1, class E2>
+        static void run_impl(E1& e1, const E2& e2, std::true_type);
+
+        template <class E1, class E2>
+        static void run_impl(E1& e1, const E2& e2, std::false_type);
+    };
+
+    /*************************
+     * strided_loop_assigner *
+     *************************/
+
+    template <bool simd>
+    class strided_loop_assigner
+    {
+    public:
+
         template <class E1, class E2>
         static void run(E1& e1, const E2& e2);
     };
@@ -190,58 +231,27 @@ namespace xt
     namespace detail
     {
         template <class E1, class E2>
-        inline bool is_trivial_broadcast(const E1& e1, const E2& e2)
+        constexpr bool linear_static_layout()
         {
-            return (E1::contiguous_layout && E2::contiguous_layout && (E1::static_layout == E2::static_layout))
-                    || e2.is_trivial_broadcast(e1.strides());
+            // A row_major or column_major container with a dimension <= 1 is computed as
+            // layout any, leading to some performance improvements, for example when
+            // assigning a col-major vector to a row-major vector etc
+            return compute_layout(select_layout<E1::static_layout, typename E1::shape_type>::value,
+                                  select_layout<E2::static_layout, typename E2::shape_type>::value) != layout_type::dynamic;
         }
 
-        template <class D, class E2, class... SL>
-        inline bool is_trivial_broadcast(const xview<D, SL...>&, const E2&)
+        template <class E1, class E2>
+        inline auto is_linear_assign(const E1& e1, const E2& e2) -> std::enable_if_t<has_strides<E1>::value, bool>
+        {
+            return (E1::contiguous_layout && E2::contiguous_layout && linear_static_layout<E1, E2>()) ||
+                   (e1.layout() != layout_type::dynamic && e2.has_linear_assign(e1.strides()));
+        }
+
+        template <class E1, class E2>
+        inline auto is_linear_assign(const E1&, const E2&) -> std::enable_if_t<!has_strides<E1>::value, bool>
         {
             return false;
         }
-
-        template <class E, class = void_t<>>
-        struct forbid_simd_assign
-        {
-            static constexpr bool value = true;
-        };
-
-        // Double steps check for xfunction because the default
-        // parameter void_t of forbid_simd_assign prevents additional
-        // specializations.
-        template <class E>
-        struct xfunction_forbid_simd;
-
-        template <class E>
-        struct forbid_simd_assign<E,
-            void_t<decltype(std::declval<E>().template load_simd<aligned_mode>(typename E::size_type(0)))>>
-        {
-            static constexpr bool value = false || xfunction_forbid_simd<E>::value;
-        };
-
-        template <class E>
-        struct xfunction_forbid_simd
-        {
-            static constexpr bool value = false;
-        };
-
-        template <class F, class R, class... CT>
-        struct xfunction_forbid_simd<xfunction<F, R, CT...>>
-        {
-            static constexpr bool value = xtl::disjunction<
-                std::integral_constant<bool, forbid_simd_assign<typename std::decay<CT>::type>::value>...>::value;
-        };
-
-        template <class F, class B, class = void>
-        struct has_simd_apply : std::false_type {};
-
-        template <class F, class B>
-        struct has_simd_apply<F, B, void_t<decltype(&F::template simd_apply<B>)>>
-            : std::true_type
-        {
-        };
 
         template <class E, class = void>
         struct has_step_leading : std::false_type
@@ -267,25 +277,49 @@ namespace xt
             static constexpr bool value = true;
         };
 
-        template <class F, class R, class... CT>
-        struct use_strided_loop<xfunction<F, R, CT...>>
+        template <class F, class... CT>
+        struct use_strided_loop<xfunction<F, CT...>>
         {
-            static constexpr bool value = xtl::conjunction<use_strided_loop<std::decay_t<CT>>...>::value &&
-                                          has_simd_apply<F, xsimd::simd_type<R>>::value;
+            static constexpr bool value = xtl::conjunction<use_strided_loop<std::decay_t<CT>>...>::value;
         };
     }
 
     template <class E1, class E2>
-    struct xassign_traits
+    class xassign_traits
     {
-        // constexpr methods instead of constexpr data members avoid the need of difinitions at namespace
-        // scope of these data members (since they are odr-used).
+    private:
+
+        using e1_value_type = typename E1::value_type;
+        using e2_value_type = typename E2::value_type;
+
+        template <class T>
+        using is_bool = std::is_same<T, bool>;
+
         static constexpr bool contiguous_layout() { return E1::contiguous_layout && E2::contiguous_layout; }
-        static constexpr bool same_type() { return std::is_same<typename E1::value_type, typename E2::value_type>::value; }
-        static constexpr bool simd_size() { return xsimd::simd_traits<typename E1::value_type>::size > 1; }
-        static constexpr bool forbid_simd() { return detail::forbid_simd_assign<E2>::value; }
-        static constexpr bool simd_assign() { return contiguous_layout() && same_type() && simd_size() && !forbid_simd(); }
-        static constexpr bool simd_strided_loop() { return same_type() && simd_size() && detail::use_strided_loop<E2>::value && detail::use_strided_loop<E1>::value; }
+        static constexpr bool convertible_types() { return std::is_convertible<e2_value_type, e1_value_type>::value; }
+
+        static constexpr bool use_xsimd() { return xt_simd::simd_traits<int8_t>::size > 1; }
+
+        template <class T>
+        static constexpr bool simd_size_impl() { return xt_simd::simd_traits<T>::size > 1 || (is_bool<T>::value && use_xsimd()); }
+        static constexpr bool simd_size() { return simd_size_impl<e1_value_type>() && simd_size_impl<e2_value_type>(); }
+        static constexpr bool simd_interface() { return has_simd_interface<E2, requested_value_type>(); }
+        static constexpr bool simd_assign() { return convertible_types() && simd_size() && simd_interface(); }
+    
+    public:
+        
+        // constexpr methods instead of constexpr data members avoid the need of definitions at namespace
+        // scope of these data members (since they are odr-used).
+
+        static constexpr bool linear_assign(const E1& e1, const E2& e2, bool trivial) { return trivial && detail::is_linear_assign(e1, e2); }
+        static constexpr bool strided_assign() { return detail::use_strided_loop<E1>::value && detail::use_strided_loop<E2>::value; }
+        static constexpr bool simd_linear_assign() { return contiguous_layout() && simd_assign(); }
+        static constexpr bool simd_strided_assign() { return strided_assign() && simd_assign(); }
+
+        using requested_value_type = std::conditional_t<is_bool<e2_value_type>::value,
+                                                        typename E2::bool_load_type,
+                                                        e2_value_type>;
+
     };
 
     template <class E1, class E2>
@@ -293,30 +327,31 @@ namespace xt
     {
         E1& de1 = e1.derived_cast();
         const E2& de2 = e2.derived_cast();
+        using traits = xassign_traits<E1, E2>;
 
-        bool trivial_broadcast = trivial && detail::is_trivial_broadcast(de1, de2);
-
-        if (trivial_broadcast)
+        bool linear_assign = traits::linear_assign(de1, de2, trivial);
+        constexpr bool simd_linear_assign = traits::simd_linear_assign();
+        constexpr bool simd_strided_assign = traits::simd_strided_assign();
+        if (linear_assign)
         {
-            constexpr bool simd_assign = xassign_traits<E1, E2>::simd_assign();
-            trivial_assigner<simd_assign>::run(de1, de2);
+            linear_assigner<simd_linear_assign>::run(de1, de2);
         }
-        else if (xassign_traits<E1, E2>::simd_strided_loop())
+        else if (simd_strided_assign)
         {
-            strided_assign(de1, de2, std::integral_constant<bool, xassign_traits<E1, E2>::simd_strided_loop()>{});
+            strided_loop_assigner<simd_strided_assign>::run(de1, de2);
         }
         else
         {
-            data_assigner<E1, E2, default_assignable_layout(E1::static_layout)> assigner(de1, de2);
+            stepper_assigner<E1, E2, default_assignable_layout(E1::static_layout)> assigner(de1, de2);
             assigner.run();
         }
     }
 
     template <class Tag>
     template <class E1, class E2>
-    inline void xexpression_assigner<Tag>::assign_xexpression(xexpression<E1>& e1, const xexpression<E2>& e2)
+    inline void xexpression_assigner<Tag>::assign_xexpression(E1& e1, const E2& e2)
     {
-        bool trivial_broadcast = resize(e1, e2);
+        bool trivial_broadcast = resize(e1.derived_cast(), e2.derived_cast());
         base_type::assign_data(e1, e2, trivial_broadcast);
     }
 
@@ -331,7 +366,7 @@ namespace xt
         const E2& de2 = e2.derived_cast();
 
         size_type dim = de2.dimension();
-        shape_type shape = xtl::make_sequence<shape_type>(dim, size_type(0));
+        shape_type shape = uninitialized_shape<shape_type>(dim);
         bool trivial_broadcast = de2.broadcast_shape(shape, true);
 
         if (dim > de1.dimension() || shape > de1.shape())
@@ -372,26 +407,98 @@ namespace xt
         }
     }
 
-    template <class Tag>
-    template <class E1, class E2>
-    inline bool xexpression_assigner<Tag>::resize(xexpression<E1>& e1, const xexpression<E2>& e2)
+    namespace detail
     {
-        using shape_type = typename E1::shape_type;
-        using size_type = typename E1::size_type;
-        const E2& de2 = e2.derived_cast();
-        size_type size = de2.dimension();
-        shape_type shape = xtl::make_sequence<shape_type>(size, size_type(0));
-        bool trivial_broadcast = de2.broadcast_shape(shape, true);
-        e1.derived_cast().resize(std::move(shape));
-        return trivial_broadcast;
+        template <bool B, class... CT>
+        struct static_trivial_broadcast;
+
+        template <class... CT>
+        struct static_trivial_broadcast<true, CT...>
+        {
+            static constexpr bool value = detail::promote_index<typename std::decay_t<CT>::shape_type...>::value;
+        };
+
+        template <class... CT>
+        struct static_trivial_broadcast<false, CT...>
+        {
+            static constexpr bool value = false;
+        };
     }
 
-    /********************************
-     * data_assigner implementation *
-     ********************************/
+    template <class Tag>
+    template <class E1, class E2>
+    inline bool xexpression_assigner<Tag>::resize(E1& e1, const E2& e2)
+    {
+        // If our RHS is not a xfunction, we know that the RHS is at least potentially trivial
+        // We check the strides of the RHS in detail::is_trivial_broadcast to see if they match up!
+        // So we can skip a shape copy and a call to broadcast_shape(...)
+        e1.resize(e2.shape());
+        return true;
+    }
+
+    template <class Tag>
+    template <class E1, class F, class... CT>
+    inline bool xexpression_assigner<Tag>::resize(E1& e1, const xfunction<F, CT...>& e2)
+    {
+        return xtl::mpl::static_if<detail::is_fixed<typename xfunction<F, CT...>::shape_type>::value>(
+            [&](auto /*self*/) {
+                /*
+                 * If the shape of the xfunction is statically known, we can compute the broadcast triviality
+                 * at compile time plus we can resize right away.
+                 */
+                // resize in case LHS is not a fixed size container. If it is, this is a NOP
+                e1.resize(typename xfunction<F, CT...>::shape_type{});
+                return detail::static_trivial_broadcast<detail::is_fixed<typename xfunction<F, CT...>::shape_type>::value, CT...>::value;
+            },
+            /* else */ [&](auto /*self*/)
+            {
+                using index_type = xindex_type_t<typename E1::shape_type>;
+                using size_type = typename E1::size_type;
+                size_type size = e2.dimension();
+                index_type shape = uninitialized_shape<index_type>(size);
+                bool trivial_broadcast = e2.broadcast_shape(shape, true);
+                e1.resize(std::move(shape));
+                return trivial_broadcast;
+            }
+        );
+    }
+
+    /***********************************
+     * stepper_assigner implementation *
+     ***********************************/
+
+    template <class FROM, class TO>
+    struct is_narrowing_conversion
+    {
+        using argument_type = std::decay_t<FROM>;
+        using result_type = std::decay_t<TO>;
+
+        static const bool value = std::is_arithmetic<result_type>::value &&
+            (sizeof(result_type) < sizeof(argument_type) ||
+             (std::is_integral<result_type>::value && std::is_floating_point<argument_type>::value));
+    };
+
+    template <class FROM, class TO>
+    struct has_sign_conversion
+    {
+        using argument_type = std::decay_t<FROM>;
+        using result_type = std::decay_t<TO>;
+
+        static const bool value = std::is_signed<argument_type>::value != std::is_signed<result_type>::value;
+    };
+
+    template <class FROM, class TO>
+    struct has_assign_conversion
+    {
+        using argument_type = std::decay_t<FROM>;
+        using result_type = std::decay_t<TO>;
+
+        static const bool value = is_narrowing_conversion<argument_type, result_type>::value ||
+                                  has_sign_conversion<argument_type, result_type>::value;
+    };
 
     template <class E1, class E2, layout_type L>
-    inline data_assigner<E1, E2, L>::data_assigner(E1& e1, const E2& e2)
+    inline stepper_assigner<E1, E2, L>::stepper_assigner(E1& e1, const E2& e2)
         : m_e1(e1), m_lhs(e1.stepper_begin(e1.shape())),
           m_rhs(e2.stepper_begin(e1.shape())),
           m_index(xtl::make_sequence<index_type>(e1.shape().size(), size_type(0)))
@@ -399,128 +506,152 @@ namespace xt
     }
 
     template <class E1, class E2, layout_type L>
-    inline void data_assigner<E1, E2, L>::run()
+    inline void stepper_assigner<E1, E2, L>::run()
     {
         using size_type = typename E1::size_type;
         using argument_type = std::decay_t<decltype(*m_rhs)>;
         using result_type = std::decay_t<decltype(*m_lhs)>;
-        constexpr bool is_narrowing = is_narrowing_conversion<argument_type, result_type>::value;
+        constexpr bool needs_cast = has_assign_conversion<argument_type, result_type>::value;
 
         size_type s = m_e1.size();
         for (size_type i = 0; i < s; ++i)
         {
-            *m_lhs = conditional_cast<is_narrowing, result_type>(*m_rhs);
+            *m_lhs = conditional_cast<needs_cast, result_type>(*m_rhs);
             stepper_tools<L>::increment_stepper(*this, m_index, m_e1.shape());
         }
     }
 
     template <class E1, class E2, layout_type L>
-    inline void data_assigner<E1, E2, L>::step(size_type i)
+    inline void stepper_assigner<E1, E2, L>::step(size_type i)
     {
         m_lhs.step(i);
         m_rhs.step(i);
     }
 
     template <class E1, class E2, layout_type L>
-    inline void data_assigner<E1, E2, L>::step(size_type i, size_type n)
+    inline void stepper_assigner<E1, E2, L>::step(size_type i, size_type n)
     {
         m_lhs.step(i, n);
         m_rhs.step(i, n);
     }
 
     template <class E1, class E2, layout_type L>
-    inline void data_assigner<E1, E2, L>::reset(size_type i)
+    inline void stepper_assigner<E1, E2, L>::reset(size_type i)
     {
         m_lhs.reset(i);
         m_rhs.reset(i);
     }
 
     template <class E1, class E2, layout_type L>
-    inline void data_assigner<E1, E2, L>::to_end(layout_type l)
+    inline void stepper_assigner<E1, E2, L>::to_end(layout_type l)
     {
         m_lhs.to_end(l);
         m_rhs.to_end(l);
     }
 
-    /***********************************
-     * trivial_assigner implementation *
-     ***********************************/
+    /**********************************
+     * linear_assigner implementation *
+     **********************************/
 
     template <bool simd_assign>
     template <class E1, class E2>
-    inline void trivial_assigner<simd_assign>::run(E1& e1, const E2& e2)
+    inline void linear_assigner<simd_assign>::run(E1& e1, const E2& e2)
     {
-        using lhs_align_mode = xsimd::container_alignment_t<E1>;
+        using lhs_align_mode = xt_simd::container_alignment_t<E1>;
         constexpr bool is_aligned = std::is_same<lhs_align_mode, aligned_mode>::value;
         using rhs_align_mode = std::conditional_t<is_aligned, inner_aligned_mode, unaligned_mode>;
-        using value_type = std::common_type_t<typename E1::value_type, typename E2::value_type>;
-        using simd_type = xsimd::simd_type<value_type>;
+        using e1_value_type = typename E1::value_type;
+        using e2_value_type = typename E2::value_type;
+        using value_type = typename xassign_traits<E1, E2>::requested_value_type;
+        using simd_type = xt_simd::simd_type<value_type>;
         using size_type = typename E1::size_type;
         size_type size = e1.size();
-        size_type simd_size = simd_type::size;
+        constexpr size_type simd_size = simd_type::size;
+        constexpr bool needs_cast = has_assign_conversion<e1_value_type, e2_value_type>::value;
 
-        size_type align_begin = is_aligned ? 0 : xsimd::get_alignment_offset(e1.data(), size, simd_size);
+        size_type align_begin = is_aligned ? 0 : xt_simd::get_alignment_offset(e1.data(), size, simd_size);
         size_type align_end = align_begin + ((size - align_begin) & ~(simd_size - 1));
 
         for (size_type i = 0; i < align_begin; ++i)
         {
-            e1.data_element(i) = e2.data_element(i);
+            e1.data_element(i) = conditional_cast<needs_cast, e1_value_type>(e2.data_element(i));
         }
+
+#if defined(XTENSOR_USE_TBB)
+        tbb::parallel_for(align_begin, align_end, simd_size, [&](size_t i)
+          {
+            e1.template store_simd<lhs_align_mode>(i, e2.template load_simd<rhs_align_mode, value_type>(i));
+          });
+#elif defined(XTENSOR_USE_OPENMP)
+        #pragma omp parallel for default(none) shared(align_begin, align_end, e1, e2)
         for (size_type i = align_begin; i < align_end; i += simd_size)
         {
-            e1.template store_simd<lhs_align_mode, simd_type>(i, e2.template load_simd<rhs_align_mode, simd_type>(i));
+          e1.template store_simd<lhs_align_mode>(i, e2.template load_simd<rhs_align_mode, value_type>(i));
         }
+#else
+        for (size_type i = align_begin; i < align_end; i += simd_size)
+        {
+          e1.template store_simd<lhs_align_mode>(i, e2.template load_simd<rhs_align_mode, value_type>(i));
+        }
+#endif
         for (size_type i = align_end; i < size; ++i)
         {
-            e1.data_element(i) = e2.data_element(i);
+            e1.data_element(i) = conditional_cast<needs_cast, e1_value_type>(e2.data_element(i));
         }
     }
 
-    namespace assigner_detail
-    {
-        template <class C, class It, class Ot>
-        inline void assign_loop(It src, Ot dst, std::size_t n)
-        {
-            for(; n > 0; --n)
-            {
-                *dst = static_cast<C>(*src);
-                ++src;
-                ++dst;
-            }
-        }
-
-        template <class E1, class E2>
-        inline void trivial_assigner_run_impl(E1& e1, const E2& e2, std::true_type)
-        {
-            using size_type = typename E1::size_type;
-            auto src = e2.storage_cbegin();
-            auto dst = e1.storage_begin();
-            assign_loop<typename E1::value_type>(src, dst, e1.size());
-        }
-
-        template <class E1, class E2>
-        inline void trivial_assigner_run_impl(E1&, const E2&, std::false_type)
-        {
-            XTENSOR_PRECONDITION(false,
-                "Internal error: trivial_assigner called with unrelated types.");
-        }
-    }
-
-    template <>
     template <class E1, class E2>
-    inline void trivial_assigner<false>::run(E1& e1, const E2& e2)
+    inline void linear_assigner<false>::run(E1& e1, const E2& e2)
     {
-        using is_convertible = std::is_convertible<typename std::decay_t<E1>::value_type,
-                                                   typename std::decay_t<E2>::value_type>;
+        using is_convertible = std::is_convertible<typename std::decay_t<E2>::value_type,
+                                                   typename std::decay_t<E1>::value_type>;
         // If the types are not compatible, this function is still instantiated but never called.
         // To avoid compilation problems in effectively unused code trivial_assigner_run_impl is
         // empty in this case.
-        assigner_detail::trivial_assigner_run_impl(e1, e2, is_convertible());
+        run_impl(e1, e2, is_convertible());
     }
 
-    /***********************
-     * Strided assign loop *
-     ***********************/
+    template <class E1, class E2>
+    inline void linear_assigner<false>::run_impl(E1& e1, const E2& e2, std::true_type /*is_convertible*/)
+    {
+        using value_type = typename E1::value_type;
+        using size_type = typename E1::size_type;
+        auto src = linear_begin(e2);
+        auto dst = linear_begin(e1);
+        size_type n = e1.size();
+
+#if defined(XTENSOR_USE_TBB)
+        tbb::parallel_for(std::ptrdiff_t(0), static_cast<std::ptrdiff_t>(n), [&](std::ptrdiff_t i)
+        {
+            *(dst + i) = static_cast<value_type>(*(src + i));
+        });
+#elif defined(XTENSOR_USE_OPENMP)
+        #pragma omp parallel for default(none) shared(src, dst, n)
+        for (std::ptrdiff_t i = std::ptrdiff_t(0); i < static_cast<std::ptrdiff_t>(n) ; i++)
+        {
+            *(dst + i) = static_cast<value_type>(*(src + i));
+        }
+#else
+        for (; n > size_type(0); --n)
+        {
+            *dst = static_cast<value_type>(*src);
+            ++src;
+            ++dst;
+        }
+#endif
+    }
+
+    template <class E1, class E2>
+    inline void linear_assigner<false>::run_impl(E1&, const E2&, std::false_type /*is_convertible*/)
+    {
+        XTENSOR_PRECONDITION(false,
+            "Internal error: linear_assigner called with unrelated types.");
+
+    }
+
+    /****************************************
+     * strided_loop_assigner implementation *
+     ****************************************/
 
     namespace strided_assign_detail
     {
@@ -614,35 +745,35 @@ namespace xt
                 return m_cut;
             }
 
-            template <class F, class R, class... CT>
-            std::size_t operator()(const xt::xfunction<F, R, CT...>& xf)
+            template <class F, class... CT>
+            std::size_t operator()(const xt::xfunction<F, CT...>& xf)
             {
                 xt::for_each(*this, xf.arguments());
                 return m_cut;
             }
 
-        private: 
+        private:
 
             std::size_t m_cut;
             const strides_type& m_strides;
         };
 
         template <class E1, class E2>
-        auto get_loop_sizes(const E1& e1, const E2& e2)
+        auto get_loop_sizes(const E1& e1, const E2& e2, bool is_row_major)
         {
             std::size_t cut = 0;
 
-            // TODO! if E1 is !contigous --> initialize cut to sensible value! 
-            if (e1.strides().back() == 1)
+            // TODO! if E1 is !contiguous --> initialize cut to sensible value!
+            if (E1::static_layout == layout_type::row_major || is_row_major)
             {
                 auto csf = check_strides_functor<layout_type::row_major, decltype(e1.strides())>(e1.strides());
                 cut = csf(e2);
             }
-            else if (e1.strides().front() == 1)
+            else if (E1::static_layout == layout_type::column_major || !is_row_major)
             {
                 auto csf = check_strides_functor<layout_type::column_major, decltype(e1.strides())>(e1.strides());
                 cut = csf(e2);
-            }
+            } // can't reach here because this would have already triggered the fallback
 
             using shape_value_type = typename E1::shape_type::value_type;
             std::size_t outer_loop_size = static_cast<std::size_t>(
@@ -652,7 +783,7 @@ namespace xt
                             std::accumulate(e1.shape().begin() + static_cast<std::ptrdiff_t>(cut), e1.shape().end(),
                                 shape_value_type(1), std::multiplies<shape_value_type>{}));
 
-            if (e1.strides().back() != 1) // column major mode
+            if (E1::static_layout == layout_type::column_major || !is_row_major)
             {
                 std::swap(outer_loop_size, inner_loop_size);
             }
@@ -661,73 +792,80 @@ namespace xt
         }
     }
 
+    template <bool simd>
     template <class E1, class E2>
-    void strided_assign(E1& e1, const E2& e2, std::true_type /*enable*/)
+    inline void strided_loop_assigner<simd>::run(E1& e1, const E2& e2)
     {
-        bool fallback = false, is_row_major = true;
+        bool is_row_major = true;
+        using fallback_assigner = stepper_assigner<E1, E2, default_assignable_layout(E1::static_layout)>;
 
-        std::size_t inner_loop_size, outer_loop_size, cut;
-        std::tie(inner_loop_size, outer_loop_size, cut) = strided_assign_detail::get_loop_sizes(e1, e2);
-
-        if (E1::static_layout == layout_type::row_major || e1.strides().back() == 1) // row major case
+        if (E1::static_layout == layout_type::dynamic)
         {
-            if (cut == e1.dimension())
+            layout_type dynamic_layout = e1.layout();
+            switch (dynamic_layout)
             {
-                fallback = true;
+                case layout_type::row_major:
+                    is_row_major = true;
+                    break;
+                case layout_type::column_major:
+                    is_row_major = false;
+                    break;
+                default:
+                    return fallback_assigner(e1, e2).run();
             }
         }
-        else if (E1::static_layout == layout_type::column_major || e1.strides().front() == 1) // col major case
+        else if (E1::static_layout == layout_type::row_major)
+        {
+            is_row_major = true;
+        }
+        else if (E1::static_layout == layout_type::column_major)
         {
             is_row_major = false;
-            if (cut == 0)
-            {
-                fallback = true;
-            }
         }
         else
         {
-            fallback = true;
+            throw std::runtime_error("Illegal layout set (layout_type::any?).");
         }
 
-        if (fallback)
+        std::size_t inner_loop_size, outer_loop_size, cut;
+        std::tie(inner_loop_size, outer_loop_size, cut) = strided_assign_detail::get_loop_sizes(e1, e2, is_row_major);
+
+        if ((is_row_major && cut == e1.dimension()) || (!is_row_major && cut == 0)) 
         {
-            data_assigner<E1, E2, default_assignable_layout(E1::static_layout)> assigner(e1, e2);
-            assigner.run();
-            return;
+            return fallback_assigner(e1, e2).run();
         }
 
         // TODO can we get rid of this and use `shape_type`?
-        dynamic_shape<std::size_t> idx;
+        dynamic_shape<std::size_t> idx, max_shape;
 
-        using iterator_type = decltype(e1.shape().begin());
-        iterator_type max_shape_begin, max_shape_end;
         if (is_row_major)
         {
             xt::resize_container(idx, cut);
-            max_shape_begin = e1.shape().begin();
-            max_shape_end = e1.shape().begin() + static_cast<std::ptrdiff_t>(cut);
+            max_shape.assign(e1.shape().begin(), e1.shape().begin() + static_cast<std::ptrdiff_t>(cut));
         }
         else
         {
             xt::resize_container(idx, e1.shape().size() - cut);
-            max_shape_begin = e1.shape().begin() + static_cast<std::ptrdiff_t>(cut);
-            max_shape_end = e1.shape().end();
+            max_shape.assign(e1.shape().begin() + static_cast<std::ptrdiff_t>(cut), e1.shape().end());
         }
 
         // add this when we have std::array index!
         // std::fill(idx.begin(), idx.end(), 0);
-
-        dynamic_shape<std::size_t> max(max_shape_begin, max_shape_end);
-
-        using simd_type = xsimd::simd_type<typename E1::value_type>;
+        using e1_value_type = typename E1::value_type;
+        using e2_value_type = typename E2::value_type;
+        constexpr bool needs_cast = has_assign_conversion<e1_value_type, e2_value_type>::value;
+        using value_type = typename xassign_traits<E1, E2>::requested_value_type;
+        using simd_type = std::conditional_t<std::is_same<e1_value_type, bool>::value,
+                                             xt_simd::simd_bool_type<value_type>,
+                                             xt_simd::simd_type<value_type>>;
 
         std::size_t simd_size = inner_loop_size / simd_type::size;
         std::size_t simd_rest = inner_loop_size % simd_type::size;
 
         auto fct_stepper = e2.stepper_begin(e1.shape());
         auto res_stepper = e1.stepper_begin(e1.shape());
-    
-        // TODO in 1D case this is ambigous -- could be RM or CM. 
+
+        // TODO in 1D case this is ambigous -- could be RM or CM.
         //      Use default layout to make decision
         std::size_t step_dim = 0;
         if (!is_row_major) // row major case
@@ -737,20 +875,20 @@ namespace xt
 
         for (std::size_t ox = 0; ox < outer_loop_size; ++ox)
         {
-            for (std::size_t i = 0; i < simd_size; i++)
+            for (std::size_t i = 0; i < simd_size; ++i)
             {
-                res_stepper.template store_simd<simd_type>(fct_stepper.template step_simd<simd_type>());
+                res_stepper.template store_simd<simd_type>(fct_stepper.template step_simd<value_type>());
             }
             for (std::size_t i = 0; i < simd_rest; ++i)
             {
-                *(res_stepper) = *(fct_stepper);
+                *(res_stepper) = conditional_cast<needs_cast, e1_value_type>(*(fct_stepper));
                 res_stepper.step_leading();
                 fct_stepper.step_leading();
             }
 
             is_row_major ?
-                strided_assign_detail::idx_tools<layout_type::row_major>::next_idx(idx, max) : 
-                strided_assign_detail::idx_tools<layout_type::column_major>::next_idx(idx, max);
+                strided_assign_detail::idx_tools<layout_type::row_major>::next_idx(idx, max_shape) :
+                strided_assign_detail::idx_tools<layout_type::column_major>::next_idx(idx, max_shape);
 
             fct_stepper.to_begin();
 
@@ -774,8 +912,9 @@ namespace xt
         }
     }
 
+    template <>
     template <class E1, class E2>
-    inline void strided_assign(E1& /*e1*/, const E2& /*e2*/, std::false_type /*disable*/)
+    inline void strided_loop_assigner<false>::run(E1& /*e1*/, const E2& /*e2*/)
     {
     }
 }

--- a/vendor/xtensor/include/xtensor/xaxis_iterator.hpp
+++ b/vendor/xtensor/include/xtensor/xaxis_iterator.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *

--- a/vendor/xtensor/include/xtensor/xbroadcast.hpp
+++ b/vendor/xtensor/include/xtensor/xbroadcast.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -19,6 +20,7 @@
 
 #include <xtl/xsequence.hpp>
 
+#include "xaccessible.hpp"
 #include "xexpression.hpp"
 #include "xiterable.hpp"
 #include "xscalar.hpp"
@@ -43,6 +45,31 @@ namespace xt
     auto broadcast(E&& e, const I (&s)[L]);
 #endif
 
+    /*************************
+     * xbroadcast extensions *
+     *************************/
+
+    namespace extension
+    {
+        template <class Tag, class CT, class X>
+        struct xbroadcast_base_impl;
+
+        template <class CT, class X>
+        struct xbroadcast_base_impl<xtensor_expression_tag, CT, X>
+        {
+            using type = xtensor_empty_base;
+        };
+
+        template <class CT, class X>
+        struct xbroadcast_base
+            : xbroadcast_base_impl<xexpression_tag_t<CT>, CT, X>
+        {
+        };
+
+        template <class CT, class X>
+        using xbroadcast_base_t = typename xbroadcast_base<CT, X>::type;
+    }
+
     /**************
      * xbroadcast *
      **************/
@@ -59,6 +86,43 @@ namespace xt
         using stepper = const_stepper;
     };
 
+    template <class CT, class X>
+    struct xcontainer_inner_types<xbroadcast<CT, X>>
+    {
+        using xexpression_type = std::decay_t<CT>;
+        using reference = typename xexpression_type::const_reference;
+        using const_reference = typename xexpression_type::const_reference;
+        using size_type = typename xexpression_type::size_type;
+    };
+
+    /*****************************
+     * linear_begin / linear_end *
+     *****************************/
+
+    template <class CT, class X>
+    XTENSOR_CONSTEXPR_RETURN auto linear_begin(xbroadcast<CT, X>& c) noexcept
+    {
+        return linear_begin(c.expression());
+    }
+
+    template <class CT, class X>
+    XTENSOR_CONSTEXPR_RETURN auto linear_end(xbroadcast<CT, X>& c) noexcept
+    {
+        return linear_end(c.expression());
+    }
+
+    template <class CT, class X>
+    XTENSOR_CONSTEXPR_RETURN auto linear_begin(const xbroadcast<CT, X>& c) noexcept
+    {
+        return linear_begin(c.expression());
+    }
+
+    template <class CT, class X>
+    XTENSOR_CONSTEXPR_RETURN auto linear_end(const xbroadcast<CT, X>& c) noexcept
+    {
+        return linear_end(c.expression());
+    }
+
     /**
      * @class xbroadcast
      * @brief Broadcasted xexpression to a specified shape.
@@ -73,20 +137,25 @@ namespace xt
      * @sa broadcast
      */
     template <class CT, class X>
-    class xbroadcast : public xexpression<xbroadcast<CT, X>>,
-                       public xconst_iterable<xbroadcast<CT, X>>
+    class xbroadcast : public xsharable_expression<xbroadcast<CT, X>>,
+                       public xconst_iterable<xbroadcast<CT, X>>,
+                       public xconst_accessible<xbroadcast<CT, X>>,
+                       public extension::xbroadcast_base_t<CT, X>
     {
     public:
 
         using self_type = xbroadcast<CT, X>;
         using xexpression_type = std::decay_t<CT>;
+        using extension_base = extension::xbroadcast_base_t<CT, X>;
+        using expression_tag = typename extension_base::expression_tag;
 
+        using inner_types = xcontainer_inner_types<self_type>;
         using value_type = typename xexpression_type::value_type;
-        using reference = typename xexpression_type::reference;
-        using const_reference = typename xexpression_type::const_reference;
-        using pointer = typename xexpression_type::pointer;
+        using reference = typename inner_types::reference;
+        using const_reference = typename inner_types::const_reference;
+        using pointer = typename xexpression_type::const_pointer;
         using const_pointer = typename xexpression_type::const_pointer;
-        using size_type = typename xexpression_type::size_type;
+        using size_type = typename inner_types::size_type;
         using difference_type = typename xexpression_type::difference_type;
 
         using iterable_base = xconst_iterable<self_type>;
@@ -96,41 +165,37 @@ namespace xt
         using stepper = typename iterable_base::stepper;
         using const_stepper = typename iterable_base::const_stepper;
 
-        static constexpr layout_type static_layout = xexpression_type::static_layout;
-        //static constexpr bool contiguous_layout = xexpression_type::contiguous_layout;
+        using bool_load_type = typename xexpression_type::bool_load_type;
+
+        static constexpr layout_type static_layout = layout_type::dynamic;
         static constexpr bool contiguous_layout = false;
 
         template <class CTA, class S>
-        xbroadcast(CTA&& e, S&& s);
+        xbroadcast(CTA&& e, const S& s);
 
-        size_type size() const noexcept;
-        size_type dimension() const noexcept;
+        template <class CTA>
+        xbroadcast(CTA&& e, shape_type&& s);
+
         const inner_shape_type& shape() const noexcept;
+        size_type shape(size_type i) const noexcept;
         layout_type layout() const noexcept;
 
         template <class... Args>
         const_reference operator()(Args... args) const;
 
         template <class... Args>
-        const_reference at(Args... args) const;
-
-        template <class... Args>
         const_reference unchecked(Args... args) const;
-
-        template <class S>
-        disable_integral_t<S, const_reference> operator[](const S& index) const;
-        template <class I>
-        const_reference operator[](std::initializer_list<I> index) const;
-        const_reference operator[](size_type i) const;
 
         template <class It>
         const_reference element(It first, It last) const;
+
+        const xexpression_type& expression() const noexcept;
 
         template <class S>
         bool broadcast_shape(S& shape, bool reuse_cache = false) const;
 
         template <class S>
-        bool is_trivial_broadcast(const S& strides) const noexcept;
+        bool has_linear_assign(const S& strides) const noexcept;
 
         template <class S>
         const_stepper stepper_begin(const S& shape) const noexcept;
@@ -139,6 +204,12 @@ namespace xt
 
         template <class E, class XCT = CT, class = std::enable_if_t<xt::is_xscalar<XCT>::value>>
         void assign_to(xexpression<E>& e) const;
+
+        template <class E>
+        using rebind_t = xbroadcast<E, X>;
+
+        template <class E>
+        rebind_t<E> build_broadcast(E&& e) const;
 
     private:
 
@@ -164,8 +235,7 @@ namespace xt
     inline auto broadcast(E&& e, const S& s)
     {
         using broadcast_type = xbroadcast<const_xclosure_t<E>, S>;
-        using shape_type = typename broadcast_type::shape_type;
-        return broadcast_type(std::forward<E>(e), xtl::forward_sequence<shape_type>(s));
+        return broadcast_type(std::forward<E>(e), s);
     }
 
 #ifdef X_OLD_CLANG
@@ -174,7 +244,7 @@ namespace xt
     {
         using broadcast_type = xbroadcast<const_xclosure_t<E>, std::vector<std::size_t>>;
         using shape_type = typename broadcast_type::shape_type;
-        return broadcast_type(std::forward<E>(e), xtl::forward_sequence<shape_type>(s));
+        return broadcast_type(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(s)>(s));
     }
 #else
     template <class E, class I, std::size_t L>
@@ -182,7 +252,7 @@ namespace xt
     {
         using broadcast_type = xbroadcast<const_xclosure_t<E>, std::array<std::size_t, L>>;
         using shape_type = typename broadcast_type::shape_type;
-        return broadcast_type(std::forward<E>(e), xtl::forward_sequence<shape_type>(s));
+        return broadcast_type(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(s)>(s));
     }
 #endif
 
@@ -203,8 +273,29 @@ namespace xt
      */
     template <class CT, class X>
     template <class CTA, class S>
-    inline xbroadcast<CT, X>::xbroadcast(CTA&& e, S&& s)
-        : m_e(std::forward<CTA>(e)), m_shape(std::forward<S>(s))
+    inline xbroadcast<CT, X>::xbroadcast(CTA&& e, const S& s)
+        : m_e(std::forward<CTA>(e))
+    {
+        if (s.size() < m_e.dimension())
+        {
+            throw xt::broadcast_error("Broadcast shape has fewer elements than original expression.");
+        }
+        xt::resize_container(m_shape, s.size());
+        std::copy(s.begin(), s.end(), m_shape.begin());
+        xt::broadcast_shape(m_e.shape(), m_shape);
+    }
+
+    /**
+     * Constructs an xbroadcast expression broadcasting the specified
+     * \ref xexpression to the given shape
+     *
+     * @param e the expression to broadcast
+     * @param s the shape to apply
+     */
+    template <class CT, class X>
+    template <class CTA>
+    inline xbroadcast<CT, X>::xbroadcast(CTA&& e, shape_type&& s)
+        : m_e(std::forward<CTA>(e)), m_shape(std::move(s))
     {
         xt::broadcast_shape(m_e.shape(), m_shape);
     }
@@ -213,24 +304,7 @@ namespace xt
     /**
      * @name Size and shape
      */
-    /**
-     * Returns the size of the expression.
-     */
-    template <class CT, class X>
-    inline auto xbroadcast<CT, X>::size() const noexcept -> size_type
-    {
-        return compute_size(shape());
-    }
-
-    /**
-     * Returns the number of dimensions of the expression.
-     */
-    template <class CT, class X>
-    inline auto xbroadcast<CT, X>::dimension() const noexcept -> size_type
-    {
-        return m_shape.size();
-    }
-
+    //@{
     /**
      * Returns the shape of the expression.
      */
@@ -238,6 +312,15 @@ namespace xt
     inline auto xbroadcast<CT, X>::shape() const noexcept -> const inner_shape_type&
     {
         return m_shape;
+    }
+
+    /**
+     * Returns the shape of the expression.
+     */
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::shape(size_type i) const noexcept -> size_type
+    {
+        return m_shape[i];
     }
 
     /**
@@ -264,23 +347,6 @@ namespace xt
     inline auto xbroadcast<CT, X>::operator()(Args... args) const -> const_reference
     {
         return m_e(args...);
-    }
-
-    /**
-     * Returns a constant reference to the element at the specified position in the expression,
-     * after dimension and bounds checking.
-     * @param args a list of indices specifying the position in the function. Indices
-     * must be unsigned integers, the number of indices should be equal to the number of dimensions
-     * of the expression.
-     * @exception std::out_of_range if the number of argument is greater than the number of dimensions
-     * or if indices are out of bounds.
-     */
-    template <class CT, class X>
-    template <class... Args>
-    inline auto xbroadcast<CT, X>::at(Args... args) const -> const_reference
-    {
-        check_access(shape(), static_cast<size_type>(args)...);
-        return this->operator()(args...);
     }
 
     /**
@@ -311,33 +377,6 @@ namespace xt
 
     /**
      * Returns a constant reference to the element at the specified position in the expression.
-     * @param index a sequence of indices specifying the position in the function. Indices
-     * must be unsigned integers, the number of indices in the sequence should be equal or greater
-     * than the number of dimensions of the container.
-     */
-    template <class CT, class X>
-    template <class S>
-    inline auto xbroadcast<CT, X>::operator[](const S& index) const
-        -> disable_integral_t<S, const_reference>
-    {
-        return element(index.cbegin(), index.cend());
-    }
-
-    template <class CT, class X>
-    template <class I>
-    inline auto xbroadcast<CT, X>::operator[](std::initializer_list<I> index) const -> const_reference
-    {
-        return element(index.begin(), index.end());
-    }
-
-    template <class CT, class X>
-    inline auto xbroadcast<CT, X>::operator[](size_type i) const -> const_reference
-    {
-        return operator()(i);
-    }
-
-    /**
-     * Returns a constant reference to the element at the specified position in the expression.
      * @param first iterator starting the sequence of indices
      * @param last iterator ending the sequence of indices
      * The number of indices in the sequence should be equal to or greater
@@ -347,7 +386,16 @@ namespace xt
     template <class It>
     inline auto xbroadcast<CT, X>::element(It, It last) const -> const_reference
     {
-        return m_e.element(last - dimension(), last);
+        return m_e.element(last - this->dimension(), last);
+    }
+
+    /**
+     * Returns a constant reference to the underlying expression of the broadcast expression.
+     */
+    template <class CT, class X>
+    inline auto xbroadcast<CT, X>::expression() const noexcept -> const xexpression_type&
+    {
+        return m_e;
     }
     //@}
 
@@ -369,17 +417,17 @@ namespace xt
     }
 
     /**
-     * Compares the specified strides with those of the container to see whether
-     * the broadcasting is trivial.
-     * @return a boolean indicating whether the broadcasting is trivial
+     * Checks whether the xbroadcast can be linearly assigned to an expression
+     * with the specified strides.
+     * @return a boolean indicating whether a linear assign is possible
      */
     template <class CT, class X>
     template <class S>
-    inline bool xbroadcast<CT, X>::is_trivial_broadcast(const S& strides) const noexcept
+    inline bool xbroadcast<CT, X>::has_linear_assign(const S& strides) const noexcept
     {
-        return dimension() == m_e.dimension() &&
+        return this->dimension() == m_e.dimension() &&
             std::equal(m_shape.cbegin(), m_shape.cend(), m_e.shape().cbegin()) &&
-            m_e.is_trivial_broadcast(strides);
+            m_e.has_linear_assign(strides);
     }
     //@}
 
@@ -406,6 +454,13 @@ namespace xt
         auto& ed = e.derived_cast();
         ed.resize(m_shape);
         std::fill(ed.begin(), ed.end(), m_e());
+    }
+
+    template <class CT, class X>
+    template <class E>
+    inline auto xbroadcast<CT, X>::build_broadcast(E&& e) const -> rebind_t<E>
+    {
+        return rebind_t<E>(std::forward<E>(e), inner_shape_type(m_shape));
     }
 }
 

--- a/vendor/xtensor/include/xtensor/xbuffer_adaptor.hpp
+++ b/vendor/xtensor/include/xtensor/xbuffer_adaptor.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -21,13 +22,12 @@
 
 namespace xt
 {
-    /******************************
-     * xbuffer_adator declaration *
-     ******************************/
 
     struct no_ownership
     {
     };
+
+    using smart_ownership = no_ownership;
 
     struct acquire_ownership
     {
@@ -36,9 +36,9 @@ namespace xt
     template <class CP, class O = no_ownership, class A = std::allocator<std::remove_pointer_t<std::remove_reference_t<CP>>>>
     class xbuffer_adaptor;
 
-    /*********************************
-     * xbuffer_adator implementation *
-     *********************************/
+    /********************
+     * buffer_storage_t *
+     ********************/
 
     namespace detail
     {
@@ -49,6 +49,7 @@ namespace xt
 
             using self_type = xbuffer_storage<CP, A>;
             using allocator_type = A;
+            using destructor_type = allocator_type;
             using value_type = typename allocator_type::value_type;
             using reference = std::conditional_t<std::is_const<std::remove_pointer_t<std::remove_reference_t<CP>>>::value,
                                   typename allocator_type::const_reference,
@@ -80,6 +81,46 @@ namespace xt
             size_type m_size;
         };
 
+        template <class CP, class D>
+        class xbuffer_smart_pointer
+        {
+        public:
+
+            using self_type = xbuffer_storage<CP, D>;
+            using destructor_type = D;
+            using value_type = std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<CP>>>;
+            using allocator_type = std::allocator<value_type>;
+            using reference = std::conditional_t<std::is_const<std::remove_pointer_t<std::remove_reference_t<CP>>>::value,
+                                  typename allocator_type::const_reference,
+                                  typename allocator_type::reference>;
+            using const_reference = typename allocator_type::const_reference;
+            using pointer = std::conditional_t<std::is_const<std::remove_pointer_t<std::remove_reference_t<CP>>>::value,
+                                  typename allocator_type::const_pointer,
+                                  typename allocator_type::pointer>;
+            using const_pointer = typename allocator_type::const_pointer;
+            using size_type = typename allocator_type::size_type;
+            using difference_type = typename allocator_type::difference_type;
+
+            xbuffer_smart_pointer();
+
+            template <class P, class DT>
+            xbuffer_smart_pointer(P&& data_ptr, size_type size, DT&& destruct);
+
+            size_type size() const noexcept;
+            void resize(size_type size);
+
+            pointer data() noexcept;
+            const_pointer data() const noexcept;
+
+            void swap(self_type& rhs) noexcept;
+
+        private:
+
+            pointer p_data;
+            size_type m_size;
+            destructor_type m_destruct;
+        };
+
         template <class CP, class A>
         class xbuffer_owner_storage
         {
@@ -87,6 +128,7 @@ namespace xt
 
             using self_type = xbuffer_owner_storage<CP, A>;
             using allocator_type = A;
+            using destructor_type = allocator_type;
             using value_type = typename allocator_type::value_type;
             using reference = std::conditional_t<std::is_const<std::remove_pointer_t<std::remove_reference_t<CP>>>::value,
                                   typename allocator_type::const_reference,
@@ -130,10 +172,41 @@ namespace xt
             allocator_type m_allocator;
         };
 
+        // Workaround for MSVC2015: using void_t results in some
+        // template instantiation caching that leads to wrong 
+        // type deduction later in xfunction.
+        template <class T>
+        struct msvc2015_void
+        {
+            using type = void;
+        };
+
+        template <class T>
+        using msvc2015_void_t = typename msvc2015_void<T>::type;
+
+        template <class E, class = void>
+        struct is_lambda_type : std::false_type
+        {
+        };
+
+        // check if operator() is available
+        template <class E>
+        struct is_lambda_type<E, msvc2015_void_t<decltype(&E::operator())>>
+            : std::true_type
+        {
+        };
+
+        template <class T>
+        struct self_type
+        {
+            using type = T;
+        };
         template <class CP, class A, class O>
         struct get_buffer_storage
         {
-            using type = xbuffer_storage<CP, A>;
+            using type = xtl::mpl::eval_if_t<is_lambda_type<A>,
+                                             self_type<xbuffer_smart_pointer<CP, A>>,
+                                             self_type<xbuffer_storage<CP, A>>>;
         };
 
         template <class CP, class A>
@@ -142,37 +215,165 @@ namespace xt
             using type = xbuffer_owner_storage<CP, A>;
         };
 
+        template <class CP, class T>
+        struct get_buffer_storage<CP, std::shared_ptr<T>, no_ownership>
+        {
+            using type = xbuffer_smart_pointer<CP, std::shared_ptr<T>>;
+        };
+
+        template <class CP, class T>
+        struct get_buffer_storage<CP, std::unique_ptr<T>, no_ownership>
+        {
+            using type = xbuffer_smart_pointer<CP, std::unique_ptr<T>>;
+        };
+
         template <class CP, class A, class O>
         using buffer_storage_t = typename get_buffer_storage<CP, A, O>::type;
     }
 
-    template <class CP, class O, class A>
-    class xbuffer_adaptor : private detail::buffer_storage_t<CP, A, O>
+    /************************
+     * xbuffer_adaptor_base *
+     ************************/
+
+    template <class D>
+    struct buffer_inner_types;
+
+    template <class D>
+    class xbuffer_adaptor_base
     {
     public:
 
+        using self_type = xbuffer_adaptor_base<D>;
+        using derived_type = D;
+        using inner_types = buffer_inner_types<D>;
+        using value_type = typename inner_types::value_type;
+        using reference = typename inner_types::reference;
+        using const_reference = typename inner_types::const_reference;
+        using pointer = typename inner_types::pointer;
+        using const_pointer = typename inner_types::const_pointer;
+        using size_type = typename inner_types::size_type;
+        using difference_type = typename inner_types::difference_type;
+        using iterator = typename inner_types::iterator;
+        using const_iterator = typename inner_types::const_iterator;
+        using reverse_iterator = typename inner_types::reverse_iterator;
+        using const_reverse_iterator = typename inner_types::const_reverse_iterator;
+        using index_type = typename inner_types::index_type;
+
+        bool empty() const noexcept;
+
+        reference operator[](size_type i);
+        const_reference operator[](size_type i) const;
+
+        reference front();
+        const_reference front() const;
+
+        reference back();
+        const_reference back() const;
+
+        iterator begin() noexcept;
+        iterator end() noexcept;
+
+        const_iterator begin() const noexcept;
+        const_iterator end() const noexcept;
+        const_iterator cbegin() const noexcept;
+        const_iterator cend() const noexcept;
+
+        reverse_iterator rbegin() noexcept;
+        reverse_iterator rend() noexcept;
+
+        const_reverse_iterator rbegin() const noexcept;
+        const_reverse_iterator rend() const noexcept;
+        const_reverse_iterator crbegin() const noexcept;
+        const_reverse_iterator crend() const noexcept;
+
+        derived_type& derived_cast() noexcept;
+        const derived_type& derived_cast() const noexcept;
+
+    protected:
+
+        xbuffer_adaptor_base() = default;
+        ~xbuffer_adaptor_base() = default;
+
+        xbuffer_adaptor_base(const self_type&) = default;
+        self_type& operator=(const self_type&) = default;
+
+        xbuffer_adaptor_base(self_type&&) = default;
+        self_type& operator=(self_type&&) = default;
+    };
+
+    template <class D>
+    bool operator==(const xbuffer_adaptor_base<D>& lhs,
+                    const xbuffer_adaptor_base<D>& rhs);
+
+    template <class D>
+    bool operator!=(const xbuffer_adaptor_base<D>& lhs,
+                    const xbuffer_adaptor_base<D>& rhs);
+
+    template <class D>
+    bool operator<(const xbuffer_adaptor_base<D>& lhs,
+                   const xbuffer_adaptor_base<D>& rhs);
+
+    template <class D>
+    bool operator<=(const xbuffer_adaptor_base<D>& lhs,
+                    const xbuffer_adaptor_base<D>& rhs);
+
+    template <class D>
+    bool operator>(const xbuffer_adaptor_base<D>& lhs,
+                   const xbuffer_adaptor_base<D>& rhs);
+
+    template <class D>
+    bool operator>=(const xbuffer_adaptor_base<D>& lhs,
+                    const xbuffer_adaptor_base<D>& rhs);
+
+    /*******************
+     * xbuffer_adaptor *
+     *******************/
+
+    template <class CP, class O, class A>
+    struct buffer_inner_types<xbuffer_adaptor<CP, O, A>>
+    {
         using base_type = detail::buffer_storage_t<CP, A, O>;
-        using self_type = xbuffer_adaptor<CP, O, A>;
-        using allocator_type = typename base_type::allocator_type;
         using value_type = typename base_type::value_type;
         using reference = typename base_type::reference;
         using const_reference = typename base_type::const_reference;
         using pointer = typename base_type::pointer;
         using const_pointer = typename base_type::const_pointer;
-        using temporary_type = uvector<value_type, allocator_type>;
-
         using size_type = typename base_type::size_type;
         using difference_type = typename base_type::difference_type;
-
         using iterator = pointer;
         using const_iterator = const_pointer;
         using reverse_iterator = std::reverse_iterator<iterator>;
         using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+        using index_type = size_type;
+    };
+
+    template <class CP, class O, class A>
+    class xbuffer_adaptor : private detail::buffer_storage_t<CP, A, O>,
+                            public xbuffer_adaptor_base<xbuffer_adaptor<CP, O, A>>
+    {
+    public:
+
+        using self_type = xbuffer_adaptor<CP, O, A>;
+        using base_type = detail::buffer_storage_t<CP, A, O>;
+        using buffer_base_type = xbuffer_adaptor_base<self_type>;
+        using allocator_type = typename base_type::allocator_type;
+        using destructor_type = typename base_type::destructor_type;
+        using value_type = typename buffer_base_type::value_type;
+        using reference = typename buffer_base_type::reference;
+        using const_reference = typename buffer_base_type::const_reference;
+        using pointer = typename buffer_base_type::pointer;
+        using const_pointer = typename buffer_base_type::const_pointer;
+        using size_type = typename buffer_base_type::size_type;
+        using difference_type = typename buffer_base_type::difference_type;
+        using iterator = typename buffer_base_type::iterator;
+        using const_iterator = typename buffer_base_type::const_iterator;
+        using reverse_iterator = typename buffer_base_type::reverse_iterator;
+        using const_reverse_iterator = typename buffer_base_type::const_reverse_iterator;
+        using temporary_type = uvector<value_type, allocator_type>;
 
         xbuffer_adaptor() = default;
 
-        template <class P>
-        xbuffer_adaptor(P&& data, size_type size, const allocator_type& alloc = allocator_type());
+        using base_type::base_type;
 
         ~xbuffer_adaptor() = default;
 
@@ -184,66 +385,92 @@ namespace xt
 
         self_type& operator=(temporary_type&&);
 
-        bool empty() const noexcept;
         using base_type::size;
         using base_type::resize;
-
-        reference operator[](size_type i);
-        const_reference operator[](size_type i) const;
-
-        reference front();
-        const_reference front() const;
-
-        reference back();
-        const_reference back() const;
-
-        iterator begin();
-        iterator end();
-
-        const_iterator begin() const;
-        const_iterator end() const;
-        const_iterator cbegin() const;
-        const_iterator cend() const;
-
-        reverse_iterator rbegin();
-        reverse_iterator rend();
-
-        const_reverse_iterator rbegin() const;
-        const_reverse_iterator rend() const;
-        const_reverse_iterator crbegin() const;
-        const_reverse_iterator crend() const;
-
         using base_type::data;
         using base_type::swap;
     };
 
     template <class CP, class O, class A>
-    bool operator==(const xbuffer_adaptor<CP, O, A>& lhs,
-                    const xbuffer_adaptor<CP, O, A>& rhs);
-
-    template <class CP, class O, class A>
-    bool operator!=(const xbuffer_adaptor<CP, O, A>& lhs,
-                    const xbuffer_adaptor<CP, O, A>& rhs);
-
-    template <class CP, class O, class A>
-    bool operator<(const xbuffer_adaptor<CP, O, A>& lhs,
-                   const xbuffer_adaptor<CP, O, A>& rhs);
-
-    template <class CP, class O, class A>
-    bool operator<=(const xbuffer_adaptor<CP, O, A>& lhs,
-                    const xbuffer_adaptor<CP, O, A>& rhs);
-
-    template <class CP, class O, class A>
-    bool operator>(const xbuffer_adaptor<CP, O, A>& lhs,
-                   const xbuffer_adaptor<CP, O, A>& rhs);
-
-    template <class CP, class O, class A>
-    bool operator>=(const xbuffer_adaptor<CP, O, A>& lhs,
-                    const xbuffer_adaptor<CP, O, A>& rhs);
-
-    template <class CP, class O, class A>
     void swap(xbuffer_adaptor<CP, O, A>& lhs,
               xbuffer_adaptor<CP, O, A>& rhs) noexcept;
+
+    /*********************
+     * xiterator_adaptor *
+     *********************/
+
+    template <class I, class CI>
+    class xiterator_adaptor;
+
+    template <class I, class CI>
+    struct buffer_inner_types<xiterator_adaptor<I, CI>>
+    {
+        using traits = std::iterator_traits<I>;
+        using const_traits = std::iterator_traits<CI>;
+
+        using value_type = std::common_type_t<typename traits::value_type,
+                                              typename const_traits::value_type>;
+        using reference = typename traits::reference;
+        using const_reference = typename const_traits::reference;
+        using pointer = typename traits::pointer;
+        using const_pointer = typename const_traits::pointer;
+        using difference_type = std::common_type_t<typename traits::difference_type,
+                                                   typename const_traits::difference_type>;
+        using size_type = std::make_unsigned_t<difference_type>;
+        
+        using iterator = I;
+        using const_iterator = CI;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+        using index_type = difference_type;
+    };
+
+    template <class I, class CI>
+    class xiterator_adaptor : public xbuffer_adaptor_base<xiterator_adaptor<I, CI>>
+    {
+    public:
+
+        using self_type = xiterator_adaptor<I, CI>;
+        using base_type = xbuffer_adaptor_base<self_type>;
+        using value_type = typename base_type::value_type;
+        using allocator_type = std::allocator<value_type>;
+        using size_type = typename base_type::size_type;
+        using iterator = typename base_type::iterator;
+        using const_iterator = typename base_type::const_iterator; 
+        using temporary_type = uvector<value_type, allocator_type>;
+
+        xiterator_adaptor() = default;
+        xiterator_adaptor(I it, CI cit, size_type size);
+
+        ~xiterator_adaptor() = default;
+
+        xiterator_adaptor(const self_type&) = default;
+        xiterator_adaptor& operator=(const self_type&) = default;
+
+        xiterator_adaptor(self_type&&) = default;
+        xiterator_adaptor& operator=(self_type&&) = default;
+
+        xiterator_adaptor& operator=(const temporary_type& rhs);
+        xiterator_adaptor& operator=(temporary_type&& rhs);
+
+        size_type size() const noexcept;
+        void resize(size_type size);
+        
+        iterator data() noexcept;
+        const_iterator data() const noexcept;
+
+        void swap(self_type& rhs) noexcept;
+    
+    private:
+
+        I m_it;
+        CI m_cit;
+        size_type m_size;
+    };
+
+    template <class I, class CI>
+    void swap(xiterator_adaptor<I, CI>& lhs,
+              xiterator_adaptor<I, CI>& rhs) noexcept;
 
     /************************************
      * temporary_container metafunction *
@@ -259,6 +486,12 @@ namespace xt
     struct temporary_container<xbuffer_adaptor<CP, O, A>>
     {
         using type = typename xbuffer_adaptor<CP, O, A>::temporary_type;
+    };
+
+    template <class I, class CI>
+    struct temporary_container<xiterator_adaptor<I, CI>>
+    {
+        using type = typename xiterator_adaptor<I, CI>::temporary_type;
     };
 
     template <class C>
@@ -378,7 +611,6 @@ namespace xt
         inline auto xbuffer_owner_storage<CP, A>::operator=(self_type&& rhs) -> self_type&
         {
             swap(rhs);
-            rhs.m_moved_from = true;
             return *this;
         }
 
@@ -429,192 +661,317 @@ namespace xt
         }
     }
 
+    /****************************************
+     * xbuffer_smart_pointer implementation *
+     ****************************************/
+
+    namespace detail
+    {
+        template <class CP, class D>
+        template <class P, class DT>
+        xbuffer_smart_pointer<CP, D>::xbuffer_smart_pointer(P&& data_ptr, size_type size, DT&& destruct)
+            : p_data(data_ptr), m_size(size), m_destruct(std::forward<DT>(destruct))
+        {
+        }
+
+        template <class CP, class D>
+        auto xbuffer_smart_pointer<CP, D>::size() const noexcept -> size_type
+        {
+            return m_size;
+        }
+
+        template <class CP, class D>
+        void xbuffer_smart_pointer<CP, D>::resize(size_type size)
+        {
+            if (m_size != size)
+            {
+                throw std::runtime_error("xbuffer_storage not resizable");
+            }
+        }
+
+        template <class CP, class D>
+        auto xbuffer_smart_pointer<CP, D>::data() noexcept -> pointer
+        {
+            return p_data;
+        }
+        template <class CP, class D>
+        auto xbuffer_smart_pointer<CP, D>::data() const noexcept -> const_pointer
+        {
+            return p_data;
+        }
+
+        template <class CP, class D>
+        void xbuffer_smart_pointer<CP, D>::swap(self_type& rhs) noexcept
+        {
+            using std::swap;
+            swap(p_data, rhs.p_data);
+            swap(m_size, rhs.m_size);
+            swap(m_destruct, rhs.m_destruct);
+        }
+    }
+
+    /***************************************
+     * xbuffer_adaptor_base implementation *
+     ***************************************/
+
+    template <class D>
+    inline bool xbuffer_adaptor_base<D>::empty() const noexcept
+    {
+        return derived_cast().size() == size_type(0);
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::operator[](size_type i) -> reference
+    {
+        return derived_cast().data()[static_cast<index_type>(i)];
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::operator[](size_type i) const -> const_reference
+    {
+        return derived_cast().data()[static_cast<index_type>(i)];
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::front() -> reference
+    {
+        return this->operator[](0);
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::front() const -> const_reference
+    {
+        return this->operator[](0);
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::back() -> reference
+    {
+        return this->operator[](derived_cast().size() - 1);
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::back() const -> const_reference
+    {
+        return this->operator[](derived_cast().size() - 1);
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::begin() noexcept -> iterator
+    {
+        return derived_cast().data();
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::end() noexcept-> iterator
+    {
+        return derived_cast().data() + static_cast<index_type>(derived_cast().size());
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::begin() const noexcept -> const_iterator
+    {
+        return derived_cast().data();
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::end() const noexcept -> const_iterator
+    {
+        return derived_cast().data() + static_cast<index_type>(derived_cast().size());
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::cbegin() const noexcept -> const_iterator
+    {
+        return begin();
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::cend() const noexcept -> const_iterator
+    {
+        return end();
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::rbegin() noexcept-> reverse_iterator
+    {
+        return reverse_iterator(end());
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::rend() noexcept -> reverse_iterator
+    {
+        return reverse_iterator(begin());
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::rbegin() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(end());
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::rend() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::crbegin() const noexcept -> const_reverse_iterator
+    {
+        return rbegin();
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::crend() const noexcept -> const_reverse_iterator
+    {
+        return rend();
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::derived_cast() noexcept -> derived_type&
+    {
+        return *static_cast<derived_type*>(this);
+    }
+
+    template <class D>
+    inline auto xbuffer_adaptor_base<D>::derived_cast() const noexcept -> const derived_type&
+    {
+        return *static_cast<const derived_type*>(this);
+    }
+
+    template <class D>
+    inline bool operator==(const xbuffer_adaptor_base<D>& lhs,
+                           const xbuffer_adaptor_base<D>& rhs)
+    {
+        return lhs.derived_cast().size() == rhs.derived_cast().size() && std::equal(lhs.begin(), lhs.end(), rhs.begin());
+    }
+
+    template <class D>
+    inline bool operator!=(const xbuffer_adaptor_base<D>& lhs,
+                           const xbuffer_adaptor_base<D>& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    template <class D>
+    inline bool operator<(const xbuffer_adaptor_base<D>& lhs,
+                          const xbuffer_adaptor_base<D>& rhs)
+    {
+        return std::lexicographical_compare(lhs.begin(), lhs.end(),
+                                            rhs.begin(), rhs.end(),
+                                            std::less<typename D::value_type>());
+    }
+
+    template <class D>
+    inline bool operator<=(const xbuffer_adaptor_base<D>& lhs,
+                           const xbuffer_adaptor_base<D>& rhs)
+    {
+        return std::lexicographical_compare(lhs.begin(), lhs.end(),
+                                            rhs.begin(), rhs.end(),
+                                            std::less_equal<typename D::value_type>());
+    }
+
+    template <class D>
+    inline bool operator>(const xbuffer_adaptor_base<D>& lhs,
+                          const xbuffer_adaptor_base<D>& rhs)
+    {
+        return std::lexicographical_compare(lhs.begin(), lhs.end(),
+                                            rhs.begin(), rhs.end(),
+                                            std::greater<typename D::value_type>());
+    }
+
+    template <class D>
+    inline bool operator>=(const xbuffer_adaptor_base<D>& lhs,
+                           const xbuffer_adaptor_base<D>& rhs)
+    {
+        return std::lexicographical_compare(lhs.begin(), lhs.end(),
+                                            rhs.begin(), rhs.end(),
+                                            std::greater_equal<typename D::value_type>());
+    }
+
     /**********************************
      * xbuffer_adaptor implementation *
      **********************************/
 
     template <class CP, class O, class A>
-    template <class P>
-    inline xbuffer_adaptor<CP, O, A>::xbuffer_adaptor(P&& data, size_type size, const allocator_type& alloc)
-        : base_type(std::forward<P>(data), size, alloc)
-    {
-    }
-
-    template <class CP, class O, class A>
     inline auto xbuffer_adaptor<CP, O, A>::operator=(temporary_type&& tmp) -> self_type&
     {
         base_type::resize(tmp.size());
-        std::copy(tmp.cbegin(), tmp.cend(), begin());
+        std::copy(tmp.cbegin(), tmp.cend(), this->begin());
         return *this;
-    }
-
-    template <class CP, class O, class A>
-    bool xbuffer_adaptor<CP, O, A>::empty() const noexcept
-    {
-        return size() == 0;
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::operator[](size_type i) -> reference
-    {
-        return data()[i];
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::operator[](size_type i) const -> const_reference
-    {
-        return data()[i];
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::front() -> reference
-    {
-        return data()[0];
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::front() const -> const_reference
-    {
-        return data()[0];
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::back() -> reference
-    {
-        return data()[size() - 1];
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::back() const -> const_reference
-    {
-        return data()[size() - 1];
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::begin() -> iterator
-    {
-        return data();
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::end() -> iterator
-    {
-        return data() + size();
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::begin() const -> const_iterator
-    {
-        return data();
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::end() const -> const_iterator
-    {
-        return data() + size();
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::cbegin() const -> const_iterator
-    {
-        return begin();
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::cend() const -> const_iterator
-    {
-        return end();
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::rbegin() -> reverse_iterator
-    {
-        return reverse_iterator(end());
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::rend() -> reverse_iterator
-    {
-        return reverse_iterator(begin());
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::rbegin() const -> const_reverse_iterator
-    {
-        return const_reverse_iterator(end());
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::rend() const -> const_reverse_iterator
-    {
-        return const_reverse_iterator(begin());
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::crbegin() const -> const_reverse_iterator
-    {
-        return rbegin();
-    }
-
-    template <class CP, class O, class A>
-    inline auto xbuffer_adaptor<CP, O, A>::crend() const -> const_reverse_iterator
-    {
-        return rend();
-    }
-
-    template <class CP, class O, class A>
-    inline bool operator==(const xbuffer_adaptor<CP, O, A>& lhs,
-                           const xbuffer_adaptor<CP, O, A>& rhs)
-    {
-        return lhs.size() == rhs.size() && std::equal(lhs.begin(), lhs.end(), rhs.begin());
-    }
-
-    template <class CP, class O, class A>
-    inline bool operator!=(const xbuffer_adaptor<CP, O, A>& lhs,
-                           const xbuffer_adaptor<CP, O, A>& rhs)
-    {
-        return !(lhs == rhs);
-    }
-
-    template <class CP, class O, class A>
-    inline bool operator<(const xbuffer_adaptor<CP, O, A>& lhs,
-                          const xbuffer_adaptor<CP, O, A>& rhs)
-    {
-        return std::lexicographical_compare(lhs.begin(), lhs.end(),
-                                            rhs.begin(), rhs.end(),
-                                            std::less<typename A::value_type>());
-    }
-
-    template <class CP, class O, class A>
-    inline bool operator<=(const xbuffer_adaptor<CP, O, A>& lhs,
-                           const xbuffer_adaptor<CP, O, A>& rhs)
-    {
-        return std::lexicographical_compare(lhs.begin(), lhs.end(),
-                                            rhs.begin(), rhs.end(),
-                                            std::less_equal<typename A::value_type>());
-    }
-
-    template <class CP, class O, class A>
-    inline bool operator>(const xbuffer_adaptor<CP, O, A>& lhs,
-                          const xbuffer_adaptor<CP, O, A>& rhs)
-    {
-        return std::lexicographical_compare(lhs.begin(), lhs.end(),
-                                            rhs.begin(), rhs.end(),
-                                            std::greater<typename A::value_type>());
-    }
-
-    template <class CP, class O, class A>
-    inline bool operator>=(const xbuffer_adaptor<CP, O, A>& lhs,
-                           const xbuffer_adaptor<CP, O, A>& rhs)
-    {
-        return std::lexicographical_compare(lhs.begin(), lhs.end(),
-                                            rhs.begin(), rhs.end(),
-                                            std::greater_equal<typename A::value_type>());
     }
 
     template <class CP, class O, class A>
     inline void swap(xbuffer_adaptor<CP, O, A>& lhs,
                      xbuffer_adaptor<CP, O, A>& rhs) noexcept
+    {
+        lhs.swap(rhs);
+    }
+
+    /************************************
+     * xiterator_adaptor implementation *
+     ************************************/
+    
+    template <class I, class CI>
+    inline xiterator_adaptor<I, CI>::xiterator_adaptor(I it, CI cit, size_type size)
+        : m_it(it), m_cit(cit), m_size(size)
+    {
+    }
+
+    template <class I, class CI>
+    inline auto xiterator_adaptor<I, CI>::operator=(const temporary_type& rhs) -> self_type&
+    {
+        resize(rhs.size());
+        std::copy(rhs.cbegin(), rhs.cend(), m_it);
+        return *this;
+    }
+
+    template <class I, class CI>
+    inline auto xiterator_adaptor<I, CI>::operator=(temporary_type&& rhs) -> self_type&
+    {
+        return (*this = rhs);
+    }
+    
+    template <class I, class CI>
+    inline auto xiterator_adaptor<I, CI>::size() const noexcept -> size_type
+    {
+        return m_size;
+    }
+
+    template <class I, class CI>
+    inline void xiterator_adaptor<I, CI>::resize(size_type size)
+    {
+        if (m_size != size)
+        {
+            throw std::runtime_error("xiterator_adaptor not resizable");
+        }
+    }
+
+    template <class I, class CI>
+    inline auto xiterator_adaptor<I, CI>::data() noexcept -> iterator
+    {
+        return m_it;
+    }
+
+    template <class I, class CI>
+    inline auto xiterator_adaptor<I, CI>::data() const noexcept -> const_iterator
+    {
+        return m_cit;
+    }
+
+    template <class I, class CI>
+    inline void xiterator_adaptor<I, CI>::swap(self_type& rhs) noexcept
+    {
+        using std::swap;
+        swap(m_it, rhs.m_it);
+        swap(m_cit, rhs.m_cit);
+        swap(m_size, rhs.m_size);
+    }
+    
+    template <class I, class CI>
+    inline void swap(xiterator_adaptor<I, CI>& lhs,
+                     xiterator_adaptor<I, CI>& rhs) noexcept
     {
         lhs.swap(rhs);
     }

--- a/vendor/xtensor/include/xtensor/xbuilder.hpp
+++ b/vendor/xtensor/include/xtensor/xbuilder.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -14,6 +15,7 @@
 #define XTENSOR_BUILDER_HPP
 
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <functional>
@@ -25,6 +27,7 @@
 
 #include <xtl/xclosure.hpp>
 #include <xtl/xsequence.hpp>
+#include <xtl/xtype_traits.hpp>
 
 #include "xbroadcast.hpp"
 #include "xfunction.hpp"
@@ -111,7 +114,7 @@ namespace xt
     inline xtensor<T, N, L> empty(const std::array<ST, N>& shape)
     {
         using shape_type = typename xtensor<T, N>::shape_type;
-        return xtensor<T, N, L>(xtl::forward_sequence<shape_type>(shape));
+        return xtensor<T, N, L>(xtl::forward_sequence<shape_type, decltype(shape)>(shape));
     }
 
 #ifndef X_OLD_CLANG
@@ -119,7 +122,13 @@ namespace xt
     inline xtensor<T, N, L> empty(const I(&shape)[N])
     {
         using shape_type = typename xtensor<T, N>::shape_type;
-        return xtensor<T, N, L>(xtl::forward_sequence<shape_type>(shape));
+        return xtensor<T, N, L>(xtl::forward_sequence<shape_type, decltype(shape)>(shape));
+    }
+#else
+    template <class T, layout_type L = XTENSOR_DEFAULT_LAYOUT, class I>
+    inline xarray<T, L> empty(const std::initializer_list<I>& init)
+    {
+        return xarray<T, L>::from_shape(init);
     }
 #endif
 
@@ -136,9 +145,10 @@ namespace xt
      * @param e the xexpression from which to extract shape, value type and layout.
      */
     template <class E>
-    inline typename E::temporary_type empty_like(const xexpression<E>& e)
+    inline auto empty_like(const xexpression<E>& e)
     {
-        typename E::temporary_type res(e.derived_cast().shape());
+        using xtype = temporary_type_t<typename E::value_type, typename E::shape_type, E::static_layout>;
+        auto res = xtype::from_shape(e.derived_cast().shape());
         return res;
     }
 
@@ -150,9 +160,11 @@ namespace xt
      * @param fill_value the value used to set each element of the returned xcontainer.
      */
     template <class E>
-    inline typename E::temporary_type full_like(const xexpression<E>& e, typename E::value_type fill_value)
+    inline auto full_like(const xexpression<E>& e, typename E::value_type fill_value)
     {
-        typename E::temporary_type res(e.derived_cast().shape(), fill_value);
+        using xtype = temporary_type_t<typename E::value_type, typename E::shape_type, E::static_layout>;
+        auto res = xtype::from_shape(e.derived_cast().shape());
+        res.fill(fill_value);
         return res;
     }
 
@@ -166,7 +178,7 @@ namespace xt
      * @param e the xexpression from which to extract shape, value type and layout.
      */
     template <class E>
-    inline typename E::temporary_type zeros_like(const xexpression<E>& e)
+    inline auto zeros_like(const xexpression<E>& e)
     {
         return full_like(e, typename E::value_type(0));
     }
@@ -181,67 +193,129 @@ namespace xt
      * @param e the xexpression from which to extract shape, value type and layout.
      */
     template <class E>
-    inline typename E::temporary_type ones_like(const xexpression<E>& e)
+    inline auto ones_like(const xexpression<E>& e)
     {
         return full_like(e, typename E::value_type(1));
     }
 
     namespace detail
     {
-        template <class T>
-        class arange_impl
+        template <class T, class S>
+        struct get_mult_type_impl
+        {
+            using type = T;
+        };
+
+        template <class T, class R, class P>
+        struct get_mult_type_impl<T, std::chrono::duration<R, P>>
+        {
+            using type = R;
+        };
+
+        template <class T, class S>
+        using get_mult_type = typename get_mult_type_impl<T, S>::type;
+
+        // These methods should be private methods of arange_generator, however thi leads
+        // to ICE on VS2015
+        template <class R, class E, class U, class X, XTL_REQUIRES(std::is_integral<X>)>
+        inline void arange_assign_to(xexpression<E>& e, U start, X step) noexcept
+        {
+            auto& de = e.derived_cast();
+            U value = start;
+
+            for (auto&& el : de.storage())
+            {
+                el = static_cast<R>(value);
+                value += step;
+            }
+        }
+
+        template <class R, class E, class U, class X, XTL_REQUIRES(xtl::negation<std::is_integral<X>>)>
+        inline void arange_assign_to(xexpression<E>& e, U start, X step) noexcept
+        {
+            auto& buf = e.derived_cast().storage();
+            using size_type = decltype(buf.size());
+            using mult_type = get_mult_type<U, X>;
+            for(size_type i = 0; i < buf.size(); ++i)
+            {
+                buf[i] = static_cast<R>(start + step * mult_type(i));
+            }
+        }
+
+        template <class T, class R = T, class S = T>
+        class arange_generator
         {
         public:
 
-            using value_type = T;
+            using value_type = R;
+            using step_type = S;
 
-            arange_impl(T start, T stop, T step)
+            arange_generator(T start, T stop, S step)
                 : m_start(start), m_stop(stop), m_step(step)
             {
             }
 
             template <class... Args>
-            inline T operator()(Args... args) const
+            inline R operator()(Args... args) const
             {
                 return access_impl(args...);
             }
 
             template <class It>
-            inline T element(It first, It) const
+            inline R element(It first, It) const
             {
-                return m_start + m_step * T(*first);
+                // Avoids warning when T = char (because char + char => int!)
+                using mult_type = get_mult_type<T, S>;
+                return static_cast<R>(m_start + m_step * mult_type(*first));
             }
 
             template <class E>
             inline void assign_to(xexpression<E>& e) const noexcept
             {
-                auto& de = e.derived_cast();
-                value_type value = m_start;
-
-                for (auto& el : de.storage())
-                {
-                    el = value;
-                    value += m_step;
-                }
+                arange_assign_to<R>(e, m_start, m_step);
             }
 
         private:
 
-            value_type m_start;
-            value_type m_stop;
-            value_type m_step;
+            T m_start;
+            T m_stop;
+            step_type m_step;
 
             template <class T1, class... Args>
-            inline T access_impl(T1 t, Args...) const
+            inline R access_impl(T1 t, Args...) const
             {
-                return m_start + m_step * T(t);
+                using mult_type = get_mult_type<T, S>;
+                return static_cast<R>(m_start + m_step * mult_type(t));
             }
 
-            inline T access_impl() const
+            inline R access_impl() const
             {
-                return m_start;
+                return static_cast<R>(m_start);
             }
         };
+
+        template <class T, class S>
+        using both_integer = xtl::conjunction<std::is_integral<T>, std::is_integral<S>>;
+
+        template <class T, class S = T, XTL_REQUIRES(xtl::negation<both_integer<T, S>>)>
+        inline auto arange_impl(T start, T stop, S step = 1) noexcept
+        {
+            std::size_t shape = static_cast<std::size_t>(std::ceil((stop - start) / step));
+            return detail::make_xgenerator(detail::arange_generator<T, T, S>(start, stop, step), {shape});
+        }
+
+        template <class T, class S = T, XTL_REQUIRES(both_integer<T, S>)>
+        inline auto arange_impl(T start, T stop, S step = 1) noexcept
+        {
+            bool empty_cond = (stop - start) / step <= 0;
+            std::size_t shape = 0;
+            if(!empty_cond)
+            {
+                shape = stop > start ? static_cast<std::size_t>((stop - start + step - S(1)) / step)
+                                     : static_cast<std::size_t>((start - stop - step - S(1)) / -step);
+            }
+            return detail::make_xgenerator(detail::arange_generator<T, T, S>(start, stop, step), {shape});
+        }
 
         template <class F>
         class fn_impl
@@ -301,12 +375,12 @@ namespace xt
             inline T operator()(const It& /*begin*/, const It& end) const
             {
                 using lvalue_type = typename std::iterator_traits<It>::value_type;
-                return *(end - 1) == *(end - 2) + static_cast<lvalue_type>(static_cast<unsigned int>(m_k)) ? T(1) : T(0);
+                return *(end - 1) == *(end - 2) + static_cast<lvalue_type>(m_k) ? T(1) : T(0);
             }
 
         private:
 
-            int m_k;
+            std::ptrdiff_t m_k;
         };
     }
 
@@ -348,11 +422,10 @@ namespace xt
      * @tparam T value_type of xexpression
      * @return xgenerator that generates the values on access
      */
-    template <class T>
-    inline auto arange(T start, T stop, T step = 1) noexcept
+    template <class T, class S = T>
+    inline auto arange(T start, T stop, S step = 1) noexcept
     {
-        std::size_t shape = static_cast<std::size_t>(std::ceil((stop - start) / step));
-        return detail::make_xgenerator(detail::arange_impl<T>(start, stop, step), {shape});
+        return detail::arange_impl(start, stop, step);
     }
 
     /**
@@ -381,8 +454,8 @@ namespace xt
     inline auto linspace(T start, T stop, std::size_t num_samples = 50, bool endpoint = true) noexcept
     {
         using fp_type = std::common_type_t<T, double>;
-        fp_type step = fp_type(stop - start) / fp_type(num_samples - (endpoint ? 1 : 0));
-        return cast<T>(detail::make_xgenerator(detail::arange_impl<fp_type>(fp_type(start), fp_type(stop), step), {num_samples}));
+        fp_type step = fp_type(stop - start) / std::fmax(fp_type(1), fp_type(num_samples - (endpoint ? 1 : 0)));
+        return detail::make_xgenerator(detail::arange_generator<fp_type, T>(fp_type(start), fp_type(stop), step), {num_samples});
     }
 
     /**
@@ -398,7 +471,7 @@ namespace xt
     template <class T>
     inline auto logspace(T start, T stop, std::size_t num_samples, T base = 10, bool endpoint = true) noexcept
     {
-        return cast<T>(pow(std::move(base), linspace(start, stop, num_samples, endpoint)));
+        return pow(std::move(base), linspace(start, stop, num_samples, endpoint));
     }
 
     namespace detail
@@ -409,7 +482,7 @@ namespace xt
         public:
 
             using size_type = std::size_t;
-            using value_type = promote_type_t<typename std::decay_t<CT>::value_type...>;
+            using value_type = xtl::promote_type_t<typename std::decay_t<CT>::value_type...>;
 
             inline concatenate_impl(std::tuple<CT...>&& t, size_type axis)
                 : m_t(t), m_axis(axis)
@@ -468,7 +541,7 @@ namespace xt
         public:
 
             using size_type = std::size_t;
-            using value_type = promote_type_t<typename std::decay_t<CT>::value_type...>;
+            using value_type = xtl::promote_type_t<typename std::decay_t<CT>::value_type...>;
 
             inline stack_impl(std::tuple<CT...>&& t, size_type axis)
                 : m_t(t), m_axis(axis)
@@ -569,11 +642,28 @@ namespace xt
     inline auto concatenate(std::tuple<CT...>&& t, std::size_t axis = 0)
     {
         using shape_type = promote_shape_t<typename std::decay_t<CT>::shape_type...>;
-        shape_type new_shape = xtl::forward_sequence<shape_type>(std::get<0>(t).shape());
+        using source_shape_type = decltype(std::get<0>(t).shape());
+        shape_type new_shape = xtl::forward_sequence<shape_type, source_shape_type>(std::get<0>(t).shape());
+
+        auto check_shape = [&axis, &new_shape](auto& arr) {
+            std::size_t s = new_shape.size();
+            bool res = s == arr.dimension();
+            for(std::size_t i = 0; i < s; ++i)
+            {
+                res = res && (i == axis || new_shape[i] == arr.shape(i));
+            }
+            if(!res)
+            {
+                throw_concatenate_error(new_shape, arr.shape());
+            }
+        };
+        for_each(check_shape, t);
+
         auto shape_at_axis = [&axis](std::size_t prev, auto& arr) -> std::size_t {
             return prev + arr.shape()[axis];
         };
         new_shape[axis] += accumulate(shape_at_axis, std::size_t(0), t) - new_shape[axis];
+
         return detail::make_xgenerator(detail::concatenate_impl<CT...>(std::forward<std::tuple<CT...>>(t), axis), new_shape);
     }
 
@@ -620,7 +710,8 @@ namespace xt
     inline auto stack(std::tuple<CT...>&& t, std::size_t axis = 0)
     {
         using shape_type = promote_shape_t<typename std::decay_t<CT>::shape_type...>;
-        auto new_shape = detail::add_axis(xtl::forward_sequence<shape_type>(std::get<0>(t).shape()), axis, sizeof...(CT));
+        using source_shape_type = decltype(std::get<0>(t).shape());
+        auto new_shape = detail::add_axis(xtl::forward_sequence<shape_type, source_shape_type>(std::get<0>(t).shape()), axis, sizeof...(CT));
         return detail::make_xgenerator(detail::stack_impl<CT...>(std::forward<std::tuple<CT...>>(t), axis), new_shape);
     }
 

--- a/vendor/xtensor/include/xtensor/xcomplex.hpp
+++ b/vendor/xtensor/include/xtensor/xcomplex.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -20,7 +21,6 @@
 
 namespace xt
 {
-
     /******************************
      * real and imag declarations *
      ******************************/
@@ -61,7 +61,7 @@ namespace xt
             template <class E>
             static inline decltype(auto) real(E&& e) noexcept
             {
-                return e;
+                return std::forward<E>(e);
             }
 
             template <class E>
@@ -75,15 +75,15 @@ namespace xt
         struct complex_expression_helper
         {
             template <class E>
-            static inline auto real(E&& e) noexcept
+            static inline decltype(auto) real(E&& e) noexcept
             {
-                return detail::complex_helper<xtl::is_complex<typename std::decay_t<E>::value_type>::value>::real(e);
+                return detail::complex_helper<xtl::is_complex<typename std::decay_t<E>::value_type>::value>::real(std::forward<E>(e));
             }
 
             template <class E>
-            static inline auto imag(E&& e) noexcept
+            static inline decltype(auto) imag(E&& e) noexcept
             {
-                return detail::complex_helper<xtl::is_complex<typename std::decay_t<E>::value_type>::value>::imag(e);
+                return detail::complex_helper<xtl::is_complex<typename std::decay_t<E>::value_type>::value>::imag(std::forward<E>(e));
             }
         };
 
@@ -132,56 +132,70 @@ namespace xt
         return detail::complex_expression_helper<is_xexpression<std::decay_t<E>>::value>::imag(std::forward<E>(e));
     }
 
-#define UNARY_COMPLEX_FUNCTOR(NAME)                                 \
-    template <class T>                                              \
+#define UNARY_COMPLEX_FUNCTOR(NS, NAME)                             \
     struct NAME##_fun                                               \
     {                                                               \
-        using argument_type = T;                                    \
-        using result_type = decltype(std::NAME(std::declval<T>())); \
-        constexpr result_type operator()(const T& t) const          \
+        template <class T>                                          \
+        constexpr auto operator()(const T& t) const                 \
         {                                                           \
-            using std::NAME;                                        \
+            using NS::NAME;                                         \
+            return NAME(t);                                         \
+        }                                                           \
+                                                                    \
+        template <class B>                                          \
+        constexpr auto simd_apply(const B& t) const                 \
+        {                                                           \
+            using NS::NAME;                                         \
             return NAME(t);                                         \
         }                                                           \
     }
 
     namespace math
     {
-        UNARY_COMPLEX_FUNCTOR(norm);
-        UNARY_COMPLEX_FUNCTOR(arg);
-
         namespace detail
         {
-            // libc++ (OSX) conj is unfortunately broken and returns
-            // std::complex<T> instead of T.
             template <class T>
-            constexpr T conj(const T& c)
-            {
-                return c;
-            }
-
-            template <class T>
-            constexpr std::complex<T> conj(const std::complex<T>& c)
+            constexpr std::complex<T> conj_impl(const std::complex<T>& c)
             {
                 return std::complex<T>(c.real(), -c.imag());
             }
+
+#ifdef XTENSOR_USE_XSIMD
+            template <class X>
+            constexpr X conj_impl(const xsimd::simd_complex_batch<X>& z)
+            {
+                return xsimd::conj(z);
+            }
+
+            template <class T>
+            struct not_complex_batch
+                : xtl::negation<std::is_base_of<xsimd::simd_complex_batch<T>, T>>
+            {
+            };
+
+            // libc++ (OSX) conj is unfortunately broken and returns
+            // std::complex<T> instead of T.
+            // This function must be deactivated for complex batches,
+            // otherwise it will be a better match than the previous one.
+            template <class T, XTL_REQUIRES(not_complex_batch<T>)>
+            constexpr T conj_impl(const T& c)
+            {
+                return c;
+            }
+#else
+            // libc++ (OSX) conj is unfortunately broken and returns
+            // std::complex<T> instead of T.
+            template <class T>
+            constexpr T conj_impl(const T& c)
+            {
+                return c;
+            }
+#endif
         }
 
-        template <class T>
-        struct conj_fun
-        {
-            using argument_type = T;
-            using result_type = decltype(detail::conj(std::declval<T>()));
-            using simd_value_type = xsimd::simd_type<T>;
-            constexpr result_type operator()(const T& t) const
-            {
-                return detail::conj(t);
-            }
-            constexpr simd_value_type simd_apply(const simd_value_type& t) const
-            {
-                return detail::conj(t);
-            }
-        };
+        UNARY_COMPLEX_FUNCTOR(std, norm);
+        UNARY_COMPLEX_FUNCTOR(std, arg);
+        UNARY_COMPLEX_FUNCTOR(detail, conj_impl);
     }
 
 #undef UNARY_COMPLEX_FUNCTOR
@@ -194,10 +208,8 @@ namespace xt
     template <class E>
     inline auto conj(E&& e) noexcept
     {
-        using value_type = typename std::decay_t<E>::value_type;
-        using functor = math::conj_fun<value_type>;
-        using result_type = typename functor::result_type;
-        using type = xfunction<functor, result_type, const_xclosure_t<E>>;
+        using functor = math::conj_impl_fun;
+        using type = xfunction<functor, const_xclosure_t<E>>;
         return type(functor(), std::forward<E>(e));
     }
 
@@ -208,10 +220,8 @@ namespace xt
     template <class E>
     inline auto arg(E&& e) noexcept
     {
-        using value_type = typename std::decay_t<E>::value_type;
-        using functor = math::arg_fun<value_type>;
-        using result_type = typename functor::result_type;
-        using type = xfunction<functor, result_type, const_xclosure_t<E>>;
+        using functor = math::arg_fun;
+        using type = xfunction<functor, const_xclosure_t<E>>;
         return type(functor(), std::forward<E>(e));
     }
 
@@ -241,10 +251,8 @@ namespace xt
     template <class E>
     inline auto norm(E&& e) noexcept
     {
-        using value_type = typename std::decay_t<E>::value_type;
-        using functor = math::norm_fun<value_type>;
-        using result_type = typename functor::result_type;
-        using type = xfunction<functor, result_type, const_xclosure_t<E>>;
+        using functor = math::norm_fun;
+        using type = xfunction<functor, const_xclosure_t<E>>;
         return type(functor(), std::forward<E>(e));
     }
 }

--- a/vendor/xtensor/include/xtensor/xcontainer.hpp
+++ b/vendor/xtensor/include/xtensor/xcontainer.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -11,13 +12,13 @@
 
 #include <algorithm>
 #include <functional>
-#include <iostream>
 #include <numeric>
 #include <stdexcept>
 
 #include <xtl/xmeta_utils.hpp>
 #include <xtl/xsequence.hpp>
 
+#include "xaccessible.hpp"
 #include "xiterable.hpp"
 #include "xiterator.hpp"
 #include "xmath.hpp"
@@ -35,8 +36,6 @@ namespace xt
         using stepper = xstepper<D>;
         using const_stepper = xstepper<const D>;
     };
-
-#define DL XTENSOR_DEFAULT_LAYOUT
 
     namespace detail
     {
@@ -56,7 +55,6 @@ namespace xt
     template <class T>
     using allocator_type_t = typename detail::allocator_type_impl<T>::type;
 
-
     /**
      * @class xcontainer
      * @brief Base class for dense multidimensional containers.
@@ -69,7 +67,8 @@ namespace xt
      *           provides the interface.
      */
     template <class D>
-    class xcontainer : private xiterable<D>
+    class xcontainer : public xcontiguous_iterable<D>,
+                       private xaccessible<D>
     {
     public:
 
@@ -79,15 +78,14 @@ namespace xt
         using storage_type = typename inner_types::storage_type;
         using allocator_type = allocator_type_t<std::decay_t<storage_type>>;
         using value_type = typename storage_type::value_type;
-        using reference = std::conditional_t<std::is_const<storage_type>::value,
-                                             typename storage_type::const_reference,
-                                             typename storage_type::reference>;
-        using const_reference = typename storage_type::const_reference;
+        using reference = typename inner_types::reference;
+        using const_reference = typename inner_types::const_reference;
         using pointer = typename storage_type::pointer;
         using const_pointer = typename storage_type::const_pointer;
-        using size_type = typename storage_type::size_type;
+        using size_type = typename inner_types::size_type;
         using difference_type = typename storage_type::difference_type;
-        using simd_value_type = xsimd::simd_type<value_type>;
+        using simd_value_type = xt_simd::simd_type<value_type>;
+        using bool_load_type = xt::bool_load_type<value_type>;
 
         using shape_type = typename inner_types::shape_type;
         using strides_type = typename inner_types::strides_type;
@@ -97,24 +95,31 @@ namespace xt
         using inner_strides_type = typename inner_types::inner_strides_type;
         using inner_backstrides_type = typename inner_types::inner_backstrides_type;
 
-        using iterable_base = xiterable<D>;
+        using iterable_base = xcontiguous_iterable<D>;
         using stepper = typename iterable_base::stepper;
         using const_stepper = typename iterable_base::const_stepper;
 
+        using accessible_base = xaccessible<D>;
+
         static constexpr layout_type static_layout = inner_types::layout;
         static constexpr bool contiguous_layout = static_layout != layout_type::dynamic;
-        using data_alignment = xsimd::container_alignment_t<storage_type>;
-        using simd_type = xsimd::simd_type<value_type>;
+        using data_alignment = xt_simd::container_alignment_t<storage_type>;
+        using simd_type = xt_simd::simd_type<value_type>;
+
+        using storage_iterator = typename iterable_base::storage_iterator;
+        using const_storage_iterator = typename iterable_base::const_storage_iterator;
+        using reverse_storage_iterator = typename iterable_base::reverse_storage_iterator;
+        using const_reverse_storage_iterator = typename iterable_base::const_reverse_storage_iterator;
 
         static_assert(static_layout != layout_type::any, "Container layout can never be layout_type::any!");
 
         size_type size() const noexcept;
 
-        constexpr size_type dimension() const noexcept;
+        XTENSOR_CONSTEXPR_RETURN size_type dimension() const noexcept;
 
-        constexpr const inner_shape_type& shape() const noexcept;
-        constexpr const inner_strides_type& strides() const noexcept;
-        constexpr const inner_backstrides_type& backstrides() const noexcept;
+        XTENSOR_CONSTEXPR_RETURN const inner_shape_type& shape() const noexcept;
+        XTENSOR_CONSTEXPR_RETURN const inner_strides_type& strides() const noexcept;
+        XTENSOR_CONSTEXPR_RETURN const inner_backstrides_type& backstrides() const noexcept;
 
         template <class T>
         void fill(const T& value);
@@ -126,28 +131,16 @@ namespace xt
         const_reference operator()(Args... args) const;
 
         template <class... Args>
-        reference at(Args... args);
-
-        template <class... Args>
-        const_reference at(Args... args) const;
-
-        template <class... Args>
         reference unchecked(Args... args);
 
         template <class... Args>
         const_reference unchecked(Args... args) const;
 
-        template <class S>
-        disable_integral_t<S, reference> operator[](const S& index);
-        template <class I>
-        reference operator[](std::initializer_list<I> index);
-        reference operator[](size_type i);
-
-        template <class S>
-        disable_integral_t<S, const_reference> operator[](const S& index) const;
-        template <class I>
-        const_reference operator[](std::initializer_list<I> index) const;
-        const_reference operator[](size_type i) const;
+        using accessible_base::shape;
+        using accessible_base::at;
+        using accessible_base::operator[];
+        using accessible_base::periodic;
+        using accessible_base::in_bounds;
 
         template <class It>
         reference element(It first, It last);
@@ -165,8 +158,7 @@ namespace xt
         bool broadcast_shape(S& shape, bool reuse_cache = false) const;
 
         template <class S>
-        bool is_trivial_broadcast(const S& strides) const noexcept;
-
+        bool has_linear_assign(const S& strides) const noexcept;
         template <class S>
         stepper stepper_begin(const S& shape) noexcept;
         template <class S>
@@ -180,149 +172,30 @@ namespace xt
         reference data_element(size_type i);
         const_reference data_element(size_type i) const;
 
-        template <class simd>
-        using simd_return_type = xsimd::simd_return_type<value_type, typename simd::value_type>;
+        template <class requested_type>
+        using simd_return_type = xt_simd::simd_return_type<value_type, requested_type>;
 
-        template <class align, class simd = simd_value_type>
+        template <class align, class simd>
         void store_simd(size_type i, const simd& e);
-        template <class align, class simd = simd_value_type>
-        simd_return_type<simd> load_simd(size_type i) const;
+        template <class align, class requested_type = value_type,
+                  std::size_t N = xt_simd::simd_traits<requested_type>::size>
+        container_simd_return_type_t<storage_type, value_type, requested_type>
+        /*simd_return_type<requested_type>*/ load_simd(size_type i) const;
 
-#if defined(_MSC_VER) && _MSC_VER >= 1910
-        // Workaround for compiler bug in Visual Studio 2017 with respect to alias templates with non-type parameters.
-        template <layout_type L>
-        using layout_iterator = xiterator<typename iterable_base::stepper, typename iterable_base::inner_shape_type*, L>;
-        template <layout_type L>
-        using const_layout_iterator = xiterator<typename iterable_base::const_stepper, typename iterable_base::inner_shape_type*, L>;
-        template <layout_type L>
-        using reverse_layout_iterator = std::reverse_iterator<layout_iterator<L>>;
-        template <layout_type L>
-        using const_reverse_layout_iterator = std::reverse_iterator<const_layout_iterator<L>>;
-#else
-        template <layout_type L>
-        using layout_iterator = typename iterable_base::template layout_iterator<L>;
-        template <layout_type L>
-        using const_layout_iterator = typename iterable_base::template const_layout_iterator<L>;
-        template <layout_type L>
-        using reverse_layout_iterator = typename iterable_base::template reverse_layout_iterator<L>;
-        template <layout_type L>
-        using const_reverse_layout_iterator = typename iterable_base::template const_reverse_layout_iterator<L>;
-#endif
-
-        template <class S, layout_type L>
-        using broadcast_iterator = typename iterable_base::template broadcast_iterator<S, L>;
-        template <class S, layout_type L>
-        using const_broadcast_iterator = typename iterable_base::template const_broadcast_iterator<S, L>;
-        template <class S, layout_type L>
-        using reverse_broadcast_iterator = typename iterable_base::template reverse_broadcast_iterator<S, L>;
-        template <class S, layout_type L>
-        using const_reverse_broadcast_iterator = typename iterable_base::template const_reverse_broadcast_iterator<S, L>;
-
-        using storage_iterator = typename storage_type::iterator;
-        using const_storage_iterator = typename storage_type::const_iterator;
-        using reverse_storage_iterator = typename storage_type::reverse_iterator;
-        using const_reverse_storage_iterator = typename storage_type::const_reverse_iterator;
-
-        template <layout_type L, class It1, class It2>
-        using select_iterator_impl = std::conditional_t<L == static_layout, It1, It2>;
-
-        template <layout_type L>
-        using select_iterator = select_iterator_impl<L, storage_iterator, layout_iterator<L>>;
-        template <layout_type L>
-        using select_const_iterator = select_iterator_impl<L, const_storage_iterator, const_layout_iterator<L>>;
-        template <layout_type L>
-        using select_reverse_iterator = select_iterator_impl<L, reverse_storage_iterator, reverse_layout_iterator<L>>;
-        template <layout_type L>
-        using select_const_reverse_iterator = select_iterator_impl<L, const_reverse_storage_iterator, const_reverse_layout_iterator<L>>;
-
-        using iterator = select_iterator<DL>;
-        using const_iterator = select_const_iterator<DL>;
-        using reverse_iterator = select_reverse_iterator<DL>;
-        using const_reverse_iterator = select_const_reverse_iterator<DL>;
-
-        template <layout_type L = DL>
-        select_iterator<L> begin() noexcept;
-        template <layout_type L = DL>
-        select_iterator<L> end() noexcept;
-
-        template <layout_type L = DL>
-        select_const_iterator<L> begin() const noexcept;
-        template <layout_type L = DL>
-        select_const_iterator<L> end() const noexcept;
-        template <layout_type L = DL>
-        select_const_iterator<L> cbegin() const noexcept;
-        template <layout_type L = DL>
-        select_const_iterator<L> cend() const noexcept;
-
-        template <layout_type L = DL>
-        select_reverse_iterator<L> rbegin() noexcept;
-        template <layout_type L = DL>
-        select_reverse_iterator<L> rend() noexcept;
-
-        template <layout_type L = DL>
-        select_const_reverse_iterator<L> rbegin() const noexcept;
-        template <layout_type L = DL>
-        select_const_reverse_iterator<L> rend() const noexcept;
-        template <layout_type L = DL>
-        select_const_reverse_iterator<L> crbegin() const noexcept;
-        template <layout_type L = DL>
-        select_const_reverse_iterator<L> crend() const noexcept;
-
-        template <class S, layout_type L = DL>
-        broadcast_iterator<S, L> begin(const S& shape) noexcept;
-        template <class S, layout_type L = DL>
-        broadcast_iterator<S, L> end(const S& shape) noexcept;
-
-        template <class S, layout_type L = DL>
-        const_broadcast_iterator<S, L> begin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_broadcast_iterator<S, L> end(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_broadcast_iterator<S, L> cbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_broadcast_iterator<S, L> cend(const S& shape) const noexcept;
-
-
-        template <class S, layout_type L = DL>
-        reverse_broadcast_iterator<S, L> rbegin(const S& shape) noexcept;
-        template <class S, layout_type L = DL>
-        reverse_broadcast_iterator<S, L> rend(const S& shape) noexcept;
-
-        template <class S, layout_type L = DL>
-        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_reverse_broadcast_iterator<S, L> rend(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_reverse_broadcast_iterator<S, L> crend(const S& shape) const noexcept;
-
-        template <layout_type L = DL>
         storage_iterator storage_begin() noexcept;
-        template <layout_type L = DL>
         storage_iterator storage_end() noexcept;
 
-        template <layout_type L = DL>
         const_storage_iterator storage_begin() const noexcept;
-        template <layout_type L = DL>
         const_storage_iterator storage_end() const noexcept;
-        template <layout_type L = DL>
         const_storage_iterator storage_cbegin() const noexcept;
-        template <layout_type L = DL>
         const_storage_iterator storage_cend() const noexcept;
 
-        template <layout_type L = DL>
         reverse_storage_iterator storage_rbegin() noexcept;
-        template <layout_type L = DL>
         reverse_storage_iterator storage_rend() noexcept;
 
-        template <layout_type L = DL>
         const_reverse_storage_iterator storage_rbegin() const noexcept;
-        template <layout_type L = DL>
         const_reverse_storage_iterator storage_rend() const noexcept;
-        template <layout_type L = DL>
         const_reverse_storage_iterator storage_crbegin() const noexcept;
-        template <layout_type L = DL>
         const_reverse_storage_iterator storage_crend() const noexcept;
 
         using container_iterator = storage_iterator;
@@ -341,8 +214,8 @@ namespace xt
 
         container_iterator data_xbegin() noexcept;
         const_container_iterator data_xbegin() const noexcept;
-        container_iterator data_xend(layout_type l) noexcept;
-        const_container_iterator data_xend(layout_type l) const noexcept;
+        container_iterator data_xend(layout_type l, size_type offset) noexcept;
+        const_container_iterator data_xend(layout_type l, size_type offset) const noexcept;
 
     protected:
 
@@ -352,21 +225,19 @@ namespace xt
 
     private:
 
-        friend class xiterable<D>;
-        friend class xconst_iterable<D>;
-
-        template <class C>
-        friend class xstepper;
-
         template <class It>
-        It data_xend_impl(It end, layout_type l) const noexcept;
+        It data_xend_impl(It begin, layout_type l, size_type offset) const noexcept;
 
         inner_shape_type& mutable_shape();
         inner_strides_type& mutable_strides();
         inner_backstrides_type& mutable_backstrides();
-    };
 
-#undef DL
+        template <class C>
+        friend class xstepper;
+
+        friend class xaccessible<D>;
+        friend class xconst_accessible<D>;
+    };
 
     /**
      * @class xstrided_container
@@ -409,6 +280,9 @@ namespace xt
         template <class S = shape_type>
         void reshape(S&& shape, layout_type layout = base_type::static_layout);
 
+        template <class T>
+        void reshape(std::initializer_list<T> shape, layout_type layout = base_type::static_layout);
+
         layout_type layout() const noexcept;
 
     protected:
@@ -423,6 +297,7 @@ namespace xt
         xstrided_container& operator=(xstrided_container&&) = default;
 
         explicit xstrided_container(inner_shape_type&&, inner_strides_type&&) noexcept;
+        explicit xstrided_container(inner_shape_type&&, inner_strides_type&&, inner_backstrides_type&&, layout_type&&) noexcept;
 
         inner_shape_type& shape_impl() noexcept;
         const inner_shape_type& shape_impl() const noexcept;
@@ -432,6 +307,16 @@ namespace xt
 
         inner_backstrides_type& backstrides_impl() noexcept;
         const inner_backstrides_type& backstrides_impl() const noexcept;
+
+        template <class S = shape_type>
+        void reshape_impl(S&& shape, std::true_type, layout_type layout = base_type::static_layout);
+        template <class S = shape_type>
+        void reshape_impl(S&& shape, std::false_type, layout_type layout = base_type::static_layout);
+
+        layout_type& mutable_layout() noexcept
+        {
+            return m_layout;
+        }
 
     private:
 
@@ -447,9 +332,9 @@ namespace xt
 
     template <class D>
     template <class It>
-    inline It xcontainer<D>::data_xend_impl(It end, layout_type l) const noexcept
+    inline It xcontainer<D>::data_xend_impl(It begin, layout_type l, size_type offset) const noexcept
     {
-        return strided_data_end(*this, end, l);
+        return strided_data_end(*this, begin, l, offset);
     }
 
     template <class D>
@@ -487,7 +372,7 @@ namespace xt
      * Returns the number of dimensions of the container.
      */
     template <class D>
-    inline constexpr auto xcontainer<D>::dimension() const noexcept -> size_type
+    XTENSOR_CONSTEXPR_RETURN auto xcontainer<D>::dimension() const noexcept -> size_type
     {
         return shape().size();
     }
@@ -496,7 +381,7 @@ namespace xt
      * Returns the shape of the container.
      */
     template <class D>
-    constexpr inline auto xcontainer<D>::shape() const noexcept -> const inner_shape_type&
+    XTENSOR_CONSTEXPR_RETURN auto xcontainer<D>::shape() const noexcept -> const inner_shape_type&
     {
         return derived_cast().shape_impl();
     }
@@ -505,7 +390,7 @@ namespace xt
      * Returns the strides of the container.
      */
     template <class D>
-    constexpr inline auto xcontainer<D>::strides() const noexcept -> const inner_strides_type&
+    XTENSOR_CONSTEXPR_RETURN auto xcontainer<D>::strides() const noexcept -> const inner_strides_type&
     {
         return derived_cast().strides_impl();
     }
@@ -514,7 +399,7 @@ namespace xt
      * Returns the backstrides of the container.
      */
     template <class D>
-    constexpr inline auto xcontainer<D>::backstrides() const noexcept -> const inner_backstrides_type&
+    XTENSOR_CONSTEXPR_RETURN auto xcontainer<D>::backstrides() const noexcept -> const inner_backstrides_type&
     {
         return derived_cast().backstrides_impl();
     }
@@ -548,7 +433,7 @@ namespace xt
     {
         XTENSOR_TRY(check_index(shape(), args...));
         XTENSOR_CHECK_DIMENSION(shape(), args...);
-        size_type index = xt::data_offset<size_type>(strides(), static_cast<size_type>(args)...);
+        size_type index = xt::data_offset<size_type>(strides(), static_cast<std::ptrdiff_t>(args)...);
         return storage()[index];
     }
 
@@ -564,42 +449,8 @@ namespace xt
     {
         XTENSOR_TRY(check_index(shape(), args...));
         XTENSOR_CHECK_DIMENSION(shape(), args...);
-        size_type index = xt::data_offset<size_type>(strides(), static_cast<size_type>(args)...);
+        size_type index = xt::data_offset<size_type>(strides(), static_cast<std::ptrdiff_t>(args)...);
         return storage()[index];
-    }
-
-    /**
-     * Returns a reference to the element at the specified position in the container,
-     * after dimension and bounds checking.
-     * @param args a list of indices specifying the position in the container. Indices
-     * must be unsigned integers, the number of indices should be equal to the number of dimensions
-     * of the container.
-     * @exception std::out_of_range if the number of argument is greater than the number of dimensions
-     * or if indices are out of bounds.
-     */
-    template <class D>
-    template <class... Args>
-    inline auto xcontainer<D>::at(Args... args) -> reference
-    {
-        check_access(shape(), static_cast<size_type>(args)...);
-        return this->operator()(args...);
-    }
-
-    /**
-     * Returns a constant reference to the element at the specified position in the container,
-     * after dimension and bounds checking.
-     * @param args a list of indices specifying the position in the container. Indices
-     * must be unsigned integers, the number of indices should be equal to the number of dimensions
-     * of the container.
-     * @exception std::out_of_range if the number of argument is greater than the number of dimensions
-     * or if indices are out of bounds.
-     */
-    template <class D>
-    template <class... Args>
-    inline auto xcontainer<D>::at(Args... args) const -> const_reference
-    {
-        check_access(shape(), static_cast<size_type>(args)...);
-        return this->operator()(args...);
     }
 
     /**
@@ -625,7 +476,7 @@ namespace xt
     template <class... Args>
     inline auto xcontainer<D>::unchecked(Args... args) -> reference
     {
-        size_type index = xt::unchecked_data_offset<size_type>(strides(), static_cast<size_type>(args)...);
+        size_type index = xt::unchecked_data_offset<size_type, static_layout>(strides(), static_cast<std::ptrdiff_t>(args)...);
         return storage()[index];
     }
 
@@ -652,62 +503,8 @@ namespace xt
     template <class... Args>
     inline auto xcontainer<D>::unchecked(Args... args) const -> const_reference
     {
-        size_type index = xt::unchecked_data_offset<size_type>(strides(), static_cast<size_type>(args)...);
+        size_type index = xt::unchecked_data_offset<size_type, static_layout>(strides(), static_cast<std::ptrdiff_t>(args)...);
         return storage()[index];
-    }
-
-    /**
-     * Returns a reference to the element at the specified position in the container.
-     * @param index a sequence of indices specifying the position in the container. Indices
-     * must be unsigned integers, the number of indices in the list should be equal or greater
-     * than the number of dimensions of the container.
-     */
-    template <class D>
-    template <class S>
-    inline auto xcontainer<D>::operator[](const S& index)
-        -> disable_integral_t<S, reference>
-    {
-        return element(index.cbegin(), index.cend());
-    }
-
-    template <class D>
-    template <class I>
-    inline auto xcontainer<D>::operator[](std::initializer_list<I> index) -> reference
-    {
-        return element(index.begin(), index.end());
-    }
-
-    template <class D>
-    inline auto xcontainer<D>::operator[](size_type i) -> reference
-    {
-        return operator()(i);
-    }
-
-    /**
-     * Returns a constant reference to the element at the specified position in the container.
-     * @param index a sequence of indices specifying the position in the container. Indices
-     * must be unsigned integers, the number of indices in the list should be equal or greater
-     * than the number of dimensions of the container.
-     */
-    template <class D>
-    template <class S>
-    inline auto xcontainer<D>::operator[](const S& index) const
-        -> disable_integral_t<S, const_reference>
-    {
-        return element(index.cbegin(), index.cend());
-    }
-
-    template <class D>
-    template <class I>
-    inline auto xcontainer<D>::operator[](std::initializer_list<I> index) const -> const_reference
-    {
-        return element(index.begin(), index.end());
-    }
-
-    template <class D>
-    inline auto xcontainer<D>::operator[](size_type i) const -> const_reference
-    {
-        return operator()(i);
     }
 
     /**
@@ -809,396 +606,18 @@ namespace xt
     }
 
     /**
-     * Compares the specified strides with those of the container to see whether
-     * the broadcasting is trivial.
-     * @return a boolean indicating whether the broadcasting is trivial
+     * Checks whether the xcontainer can be linearly assigned to an expression
+     * with the specified strides.
+     * @return a boolean indicating whether a linear assign is possible
      */
     template <class D>
     template <class S>
-    inline bool xcontainer<D>::is_trivial_broadcast(const S& str) const noexcept
+    inline bool xcontainer<D>::has_linear_assign(const S& str) const noexcept
     {
         return str.size() == strides().size() &&
             std::equal(str.cbegin(), str.cend(), strides().begin());
     }
     //@}
-
-    /****************
-     * Iterator api *
-     ****************/
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::begin() noexcept -> select_iterator<L>
-    {
-        return xtl::mpl::static_if<L == static_layout>([&](auto self)
-        {
-            return self(*this).template storage_begin<L>();
-        }, /*else*/ [&](auto self)
-        {
-            return self(*this).iterable_base::template begin<L>();
-        });
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::end() noexcept -> select_iterator<L>
-    {
-        return xtl::mpl::static_if<L == static_layout>([&](auto self)
-        {
-            return self(*this).template storage_end<L>();
-        }, /*else*/ [&](auto self)
-        {
-            return self(*this).iterable_base::template end<L>();
-        });
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::begin() const noexcept -> select_const_iterator<L>
-    {
-        return this->template cbegin<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::end() const noexcept -> select_const_iterator<L>
-    {
-        return this->template cend<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::cbegin() const noexcept -> select_const_iterator<L>
-    {
-        return xtl::mpl::static_if<L == static_layout>([&](auto self)
-        {
-            return self(*this).template storage_cbegin<L>();
-        }, /*else*/ [&](auto self)
-        {
-            return self(*this).iterable_base::template cbegin<L>();
-        });
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::cend() const noexcept -> select_const_iterator<L>
-    {
-        return xtl::mpl::static_if<L == static_layout>([&](auto self)
-        {
-            return self(*this).template storage_cend<L>();
-        }, /*else*/ [&](auto self)
-        {
-            return self(*this).iterable_base::template cend<L>();
-        });
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::rbegin() noexcept -> select_reverse_iterator<L>
-    {
-        return xtl::mpl::static_if<L == static_layout>([&](auto self)
-        {
-            return self(*this).template storage_rbegin<L>();
-        }, /*else*/ [&](auto self)
-        {
-            return self(*this).iterable_base::template rbegin<L>();
-        });
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::rend() noexcept -> select_reverse_iterator<L>
-    {
-        return xtl::mpl::static_if<L == static_layout>([&](auto self)
-        {
-            return self(*this).template storage_rend<L>();
-        }, /*else*/ [&](auto self)
-        {
-            return self(*this).iterable_base::template rend<L>();
-        });
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::rbegin() const noexcept -> select_const_reverse_iterator<L>
-    {
-        return this->template crbegin<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::rend() const noexcept -> select_const_reverse_iterator<L>
-    {
-        return this->template crend<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::crbegin() const noexcept -> select_const_reverse_iterator<L>
-    {
-        return xtl::mpl::static_if<L == static_layout>([&](auto self)
-        {
-            return self(*this).template storage_crbegin<L>();
-        }, /*else*/ [&](auto self)
-        {
-            return self(*this).iterable_base::template crbegin<L>();
-        });
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::crend() const noexcept -> select_const_reverse_iterator<L>
-    {
-        return xtl::mpl::static_if<L == static_layout>([&](auto self)
-        {
-            return self(*this).template storage_crend<L>();
-        }, /*else*/ [&](auto self)
-        {
-            return self(*this).iterable_base::template crend<L>();
-        });
-    }
-
-    /*****************************
-     * Broadcasting iterator api *
-     *****************************/
-
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xcontainer<D>::begin(const S& shape) noexcept -> broadcast_iterator<S, L>
-    {
-        return iterable_base::template begin<S, L>(shape);
-    }
-
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xcontainer<D>::end(const S& shape) noexcept -> broadcast_iterator<S, L>
-    {
-        return iterable_base::template end<S, L>(shape);
-    }
-
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xcontainer<D>::begin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
-    {
-        return iterable_base::template begin<S, L>(shape);
-    }
-
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xcontainer<D>::end(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
-    {
-        return iterable_base::template end<S, L>(shape);
-    }
-
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xcontainer<D>::cbegin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
-    {
-        return iterable_base::template cbegin<S, L>(shape);
-    }
-
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xcontainer<D>::cend(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
-    {
-        return iterable_base::template cend<S, L>(shape);
-    }
-
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xcontainer<D>::rbegin(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
-    {
-        return iterable_base::template rbegin<S, L>(shape);
-    }
-
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xcontainer<D>::rend(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
-    {
-        return iterable_base::template rend<S, L>(shape);
-    }
-
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xcontainer<D>::rbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
-    {
-        return iterable_base::template rbegin<S, L>(shape);
-    }
-
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xcontainer<D>::rend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
-    {
-        return iterable_base::template rend<S, L>(shape);
-    }
-
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xcontainer<D>::crbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
-    {
-        return iterable_base::template crbegin<S, L>(shape);
-    }
-
-    template <class D>
-    template <class S, layout_type L>
-    inline auto xcontainer<D>::crend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
-    {
-        return iterable_base::template crend<S, L>(shape);
-    }
-
-    /***********************
-     * Linear iterator api *
-     ***********************/
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::storage_begin() noexcept -> storage_iterator
-    {
-        return storage().begin();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::storage_end() noexcept -> storage_iterator
-    {
-        return storage().end();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::storage_begin() const noexcept -> const_storage_iterator
-    {
-        return storage().begin();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::storage_end() const noexcept -> const_storage_iterator
-    {
-        return storage().end();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::storage_cbegin() const noexcept -> const_storage_iterator
-    {
-        return storage().cbegin();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::storage_cend() const noexcept -> const_storage_iterator
-    {
-        return storage().cend();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::storage_rbegin() noexcept -> reverse_storage_iterator
-    {
-        return storage().rbegin();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::storage_rend() noexcept -> reverse_storage_iterator
-    {
-        return storage().rend();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::storage_rbegin() const noexcept -> const_reverse_storage_iterator
-    {
-        return storage().rbegin();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::storage_rend() const noexcept -> const_reverse_storage_iterator
-    {
-        return storage().rend();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::storage_crbegin() const noexcept -> const_reverse_storage_iterator
-    {
-        return storage().crbegin();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xcontainer<D>::storage_crend() const noexcept -> const_reverse_storage_iterator
-    {
-        return storage().crend();
-    }
-
-    /***************
-     * stepper api *
-     ***************/
-
-    template <class D>
-    template <class S>
-    inline auto xcontainer<D>::stepper_begin(const S& shape) noexcept -> stepper
-    {
-        size_type offset = shape.size() - dimension();
-        return stepper(static_cast<derived_type*>(this), data_xbegin(), offset);
-    }
-
-    template <class D>
-    template <class S>
-    inline auto xcontainer<D>::stepper_end(const S& shape, layout_type l) noexcept -> stepper
-    {
-        size_type offset = shape.size() - dimension();
-        return stepper(static_cast<derived_type*>(this), data_xend(l), offset);
-    }
-
-    template <class D>
-    template <class S>
-    inline auto xcontainer<D>::stepper_begin(const S& shape) const noexcept -> const_stepper
-    {
-        size_type offset = shape.size() - dimension();
-        return const_stepper(static_cast<const derived_type*>(this), data_xbegin(), offset);
-    }
-
-    template <class D>
-    template <class S>
-    inline auto xcontainer<D>::stepper_end(const S& shape, layout_type l) const noexcept -> const_stepper
-    {
-        size_type offset = shape.size() - dimension();
-        return const_stepper(static_cast<const derived_type*>(this), data_xend(l), offset);
-    }
-
-    template <class D>
-    inline auto xcontainer<D>::data_xbegin() noexcept -> container_iterator
-    {
-        return storage().begin();
-    }
-
-    template <class D>
-    inline auto xcontainer<D>::data_xbegin() const noexcept -> const_container_iterator
-    {
-        return storage().begin();
-    }
-
-    template <class D>
-    inline auto xcontainer<D>::data_xend(layout_type l) noexcept -> container_iterator
-    {
-        return data_xend_impl(storage().end(), l);
-    }
-
-    template <class D>
-    inline auto xcontainer<D>::data_xend(layout_type l) const noexcept -> const_container_iterator
-    {
-        return data_xend_impl(storage().end(), l);
-    }
-
-    template <class D>
-    inline auto xcontainer<D>::derived_cast() & noexcept -> derived_type&
-    {
-        return *static_cast<derived_type*>(this);
-    }
 
     template <class D>
     inline auto xcontainer<D>::derived_cast() const & noexcept -> const derived_type&
@@ -1224,20 +643,160 @@ namespace xt
         return storage()[i];
     }
 
+    /***************
+     * stepper api *
+     ***************/
+
+    template <class D>
+    template <class S>
+    inline auto xcontainer<D>::stepper_begin(const S& shape) noexcept -> stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return stepper(static_cast<derived_type*>(this), data_xbegin(), offset);
+    }
+
+    template <class D>
+    template <class S>
+    inline auto xcontainer<D>::stepper_end(const S& shape, layout_type l) noexcept -> stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return stepper(static_cast<derived_type*>(this), data_xend(l, offset), offset);
+    }
+
+    template <class D>
+    template <class S>
+    inline auto xcontainer<D>::stepper_begin(const S& shape) const noexcept -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(static_cast<const derived_type*>(this), data_xbegin(), offset);
+    }
+
+    template <class D>
+    template <class S>
+    inline auto xcontainer<D>::stepper_end(const S& shape, layout_type l) const noexcept -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(static_cast<const derived_type*>(this), data_xend(l, offset), offset);
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::data_xbegin() noexcept -> container_iterator
+    {
+        return storage().begin();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::data_xbegin() const noexcept -> const_container_iterator
+    {
+        return storage().cbegin();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::data_xend(layout_type l, size_type offset) noexcept -> container_iterator
+    {
+        return data_xend_impl(storage().begin(), l, offset);
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::data_xend(layout_type l, size_type offset) const noexcept -> const_container_iterator
+    {
+        return data_xend_impl(storage().cbegin(), l, offset);
+    }
+
     template <class D>
     template <class alignment, class simd>
     inline void xcontainer<D>::store_simd(size_type i, const simd& e)
     {
         using align_mode = driven_align_mode_t<alignment, data_alignment>;
-        xsimd::store_simd<value_type, typename simd::value_type>(&(storage()[i]), e, align_mode());
+        xt_simd::store_simd<value_type, typename simd::value_type>(&(storage()[i]), e, align_mode());
     }
 
     template <class D>
-    template <class alignment, class simd>
-    inline auto xcontainer<D>::load_simd(size_type i) const -> simd_return_type<simd>
+    template <class alignment, class requested_type, std::size_t N>
+    inline auto xcontainer<D>::load_simd(size_type i) const
+        -> container_simd_return_type_t<storage_type, value_type, requested_type>
+        //-> simd_return_type<requested_type>
     {
         using align_mode = driven_align_mode_t<alignment, data_alignment>;
-        return xsimd::load_simd<value_type, typename simd::value_type>(&(storage()[i]), align_mode());
+        return xt_simd::load_simd<value_type, requested_type>(&(storage()[i]), align_mode());
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::storage_begin() noexcept -> storage_iterator
+    {
+        return storage().begin();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::storage_end() noexcept -> storage_iterator
+    {
+        return storage().end();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::storage_begin() const noexcept -> const_storage_iterator
+    {
+        return storage().begin();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::storage_end() const noexcept -> const_storage_iterator
+    {
+        return storage().cend();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::storage_cbegin() const noexcept -> const_storage_iterator
+    {
+        return storage().cbegin();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::storage_cend() const noexcept -> const_storage_iterator
+    {
+        return storage().cend();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::storage_rbegin() noexcept -> reverse_storage_iterator
+    {
+        return storage().rbegin();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::storage_rend() noexcept -> reverse_storage_iterator
+    {
+        return storage().rend();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::storage_rbegin() const noexcept -> const_reverse_storage_iterator
+    {
+        return storage().rbegin();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::storage_rend() const noexcept -> const_reverse_storage_iterator
+    {
+        return storage().rend();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::storage_crbegin() const noexcept -> const_reverse_storage_iterator
+    {
+        return storage().crbegin();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::storage_crend() const noexcept -> const_reverse_storage_iterator
+    {
+        return storage().crend();
+    }
+
+    template <class D>
+    inline auto xcontainer<D>::derived_cast() & noexcept -> derived_type&
+    {
+        return *static_cast<derived_type*>(this);
     }
 
     /*************************************
@@ -1248,7 +807,7 @@ namespace xt
     inline xstrided_container<D>::xstrided_container() noexcept
         : base_type()
     {
-        m_shape = xtl::make_sequence<inner_shape_type>(base_type::dimension(), 1);
+        m_shape = xtl::make_sequence<inner_shape_type>(base_type::dimension(), 0);
         m_strides = xtl::make_sequence<inner_strides_type>(base_type::dimension(), 0);
         m_backstrides = xtl::make_sequence<inner_backstrides_type>(base_type::dimension(), 0);
     }
@@ -1259,6 +818,12 @@ namespace xt
     {
         m_backstrides = xtl::make_sequence<inner_backstrides_type>(m_shape.size(), 0);
         adapt_strides(m_shape, m_strides, m_backstrides);
+    }
+
+    template <class D>
+    inline xstrided_container<D>::xstrided_container(inner_shape_type&& shape, inner_strides_type&& strides, inner_backstrides_type&& backstrides, layout_type&& layout) noexcept
+        : base_type(), m_shape(std::move(shape)), m_strides(std::move(strides)), m_backstrides(std::move(backstrides)), m_layout(std::move(layout))
+    {
     }
 
     template <class D>
@@ -1325,7 +890,9 @@ namespace xt
     }
 
     /**
-     * resizes the container.
+     * Resizes the container.
+     * @warning Contrary to STL containers like std::vector, resize
+     * does NOT preserve the container elements.
      * @param shape the new shape
      * @param force force reshaping, even if the shape stays the same (default: false)
      */
@@ -1333,22 +900,25 @@ namespace xt
     template <class S>
     inline void xstrided_container<D>::resize(S&& shape, bool force)
     {
-        if (m_shape.size() != shape.size() || !std::equal(std::begin(shape), std::end(shape), std::begin(m_shape)) || force)
+        std::size_t dim = shape.size();
+        if (m_shape.size() != dim || !std::equal(std::begin(shape), std::end(shape), std::begin(m_shape)) || force)
         {
-            if (m_layout == layout_type::dynamic || m_layout == layout_type::any)
+            if (D::static_layout == layout_type::dynamic && m_layout == layout_type::dynamic)
             {
                 m_layout = XTENSOR_DEFAULT_LAYOUT;  // fall back to default layout
             }
-            m_shape = xtl::forward_sequence<shape_type>(shape);
-            resize_container(m_strides, m_shape.size());
-            resize_container(m_backstrides, m_shape.size());
-            size_type data_size = compute_strides(m_shape, m_layout, m_strides, m_backstrides);
+            m_shape = xtl::forward_sequence<shape_type, S>(shape);
+            resize_container(m_strides, dim);
+            resize_container(m_backstrides, dim);
+            size_type data_size = compute_strides<D::static_layout>(m_shape, m_layout, m_strides, m_backstrides);
             detail::resize_data_container(this->storage(), data_size);
         }
     }
 
     /**
-     * resizes the container.
+     * Resizes the container.
+     * @warning Contrary to STL containers like std::vector, resize
+     * does NOT preserve the container elements.
      * @param shape the new shape
      * @param l the new layout_type
      */
@@ -1366,6 +936,8 @@ namespace xt
 
     /**
      * Resizes the container.
+     * @warning Contrary to STL containers like std::vector, resize
+     * does NOT preserve the container elements.
      * @param shape the new shape
      * @param strides the new strides
      */
@@ -1377,7 +949,7 @@ namespace xt
         {
             throw std::runtime_error("Cannot resize with custom strides when layout() is != layout_type::dynamic.");
         }
-        m_shape = xtl::forward_sequence<shape_type>(shape);
+        m_shape = xtl::forward_sequence<shape_type, S>(shape);
         m_strides = strides;
         resize_container(m_backstrides, m_strides.size());
         adapt_strides(m_shape, m_strides, m_backstrides);
@@ -1386,7 +958,14 @@ namespace xt
     }
 
     /**
-     * Reshapes the container and keeps old elements
+     * Reshapes the container and keeps old elements. The `shape` argument can have one of its value
+     * equal to `-1`, in this case the value is inferred from the number of elements in the container
+     * and the remaining values in the `shape`.
+     * \code{.cpp}
+     * xt::xarray<int> a = { 1, 2, 3, 4, 5, 6, 7, 8 };
+     * a.reshape({-1, 4});
+     * //a.shape() is {2, 4}
+     * \endcode
      * @param shape the new shape (has to have same number of elements as the original container)
      * @param layout the layout to compute the strides (defaults to static layout of the container,
      *               or for a container with dynamic layout to XTENSOR_DEFAULT_LAYOUT)
@@ -1395,23 +974,73 @@ namespace xt
     template <class S>
     inline void xstrided_container<D>::reshape(S&& shape, layout_type layout)
     {
+        reshape_impl(std::forward<S>(shape), std::is_signed<std::decay_t<typename std::decay_t<S>::value_type>>(), std::forward<layout_type>(layout));
+    }
+
+    template <class D>
+    template <class T>
+    inline void xstrided_container<D>::reshape(std::initializer_list<T> shape, layout_type layout)
+    {
+        using sh_type = rebind_container_t<T, shape_type>;
+        sh_type sh = xtl::make_sequence<sh_type>(shape.size());
+        std::copy(shape.begin(), shape.end(), sh.begin());
+        reshape_impl(std::move(sh), std::is_signed<T>(), std::forward<layout_type>(layout));
+    }
+
+    template <class D>
+    template <class S>
+    inline void xstrided_container<D>::reshape_impl(S&& shape, std::false_type /* is unsigned */, layout_type layout)
+    {
         if (compute_size(shape) != this->size())
         {
             throw std::runtime_error("Cannot reshape with incorrect number of elements. Do you mean to resize?");
         }
-        if (layout == layout_type::dynamic || layout == layout_type::any)
+        if (D::static_layout == layout_type::dynamic && layout == layout_type::dynamic)
         {
             layout = XTENSOR_DEFAULT_LAYOUT;  // fall back to default layout
         }
-        if (layout != base_type::static_layout && base_type::static_layout != layout_type::dynamic)
+        if (D::static_layout != layout_type::dynamic && layout != D::static_layout)
         {
             throw std::runtime_error("Cannot reshape with different layout if static layout != dynamic.");
         }
         m_layout = layout;
-        m_shape = xtl::forward_sequence<shape_type>(shape);
+        m_shape = xtl::forward_sequence<shape_type, S>(shape);
         resize_container(m_strides, m_shape.size());
         resize_container(m_backstrides, m_shape.size());
-        compute_strides(m_shape, m_layout, m_strides, m_backstrides);
+        compute_strides<D::static_layout>(m_shape, m_layout, m_strides, m_backstrides);
+    }
+    template <class D>
+    template <class S>
+    inline void xstrided_container<D>::reshape_impl(S&& _shape, std::true_type /* is signed */, layout_type layout)
+    {
+        using value_type = typename std::decay_t<S>::value_type;
+        if (this->size() % compute_size(_shape))
+        {
+            throw std::runtime_error("Negative axis size cannot be inferred. Shape mismatch.");
+        }
+        std::decay_t<S> shape = _shape;
+        value_type accumulator = 1;
+        std::size_t neg_idx = 0;
+        std::size_t i = 0;
+        for(auto it = shape.begin(); it != shape.end(); ++it, i++)
+        {
+            auto&& dim = *it;
+            if(dim < 0)
+            {
+                XTENSOR_ASSERT(dim == -1 && !neg_idx);
+                neg_idx = i;
+            }
+            accumulator *= dim;
+        }
+        if(accumulator < 0)
+        {
+            shape[neg_idx] = static_cast<value_type>(this->size()) / std::abs(accumulator);
+        }
+        m_layout = layout;
+        m_shape = xtl::forward_sequence<shape_type, S>(shape);
+        resize_container(m_strides, m_shape.size());
+        resize_container(m_backstrides, m_shape.size());
+        compute_strides<D::static_layout>(m_shape, m_layout, m_strides, m_backstrides);
     }
 }
 

--- a/vendor/xtensor/include/xtensor/xcsv.hpp
+++ b/vendor/xtensor/include/xtensor/xcsv.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -29,7 +30,7 @@ namespace xt
     using xcsv_tensor = xtensor_container<std::vector<T, A>, 2, layout_type::row_major>;
 
     template <class T, class A = std::allocator<T>>
-    xcsv_tensor<T, A> load_csv(std::istream& stream);
+    xcsv_tensor<T, A> load_csv(std::istream& stream, const char delimiter = ',', const std::size_t skip_rows = 0, const ptrdiff_t max_rows = -1, const std::string comments = "#");
 
     template <class E>
     void dump_csv(std::ostream& stream, const xexpression<E>& e);
@@ -47,6 +48,17 @@ namespace xt
             std::istringstream iss(cell);
             iss >> res;
             return res;
+        }
+
+        template <>
+        inline std::string lexical_cast(const std::string& cell)
+        {
+            size_t first = cell.find_first_not_of(' ');
+            if (first == std::string::npos)
+                return cell;
+
+            size_t last = cell.find_last_not_of(' ');
+            return cell.substr(first, last==std::string::npos?cell.size():last+1);
         }
 
         template <>
@@ -77,10 +89,10 @@ namespace xt
         inline unsigned long long lexical_cast<unsigned long long>(const std::string& cell) { return std::stoull(cell); }
 
         template <class ST, class T, class OI>
-        ST load_csv_row(std::istream& row_stream, OI output, std::string cell)
+        ST load_csv_row(std::istream& row_stream, OI output, std::string cell, const char delimiter = ',')
         {
             ST length = 0;
-            while (std::getline(row_stream, cell, ','))
+            while (std::getline(row_stream, cell, delimiter))
             {
                 *output++ = lexical_cast<T>(cell);
                 ++length;
@@ -94,9 +106,13 @@ namespace xt
      * 
      * Returns an \ref xexpression for the parsed CSV
      * @param stream the input stream containing the CSV encoded values
+     * @param delimiter the character used to separate values. [default: ',']
+     * @param skip the first skip_rows lines. [default: 0]
+     * @param read max_rows lines of content after skip_rows lines; the default is to read all the lines. [default: -1]
+     * @param comments the string used to indicate the start of a comment. [default: "#"]
      */
     template <class T, class A>
-    xcsv_tensor<T, A> load_csv(std::istream& stream)
+    xcsv_tensor<T, A> load_csv(std::istream& stream, const char delimiter, const std::size_t skip_rows, const std::ptrdiff_t max_rows, const std::string comments)
     {
         using tensor_type = xcsv_tensor<T, A>;
         using storage_type = typename tensor_type::storage_type;
@@ -106,14 +122,27 @@ namespace xt
         using output_iterator = std::back_insert_iterator<storage_type>;
 
         storage_type data;
-        size_type nbrow = 0, nbcol = 0;
+        size_type nbrow = 0, nbcol = 0, nhead = 0;
         {
             output_iterator output(data);
             std::string row, cell;
             while (std::getline(stream, row))
             {
+                if (nhead < skip_rows) 
+                {
+                    ++nhead;
+                    continue;
+                }
+                if (std::equal(comments.begin(), comments.end(), row.begin()))
+                {
+                    continue;
+                }
+                if (0 < max_rows && max_rows <= static_cast<const long long>(nbrow))
+                {
+                    break;
+                }
                 std::stringstream row_stream(row);
-                nbcol = detail::load_csv_row<size_type, T, output_iterator>(row_stream, output, cell);
+                nbcol = detail::load_csv_row<size_type, T, output_iterator>(row_stream, output, cell, delimiter);
                 ++nbrow;
             }
         }

--- a/vendor/xtensor/include/xtensor/xdynamic_view.hpp
+++ b/vendor/xtensor/include/xtensor/xdynamic_view.hpp
@@ -1,0 +1,704 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_DYNAMIC_VIEW_HPP
+#define XTENSOR_DYNAMIC_VIEW_HPP
+
+#include <xtl/xsequence.hpp>
+#include <xtl/xvariant.hpp>
+
+#include "xexpression.hpp"
+#include "xiterable.hpp"
+#include "xlayout.hpp"
+#include "xsemantic.hpp"
+#include "xstrided_view_base.hpp"
+
+namespace xt
+{
+
+    template <class CT, class S, layout_type L, class FST>
+    class xdynamic_view;
+
+    template <class CT, class S, layout_type L, class FST>
+    struct xcontainer_inner_types<xdynamic_view<CT, S, L, FST>>
+    {
+        using xexpression_type = std::decay_t<CT>;
+        using undecay_expression = CT;
+        using reference = inner_reference_t<undecay_expression>;
+        using const_reference = typename xexpression_type::const_reference;
+        using size_type = typename xexpression_type::size_type;
+        using shape_type = std::decay_t<S>;
+        using undecay_shape = S;
+        using storage_getter = FST;
+        using inner_storage_type = typename storage_getter::type;
+        using temporary_type = xarray<std::decay_t<typename xexpression_type::value_type>, xexpression_type::static_layout>;
+        static constexpr layout_type layout = L;
+    };
+
+    template <class CT, class S, layout_type L, class FST>
+    struct xiterable_inner_types<xdynamic_view<CT, S, L, FST>>
+    {
+        using inner_shape_type = S;
+        using inner_strides_type = inner_shape_type;
+        using inner_backstrides_type = inner_shape_type;
+
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ == 8
+        constexpr static auto random_instantiation_var_for_gcc8_data_iface = has_data_interface<xdynamic_view<CT, S, L, FST>>::value;
+        constexpr static auto random_instantiation_var_for_gcc8_has_strides = has_strides<xdynamic_view<CT, S, L, FST>>::value;
+#endif
+
+        // TODO: implement efficient stepper specific to the dynamic_view
+        using const_stepper = xindexed_stepper<const xdynamic_view<CT, S, L, FST>, true>;
+        using stepper = xindexed_stepper<xdynamic_view<CT, S, L, FST>, false>;
+    };
+
+    /****************************
+     * xdynamic_view extensions *
+     ****************************/
+
+    namespace extension
+    {
+        template <class Tag, class CT, class S, layout_type L, class FST>
+        struct xdynamic_view_base_impl;
+
+        template <class CT, class S, layout_type L, class FST>
+        struct xdynamic_view_base_impl<xtensor_expression_tag, CT, S, L, FST>
+        {
+            using type = xtensor_empty_base;
+        };
+
+        template <class CT, class S, layout_type L, class FST>
+        struct xdynamic_view_base
+            : xdynamic_view_base_impl<xexpression_tag_t<CT>, CT, S, L, FST>
+        {
+        };
+
+        template <class CT, class S, layout_type L, class FST>
+        using xdynamic_view_base_t = typename xdynamic_view_base<CT, S, L, FST>::type;
+    }
+
+    /*****************
+     * xdynamic_view *
+     *****************/
+
+    namespace detail
+    {
+        template <class T>
+        class xfake_slice;
+    }
+
+    template <class CT, class S, layout_type L = layout_type::dynamic, class FST = detail::flat_storage_getter<CT, XTENSOR_DEFAULT_TRAVERSAL>>
+    class xdynamic_view : public xview_semantic<xdynamic_view<CT, S, L, FST>>,
+                          public xiterable<xdynamic_view<CT, S, L, FST>>,
+                          public extension::xdynamic_view_base_t<CT, S, L, FST>,
+                          private xstrided_view_base<xdynamic_view<CT, S, L, FST>>
+    {
+    public:
+
+        using self_type = xdynamic_view<CT, S, L, FST>;
+        using base_type = xstrided_view_base<self_type>;
+        using semantic_base = xview_semantic<self_type>;
+        using extension_base = extension::xdynamic_view_base_t<CT, S, L, FST>;
+        using expression_tag = typename extension_base::expression_tag;
+
+        using xexpression_type = typename base_type::xexpression_type;
+        using base_type::is_const;
+
+        using value_type = typename base_type::value_type;
+        using reference = typename base_type::reference;
+        using const_reference = typename base_type::const_reference;
+        using pointer = typename base_type::pointer;
+        using const_pointer = typename base_type::const_pointer;
+        using size_type = typename base_type::size_type;
+        using difference_type = typename base_type::difference_type;
+
+        using inner_storage_type = typename base_type::inner_storage_type;
+        using storage_type = typename base_type::storage_type;
+
+        using iterable_base = xiterable<self_type>;
+        using inner_shape_type = typename iterable_base::inner_shape_type;
+        using inner_strides_type = typename base_type::inner_strides_type;
+        using inner_backstrides_type = typename base_type::inner_backstrides_type;
+
+        using shape_type = typename base_type::shape_type;
+        using strides_type = typename base_type::strides_type;
+        using backstrides_type = typename base_type::backstrides_type;
+
+        using stepper = typename iterable_base::stepper;
+        using const_stepper = typename iterable_base::const_stepper;
+
+        using base_type::static_layout;
+        using base_type::contiguous_layout;
+
+        using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
+        using base_index_type = xindex_type_t<shape_type>;
+
+        using simd_value_type = typename base_type::simd_value_type;
+        using bool_load_type = typename base_type::bool_load_type;
+
+        using strides_vt = typename strides_type::value_type;
+        using slice_type = xtl::variant<detail::xfake_slice<strides_vt>, xkeep_slice<strides_vt>, xdrop_slice<strides_vt>>;
+        using slice_vector_type = std::vector<slice_type>;
+
+        template <class CTA, class SA>
+        xdynamic_view(CTA&& e, SA&& shape, get_strides_t<S>&& strides, std::size_t offset, layout_type layout,
+                      slice_vector_type&& slices, get_strides_t<S>&& adj_strides) noexcept;
+
+        template <class E>
+        self_type& operator=(const xexpression<E>& e);
+
+        template <class E>
+        disable_xexpression<E, self_type>& operator=(const E& e);
+
+        using base_type::size;
+        using base_type::dimension;
+        using base_type::shape;
+        using base_type::layout;
+
+        // Explicitly deleting strides method to avoid compilers complaining
+        // about not being able to call the strides method from xstrided_view_base
+        // private base
+        const inner_strides_type& strides() const noexcept = delete;
+
+        reference operator()();
+        const_reference operator()() const;
+
+        template <class... Args>
+        reference operator()(Args... args);
+
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+
+        template <class... Args>
+        reference unchecked(Args... args);
+
+        template <class... Args>
+        const_reference unchecked(Args... args) const;
+
+        using base_type::operator[];
+        using base_type::at;
+        using base_type::periodic;
+        using base_type::in_bounds;
+
+        template <class It>
+        reference element(It first, It last);
+
+        template <class It>
+        const_reference element(It first, It last) const;
+
+        size_type data_offset() const noexcept;
+
+        // Explicitly deleting data methods so has_data_interface results
+        // to false instead of having compilers complaining about not being
+        // able to call the methods from the private base
+        value_type* data() noexcept = delete;
+        const value_type* data() const noexcept = delete;
+
+        using base_type::storage;
+        using base_type::expression;
+        using base_type::broadcast_shape;
+
+        template <class O>
+        bool has_linear_assign(const O& str) const noexcept;
+
+        template <class T>
+        void fill(const T& value);
+
+        template <class ST>
+        stepper stepper_begin(const ST& shape);
+        template <class ST>
+        stepper stepper_end(const ST& shape, layout_type l);
+
+        template <class ST>
+        const_stepper stepper_begin(const ST& shape) const;
+        template <class ST>
+        const_stepper stepper_end(const ST& shape, layout_type l) const;
+
+        using container_iterator = std::conditional_t<is_const,
+                                                      typename storage_type::const_iterator,
+                                                      typename storage_type::iterator>;
+        using const_container_iterator = typename storage_type::const_iterator;
+
+        template <class E>
+        using rebind_t = xdynamic_view<E, S, L, typename FST::template rebind_t<E>>;
+
+        template <class E>
+        rebind_t<E> build_view(E&& e) const;
+
+    private:
+
+        using offset_type = typename base_type::offset_type;
+
+        slice_vector_type m_slices;
+        inner_strides_type m_adj_strides;
+
+        container_iterator data_xbegin() noexcept;
+        const_container_iterator data_xbegin() const noexcept;
+        container_iterator data_xend(layout_type l, size_type offset) noexcept;
+        const_container_iterator data_xend(layout_type l, size_type offset) const noexcept;
+
+        template <class It>
+        It data_xbegin_impl(It begin) const noexcept;
+
+        template <class It>
+        It data_xend_impl(It end, layout_type l, size_type offset) const noexcept;
+
+        void assign_temporary_impl(temporary_type&& tmp);
+
+        template <class T,  class... Args>
+        offset_type adjust_offset(offset_type offset, T idx, Args... args) const noexcept;
+        offset_type adjust_offset(offset_type offset) const noexcept;
+
+        template <class T, class... Args>
+        offset_type adjust_offset_impl(offset_type offset, size_type idx_offset, T idx, Args... args) const noexcept;
+        offset_type adjust_offset_impl(offset_type offset, size_type idx_offset) const noexcept;
+
+        template <class It>
+        offset_type adjust_element_offset(offset_type offset, It first, It last) const noexcept;
+
+        template <class C>
+        friend class xstepper;
+        friend class xview_semantic<self_type>;
+        friend class xaccessible<self_type>;
+        friend class xconst_accessible<self_type>;
+    };
+
+    /**************************
+     * xdynamic_view builders *
+     **************************/
+
+    template <class T>
+    using xdynamic_slice = xtl::variant<
+        T,
+
+        xrange_adaptor<placeholders::xtuph, T, T>,
+        xrange_adaptor<T, placeholders::xtuph, T>,
+        xrange_adaptor<T, T, placeholders::xtuph>,
+
+        xrange_adaptor<T, placeholders::xtuph, placeholders::xtuph>,
+        xrange_adaptor<placeholders::xtuph, T, placeholders::xtuph>,
+        xrange_adaptor<placeholders::xtuph, placeholders::xtuph, T>,
+
+        xrange_adaptor<T, T, T>,
+        xrange_adaptor<placeholders::xtuph, placeholders::xtuph, placeholders::xtuph>,
+
+        xrange<T>,
+        xstepped_range<T>,
+
+        xkeep_slice<T>,
+        xdrop_slice<T>,
+
+        xall_tag,
+        xellipsis_tag,
+        xnewaxis_tag
+    >;
+
+    using xdynamic_slice_vector = std::vector<xdynamic_slice<std::ptrdiff_t>>;
+
+    template <class E>
+    auto dynamic_view(E&& e, const xdynamic_slice_vector& slices);
+
+    /******************************
+     * xfake_slice implementation *
+     ******************************/
+
+    namespace detail
+    {
+        template <class T>
+        class xfake_slice : public xslice<xfake_slice<T>>
+        {
+        public:
+
+            using size_type = T;
+            using self_type = xfake_slice<T>;
+
+            xfake_slice() = default;
+
+            size_type operator()(size_type /*i*/) const noexcept
+            {
+                return size_type(0);
+            }
+
+            size_type size() const noexcept
+            {
+                return size_type(1);
+            }
+
+            size_type step_size() const noexcept
+            {
+                return size_type(0);
+            }
+
+            size_type step_size(std::size_t /*i*/, std::size_t /*n*/ = 1) const noexcept
+            {
+                return size_type(0);
+            }
+
+            size_type revert_index(std::size_t i) const noexcept
+            {
+                return i;
+            }
+
+            bool contains(size_type /*i*/) const noexcept
+            {
+                return true;
+            }
+
+            bool operator==(const self_type& /*rhs*/) const noexcept
+            {
+                return true;
+            }
+
+            bool operator!=(const self_type& /*rhs*/) const noexcept
+            {
+                return false;
+            }
+        };
+    }
+
+    /********************************
+     * xdynamic_view implementation *
+     ********************************/
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class CTA, class SA>
+    inline xdynamic_view<CT, S, L, FST>::xdynamic_view(CTA&& e, SA&& shape, get_strides_t<S>&& strides,
+                                                       std::size_t offset, layout_type layout,
+                                                       slice_vector_type&& slices, get_strides_t<S>&& adj_strides) noexcept
+        : base_type(std::forward<CTA>(e), std::forward<SA>(shape), std::move(strides), offset, layout),
+          m_slices(std::move(slices)), m_adj_strides(std::move(adj_strides))
+    {
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class E>
+    inline auto xdynamic_view<CT, S, L, FST>::operator=(const xexpression<E>& e) -> self_type&
+    {
+        return semantic_base::operator=(e);
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class E>
+    inline auto xdynamic_view<CT, S, L, FST>::operator=(const E& e) -> disable_xexpression<E, self_type>&
+    {
+        std::fill(this->begin(), this->end(), e);
+        return *this;
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xdynamic_view<CT, S, L, FST>::operator()() -> reference
+    {
+        return base_type::storage()[data_offset()];
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xdynamic_view<CT, S, L, FST>::operator()() const -> const_reference
+    {
+        return base_type::storage()[data_offset()];
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class... Args>
+    inline auto xdynamic_view<CT, S, L, FST>::operator()(Args... args) -> reference
+    {
+        XTENSOR_TRY(check_index(base_type::shape(), args...));
+        XTENSOR_CHECK_DIMENSION(base_type::shape(), args...);
+        offset_type offset = base_type::compute_index(args...);
+        offset = adjust_offset(offset, args...);
+        return base_type::storage()[static_cast<size_type>(offset)];
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class... Args>
+    inline auto xdynamic_view<CT, S, L, FST>::operator()(Args... args) const -> const_reference
+    {
+        XTENSOR_TRY(check_index(base_type::shape(), args...));
+        XTENSOR_CHECK_DIMENSION(base_type::shape(), args...);
+        offset_type offset = base_type::compute_index(args...);
+        offset = adjust_offset(offset, args...);
+        return base_type::storage()[static_cast<size_type>(offset)];
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class O>
+    inline bool xdynamic_view<CT, S, L, FST>::has_linear_assign(const O&) const noexcept
+    {
+        return false;
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class... Args>
+    inline auto xdynamic_view<CT, S, L, FST>::unchecked(Args... args) -> reference
+    {
+        offset_type offset = base_type::compute_unchecked_index(args...);
+        offset = adjust_offset(args...);
+        return base_type::storage()[static_cast<size_type>(offset)];
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class... Args>
+    inline auto xdynamic_view<CT, S, L, FST>::unchecked(Args... args) const -> const_reference
+    {
+        offset_type offset = base_type::compute_unchecked_index(args...);
+        offset = adjust_offset(args...);
+        return base_type::storage()[static_cast<size_type>(offset)];
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class It>
+    inline auto xdynamic_view<CT, S, L, FST>::element(It first, It last) -> reference
+    {
+        XTENSOR_TRY(check_element_index(base_type::shape(), first, last));
+        offset_type offset = base_type::compute_element_index(first, last);
+        offset = adjust_element_offset(offset, first, last);
+        return base_type::storage()[static_cast<size_type>(offset)];
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class It>
+    inline auto xdynamic_view<CT, S, L, FST>::element(It first, It last) const -> const_reference
+    {
+        XTENSOR_TRY(check_element_index(base_type::shape(), first, last));
+        offset_type offset = base_type::compute_element_index(first, last);
+        offset = adjust_element_offset(offset, first, last);
+        return base_type::storage()[static_cast<size_type>(offset)];
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xdynamic_view<CT, S, L, FST>::data_offset() const noexcept -> size_type
+    {
+        size_type offset = base_type::data_offset();
+        size_type sl_offset = xtl::visit([](const auto& sl) { return sl(size_type(0)); }, m_slices[0]);
+        return offset + sl_offset * m_adj_strides[0];
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class T>
+    inline void xdynamic_view<CT, S, L, FST>::fill(const T& value)
+    {
+        return std::fill(this->storage_begin(), this->storage_end(), value);
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class ST>
+    inline auto xdynamic_view<CT, S, L, FST>::stepper_begin(const ST& shape) -> stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return stepper(this, offset);
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class ST>
+    inline auto xdynamic_view<CT, S, L, FST>::stepper_end(const ST& shape, layout_type /*l*/) -> stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return stepper(this, offset, true);
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class ST>
+    inline auto xdynamic_view<CT, S, L, FST>::stepper_begin(const ST& shape) const -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(this, offset);
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class ST>
+    inline auto xdynamic_view<CT, S, L, FST>::stepper_end(const ST& shape, layout_type /*l*/) const -> const_stepper
+    {
+        size_type offset = shape.size() - dimension();
+        return const_stepper(this, offset, true);
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class E>
+    inline auto xdynamic_view<CT, S, L, FST>::build_view(E&& e) const -> rebind_t<E>
+    {
+        inner_shape_type sh(this->shape());
+        inner_strides_type str(base_type::strides());
+        slice_vector_type svt(m_slices);
+        inner_strides_type adj_str(m_adj_strides);
+        return rebind_t<E>(std::forward<E>(e), std::move(sh), std::move(str),
+                           base_type::data_offset(), this->layout(), std::move(svt), std::move(adj_str));
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xdynamic_view<CT, S, L, FST>::data_xbegin() noexcept -> container_iterator
+    {
+        return data_xbegin_impl(this->storage().begin());
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xdynamic_view<CT, S, L, FST>::data_xbegin() const noexcept -> const_container_iterator
+    {
+        return data_xbegin_impl(this->storage().cbegin());
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xdynamic_view<CT, S, L, FST>::data_xend(layout_type l, size_type offset) noexcept -> container_iterator
+    {
+        return data_xend_impl(this->storage().begin(), l, offset);
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xdynamic_view<CT, S, L, FST>::data_xend(layout_type l, size_type offset) const noexcept -> const_container_iterator
+    {
+        return data_xend_impl(this->storage().cbegin(), l, offset);
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class It>
+    inline It xdynamic_view<CT, S, L, FST>::data_xbegin_impl(It begin) const noexcept
+    {
+        return begin + static_cast<std::ptrdiff_t>(data_offset());
+    }
+
+    // TODO: fix the data_xend implementation and assign_temporary_impl
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class It>
+    inline It xdynamic_view<CT, S, L, FST>::data_xend_impl(It begin, layout_type l, size_type offset) const noexcept
+    {
+        return strided_data_end(*this, begin + std::ptrdiff_t(data_offset()), l, offset);
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline void xdynamic_view<CT, S, L, FST>::assign_temporary_impl(temporary_type&& tmp)
+    {
+        std::copy(tmp.cbegin(), tmp.cend(), this->begin());
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class T, class... Args>
+    inline auto xdynamic_view<CT, S, L, FST>::adjust_offset(offset_type offset, T idx, Args... args) const noexcept -> offset_type
+    {
+        constexpr size_type nb_args = sizeof...(Args) + 1;
+        size_type dim = base_type::dimension();
+        offset_type res = nb_args > dim ? adjust_offset(offset, args...) : adjust_offset_impl(offset, dim - nb_args, idx, args...);
+        return res;
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xdynamic_view<CT, S, L, FST>::adjust_offset(offset_type offset) const noexcept -> offset_type
+    {
+        return offset;
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class T, class... Args>
+    inline auto xdynamic_view<CT, S, L, FST>::adjust_offset_impl(offset_type offset, size_type idx_offset, T idx, Args... args) const noexcept
+        -> offset_type
+    {
+        offset_type sl_offset = xtl::visit([idx](const auto& sl) {
+                using type = typename std::decay_t<decltype(sl)>::size_type;
+                return sl(type(idx));
+        }, m_slices[idx_offset]);
+        offset_type res = offset + sl_offset * m_adj_strides[idx_offset];
+        return adjust_offset_impl(res, idx_offset + 1, args...);
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xdynamic_view<CT, S, L, FST>::adjust_offset_impl(offset_type offset, size_type) const noexcept
+        -> offset_type
+    {
+        return offset;
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class It>
+    inline auto xdynamic_view<CT, S, L, FST>::adjust_element_offset(offset_type offset, It first, It last) const noexcept -> offset_type
+    {
+        auto dst = std::distance(first, last);
+        offset_type dim = static_cast<offset_type>(dimension());
+        offset_type loop_offset = dst < dim ? dim - dst : offset_type(0);
+        offset_type idx_offset = dim < dst ? dst - dim : offset_type(0);
+        offset_type res = offset;
+        for (offset_type i = loop_offset; i < dim; ++i, ++first)
+        {
+            offset_type j = static_cast<offset_type>(first[idx_offset]);
+            offset_type sl_offset = xtl::visit([j](const auto& sl) { return static_cast<offset_type>(sl(j)); }, m_slices[static_cast<std::size_t>(i)]);
+            res += sl_offset * m_adj_strides[static_cast<std::size_t>(i)];
+        }
+        return res;
+    }
+
+    /*****************************************
+     * xdynamic_view builders implementation *
+     *****************************************/
+
+    namespace detail
+    {
+        template <class V>
+        struct adj_strides_policy
+        {
+            using slice_vector = V;
+            using strides_type = dynamic_shape<std::ptrdiff_t>;
+
+            slice_vector new_slices;
+            strides_type new_adj_strides;
+
+        protected:
+
+            inline void resize(std::size_t size)
+            {
+                new_slices.resize(size);
+                new_adj_strides.resize(size);
+            }
+
+            inline void set_fake_slice(std::size_t idx)
+            {
+                new_slices[idx] = xfake_slice<std::ptrdiff_t>();
+                new_adj_strides[idx] = std::ptrdiff_t(0);
+            }
+
+            template <class ST, class S>
+            bool fill_args(const xdynamic_slice_vector& slices, std::size_t sl_idx,
+                           std::size_t i, std::size_t old_shape,
+                           const ST& old_stride,
+                           S& shape, get_strides_t<S>& strides)
+            {
+                return fill_args_impl<xkeep_slice<std::ptrdiff_t>>(slices, sl_idx, i, old_shape, old_stride, shape, strides)
+                    || fill_args_impl<xdrop_slice<std::ptrdiff_t>>(slices, sl_idx, i, old_shape, old_stride, shape, strides);
+            }
+
+            template <class SL, class ST, class S>
+            bool fill_args_impl(const xdynamic_slice_vector& slices, std::size_t sl_idx,
+                                std::size_t i, std::size_t old_shape,
+                                const ST& old_stride,
+                                S& shape, get_strides_t<S>& strides)
+            {
+                auto* sl = xtl::get_if<SL>(&slices[sl_idx]);
+                if (sl != nullptr)
+                {
+                    new_slices[i] = *sl;
+                    auto& ns = xtl::get<SL>(new_slices[i]);
+                    ns.normalize(old_shape);
+                    shape[i] = static_cast<std::size_t>(ns.size());
+                    strides[i] = std::ptrdiff_t(0);
+                    new_adj_strides[i] = static_cast<std::ptrdiff_t>(old_stride);
+                }
+                return sl != nullptr;
+            }
+        };
+    }
+
+    template <class E>
+    inline auto dynamic_view(E&& e, const xdynamic_slice_vector& slices)
+    {
+        using view_type = xdynamic_view<xclosure_t<E>, dynamic_shape<std::size_t>>;
+        using slice_vector = typename view_type::slice_vector_type;
+        using policy = detail::adj_strides_policy<slice_vector>;
+        detail::strided_view_args<policy> args;
+        args.fill_args(e.shape(), detail::get_strides<XTENSOR_DEFAULT_TRAVERSAL>(e), detail::get_offset<XTENSOR_DEFAULT_TRAVERSAL>(e), e.layout(), slices);
+        return view_type(std::forward<E>(e), std::move(args.new_shape), std::move(args.new_strides), args.new_offset,
+                         args.new_layout, std::move(args.new_slices), std::move(args.new_adj_strides));
+    }
+}
+
+#endif

--- a/vendor/xtensor/include/xtensor/xeval.hpp
+++ b/vendor/xtensor/include/xtensor/xeval.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -10,6 +11,7 @@
 #define XTENSOR_EVAL_HPP
 
 #include "xtensor_forward.hpp"
+#include "xshape.hpp"
 
 namespace xt
 {
@@ -40,16 +42,24 @@ namespace xt
     /// @cond DOXYGEN_INCLUDE_SFINAE
     template <class T, class I = std::decay_t<T>>
     inline auto eval(T&& t)
-        -> std::enable_if_t<!detail::is_container<I>::value && detail::is_array<typename I::shape_type>::value, xtensor<typename I::value_type, std::tuple_size<typename I::shape_type>::value>>
+        -> std::enable_if_t<!detail::is_container<I>::value && detail::is_array<typename I::shape_type>::value && !detail::is_fixed<typename I::shape_type>::value, xtensor<typename I::value_type, std::tuple_size<typename I::shape_type>::value>>
     {
         return xtensor<typename I::value_type, std::tuple_size<typename I::shape_type>::value>(std::forward<T>(t));
     }
 
     template <class T, class I = std::decay_t<T>>
     inline auto eval(T&& t)
-        -> std::enable_if_t<!detail::is_container<I>::value && !detail::is_array<typename I::shape_type>::value, xt::xarray<typename I::value_type>>
+        -> std::enable_if_t<!detail::is_container<I>::value && !detail::is_array<typename I::shape_type>::value && !detail::is_fixed<typename I::shape_type>::value, xt::xarray<typename I::value_type>>
     {
         return xarray<typename I::value_type>(std::forward<T>(t));
+    }
+
+    template <class T, class I = std::decay_t<T>>
+    inline auto eval(T&& t)
+        -> std::enable_if_t<!detail::is_container<I>::value && detail::is_fixed<typename I::shape_type>::value && !detail::is_array<typename I::shape_type>::value,
+                            xt::xtensor_fixed<typename I::value_type, typename I::shape_type>>
+    {
+        return xtensor_fixed<typename I::value_type, typename I::shape_type>(std::forward<T>(t));
     }
     /// @endcond
 }

--- a/vendor/xtensor/include/xtensor/xexpression.hpp
+++ b/vendor/xtensor/include/xtensor/xexpression.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -14,9 +15,12 @@
 #include <vector>
 
 #include <xtl/xclosure.hpp>
+#include <xtl/xmeta_utils.hpp>
 #include <xtl/xtype_traits.hpp>
 
+#include "xlayout.hpp"
 #include "xshape.hpp"
+#include "xtensor_forward.hpp"
 #include "xutils.hpp"
 
 namespace xt
@@ -61,6 +65,43 @@ namespace xt
         xexpression& operator=(xexpression&&) = default;
     };
 
+    /************************************
+     * xsharable_expression declaration *
+     ************************************/
+
+    template <class E>
+    class xshared_expression;
+
+    template <class E>
+    class xsharable_expression;
+
+    namespace detail
+    {
+        template <class E>
+        xshared_expression<E> make_xshared_impl(xsharable_expression<E>&&);
+    }
+
+    template <class D>
+    class xsharable_expression : public xexpression<D>
+    {
+    protected:
+
+        xsharable_expression();
+        ~xsharable_expression() = default;
+
+        xsharable_expression(const xsharable_expression&) = default;
+        xsharable_expression& operator=(const xsharable_expression&) = default;
+
+        xsharable_expression(xsharable_expression&&) = default;
+        xsharable_expression& operator=(xsharable_expression&&) = default;
+
+    private:
+
+        std::shared_ptr<D> p_shared;
+
+        friend xshared_expression<D> detail::make_xshared_impl<D>(xsharable_expression<D>&&);
+    };
+
     /******************************
      * xexpression implementation *
      ******************************/
@@ -97,21 +138,41 @@ namespace xt
     }
     //@}
 
-    namespace detail
-    {
-        template <class E>
-        struct is_xexpression_impl : std::is_base_of<xexpression<std::decay_t<E>>, std::decay_t<E>>
-        {
-        };
+    /***************************************
+     * xsharable_expression implementation *
+     ***************************************/
 
-        template <class E>
-        struct is_xexpression_impl<xexpression<E>> : std::true_type
-        {
-        };
+    template <class D>
+    inline xsharable_expression<D>::xsharable_expression()
+        : p_shared(nullptr)
+    {
     }
 
+    /**
+     * is_crtp_base_of<B, E>
+     * Resembles std::is_base_of, but adresses the problem of whether _some_ instantiation
+     * of a CRTP templated class B is a base of class E. A CRTP templated class is correctly
+     * templated with the most derived type in the CRTP hierarchy. Using this assumption,
+     * this implementation deals with either CRTP final classes (checks for inheritance
+     * with E as the CRTP parameter of B) or CRTP base classes (which are singly templated
+     * by the most derived class, and that's pulled out to use as a templete parameter for B).
+     */
+
+    namespace detail
+    {
+        template <template <class> class B, class E>
+        struct is_crtp_base_of_impl : std::is_base_of<B<E>, E> {};
+
+        template <template <class> class B, class E, template <class> class F>
+        struct is_crtp_base_of_impl<B, F<E>> :
+        xtl::disjunction< std::is_base_of<B<E>, F<E>>, std::is_base_of<B<F<E>>, F<E>>> {};
+    }
+
+    template <template <class> class B, class E>
+    using is_crtp_base_of = detail::is_crtp_base_of_impl<B, std::decay_t<E>>;
+
     template <class E>
-    using is_xexpression = detail::is_xexpression_impl<E>;
+    using is_xexpression = is_crtp_base_of<xexpression, E>;
 
     template <class E, class R = void>
     using enable_xexpression = typename std::enable_if<is_xexpression<E>::value, R>::type;
@@ -121,6 +182,42 @@ namespace xt
 
     template <class... E>
     using has_xexpression = xtl::disjunction<is_xexpression<E>...>;
+
+    template <class E>
+    using is_xsharable_expression = is_crtp_base_of<xsharable_expression, E>;
+
+    template <class E, class R = void>
+    using enable_xsharable_expression = typename std::enable_if<is_xsharable_expression<E>::value, R>::type;
+
+    template <class E, class R = void>
+    using disable_xsharable_expression = typename std::enable_if<!is_xsharable_expression<E>::value, R>::type;
+
+    /***********************
+     * evaluation_strategy *
+     ***********************/
+
+    namespace detail
+    {
+        struct option_base {};
+    }
+
+    namespace evaluation_strategy
+    {
+
+        struct immediate_type : xt::detail::option_base {};
+        constexpr auto immediate = std::tuple<immediate_type>{};
+        struct lazy_type : xt::detail::option_base {};
+        constexpr auto lazy = std::tuple<lazy_type>{};
+
+        /*
+        struct cached {};
+        */
+    }
+
+    template <class T>
+    struct is_evaluation_strategy : std::is_base_of<detail::option_base, std::decay_t<T>>
+    {
+    };
 
     /************
      * xclosure *
@@ -133,6 +230,12 @@ namespace xt
     struct xclosure
     {
         using type = xtl::closure_type_t<E>;
+    };
+
+    template <class E>
+    struct xclosure<xshared_expression<E>, std::enable_if_t<true>>
+    {
+        using type = xshared_expression<E>; // force copy
     };
 
     template <class E>
@@ -157,40 +260,17 @@ namespace xt
     };
 
     template <class E>
-    using const_xclosure_t = typename const_xclosure<E>::type;
-
-    /***************
-     * xvalue_type *
-     ***************/
-
-    namespace detail
+    struct const_xclosure<xshared_expression<E>&, std::enable_if_t<true>>
     {
-        template <class E, class enable = void>
-        struct xvalue_type_impl
-        {
-            using type = E;
-        };
-
-        template <class E>
-        struct xvalue_type_impl<E, std::enable_if_t<is_xexpression<E>::value>>
-        {
-            using type = typename E::value_type;
-        };
-    }
+        using type = xshared_expression<E>; // force copy
+    };
 
     template <class E>
-    using xvalue_type = detail::xvalue_type_impl<E>;
-
-    template <class E>
-    using xvalue_type_t = typename xvalue_type<E>::type;
-
+    using const_xclosure_t = typename const_xclosure<E>::type;
+ 
     /*************************
      * expression tag system *
      *************************/
-
-    struct xscalar_expression_tag
-    {
-    };
 
     struct xtensor_expression_tag
     {
@@ -200,18 +280,23 @@ namespace xt
     {
     };
 
-    namespace detail
+    namespace extension
     {
         template <class E, class = void_t<int>>
-        struct get_expression_tag
+        struct get_expression_tag_impl
         {
             using type = xtensor_expression_tag;
         };
 
         template <class E>
-        struct get_expression_tag<E, void_t<typename std::decay_t<E>::expression_tag>>
+        struct get_expression_tag_impl<E, void_t<typename std::decay_t<E>::expression_tag>>
         {
             using type = typename std::decay_t<E>::expression_tag;
+        };
+
+        template <class E>
+        struct get_expression_tag : get_expression_tag_impl<E>
+        {
         };
 
         template <class E>
@@ -219,6 +304,12 @@ namespace xt
 
         template <class... T>
         struct expression_tag_and;
+
+        template <>
+        struct expression_tag_and<>
+        {
+            using type = xtensor_expression_tag;
+        };
 
         template <class T>
         struct expression_tag_and<T>
@@ -232,34 +323,22 @@ namespace xt
             using type = T;
         };
 
-        template <>
-        struct expression_tag_and<xscalar_expression_tag, xscalar_expression_tag>
-        {
-            using type = xscalar_expression_tag;
-        };
-
         template <class T>
-        struct expression_tag_and<xscalar_expression_tag, T>
+        struct expression_tag_and<xtensor_expression_tag, T>
         {
             using type = T;
         };
 
         template <class T>
-        struct expression_tag_and<T, xscalar_expression_tag>
-            : expression_tag_and<xscalar_expression_tag, T>
+        struct expression_tag_and<T, xtensor_expression_tag>
+            : expression_tag_and<xtensor_expression_tag, T>
         {
         };
 
         template <>
-        struct expression_tag_and<xtensor_expression_tag, xoptional_expression_tag>
+        struct expression_tag_and<xtensor_expression_tag, xtensor_expression_tag>
         {
-            using type = xoptional_expression_tag;
-        };
-
-        template <>
-        struct expression_tag_and<xoptional_expression_tag, xtensor_expression_tag>
-            : expression_tag_and<xtensor_expression_tag, xoptional_expression_tag>
-        {
+            using type = xtensor_expression_tag;
         };
 
         template <class T1, class... T>
@@ -270,12 +349,17 @@ namespace xt
 
         template <class... T>
         using expression_tag_and_t = typename expression_tag_and<T...>::type;
+
+        struct xtensor_empty_base
+        {
+            using expression_tag = xtensor_expression_tag;
+        };
     }
 
     template <class... T>
     struct xexpression_tag
     {
-        using type = detail::expression_tag_and_t<detail::get_expression_tag_t<std::decay_t<const_xclosure_t<T>>>...>;
+        using type = extension::expression_tag_and_t<extension::get_expression_tag_t<std::decay_t<const_xclosure_t<T>>>...>;
     };
 
     template <class... T>
@@ -302,6 +386,374 @@ namespace xt
                                                   >
     {
     };
+
+#define XTENSOR_FORWARD_CONST_METHOD(name)                                      \
+    auto name() const                                                           \
+        -> decltype(std::declval<xtl::constify_t<E>>().name())                  \
+    {                                                                           \
+        return m_ptr->name();                                                   \
+    }
+
+#define XTENSOR_FORWARD_METHOD(name)                                            \
+    auto name() -> decltype(std::declval<E>().name())                           \
+    {                                                                           \
+        return m_ptr->name();                                                   \
+    }
+
+#define XTENSOR_FORWARD_CONST_ITERATOR_METHOD(name)                             \
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>                        \
+    auto name() const noexcept                                                  \
+        -> decltype(std::declval<xtl::constify_t<E>>().template name<L>())      \
+    {                                                                           \
+        return m_ptr->template name<L>();                                       \
+    }                                                                           \
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>               \
+    auto name(const S& shape) const noexcept                                    \
+        -> decltype(std::declval<xtl::constify_t<E>>().template name<L>(shape)) \
+    {                                                                           \
+        return m_ptr->template name<L>();                                       \
+    }
+
+#define XTENSOR_FORWARD_ITERATOR_METHOD(name)                                   \
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>               \
+    auto name(const S& shape) noexcept                                          \
+        -> decltype(std::declval<E>().template name<L>(shape))                  \
+    {                                                                           \
+        return m_ptr->template name<L>();                                       \
+    }                                                                           \
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>                        \
+    auto name() noexcept -> decltype(std::declval<E>().template name<L>())      \
+    {                                                                           \
+        return m_ptr->template name<L>();                                       \
+    }                                                                           \
+
+    namespace detail
+    {
+        template <class E>
+        struct expr_strides_type
+        {
+            using type = typename E::strides_type;
+        };
+
+        template <class E>
+        struct expr_inner_strides_type
+        {
+            using type = typename E::inner_strides_type;
+        };
+
+        template <class E>
+        struct expr_backstrides_type
+        {
+            using type = typename E::backstrides_type;
+        };
+
+        template <class E>
+        struct expr_inner_backstrides_type
+        {
+            using type = typename E::inner_backstrides_type;
+        };
+
+        template <class E>
+        struct expr_storage_type
+        {
+            using type = typename E::storage_type;
+        };
+    }
+
+    /**
+     * @class xshared_expression
+     * @brief Shared xexpressions
+     *
+     * Due to C++ lifetime constraints it's sometimes necessary to create shared
+     * expressions (akin to a shared pointer).
+     *
+     * For example, when a temporary expression needs to be used twice in another
+     * expression, shared expressions can come to the rescue:
+     *
+     * \code{.cpp}
+     * template <class E>
+     * auto cos_plus_sin(xexpression<E>&& expr)
+     * {
+     *     // THIS IS WRONG: forwarding rvalue twice not permitted!
+     *     // return xt::sin(std::forward<E>(expr)) + xt::cos(std::forward<E>(expr));
+     *     // THIS IS WRONG TOO: because second `expr` is taken as reference (which will be invalid)
+     *     // return xt::sin(std::forward<E>(expr)) + xt::cos(expr)
+     *     auto shared_expr = xt::make_xshared(std::forward<E>(expr));
+     *     auto result = xt::sin(shared_expr) + xt::cos(shared_expr);
+     *     std::cout << shared_expr.use_count() << std::endl; // Will print 3 because used twice in expression
+     *     return result; // all valid because expr lifetime managed by xshared_expression / shared_ptr.
+     * }
+     * \endcode
+     */
+    template <class E>
+    class xshared_expression
+        : public xexpression<xshared_expression<E>>
+    {
+    public:
+
+        using base_class = xexpression<xshared_expression<E>>;
+
+        using value_type = typename E::value_type;
+        using reference = typename E::reference;
+        using const_reference = typename E::const_reference;
+        using pointer = typename E::pointer;
+        using const_pointer = typename E::const_pointer;
+        using size_type = typename E::size_type;
+        using difference_type = typename E::difference_type;
+
+        using inner_shape_type = typename E::inner_shape_type;
+        using shape_type = typename E::shape_type;
+
+        using strides_type = xtl::mpl::eval_if_t<has_strides<E>,
+                                                 detail::expr_strides_type<E>,
+                                                 get_strides_type<shape_type>>;
+        using backstrides_type = xtl::mpl::eval_if_t<has_strides<E>,
+                                                     detail::expr_backstrides_type<E>,
+                                                     get_strides_type<shape_type>>;
+        using inner_strides_type = xtl::mpl::eval_if_t<has_strides<E>,
+                                                       detail::expr_inner_strides_type<E>,
+                                                       get_strides_type<shape_type>>;
+        using inner_backstrides_type = xtl::mpl::eval_if_t<has_strides<E>,
+                                                           detail::expr_inner_backstrides_type<E>,
+                                                           get_strides_type<shape_type>>;
+        using storage_type = xtl::mpl::eval_if_t<has_data_interface<E>,
+                                                 detail::expr_storage_type<E>,
+                                                 make_invalid_type<>>;
+
+        using stepper = typename E::stepper;
+        using const_stepper = typename E::const_stepper;
+
+        using storage_iterator = typename E::storage_iterator;
+        using const_storage_iterator = typename E::const_storage_iterator;
+
+        using bool_load_type = typename E::bool_load_type;
+
+        static constexpr layout_type static_layout = E::static_layout;
+        static constexpr bool contiguous_layout = static_layout != layout_type::dynamic;
+
+        explicit xshared_expression(const std::shared_ptr<E>& ptr);
+        long use_count() const noexcept;
+
+        template <class... Args>
+        auto operator()(Args... args)
+            -> decltype(std::declval<E>()(args...))
+        {
+            return m_ptr->operator()(args...);
+        }
+
+        XTENSOR_FORWARD_CONST_METHOD(shape)
+        XTENSOR_FORWARD_CONST_METHOD(dimension)
+        XTENSOR_FORWARD_CONST_METHOD(size)
+        XTENSOR_FORWARD_CONST_METHOD(layout)
+
+        XTENSOR_FORWARD_ITERATOR_METHOD(begin)
+        XTENSOR_FORWARD_ITERATOR_METHOD(end)
+        XTENSOR_FORWARD_CONST_ITERATOR_METHOD(begin)
+        XTENSOR_FORWARD_CONST_ITERATOR_METHOD(end)
+        XTENSOR_FORWARD_CONST_ITERATOR_METHOD(cbegin)
+        XTENSOR_FORWARD_CONST_ITERATOR_METHOD(cend)
+
+        XTENSOR_FORWARD_ITERATOR_METHOD(rbegin)
+        XTENSOR_FORWARD_ITERATOR_METHOD(rend)
+        XTENSOR_FORWARD_CONST_ITERATOR_METHOD(rbegin)
+        XTENSOR_FORWARD_CONST_ITERATOR_METHOD(rend)
+        XTENSOR_FORWARD_CONST_ITERATOR_METHOD(crbegin)
+        XTENSOR_FORWARD_CONST_ITERATOR_METHOD(crend)
+        
+        XTENSOR_FORWARD_METHOD(storage_begin)
+        XTENSOR_FORWARD_METHOD(storage_end)
+        XTENSOR_FORWARD_CONST_METHOD(storage_begin)
+        XTENSOR_FORWARD_CONST_METHOD(storage_end)
+        XTENSOR_FORWARD_CONST_METHOD(storage_cbegin)
+        XTENSOR_FORWARD_CONST_METHOD(storage_cend)
+        
+        XTENSOR_FORWARD_METHOD(storage_rbegin)
+        XTENSOR_FORWARD_METHOD(storage_rend)
+        XTENSOR_FORWARD_CONST_METHOD(storage_rbegin)
+        XTENSOR_FORWARD_CONST_METHOD(storage_rend)
+        XTENSOR_FORWARD_CONST_METHOD(storage_crbegin)
+        XTENSOR_FORWARD_CONST_METHOD(storage_crend)
+
+        template <class T = E>
+        std::enable_if_t<has_strides<T>::value, const inner_strides_type&>
+        strides() const
+        {
+            return m_ptr->strides();
+        }
+
+        template <class T = E>
+        std::enable_if_t<has_strides<T>::value, const inner_strides_type&>
+        backstrides() const
+        {
+            return m_ptr->backstrides();
+        }
+
+        template <class T = E>
+        std::enable_if_t<has_data_interface<T>::value, pointer>
+        data() noexcept
+        {
+            return m_ptr->data();
+        }
+
+        template <class T = E>
+        std::enable_if_t<has_data_interface<T>::value, pointer>
+        data() const noexcept
+        {
+            return m_ptr->data();
+        }
+
+        template <class T = E>
+        std::enable_if_t<has_data_interface<T>::value, size_type>
+        data_offset() const noexcept
+        {
+            return m_ptr->data_offset();
+        }
+
+        template <class T = E>
+        std::enable_if_t<has_data_interface<T>::value, typename T::storage_type&>
+        storage() noexcept
+        {
+            return m_ptr->storage();
+        }
+
+        template <class T = E>
+        std::enable_if_t<has_data_interface<T>::value, const typename T::storage_type&>
+        storage() const noexcept
+        {
+            return m_ptr->storage();
+        }
+
+        template <class It>
+        reference element(It first, It last) {
+            return m_ptr->element(first, last);
+        }
+
+        template <class It>
+        const_reference element(It first, It last) const {
+            return m_ptr->element(first, last);
+        }
+
+        template <class S>
+        bool broadcast_shape(S& shape, bool reuse_cache = false) const
+        {
+            return m_ptr->broadcast_shape(shape, reuse_cache);
+        }
+
+        template <class S>
+        bool has_linear_assign(const S& strides) const noexcept
+        {
+            return m_ptr->has_linear_assign(strides);
+        }
+
+        template <class S>
+        auto stepper_begin(const S& shape) noexcept
+            -> decltype(std::declval<E>().stepper_begin(shape))
+        {
+            return m_ptr->stepper_begin(shape);
+        }
+
+        template <class S>
+        auto stepper_end(const S& shape, layout_type l) noexcept
+            -> decltype(std::declval<E>().stepper_end(shape, l))
+        {
+            return m_ptr->stepper_end(shape, l);
+        }
+
+        template <class S>
+        auto stepper_begin(const S& shape) const noexcept
+            -> decltype(std::declval<const E>().stepper_begin(shape))
+        {
+            return static_cast<const E*>(m_ptr.get())->stepper_begin(shape);
+        }
+        template <class S>
+        auto stepper_end(const S& shape, layout_type l) const noexcept
+            -> decltype(std::declval<const E>().stepper_end(shape, l))
+        {
+            return static_cast<const E*>(m_ptr.get())->stepper_end(shape, l);
+        }
+
+    private:
+
+        std::shared_ptr<E> m_ptr;
+    };
+
+    /**
+     * Constructor for xshared expression (note: usually the free function
+     * `make_xshared` is recommended).
+     *
+     * @param ptr shared ptr that contains the expression
+     * @sa make_xshared
+     */
+    template <class E>
+    inline xshared_expression<E>::xshared_expression(const std::shared_ptr<E>& ptr)
+        : m_ptr(ptr)
+    {
+    }
+
+    /**
+     * Return the number of times this expression is referenced.
+     * Internally calls the use_count() function of the std::shared_ptr.
+     */
+    template <class E>
+    inline long xshared_expression<E>::use_count() const noexcept
+    {
+        return m_ptr.use_count();
+    }
+
+    namespace detail
+    {
+        template <class E>
+        inline xshared_expression<E> make_xshared_impl(xsharable_expression<E>&& expr)
+        {
+            if(expr.p_shared == nullptr)
+            {
+                expr.p_shared = std::make_shared<E>(std::move(expr).derived_cast());
+            }
+            return xshared_expression<E>(expr.p_shared);
+        }
+    }
+
+    /**
+     * Helper function to create shared expression from any xexpression
+     *
+     * @param expr rvalue expression that will be shared
+     * @return xshared expression
+     */
+    template <class E>
+    inline xshared_expression<E> make_xshared(xexpression<E>&& expr)
+    {
+        static_assert(is_xsharable_expression<E>::value, "make_shared requires E to inherit from xsharable_expression");
+        return detail::make_xshared_impl(std::move(expr.derived_cast()));
+    }
+
+    /**
+     * Helper function to create shared expression from any xexpression
+     *
+     * @param expr rvalue expression that will be shared
+     * @return xshared expression
+     * @sa make_xshared
+     */
+    template <class E>
+    inline auto share(xexpression<E>& expr)
+    {
+        return make_xshared(std::move(expr));
+    }
+
+    /**
+     * Helper function to create shared expression from any xexpression
+     *
+     * @param expr rvalue expression that will be shared
+     * @return xshared expression
+     * @sa make_xshared
+     */
+    template <class E>
+    inline auto share(xexpression<E>&& expr)
+    {
+        return make_xshared(std::move(expr));
+    }
+
+#undef XTENSOR_FORWARD_METHOD
+
 }
 
 #endif

--- a/vendor/xtensor/include/xtensor/xexpression_holder.hpp
+++ b/vendor/xtensor/include/xtensor/xexpression_holder.hpp
@@ -1,0 +1,281 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_XEXPRESSION_HOLDER_HPP
+#define XTENSOR_XEXPRESSION_HOLDER_HPP
+
+#include <nlohmann/json.hpp>
+
+#include "xtl/xany.hpp"
+
+#include "xarray.hpp"
+#include "xjson.hpp"
+
+namespace xt
+{
+
+    namespace detail
+    {
+        class xexpression_holder_impl;
+
+        template <class CTE>
+        class xexpression_wrapper;
+    }
+
+    class xexpression_holder // Value semantic
+    {
+    public:
+
+        using implementation_type = detail::xexpression_holder_impl;
+
+        xexpression_holder();
+
+        template <class E>
+        xexpression_holder(E&& expr);
+
+        xexpression_holder(implementation_type* holder);
+        xexpression_holder(const xexpression_holder& holder);
+        xexpression_holder(xexpression_holder&& holder);
+
+        xexpression_holder& operator=(const xexpression_holder&);
+        xexpression_holder& operator=(xexpression_holder&&);
+
+        void swap(xexpression_holder&);
+
+        void to_json(nlohmann::json&) const;
+        void from_json(const nlohmann::json&);
+
+        ~xexpression_holder();
+
+    private:
+
+        void init_pointer_from_json(const nlohmann::json&);
+        void check_holder() const;
+
+        implementation_type* p_holder;
+    };
+
+    /*************************************
+     * to_json and from_json declaration *
+     *************************************/
+
+    /// @cond DOXYGEN_INCLUDE_SFINAE
+    void to_json(nlohmann::json& j, const xexpression_holder& o);
+    void from_json(const nlohmann::json& j, xexpression_holder& o);
+    /// @endcond
+
+    namespace detail
+    {
+        class xexpression_holder_impl // Entity semantic
+        {
+        public:
+
+            xexpression_holder_impl(xexpression_holder_impl&&) = delete;
+
+            xexpression_holder_impl& operator=(const xexpression_holder_impl&) = delete;
+            xexpression_holder_impl& operator=(xexpression_holder_impl&&) = delete;
+
+            virtual xexpression_holder_impl* clone() const = 0;
+            virtual void to_json(nlohmann::json&) const = 0;
+            virtual void from_json(const nlohmann::json&) = 0;
+            virtual ~xexpression_holder_impl() = default;
+
+        protected:
+
+            xexpression_holder_impl() = default;
+            xexpression_holder_impl(const xexpression_holder_impl&) = default;
+        };
+
+        template <class CTE>
+        class xexpression_wrapper : public xexpression_holder_impl
+        {
+        public:
+            template <class E>
+            xexpression_wrapper(E&& expr);
+
+            xexpression_wrapper* clone() const;
+
+            void to_json(nlohmann::json&) const;
+            void from_json(const nlohmann::json&);
+
+            ~xexpression_wrapper() = default;
+
+        protected:
+
+            xexpression_wrapper(const xexpression_wrapper&);
+
+        private:
+
+            CTE m_expression;
+        };
+    }
+
+    inline xexpression_holder::xexpression_holder()
+        : p_holder(nullptr)
+    {
+    }
+
+    template <class E>
+    inline xexpression_holder::xexpression_holder(E&& expr)
+        : p_holder(new detail::xexpression_wrapper<E>(std::forward<E>(expr)))
+    {
+    }
+
+    inline xexpression_holder::xexpression_holder(implementation_type* holder)
+        : p_holder(holder)
+    {
+    }
+
+    inline xexpression_holder::xexpression_holder(const xexpression_holder& holder)
+        : p_holder(holder.p_holder->clone())
+    {
+    }
+
+    inline xexpression_holder::xexpression_holder(xexpression_holder&& holder)
+        : p_holder(holder.p_holder)
+    {
+        holder.p_holder = nullptr;
+    }
+
+    inline xexpression_holder& xexpression_holder::operator=(const xexpression_holder& holder)
+    {
+        xexpression_holder tmp(holder);
+        swap(tmp);
+        return *this;
+    }
+
+    inline xexpression_holder& xexpression_holder::operator=(xexpression_holder&& holder)
+    {
+        swap(holder);
+        return *this;
+    }
+
+    inline void xexpression_holder::swap(xexpression_holder& holder)
+    {
+        std::swap(p_holder, holder.p_holder);
+    }
+
+    inline void xexpression_holder::to_json(nlohmann::json& j) const
+    {
+        if (p_holder == nullptr)
+        {
+            return;
+        }
+        p_holder->to_json(j);
+    }
+
+    inline void xexpression_holder::from_json(const nlohmann::json& j)
+    {
+        if (!j.is_array())
+        {
+            throw std::runtime_error("Received a JSON that does not contain a tensor");
+        }
+
+        if (p_holder == nullptr)
+        {
+            init_pointer_from_json(j);
+        }
+        p_holder->from_json(j);
+    }
+
+    inline void xexpression_holder::init_pointer_from_json(const nlohmann::json& j)
+    {
+        if (j.is_array())
+        {
+            return init_pointer_from_json(j[0]);
+        }
+
+        if (j.is_number())
+        {
+            xt::xarray<double> empty_arr;
+            p_holder = new detail::xexpression_wrapper<xt::xarray<double>>(std::move(empty_arr));
+        }
+
+        if (j.is_boolean())
+        {
+            xt::xarray<bool> empty_arr;
+            p_holder = new detail::xexpression_wrapper<xt::xarray<bool>>(std::move(empty_arr));
+        }
+
+        if (j.is_string())
+        {
+            xt::xarray<std::string> empty_arr;
+            p_holder = new detail::xexpression_wrapper<xt::xarray<std::string>>(std::move(empty_arr));
+        }
+
+        throw std::runtime_error("Received a JSON with a tensor that contains unsupported data type");
+    }
+
+    inline void xexpression_holder::check_holder() const
+    {
+        if (p_holder == nullptr)
+        {
+            throw std::runtime_error("The holder does not contain an expression");
+        }
+    }
+
+    inline xexpression_holder::~xexpression_holder()
+    {
+        delete p_holder;
+    }
+
+    /****************************************
+     * to_json and from_json implementation *
+     ****************************************/
+
+    /// @cond DOXYGEN_INCLUDE_SFINAE
+    inline void to_json(nlohmann::json& j, const xexpression_holder& o)
+    {
+        o.to_json(j);
+    }
+
+    inline void from_json(const nlohmann::json& j, xexpression_holder& o)
+    {
+        o.from_json(j);
+    }
+    /// @endcond
+
+    namespace detail
+    {
+        template <class CTE>
+        template <class E>
+        inline xexpression_wrapper<CTE>::xexpression_wrapper(E&& expr)
+            : xexpression_holder_impl(),
+              m_expression(std::forward<E>(expr))
+        {
+        }
+
+        template <class CTE>
+        inline xexpression_wrapper<CTE>* xexpression_wrapper<CTE>::clone() const
+        {
+            return new xexpression_wrapper<CTE>(*this);
+        }
+
+        template <class CTE>
+        inline void xexpression_wrapper<CTE>::to_json(nlohmann::json& j) const
+        {
+            ::xt::to_json(j, m_expression);
+        }
+
+        template <class CTE>
+        inline void xexpression_wrapper<CTE>::from_json(const nlohmann::json& j)
+        {
+            ::xt::from_json(j, m_expression);
+        }
+
+        template <class CTE>
+        inline xexpression_wrapper<CTE>::xexpression_wrapper(const xexpression_wrapper& wrapper)
+            : xexpression_holder_impl(),
+              m_expression(wrapper.m_expression)
+        {
+        }
+    }
+}
+
+#endif

--- a/vendor/xtensor/include/xtensor/xexpression_traits.hpp
+++ b/vendor/xtensor/include/xtensor/xexpression_traits.hpp
@@ -1,0 +1,166 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_EXPRESSION_TRAITS_HPP
+#define XTENSOR_EXPRESSION_TRAITS_HPP
+
+#include "xexpression.hpp"
+
+namespace xt
+{
+    /***************
+     * xvalue_type *
+     ***************/
+
+    namespace detail
+    {
+        template <class E, class enable = void>
+        struct xvalue_type_impl
+        {
+            using type = E;
+        };
+
+        template <class E>
+        struct xvalue_type_impl<E, std::enable_if_t<is_xexpression<E>::value>>
+        {
+            using type = typename E::value_type;
+        };
+    }
+
+    template <class E>
+    using xvalue_type = detail::xvalue_type_impl<E>;
+
+    template <class E>
+    using xvalue_type_t = typename xvalue_type<E>::type;
+
+    /*********************
+     * common_value_type *
+     *********************/
+
+    template <class... C>
+    struct common_value_type
+    {
+        using type = std::common_type_t<typename std::decay_t<C>::value_type...>;
+    };
+
+    template <class... C>
+    using common_value_type_t = typename common_value_type<C...>::type;
+    
+    /********************
+     * common_size_type *
+     ********************/
+
+    template <class... Args>
+    struct common_size_type
+    {
+        using type = std::common_type_t<typename Args::size_type...>;
+    };
+
+    template <>
+    struct common_size_type<>
+    {
+        using type = std::size_t;
+    };
+
+    template <class... Args>
+    using common_size_type_t = typename common_size_type<Args...>::type;
+
+    /**************************
+     * common_difference type *
+     **************************/
+
+    template <class... Args>
+    struct common_difference_type
+    {
+        using type = std::common_type_t<typename Args::difference_type...>;
+    };
+
+    template <>
+    struct common_difference_type<>
+    {
+        using type = std::ptrdiff_t;
+    };
+
+    template <class... Args>
+    using common_difference_type_t = typename common_difference_type<Args...>::type;
+    
+    /******************
+     * temporary_type *
+     ******************/
+
+    namespace detail
+    {
+        template <class S>
+        struct xtype_for_shape
+        {
+            template <class T, layout_type L>
+            using type = xarray<T, L>;
+        };
+
+#if defined(__GNUC__) && (__GNUC__ > 6)
+#if __cplusplus == 201703L 
+        template <template <class, std::size_t, class, bool> class S, class X, std::size_t N, class A, bool Init>
+        struct xtype_for_shape<S<X, N, A, Init>>
+        {
+            template <class T, layout_type L>
+            using type = xarray<T, L>;
+        };
+#endif // __cplusplus == 201703L
+#endif // __GNUC__ && (__GNUC__ > 6)
+
+        template <template <class, std::size_t> class S, class X, std::size_t N>
+        struct xtype_for_shape<S<X, N>>
+        {
+            template <class T, layout_type L>
+            using type = xtensor<T, N, L>;
+        };
+
+        template <template <std::size_t...> class S, std::size_t... X>
+        struct xtype_for_shape<S<X...>>
+        {
+            template <class T, layout_type L>
+            using type = xtensor_fixed<T, xshape<X...>, L>;
+        };
+    }
+    
+    template <class T, class S, layout_type L>
+    struct temporary_type
+    {
+        using type = typename detail::xtype_for_shape<S>::template type<T, L>;
+    };
+
+    template <class T, class S, layout_type L>
+    using temporary_type_t = typename temporary_type<T, S, L>::type;
+
+    /**********************
+     * common_tensor_type *
+     **********************/
+
+    namespace detail
+    {
+        template <class... C>
+        struct common_tensor_type_impl
+        {
+            static constexpr layout_type static_layout = compute_layout(std::decay_t<C>::static_layout...);
+            using type = temporary_type_t<common_value_type_t<C...>,
+                                          promote_shape_t<typename C::shape_type...>,
+                                          static_layout>;
+        };
+    }
+
+    template <class... C>
+    struct common_tensor_type : detail::common_tensor_type_impl<std::decay_t<C>...>
+    {
+    };
+
+    template <class... C>
+    using common_tensor_type_t = typename common_tensor_type<C...>::type;
+}
+
+#endif

--- a/vendor/xtensor/include/xtensor/xfunction.hpp
+++ b/vendor/xtensor/include/xtensor/xfunction.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -20,173 +21,170 @@
 #include <xtl/xsequence.hpp>
 #include <xtl/xtype_traits.hpp>
 
-#include "xexpression.hpp"
+#include "xaccessible.hpp"
+#include "xexpression_traits.hpp"
 #include "xiterable.hpp"
 #include "xlayout.hpp"
 #include "xscalar.hpp"
+#include "xshape.hpp"
 #include "xstrides.hpp"
 #include "xtensor_simd.hpp"
 #include "xutils.hpp"
 
 namespace xt
 {
-
     namespace detail
     {
-
-        /********************
-         * common_size_type *
-         ********************/
-
-        template <class... Args>
-        struct common_size_type
-        {
-            using type = std::common_type_t<typename Args::size_type...>;
-        };
-
-        template <>
-        struct common_size_type<>
-        {
-            using type = std::size_t;
-        };
-
-        template <class... Args>
-        using common_size_type_t = typename common_size_type<Args...>::type;
 
         template <bool... B>
         using conjunction_c = xtl::conjunction<std::integral_constant<bool, B>...>;
 
-        /**************************
-         * common_difference type *
-         **************************/
+        /************************
+         * xfunction_cache_impl *
+         ************************/
 
-        template <class... Args>
-        struct common_difference_type
+        template<class S, class is_shape_trivial>
+        struct xfunction_cache_impl
         {
-            using type = std::common_type_t<typename Args::difference_type...>;
+            S shape;
+            bool is_trivial;
+            bool is_initialized;
+
+            xfunction_cache_impl() : shape(xtl::make_sequence<S>(0, std::size_t(0))), is_initialized(false) {}
         };
 
-        template <>
-        struct common_difference_type<>
+        template<std::size_t... N, class is_shape_trivial>
+        struct xfunction_cache_impl<fixed_shape<N...>, is_shape_trivial>
         {
-            using type = std::ptrdiff_t;
+            XTENSOR_CONSTEXPR_ENHANCED_STATIC fixed_shape<N...> shape = fixed_shape<N...>();
+            XTENSOR_CONSTEXPR_ENHANCED_STATIC bool is_trivial = is_shape_trivial::value;
+            XTENSOR_CONSTEXPR_ENHANCED_STATIC bool is_initialized = true;
         };
 
-        template <class... Args>
-        using common_difference_type_t = typename common_difference_type<Args...>::type;
+        #ifdef XTENSOR_HAS_CONSTEXPR_ENHANCED
+            // Out of line definitions to prevent linker errors prior to C++17
+            template <std::size_t... N, class is_shape_trivial>
+            constexpr fixed_shape<N...> xfunction_cache_impl<fixed_shape<N...>, is_shape_trivial>::shape;
 
-        /*********************
-         * common_value_type *
-         *********************/
+            template <std::size_t... N, class is_shape_trivial>
+            constexpr bool xfunction_cache_impl<fixed_shape<N...>, is_shape_trivial>::is_trivial;
 
-        template <class... Args>
-        struct common_value_type
-        {
-            using type = promote_type_t<xvalue_type_t<Args>...>;
-        };
-
-        template <class... Args>
-        using common_value_type_t = typename common_value_type<Args...>::type;
-
-        template <class F, class CST, class R, class = void_t<>>
-        struct simd_return_type
-        {
-        };
-
-        template <class F, class CST, class R>
-        struct simd_return_type<F, CST, R, void_t<decltype(&F::template simd_apply<CST>)>>
-        {
-            using type = xsimd::simd_type<xsimd::simd_return_type<CST, R>>;
-        };
-
-        template <class F, class CST, class R>
-        using simd_return_type_t = typename simd_return_type<F, CST, R>::type;
-
-        template <class T, class R>
-        struct functor_return_type
-        {
-            using type = R;
-            using simd_type = xsimd::simd_type<T>;
-        };
-
-        template <class T>
-        struct functor_return_type<T, std::complex<T>>
-        {
-            using type = std::complex<T>;
-            using simd_type = xsimd::simd_type<std::complex<T>>;
-        };
-
-        template <class T>
-        struct functor_return_type<T, bool>
-        {
-            using type = bool;
-            using simd_type = xsimd::simd_bool_type<T>;
-        };
-
-        template <>
-        struct functor_return_type<void, bool>
-        {
-            using type = bool;
-            using simd_type = bool;
-        };
+            template <std::size_t... N, class is_shape_trivial>
+            constexpr bool xfunction_cache_impl<fixed_shape<N...>, is_shape_trivial>::is_initialized;
+        #endif
     }
 
-    template <class F, class R, class... CT>
+    /************************
+     * xfunction extensions *
+     ************************/
+
+    namespace extension
+    {
+
+        template <class Tag, class F, class... CT>
+        struct xfunction_base_impl;
+
+        template <class F, class... CT>
+        struct xfunction_base_impl<xtensor_expression_tag, F, CT...>
+        {
+            using type = xtensor_empty_base;
+        };
+
+        template <class F, class... CT>
+        struct xfunction_base
+            : xfunction_base_impl<xexpression_tag_t<CT...>, F, CT...>
+        {
+        };
+
+        template <class F, class... CT>
+        using xfunction_base_t = typename xfunction_base<F, CT...>::type;
+    }
+
+    template<class promote>
+    struct xfunction_cache : detail::xfunction_cache_impl<typename promote::type, promote> {};
+
+    template <class F, class... CT>
     class xfunction_iterator;
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     class xfunction_stepper;
 
-    template <class F, class R, class... CT>
-    class xfunction_base;
+    template <class F, class... CT>
+    class xfunction;
 
-    template <class F, class R, class... CT>
-    struct xiterable_inner_types<xfunction_base<F, R, CT...>>
+    template <class F, class... CT>
+    struct xiterable_inner_types<xfunction<F, CT...>>
     {
         using inner_shape_type = promote_shape_t<typename std::decay_t<CT>::shape_type...>;
-        using const_stepper = xfunction_stepper<F, R, CT...>;
+        using const_stepper = xfunction_stepper<F, CT...>;
         using stepper = const_stepper;
     };
 
-    /******************
-     * xfunction_base *
-     ******************/
+    template <class F, class... CT>
+    struct xcontainer_inner_types<xfunction<F, CT...>>
+    {
+        // Added indirection for MSVC 2017 bug with the operator value_type()
+        using value_type = typename meta_identity<decltype(std::declval<F>()(std::declval<xvalue_type_t<std::decay_t<CT>>>()...))>::type;
+        using reference = value_type;
+        using const_reference = value_type;
+        using size_type = common_size_type_t<std::decay_t<CT>...>;
+    };
 
-#define DL XTENSOR_DEFAULT_LAYOUT
+    template <class T, class F, class... CT>
+    struct has_simd_interface<xfunction<F, CT...>, T>
+        : xtl::conjunction<has_simd_type<T>,
+                           has_simd_apply<F, xt_simd::simd_type<T>>,
+                           has_simd_interface<std::decay_t<CT>, T>...>
+    {
+    };
+                            
+    /*************
+     * xfunction *
+     *************/
 
     /**
-     * @class xfunction_base
-     * @brief Base class for multidimensional function operating on
-     * xexpression.
+     * @class xfunction
+     * @brief Multidimensional function operating on
+     * xtensor expressions.
      *
-     * The xfunction_base class implements a multidimensional function
-     * operating on xexpression. Inheriting classes specify which
-     * kind of xexpression the xfunction_base operates on.
+     * The xfunction class implements a multidimensional function
+     * operating on xtensor expressions.
      *
      * @tparam F the function type
-     * @tparam R the return type of the function
      * @tparam CT the closure types for arguments of the function
      */
-    template <class F, class R, class... CT>
-    class xfunction_base : private xconst_iterable<xfunction_base<F, R, CT...>>
+    template <class F, class... CT>
+    class xfunction : private xconst_iterable<xfunction<F, CT...>>,
+                      public xsharable_expression<xfunction<F, CT...>>,
+                      private xconst_accessible<xfunction<F, CT...>>,
+                      public extension::xfunction_base_t<F, CT...>
     {
     public:
 
-        using self_type = xfunction_base<F, R, CT...>;
+        using self_type = xfunction<F, CT...>;
+        using accessible_base = xconst_accessible<self_type>;
+        using extension_base = extension::xfunction_base_t<F, CT...>;
+        using expression_tag = typename extension_base::expression_tag;
         using only_scalar = all_xscalar<CT...>;
         using functor_type = typename std::remove_reference<F>::type;
         using tuple_type = std::tuple<CT...>;
 
-        using value_type = R;
-        using reference = value_type;
-        using const_reference = value_type;
+        using inner_types = xcontainer_inner_types<self_type>;
+        using value_type = typename inner_types::value_type;
+        using reference = typename inner_types::reference;
+        using const_reference = typename inner_types::const_reference;
         using pointer = value_type*;
         using const_pointer = const value_type*;
-        using size_type = detail::common_size_type_t<std::decay_t<CT>...>;
-        using difference_type = detail::common_difference_type_t<std::decay_t<CT>...>;
-        using simd_value_type = typename detail::functor_return_type<detail::common_value_type_t<std::decay_t<CT>...>, R>::simd_type;
-        using simd_argument_type = xsimd::simd_type<detail::common_value_type_t<std::decay_t<CT>...>>;
-        using iterable_base = xconst_iterable<xfunction_base<F, R, CT...>>;
+        using size_type = typename inner_types::size_type;
+        using difference_type = common_difference_type_t<std::decay_t<CT>...>;
+
+        using simd_value_type = xt_simd::simd_type<value_type>;
+        using bool_load_type = xtl::promote_type_t<typename std::decay_t<CT>::bool_load_type...>;
+
+        template <class requested_type>
+        using simd_return_type = xt_simd::simd_return_type<value_type, requested_type>;
+
+        using iterable_base = xconst_iterable<xfunction<F, CT...>>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
         using shape_type = inner_shape_type;
 
@@ -214,7 +212,7 @@ namespace xt
         template <class S, layout_type L>
         using const_reverse_broadcast_iterator = typename iterable_base::template const_reverse_broadcast_iterator<S, L>;
 
-        using const_storage_iterator = xfunction_iterator<F, R, CT...>;
+        using const_storage_iterator = xfunction_iterator<F, CT...>;
         using storage_iterator = const_storage_iterator;
         using const_reverse_storage_iterator = std::reverse_iterator<const_storage_iterator>;
         using reverse_storage_iterator = std::reverse_iterator<storage_iterator>;
@@ -224,25 +222,33 @@ namespace xt
         using reverse_iterator = typename iterable_base::reverse_iterator;
         using const_reverse_iterator = typename iterable_base::const_reverse_iterator;
 
-        size_type size() const noexcept;
+        template <class Func, class... CTA, class U = std::enable_if_t<!std::is_base_of<std::decay_t<Func>, self_type>::value>>
+        xfunction(Func&& f, CTA&&... e) noexcept;
+
+        ~xfunction() = default;
+
+        xfunction(const xfunction&) = default;
+        xfunction& operator=(const xfunction&) = default;
+
+        xfunction(xfunction&&) = default;
+        xfunction& operator=(xfunction&&) = default;
+
+        using accessible_base::size;
         size_type dimension() const noexcept;
-        const shape_type& shape() const;
+        const inner_shape_type& shape() const;
         layout_type layout() const noexcept;
+        using accessible_base::shape;
 
         template <class... Args>
         const_reference operator()(Args... args) const;
 
         template <class... Args>
-        const_reference at(Args... args) const;
-
-        template <class... Args>
         const_reference unchecked(Args... args) const;
 
-        template <class S>
-        disable_integral_t<S, const_reference> operator[](const S& index) const;
-        template <class I>
-        const_reference operator[](std::initializer_list<I> index) const;
-        const_reference operator[](size_type i) const;
+        using accessible_base::at;
+        using accessible_base::operator[];
+        using accessible_base::periodic;
+        using accessible_base::in_bounds;
 
         template <class It>
         const_reference element(It first, It last) const;
@@ -251,7 +257,7 @@ namespace xt
         bool broadcast_shape(S& shape, bool reuse_cache = false) const;
 
         template <class S>
-        bool is_trivial_broadcast(const S& strides) const noexcept;
+        bool has_linear_assign(const S& strides) const noexcept;
 
         using iterable_base::begin;
         using iterable_base::end;
@@ -262,22 +268,14 @@ namespace xt
         using iterable_base::crbegin;
         using iterable_base::crend;
 
-        template <layout_type L = DL>
         const_storage_iterator storage_begin() const noexcept;
-        template <layout_type L = DL>
         const_storage_iterator storage_end() const noexcept;
-        template <layout_type L = DL>
         const_storage_iterator storage_cbegin() const noexcept;
-        template <layout_type L = DL>
         const_storage_iterator storage_cend() const noexcept;
 
-        template <layout_type L = DL>
         const_reverse_storage_iterator storage_rbegin() const noexcept;
-        template <layout_type L = DL>
         const_reverse_storage_iterator storage_rend() const noexcept;
-        template <layout_type L = DL>
         const_reverse_storage_iterator storage_crbegin() const noexcept;
-        template <layout_type L = DL>
         const_reverse_storage_iterator storage_crend() const noexcept;
 
         template <class S>
@@ -290,23 +288,11 @@ namespace xt
         template <class UT = self_type, class = typename std::enable_if<UT::only_scalar::value>::type>
         operator value_type() const;
 
-        template <class align, class simd = simd_value_type>
-        detail::simd_return_type_t<functor_type, simd_argument_type, simd> load_simd(size_type i) const;
+        template <class align, class requested_type = value_type,
+                  std::size_t N = xt_simd::simd_traits<requested_type>::size>
+        simd_return_type<requested_type> load_simd(size_type i) const;
 
         const tuple_type& arguments() const noexcept;
-
-    protected:
-
-        template <class Func, class... CTA, class U = std::enable_if_t<!std::is_base_of<std::decay_t<Func>, self_type>::value>>
-        xfunction_base(Func&& f, CTA&&... e) noexcept;
-
-        ~xfunction_base() = default;
-
-        xfunction_base(const xfunction_base&) = default;
-        xfunction_base& operator=(const xfunction_base&) = default;
-
-        xfunction_base(xfunction_base&&) = default;
-        xfunction_base& operator=(xfunction_base&&) = default;
 
     private:
 
@@ -315,7 +301,7 @@ namespace xt
 
         template <std::size_t... I, class... Args>
         const_reference access_impl(std::index_sequence<I...>, Args... args) const;
-        
+
         template <std::size_t... I, class... Args>
         const_reference unchecked_impl(std::index_sequence<I...>, Args... args) const;
 
@@ -325,79 +311,45 @@ namespace xt
         template <std::size_t... I>
         const_reference data_element_impl(std::index_sequence<I...>, size_type i) const;
 
-        template <class align, class simd, std::size_t... I>
+        template <class align, class requested_type, std::size_t N, std::size_t... I>
         auto load_simd_impl(std::index_sequence<I...>, size_type i) const;
 
         template <class Func, std::size_t... I>
         const_stepper build_stepper(Func&& f, std::index_sequence<I...>) const noexcept;
 
         template <class Func, std::size_t... I>
-        const_storage_iterator build_iterator(Func&& f, std::index_sequence<I...>) const noexcept;
+        auto build_iterator(Func&& f, std::index_sequence<I...>) const noexcept;
 
         size_type compute_dimension() const noexcept;
 
+        void compute_cached_shape() const;
+
         tuple_type m_e;
         functor_type m_f;
-        mutable shape_type m_shape;
-        mutable bool m_shape_trivial;
-        mutable bool m_shape_computed;
+        mutable xfunction_cache<detail::promote_index<typename std::decay_t<CT>::shape_type...>> m_cache;
 
-        friend class xfunction_iterator<F, R, CT...>;
-        friend class xfunction_stepper<F, R, CT...>;
+        friend class xfunction_iterator<F, CT...>;
+        friend class xfunction_stepper<F, CT...>;
         friend class xconst_iterable<self_type>;
+        friend class xconst_accessible<self_type>;
     };
-
-#undef DL
 
     /**********************
      * xfunction_iterator *
      **********************/
 
-    template <class CT>
-    class xscalar;
-
-    namespace detail
-    {
-        template <class C>
-        struct get_iterator_impl
-        {
-            using type = typename C::storage_iterator;
-        };
-
-        template <class C>
-        struct get_iterator_impl<const C>
-        {
-            using type = typename C::const_storage_iterator;
-        };
-
-        template <class CT>
-        struct get_iterator_impl<xscalar<CT>>
-        {
-            using type = typename xscalar<CT>::dummy_iterator;
-        };
-
-        template <class CT>
-        struct get_iterator_impl<const xscalar<CT>>
-        {
-            using type = typename xscalar<CT>::const_dummy_iterator;
-        };
-    }
-
-    template <class C>
-    using get_iterator = typename detail::get_iterator_impl<C>::type;
-
-    template <class F, class R, class... CT>
-    class xfunction_iterator : public xtl::xrandom_access_iterator_base<xfunction_iterator<F, R, CT...>,
-                                                                        typename xfunction_base<F, R, CT...>::value_type,
-                                                                        typename xfunction_base<F, R, CT...>::difference_type,
-                                                                        typename xfunction_base<F, R, CT...>::pointer,
-                                                                        typename xfunction_base<F, R, CT...>::reference>
+    template <class F, class... CT>
+    class xfunction_iterator : public xtl::xrandom_access_iterator_base<xfunction_iterator<F, CT...>,
+                                                                        typename xfunction<F, CT...>::value_type,
+                                                                        typename xfunction<F, CT...>::difference_type,
+                                                                        typename xfunction<F, CT...>::pointer,
+                                                                        typename xfunction<F, CT...>::reference>
     {
     public:
 
-        using self_type = xfunction_iterator<F, R, CT...>;
+        using self_type = xfunction_iterator<F, CT...>;
         using functor_type = typename std::remove_reference<F>::type;
-        using xfunction_type = xfunction_base<F, R, CT...>;
+        using xfunction_type = xfunction<F, CT...>;
 
         using value_type = typename xfunction_type::value_type;
         using reference = typename xfunction_type::value_type;
@@ -423,7 +375,7 @@ namespace xt
 
     private:
 
-        using data_type = std::tuple<get_iterator<const std::decay_t<CT>>...>;
+        using data_type = std::tuple<decltype(linear_begin(std::declval<const std::decay_t<CT>>()))...>;
 
         template <std::size_t... I>
         reference deref_impl(std::index_sequence<I...>) const;
@@ -437,26 +389,26 @@ namespace xt
         data_type m_it;
     };
 
-    template <class F, class R, class... CT>
-    bool operator==(const xfunction_iterator<F, R, CT...>& it1,
-                    const xfunction_iterator<F, R, CT...>& it2);
+    template <class F, class... CT>
+    bool operator==(const xfunction_iterator<F, CT...>& it1,
+                    const xfunction_iterator<F, CT...>& it2);
 
-    template <class F, class R, class... CT>
-    bool operator<(const xfunction_iterator<F, R, CT...>& it1,
-                   const xfunction_iterator<F, R, CT...>& it2);
+    template <class F, class... CT>
+    bool operator<(const xfunction_iterator<F, CT...>& it1,
+                   const xfunction_iterator<F, CT...>& it2);
 
     /*********************
      * xfunction_stepper *
      *********************/
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     class xfunction_stepper
     {
     public:
 
-        using self_type = xfunction_stepper<F, R, CT...>;
+        using self_type = xfunction_stepper<F, CT...>;
         using functor_type = typename std::remove_reference<F>::type;
-        using xfunction_type = xfunction_base<F, R, CT...>;
+        using xfunction_type = xfunction<F, CT...>;
 
         using value_type = typename xfunction_type::value_type;
         using reference = typename xfunction_type::value_type;
@@ -466,8 +418,11 @@ namespace xt
 
         using shape_type = typename xfunction_type::shape_type;
 
-        template <class... It>
-        xfunction_stepper(const xfunction_type* func, It&&... it) noexcept;
+        template <class requested_type>
+        using simd_return_type = xt_simd::simd_return_type<value_type, requested_type>;
+
+        template <class... St>
+        xfunction_stepper(const xfunction_type* func, St&&... st) noexcept;
 
         void step(size_type dim);
         void step_back(size_type dim);
@@ -481,65 +436,25 @@ namespace xt
 
         reference operator*() const;
 
-        template <class ST>
-        ST step_simd();
+        template <class T>
+        simd_return_type<T> step_simd();
 
-        value_type step_leading();
+        void step_leading();
 
     private:
 
         template <std::size_t... I>
         reference deref_impl(std::index_sequence<I...>) const;
 
-        template <class ST, std::size_t... I>
-        ST step_simd_impl(std::index_sequence<I...>);
-
-        template <std::size_t... I>
-        value_type step_leading_impl(std::index_sequence<I...>);
+        template <class T, std::size_t... I>
+        simd_return_type<T> step_simd_impl(std::index_sequence<I...>);
 
         const xfunction_type* p_f;
-        std::tuple<typename std::decay_t<CT>::const_stepper...> m_it;
-    };
-
-    /*************
-     * xfunction *
-     *************/
-
-    /**
-     * @class xfunction
-     * @brief Multidimensional function operating on
-     * xtensor expressions.
-     *
-     * The xfunction class implements a multidimensional function
-     * operating on xtensor expressions.
-     *
-     * @tparam F the function type
-     * @tparam R the return type of the function
-     * @tparam CT the closure types for arguments of the function
-     */
-    template <class F, class R, class... CT>
-    class xfunction : public xfunction_base<F, R, CT...>,
-                      public xexpression<xfunction<F, R, CT...>>
-    {
-    public:
-
-        using self_type = xfunction<F, R, CT...>;
-        using base_type = xfunction_base<F, R, CT...>;
-
-        template <class Func, class... CTA, class U = std::enable_if_t<!std::is_base_of<std::decay_t<Func>, self_type>::value>>
-        xfunction(Func&& f, CTA&&... e) noexcept;
-
-        ~xfunction() = default;
-
-        xfunction(const xfunction&) = default;
-        xfunction& operator=(const xfunction&) = default;
-
-        xfunction(xfunction&&) = default;
-        xfunction& operator=(xfunction&&) = default;
+        std::tuple<typename std::decay_t<CT>::const_stepper...> m_st;
     };
 
     /*********************************
-     * xfunction_base implementation *
+     * xfunction implementation *
      *********************************/
 
     /**
@@ -547,18 +462,15 @@ namespace xt
      */
     //@{
     /**
-     * Constructs an xfunction_base applying the specified function to the given
+     * Constructs an xfunction applying the specified function to the given
      * arguments.
      * @param f the function to apply
      * @param e the \ref xexpression arguments
      */
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <class Func, class... CTA, class U>
-    inline xfunction_base<F, R, CT...>::xfunction_base(Func&& f, CTA&&... e) noexcept
-        : m_e(std::forward<CTA>(e)...), m_f(std::forward<Func>(f)), m_shape(xtl::make_sequence<shape_type>(0, size_type(0))),
-          m_shape_computed(false)
-    {
-    }
+    inline xfunction<F, CT...>::xfunction(Func&& f, CTA&&... e) noexcept
+        : m_e(std::forward<CTA>(e)...), m_f(std::forward<Func>(f)) {}
     //@}
 
     /**
@@ -566,44 +478,47 @@ namespace xt
      */
     //@{
     /**
-     * Returns the size of the expression.
-     */
-    template <class F, class R, class... CT>
-    inline auto xfunction_base<F, R, CT...>::size() const noexcept -> size_type
-    {
-        return compute_size(shape());
-    }
-
-    /**
      * Returns the number of dimensions of the function.
      */
-    template <class F, class R, class... CT>
-    inline auto xfunction_base<F, R, CT...>::dimension() const noexcept -> size_type
+    template <class F, class... CT>
+    inline auto xfunction<F, CT...>::dimension() const noexcept -> size_type
     {
-        size_type dimension = m_shape_computed ? m_shape.size() : compute_dimension();
+        size_type dimension = m_cache.is_initialized ? m_cache.shape.size() : compute_dimension();
         return dimension;
+    }
+
+    template <class F, class... CT>
+    inline void xfunction<F, CT...>::compute_cached_shape() const
+    {
+        static_assert(!detail::is_fixed<shape_type>::value, "Calling compute_cached_shape on fixed!");
+
+        m_cache.shape = uninitialized_shape<xindex_type_t<inner_shape_type>>(compute_dimension());
+        m_cache.is_trivial = broadcast_shape(m_cache.shape, false);
+        m_cache.is_initialized = true;
     }
 
     /**
      * Returns the shape of the xfunction.
      */
-    template <class F, class R, class... CT>
-    inline auto xfunction_base<F, R, CT...>::shape() const -> const shape_type&
+    template <class F, class... CT>
+    inline auto xfunction<F, CT...>::shape() const -> const inner_shape_type&
     {
-        if (!m_shape_computed)
+        xtl::mpl::static_if<!detail::is_fixed<inner_shape_type>::value>([&](auto self)
         {
-            m_shape = xtl::make_sequence<shape_type>(compute_dimension(), size_type(0));
-            m_shape_trivial = broadcast_shape(m_shape, false);
-            m_shape_computed = true;
-        }
-        return m_shape;
+            if(!m_cache.is_initialized)
+            {
+                self(this)->compute_cached_shape();
+            }
+        },
+        [](auto /*self*/){});
+        return m_cache.shape;
     }
 
     /**
      * Returns the layout_type of the xfunction.
      */
-    template <class F, class R, class... CT>
-    inline layout_type xfunction_base<F, R, CT...>::layout() const noexcept
+    template <class F, class... CT>
+    inline layout_type xfunction<F, CT...>::layout() const noexcept
     {
         return layout_impl(std::make_index_sequence<sizeof...(CT)>());
     }
@@ -618,30 +533,13 @@ namespace xt
      * must be unsigned integers, the number of indices should be equal or greater than
      * the number of dimensions of the function.
      */
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <class... Args>
-    inline auto xfunction_base<F, R, CT...>::operator()(Args... args) const -> const_reference
+    inline auto xfunction<F, CT...>::operator()(Args... args) const -> const_reference
     {
         // The static cast prevents the compiler from instantiating the template methods with signed integers,
         // leading to warning about signed/unsigned conversions in the deeper layers of the access methods
         return access_impl(std::make_index_sequence<sizeof...(CT)>(), static_cast<size_type>(args)...);
-    }
-
-    /**
-     * Returns a constant reference to the element at the specified position in the expression,
-     * after dimension and bounds checking.
-     * @param args a list of indices specifying the position in the function. Indices
-     * must be unsigned integers, the number of indices should be equal to the number of dimensions
-     * of the expression.
-     * @exception std::out_of_range if the number of argument is greater than the number of dimensions
-     * or if indices are out of bounds.
-     */
-    template <class F, class R, class... CT>
-    template <class... Args>
-    inline auto xfunction_base<F, R, CT...>::at(Args... args) const -> const_reference
-    {
-        check_access(shape(), static_cast<size_type>(args)...);
-        return this->operator()(args...);
     }
 
     /**
@@ -652,7 +550,7 @@ namespace xt
      *
      * @warning This method is meant for performance, for expressions with a dynamic
      * number of dimensions (i.e. not known at compile time). Since it may have
-     * undefined behavior (see parameters), operator() should be prefered whenever
+     * undefined behavior (see parameters), operator() should be preferred whenever
      * it is possible.
      * @warning This method is NOT compatible with broadcasting, meaning the following
      * code has undefined behavior:
@@ -660,37 +558,16 @@ namespace xt
      * xt::xarray<double> a = {{0, 1}, {2, 3}};
      * xt::xarray<double> b = {0, 1};
      * auto fd = a + b;
-     * double res = fd.uncheked(0, 1);
+     * double res = fd.unchecked(0, 1);
      * \endcode
      */
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <class... Args>
-    inline auto xfunction_base<F, R, CT...>::unchecked(Args... args) const -> const_reference
+    inline auto xfunction<F, CT...>::unchecked(Args... args) const -> const_reference
     {
         // The static cast prevents the compiler from instantiating the template methods with signed integers,
         // leading to warning about signed/unsigned conversions in the deeper layers of the access methods
         return unchecked_impl(std::make_index_sequence<sizeof...(CT)>(), static_cast<size_type>(args)...);
-    }
-
-    template <class F, class R, class... CT>
-    template <class S>
-    inline auto xfunction_base<F, R, CT...>::operator[](const S& index) const
-        -> disable_integral_t<S, const_reference>
-    {
-        return element(index.cbegin(), index.cend());
-    }
-
-    template <class F, class R, class... CT>
-    template <class I>
-    inline auto xfunction_base<F, R, CT...>::operator[](std::initializer_list<I> index) const -> const_reference
-    {
-        return element(index.begin(), index.end());
-    }
-
-    template <class F, class R, class... CT>
-    inline auto xfunction_base<F, R, CT...>::operator[](size_type i) const -> const_reference
-    {
-        return operator()(i);
     }
 
     /**
@@ -700,9 +577,9 @@ namespace xt
      * The number of indices in the sequence should be equal to or greater
      * than the number of dimensions of the container.
      */
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <class It>
-    inline auto xfunction_base<F, R, CT...>::element(It first, It last) const -> const_reference
+    inline auto xfunction<F, CT...>::element(It first, It last) const -> const_reference
     {
         return element_access_impl(std::make_index_sequence<sizeof...(CT)>(), first, last);
     }
@@ -718,14 +595,14 @@ namespace xt
      * @param reuse_cache boolean for reusing a previously computed shape
      * @return a boolean indicating whether the broadcasting is trivial
      */
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <class S>
-    inline bool xfunction_base<F, R, CT...>::broadcast_shape(S& shape, bool reuse_cache) const
+    inline bool xfunction<F, CT...>::broadcast_shape(S& shape, bool reuse_cache) const
     {
-        if (reuse_cache && m_shape_computed)
+        if(m_cache.is_initialized && reuse_cache)
         {
-            std::copy(m_shape.cbegin(), m_shape.cend(), shape.begin());
-            return m_shape_trivial;
+            std::copy(m_cache.shape.cbegin(), m_cache.shape.cend(), shape.begin());
+            return m_cache.is_trivial;
         }
         else
         {
@@ -736,219 +613,174 @@ namespace xt
     }
 
     /**
-     * Compares the specified strides with those of the container to see whether
-     * the broadcasting is trivial.
-     * @return a boolean indicating whether the broadcasting is trivial
-     */
-    template <class F, class R, class... CT>
+    * Checks whether the xfunction can be linearly assigned to an expression
+    * with the specified strides.
+    * @return a boolean indicating whether a linear assign is possible
+    */
+    template <class F, class... CT>
     template <class S>
-    inline bool xfunction_base<F, R, CT...>::is_trivial_broadcast(const S& strides) const noexcept
+    inline bool xfunction<F, CT...>::has_linear_assign(const S& strides) const noexcept
     {
-        auto func = [&strides](bool b, auto&& e) { return b && e.is_trivial_broadcast(strides); };
+        auto func = [&strides](bool b, auto&& e) { return b && e.has_linear_assign(strides); };
         return accumulate(func, true, m_e);
     }
     //@}
 
-    template <class F, class R, class... CT>
-    template <layout_type L>
-    inline auto xfunction_base<F, R, CT...>::storage_begin() const noexcept -> const_storage_iterator
+    template <class F, class... CT>
+    inline auto xfunction<F, CT...>::storage_begin() const noexcept -> const_storage_iterator
     {
-        return storage_cbegin<L>();
+        return storage_cbegin();
     }
 
-    template <class F, class R, class... CT>
-    template <layout_type L>
-    inline auto xfunction_base<F, R, CT...>::storage_end() const noexcept -> const_storage_iterator
+    template <class F, class... CT>
+    inline auto xfunction<F, CT...>::storage_end() const noexcept -> const_storage_iterator
     {
-        return storage_cend<L>();
+        return storage_cend();
     }
 
-    template <class F, class R, class... CT>
-    template <layout_type L>
-    inline auto xfunction_base<F, R, CT...>::storage_cbegin() const noexcept -> const_storage_iterator
+    template <class F, class... CT>
+    inline auto xfunction<F, CT...>::storage_cbegin() const noexcept -> const_storage_iterator
     {
-        auto f = [](const auto& e) noexcept { return detail::trivial_begin(e); };
+        auto f = [](const auto& e) noexcept { return linear_begin(e); };
         return build_iterator(f, std::make_index_sequence<sizeof...(CT)>());
     }
 
-    template <class F, class R, class... CT>
-    template <layout_type L>
-    inline auto xfunction_base<F, R, CT...>::storage_cend() const noexcept -> const_storage_iterator
+    template <class F, class... CT>
+    inline auto xfunction<F, CT...>::storage_cend() const noexcept -> const_storage_iterator
     {
-        auto f = [](const auto& e) noexcept { return detail::trivial_end(e); };
+        auto f = [](const auto& e) noexcept { return linear_end(e); };
         return build_iterator(f, std::make_index_sequence<sizeof...(CT)>());
     }
 
-    template <class F, class R, class... CT>
-    template <layout_type L>
-    inline auto xfunction_base<F, R, CT...>::storage_rbegin() const noexcept -> const_reverse_storage_iterator
+    template <class F, class... CT>
+    inline auto xfunction<F, CT...>::storage_rbegin() const noexcept -> const_reverse_storage_iterator
     {
-        return storage_crbegin<L>();
+        return storage_crbegin();
     }
 
-    template <class F, class R, class... CT>
-    template <layout_type L>
-    inline auto xfunction_base<F, R, CT...>::storage_rend() const noexcept -> const_reverse_storage_iterator
+    template <class F, class... CT>
+    inline auto xfunction<F, CT...>::storage_rend() const noexcept -> const_reverse_storage_iterator
     {
-        return storage_crend<L>();
+        return storage_crend();
     }
 
-    template <class F, class R, class... CT>
-    template <layout_type L>
-    inline auto xfunction_base<F, R, CT...>::storage_crbegin() const noexcept -> const_reverse_storage_iterator
+    template <class F, class... CT>
+    inline auto xfunction<F, CT...>::storage_crbegin() const noexcept -> const_reverse_storage_iterator
     {
-        return const_reverse_storage_iterator(storage_cend<L>());
+        return const_reverse_storage_iterator(storage_cend());
     }
 
-    template <class F, class R, class... CT>
-    template <layout_type L>
-    inline auto xfunction_base<F, R, CT...>::storage_crend() const noexcept -> const_reverse_storage_iterator
+    template <class F, class... CT>
+    inline auto xfunction<F, CT...>::storage_crend() const noexcept -> const_reverse_storage_iterator
     {
-        return const_reverse_storage_iterator(storage_cbegin<L>());
+        return const_reverse_storage_iterator(storage_cbegin());
     }
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <class S>
-    inline auto xfunction_base<F, R, CT...>::stepper_begin(const S& shape) const noexcept -> const_stepper
+    inline auto xfunction<F, CT...>::stepper_begin(const S& shape) const noexcept -> const_stepper
     {
         auto f = [&shape](const auto& e) noexcept { return e.stepper_begin(shape); };
         return build_stepper(f, std::make_index_sequence<sizeof...(CT)>());
     }
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <class S>
-    inline auto xfunction_base<F, R, CT...>::stepper_end(const S& shape, layout_type l) const noexcept -> const_stepper
+    inline auto xfunction<F, CT...>::stepper_end(const S& shape, layout_type l) const noexcept -> const_stepper
     {
         auto f = [&shape, l](const auto& e) noexcept { return e.stepper_end(shape, l); };
         return build_stepper(f, std::make_index_sequence<sizeof...(CT)>());
     }
 
-    template <class F, class R, class... CT>
-    inline auto xfunction_base<F, R, CT...>::data_element(size_type i) const -> const_reference
+    template <class F, class... CT>
+    inline auto xfunction<F, CT...>::data_element(size_type i) const -> const_reference
     {
         return data_element_impl(std::make_index_sequence<sizeof...(CT)>(), i);
     }
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <class UT, class>
-    inline xfunction_base<F, R, CT...>::operator value_type() const
+    inline xfunction<F, CT...>::operator value_type() const
     {
         return operator()();
     }
 
-    template <class F, class R, class... CT>
-    template <class align, class simd>
-    inline auto xfunction_base<F, R, CT...>::load_simd(size_type i) const -> detail::simd_return_type_t<functor_type, simd_argument_type, simd>
+    template <class F, class... CT>
+    template <class align, class requested_type, std::size_t N>
+    inline auto xfunction<F, CT...>::load_simd(size_type i) const
+        -> simd_return_type<requested_type>
     {
-        return load_simd_impl<align, simd>(std::make_index_sequence<sizeof...(CT)>(), i);
+        return load_simd_impl<align, requested_type, N>(std::make_index_sequence<sizeof...(CT)>(), i);
     }
 
-    template <class F, class R, class... CT>
-    inline auto xfunction_base<F, R, CT...>::arguments() const noexcept -> const tuple_type&
+    template <class F, class... CT>
+    inline auto xfunction<F, CT...>::arguments() const noexcept -> const tuple_type&
     {
         return m_e;
     }
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <std::size_t... I>
-    inline layout_type xfunction_base<F, R, CT...>::layout_impl(std::index_sequence<I...>) const noexcept
+    inline layout_type xfunction<F, CT...>::layout_impl(std::index_sequence<I...>) const noexcept
     {
         return compute_layout(std::get<I>(m_e).layout()...);
     }
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <std::size_t... I, class... Args>
-    inline auto xfunction_base<F, R, CT...>::access_impl(std::index_sequence<I...>, Args... args) const -> const_reference
+    inline auto xfunction<F, CT...>::access_impl(std::index_sequence<I...>, Args... args) const -> const_reference
     {
         XTENSOR_TRY(check_index(shape(), args...));
         XTENSOR_CHECK_DIMENSION(shape(), args...);
         return m_f(std::get<I>(m_e)(args...)...);
     }
-    
-    template <class F, class R, class... CT>
+
+    template <class F, class... CT>
     template <std::size_t... I, class... Args>
-    inline auto xfunction_base<F, R, CT...>::unchecked_impl(std::index_sequence<I...>, Args... args) const -> const_reference
+    inline auto xfunction<F, CT...>::unchecked_impl(std::index_sequence<I...>, Args... args) const -> const_reference
     {
         return m_f(std::get<I>(m_e).unchecked(args...)...);
     }
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <std::size_t... I, class It>
-    inline auto xfunction_base<F, R, CT...>::element_access_impl(std::index_sequence<I...>, It first, It last) const -> const_reference
+    inline auto xfunction<F, CT...>::element_access_impl(std::index_sequence<I...>, It first, It last) const -> const_reference
     {
         XTENSOR_TRY(check_element_index(shape(), first, last));
         return m_f((std::get<I>(m_e).element(first, last))...);
     }
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <std::size_t... I>
-    inline auto xfunction_base<F, R, CT...>::data_element_impl(std::index_sequence<I...>, size_type i) const -> const_reference
+    inline auto xfunction<F, CT...>::data_element_impl(std::index_sequence<I...>, size_type i) const -> const_reference
     {
         return m_f((std::get<I>(m_e).data_element(i))...);
     }
 
-    namespace detail
-    {
-// TODO: add traits for batch_bool in xsimd and remove this ugly hack
-
-        template <class V>
-        struct is_batch_bool
-        {
-            static constexpr bool value = false;
-        };
-
-#ifdef XTENSOR_USE_XSIMD
-        template <class T, std::size_t N>
-        struct is_batch_bool<xsimd::batch_bool<T, N>>
-        {
-            static constexpr bool value = true;
-        };
-#endif
-
-        // This metafunction avoids loading boolean values as batches of floating points and
-        // reciprocally. However, we cannot always load data as batches of their scalar type
-        // since this prevents mixed arithmetic.
-        template <class T, class simd, class common_simd>
-        struct get_simd_type
-        {
-            using simd_value_type = typename std::decay_t<T>::simd_value_type;
-            static constexpr bool is_arg_bool = is_batch_bool<simd_value_type>::value;
-            static constexpr bool is_res_bool = is_batch_bool<simd>::value;
-            using type = std::conditional_t<is_res_bool,
-                                            common_simd,
-                                            std::conditional_t<is_arg_bool,
-                                                               simd_value_type,
-                                                               simd>>;
-        };
-
-        template <class T, class simd, class common_simd>
-        using get_simd_type_t = typename get_simd_type<T, simd, common_simd>::type;
-    }
-
-    template <class F, class R, class... CT>
-    template <class align, class simd, std::size_t... I>
-    inline auto xfunction_base<F, R, CT...>::load_simd_impl(std::index_sequence<I...>, size_type i) const
+    template <class F, class... CT>
+    template <class align, class requested_type, std::size_t N, std::size_t... I>
+    inline auto xfunction<F, CT...>::load_simd_impl(std::index_sequence<I...>, size_type i) const
     {
         return m_f.simd_apply((std::get<I>(m_e)
-            .template load_simd<align, detail::get_simd_type_t<std::tuple_element_t<I, tuple_type>, simd, simd_argument_type>>(i))...);
+            .template load_simd<align, requested_type>(i))...);
     }
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <class Func, std::size_t... I>
-    inline auto xfunction_base<F, R, CT...>::build_stepper(Func&& f, std::index_sequence<I...>) const noexcept -> const_stepper
+    inline auto xfunction<F, CT...>::build_stepper(Func&& f, std::index_sequence<I...>) const noexcept -> const_stepper
     {
         return const_stepper(this, f(std::get<I>(m_e))...);
     }
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <class Func, std::size_t... I>
-    inline auto xfunction_base<F, R, CT...>::build_iterator(Func&& f, std::index_sequence<I...>) const noexcept -> const_storage_iterator
+    inline auto xfunction<F, CT...>::build_iterator(Func&& f, std::index_sequence<I...>) const noexcept
     {
         return const_storage_iterator(this, f(std::get<I>(m_e))...);
     }
 
-    template <class F, class R, class... CT>
-    inline auto xfunction_base<F, R, CT...>::compute_dimension() const noexcept -> size_type
+    template <class F, class... CT>
+    inline auto xfunction<F, CT...>::compute_dimension() const noexcept -> size_type
     {
         auto func = [](size_type d, auto&& e) noexcept { return (std::max)(d, e.dimension()); };
         return accumulate(func, size_type(0), m_e);
@@ -958,79 +790,87 @@ namespace xt
      * xfunction_iterator implementation *
      *************************************/
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <class... It>
-    inline xfunction_iterator<F, R, CT...>::xfunction_iterator(const xfunction_type* func, It&&... it) noexcept
+    inline xfunction_iterator<F, CT...>::xfunction_iterator(const xfunction_type* func, It&&... it) noexcept
         : p_f(func), m_it(std::forward<It>(it)...)
     {
     }
 
-    template <class F, class R, class... CT>
-    inline auto xfunction_iterator<F, R, CT...>::operator++() -> self_type&
+    template <class F, class... CT>
+    inline auto xfunction_iterator<F, CT...>::operator++() -> self_type&
     {
         auto f = [](auto& it) { ++it; };
         for_each(f, m_it);
         return *this;
     }
 
-    template <class F, class R, class... CT>
-    inline auto xfunction_iterator<F, R, CT...>::operator--() -> self_type&
+    template <class F, class... CT>
+    inline auto xfunction_iterator<F, CT...>::operator--() -> self_type&
     {
         auto f = [](auto& it) { return --it; };
         for_each(f, m_it);
         return *this;
     }
 
-    template <class F, class R, class... CT>
-    inline auto xfunction_iterator<F, R, CT...>::operator+=(difference_type n) -> self_type&
+    template <class F, class... CT>
+    inline auto xfunction_iterator<F, CT...>::operator+=(difference_type n) -> self_type&
     {
         auto f = [n](auto& it) { it += n; };
         for_each(f, m_it);
         return *this;
     }
 
-    template <class F, class R, class... CT>
-    inline auto xfunction_iterator<F, R, CT...>::operator-=(difference_type n) -> self_type&
+    template <class F, class... CT>
+    inline auto xfunction_iterator<F, CT...>::operator-=(difference_type n) -> self_type&
     {
         auto f = [n](auto& it) { it -= n; };
         for_each(f, m_it);
         return *this;
     }
 
-    template <class F, class R, class... CT>
-    inline auto xfunction_iterator<F, R, CT...>::operator-(const self_type& rhs) const -> difference_type
+    template <class F, class... CT>
+    inline auto xfunction_iterator<F, CT...>::operator-(const self_type& rhs) const -> difference_type
     {
         return tuple_max_diff(std::make_index_sequence<sizeof...(CT)>(), m_it, rhs.m_it);
     }
 
-    template <class F, class R, class... CT>
-    inline auto xfunction_iterator<F, R, CT...>::operator*() const -> reference
+    template <class F, class... CT>
+    inline auto xfunction_iterator<F, CT...>::operator*() const -> reference
     {
         return deref_impl(std::make_index_sequence<sizeof...(CT)>());
     }
 
-    template <class F, class R, class... CT>
-    inline bool xfunction_iterator<F, R, CT...>::equal(const self_type& rhs) const
+    template <class F, class... CT>
+    inline bool xfunction_iterator<F, CT...>::equal(const self_type& rhs) const
     {
-        return p_f == rhs.p_f && m_it == rhs.m_it;
+        // Optimization: no need to compare each subiterator since they all
+        // are incremented decremented together.
+        constexpr std::size_t temp = xtl::mpl::find_if<is_not_xdummy_iterator, data_type>::value;
+        constexpr std::size_t index = (temp == std::tuple_size<data_type>::value) ? 0 : temp;
+        return std::get<index>(m_it) == std::get<index>(rhs.m_it);
     }
 
-    template <class F, class R, class... CT>
-    inline bool xfunction_iterator<F, R, CT...>::less_than(const self_type& rhs) const
+    template <class F, class... CT>
+    inline bool xfunction_iterator<F, CT...>::less_than(const self_type& rhs) const
     {
-        return p_f == rhs.p_f && m_it < rhs.m_it;
+        // Optimization: no need to compare each subiterator since they all
+        // are incremented decremented together.
+        constexpr std::size_t temp = xtl::mpl::find_if<is_not_xdummy_iterator, data_type>::value;
+        constexpr std::size_t index = (temp == std::tuple_size<data_type>::value) ? 0 : temp;
+        return std::get<index>(m_it) < std::get<index>(rhs.m_it);
     }
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <std::size_t... I>
-    inline auto xfunction_iterator<F, R, CT...>::deref_impl(std::index_sequence<I...>) const -> reference
+    inline auto xfunction_iterator<F, CT...>::deref_impl(std::index_sequence<I...>) const -> reference
     {
         return (p_f->m_f)(*std::get<I>(m_it)...);
     }
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <std::size_t... I>
-    inline auto xfunction_iterator<F, R, CT...>::tuple_max_diff(std::index_sequence<I...>,
+    inline auto xfunction_iterator<F, CT...>::tuple_max_diff(std::index_sequence<I...>,
                                                                 const data_type& lhs,
                                                                 const data_type& rhs) const -> difference_type
     {
@@ -1039,16 +879,16 @@ namespace xt
         return accumulate(func, difference_type(0), diff);
     }
 
-    template <class F, class R, class... CT>
-    inline bool operator==(const xfunction_iterator<F, R, CT...>& it1,
-                           const xfunction_iterator<F, R, CT...>& it2)
+    template <class F, class... CT>
+    inline bool operator==(const xfunction_iterator<F, CT...>& it1,
+                           const xfunction_iterator<F, CT...>& it2)
     {
         return it1.equal(it2);
     }
 
-    template <class F, class R, class... CT>
-    inline bool operator<(const xfunction_iterator<F, R, CT...>& it1,
-                          const xfunction_iterator<F, R, CT...>& it2)
+    template <class F, class... CT>
+    inline bool operator<(const xfunction_iterator<F, CT...>& it1,
+                          const xfunction_iterator<F, CT...>& it2)
     {
         return it1.less_than(it2);
     }
@@ -1057,127 +897,101 @@ namespace xt
      * xfunction_stepper implementation *
      ************************************/
 
-    template <class F, class R, class... CT>
-    template <class... It>
-    inline xfunction_stepper<F, R, CT...>::xfunction_stepper(const xfunction_type* func, It&&... it) noexcept
-        : p_f(func), m_it(std::forward<It>(it)...)
+    template <class F, class... CT>
+    template <class... St>
+    inline xfunction_stepper<F, CT...>::xfunction_stepper(const xfunction_type* func, St&&... st) noexcept
+        : p_f(func), m_st(std::forward<St>(st)...)
     {
     }
 
-    template <class F, class R, class... CT>
-    inline void xfunction_stepper<F, R, CT...>::step(size_type dim)
+    template <class F, class... CT>
+    inline void xfunction_stepper<F, CT...>::step(size_type dim)
     {
-        auto f = [dim](auto& it) { it.step(dim); };
-        for_each(f, m_it);
+        auto f = [dim](auto& st) { st.step(dim); };
+        for_each(f, m_st);
     }
 
-    template <class F, class R, class... CT>
-    inline void xfunction_stepper<F, R, CT...>::step_back(size_type dim)
+    template <class F, class... CT>
+    inline void xfunction_stepper<F, CT...>::step_back(size_type dim)
     {
-        auto f = [dim](auto& it) { it.step_back(dim); };
-        for_each(f, m_it);
+        auto f = [dim](auto& st) { st.step_back(dim); };
+        for_each(f, m_st);
     }
 
-    template <class F, class R, class... CT>
-    inline void xfunction_stepper<F, R, CT...>::step(size_type dim, size_type n)
+    template <class F, class... CT>
+    inline void xfunction_stepper<F, CT...>::step(size_type dim, size_type n)
     {
-        auto f = [dim, n](auto& it) { it.step(dim, n); };
-        for_each(f, m_it);
+        auto f = [dim, n](auto& st) { st.step(dim, n); };
+        for_each(f, m_st);
     }
 
-    template <class F, class R, class... CT>
-    inline void xfunction_stepper<F, R, CT...>::step_back(size_type dim, size_type n)
+    template <class F, class... CT>
+    inline void xfunction_stepper<F, CT...>::step_back(size_type dim, size_type n)
     {
-        auto f = [dim, n](auto& it) { it.step_back(dim, n); };
-        for_each(f, m_it);
+        auto f = [dim, n](auto& st) { st.step_back(dim, n); };
+        for_each(f, m_st);
     }
 
-    template <class F, class R, class... CT>
-    inline void xfunction_stepper<F, R, CT...>::reset(size_type dim)
+    template <class F, class... CT>
+    inline void xfunction_stepper<F, CT...>::reset(size_type dim)
     {
-        auto f = [dim](auto& it) { it.reset(dim); };
-        for_each(f, m_it);
+        auto f = [dim](auto& st) { st.reset(dim); };
+        for_each(f, m_st);
     }
 
-    template <class F, class R, class... CT>
-    inline void xfunction_stepper<F, R, CT...>::reset_back(size_type dim)
+    template <class F, class... CT>
+    inline void xfunction_stepper<F, CT...>::reset_back(size_type dim)
     {
-        auto f = [dim](auto& it) { it.reset_back(dim); };
-        for_each(f, m_it);
+        auto f = [dim](auto& st) { st.reset_back(dim); };
+        for_each(f, m_st);
     }
 
-    template <class F, class R, class... CT>
-    inline void xfunction_stepper<F, R, CT...>::to_begin()
+    template <class F, class... CT>
+    inline void xfunction_stepper<F, CT...>::to_begin()
     {
-        auto f = [](auto& it) { it.to_begin(); };
-        for_each(f, m_it);
+        auto f = [](auto& st) { st.to_begin(); };
+        for_each(f, m_st);
     }
 
-    template <class F, class R, class... CT>
-    inline void xfunction_stepper<F, R, CT...>::to_end(layout_type l)
+    template <class F, class... CT>
+    inline void xfunction_stepper<F, CT...>::to_end(layout_type l)
     {
-        auto f = [l](auto& it) { it.to_end(l); };
-        for_each(f, m_it);
+        auto f = [l](auto& st) { st.to_end(l); };
+        for_each(f, m_st);
     }
 
-    template <class F, class R, class... CT>
-    inline auto xfunction_stepper<F, R, CT...>::operator*() const -> reference
+    template <class F, class... CT>
+    inline auto xfunction_stepper<F, CT...>::operator*() const -> reference
     {
         return deref_impl(std::make_index_sequence<sizeof...(CT)>());
     }
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     template <std::size_t... I>
-    inline auto xfunction_stepper<F, R, CT...>::deref_impl(std::index_sequence<I...>) const -> reference
+    inline auto xfunction_stepper<F, CT...>::deref_impl(std::index_sequence<I...>) const -> reference
     {
-        return (p_f->m_f)(*std::get<I>(m_it)...);
+        return (p_f->m_f)(*std::get<I>(m_st)...);
     }
 
-    template <class F, class R, class... CT>
-    template <class ST, std::size_t... I>
-    inline ST xfunction_stepper<F, R, CT...>::step_simd_impl(std::index_sequence<I...>)
+    template <class F, class... CT>
+    template <class T, std::size_t... I>
+    inline auto xfunction_stepper<F, CT...>::step_simd_impl(std::index_sequence<I...>) -> simd_return_type<T>
     {
-        return (p_f->m_f.simd_apply)(std::get<I>(m_it).template
-            step_simd<detail::get_simd_type_t<std::tuple_element_t<I, typename xfunction_type::tuple_type>, ST, typename xfunction_type::simd_argument_type>>()...);
+        return (p_f->m_f.simd_apply)(std::get<I>(m_st). template step_simd<T>()...);
     }
 
-    template <class F, class R, class... CT>
-    template <class ST>
-    inline ST xfunction_stepper<F, R, CT...>::step_simd()
+    template <class F, class... CT>
+    template <class T>
+    inline auto xfunction_stepper<F, CT...>::step_simd() -> simd_return_type<T>
     {
-        return step_simd_impl<ST>(std::make_index_sequence<sizeof...(CT)>());
+        return step_simd_impl<T>(std::make_index_sequence<sizeof...(CT)>());
     }
 
-    template <class F, class R, class... CT>
-    template <std::size_t... I>
-    inline auto xfunction_stepper<F, R, CT...>::step_leading_impl(std::index_sequence<I...>)
-        -> value_type
+    template <class F, class... CT>
+    inline void xfunction_stepper<F, CT...>::step_leading()
     {
-        return (p_f->m_f)(std::get<I>(m_it).step_leading()...);
-    }
-
-    template <class F, class R, class... CT>
-    inline auto xfunction_stepper<F, R, CT...>::step_leading() 
-        -> value_type
-    {
-        return step_leading_impl(std::make_index_sequence<sizeof...(CT)>());
-    }
-
-    /****************************
-     * xfunction implementation *
-     ****************************/
-
-    /**
-     * Constructs an xfunction applying the specified function to the given
-     * arguments.
-     * @param f the function to apply
-     * @param e the \ref xexpression arguments
-     */
-    template <class F, class R, class... CT>
-    template <class Func, class... CTA, class U>
-    xfunction<F, R, CT...>::xfunction(Func&& f, CTA&&... e) noexcept
-        : base_type(std::forward<Func>(f), std::forward<CTA>(e)...)
-    {
+        auto step_leading_lambda = [](auto&& st) { st.step_leading(); };
+        for_each(step_leading_lambda, m_st);
     }
 }
 

--- a/vendor/xtensor/include/xtensor/xfunctor_view.hpp
+++ b/vendor/xtensor/include/xtensor/xfunctor_view.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -17,20 +18,46 @@
 
 #include <xtl/xproxy_wrapper.hpp>
 
-#include "xtensor/xexpression.hpp"
-#include "xtensor/xiterator.hpp"
-#include "xtensor/xsemantic.hpp"
-#include "xtensor/xutils.hpp"
+#include "xaccessible.hpp"
+#include "xexpression.hpp"
+#include "xiterator.hpp"
+#include "xsemantic.hpp"
+#include "xutils.hpp"
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xtensor.hpp"
+#include "xarray.hpp"
+#include "xtensor.hpp"
 
 namespace xt
 {
 
-    /*****************************
-     * xfunctor_view declaration *
-     *****************************/
+    /************************************************
+     * xfunctor_view and xfunctor_adaptor extension *
+     ************************************************/
+
+    namespace extension
+    {
+        template <class Tag, class F, class CT>
+        struct xfunctor_view_base_impl;
+
+        template <class F, class CT>
+        struct xfunctor_view_base_impl<xtensor_expression_tag, F, CT>
+        {
+            using type = xtensor_empty_base;
+        };
+
+        template <class F, class CT>
+        struct xfunctor_view_base
+            : xfunctor_view_base_impl<xexpression_tag_t<CT>, F, CT>
+        {
+        };
+
+        template <class F, class CT>
+        using xfunctor_view_base_t = typename xfunctor_view_base<F, CT>::type;
+    }
+
+    /*************************************
+     * xfunctor_applier_base declaration *
+     *************************************/
 
     template <class F, class IT>
     class xfunctor_iterator;
@@ -38,8 +65,259 @@ namespace xt
     template <class F, class ST>
     class xfunctor_stepper;
 
-    template <class F, class CT>
-    class xfunctor_view;
+    template <class D>
+    class xfunctor_applier_base : private xaccessible<D>
+    {
+    public:
+
+        using self_type = xfunctor_applier_base<D>;
+        using inner_types = xcontainer_inner_types<D>;
+        using xexpression_type = typename inner_types::xexpression_type;
+        using undecay_expression = typename inner_types::undecay_expression;
+        using functor_type = typename inner_types::functor_type;
+        using accessible_base = xaccessible<D>;
+
+        using extension_base = extension::xfunctor_view_base_t<functor_type, undecay_expression>;
+        using expression_tag = typename extension_base::expression_tag;
+
+        using value_type = typename functor_type::value_type;
+        using reference = typename inner_types::reference;
+        using const_reference = typename inner_types::const_reference;
+        using pointer = typename functor_type::pointer;
+        using const_pointer = typename functor_type::const_pointer;
+        using size_type = typename inner_types::size_type;
+        using difference_type = typename xexpression_type::difference_type;
+
+        using shape_type = typename xexpression_type::shape_type;
+        using strides_type = xtl::mpl::eval_if_t<has_strides<xexpression_type>,
+                                                 detail::expr_strides_type<xexpression_type>,
+                                                 get_strides_type<shape_type>>;
+        using backstrides_type = xtl::mpl::eval_if_t<has_strides<xexpression_type>,
+                                                     detail::expr_backstrides_type<xexpression_type>,
+                                                     get_strides_type<shape_type>>;
+
+        using inner_shape_type = typename xexpression_type::inner_shape_type;
+        using inner_strides_type = xtl::mpl::eval_if_t<has_strides<xexpression_type>,
+                                                       detail::expr_inner_strides_type<xexpression_type>,
+                                                       get_strides_type<shape_type>>;
+        using inner_backstrides_type = xtl::mpl::eval_if_t<has_strides<xexpression_type>,
+                                                           detail::expr_inner_backstrides_type<xexpression_type>,
+                                                           get_strides_type<shape_type>>;
+
+        using bool_load_type = xt::bool_load_type<value_type>;
+
+        static constexpr layout_type static_layout = xexpression_type::static_layout;
+        static constexpr bool contiguous_layout = xexpression_type::contiguous_layout;
+
+        using stepper = xfunctor_stepper<functor_type, typename xexpression_type::stepper>;
+        using const_stepper = xfunctor_stepper<const functor_type, typename xexpression_type::const_stepper>;
+
+        template <layout_type L>
+        using layout_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template layout_iterator<L>>;
+        template <layout_type L>
+        using const_layout_iterator = xfunctor_iterator<const functor_type, typename xexpression_type::template const_layout_iterator<L>>;
+
+        template <layout_type L>
+        using reverse_layout_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template reverse_layout_iterator<L>>;
+        template <layout_type L>
+        using const_reverse_layout_iterator = xfunctor_iterator<const functor_type, typename xexpression_type::template const_reverse_layout_iterator<L>>;
+
+        template <class S, layout_type L>
+        using broadcast_iterator = xfunctor_iterator<functor_type, xiterator<typename xexpression_type::stepper, S, L>>;
+        template <class S, layout_type L>
+        using const_broadcast_iterator = xfunctor_iterator<functor_type, xiterator<typename xexpression_type::const_stepper, S, L>>;
+
+        template <class S, layout_type L>
+        using reverse_broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template reverse_broadcast_iterator<S, L>>;
+        template <class S, layout_type L>
+        using const_reverse_broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template const_reverse_broadcast_iterator<S, L>>;
+
+        using storage_iterator = xfunctor_iterator<functor_type, typename xexpression_type::storage_iterator>;
+        using const_storage_iterator = xfunctor_iterator<const functor_type, typename xexpression_type::const_storage_iterator>;
+        using reverse_storage_iterator = xfunctor_iterator<functor_type, typename xexpression_type::reverse_storage_iterator>;
+        using const_reverse_storage_iterator = xfunctor_iterator<const functor_type, typename xexpression_type::const_reverse_storage_iterator>;
+
+        using iterator = xfunctor_iterator<functor_type, typename xexpression_type::iterator>;
+        using const_iterator = xfunctor_iterator<const functor_type, typename xexpression_type::const_iterator>;
+        using reverse_iterator = xfunctor_iterator<functor_type, typename xexpression_type::reverse_iterator>;
+        using const_reverse_iterator = xfunctor_iterator<const functor_type, typename xexpression_type::const_reverse_iterator>;
+
+        explicit xfunctor_applier_base(undecay_expression) noexcept;
+
+        template <class Func, class E>
+        xfunctor_applier_base(Func&&, E&&) noexcept;
+
+        size_type size() const noexcept;
+        const inner_shape_type& shape() const noexcept;
+        const inner_strides_type& strides() const noexcept;
+        const inner_backstrides_type& backstrides() const noexcept;
+        using accessible_base::dimension;
+        using accessible_base::shape;
+
+        layout_type layout() const noexcept;
+
+        template <class... Args>
+        reference operator()(Args... args);
+
+        template <class... Args>
+        reference unchecked(Args... args);
+
+        template <class IT>
+        reference element(IT first, IT last);
+
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+
+        template <class... Args>
+        const_reference unchecked(Args... args) const;
+
+        template <class IT>
+        const_reference element(IT first, IT last) const;
+
+        using accessible_base::at;
+        using accessible_base::operator[];
+        using accessible_base::periodic;
+        using accessible_base::in_bounds;
+
+        xexpression_type& expression() noexcept;
+        const xexpression_type& expression() const noexcept;
+
+        template <class S>
+        bool broadcast_shape(S& shape, bool reuse_cache = false) const;
+
+        template <class S>
+        bool has_linear_assign(const S& strides) const;
+
+        template <class FCT = functor_type>
+        auto data_element(size_type i)
+            -> decltype(std::declval<FCT>()(std::declval<undecay_expression>().data_element(i)))
+        {
+            return m_functor(m_e.data_element(i));
+        }
+
+        template <class FCT = functor_type>
+        auto data_element(size_type i) const
+            -> decltype(std::declval<FCT>()(std::declval<undecay_expression>().data_element(i)))
+        {
+            return m_functor(m_e.data_element(i));
+        }
+
+        // The following functions are defined inline because otherwise signatures
+        // don't match on GCC.
+        template <class align, class requested_type = typename xexpression_type::value_type,
+                  std::size_t N = xt_simd::simd_traits<requested_type>::size, class FCT = functor_type>
+        auto load_simd(size_type i) const
+            -> decltype(std::declval<FCT>().template proxy_simd_load<align, requested_type, N>(std::declval<undecay_expression>(), i))
+        {
+            return m_functor.template proxy_simd_load<align, requested_type, N>(m_e, i);
+        }
+
+        template <class align, class simd, class FCT = functor_type>
+        auto store_simd(size_type i, const simd& e)
+            -> decltype(std::declval<FCT>().template proxy_simd_store<align>(std::declval<undecay_expression>(), i, e))
+        {
+            return m_functor.template proxy_simd_store<align>(m_e, i, e);
+        }
+
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        auto begin() noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        auto end() noexcept;
+
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        auto begin() const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        auto end() const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        auto cbegin() const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        auto cend() const noexcept;
+
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        auto rbegin() noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        auto rend() noexcept;
+
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        auto rbegin() const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        auto rend() const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        auto crbegin() const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        auto crend() const noexcept;
+
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        broadcast_iterator<S, L> begin(const S& shape) noexcept;
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        broadcast_iterator<S, L> end(const S& shape) noexcept;
+
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        const_broadcast_iterator<S, L> begin(const S& shape) const noexcept;
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        const_broadcast_iterator<S, L> end(const S& shape) const noexcept;
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        const_broadcast_iterator<S, L> cbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        const_broadcast_iterator<S, L> cend(const S& shape) const noexcept;
+
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        reverse_broadcast_iterator<S, L> rbegin(const S& shape) noexcept;
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        reverse_broadcast_iterator<S, L> rend(const S& shape) noexcept;
+
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        const_reverse_broadcast_iterator<S, L> rend(const S& shape) const noexcept;
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape) const noexcept;
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        const_reverse_broadcast_iterator<S, L> crend(const S& shape) const noexcept;
+
+        storage_iterator storage_begin() noexcept;
+        storage_iterator storage_end() noexcept;
+
+        const_storage_iterator storage_begin() const noexcept;
+        const_storage_iterator storage_end() const noexcept;
+        const_storage_iterator storage_cbegin() const noexcept;
+        const_storage_iterator storage_cend() const noexcept;
+
+        reverse_storage_iterator storage_rbegin() noexcept;
+        reverse_storage_iterator storage_rend() noexcept;
+
+        const_reverse_storage_iterator storage_rbegin() const noexcept;
+        const_reverse_storage_iterator storage_rend() const noexcept;
+        const_reverse_storage_iterator storage_crbegin() const noexcept;
+        const_reverse_storage_iterator storage_crend() const noexcept;
+
+        template <class S>
+        stepper stepper_begin(const S& shape) noexcept;
+        template <class S>
+        stepper stepper_end(const S& shape, layout_type l) noexcept;
+        template <class S>
+        const_stepper stepper_begin(const S& shape) const noexcept;
+        template <class S>
+        const_stepper stepper_end(const S& shape, layout_type l) const noexcept;
+
+    protected:
+
+        undecay_expression m_e;
+        functor_type m_functor;
+
+    private:
+
+        friend class xaccessible<D>;
+        friend class xconst_accessible<D>;
+    };
+
+    template <class D, class T>
+    struct has_simd_interface<xfunctor_applier_base<D>, T>
+        : xtl::conjunction<has_simd_type<T>,
+                           has_simd_interface<typename xfunctor_applier_base<D>::xexpression_type>,
+                           detail::has_simd_interface_impl<xfunctor_applier_base<D>, T>>
+    {
+    };
 
     /********************************
      * xfunctor_view_temporary_type *
@@ -47,6 +325,7 @@ namespace xt
 
     namespace detail
     {
+        // TODO replace with xexpression_for_shape ...
         template <class F, class S, layout_type L>
         struct functorview_temporary_type_impl
         {
@@ -66,14 +345,31 @@ namespace xt
         using type = typename detail::functorview_temporary_type_impl<F, typename E::shape_type, E::static_layout>::type;
     };
 
+    /*****************************
+     * xfunctor_view declaration *
+     *****************************/
+
+    template <class F, class CT>
+    class xfunctor_view;
+
     template <class F, class CT>
     struct xcontainer_inner_types<xfunctor_view<F, CT>>
     {
         using xexpression_type = std::decay_t<CT>;
+        using undecay_expression = CT;
+        using functor_type = std::decay_t<F>;
+        using reference = decltype(std::declval<F>()(std::declval<xexpression_type>()()));
+        using const_reference = decltype(std::declval<F>()(std::declval<const xexpression_type>()()));
+        using size_type = typename xexpression_type::size_type;
         using temporary_type = typename xfunctor_view_temporary_type<F, xexpression_type>::type;
     };
 
-#define DL XTENSOR_DEFAULT_LAYOUT
+    template <class F, class CT, class T>
+    struct has_simd_interface<xfunctor_view<F, CT>, T>
+        : has_simd_interface<xfunctor_applier_base<xfunctor_view<F, CT>>, T>
+    {
+    };
+
     /**
      * @class xfunctor_view
      * @brief View of an xexpression .
@@ -81,6 +377,9 @@ namespace xt
      * The xfunctor_view class is an expression addressing its elements by applying a functor to the
      * corresponding element of an underlying expression. Unlike e.g. xgenerator, an xfunctor_view is
      * an lvalue. It is used e.g. to access real and imaginary parts of complex expressions.
+     *
+     * xfunctor_view has a view semantics and can be used on any expression.
+     * For a similar feature with a container semantics, one can use \ref xfunctor_adaptor.
      *
      * xfunctor_view is not meant to be used directly, but through helper functions such
      * as \ref real or \ref imag.
@@ -91,65 +390,17 @@ namespace xt
      * @sa real, imag
      */
     template <class F, class CT>
-    class xfunctor_view : public xview_semantic<xfunctor_view<F, CT>>
+    class xfunctor_view : public xfunctor_applier_base<xfunctor_view<F, CT>>,
+                          public xview_semantic<xfunctor_view<F, CT>>,
+                          public extension::xfunctor_view_base_t<F, CT>
     {
     public:
 
         using self_type = xfunctor_view<F, CT>;
-        using xexpression_type = std::decay_t<CT>;
         using semantic_base = xview_semantic<self_type>;
-        using functor_type = typename std::decay_t<F>;
 
-        using value_type = typename functor_type::value_type;
-        using reference = typename functor_type::reference;
-        using const_reference = typename functor_type::const_reference;
-        using pointer = typename functor_type::pointer;
-        using const_pointer = typename functor_type::const_pointer;
-        using size_type = typename xexpression_type::size_type;
-        using difference_type = typename xexpression_type::difference_type;
-
-        using shape_type = typename xexpression_type::shape_type;
-
-        static constexpr layout_type static_layout = xexpression_type::static_layout;
-        static constexpr bool contiguous_layout = false;
-
-        using stepper = xfunctor_stepper<functor_type, typename xexpression_type::stepper>;
-        using const_stepper = xfunctor_stepper<functor_type, typename xexpression_type::const_stepper>;
-
-        template <layout_type L>
-        using layout_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template layout_iterator<L>>;
-        template <layout_type L>
-        using const_layout_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template const_layout_iterator<L>>;
-
-        template <layout_type L>
-        using reverse_layout_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template reverse_layout_iterator<L>>;
-        template <layout_type L>
-        using const_reverse_layout_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template const_reverse_layout_iterator<L>>;
-
-        template <class S, layout_type L>
-        using broadcast_iterator = xfunctor_iterator<functor_type, xiterator<typename xexpression_type::stepper, S, L>>;
-        template <class S, layout_type L>
-        using const_broadcast_iterator = xfunctor_iterator<functor_type, xiterator<typename xexpression_type::const_stepper, S, L>>;
-
-        template <class S, layout_type L>
-        using reverse_broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template reverse_broadcast_iterator<S, L>>;
-        template <class S, layout_type L>
-        using const_reverse_broadcast_iterator = xfunctor_iterator<functor_type, typename xexpression_type::template const_reverse_broadcast_iterator<S, L>>;
-
-        using storage_iterator = xfunctor_iterator<functor_type, typename xexpression_type::storage_iterator>;
-        using const_storage_iterator = xfunctor_iterator<functor_type, typename xexpression_type::const_storage_iterator>;
-        using reverse_storage_iterator = xfunctor_iterator<functor_type, typename xexpression_type::reverse_storage_iterator>;
-        using const_reverse_storage_iterator = xfunctor_iterator<functor_type, typename xexpression_type::const_reverse_storage_iterator>;
-
-        using iterator = xfunctor_iterator<functor_type, typename xexpression_type::iterator>;
-        using const_iterator = xfunctor_iterator<functor_type, typename xexpression_type::const_iterator>;
-        using reverse_iterator = xfunctor_iterator<functor_type, typename xexpression_type::reverse_iterator>;
-        using const_reverse_iterator = xfunctor_iterator<functor_type, typename xexpression_type::const_reverse_iterator>;
-
-        explicit xfunctor_view(CT) noexcept;
-
-        template <class Func, class E>
-        xfunctor_view(Func&&, E&&) noexcept;
+        // constructors
+        using xfunctor_applier_base<self_type>::xfunctor_applier_base;
 
         template <class E>
         self_type& operator=(const xexpression<E>& e);
@@ -157,183 +408,144 @@ namespace xt
         template <class E>
         disable_xexpression<E, self_type>& operator=(const E& e);
 
-        size_type size() const noexcept;
-        size_type dimension() const noexcept;
-        const shape_type& shape() const noexcept;
-        layout_type layout() const noexcept;
+        template <class E>
+        using rebind_t = xfunctor_view<F, E>;
 
-        template <class... Args>
-        reference operator()(Args... args);
-
-        template <class... Args>
-        reference at(Args... args);
-
-        template <class... Args>
-        reference unchecked(Args... args);
-
-        template <class S>
-        disable_integral_t<S, reference> operator[](const S& index);
-        template <class I>
-        reference operator[](std::initializer_list<I> index);
-        reference operator[](size_type i);
-
-        template <class IT>
-        reference element(IT first, IT last);
-
-        template <class... Args>
-        const_reference operator()(Args... args) const;
-
-        template <class... Args>
-        const_reference unchecked(Args... args) const;
-
-        template <class... Args>
-        const_reference at(Args... args) const;
-
-        template <class S>
-        disable_integral_t<S, const_reference> operator[](const S& index) const;
-        template <class I>
-        const_reference operator[](std::initializer_list<I> index) const;
-        const_reference operator[](size_type i) const;
-
-        template <class IT>
-        const_reference element(IT first, IT last) const;
-
-        template <class S>
-        bool broadcast_shape(S& shape, bool reuse_cache = false) const;
-
-        template <class S>
-        bool is_trivial_broadcast(const S& strides) const;
-
-        template <layout_type L = DL>
-        auto begin() noexcept;
-        template <layout_type L = DL>
-        auto end() noexcept;
-
-        template <layout_type L = DL>
-        auto begin() const noexcept;
-        template <layout_type L = DL>
-        auto end() const noexcept;
-        template <layout_type L = DL>
-        auto cbegin() const noexcept;
-        template <layout_type L = DL>
-        auto cend() const noexcept;
-
-        template <layout_type L = DL>
-        auto rbegin() noexcept;
-        template <layout_type L = DL>
-        auto rend() noexcept;
-
-        template <layout_type L = DL>
-        auto rbegin() const noexcept;
-        template <layout_type L = DL>
-        auto rend() const noexcept;
-        template <layout_type L = DL>
-        auto crbegin() const noexcept;
-        template <layout_type L = DL>
-        auto crend() const noexcept;
-
-        template <class S, layout_type L = DL>
-        broadcast_iterator<S, L> begin(const S& shape) noexcept;
-        template <class S, layout_type L = DL>
-        broadcast_iterator<S, L> end(const S& shape) noexcept;
-
-        template <class S, layout_type L = DL>
-        const_broadcast_iterator<S, L> begin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_broadcast_iterator<S, L> end(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_broadcast_iterator<S, L> cbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_broadcast_iterator<S, L> cend(const S& shape) const noexcept;
-
-        template <class S, layout_type L = DL>
-        reverse_broadcast_iterator<S, L> rbegin(const S& shape) noexcept;
-        template <class S, layout_type L = DL>
-        reverse_broadcast_iterator<S, L> rend(const S& shape) noexcept;
-
-        template <class S, layout_type L = DL>
-        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_reverse_broadcast_iterator<S, L> rend(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
-        const_reverse_broadcast_iterator<S, L> crend(const S& shape) const noexcept;
-
-        template <layout_type L = DL>
-        storage_iterator storage_begin() noexcept;
-        template <layout_type L = DL>
-        storage_iterator storage_end() noexcept;
-
-        template <layout_type L = DL>
-        const_storage_iterator storage_begin() const noexcept;
-        template <layout_type L = DL>
-        const_storage_iterator storage_end() const noexcept;
-        template <layout_type L = DL>
-        const_storage_iterator storage_cbegin() const noexcept;
-        template <layout_type L = DL>
-        const_storage_iterator storage_cend() const noexcept;
-
-        template <layout_type L = DL>
-        reverse_storage_iterator storage_rbegin() noexcept;
-        template <layout_type L = DL>
-        reverse_storage_iterator storage_rend() noexcept;
-
-        template <layout_type L = DL>
-        const_reverse_storage_iterator storage_rbegin() const noexcept;
-        template <layout_type L = DL>
-        const_reverse_storage_iterator storage_rend() const noexcept;
-        template <layout_type L = DL>
-        const_reverse_storage_iterator storage_crbegin() const noexcept;
-        template <layout_type L = DL>
-        const_reverse_storage_iterator storage_crend() const noexcept;
-
-        template <class S>
-        stepper stepper_begin(const S& shape) noexcept;
-        template <class S>
-        stepper stepper_end(const S& shape, layout_type l) noexcept;
-        template <class S>
-        const_stepper stepper_begin(const S& shape) const noexcept;
-        template <class S>
-        const_stepper stepper_end(const S& shape, layout_type l) const noexcept;
+        template <class E>
+        rebind_t<E> build_functor_view(E&& e) const;
 
     private:
 
-        CT m_e;
-        functor_type m_functor;
+        using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
+        void assign_temporary_impl(temporary_type&& tmp);
+        friend class xview_semantic<self_type>;
+        friend class xaccessible<self_type>;
+    };
+
+    /********************************
+     * xfunctor_adaptor declaration *
+     ********************************/
+
+    template <class F, class CT>
+    class xfunctor_adaptor;
+
+    template <class F, class CT>
+    struct xcontainer_inner_types<xfunctor_adaptor<F, CT>>
+    {
+        using xexpression_type = std::decay_t<CT>;
+        using undecay_expression = CT;
+        using functor_type = std::decay_t<F>;
+        using reference = typename functor_type::reference;
+        using const_reference = typename functor_type::const_reference;
+        using size_type = typename xexpression_type::size_type;
+        using temporary_type = typename xfunctor_view_temporary_type<F, xexpression_type>::type;
+    };
+
+    template <class F, class CT, class T>
+    struct has_simd_interface<xfunctor_adaptor<F, CT>, T>
+        : has_simd_interface<xfunctor_applier_base<xfunctor_adaptor<F, CT>>, T>
+    {
+    };
+
+    /**
+     * @class xfunctor_adaptor
+     * @brief Adapt a container with a functor, forwarding methods such as resize / reshape.
+     *
+     * xfunctor_adaptor has a container semantics and can only be used with containers.
+     * For a similar feature with a view semantics, one can use \ref xfunctor_view.
+     *
+     * @tparam F the functor type to be applied to the elements of specified expression.
+     * @tparam CT the closure type of the \ref xexpression type underlying this view
+     *
+     * @sa xfunctor_view
+     */
+    template <class F, class CT>
+    class xfunctor_adaptor : public xfunctor_applier_base<xfunctor_adaptor<F, CT>>,
+                             public xcontainer_semantic<xfunctor_adaptor<F, CT>>,
+                             public extension::xfunctor_view_base_t<F, CT>
+    {
+    public:
+
+        using self_type = xfunctor_adaptor<F, CT>;
+        using semantic_base = xcontainer_semantic<self_type>;
+        using xexpression_type = std::decay_t<CT>;
+        using base_type = xfunctor_applier_base<self_type>;
+        using shape_type = typename base_type::shape_type;
+        using strides_type = typename xexpression_type::strides_type;
+        // constructors
+        using xfunctor_applier_base<self_type>::xfunctor_applier_base;
+
+        template <class E>
+        self_type& operator=(const xexpression<E>& e);
+
+        template <class E>
+        disable_xexpression<E, self_type>& operator=(const E& e);
+
+        template <class S = shape_type>
+        auto resize(S&& shape, bool force = false);
+
+        template <class S = shape_type>
+        auto resize(S&& shape, layout_type l);
+
+        template <class S = shape_type>
+        auto resize(S&& shape, const strides_type& strides);
+
+        template <class S = shape_type>
+        auto reshape(S&& shape, layout_type layout = base_type::static_layout);
+
+    private:
 
         using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
         void assign_temporary_impl(temporary_type&& tmp);
-        friend class xview_semantic<xfunctor_view<F, CT>>;
+        friend class xcontainer_semantic<self_type>;
+        friend class xaccessible<self_type>;
     };
-
-#undef DL
 
     /*********************************
      * xfunctor_iterator declaration *
      *********************************/
 
+    template <class R>
+    struct xproxy_inner_types
+    {
+        using reference = R;
+        using pointer = std::add_pointer_t<std::remove_reference_t<R>>;
+    };
+
+    namespace detail
+    {
+        template <class F, class IT>
+        struct xfunctor_invoker
+        {
+            using type = decltype(std::declval<F>()(*(std::declval<IT>())));
+        };
+
+        template <class F, class IT>
+        using xfunctor_invoker_t = typename xfunctor_invoker<F, IT>::type;
+    }
+
     template <class F, class IT>
     class xfunctor_iterator : public xtl::xrandom_access_iterator_base<xfunctor_iterator<F, IT>,
-                                                                       typename F::value_type,
+                                                                       typename std::decay_t<F>::value_type,
                                                                        typename std::iterator_traits<IT>::difference_type,
-                                                                       typename xtl::xproxy_wrapper<decltype(std::declval<F>()(*(IT())))>::pointer,
-                                                                       xtl::xproxy_wrapper<decltype(std::declval<F>()(*(IT())))>>
+                                                                       typename xproxy_inner_types<detail::xfunctor_invoker_t<F, IT>>::pointer,
+                                                                       typename xproxy_inner_types<detail::xfunctor_invoker_t<F, IT>>::reference>
     {
     public:
 
-        using functor_type = std::decay_t<F>;
+        using functor_type = F;
         using subiterator_traits = std::iterator_traits<IT>;
 
+        using proxy_inner = xproxy_inner_types<detail::xfunctor_invoker_t<F, IT>>;
         using value_type = typename functor_type::value_type;
-        using reference = xtl::xproxy_wrapper<decltype(std::declval<functor_type>()(*(IT())))>;
-        using pointer = typename reference::pointer;
+        using reference = typename proxy_inner::reference;
+        using pointer = typename proxy_inner::pointer;
         using difference_type = typename subiterator_traits::difference_type;
         using iterator_category = typename subiterator_traits::iterator_category;
 
         using self_type = xfunctor_iterator<F, IT>;
 
-        xfunctor_iterator(const IT&, const functor_type*);
+        xfunctor_iterator(const IT&, functor_type*);
 
         self_type& operator++();
         self_type& operator--();
@@ -352,7 +564,7 @@ namespace xt
     private:
 
         IT m_it;
-        const functor_type* p_functor;
+        functor_type* p_functor;
     };
 
     template <class F, class IT>
@@ -372,16 +584,17 @@ namespace xt
     {
     public:
 
-        using functor_type = std::decay_t<F>;
+        using functor_type = F;
 
+        using proxy_inner = xproxy_inner_types<detail::xfunctor_invoker_t<F, ST>>;
         using value_type = typename functor_type::value_type;
-        using reference = apply_cv_t<typename ST::reference, value_type>;
+        using reference = typename proxy_inner::reference;
         using pointer = std::remove_reference_t<reference>*;
         using size_type = typename ST::size_type;
         using difference_type = typename ST::difference_type;
 
         xfunctor_stepper() = default;
-        xfunctor_stepper(const ST&, const functor_type*);
+        xfunctor_stepper(const ST&, functor_type*);
 
         reference operator*() const;
 
@@ -398,12 +611,12 @@ namespace xt
     private:
 
         ST m_stepper;
-        const functor_type* p_functor;
+        functor_type* p_functor;
     };
 
-    /********************************
-     * xfunctor_view implementation *
-     ********************************/
+    /****************************************
+     * xfunctor_applier_base implementation *
+     ****************************************/
 
     /**
      * @name Constructors
@@ -411,67 +624,29 @@ namespace xt
     //@{
 
     /**
-     * Constructs an xfunctor_view expression wrappering the specified \ref xexpression.
+     * Constructs an xfunctor_applier_base expression wrappering the specified \ref xexpression.
      *
      * @param e the underlying expression
      */
-    template <class F, class CT>
-    inline xfunctor_view<F, CT>::xfunctor_view(CT e) noexcept
+    template <class D>
+    inline xfunctor_applier_base<D>::xfunctor_applier_base(undecay_expression e) noexcept
         : m_e(e), m_functor(functor_type())
     {
     }
 
     /**
-    * Constructs an xfunctor_view expression wrappering the specified \ref xexpression.
+    * Constructs an xfunctor_applier_base expression wrappering the specified \ref xexpression.
     *
     * @param func the functor to be applied to the elements of the underlying expression.
     * @param e the underlying expression
     */
-    template <class F, class CT>
+    template <class D>
     template <class Func, class E>
-    inline xfunctor_view<F, CT>::xfunctor_view(Func&& func, E&& e) noexcept
+    inline xfunctor_applier_base<D>::xfunctor_applier_base(Func&& func, E&& e) noexcept
         : m_e(std::forward<E>(e)), m_functor(std::forward<Func>(func))
     {
     }
     //@}
-
-    /**
-     * @name Extended copy semantic
-     */
-    //@{
-    /**
-     * The extended assignment operator.
-     */
-    template <class F, class CT>
-    template <class E>
-    inline auto xfunctor_view<F, CT>::operator=(const xexpression<E>& e) -> self_type&
-    {
-        bool cond = (e.derived_cast().shape().size() == dimension()) && std::equal(shape().begin(), shape().end(), e.derived_cast().shape().begin());
-        if (!cond)
-        {
-            semantic_base::operator=(broadcast(e.derived_cast(), shape()));
-        }
-        else
-        {
-            semantic_base::operator=(e);
-        }
-        return *this;
-    }
-    //@}
-
-    template <class F, class CT>
-    template <class E>
-    inline auto xfunctor_view<F, CT>::operator=(const E& e) -> disable_xexpression<E, self_type>&
-    {
-        std::fill(begin(), end(), e);
-        return *this;
-    }
-
-    template <class F, class CT>
-    inline void xfunctor_view<F, CT>::assign_temporary_impl(temporary_type&& tmp)
-    {
-        std::copy(tmp.cbegin(), tmp.cend(), begin());
-    }
 
     /**
      * @name Size and shape
@@ -479,35 +654,44 @@ namespace xt
     /**
      * Returns the size of the expression.
      */
-    template <class F, class CT>
-    inline auto xfunctor_view<F, CT>::size() const noexcept -> size_type
+    template <class D>
+    inline auto xfunctor_applier_base<D>::size() const noexcept -> size_type
     {
         return m_e.size();
     }
 
     /**
-     * Returns the number of dimensions of the expression.
-     */
-    template <class F, class CT>
-    inline auto xfunctor_view<F, CT>::dimension() const noexcept -> size_type
-    {
-        return m_e.dimension();
-    }
-
-    /**
      * Returns the shape of the expression.
      */
-    template <class F, class CT>
-    inline auto xfunctor_view<F, CT>::shape() const noexcept -> const shape_type&
+    template <class D>
+    inline auto xfunctor_applier_base<D>::shape() const noexcept -> const inner_shape_type&
     {
         return m_e.shape();
     }
 
     /**
+     * Returns the strides of the expression.
+     */
+    template <class D>
+    inline auto xfunctor_applier_base<D>::strides() const noexcept -> const inner_strides_type&
+    {
+        return m_e.strides();
+    }
+
+    /**
+     * Returns the backstrides of the expression.
+     */
+    template <class D>
+    inline auto xfunctor_applier_base<D>::backstrides() const noexcept -> const inner_backstrides_type&
+    {
+        return m_e.backstrides();
+    }
+
+    /**
      * Returns the layout_type of the expression.
      */
-    template <class F, class CT>
-    inline layout_type xfunctor_view<F, CT>::layout() const noexcept
+    template <class D>
+    inline layout_type xfunctor_applier_base<D>::layout() const noexcept
     {
         return m_e.layout();
     }
@@ -522,30 +706,13 @@ namespace xt
      * must be unsigned integers, the number of indices should be equal or greater than
      * the number of dimensions of the expression.
      */
-    template <class F, class CT>
+    template <class D>
     template <class... Args>
-    inline auto xfunctor_view<F, CT>::operator()(Args... args) -> reference
+    inline auto xfunctor_applier_base<D>::operator()(Args... args) -> reference
     {
         XTENSOR_TRY(check_index(shape(), args...));
         XTENSOR_CHECK_DIMENSION(shape(), args...);
         return m_functor(m_e(args...));
-    }
-
-    /**
-     * Returns a reference to the element at the specified position in the expression,
-     * after dimension and bounds checking.
-     * @param args a list of indices specifying the position in the function. Indices
-     * must be unsigned integers, the number of indices should be equal to the number of dimensions
-     * of the expression.
-     * @exception std::out_of_range if the number of argument is greater than the number of dimensions
-     * or if indices are out of bounds.
-     */
-    template <class F, class CT>
-    template <class... Args>
-    inline auto xfunctor_view<F, CT>::at(Args... args) -> reference
-    {
-        check_access(shape(), args...);
-        return this->operator()(args...);
     }
 
     /**
@@ -567,39 +734,11 @@ namespace xt
      * double res = fd.uncheked(0, 1);
      * \endcode
      */
-    template <class F, class CT>
+    template <class D>
     template <class... Args>
-    inline auto xfunctor_view<F, CT>::unchecked(Args... args) -> reference
+    inline auto xfunctor_applier_base<D>::unchecked(Args... args) -> reference
     {
         return m_functor(m_e.unchecked(args...));
-    }
-
-    /**
-     * Returns a reference to the element at the specified position in the expression.
-     * @param index a sequence of indices specifying the position in the function. Indices
-     * must be unsigned integers, the number of indices in the sequence should be equal or greater
-     * than the number of dimensions of the container.
-     */
-    template <class F, class CT>
-    template <class S>
-    inline auto xfunctor_view<F, CT>::operator[](const S& index)
-        -> disable_integral_t<S, reference>
-    {
-        return m_functor(m_e[index]);
-    }
-
-    template <class F, class CT>
-    template <class I>
-    inline auto xfunctor_view<F, CT>::operator[](std::initializer_list<I> index)
-        -> reference
-    {
-        return m_functor(m_e[index]);
-    }
-
-    template <class F, class CT>
-    inline auto xfunctor_view<F, CT>::operator[](size_type i) -> reference
-    {
-        return operator()(i);
     }
 
     /**
@@ -609,9 +748,9 @@ namespace xt
      * The number of indices in the sequence should be equal to or greater
      * than the number of dimensions of the function.
      */
-    template <class F, class CT>
+    template <class D>
     template <class IT>
-    inline auto xfunctor_view<F, CT>::element(IT first, IT last) -> reference
+    inline auto xfunctor_applier_base<D>::element(IT first, IT last) -> reference
     {
         XTENSOR_TRY(check_element_index(shape(), first, last));
         return m_functor(m_e.element(first, last));
@@ -623,30 +762,13 @@ namespace xt
      * must be unsigned integers, the number of indices should be equal or greater than
      * the number of dimensions of the expression.
      */
-    template <class F, class CT>
+    template <class D>
     template <class... Args>
-    inline auto xfunctor_view<F, CT>::operator()(Args... args) const -> const_reference
+    inline auto xfunctor_applier_base<D>::operator()(Args... args) const -> const_reference
     {
         XTENSOR_TRY(check_index(shape(), args...));
         XTENSOR_CHECK_DIMENSION(shape(), args...);
         return m_functor(m_e(args...));
-    }
-
-    /**
-     * Returns a constant reference to the element at the specified position in the expression,
-     * after dimension and bounds checking.
-     * @param args a list of indices specifying the position in the function. Indices
-     * must be unsigned integers, the number of indices should be equal to the number of dimensions
-     * of the expression.
-     * @exception std::out_of_range if the number of argument is greater than the number of dimensions
-     * or if indices are out of bounds.
-     */
-    template <class F, class CT>
-    template <class... Args>
-    inline auto xfunctor_view<F, CT>::at(Args... args) const -> const_reference
-    {
-        check_access(shape(), args...);
-        return this->operator()(args...);
     }
 
     /**
@@ -668,39 +790,11 @@ namespace xt
      * double res = fd.uncheked(0, 1);
      * \endcode
      */
-    template <class F, class CT>
+    template <class D>
     template <class... Args>
-    inline auto xfunctor_view<F, CT>::unchecked(Args... args) const -> const_reference
+    inline auto xfunctor_applier_base<D>::unchecked(Args... args) const -> const_reference
     {
         return m_functor(m_e.unchecked(args...));
-    }
-
-    /**
-     * Returns a constant reference to the element at the specified position in the expression.
-     * @param index a sequence of indices specifying the position in the function. Indices
-     * must be unsigned integers, the number of indices in the sequence should be equal or greater
-     * than the number of dimensions of the container.
-     */
-    template <class F, class CT>
-    template <class S>
-    inline auto xfunctor_view<F, CT>::operator[](const S& index) const
-        -> disable_integral_t<S, const_reference>
-    {
-        return m_functor(m_e[index]);
-    }
-
-    template <class F, class CT>
-    template <class I>
-    inline auto xfunctor_view<F, CT>::operator[](std::initializer_list<I> index) const
-        -> const_reference
-    {
-        return m_functor(m_e[index]);
-    }
-
-    template <class F, class CT>
-    inline auto xfunctor_view<F, CT>::operator[](size_type i) const -> const_reference
-    {
-        return operator()(i);
     }
 
     /**
@@ -710,12 +804,30 @@ namespace xt
      * The number of indices in the sequence should be equal to or greater
      * than the number of dimensions of the function.
      */
-    template <class F, class CT>
+    template <class D>
     template <class IT>
-    inline auto xfunctor_view<F, CT>::element(IT first, IT last) const -> const_reference
+    inline auto xfunctor_applier_base<D>::element(IT first, IT last) const -> const_reference
     {
         XTENSOR_TRY(check_element_index(shape(), first, last));
         return m_functor(m_e.element(first, last));
+    }
+
+    /**
+     * Returns a reference to the underlying expression of the view.
+     */
+    template <class D>
+    inline auto xfunctor_applier_base<D>::expression() noexcept -> xexpression_type&
+    {
+        return m_e;
+    }
+
+    /**
+     * Returns a consttant reference to the underlying expression of the view.
+     */
+    template <class D>
+    inline auto xfunctor_applier_base<D>::expression() const noexcept -> const xexpression_type&
+    {
+        return m_e;
     }
     //@}
 
@@ -729,23 +841,23 @@ namespace xt
      * @param reuse_cache boolean for reusing a previously computed shape
      * @return a boolean indicating whether the broadcasting is trivial
      */
-    template <class F, class CT>
+    template <class D>
     template <class S>
-    inline bool xfunctor_view<F, CT>::broadcast_shape(S& shape, bool reuse_cache) const
+    inline bool xfunctor_applier_base<D>::broadcast_shape(S& shape, bool reuse_cache) const
     {
         return m_e.broadcast_shape(shape, reuse_cache);
     }
 
     /**
-     * Compares the specified strides with those of the container to see whether
-     * the broadcasting is trivial.
-     * @return a boolean indicating whether the broadcasting is trivial
-     */
-    template <class F, class CT>
+    * Checks whether the xfunctor_applier_base can be linearly assigned to an expression
+    * with the specified strides.
+    * @return a boolean indicating whether a linear assign is possible
+    */
+    template <class D>
     template <class S>
-    inline bool xfunctor_view<F, CT>::is_trivial_broadcast(const S& strides) const
+    inline bool xfunctor_applier_base<D>::has_linear_assign(const S& strides) const
     {
-        return m_e.is_trivial_broadcast(strides);
+        return m_e.has_linear_assign(strides);
     }
     //@}
 
@@ -755,11 +867,11 @@ namespace xt
     //@{
     /**
      * Returns an iterator to the first element of the expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <layout_type L>
-    inline auto xfunctor_view<F, CT>::begin() noexcept
+    inline auto xfunctor_applier_base<D>::begin() noexcept
     {
         return xfunctor_iterator<functor_type, decltype(m_e.template begin<L>())>
             (m_e.template begin<L>(), &m_functor);
@@ -768,11 +880,11 @@ namespace xt
     /**
      * Returns an iterator to the element following the last element
      * of the expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <layout_type L>
-    inline auto xfunctor_view<F, CT>::end() noexcept
+    inline auto xfunctor_applier_base<D>::end() noexcept
     {
         return xfunctor_iterator<functor_type, decltype(m_e.template end<L>())>
             (m_e.template end<L>(), &m_functor);
@@ -780,11 +892,11 @@ namespace xt
 
     /**
      * Returns a constant iterator to the first element of the expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <layout_type L>
-    inline auto xfunctor_view<F, CT>::begin() const noexcept
+    inline auto xfunctor_applier_base<D>::begin() const noexcept
     {
         return this->template cbegin<L>();
     }
@@ -792,37 +904,37 @@ namespace xt
     /**
      * Returns a constant iterator to the element following the last element
      * of the expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <layout_type L>
-    inline auto xfunctor_view<F, CT>::end() const noexcept
+    inline auto xfunctor_applier_base<D>::end() const noexcept
     {
         return this->template cend<L>();
     }
 
     /**
      * Returns a constant iterator to the first element of the expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <layout_type L>
-    inline auto xfunctor_view<F, CT>::cbegin() const noexcept
+    inline auto xfunctor_applier_base<D>::cbegin() const noexcept
     {
-        return xfunctor_iterator<functor_type, decltype(m_e.template cbegin<L>())>
+        return xfunctor_iterator<const functor_type, decltype(m_e.template cbegin<L>())>
             (m_e.template cbegin<L>(), &m_functor);
     }
 
     /**
      * Returns a constant iterator to the element following the last element
      * of the expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <layout_type L>
-    inline auto xfunctor_view<F, CT>::cend() const noexcept
+    inline auto xfunctor_applier_base<D>::cend() const noexcept
     {
-        return xfunctor_iterator<functor_type, decltype(m_e.template cend<L>())>
+        return xfunctor_iterator<const functor_type, decltype(m_e.template cend<L>())>
             (m_e.template cend<L>(), &m_functor);
     }
     //@}
@@ -836,11 +948,11 @@ namespace xt
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <class S, layout_type L>
-    inline auto xfunctor_view<F, CT>::begin(const S& shape) noexcept -> broadcast_iterator<S, L>
+    inline auto xfunctor_applier_base<D>::begin(const S& shape) noexcept -> broadcast_iterator<S, L>
     {
         return broadcast_iterator<S, L>(m_e.template begin<S, L>(shape), &m_functor);
     }
@@ -850,11 +962,11 @@ namespace xt
      * expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <class S, layout_type L>
-    inline auto xfunctor_view<F, CT>::end(const S& shape) noexcept -> broadcast_iterator<S, L>
+    inline auto xfunctor_applier_base<D>::end(const S& shape) noexcept -> broadcast_iterator<S, L>
     {
         return broadcast_iterator<S, L>(m_e.template end<S, L>(shape), &m_functor);
     }
@@ -864,11 +976,11 @@ namespace xt
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <class S, layout_type L>
-    inline auto xfunctor_view<F, CT>::begin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xfunctor_applier_base<D>::begin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
         return cbegin<S, L>(shape);
     }
@@ -878,11 +990,11 @@ namespace xt
      * expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <class S, layout_type L>
-    inline auto xfunctor_view<F, CT>::end(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xfunctor_applier_base<D>::end(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
         return cend<S, L>(shape);
     }
@@ -892,11 +1004,11 @@ namespace xt
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <class S, layout_type L>
-    inline auto xfunctor_view<F, CT>::cbegin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xfunctor_applier_base<D>::cbegin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
         return const_broadcast_iterator<S, L>(m_e.template cbegin<S, L>(shape), &m_functor);
     }
@@ -906,11 +1018,11 @@ namespace xt
      * expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <class S, layout_type L>
-    inline auto xfunctor_view<F, CT>::cend(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    inline auto xfunctor_applier_base<D>::cend(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
         return const_broadcast_iterator<S, L>(m_e.template cend<S, L>(shape), &m_functor);
     }
@@ -922,11 +1034,11 @@ namespace xt
     //@{
     /**
      * Returns an iterator to the first element of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <layout_type L>
-    inline auto xfunctor_view<F, CT>::rbegin() noexcept
+    inline auto xfunctor_applier_base<D>::rbegin() noexcept
     {
         return xfunctor_iterator<functor_type, decltype(m_e.template rbegin<L>())>
             (m_e.template rbegin<L>(), &m_functor);
@@ -935,11 +1047,11 @@ namespace xt
     /**
      * Returns an iterator to the element following the last element
      * of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <layout_type L>
-    inline auto xfunctor_view<F, CT>::rend() noexcept
+    inline auto xfunctor_applier_base<D>::rend() noexcept
     {
         return xfunctor_iterator<functor_type, decltype(m_e.template rend<L>())>
             (m_e.template rend<L>(), &m_functor);
@@ -947,11 +1059,11 @@ namespace xt
 
     /**
      * Returns a constant iterator to the first element of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <layout_type L>
-    inline auto xfunctor_view<F, CT>::rbegin() const noexcept
+    inline auto xfunctor_applier_base<D>::rbegin() const noexcept
     {
         return this->template crbegin<L>();
     }
@@ -959,22 +1071,22 @@ namespace xt
     /**
      * Returns a constant iterator to the element following the last element
      * of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <layout_type L>
-    inline auto xfunctor_view<F, CT>::rend() const noexcept
+    inline auto xfunctor_applier_base<D>::rend() const noexcept
     {
         return this->template crend<L>();
     }
 
     /**
      * Returns a constant iterator to the first element of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <layout_type L>
-    inline auto xfunctor_view<F, CT>::crbegin() const noexcept
+    inline auto xfunctor_applier_base<D>::crbegin() const noexcept
     {
         return xfunctor_iterator<functor_type, decltype(m_e.template rbegin<L>())>
             (m_e.template rbegin<L>(), &m_functor);
@@ -983,11 +1095,11 @@ namespace xt
     /**
      * Returns a constant iterator to the element following the last element
      * of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <layout_type L>
-    inline auto xfunctor_view<F, CT>::crend() const noexcept
+    inline auto xfunctor_applier_base<D>::crend() const noexcept
     {
         return xfunctor_iterator<functor_type, decltype(m_e.template rend<L>())>
             (m_e.template rend<L>(), &m_functor);
@@ -1002,11 +1114,11 @@ namespace xt
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <class S, layout_type L>
-    inline auto xfunctor_view<F, CT>::rbegin(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    inline auto xfunctor_applier_base<D>::rbegin(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
     {
         return reverse_broadcast_iterator<S, L>(m_e.template rbegin<S, L>(shape), &m_functor);
     }
@@ -1016,11 +1128,11 @@ namespace xt
      * reversed expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <class S, layout_type L>
-    inline auto xfunctor_view<F, CT>::rend(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    inline auto xfunctor_applier_base<D>::rend(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
     {
         return reverse_broadcast_iterator<S, L>(m_e.template rend<S, L>(shape), &m_functor);
     }
@@ -1030,11 +1142,11 @@ namespace xt
      * The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <class S, layout_type L>
-    inline auto xfunctor_view<F, CT>::rbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    inline auto xfunctor_applier_base<D>::rbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
         return crbegin<S, L>(shape);
     }
@@ -1044,11 +1156,11 @@ namespace xt
      * of the reversed expression.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <class S, layout_type L>
-    inline auto xfunctor_view<F, CT>::rend(const S& /*shape*/) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    inline auto xfunctor_applier_base<D>::rend(const S& /*shape*/) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
         return crend<S, L>();
     }
@@ -1058,11 +1170,11 @@ namespace xt
      * The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <class S, layout_type L>
-    inline auto xfunctor_view<F, CT>::crbegin(const S& /*shape*/) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    inline auto xfunctor_applier_base<D>::crbegin(const S& /*shape*/) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
         return const_reverse_broadcast_iterator<S, L>(m_e.template crbegin<S, L>(), &m_functor);
     }
@@ -1072,132 +1184,231 @@ namespace xt
      * of the reversed expression.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
-    template <class F, class CT>
+    template <class D>
     template <class S, layout_type L>
-    inline auto xfunctor_view<F, CT>::crend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    inline auto xfunctor_applier_base<D>::crend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
         return const_reverse_broadcast_iterator<S, L>(m_e.template crend<S, L>(shape), &m_functor);
     }
     //@}
 
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctor_view<F, CT>::storage_begin() noexcept -> storage_iterator
+    template <class D>
+    inline auto xfunctor_applier_base<D>::storage_begin() noexcept -> storage_iterator
     {
-        return storage_iterator(m_e.template storage_begin<L>(), &m_functor);
+        return storage_iterator(m_e.storage_begin(), &m_functor);
     }
 
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctor_view<F, CT>::storage_end() noexcept -> storage_iterator
+    template <class D>
+    inline auto xfunctor_applier_base<D>::storage_end() noexcept -> storage_iterator
     {
-        return storage_iterator(m_e.template storage_end<L>(), &m_functor);
+        return storage_iterator(m_e.storage_end(), &m_functor);
     }
 
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctor_view<F, CT>::storage_begin() const noexcept -> const_storage_iterator
+    template <class D>
+    inline auto xfunctor_applier_base<D>::storage_begin() const noexcept -> const_storage_iterator
     {
-        return const_storage_iterator(m_e.template storage_begin<L>(), &m_functor);
+        return const_storage_iterator(m_e.storage_begin(), &m_functor);
     }
 
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctor_view<F, CT>::storage_end() const noexcept -> const_storage_iterator
+    template <class D>
+    inline auto xfunctor_applier_base<D>::storage_end() const noexcept -> const_storage_iterator
     {
-        return const_storage_iterator(m_e.template storage_end<L>(), &m_functor);
+        return const_storage_iterator(m_e.storage_end(), &m_functor);
     }
 
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctor_view<F, CT>::storage_cbegin() const noexcept -> const_storage_iterator
+    template <class D>
+    inline auto xfunctor_applier_base<D>::storage_cbegin() const noexcept -> const_storage_iterator
     {
-        return const_storage_iterator(m_e.template storage_cbegin<L>(), &m_functor);
+        return const_storage_iterator(m_e.storage_cbegin(), &m_functor);
     }
 
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctor_view<F, CT>::storage_cend() const noexcept -> const_storage_iterator
+    template <class D>
+    inline auto xfunctor_applier_base<D>::storage_cend() const noexcept -> const_storage_iterator
     {
-        return const_storage_iterator(m_e.template storage_cend<L>(), &m_functor);
+        return const_storage_iterator(m_e.storage_cend(), &m_functor);
     }
 
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctor_view<F, CT>::storage_rbegin() noexcept -> reverse_storage_iterator
+    template <class D>
+    inline auto xfunctor_applier_base<D>::storage_rbegin() noexcept -> reverse_storage_iterator
     {
-        return reverse_storage_iterator(m_e.template storage_rbegin<L>(), &m_functor);
+        return reverse_storage_iterator(m_e.storage_rbegin(), &m_functor);
     }
 
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctor_view<F, CT>::storage_rend() noexcept -> reverse_storage_iterator
+    template <class D>
+    inline auto xfunctor_applier_base<D>::storage_rend() noexcept -> reverse_storage_iterator
     {
-        return reverse_storage_iterator(m_e.template storage_rend<L>(), &m_functor);
+        return reverse_storage_iterator(m_e.storage_rend(), &m_functor);
     }
 
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctor_view<F, CT>::storage_rbegin() const noexcept -> const_reverse_storage_iterator
+    template <class D>
+    inline auto xfunctor_applier_base<D>::storage_rbegin() const noexcept -> const_reverse_storage_iterator
     {
-        return const_reverse_storage_iterator(m_e.template storage_rbegin<L>(), &m_functor);
+        return const_reverse_storage_iterator(m_e.storage_rbegin(), &m_functor);
     }
 
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctor_view<F, CT>::storage_rend() const noexcept -> const_reverse_storage_iterator
+    template <class D>
+    inline auto xfunctor_applier_base<D>::storage_rend() const noexcept -> const_reverse_storage_iterator
     {
-        return const_reverse_storage_iterator(m_e.template storage_rend<L>(), &m_functor);
+        return const_reverse_storage_iterator(m_e.storage_rend(), &m_functor);
     }
 
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctor_view<F, CT>::storage_crbegin() const noexcept -> const_reverse_storage_iterator
+    template <class D>
+    inline auto xfunctor_applier_base<D>::storage_crbegin() const noexcept -> const_reverse_storage_iterator
     {
-        return const_reverse_storage_iterator(m_e.template storage_crbegin<L>(), &m_functor);
+        return const_reverse_storage_iterator(m_e.storage_crbegin(), &m_functor);
     }
 
-    template <class F, class CT>
-    template <layout_type L>
-    inline auto xfunctor_view<F, CT>::storage_crend() const noexcept -> const_reverse_storage_iterator
+    template <class D>
+    inline auto xfunctor_applier_base<D>::storage_crend() const noexcept -> const_reverse_storage_iterator
     {
-        return const_reverse_storage_iterator(m_e.template storage_crend<L>(), &m_functor);
+        return const_reverse_storage_iterator(m_e.storage_crend(), &m_functor);
     }
 
     /***************
      * stepper api *
      ***************/
 
-    template <class F, class CT>
+    template <class D>
     template <class S>
-    inline auto xfunctor_view<F, CT>::stepper_begin(const S& shape) noexcept -> stepper
+    inline auto xfunctor_applier_base<D>::stepper_begin(const S& shape) noexcept -> stepper
     {
         return stepper(m_e.stepper_begin(shape), &m_functor);
     }
 
-    template <class F, class CT>
+    template <class D>
     template <class S>
-    inline auto xfunctor_view<F, CT>::stepper_end(const S& shape, layout_type l) noexcept -> stepper
+    inline auto xfunctor_applier_base<D>::stepper_end(const S& shape, layout_type l) noexcept -> stepper
     {
         return stepper(m_e.stepper_end(shape, l), &m_functor);
     }
 
-    template <class F, class CT>
+    template <class D>
     template <class S>
-    inline auto xfunctor_view<F, CT>::stepper_begin(const S& shape) const noexcept -> const_stepper
+    inline auto xfunctor_applier_base<D>::stepper_begin(const S& shape) const noexcept -> const_stepper
     {
         const xexpression_type& const_m_e = m_e;
         return const_stepper(const_m_e.stepper_begin(shape), &m_functor);
     }
 
-    template <class F, class CT>
+    template <class D>
     template <class S>
-    inline auto xfunctor_view<F, CT>::stepper_end(const S& shape, layout_type l) const noexcept -> const_stepper
+    inline auto xfunctor_applier_base<D>::stepper_end(const S& shape, layout_type l) const noexcept -> const_stepper
     {
         const xexpression_type& const_m_e = m_e;
         return const_stepper(const_m_e.stepper_end(shape, l), &m_functor);
+    }
+
+
+    /********************************
+     * xfunctor_view implementation *
+     ********************************/
+
+    /**
+     * @name Extended copy semantic
+     */
+    //@{
+    /**
+     * The extended assignment operator.
+     */
+    template <class F, class CT>
+    template <class E>
+    inline auto xfunctor_view<F, CT>::operator=(const xexpression<E>& e) -> self_type&
+    {
+        bool cond = (e.derived_cast().shape().size() == this->dimension()) &&
+                     std::equal(this->shape().begin(), this->shape().end(), e.derived_cast().shape().begin());
+        if (!cond)
+        {
+            semantic_base::operator=(broadcast(e.derived_cast(), this->shape()));
+        }
+        else
+        {
+            semantic_base::operator=(e);
+        }
+        return *this;
+    }
+    //@}
+
+    template <class F, class CT>
+    template <class E>
+    inline auto xfunctor_view<F, CT>::operator=(const E& e) -> disable_xexpression<E, self_type>&
+    {
+        std::fill(this->begin(), this->end(), e);
+        return *this;
+    }
+
+    template <class F, class CT>
+    inline void xfunctor_view<F, CT>::assign_temporary_impl(temporary_type&& tmp)
+    {
+        std::copy(tmp.cbegin(), tmp.cend(), this->begin());
+    }
+
+    template <class F, class CT>
+    template <class E>
+    inline auto xfunctor_view<F, CT>::build_functor_view(E&& e) const -> rebind_t<E>
+    {
+        return rebind_t<E>((this->m_functor), std::forward<E>(e));
+    }
+
+    /***********************************
+     * xfunctor_adaptor implementation *
+     ***********************************/
+
+    /**
+     * @name Extended copy semantic
+     */
+    //@{
+    /**
+     * The extended assignment operator.
+     */
+    template <class F, class CT>
+    template <class E>
+    inline auto xfunctor_adaptor<F, CT>::operator=(const xexpression<E>& e) -> self_type&
+    {
+        const auto& de = e.derived_cast();
+        this->m_e.resize(de.shape());
+
+        if (this->layout() == de.layout())
+        {
+            std::copy(de.storage_begin(), de.storage_end(), this->storage_begin());
+        }
+        else
+        {
+            // note: does this even select the current layout of *this* for iteration?
+            std::copy(de.begin(), de.end(), this->begin());
+        }
+
+        return *this;
+    }
+    //@}
+
+    template <class F, class CT>
+    template <class S>
+    auto xfunctor_adaptor<F, CT>::resize(S&& shape, bool force)
+    {
+        this->m_e.resize(std::forward<S>(shape), force);
+    }
+
+    template <class F, class CT>
+    template <class S>
+    auto xfunctor_adaptor<F, CT>::resize(S&& shape, layout_type l)
+    {
+        this->m_e.resize(std::forward<S>(shape), l);
+    }
+
+    template <class F, class CT>
+    template <class S>
+    auto xfunctor_adaptor<F, CT>::resize(S&& shape, const strides_type& strides)
+    {
+        this->m_e.resize(std::forward<S>(shape), strides);
+    }
+
+    template <class F, class CT>
+    template <class S>
+    auto xfunctor_adaptor<F, CT>::reshape(S&& shape, layout_type layout)
+    {
+        this->m_e.reshape(std::forward<S>(shape), layout);
     }
 
     /************************************
@@ -1205,7 +1416,7 @@ namespace xt
      ************************************/
 
     template <class F, class IT>
-    xfunctor_iterator<F, IT>::xfunctor_iterator(const IT& it, const functor_type* pf)
+    xfunctor_iterator<F, IT>::xfunctor_iterator(const IT& it, functor_type* pf)
         : m_it(it), p_functor(pf)
     {
     }
@@ -1247,7 +1458,7 @@ namespace xt
     template <class F, class IT>
     auto xfunctor_iterator<F, IT>::operator*() const -> reference
     {
-        return xtl::proxy_wrapper((*p_functor)(*m_it));
+        return (*p_functor)(*m_it);
     }
 
     template <class F, class IT>
@@ -1287,7 +1498,7 @@ namespace xt
      ***********************************/
 
     template <class F, class ST>
-    xfunctor_stepper<F, ST>::xfunctor_stepper(const ST& stepper, const functor_type* pf)
+    xfunctor_stepper<F, ST>::xfunctor_stepper(const ST& stepper, functor_type* pf)
         : m_stepper(stepper), p_functor(pf)
     {
     }

--- a/vendor/xtensor/include/xtensor/xhistogram.hpp
+++ b/vendor/xtensor/include/xtensor/xhistogram.hpp
@@ -1,0 +1,431 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+/**
+ * @brief construct histogram
+ */
+
+#ifndef XTENSOR_HISTOGRAM_HPP
+#define XTENSOR_HISTOGRAM_HPP
+
+#include "xtensor.hpp"
+#include "xsort.hpp"
+
+namespace xt
+{
+    /**
+     * @ingroup histogram
+     * @brief Compute the histogram of a set of data.
+     *
+     * @param data The data.
+     * @param bin_edges The bin-edges.
+     * @param weights Weight factors corresponding to each data-point.
+     * @param density If true the resulting integral is normalized to 1. [default: false]
+     * @return An one-dimensional xarray<double>, length: bin_edges.size()-1.
+     */
+    template <class R = double, class E1, class E2, class E3>
+    inline auto histogram(E1&& data, E2&& bin_edges, E3&& weights, bool density = false)
+    {
+        // alias counter and value type
+        using size_type = common_size_type_t<std::decay_t<E1>, std::decay_t<E2>, std::decay_t<E3>>;
+        using value_type = typename std::decay_t<E3>::value_type;
+
+        // basic checks
+        // - rank
+        XTENSOR_ASSERT(data.dimension() == 1);
+        XTENSOR_ASSERT(weights.dimension() == 1);
+        XTENSOR_ASSERT(bin_edges.dimension() == 1);
+        // - size
+        XTENSOR_ASSERT(weights.size() == data.size());
+        XTENSOR_ASSERT(bin_edges.size() >= 2);
+        // - bin-edges must be sorted
+        XTENSOR_ASSERT(std::is_sorted(bin_edges.cbegin(), bin_edges.cend()));
+        // - data must be enclosed in the bins
+        XTENSOR_ASSERT(xt::amin(data)[0] >= bin_edges[0]);
+        XTENSOR_ASSERT(xt::amax(data)[0] <= bin_edges[bin_edges.size() - 1]);
+
+        // initialize output
+        xt::xtensor<value_type, 1> count = xt::zeros<value_type>({ bin_edges.size() - 1 });
+
+        // indices that sort "data"
+        auto isort = xt::argsort(data);
+
+        // index of the current bin
+        size_type ibin = 0;
+
+        // fill the histogram: loop over (sorted) data
+        for (auto& idx : isort)
+        {
+            // - proceed to the relevant bin
+            while (data[idx] >= bin_edges[ibin + 1] && ibin < bin_edges.size() - 2)
+            {
+                ++ibin;
+            }
+            // - update the count
+            count[ibin] += weights[idx];
+        }
+
+        // cast type
+        xt::xtensor<R, 1> prob = xt::cast<R>(count);
+
+        // normalize
+        if (density)
+        {
+            // - size as doubles
+            R n = static_cast<R>(data.size());
+            // - apply normalization
+            for (size_type i = 0; i < bin_edges.size() - 1; ++i)
+            {
+                prob[i] /= (static_cast<R>(bin_edges[i + 1] - bin_edges[i]) * n);
+            }
+        }
+
+        return prob;
+    }
+
+    /**
+     * @ingroup histogram
+     * @brief Compute the histogram of a set of data.
+     *
+     * @param data The data.
+     * @param bin_edges The bin-edges.
+     * @param density If true the resulting integral is normalized to 1. [default: false]
+     * @return An one-dimensional xarray<double>, length: bin_edges.size()-1.
+     */
+    template <class E1, class E2>
+    inline auto histogram(E1&& data, E2&& bin_edges, bool density = false)
+    {
+        using value_type = typename std::decay_t<E1>::value_type;
+
+        auto n = data.size();
+
+        return histogram(std::forward<E1>(data),
+                         std::forward<E2>(bin_edges),
+                         xt::ones<value_type>({ n }),
+                         density);
+    }
+
+    /**
+     * @ingroup histogram
+     * @brief Compute the histogram of a set of data.
+     *
+     * @param data The data.
+     * @param bins The number of bins. [default: 10]
+     * @param density If true the resulting integral is normalized to 1. [default: false]
+     * @return An one-dimensional xarray<double>, length: bin_edges.size()-1.
+     */
+    template <class E1>
+    inline auto histogram(E1&& data, std::size_t bins = 10, bool density = false)
+    {
+        using value_type = typename std::decay_t<E1>::value_type;
+
+        auto n = data.size();
+
+        auto bin_edges = histogram_bin_edges(data, xt::ones<value_type>({ n }), bins);
+
+        return histogram(std::forward<E1>(data),
+                         std::forward<E1>(bin_edges),
+                         xt::ones<value_type>({ n }),
+                         density);
+    }
+
+    /**
+     * @ingroup histogram
+     * @brief Compute the histogram of a set of data.
+     *
+     * @param data The data.
+     * @param bins The number of bins.
+     * @param weights Weight factors corresponding to each data-point.
+     * @param density If true the resulting integral is normalized to 1. [default: false]
+     * @return An one-dimensional xarray<double>, length: bin_edges.size()-1.
+     */
+    template <class E1, class E2>
+    inline auto histogram(E1&& data, std::size_t bins, E2&& weights, bool density = false)
+    {
+        auto bin_edges = histogram_bin_edges(data, weights, bins);
+
+        return histogram(std::forward<E1>(data),
+                         std::forward<E1>(bin_edges),
+                         std::forward<E2>(weights),
+                         density);
+    }
+
+    /**
+     * @ingroup histogram
+     * @brief Defines different algorithms to be used in "histogram_bin_edges"
+     */
+    enum class histogram_algorithm
+    {
+        automatic,
+        linspace,
+        logspace,
+        uniform
+    };
+
+    /**
+     * @ingroup histogram
+     * @brief Compute the bin-edges of a histogram of a set of data using different algorithms.
+     *
+     * @param data The data.
+     * @param weights Weight factors corresponding to each data-point.
+     * @param left The lower-most edge.
+     * @param right The upper-most edge.
+     * @param bins The number of bins. [default: 10]
+     * @param mode The type of algorithm to use. [default: "auto"]
+     * @return An one-dimensional xarray<double>, length: bins+1.
+     */
+    template <class E1, class E2, class E3>
+    inline auto histogram_bin_edges(E1&& data,
+                                    E2&& weights,
+                                    E3 left,
+                                    E3 right,
+                                    std::size_t bins = 10,
+                                    histogram_algorithm mode = histogram_algorithm::automatic)
+    {
+        // counter and return type
+        using size_type = common_size_type_t<std::decay_t<E1>, std::decay_t<E2>>;
+        using value_type = typename std::decay_t<E1>::value_type;
+        using weights_type = typename std::decay_t<E2>::value_type;
+
+        // basic checks
+        // - rank
+        XTENSOR_ASSERT(data.dimension() == 1);
+        XTENSOR_ASSERT(weights.dimension() == 1);
+        // - size
+        XTENSOR_ASSERT(weights.size() == data.size());
+        // - bounds
+        XTENSOR_ASSERT(left <= xt::amin(data)[0]);
+        XTENSOR_ASSERT(right >= xt::amax(data)[0]);
+        // - non-empty
+        XTENSOR_ASSERT(bins > std::size_t(0));
+
+        // act on different modes
+        switch (mode)
+        {
+            // bins of equal width
+            case histogram_algorithm::automatic:
+            {
+                xt::xtensor<value_type, 1> bin_edges
+                    = xt::linspace<value_type>(left, right, bins + 1);
+                return bin_edges;
+            }
+
+            // bins of equal width
+            case histogram_algorithm::linspace:
+            {
+                xt::xtensor<value_type, 1> bin_edges
+                    = xt::linspace<value_type>(left, right, bins + 1);
+                return bin_edges;
+            }
+
+            // bins of logarithmically increasing size
+            case histogram_algorithm::logspace:
+            {
+                using rhs_value_type
+                    = std::conditional_t<std::is_integral<value_type>::value, double, value_type>;
+
+                xtensor<value_type, 1> bin_edges = xt::cast<value_type>(
+                    xt::logspace<rhs_value_type>(std::log10(left), std::log10(right), bins + 1));
+
+                // TODO: replace above with below after 'xsimd' fix
+                // xt::xtensor<value_type,1> bin_edges = xt::logspace<value_type>(
+                //     std::log10(left), std::log10(right), bins+1);
+
+                return bin_edges;
+            }
+
+            // same amount of data in each bin
+            case histogram_algorithm::uniform:
+            {
+                // indices that sort "data"
+                auto isort = xt::argsort(data);
+
+                // histogram: all of equal 'height'
+                // - height
+                weights_type w
+                    = xt::sum<weights_type>(weights)[0] / static_cast<weights_type>(bins);
+                // - apply to all bins
+                xt::xtensor<weights_type, 1> count = w * xt::ones<weights_type>({ bins });
+
+                // take cumulative sum, to act as easy look-up
+                count = xt::cumsum(count);
+
+                // edges
+                // - allocate
+                std::vector<size_t> shape = { bins + 1 };
+                xt::xtensor<value_type, 1> bin_edges = xtensor<value_type, 1>::from_shape(shape);
+                // - first/last edge
+                bin_edges[0] = left;
+                bin_edges[bins] = right;
+                // - cumulative weight
+                weights_type cum_weight = static_cast<weights_type>(0);
+                // - current bin
+                size_type ibin = 0;
+                // - loop to find interior bin-edges
+                for (size_type i = 0; i < weights.size(); ++i)
+                {
+                    if (cum_weight >= count[ibin])
+                    {
+                        bin_edges[ibin + 1] = data[isort[i]];
+                        ++ibin;
+                    }
+                    cum_weight += weights[isort[i]];
+                }
+                return bin_edges;
+            }
+            default:
+            {
+                xt::xtensor<value_type, 1> bin_edges
+                    = xt::linspace<value_type>(left, right, bins + 1);
+                return bin_edges;
+            }
+        }
+    }
+
+    /**
+     * @ingroup histogram
+     * @brief Compute the bin-edges of a histogram of a set of data using different algorithms.
+     *
+     * @param data The data.
+     * @param weights Weight factors corresponding to each data-point.
+     * @param bins The number of bins. [default: 10]
+     * @param mode The type of algorithm to use. [default: "auto"]
+     * @return An one-dimensional xarray<double>, length: bins+1.
+     */
+    template <class E1, class E2>
+    inline auto histogram_bin_edges(E1&& data,
+                                    E2&& weights,
+                                    std::size_t bins = 10,
+                                    histogram_algorithm mode = histogram_algorithm::automatic)
+    {
+        using value_type = typename std::decay_t<E1>::value_type;
+        std::array<value_type, 2> left_right;
+        left_right = xt::minmax(data)();
+
+        return histogram_bin_edges(std::forward<E1>(data),
+                                   std::forward<E2>(weights),
+                                   left_right[0],
+                                   left_right[1],
+                                   bins,
+                                   mode);
+    }
+
+    /**
+     * @ingroup histogram
+     * @brief Compute the bin-edges of a histogram of a set of data using different algorithms.
+     *
+     * @param data The data.
+     * @param bins The number of bins. [default: 10]
+     * @param mode The type of algorithm to use. [default: "auto"]
+     * @return An one-dimensional xarray<double>, length: bins+1.
+     */
+    template <class E1>
+    inline auto histogram_bin_edges(E1&& data,
+                                    std::size_t bins = 10,
+                                    histogram_algorithm mode = histogram_algorithm::automatic)
+    {
+        using value_type = typename std::decay_t<E1>::value_type;
+
+        auto n = data.size();
+        std::array<value_type, 2> left_right;
+        left_right = xt::minmax(data)();
+
+        return histogram_bin_edges(std::forward<E1>(data),
+                                   xt::ones<value_type>({ n }),
+                                   left_right[0],
+                                   left_right[1],
+                                   bins,
+                                   mode);
+    }
+
+    /**
+     * @ingroup histogram
+     * @brief Compute the bin-edges of a histogram of a set of data using different algorithms.
+     *
+     * @param data The data.
+     * @param left The lower-most edge.
+     * @param right The upper-most edge.
+     * @param bins The number of bins. [default: 10]
+     * @param mode The type of algorithm to use. [default: "auto"]
+     * @return An one-dimensional xarray<double>, length: bins+1.
+     */
+    template <class E1, class E2>
+    inline auto histogram_bin_edges(E1&& data,
+                                    E2 left,
+                                    E2 right,
+                                    std::size_t bins = 10,
+                                    histogram_algorithm mode = histogram_algorithm::automatic)
+    {
+        using value_type = typename std::decay_t<E1>::value_type;
+
+        auto n = data.size();
+
+        return histogram_bin_edges(
+            std::forward<E1>(data), xt::ones<value_type>({ n }), left, right, bins, mode);
+    }
+
+    /**
+     * Count number of occurrences of each value in array of non-negative ints.
+     *
+     * The number of bins (of size 1) is one larger than the largest value in x.
+     * If minlength is specified, there will be at least this number of bins in
+     * the output array (though it will be longer if necessary, depending on the
+     * contents of x). Each bin gives the number of occurrences of its index
+     * value in x. If weights is specified the input array is weighted by it,
+     * i.e. if a value ``n`` is found at position ``i``, ``out[n] += weight[i]``
+     * instead of ``out[n] += 1``.
+     *
+     * @param data the 1D container with integers to count into bins
+     * @param weights a 1D container with the same number of elements as ``data``
+     * @param minlength The minlength
+     *
+     * @return 1D container with the bincount
+     */
+    template <class E1, class E2, XTL_REQUIRES(is_xexpression<std::decay_t<E2>>)>
+    inline auto bincount(E1&& data, E2&& weights, std::size_t minlength = 0)
+    {
+        using result_value_type = typename std::decay_t<E2>::value_type;
+        using input_value_type = typename std::decay_t<E1>::value_type;
+        using size_type = typename std::decay_t<E1>::size_type;
+
+        static_assert(std::is_integral<typename std::decay_t<E1>::value_type>::value,
+                      "Bincount data has to be integral type.");
+        XTENSOR_ASSERT(data.dimension() == 1);
+        XTENSOR_ASSERT(weights.dimension() == 1);
+
+        std::array<input_value_type, 2> left_right;
+        left_right = xt::minmax(data)();
+
+        if (left_right[0] < input_value_type(0))
+        {
+            throw std::runtime_error(
+                "Data argument for bincount can only contain positive integers!");
+        }
+
+        xt::xtensor<result_value_type, 1> res = xt::zeros<result_value_type>(
+            { (std::max)(minlength, std::size_t(left_right[1] + 1)) });
+
+        for (size_type i = 0; i < data.size(); ++i)
+        {
+            res(data(i)) += weights(i);
+        }
+
+        return res;
+    }
+
+    template <class E1>
+    inline auto bincount(E1&& data, std::size_t minlength = 0)
+    {
+        return bincount(std::forward<E1>(data),
+                        xt::ones<typename std::decay_t<E1>::value_type>(data.shape()),
+                        minlength);
+    }
+}
+
+#endif

--- a/vendor/xtensor/include/xtensor/xindex_view.hpp
+++ b/vendor/xtensor/include/xtensor/xindex_view.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -17,11 +18,42 @@
 
 #include "xexpression.hpp"
 #include "xiterable.hpp"
+#include "xoperation.hpp"
+#include "xsemantic.hpp"
 #include "xstrides.hpp"
 #include "xutils.hpp"
 
 namespace xt
 {
+
+    /*************************
+     * xindex_view extension *
+     *************************/
+
+    namespace extension
+    {
+        template <class Tag, class CT, class I>
+        struct xindex_view_base_impl;
+
+        template <class CT, class I>
+        struct xindex_view_base_impl<xtensor_expression_tag, CT, I>
+        {
+            using type = xtensor_empty_base;
+        };
+
+        template <class CT, class I>
+        struct xindex_view_base
+            : xindex_view_base_impl<xexpression_tag_t<CT>, CT, I>
+        {
+        };
+
+        template <class CT, class I>
+        using xindex_view_base_t = typename xindex_view_base<CT, I>::type;
+    }
+
+    /***************
+     * xindex_view *
+     ***************/
 
     template <class CT, class I>
     class xindex_view;
@@ -41,10 +73,6 @@ namespace xt
         using stepper = xindexed_stepper<xindex_view<CT, I>, false>;
     };
 
-    /***************
-     * xindex_view *
-     ***************/
-
     /**
      * @class xindex_view
      * @brief View of an xexpression from vector of indices.
@@ -61,13 +89,17 @@ namespace xt
      */
     template <class CT, class I>
     class xindex_view : public xview_semantic<xindex_view<CT, I>>,
-                        public xiterable<xindex_view<CT, I>>
+                        public xiterable<xindex_view<CT, I>>,
+                        public extension::xindex_view_base_t<CT, I>
     {
     public:
 
         using self_type = xindex_view<CT, I>;
         using xexpression_type = std::decay_t<CT>;
         using semantic_base = xview_semantic<self_type>;
+
+        using extension_base = extension::xindex_view_base_t<CT, I>;
+        using expression_tag = typename extension_base::expression_tag;
 
         using value_type = typename xexpression_type::value_type;
         using reference = typename xexpression_type::reference;
@@ -80,7 +112,6 @@ namespace xt
         using iterable_base = xiterable<self_type>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
         using shape_type = inner_shape_type;
-        using strides_type = shape_type;
 
         using indices_type = I;
 
@@ -89,6 +120,8 @@ namespace xt
 
         using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
         using base_index_type = xindex_type_t<shape_type>;
+
+        using bool_load_type = typename xexpression_type::bool_load_type;
 
         static constexpr layout_type static_layout = layout_type::dynamic;
         static constexpr bool contiguous_layout = false;
@@ -106,7 +139,7 @@ namespace xt
         size_type dimension() const noexcept;
         const inner_shape_type& shape() const noexcept;
         layout_type layout() const noexcept;
-        
+
         template <class T>
         void fill(const T& value);
 
@@ -136,11 +169,14 @@ namespace xt
         template <class It>
         const_reference element(It first, It last) const;
 
+        xexpression_type& expression() noexcept;
+        const xexpression_type& expression() const noexcept;
+
         template <class O>
         bool broadcast_shape(O& shape, bool reuse_cache = false) const;
 
         template <class O>
-        bool is_trivial_broadcast(const O& /*strides*/) const noexcept;
+        bool has_linear_assign(const O& /*strides*/) const noexcept;
 
         template <class ST>
         stepper stepper_begin(const ST& shape);
@@ -151,6 +187,12 @@ namespace xt
         const_stepper stepper_begin(const ST& shape) const;
         template <class ST>
         const_stepper stepper_end(const ST& shape, layout_type) const;
+
+        template <class E>
+        using rebind_t = xindex_view<E, I>;
+
+        template <class E>
+        rebind_t<E> build_index_view(E&& e) const;
 
     private:
 
@@ -214,7 +256,7 @@ namespace xt
 
         template <class E>
         disable_xexpression<E, self_type&> operator%=(const E&);
-        
+
     private:
 
         template <class F>
@@ -235,7 +277,7 @@ namespace xt
     /**
      * Constructs an xindex_view, selecting the indices specified by \a indices.
      * The resulting xexpression has a 1D shape with a length of n for n indices.
-     * 
+     *
      * @param e the underlying xexpression for this view
      * @param indices the indices to select
      */
@@ -319,7 +361,7 @@ namespace xt
      * @name Data
      */
     //@{
-    
+
     /**
      * Fills the view with the given value.
      * @param value the value to fill the view with.
@@ -328,7 +370,7 @@ namespace xt
     template <class T>
     inline void xindex_view<CT, I>::fill(const T& value)
     {
-        std::fill(this->storage_begin(), this->storage_end(), value);
+        std::fill(this->begin(), this->end(), value);
     }
 
     /**
@@ -466,6 +508,24 @@ namespace xt
     {
         return m_e[m_indices[(*first)]];
     }
+
+    /**
+     * Returns a reference to the underlying expression of the view.
+     */
+    template <class CT, class I>
+    inline auto xindex_view<CT, I>::expression() noexcept -> xexpression_type&
+    {
+        return m_e;
+    }
+
+    /**
+     * Returns a constant reference to the underlying expression of the view.
+     */
+    template <class CT, class I>
+    inline auto xindex_view<CT, I>::expression() const noexcept -> const xexpression_type&
+    {
+        return m_e;
+    }
     //@}
 
     /**
@@ -486,13 +546,13 @@ namespace xt
     }
 
     /**
-     * Compares the specified strides with those of the container to see whether
-     * the broadcasting is trivial.
-     * @return a boolean indicating whether the broadcasting is trivial
+     * Checks whether the xindex_view can be linearly assigned to an expression
+     * with the specified strides.
+     * @return a boolean indicating whether a linear assign is possible
      */
     template <class CT, class I>
     template <class O>
-    inline bool xindex_view<CT, I>::is_trivial_broadcast(const O& /*strides*/) const noexcept
+    inline bool xindex_view<CT, I>::has_linear_assign(const O& /*strides*/) const noexcept
     {
         return false;
     }
@@ -534,6 +594,13 @@ namespace xt
         return const_stepper(this, offset, true);
     }
 
+    template <class CT, class I>
+    template <class E>
+    inline auto xindex_view<CT, I>::build_index_view(E&& e) const -> rebind_t<E>
+    {
+        return rebind_t<E>(std::forward<E>(e), indices_type(m_indices));
+    }
+
     /******************************
      * xfiltration implementation *
      ******************************/
@@ -544,7 +611,7 @@ namespace xt
     //@{
     /**
      * Constructs a xfiltration on the given expression \c e, selecting
-     * the elements matching the specified \c condition. 
+     * the elements matching the specified \c condition.
      *
      * @param e the \ref xexpression to filter.
      * @param condition the filtering \ref xexpression to apply.
@@ -587,7 +654,7 @@ namespace xt
     template <class E>
     inline auto xfiltration<ECT, CCT>::operator+=(const E& e) -> disable_xexpression<E, self_type&>
     {
-        return apply([this, &e](const_reference v, bool cond) { return cond ? v + e : v; });
+        return apply([&e](const_reference v, bool cond) { return cond ? v + e : v; });
     }
 
     /**
@@ -599,7 +666,7 @@ namespace xt
     template <class E>
     inline auto xfiltration<ECT, CCT>::operator-=(const E& e) -> disable_xexpression<E, self_type&>
     {
-        return apply([this, &e](const_reference v, bool cond) { return cond ? v - e : v; });
+        return apply([&e](const_reference v, bool cond) { return cond ? v - e : v; });
     }
 
     /**
@@ -611,7 +678,7 @@ namespace xt
     template <class E>
     inline auto xfiltration<ECT, CCT>::operator*=(const E& e) -> disable_xexpression<E, self_type&>
     {
-        return apply([this, &e](const_reference v, bool cond) { return cond ? v * e : v; });
+        return apply([&e](const_reference v, bool cond) { return cond ? v * e : v; });
     }
 
     /**
@@ -623,7 +690,7 @@ namespace xt
     template <class E>
     inline auto xfiltration<ECT, CCT>::operator/=(const E& e) -> disable_xexpression<E, self_type&>
     {
-        return apply([this, &e](const_reference v, bool cond) { return cond ? v / e : v; });
+        return apply([&e](const_reference v, bool cond) { return cond ? v / e : v; });
     }
 
     /**
@@ -635,7 +702,7 @@ namespace xt
     template <class E>
     inline auto xfiltration<ECT, CCT>::operator%=(const E& e) -> disable_xexpression<E, self_type&>
     {
-        return apply([this, &e](const_reference v, bool cond) { return cond ? v % e : v; });
+        return apply([&e](const_reference v, bool cond) { return cond ? v % e : v; });
     }
 
     template <class ECT, class CCT>
@@ -648,12 +715,12 @@ namespace xt
 
     /**
      * @brief creates an indexview from a container of indices.
-     *        
+     *
      * Returns a 1D view with the elements at \a indices selected.
      *
      * @param e the underlying xexpression
      * @param indices the indices to select
-     * 
+     *
      * \code{.cpp}
      * xarray<double> a = {{1,5,3}, {4,5,6}};
      * b = index_view(a, {{0, 0}, {1, 0}, {1, 1}});
@@ -691,13 +758,14 @@ namespace xt
 
     /**
      * @brief creates a view into \a e filtered by \a condition.
-     *        
+     *
      * Returns a 1D view with the elements selected where \a condition evaluates to \em true.
-     * This is equivalent to \verbatim{index_view(e, where(condition));}\endverbatim
+     * This is equivalent to \verbatim{index_view(e, argwhere(condition));}\endverbatim
      * The returned view is not optimal if you just want to assign a scalar to the filtered
      * elements. In that case, you should consider using the \ref filtration function
      * instead.
      *
+     * @tparam L the traversal order
      * @param e the underlying xexpression
      * @param condition xexpression with shape of \a e which selects indices
      *
@@ -709,10 +777,10 @@ namespace xt
      *
      * \sa filtration
      */
-    template <class E, class O>
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E, class O>
     inline auto filter(E&& e, O&& condition) noexcept
     {
-        auto indices = where(std::forward<O>(condition));
+        auto indices = argwhere<L>(std::forward<O>(condition));
         using view_type = xindex_view<xclosure_t<E>, decltype(indices)>;
         return view_type(std::forward<E>(e), std::move(indices));
     }

--- a/vendor/xtensor/include/xtensor/xinfo.hpp
+++ b/vendor/xtensor/include/xtensor/xinfo.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *

--- a/vendor/xtensor/include/xtensor/xiterable.hpp
+++ b/vendor/xtensor/include/xtensor/xiterable.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -20,8 +21,6 @@ namespace xt
 
     template <class D>
     struct xiterable_inner_types;
-
-#define DL XTENSOR_DEFAULT_LAYOUT
 
     /**
      * @class xconst_iterable
@@ -55,6 +54,11 @@ namespace xt
         template <layout_type L>
         using const_reverse_layout_iterator = std::reverse_iterator<const_layout_iterator<L>>;
 
+        using storage_iterator = layout_iterator<XTENSOR_DEFAULT_TRAVERSAL>;
+        using const_storage_iterator = const_layout_iterator<XTENSOR_DEFAULT_TRAVERSAL>;
+        using reverse_storage_iterator = reverse_layout_iterator<XTENSOR_DEFAULT_TRAVERSAL>;
+        using const_reverse_storage_iterator = const_reverse_layout_iterator<XTENSOR_DEFAULT_TRAVERSAL>;
+
         template <class S, layout_type L>
         using broadcast_iterator = xiterator<stepper, S, L>;
         template <class S, layout_type L>
@@ -64,69 +68,46 @@ namespace xt
         template <class S, layout_type L>
         using const_reverse_broadcast_iterator = std::reverse_iterator<const_broadcast_iterator<S, L>>;
 
-        using storage_iterator = layout_iterator<DL>;
-        using const_storage_iterator = const_layout_iterator<DL>;
-        using reverse_storage_iterator = reverse_layout_iterator<DL>;
-        using const_reverse_storage_iterator = const_reverse_layout_iterator<DL>;
+        using iterator = layout_iterator<XTENSOR_DEFAULT_TRAVERSAL>;
+        using const_iterator = const_layout_iterator<XTENSOR_DEFAULT_TRAVERSAL>;
+        using reverse_iterator = reverse_layout_iterator<XTENSOR_DEFAULT_TRAVERSAL>;
+        using const_reverse_iterator = const_reverse_layout_iterator<XTENSOR_DEFAULT_TRAVERSAL>;
 
-        using iterator = layout_iterator<DL>;
-        using const_iterator = const_layout_iterator<DL>;
-        using reverse_iterator = reverse_layout_iterator<DL>;
-        using const_reverse_iterator = const_reverse_layout_iterator<DL>;
-
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_layout_iterator<L> begin() const noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_layout_iterator<L> end() const noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_layout_iterator<L> cbegin() const noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_layout_iterator<L> cend() const noexcept;
 
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_reverse_layout_iterator<L> rbegin() const noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_reverse_layout_iterator<L> rend() const noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_reverse_layout_iterator<L> crbegin() const noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_reverse_layout_iterator<L> crend() const noexcept;
 
-        template <class S, layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
         const_broadcast_iterator<S, L> begin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
         const_broadcast_iterator<S, L> end(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
         const_broadcast_iterator<S, L> cbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
         const_broadcast_iterator<S, L> cend(const S& shape) const noexcept;
 
-        template <class S, layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
         const_reverse_broadcast_iterator<S, L> rbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
         const_reverse_broadcast_iterator<S, L> rend(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
         const_reverse_broadcast_iterator<S, L> crbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
         const_reverse_broadcast_iterator<S, L> crend(const S& shape) const noexcept;
-
-        template <layout_type L = DL>
-        const_layout_iterator<L> storage_begin() const noexcept;
-        template <layout_type L = DL>
-        const_layout_iterator<L> storage_end() const noexcept;
-        template <layout_type L = DL>
-        const_layout_iterator<L> storage_cbegin() const noexcept;
-        template <layout_type L = DL>
-        const_layout_iterator<L> storage_cend() const noexcept;
-
-        template <layout_type L = DL>
-        const_reverse_layout_iterator<L> storage_rbegin() const noexcept;
-        template <layout_type L = DL>
-        const_reverse_layout_iterator<L> storage_rend() const noexcept;
-        template <layout_type L = DL>
-        const_reverse_layout_iterator<L> storage_crbegin() const noexcept;
-        template <layout_type L = DL>
-        const_reverse_layout_iterator<L> storage_crend() const noexcept;
 
     protected:
 
@@ -139,9 +120,9 @@ namespace xt
         template <layout_type L>
         const_layout_iterator<L> get_cend(bool end_index) const noexcept;
 
-        template <class S, layout_type L>
+        template <layout_type L, class S>
         const_broadcast_iterator<S, L> get_cbegin(const S& shape, bool end_index) const noexcept;
-        template <class S, layout_type L>
+        template <layout_type L, class S>
         const_broadcast_iterator<S, L> get_cend(const S& shape, bool end_index) const noexcept;
 
         template <class S>
@@ -179,6 +160,9 @@ namespace xt
         using stepper = typename base_type::stepper;
         using const_stepper = typename base_type::const_stepper;
 
+        using storage_iterator = typename base_type::storage_iterator;
+        using reverse_storage_iterator = typename base_type::reverse_storage_iterator;
+
         template <layout_type L>
         using layout_iterator = typename base_type::template layout_iterator<L>;
         template <layout_type L>
@@ -206,38 +190,26 @@ namespace xt
         using base_type::end;
         using base_type::rbegin;
         using base_type::rend;
-        using base_type::storage_begin;
-        using base_type::storage_end;
 
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         layout_iterator<L> begin() noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         layout_iterator<L> end() noexcept;
 
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         reverse_layout_iterator<L> rbegin() noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         reverse_layout_iterator<L> rend() noexcept;
 
-        template <class S, layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
         broadcast_iterator<S, L> begin(const S& shape) noexcept;
-        template <class S, layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
         broadcast_iterator<S, L> end(const S& shape) noexcept;
 
-        template <class S, layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
         reverse_broadcast_iterator<S, L> rbegin(const S& shape) noexcept;
-        template <class S, layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
         reverse_broadcast_iterator<S, L> rend(const S& shape) noexcept;
-
-        template <layout_type L = DL>
-        layout_iterator<L> storage_begin() noexcept;
-        template <layout_type L = DL>
-        layout_iterator<L> storage_end() noexcept;
-
-        template <layout_type L = DL>
-        reverse_layout_iterator<L> storage_rbegin() noexcept;
-        template <layout_type L = DL>
-        reverse_layout_iterator<L> storage_rend() noexcept;
 
     private:
 
@@ -246,9 +218,9 @@ namespace xt
         template <layout_type L>
         layout_iterator<L> get_end(bool end_index) noexcept;
 
-        template <class S, layout_type L>
+        template <layout_type L, class S>
         broadcast_iterator<S, L> get_begin(const S& shape, bool end_index) noexcept;
-        template <class S, layout_type L>
+        template <layout_type L, class S>
         broadcast_iterator<S, L> get_end(const S& shape, bool end_index) noexcept;
 
         template <class S>
@@ -264,7 +236,178 @@ namespace xt
         derived_type& derived_cast();
     };
 
-#undef DL
+    /************************
+     * xcontiguous_iterable *
+     ************************/
+
+    template <class D>
+    struct xcontainer_inner_types;
+
+    namespace detail
+    {
+        template <class C>
+        struct storage_iterator_traits
+        {
+            using iterator = typename C::iterator;
+            using const_iterator = typename C::const_iterator;
+            using reverse_iterator = typename C::reverse_iterator;
+            using const_reverse_iterator = typename C::const_reverse_iterator;
+        };
+
+        template <class C>
+        struct storage_iterator_traits<const C>
+        {
+            using iterator = typename C::const_iterator;
+            using const_iterator = iterator;
+            using reverse_iterator = typename C::const_reverse_iterator;
+            using const_reverse_iterator = reverse_iterator;
+        };
+    }
+
+    /**
+     * @class xcontiguous_iterable
+     * @brief Base class for multidimensional iterable expressions with
+     * contiguous storage
+     *
+     * The xcontiguous_iterable class defines the interface for multidimensional
+     * expressions with contiguous that can be iterated.
+     *
+     * @tparam D The derived type, i.e. the inheriting class for which xcontiguous_iterable
+     *           provides the interface.
+     */
+    template <class D>
+    class xcontiguous_iterable : private xiterable<D>
+    {
+    public:
+
+        using derived_type = D;
+
+        using inner_types = xcontainer_inner_types<D>;
+        using storage_type = typename inner_types::storage_type;
+
+        using iterable_base = xiterable<D>;
+        using stepper = typename iterable_base::stepper;
+        using const_stepper = typename iterable_base::const_stepper;
+
+        static constexpr layout_type static_layout = inner_types::layout;
+
+#if defined(_MSC_VER) && _MSC_VER >= 1910
+        // Workaround for compiler bug in Visual Studio 2017 with respect to alias templates with non-type parameters.
+        template <layout_type L>
+        using layout_iterator = xiterator<typename iterable_base::stepper, typename iterable_base::inner_shape_type*, L>;
+        template <layout_type L>
+        using const_layout_iterator = xiterator<typename iterable_base::const_stepper, typename iterable_base::inner_shape_type*, L>;
+        template <layout_type L>
+        using reverse_layout_iterator = std::reverse_iterator<layout_iterator<L>>;
+        template <layout_type L>
+        using const_reverse_layout_iterator = std::reverse_iterator<const_layout_iterator<L>>;
+#else
+        template <layout_type L>
+        using layout_iterator = typename iterable_base::template layout_iterator<L>;
+        template <layout_type L>
+        using const_layout_iterator = typename iterable_base::template const_layout_iterator<L>;
+        template <layout_type L>
+        using reverse_layout_iterator = typename iterable_base::template reverse_layout_iterator<L>;
+        template <layout_type L>
+        using const_reverse_layout_iterator = typename iterable_base::template const_reverse_layout_iterator<L>;
+#endif
+
+        template <class S, layout_type L>
+        using broadcast_iterator = typename iterable_base::template broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using const_broadcast_iterator = typename iterable_base::template const_broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using reverse_broadcast_iterator = typename iterable_base::template reverse_broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using const_reverse_broadcast_iterator = typename iterable_base::template const_reverse_broadcast_iterator<S, L>;
+
+        using storage_traits = detail::storage_iterator_traits<storage_type>;
+        using storage_iterator = typename storage_traits::iterator;
+        using const_storage_iterator = typename storage_traits::const_iterator;
+        using reverse_storage_iterator = typename storage_traits::reverse_iterator;
+        using const_reverse_storage_iterator = typename storage_traits::const_reverse_iterator;
+
+        template <layout_type L, class It1, class It2>
+        using select_iterator_impl = std::conditional_t<L == static_layout, It1, It2>;
+
+        template <layout_type L>
+        using select_iterator = select_iterator_impl<L, storage_iterator, layout_iterator<L>>;
+        template <layout_type L>
+        using select_const_iterator = select_iterator_impl<L, const_storage_iterator, const_layout_iterator<L>>;
+        template <layout_type L>
+        using select_reverse_iterator = select_iterator_impl<L, reverse_storage_iterator, reverse_layout_iterator<L>>;
+        template <layout_type L>
+        using select_const_reverse_iterator = select_iterator_impl<L, const_reverse_storage_iterator, const_reverse_layout_iterator<L>>;
+
+        using iterator = select_iterator<XTENSOR_DEFAULT_TRAVERSAL>;
+        using const_iterator = select_const_iterator<XTENSOR_DEFAULT_TRAVERSAL>;
+        using reverse_iterator = select_reverse_iterator<XTENSOR_DEFAULT_TRAVERSAL>;
+        using const_reverse_iterator = select_const_reverse_iterator<XTENSOR_DEFAULT_TRAVERSAL>;
+
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        select_iterator<L> begin() noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        select_iterator<L> end() noexcept;
+
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        select_const_iterator<L> begin() const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        select_const_iterator<L> end() const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        select_const_iterator<L> cbegin() const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        select_const_iterator<L> cend() const noexcept;
+
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        select_reverse_iterator<L> rbegin() noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        select_reverse_iterator<L> rend() noexcept;
+
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        select_const_reverse_iterator<L> rbegin() const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        select_const_reverse_iterator<L> rend() const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        select_const_reverse_iterator<L> crbegin() const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
+        select_const_reverse_iterator<L> crend() const noexcept;
+
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        broadcast_iterator<S, L> begin(const S& shape) noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        broadcast_iterator<S, L> end(const S& shape) noexcept;
+
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_broadcast_iterator<S, L> begin(const S& shape) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_broadcast_iterator<S, L> end(const S& shape) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_broadcast_iterator<S, L> cbegin(const S& shape) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_broadcast_iterator<S, L> cend(const S& shape) const noexcept;
+
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        reverse_broadcast_iterator<S, L> rbegin(const S& shape) noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        reverse_broadcast_iterator<S, L> rend(const S& shape) noexcept;
+
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_reverse_broadcast_iterator<S, L> rbegin(const S& shape) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_reverse_broadcast_iterator<S, L> rend(const S& shape) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_reverse_broadcast_iterator<S, L> crbegin(const S& shape) const noexcept;
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class S>
+        const_reverse_broadcast_iterator<S, L> crend(const S& shape) const noexcept;
+
+    private:
+
+        derived_type& derived_cast();
+        const derived_type& derived_cast() const;
+
+        friend class xiterable<D>;
+        friend class xconst_iterable<D>;
+    };
 
     /**********************************
      * xconst_iterable implementation *
@@ -276,7 +419,7 @@ namespace xt
     //@{
     /**
      * Returns a constant iterator to the first element of the expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
@@ -288,7 +431,7 @@ namespace xt
     /**
      * Returns a constant iterator to the element following the last element
      * of the expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
@@ -299,7 +442,7 @@ namespace xt
 
     /**
      * Returns a constant iterator to the first element of the expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
@@ -311,7 +454,7 @@ namespace xt
     /**
      * Returns a constant iterator to the element following the last element
      * of the expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
@@ -327,7 +470,7 @@ namespace xt
     //@{
     /**
      * Returns a constant iterator to the first element of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
@@ -339,7 +482,7 @@ namespace xt
     /**
      * Returns a constant iterator to the element following the last element
      * of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
@@ -350,7 +493,7 @@ namespace xt
 
     /**
      * Returns a constant iterator to the first element of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
@@ -362,7 +505,7 @@ namespace xt
     /**
      * Returns a constant iterator to the element following the last element
      * of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
@@ -381,13 +524,13 @@ namespace xt
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xconst_iterable<D>::begin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return cbegin<S, L>(shape);
+        return cbegin<L>(shape);
     }
 
     /**
@@ -395,13 +538,13 @@ namespace xt
      * expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xconst_iterable<D>::end(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return cend<S, L>(shape);
+        return cend<L>(shape);
     }
 
     /**
@@ -409,13 +552,13 @@ namespace xt
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xconst_iterable<D>::cbegin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return get_cbegin<S, L>(shape, false);
+        return get_cbegin<L, S>(shape, false);
     }
 
     /**
@@ -423,13 +566,13 @@ namespace xt
      * expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xconst_iterable<D>::cend(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
     {
-        return get_cend<S, L>(shape, true);
+        return get_cend<L, S>(shape, true);
     }
     //@}
 
@@ -442,13 +585,13 @@ namespace xt
      * The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xconst_iterable<D>::rbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return crbegin<S, L>(shape);
+        return crbegin<L, S>(shape);
     }
 
     /**
@@ -456,13 +599,13 @@ namespace xt
      * reversed expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xconst_iterable<D>::rend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return crend<S, L>(shape);
+        return crend<L, S>(shape);
     }
 
     /**
@@ -470,13 +613,13 @@ namespace xt
      * The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xconst_iterable<D>::crbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return const_reverse_broadcast_iterator<S, L>(get_cend<S, L>(shape, true));
+        return const_reverse_broadcast_iterator<S, L>(get_cend<L, S>(shape, true));
     }
 
     /**
@@ -484,71 +627,15 @@ namespace xt
      * reversed expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xconst_iterable<D>::crend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
     {
-        return const_reverse_broadcast_iterator<S, L>(get_cbegin<S, L>(shape, false));
+        return const_reverse_broadcast_iterator<S, L>(get_cbegin<L, S>(shape, false));
     }
     //@}
-
-    template <class D>
-    template <layout_type L>
-    inline auto xconst_iterable<D>::storage_begin() const noexcept -> const_layout_iterator<L>
-    {
-        return this->template cbegin<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xconst_iterable<D>::storage_end() const noexcept -> const_layout_iterator<L>
-    {
-        return this->template cend<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xconst_iterable<D>::storage_cbegin() const noexcept -> const_layout_iterator<L>
-    {
-        return this->template cbegin<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xconst_iterable<D>::storage_cend() const noexcept -> const_layout_iterator<L>
-    {
-        return this->template cend<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xconst_iterable<D>::storage_rbegin() const noexcept -> const_reverse_layout_iterator<L>
-    {
-        return this->template crbegin<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xconst_iterable<D>::storage_rend() const noexcept -> const_reverse_layout_iterator<L>
-    {
-        return this->template crend<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xconst_iterable<D>::storage_crbegin() const noexcept -> const_reverse_layout_iterator<L>
-    {
-        return this->template crbegin<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xconst_iterable<D>::storage_crend() const noexcept -> const_reverse_layout_iterator<L>
-    {
-        return this->template crend<L>();
-    }
 
     template <class D>
     template <layout_type L>
@@ -565,14 +652,14 @@ namespace xt
     }
 
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xconst_iterable<D>::get_cbegin(const S& shape, bool end_index) const noexcept -> const_broadcast_iterator<S, L>
     {
         return const_broadcast_iterator<S, L>(get_stepper_begin(shape), shape, end_index);
     }
 
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xconst_iterable<D>::get_cend(const S& shape, bool end_index) const noexcept -> const_broadcast_iterator<S, L>
     {
         return const_broadcast_iterator<S, L>(get_stepper_end(shape, L), shape, end_index);
@@ -614,7 +701,7 @@ namespace xt
     //@{
     /**
      * Returns an iterator to the first element of the expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
@@ -626,7 +713,7 @@ namespace xt
     /**
      * Returns an iterator to the element following the last element
      * of the expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
@@ -642,7 +729,7 @@ namespace xt
     //@{
     /**
      * Returns an iterator to the first element of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
@@ -654,7 +741,7 @@ namespace xt
     /**
      * Returns an iterator to the element following the last element
      * of the reversed expression.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
     template <layout_type L>
@@ -673,13 +760,13 @@ namespace xt
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xiterable<D>::begin(const S& shape) noexcept -> broadcast_iterator<S, L>
     {
-        return get_begin<S, L>(shape, false);
+        return get_begin<L, S>(shape, false);
     }
 
     /**
@@ -687,13 +774,13 @@ namespace xt
      * expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xiterable<D>::end(const S& shape) noexcept -> broadcast_iterator<S, L>
     {
-        return get_end<S, L>(shape, true);
+        return get_end<L, S>(shape, true);
     }
     //@}
 
@@ -706,13 +793,13 @@ namespace xt
      * iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xiterable<D>::rbegin(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
     {
-        return reverse_broadcast_iterator<S, L>(get_end<S, L>(shape, true));
+        return reverse_broadcast_iterator<S, L>(get_end<L, S>(shape, true));
     }
 
     /**
@@ -720,43 +807,15 @@ namespace xt
      * reversed expression. The iteration is broadcasted to the specified shape.
      * @param shape the shape used for broadcasting
      * @tparam S type of the \c shape parameter.
-     * @tparam L layout used for the traversal. Default value is \c XTENSOR_DEFAULT_LAYOUT.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
      */
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xiterable<D>::rend(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
     {
-        return reverse_broadcast_iterator<S, L>(get_begin<S, L>(shape, false));
+        return reverse_broadcast_iterator<S, L>(get_begin<L, S>(shape, false));
     }
     //@}
-
-    template <class D>
-    template <layout_type L>
-    inline auto xiterable<D>::storage_begin() noexcept -> layout_iterator<L>
-    {
-        return this->template begin<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xiterable<D>::storage_end() noexcept -> layout_iterator<L>
-    {
-        return this->template end<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xiterable<D>::storage_rbegin() noexcept -> reverse_layout_iterator<L>
-    {
-        return this->template rbegin<L>();
-    }
-
-    template <class D>
-    template <layout_type L>
-    inline auto xiterable<D>::storage_rend() noexcept -> reverse_layout_iterator<L>
-    {
-        return this->template rend<L>();
-    }
 
     template <class D>
     template <layout_type L>
@@ -773,14 +832,14 @@ namespace xt
     }
 
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xiterable<D>::get_begin(const S& shape, bool end_index) noexcept -> broadcast_iterator<S, L>
     {
         return broadcast_iterator<S, L>(get_stepper_begin(shape), shape, end_index);
     }
 
     template <class D>
-    template <class S, layout_type L>
+    template <layout_type L, class S>
     inline auto xiterable<D>::get_end(const S& shape, bool end_index) noexcept -> broadcast_iterator<S, L>
     {
         return broadcast_iterator<S, L>(get_stepper_end(shape, L), shape, end_index);
@@ -819,6 +878,398 @@ namespace xt
     {
         return *static_cast<derived_type*>(this);
     }
+
+    /***************************************
+     * xcontiguous_iterable implementation *
+     ***************************************/
+
+     /**
+      * @name Iterators
+      */
+     //@{
+     /**
+      * Returns an iterator to the first element of the expression.
+      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+      */
+    template <class D>
+    template <layout_type L>
+    inline auto xcontiguous_iterable<D>::begin() noexcept -> select_iterator<L>
+    {
+        return xtl::mpl::static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).derived_cast().storage_begin();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template begin<L>();
+        });
+    }
+
+    /**
+     * Returns an iterator to the element following the last element
+     * of the expression.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xcontiguous_iterable<D>::end() noexcept -> select_iterator<L>
+    {
+        return xtl::mpl::static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).derived_cast().storage_end();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template end<L>();
+        });
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xcontiguous_iterable<D>::begin() const noexcept -> select_const_iterator<L>
+    {
+        return this->template cbegin<L>();
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the expression.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xcontiguous_iterable<D>::end() const noexcept -> select_const_iterator<L>
+    {
+        return this->template cend<L>();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xcontiguous_iterable<D>::cbegin() const noexcept -> select_const_iterator<L>
+    {
+        return xtl::mpl::static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).derived_cast().storage_cbegin();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template cbegin<L>();
+        });
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the expression.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xcontiguous_iterable<D>::cend() const noexcept -> select_const_iterator<L>
+    {
+        return xtl::mpl::static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).derived_cast().storage_cend();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template cend<L>();
+        });
+    }
+    //@}
+
+    /**
+     * @name Reverse iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the reversed expression.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xcontiguous_iterable<D>::rbegin() noexcept -> select_reverse_iterator<L>
+    {
+        return xtl::mpl::static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).derived_cast().storage_rbegin();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template rbegin<L>();
+        });
+    }
+
+    /**
+     * Returns an iterator to the element following the last element
+     * of the reversed expression.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xcontiguous_iterable<D>::rend() noexcept -> select_reverse_iterator<L>
+    {
+        return xtl::mpl::static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).derived_cast().storage_rend();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template rend<L>();
+        });
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xcontiguous_iterable<D>::rbegin() const noexcept -> select_const_reverse_iterator<L>
+    {
+        return this->template crbegin<L>();
+    }
+
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xcontiguous_iterable<D>::rend() const noexcept -> select_const_reverse_iterator<L>
+    {
+        return this->template crend<L>();
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xcontiguous_iterable<D>::crbegin() const noexcept -> select_const_reverse_iterator<L>
+    {
+        return xtl::mpl::static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).derived_cast().storage_crbegin();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template crbegin<L>();
+        });
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element
+     * of the reversed expression.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L>
+    inline auto xcontiguous_iterable<D>::crend() const noexcept -> select_const_reverse_iterator<L>
+    {
+        return xtl::mpl::static_if<L == static_layout>([&](auto self)
+        {
+            return self(*this).derived_cast().storage_crend();
+        }, /*else*/ [&](auto self)
+        {
+            return self(*this).iterable_base::template crend<L>();
+        });
+    }
+    //@}
+
+    /**
+     * @name Broadcast iterators
+     */
+     /**
+      * Returns an iterator to the first element of the expression. The
+      * iteration is broadcasted to the specified shape.
+      * @param shape the shape used for broadcasting
+      * @tparam S type of the \c shape parameter.
+      * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+      */
+    //@{
+    template <class D>
+    template <layout_type L, class S>
+    inline auto xcontiguous_iterable<D>::begin(const S& shape) noexcept -> broadcast_iterator<S, L>
+    {
+        return iterable_base::template begin<L, S>(shape);
+    }
+
+    /**
+     * Returns an iterator to the element following the last element of the
+     * expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L, class S>
+    inline auto xcontiguous_iterable<D>::end(const S& shape) noexcept -> broadcast_iterator<S, L>
+    {
+        return iterable_base::template end<L, S>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L, class S>
+    inline auto xcontiguous_iterable<D>::begin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return iterable_base::template begin<L, S>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L, class S>
+    inline auto xcontiguous_iterable<D>::end(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return iterable_base::template end<L, S>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the expression. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L, class S>
+    inline auto xcontiguous_iterable<D>::cbegin(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return iterable_base::template cbegin<L, S>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L, class S>
+    inline auto xcontiguous_iterable<D>::cend(const S& shape) const noexcept -> const_broadcast_iterator<S, L>
+    {
+        return iterable_base::template cend<L, S>(shape);
+    }
+    //@}
+
+    /**
+     * @name Reverse broadcast iterators
+     */
+    //@{
+    /**
+     * Returns an iterator to the first element of the reversed expression. The
+     * iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L, class S>
+    inline auto xcontiguous_iterable<D>::rbegin(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template rbegin<L, S>(shape);
+    }
+
+    /**
+     * Returns an iterator to the element following the last element of the
+     * reversed expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L, class S>
+    inline auto xcontiguous_iterable<D>::rend(const S& shape) noexcept -> reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template rend<L, S>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L, class S>
+    inline auto xcontiguous_iterable<D>::rbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template rbegin<L, S>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * reversed expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L, class S>
+    inline auto xcontiguous_iterable<D>::rend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template rend<L, S>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the first element of the reversed expression.
+     * The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L, class S>
+    inline auto xcontiguous_iterable<D>::crbegin(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template crbegin<L, S>(shape);
+    }
+
+    /**
+     * Returns a constant iterator to the element following the last element of the
+     * reversed expression. The iteration is broadcasted to the specified shape.
+     * @param shape the shape used for broadcasting
+     * @tparam S type of the \c shape parameter.
+     * @tparam L order used for the traversal. Default value is \c XTENSOR_DEFAULT_TRAVERSAL.
+     */
+    template <class D>
+    template <layout_type L, class S>
+    inline auto xcontiguous_iterable<D>::crend(const S& shape) const noexcept -> const_reverse_broadcast_iterator<S, L>
+    {
+        return iterable_base::template crend<L, S>(shape);
+    }
+    //@}
+
+    template <class D>
+    inline auto xcontiguous_iterable<D>::derived_cast() -> derived_type&
+    {
+        return *static_cast<derived_type*>(this);
+    }
+
+    template <class D>
+    inline auto xcontiguous_iterable<D>::derived_cast() const -> const derived_type&
+    {
+        return *static_cast<const derived_type*>(this);
+    }
+
 }
 
 #endif

--- a/vendor/xtensor/include/xtensor/xiterator.hpp
+++ b/vendor/xtensor/include/xtensor/xiterator.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -17,6 +18,7 @@
 #include <vector>
 
 #include <xtl/xiterator_base.hpp>
+#include <xtl/xmeta_utils.hpp>
 #include <xtl/xsequence.hpp>
 
 #include "xexception.hpp"
@@ -33,6 +35,9 @@ namespace xt
 
     template <class CT>
     class xscalar;
+
+    template <bool is_const, class CT>
+    class xscalar_stepper;
 
     namespace detail
     {
@@ -64,6 +69,10 @@ namespace xt
     template <class C>
     using get_stepper_iterator = typename detail::get_stepper_iterator_impl<C>::type;
 
+    /********************************
+     * xindex_type_t implementation *
+     ********************************/
+
     namespace detail
     {
         template <class ST>
@@ -76,6 +85,12 @@ namespace xt
         struct index_type_impl<std::array<V, L>>
         {
             using type = std::array<V, L>;
+        };
+
+        template <std::size_t... I>
+        struct index_type_impl<fixed_shape<I...>>
+        {
+            using type = std::array<std::size_t, sizeof...(I)>;
         };
     }
 
@@ -100,7 +115,10 @@ namespace xt
         using difference_type = typename subiterator_traits::difference_type;
         using size_type = typename storage_type::size_type;
         using shape_type = typename storage_type::shape_type;
-        using simd_type = xsimd::simd_type<value_type>;
+        using simd_value_type = xt_simd::simd_type<value_type>;
+
+        template <class requested_type>
+        using simd_return_type = xt_simd::simd_return_type<value_type, requested_type>;
 
         xstepper() = default;
         xstepper(storage_type* c, subiterator_type it, size_type offset) noexcept;
@@ -115,10 +133,10 @@ namespace xt
         void to_begin();
         void to_end(layout_type l);
 
-        template <class R>
-        R step_simd();
+        template <class T>
+        simd_return_type<T> step_simd();
 
-        value_type step_leading();
+        void step_leading();
 
         template <class R>
         void store_simd(const R& vec);
@@ -260,24 +278,24 @@ namespace xt
         struct LAYOUT_FORBIDEN_FOR_XITERATOR;
     }
 
-    template <class It, class S, layout_type L>
-    class xiterator : public xtl::xrandom_access_iterator_base<xiterator<It, S, L>,
-                                                               typename It::value_type,
-                                                               typename It::difference_type,
-                                                               typename It::pointer,
-                                                               typename It::reference>,
+    template <class St, class S, layout_type L>
+    class xiterator : public xtl::xrandom_access_iterator_base<xiterator<St, S, L>,
+                                                               typename St::value_type,
+                                                               typename St::difference_type,
+                                                               typename St::pointer,
+                                                               typename St::reference>,
                       private detail::shape_storage<S>
     {
     public:
 
-        using self_type = xiterator<It, S, L>;
+        using self_type = xiterator<St, S, L>;
 
-        using subiterator_type = It;
-        using value_type = typename subiterator_type::value_type;
-        using reference = typename subiterator_type::reference;
-        using pointer = typename subiterator_type::pointer;
-        using difference_type = typename subiterator_type::difference_type;
-        using size_type = typename subiterator_type::size_type;
+        using stepper_type = St;
+        using value_type = typename stepper_type::value_type;
+        using reference = typename stepper_type::reference;
+        using pointer = typename stepper_type::pointer;
+        using difference_type = typename stepper_type::difference_type;
+        using size_type = typename stepper_type::size_type;
         using iterator_category = std::random_access_iterator_tag;
 
         using private_base = detail::shape_storage<S>;
@@ -286,8 +304,9 @@ namespace xt
         using index_type = xindex_type_t<shape_type>;
 
         xiterator() = default;
+
         // end_index means either reverse_iterator && !end or !reverse_iterator && end
-        xiterator(It it, shape_param_type shape, bool end_index);
+        xiterator(St st, shape_param_type shape, bool end_index);
 
         self_type& operator++();
         self_type& operator--();
@@ -305,20 +324,20 @@ namespace xt
 
     private:
 
-        subiterator_type m_it;
+        stepper_type m_st;
         index_type m_index;
         difference_type m_linear_index;
 
         using checking_type = typename detail::LAYOUT_FORBIDEN_FOR_XITERATOR<L>::type;
     };
 
-    template <class It, class S, layout_type L>
-    bool operator==(const xiterator<It, S, L>& lhs,
-                    const xiterator<It, S, L>& rhs);
+    template <class St, class S, layout_type L>
+    bool operator==(const xiterator<St, S, L>& lhs,
+                    const xiterator<St, S, L>& rhs);
 
-    template <class It, class S, layout_type L>
-    bool operator<(const xiterator<It, S, L>& lhs,
-                   const xiterator<It, S, L>& rhs);
+    template <class St, class S, layout_type L>
+    bool operator<(const xiterator<St, S, L>& lhs,
+                   const xiterator<St, S, L>& rhs);
 
     /*********************
      * xbounded_iterator *
@@ -373,35 +392,70 @@ namespace xt
     bool operator<(const xbounded_iterator<It, BIt>& lhs,
                    const xbounded_iterator<It, BIt>& rhs);
 
-    /*******************************
-    * trivial_begin / trivial_end *
-    *******************************/
+    /*****************************
+     * linear_begin / linear_end *
+     *****************************/
 
     namespace detail
     {
-        template <class C>
-        constexpr auto trivial_begin(C& c) noexcept
+        template <class C, class = void_t<>>
+        struct has_storage_iterator : std::false_type
         {
-            return c.storage_begin();
-        }
+        };
 
         template <class C>
-        constexpr auto trivial_end(C& c) noexcept
+        struct has_storage_iterator<C, void_t<decltype(std::declval<C>().storage_cbegin())>>
+            : std::true_type
         {
-            return c.storage_end();
-        }
+        };
+    }
 
-        template <class C>
-        constexpr auto trivial_begin(const C& c) noexcept
+    template <class C>
+    XTENSOR_CONSTEXPR_RETURN auto linear_begin(C& c) noexcept
+    {
+        return xtl::mpl::static_if<detail::has_storage_iterator<C>::value>([&](auto self)
         {
-            return c.storage_begin();
-        }
+            return self(c).storage_begin();
+        }, /*else*/ [&](auto self)
+        {
+            return self(c).begin();
+        });
+    }
 
-        template <class C>
-        constexpr auto trivial_end(const C& c) noexcept
+    template <class C>
+    XTENSOR_CONSTEXPR_RETURN auto linear_end(C& c) noexcept
+    {
+        return xtl::mpl::static_if<detail::has_storage_iterator<C>::value>([&](auto self)
         {
-            return c.storage_end();
-        }
+            return self(c).storage_end();
+        }, /*else*/ [&](auto self)
+        {
+            return self(c).end();
+        });
+    }
+
+    template <class C>
+    XTENSOR_CONSTEXPR_RETURN auto linear_begin(const C& c) noexcept
+    {
+        return xtl::mpl::static_if<detail::has_storage_iterator<C>::value>([&](auto self)
+        {
+            return self(c).storage_cbegin();
+        }, /*else*/ [&](auto self)
+        {
+            return self(c).cbegin();
+        });
+    }
+
+    template <class C>
+    XTENSOR_CONSTEXPR_RETURN auto linear_end(const C& c) noexcept
+    {
+        return xtl::mpl::static_if<detail::has_storage_iterator<C>::value>([&](auto self)
+        {
+            return self(c).storage_cend();
+        }, /*else*/ [&](auto self)
+        {
+            return self(c).cend();
+        });
     }
 
     /***************************
@@ -425,7 +479,7 @@ namespace xt
     {
         if (dim >= m_offset)
         {
-            using strides_value_type = decltype(p_c->strides()[0]);
+            using strides_value_type = typename std::decay_t<decltype(p_c->strides())>::value_type;
             m_it += difference_type(static_cast<strides_value_type>(n) * p_c->strides()[dim - m_offset]);
         }
     }
@@ -435,7 +489,7 @@ namespace xt
     {
         if (dim >= m_offset)
         {
-            using strides_value_type = decltype(p_c->strides()[0]);
+            using strides_value_type = typename std::decay_t<decltype(p_c->strides())>::value_type;
             m_it -= difference_type(static_cast<strides_value_type>(n) * p_c->strides()[dim - m_offset]);
         }
     }
@@ -467,16 +521,41 @@ namespace xt
     template <class C>
     inline void xstepper<C>::to_end(layout_type l)
     {
-        m_it = p_c->data_xend(l);
+        m_it = p_c->data_xend(l, m_offset);
+    }
+
+    namespace detail
+    {
+        template <class It>
+        struct step_simd_invoker
+        {
+            template <class R>
+            static R apply(const It& it)
+            {
+                R reg;
+                reg.load_unaligned(&(*it));
+                return reg;
+            }
+        };
+
+        template <bool is_const, class T, class S, layout_type L>
+        struct step_simd_invoker<xiterator<xscalar_stepper<is_const, T>, S, L>>
+        {
+            template <class R>
+            static R apply(const xiterator<xscalar_stepper<is_const, T>, S, L>& it)
+            {
+                return R(*it);
+            }
+        };
     }
 
     template <class C>
-    template <class R>
-    inline R xstepper<C>::step_simd()
+    template <class T>
+    inline auto xstepper<C>::step_simd() -> simd_return_type<T>
     {
-        R reg;
-        reg.load_unaligned(&(*m_it));
-        m_it += xsimd::revert_simd_traits<R>::size;
+        using simd_type = simd_return_type<T>;
+        simd_type reg = detail::step_simd_invoker<subiterator_type>::template apply<simd_type>(m_it);
+        m_it += xt_simd::revert_simd_traits<simd_type>::size;
         return reg;
     }
 
@@ -485,14 +564,13 @@ namespace xt
     inline void xstepper<C>::store_simd(const R& vec)
     {
         vec.store_unaligned(&(*m_it));
-        m_it += xsimd::revert_simd_traits<R>::size;;
+        m_it += xt_simd::revert_simd_traits<R>::size;;
     }
 
     template <class C>
-    auto xstepper<C>::step_leading() -> value_type
+    void xstepper<C>::step_leading()
     {
         ++m_it;
-        return *m_it;
     }
 
     template <>
@@ -567,7 +645,7 @@ namespace xt
                 }
             }
         }
-        if (i == 0)
+        if (i == 0 && n != 0)
         {
             std::copy(shape.cbegin(), shape.cend(), index.begin());
             stepper.to_end(layout_type::row_major);
@@ -645,7 +723,7 @@ namespace xt
                 }
             }
         }
-        if (i == 0)
+        if (i == 0 && n != 0)
         {
             stepper.to_begin();
         }
@@ -726,7 +804,7 @@ namespace xt
             }
             ++i;
         }
-        if (i == size)
+        if (i == size && n != 0)
         {
             std::copy(shape.cbegin(), shape.cend(), index.begin());
             stepper.to_end(layout_type::column_major);
@@ -807,7 +885,7 @@ namespace xt
             }
             ++i;
         }
-        if (i == size)
+        if (i == size && n != 0)
         {
             stepper.to_begin();
         }
@@ -823,8 +901,8 @@ namespace xt
     {
         if (end)
         {
-            // Note: the layout here doesn't matter (unused) but using default layout looks more "correct"
-            to_end(XTENSOR_DEFAULT_LAYOUT);
+            // Note: the layout here doesn't matter (unused) but using default traversal looks more "correct".
+            to_end(XTENSOR_DEFAULT_TRAVERSAL);
         }
     }
 
@@ -925,9 +1003,9 @@ namespace xt
         };
     }
 
-    template <class It, class S, layout_type L>
-    inline xiterator<It, S, L>::xiterator(It it, shape_param_type shape, bool end_index)
-        : private_base(shape), m_it(it),
+    template <class St, class S, layout_type L>
+    inline xiterator<St, S, L>::xiterator(St st, shape_param_type shape, bool end_index)
+        : private_base(shape), m_st(st),
           m_index(end_index ? xtl::forward_sequence<index_type, const shape_type&>(this->shape())
                             : xtl::make_sequence<index_type>(this->shape().size(), size_type(0))),
           m_linear_index(0)
@@ -946,94 +1024,94 @@ namespace xt
         }
     }
 
-    template <class It, class S, layout_type L>
-    inline auto xiterator<It, S, L>::operator++() -> self_type&
+    template <class St, class S, layout_type L>
+    inline auto xiterator<St, S, L>::operator++() -> self_type&
     {
-        stepper_tools<L>::increment_stepper(m_it, m_index, this->shape());
+        stepper_tools<L>::increment_stepper(m_st, m_index, this->shape());
         ++m_linear_index;
         return *this;
     }
 
-    template <class It, class S, layout_type L>
-    inline auto xiterator<It, S, L>::operator--() -> self_type&
+    template <class St, class S, layout_type L>
+    inline auto xiterator<St, S, L>::operator--() -> self_type&
     {
-        stepper_tools<L>::decrement_stepper(m_it, m_index, this->shape());
+        stepper_tools<L>::decrement_stepper(m_st, m_index, this->shape());
         --m_linear_index;
         return *this;
     }
 
-    template <class It, class S, layout_type L>
-    inline auto xiterator<It, S, L>::operator+=(difference_type n) -> self_type&
+    template <class St, class S, layout_type L>
+    inline auto xiterator<St, S, L>::operator+=(difference_type n) -> self_type&
     {
         if (n >= 0)
         {
-            stepper_tools<L>::increment_stepper(m_it, m_index, this->shape(), static_cast<size_type>(n));
+            stepper_tools<L>::increment_stepper(m_st, m_index, this->shape(), static_cast<size_type>(n));
         }
         else
         {
-            stepper_tools<L>::decrement_stepper(m_it, m_index, this->shape(), static_cast<size_type>(-n));
+            stepper_tools<L>::decrement_stepper(m_st, m_index, this->shape(), static_cast<size_type>(-n));
         }
         m_linear_index += n;
         return *this;
     }
 
-    template <class It, class S, layout_type L>
-    inline auto xiterator<It, S, L>::operator-=(difference_type n) -> self_type&
+    template <class St, class S, layout_type L>
+    inline auto xiterator<St, S, L>::operator-=(difference_type n) -> self_type&
     {
         if (n >= 0)
         {
-            stepper_tools<L>::decrement_stepper(m_it, m_index, this->shape(), static_cast<size_type>(n));
+            stepper_tools<L>::decrement_stepper(m_st, m_index, this->shape(), static_cast<size_type>(n));
         }
         else
         {
-            stepper_tools<L>::increment_stepper(m_it, m_index, this->shape(), static_cast<size_type>(-n));
+            stepper_tools<L>::increment_stepper(m_st, m_index, this->shape(), static_cast<size_type>(-n));
         }
         m_linear_index -= n;
         return *this;
     }
 
-    template <class It, class S, layout_type L>
-    inline auto xiterator<It, S, L>::operator-(const self_type& rhs) const -> difference_type
+    template <class St, class S, layout_type L>
+    inline auto xiterator<St, S, L>::operator-(const self_type& rhs) const -> difference_type
     {
         return m_linear_index - rhs.m_linear_index;
     }
 
-    template <class It, class S, layout_type L>
-    inline auto xiterator<It, S, L>::operator*() const -> reference
+    template <class St, class S, layout_type L>
+    inline auto xiterator<St, S, L>::operator*() const -> reference
     {
-        return *m_it;
+        return *m_st;
     }
 
-    template <class It, class S, layout_type L>
-    inline auto xiterator<It, S, L>::operator->() const -> pointer
+    template <class St, class S, layout_type L>
+    inline auto xiterator<St, S, L>::operator->() const -> pointer
     {
-        return &(*m_it);
+        return &(*m_st);
     }
 
-    template <class It, class S, layout_type L>
-    inline bool xiterator<It, S, L>::equal(const xiterator& rhs) const
+    template <class St, class S, layout_type L>
+    inline bool xiterator<St, S, L>::equal(const xiterator& rhs) const
     {
         XTENSOR_ASSERT(this->shape() == rhs.shape());
         return m_linear_index == rhs.m_linear_index;
     }
 
-    template <class It, class S, layout_type L>
-    inline bool xiterator<It, S, L>::less_than(const xiterator& rhs) const
+    template <class St, class S, layout_type L>
+    inline bool xiterator<St, S, L>::less_than(const xiterator& rhs) const
     {
         XTENSOR_ASSERT(this->shape() == rhs.shape());
         return m_linear_index < rhs.m_linear_index;
     }
 
-    template <class It, class S, layout_type L>
-    inline bool operator==(const xiterator<It, S, L>& lhs,
-                           const xiterator<It, S, L>& rhs)
+    template <class St, class S, layout_type L>
+    inline bool operator==(const xiterator<St, S, L>& lhs,
+                           const xiterator<St, S, L>& rhs)
     {
         return lhs.equal(rhs);
     }
 
-    template <class It, class S, layout_type L>
-    bool operator<(const xiterator<It, S, L>& lhs,
-                   const xiterator<It, S, L>& rhs)
+    template <class St, class S, layout_type L>
+    bool operator<(const xiterator<St, S, L>& lhs,
+                   const xiterator<St, S, L>& rhs)
     {
         return lhs.less_than(rhs);
     }

--- a/vendor/xtensor/include/xtensor/xjson.hpp
+++ b/vendor/xtensor/include/xtensor/xjson.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -23,15 +24,15 @@ namespace xt
      * to_json and from_json declaration *
      *************************************/
 
-    template <class E>
-    enable_xexpression<E> to_json(nlohmann::json&, const E&);
+    template <template <typename U, typename V, typename... Args> class M, class E>
+    enable_xexpression<E> to_json(nlohmann::basic_json<M>&, const E&);
 
-    template <class E>
-    enable_xcontainer_semantics<E> from_json(const nlohmann::json&, E&);
+    template <template <typename U, typename V, typename... Args> class M, class E>
+    enable_xcontainer_semantics<E> from_json(const nlohmann::basic_json<M>&, E&);
 
     /// @cond DOXYGEN_INCLUDE_SFINAE
-    template <class E>
-    enable_xview_semantics<E> from_json(const nlohmann::json&, E&);
+    template <template <typename U, typename V, typename... Args> class M, class E>
+    enable_xview_semantics<E> from_json(const nlohmann::basic_json<M>&, E&);
     /// @endcond
 
     /****************************************
@@ -40,8 +41,9 @@ namespace xt
 
     namespace detail
     {
-        template <class D>
-        void to_json_impl(nlohmann::json& j, const xexpression<D>& e, xstrided_slice_vector& slices)
+        template <template <typename U, typename V, typename... Args> class M, class D>
+        void to_json_impl(nlohmann::basic_json<M>& j, const xexpression<D>& e,
+                          xstrided_slice_vector& slices)
         {
             const auto view = strided_view(e.derived_cast(), slices);
             if (view.dimension() == 0)
@@ -50,13 +52,13 @@ namespace xt
             }
             else
             {
-                j = nlohmann::json::array();
+                j = nlohmann::basic_json<M>::array();
                 using size_type = typename D::size_type;
                 size_type nrows = view.shape()[0];
                 for (size_type i = 0; i != nrows; ++i)
                 {
                     slices.push_back(i);
-                    nlohmann::json k;
+                    nlohmann::basic_json<M> k;
                     to_json_impl(k, e, slices);
                     j.push_back(std::move(k));
                     slices.pop_back();
@@ -64,14 +66,15 @@ namespace xt
             }
         }
 
-        template <class D>
-        inline void from_json_impl(const nlohmann::json& j, xexpression<D>& e, xstrided_slice_vector& slices)
+        template <template <typename U, typename V, typename... Args> class M, class D>
+        inline void from_json_impl(const nlohmann::basic_json<M>& j, xexpression<D>& e,
+                                   xstrided_slice_vector& slices)
         {
             auto view = strided_view(e.derived_cast(), slices);
 
             if (view.dimension() == 0)
             {
-                view() = j;
+                view() = j.template get<std::remove_reference_t<decltype(view())>>();
             }
             else
             {
@@ -80,14 +83,15 @@ namespace xt
                 for (size_type i = 0; i != nrows; ++i)
                 {
                     slices.push_back(i);
-                    const nlohmann::json& k = j[i];
+                    const nlohmann::basic_json<M>& k = j[i];
                     from_json_impl(k, e, slices);
                     slices.pop_back();
                 }
             }
         }
 
-        inline unsigned int json_dimension(const nlohmann::json& j)
+        template <template <typename U, typename V, typename... Args> class M>
+        inline unsigned int json_dimension(const nlohmann::basic_json<M>& j)
         {
             if (j.is_array() && j.size())
             {
@@ -99,8 +103,8 @@ namespace xt
             }
         }
 
-        template <class S>
-        inline void json_shape(const nlohmann::json& j, S& s, std::size_t pos = 0)
+        template <template <typename U, typename V, typename... Args> class M, class S>
+        inline void json_shape(const nlohmann::basic_json<M>& j, S& s, std::size_t pos = 0)
         {
             if (j.is_array())
             {
@@ -124,8 +128,8 @@ namespace xt
      * @param j a JSON object
      * @param e a const \ref xexpression
      */
-    template <class E>
-    inline enable_xexpression<E> to_json(nlohmann::json& j, const E& e)
+    template <template <typename U, typename V, typename... Args> class M, class E>
+    inline enable_xexpression<E> to_json(nlohmann::basic_json<M>& j, const E& e)
     {
         auto sv = xstrided_slice_vector();
         detail::to_json_impl(j, e, sv);
@@ -139,7 +143,7 @@ namespace xt
      * serialization of user-defined types. The method is picked up by
      * argument-dependent lookup.
      *
-     * Note: for converting a JSON object to a value, nlohmann_json requiress
+     * Note: for converting a JSON object to a value, nlohmann_json requires
      * the value type to be default constructible, which is typically not the
      * case for expressions with a view semantics. In this case, from_json can
      * be called directly.
@@ -147,8 +151,8 @@ namespace xt
      * @param j a const JSON object
      * @param e an \ref xexpression
      */
-    template <class E>
-    inline enable_xcontainer_semantics<E> from_json(const nlohmann::json& j, E& e)
+    template <template <typename U, typename V, typename... Args> class M, class E>
+    inline enable_xcontainer_semantics<E> from_json(const nlohmann::basic_json<M>& j, E& e)
     {
         auto dimension = detail::json_dimension(j);
         auto s = xtl::make_sequence<typename E::shape_type>(dimension);
@@ -162,8 +166,8 @@ namespace xt
     }
 
     /// @cond DOXYGEN_INCLUDE_SFINAE
-    template <class E>
-    inline enable_xview_semantics<E> from_json(const nlohmann::json& j, E& e)
+    template <template <typename U, typename V, typename... Args> class M, class E>
+    inline enable_xview_semantics<E> from_json(const nlohmann::basic_json<M>& j, E& e)
     {
         typename E::shape_type s;
         detail::json_shape(j, s);

--- a/vendor/xtensor/include/xtensor/xlayout.hpp
+++ b/vendor/xtensor/include/xtensor/xlayout.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -9,6 +10,9 @@
 #ifndef XTENSOR_LAYOUT_HPP
 #define XTENSOR_LAYOUT_HPP
 
+// Do not include anything else here.
+// xlayout.hpp is included in xtensor_forward.hpp
+// and we don't want to bring other headers to it.
 #include "xtensor_config.hpp"
 
 namespace xt

--- a/vendor/xtensor/include/xtensor/xmanipulation.hpp
+++ b/vendor/xtensor/include/xtensor/xmanipulation.hpp
@@ -1,0 +1,612 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_MANIPULATION_HPP
+#define XTENSOR_MANIPULATION_HPP
+
+#include "xstrided_view.hpp"
+#include "xutils.hpp"
+
+namespace xt
+{
+    namespace check_policy
+    {
+        struct none
+        {
+        };
+        struct full
+        {
+        };
+    }
+
+    template <class E>
+    auto transpose(E&& e) noexcept;
+
+    template <class E, class S, class Tag = check_policy::none>
+    auto transpose(E&& e, S&& permutation, Tag check_policy = Tag());
+
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E>
+    auto ravel(E&& e);
+
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E>
+    auto flatten(E&& e);
+
+    template <class E>
+    auto trim_zeros(E&& e, const std::string& direction = "fb");
+
+    template <class E>
+    auto squeeze(E&& e);
+
+    template <class E, class S, class Tag = check_policy::none, std::enable_if_t<!std::is_integral<S>::value, int> = 0>
+    auto squeeze(E&& e, S&& axis, Tag check_policy = Tag());
+
+    /****************************
+     * transpose implementation *
+     ****************************/
+
+    namespace detail
+    {
+        inline layout_type transpose_layout_noexcept(layout_type l) noexcept
+        {
+            layout_type result = l;
+            if (l == layout_type::row_major)
+            {
+                result = layout_type::column_major;
+            }
+            else if (l == layout_type::column_major)
+            {
+                result = layout_type::row_major;
+            }
+            return result;
+        }
+
+        inline layout_type transpose_layout(layout_type l)
+        {
+            if (l != layout_type::row_major && l != layout_type::column_major)
+            {
+                throw transpose_error("cannot compute transposed layout of dynamic layout");
+            }
+            return transpose_layout_noexcept(l);
+        }
+
+        template <class E, class S>
+        inline auto transpose_impl(E&& e, S&& permutation, check_policy::none)
+        {
+            if (sequence_size(permutation) != e.dimension())
+            {
+                throw transpose_error("Permutation does not have the same size as shape");
+            }
+
+            // permute stride and shape
+            using shape_type = xindex_type_t<typename std::decay_t<E>::shape_type>;
+            shape_type temp_shape;
+            resize_container(temp_shape, e.shape().size());
+
+            using strides_type = get_strides_t<shape_type>;
+            strides_type temp_strides;
+            resize_container(temp_strides, e.strides().size());
+
+            using size_type = typename std::decay_t<E>::size_type;
+            for (std::size_t i = 0; i < e.shape().size(); ++i)
+            {
+                if (std::size_t(permutation[i]) >= e.dimension())
+                {
+                    throw transpose_error("Permutation contains wrong axis");
+                }
+                size_type perm = static_cast<size_type>(permutation[i]);
+                temp_shape[i] = e.shape()[perm];
+                temp_strides[i] = e.strides()[perm];
+            }
+
+            layout_type new_layout = layout_type::dynamic;
+            if (std::is_sorted(std::begin(permutation), std::end(permutation)))
+            {
+                // keep old layout
+                new_layout = e.layout();
+            }
+            else if (std::is_sorted(std::begin(permutation), std::end(permutation), std::greater<>()))
+            {
+                new_layout = transpose_layout_noexcept(e.layout());
+            }
+
+            return strided_view(std::forward<E>(e), std::move(temp_shape), std::move(temp_strides), get_offset<XTENSOR_DEFAULT_LAYOUT>(e), new_layout);
+        }
+
+        template <class E, class S>
+        inline auto transpose_impl(E&& e, S&& permutation, check_policy::full)
+        {
+            // check if axis appears twice in permutation
+            for (std::size_t i = 0; i < sequence_size(permutation); ++i)
+            {
+                for (std::size_t j = i + 1; j < sequence_size(permutation); ++j)
+                {
+                    if (permutation[i] == permutation[j])
+                    {
+                        throw transpose_error("Permutation contains axis more than once");
+                    }
+                }
+            }
+            return transpose_impl(std::forward<E>(e), std::forward<S>(permutation), check_policy::none());
+        }
+
+        template <class E, class S, class X, std::enable_if_t<has_data_interface<std::decay_t<E>>::value>* = nullptr>
+        inline void compute_transposed_strides(E&& e, const S&, X& strides)
+        {
+            std::copy(e.strides().crbegin(), e.strides().crend(), strides.begin());
+        }
+
+        template <class E, class S, class X, std::enable_if_t<!has_data_interface<std::decay_t<E>>::value>* = nullptr>
+        inline void compute_transposed_strides(E&&, const S& shape, X& strides)
+        {
+            // In the case where E does not have a data interface, the transposition
+            // makes use of a flat storage adaptor that has layout XTENSOR_DEFAULT_TRAVERSAL
+            // which should be the one inverted.
+            layout_type l = transpose_layout(XTENSOR_DEFAULT_TRAVERSAL);
+            compute_strides(shape, l, strides);
+        }
+    }
+
+    /**
+     * Returns a transpose view by reversing the dimensions of xexpression e
+     * @param e the input expression
+     */
+    template <class E>
+    inline auto transpose(E&& e) noexcept
+    {
+        using shape_type = xindex_type_t<typename std::decay_t<E>::shape_type>;
+        shape_type shape;
+        resize_container(shape, e.shape().size());
+        std::copy(e.shape().crbegin(), e.shape().crend(), shape.begin());
+
+        get_strides_t<shape_type> strides;
+        resize_container(strides, e.shape().size());
+        detail::compute_transposed_strides(e, shape, strides);
+
+        layout_type new_layout = detail::transpose_layout_noexcept(e.layout());
+
+        return strided_view(std::forward<E>(e), std::move(shape), std::move(strides), detail::get_offset<XTENSOR_DEFAULT_TRAVERSAL>(e), new_layout);
+    }
+
+    /**
+     * Returns a transpose view by permuting the xexpression e with @p permutation.
+     * @param e the input expression
+     * @param permutation the sequence containing permutation
+     * @param check_policy the check level (check_policy::full() or check_policy::none())
+     * @tparam Tag selects the level of error checking on permutation vector defaults to check_policy::none.
+     */
+    template <class E, class S, class Tag>
+    inline auto transpose(E&& e, S&& permutation, Tag check_policy)
+    {
+        return detail::transpose_impl(std::forward<E>(e), std::forward<S>(permutation), check_policy);
+    }
+
+    /// @cond DOXYGEN_INCLUDE_SFINAE
+#ifdef X_OLD_CLANG
+    template <class E, class I, class Tag = check_policy::none>
+    inline auto transpose(E&& e, std::initializer_list<I> permutation, Tag check_policy = Tag())
+    {
+        dynamic_shape<I> perm(permutation);
+        return detail::transpose_impl(std::forward<E>(e), std::move(perm), check_policy);
+    }
+#else
+    template <class E, class I, std::size_t N, class Tag = check_policy::none>
+    inline auto transpose(E&& e, const I(&permutation)[N], Tag check_policy = Tag())
+    {
+        return detail::transpose_impl(std::forward<E>(e), permutation, check_policy);
+    }
+#endif
+    /// @endcond
+
+    /***************************
+     * ravel and flatten views *
+     ***************************/
+
+    template <class I, class CI>
+    class xiterator_adaptor;
+
+    /**
+     * Returns a flatten view of the given expression. No copy is made.
+     * @param e the input expression
+     * @tparam L the layout used to read the elements of e. If no parameter
+     * is specified, XTENSOR_DEFAULT_TRAVERSAL is used.
+     * @tparam E the type of the expression
+     */
+    template <layout_type L, class E>
+    inline auto ravel(E&& e)
+    {
+        using iterator = decltype(e.template begin<L>());
+        using const_iterator = decltype(e.template cbegin<L>());
+        using adaptor_type = xiterator_adaptor<iterator, const_iterator>;
+        constexpr layout_type layout = std::is_pointer<iterator>::value ? L : layout_type::dynamic;
+        using type = xtensor_view<adaptor_type, 1, layout, extension::get_expression_tag_t<E>>;
+        return type(adaptor_type(e.template begin<L>(), e.template cbegin<L>(), e.size()), { e.size() });
+    }
+
+    /**
+     * Returns a flatten view of the given expression. No copy is made. This
+     * method is equivalent to ravel and is provided for API sameness with
+     * Numpy.
+     * @param e the input expression
+     * @tparam L the layout used to read the elements of e. If no parameter
+     * is specified, XTENSOR_DEFAULT_TRAVERSAL is used.
+     * @tparam E the type of the expression
+     * @sa ravel
+     */
+    template <layout_type L, class E>
+    inline auto flatten(E&& e)
+    {
+        return ravel<L>(std::forward<E>(e));
+    }
+
+    /**
+     * Trim zeros at beginning, end or both of 1D sequence.
+     *
+     * @param e input xexpression
+     * @param direction string of either 'f' for trim from beginning, 'b' for trim from end
+     *                  or 'fb' (default) for both.
+     * @return returns a view without zeros at the beginning and end
+     */
+    template <class E>
+    inline auto trim_zeros(E&& e, const std::string& direction)
+    {
+        XTENSOR_ASSERT_MSG(e.dimension() == 1, "Dimension for trim_zeros has to be 1.");
+
+        std::ptrdiff_t begin = 0, end = static_cast<std::ptrdiff_t>(e.size());
+
+        auto find_fun = [](const auto& i) {
+            return i != 0;
+        };
+
+        if (direction.find("f") != std::string::npos)
+        {
+            begin = std::find_if(e.cbegin(), e.cend(), find_fun) - e.cbegin();
+        }
+
+        if (direction.find("b") != std::string::npos && begin != end)
+        {
+            end -= std::find_if(e.crbegin(), e.crend(), find_fun) - e.crbegin();
+        }
+
+        return strided_view(std::forward<E>(e), { range(begin, end) });
+    }
+
+    /**
+     * Returns a squeeze view of the given expression. No copy is made.
+     * Squeezing an expression removes dimensions of extent 1.
+     *
+     * @param e the input expression
+     * @tparam E the type of the expression
+     */
+    template <class E>
+    inline auto squeeze(E&& e)
+    {
+        dynamic_shape<std::size_t> new_shape;
+        dynamic_shape<std::ptrdiff_t> new_strides;
+        std::copy_if(e.shape().cbegin(), e.shape().cend(), std::back_inserter(new_shape),
+                     [](std::size_t i) { return i != 1; });
+        decltype(auto) old_strides = detail::get_strides<XTENSOR_DEFAULT_LAYOUT>(e);
+        std::copy_if(old_strides.cbegin(), old_strides.cend(), std::back_inserter(new_strides),
+                     [](std::ptrdiff_t i) { return i != 0; });
+
+        return strided_view(std::forward<E>(e), std::move(new_shape), std::move(new_strides), 0, e.layout());
+    }
+
+    namespace detail
+    {
+        template <class E, class S>
+        inline auto squeeze_impl(E&& e, S&& axis, check_policy::none)
+        {
+            std::size_t new_dim = e.dimension() - axis.size();
+            dynamic_shape<std::size_t> new_shape(new_dim);
+            dynamic_shape<std::ptrdiff_t> new_strides(new_dim);
+
+            decltype(auto) old_strides = detail::get_strides<XTENSOR_DEFAULT_LAYOUT>(e);
+
+            for (std::size_t i = 0, ix = 0; i < e.dimension(); ++i)
+            {
+                if (axis.cend() == std::find(axis.cbegin(), axis.cend(), i))
+                {
+                    new_shape[ix] = e.shape()[i];
+                    new_strides[ix++] = old_strides[i];
+                }
+            }
+
+            return strided_view(std::forward<E>(e), std::move(new_shape), std::move(new_strides), 0, e.layout());
+        }
+
+        template <class E, class S>
+        inline auto squeeze_impl(E&& e, S&& axis, check_policy::full)
+        {
+            for (auto ix : axis)
+            {
+                if (static_cast<std::size_t>(ix) > e.dimension())
+                {
+                    throw std::runtime_error("Axis argument to squeeze > dimension of expression");
+                }
+                if (e.shape()[static_cast<std::size_t>(ix)] != 1)
+                {
+                    throw std::runtime_error("Trying to squeeze axis != 1");
+                }
+            }
+            return squeeze_impl(std::forward<E>(e), std::forward<S>(axis), check_policy::none());
+        }
+    }
+
+    /**
+     * @brief Remove single-dimensional entries from the shape of an xexpression
+     *
+     * @param e input xexpression
+     * @param axis integer or container of integers, select a subset of single-dimensional
+     *        entries of the shape.
+     * @param check_policy select check_policy. With check_policy::full(), selecting an axis
+     *        which is greater than one will throw a runtime_error.
+     */
+    template <class E, class S, class Tag, std::enable_if_t<!std::is_integral<S>::value, int>>
+    inline auto squeeze(E&& e, S&& axis, Tag check_policy)
+    {
+        return detail::squeeze_impl(std::forward<E>(e), std::forward<S>(axis), check_policy);
+    }
+
+    /// @cond DOXYGEN_INCLUDE_SFINAE
+#ifdef X_OLD_CLANG
+    template <class E, class I, class Tag = check_policy::none>
+    inline auto squeeze(E&& e, std::initializer_list<I> axis, Tag check_policy = Tag())
+    {
+        dynamic_shape<I> ax(axis);
+        return detail::squeeze_impl(std::forward<E>(e), std::move(ax), check_policy);
+    }
+#else
+    template <class E, class I, std::size_t N, class Tag = check_policy::none>
+    inline auto squeeze(E&& e, const I(&axis)[N], Tag check_policy = Tag())
+    {
+        using arr_t = std::array<I, N>;
+        return detail::squeeze_impl(std::forward<E>(e), xtl::forward_sequence<arr_t, decltype(axis)>(axis), check_policy);
+    }
+#endif
+
+    template <class E, class Tag = check_policy::none>
+    inline auto squeeze(E&& e, std::size_t axis, Tag check_policy = Tag())
+    {
+        return squeeze(std::forward<E>(e), std::array<std::size_t, 1>{ axis }, check_policy);
+    }
+    /// @endcond
+
+    /**
+     * @brief Expand the shape of an xexpression.
+     *
+     * Insert a new axis that will appear at the axis position in the expanded array shape.
+     * This will return a ``strided_view`` with a ``xt::newaxis()`` at the indicated axis.
+     *
+     * @param e input xexpression
+     * @param axis axis to expand
+     * @return returns a ``strided_view`` with expanded dimension
+     */
+    template <class E>
+    auto expand_dims(E&& e, std::size_t axis)
+    {
+        xstrided_slice_vector sv(e.dimension() + 1, all());
+        sv[axis] = newaxis();
+        return strided_view(std::forward<E>(e), std::move(sv));
+    }
+
+    /**
+     * Expand dimensions of xexpression to at least `N`
+     *
+     * This adds ``newaxis()`` slices to a ``strided_view`` until
+     * the dimension of the view reaches at least `N`.
+     * Note: dimensions are added equally at the beginning and the end.
+     * For example, a 1-D array of shape (N,) becomes a view of shape (1, N, 1).
+     *
+     * @param e input xexpression
+     * @tparam N the number of requested dimensions
+     * @return ``strided_view`` with expanded dimensions
+     */
+    template <std::size_t N, class E>
+    auto atleast_Nd(E&& e)
+    {
+        xstrided_slice_vector sv((std::max)(e.dimension(), N), all());
+        if (e.dimension() < N)
+        {
+            std::size_t i = 0;
+            std::size_t end = static_cast<std::size_t>(std::round(double(N - e.dimension()) / double(N)));
+            for (; i < end; ++i)
+            {
+                sv[i] = newaxis();
+            }
+            i += e.dimension();
+            for (; i < N; ++i)
+            {
+                sv[i] = newaxis();
+            }
+        }
+        return strided_view(std::forward<E>(e), std::move(sv));
+    }
+
+    /**
+     * Expand to at least 1D
+     * @sa atleast_Nd
+     */
+    template <class E>
+    auto atleast_1d(E&& e)
+    {
+        return atleast_Nd<1>(std::forward<E>(e));
+    }
+
+    /**
+     * Expand to at least 2D
+     * @sa atleast_Nd
+     */
+    template <class E>
+    auto atleast_2d(E&& e)
+    {
+        return atleast_Nd<2>(std::forward<E>(e));
+    }
+
+    /**
+     * Expand to at least 3D
+     * @sa atleast_Nd
+     */
+    template <class E>
+    auto atleast_3d(E&& e)
+    {
+        return atleast_Nd<3>(std::forward<E>(e));
+    }
+
+    /**
+     * @brief Split xexpression along axis into subexpressions
+     *
+     * This splits an xexpression along the axis in `n` equal parts and
+     * returns a vector of ``strided_view``.
+     * Calling split with axis > dimension of e or a `n` that does not result in
+     * an equal division of the xexpression will throw a runtime_error.
+     *
+     * @param e input xexpression
+     * @param n number of elements to return
+     * @param axis axis along which to split the expression
+     */
+    template <class E>
+    auto split(E& e, std::size_t n, std::size_t axis = 0)
+    {
+        if (axis >= e.dimension())
+        {
+            throw std::runtime_error("Split along axis > dimension.");
+        }
+
+        std::size_t ax_sz = e.shape()[axis];
+        xstrided_slice_vector sv(e.dimension(), all());
+        std::size_t step = ax_sz / n;
+        std::size_t rest = ax_sz % n;
+
+        if (rest)
+        {
+            throw std::runtime_error("Split does not result in equal division.");
+        }
+
+        std::vector<decltype(strided_view(e, sv))> result;
+        for (std::size_t i = 0; i < n; ++i)
+        {
+            sv[axis] = range(i * step, (i + 1) * step);
+            result.emplace_back(strided_view(e, sv));
+        }
+        return result;
+    }
+
+    /**
+     * @brief Reverse the order of elements in an xexpression along the given axis.
+     * Note: A NumPy/Matlab style `flipud(arr)` is equivalent to `xt::flip(arr, 0)`,
+     * `fliplr(arr)` to `xt::flip(arr, 1)`.
+     *
+     * @param e the input xexpression
+     * @param axis the axis along which elements should be reversed
+     *
+     * @return returns a view with the result of the flip
+     */
+    template <class E>
+    inline auto flip(E&& e, std::size_t axis)
+    {
+        using shape_type = xindex_type_t<typename std::decay_t<E>::shape_type>;
+
+        shape_type shape;
+        resize_container(shape, e.shape().size());
+        std::copy(e.shape().cbegin(), e.shape().cend(), shape.begin());
+
+        get_strides_t<shape_type> strides;
+        decltype(auto) old_strides = detail::get_strides<XTENSOR_DEFAULT_LAYOUT>(e);
+        resize_container(strides, old_strides.size());
+        std::copy(old_strides.cbegin(), old_strides.cend(), strides.begin());
+
+        strides[axis] *= -1;
+        std::size_t offset = static_cast<std::size_t>(static_cast<std::ptrdiff_t>(e.data_offset()) + old_strides[axis] * (static_cast<std::ptrdiff_t>(e.shape()[axis]) - 1));
+
+        return strided_view(std::forward<E>(e), std::move(shape), std::move(strides), offset);
+    }
+
+    template <std::ptrdiff_t N>
+    struct rot90_impl;
+
+    template <>
+    struct rot90_impl<0>
+    {
+        template <class E>
+        inline auto operator()(E&& e, const std::array<std::size_t, 2>& /*axes*/)
+        {
+            return std::forward<E>(e);
+        }
+    };
+
+    template <>
+    struct rot90_impl<1>
+    {
+        template <class E>
+        inline auto operator()(E&& e, const std::array<std::size_t, 2>& axes)
+        {
+            using std::swap;
+
+            dynamic_shape<std::ptrdiff_t> axes_list(e.shape().size());
+            std::iota(axes_list.begin(), axes_list.end(), 0);
+            swap(axes_list[axes[0]], axes_list[axes[1]]);
+
+            return transpose(flip(std::forward<E>(e), axes[1]), std::move(axes_list));
+        }
+    };
+
+    template <>
+    struct rot90_impl<2>
+    {
+        template <class E>
+        inline auto operator()(E&& e, const std::array<std::size_t, 2>& axes)
+        {
+            return flip(flip(std::forward<E>(e), axes[0]), axes[1]);
+        }
+    };
+
+    template <>
+    struct rot90_impl<3>
+    {
+        template <class E>
+        inline auto operator()(E&& e, const std::array<std::size_t, 2>& axes)
+        {
+            using std::swap;
+
+            dynamic_shape<std::ptrdiff_t> axes_list(e.shape().size());
+            std::iota(axes_list.begin(), axes_list.end(), 0);
+            swap(axes_list[axes[0]], axes_list[axes[1]]);
+
+            return flip(transpose(std::forward<E>(e), std::move(axes_list)), axes[1]);
+        }
+    };
+
+    /**
+     * @brief Rotate an array by 90 degrees in the plane specified by axes.
+     * Rotation direction is from the first towards the second axis.
+     *
+     * @param e the input xexpression
+     * @param axes the array is rotated in the plane defined by the axes. Axes must be different.
+     * @tparam N number of times the array is rotated by 90 degrees. Default is 1.
+     *
+     * @return returns a view with the result of the rotation
+     */
+    template <std::ptrdiff_t N = 1, class E>
+    inline auto rot90(E&& e, const std::array<std::ptrdiff_t, 2>& axes = {0, 1})
+    {
+        auto ndim = std::ptrdiff_t(e.shape().size());
+
+        if (axes[0] == axes[1] || std::abs(axes[0] - axes[1]) == ndim)
+        {
+            throw std::runtime_error("Axes must be different");
+        }
+
+        auto norm_axes = forward_normalize<std::array<std::size_t, 2>>(e, axes);
+        constexpr std::ptrdiff_t n = (4 + (N % 4)) % 4;
+
+        return rot90_impl<n>()(std::forward<E>(e), norm_axes);
+    }
+}
+
+#endif

--- a/vendor/xtensor/include/xtensor/xmasked_view.hpp
+++ b/vendor/xtensor/include/xtensor/xmasked_view.hpp
@@ -1,0 +1,647 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_XMASKED_VIEW_HPP
+#define XTENSOR_XMASKED_VIEW_HPP
+
+#include "xtl/xmasked_value.hpp"
+
+#include "xaccessible.hpp"
+#include "xexpression.hpp"
+#include "xiterable.hpp"
+#include "xutils.hpp"
+#include "xshape.hpp"
+#include "xsemantic.hpp"
+#include "xtensor_forward.hpp"
+
+namespace xt
+{
+    /****************************
+     * xmasked_view declaration  *
+     *****************************/
+
+    template <class CTD, class CTM>
+    class xmasked_view;
+
+    template <class D, bool is_const>
+    class xmasked_view_stepper;
+
+    template <class T>
+    struct xcontainer_inner_types;
+
+    template <class CTD, class CTM>
+    struct xcontainer_inner_types<xmasked_view<CTD, CTM>>
+    {   
+        using data_type = std::decay_t<CTD>;
+        using mask_type = std::decay_t<CTM>;
+        using base_value_type = typename data_type::value_type;
+        using flag_type = typename mask_type::value_type;
+        using val_reference = inner_reference_t<CTD>;
+        using mask_reference = inner_reference_t<CTM>;
+        using value_type = xtl::xmasked_value<base_value_type, flag_type>;
+        using reference = xtl::xmasked_value<val_reference, mask_reference>;
+        using const_reference = xtl::xmasked_value<typename data_type::const_reference, typename mask_type::const_reference>;
+        using size_type = typename data_type::size_type;
+        using temporary_type = xarray<xtl::xmasked_value<base_value_type, flag_type>>;
+    };
+
+    template <class CTD, class CTM>
+    struct xiterable_inner_types<xmasked_view<CTD, CTM>>
+    {
+        using masked_view_type = xmasked_view<CTD, CTM>;
+        using inner_shape_type = typename std::decay_t<CTD>::inner_shape_type;
+        using stepper = xmasked_view_stepper<masked_view_type, false>;
+        using const_stepper = xmasked_view_stepper<masked_view_type, true>;
+    };
+
+    /**
+     * @class xmasked_view
+     * @brief View on an xoptional_assembly or xoptional_assembly_adaptor
+     * hiding values depending on a given mask.
+     *
+     * The xmasked_view class implements a view on an xoptional_assembly or
+     * xoptional_assembly_adaptor, it takes this xoptional_assembly and a
+     * mask as input. The mask is an xexpression containing boolean values,
+     * whenever the value of the mask is false, the optional value of
+     * xmasked_view is considered missing, otherwise it depends on the
+     * underlying xoptional_assembly.
+     *
+     * @tparam CTD The type of expression holding the values.
+     * @tparam CTM The type of expression holding the mask.
+     */
+    template <class CTD, class CTM>
+    class xmasked_view : public xview_semantic<xmasked_view<CTD, CTM>>,
+                         private xaccessible<xmasked_view<CTD, CTM>>,
+                         private xiterable<xmasked_view<CTD, CTM>>
+    {
+    public:
+
+        using self_type = xmasked_view<CTD, CTM>;
+        using semantic_base = xview_semantic<xmasked_view<CTD, CTM>>;
+        using accessible_base = xaccessible<self_type>;
+        using inner_types = xcontainer_inner_types<self_type>;
+        using temporary_type = typename inner_types::temporary_type;
+
+        using data_type = typename inner_types::data_type;
+        using mask_type = typename inner_types::mask_type;
+        using value_expression = CTD;
+        using mask_expression = CTM;
+
+        static constexpr bool is_data_const = std::is_const<std::remove_reference_t<value_expression>>::value;
+
+        using base_value_type = typename inner_types::base_value_type;
+        using base_reference = typename data_type::reference;
+        using base_const_reference = typename data_type::const_reference;
+
+        using flag_type = typename inner_types::flag_type;
+        using flag_reference = typename mask_type::reference;
+        using flag_const_reference = typename mask_type::const_reference;
+
+        using val_reference = typename inner_types::val_reference;
+        using mask_reference = typename inner_types::mask_reference;
+
+        using value_type = typename inner_types::value_type;
+        using reference = typename inner_types::reference;
+        using const_reference = typename inner_types::const_reference;
+
+        using pointer = xtl::xclosure_pointer<reference>;
+        using const_pointer = xtl::xclosure_pointer<const_reference>;
+
+        using size_type = typename inner_types::size_type;
+        using difference_type = typename data_type::difference_type;
+
+        using shape_type = typename data_type::shape_type;
+        using strides_type = typename data_type::strides_type;
+
+        static constexpr layout_type static_layout = data_type::static_layout;
+        static constexpr bool contiguous_layout = false;
+
+        using inner_shape_type = typename data_type::inner_shape_type;
+        using inner_strides_type = typename data_type::inner_strides_type;
+        using inner_backstrides_type = typename data_type::inner_backstrides_type;
+
+        using expression_tag = xtensor_expression_tag;
+
+        using iterable_base = xiterable<xmasked_view<CTD, CTM>>;
+        using stepper = typename iterable_base::stepper;
+        using const_stepper = typename iterable_base::const_stepper;
+
+        template <layout_type L>
+        using layout_iterator = typename iterable_base::template layout_iterator<L>;
+        template <layout_type L>
+        using const_layout_iterator = typename iterable_base::template const_layout_iterator<L>;
+        template <layout_type L>
+        using reverse_layout_iterator = typename iterable_base::template reverse_layout_iterator<L>;
+        template <layout_type L>
+        using const_reverse_layout_iterator = typename iterable_base::template const_reverse_layout_iterator<L>;
+
+        template <class S, layout_type L>
+        using broadcast_iterator = typename iterable_base::template broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using const_broadcast_iterator = typename iterable_base::template const_broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using reverse_broadcast_iterator = typename iterable_base::template reverse_broadcast_iterator<S, L>;
+        template <class S, layout_type L>
+        using const_reverse_broadcast_iterator = typename iterable_base::template const_reverse_broadcast_iterator<S, L>;
+
+        using iterator = typename iterable_base::iterator;
+        using const_iterator = typename iterable_base::const_iterator;
+        using reverse_iterator = typename iterable_base::reverse_iterator;
+        using const_reverse_iterator = typename iterable_base::const_reverse_iterator;
+
+        template <class D, class M>
+        xmasked_view(D&& data, M&& mask);
+
+        size_type size() const noexcept;
+        const inner_shape_type& shape() const noexcept;
+        const inner_strides_type& strides() const noexcept;
+        const inner_backstrides_type& backstrides() const noexcept;
+        using accessible_base::dimension;
+        using accessible_base::shape;
+
+        layout_type layout() const noexcept;
+
+        template <class T>
+        void fill(const T& value);
+
+        template <class... Args>
+        reference operator()(Args... args);
+
+        template <class... Args>
+        const_reference operator()(Args... args) const;
+
+        template <class... Args>
+        reference unchecked(Args... args);
+
+        template <class... Args>
+        const_reference unchecked(Args... args) const;
+
+        using accessible_base::at;
+        using accessible_base::operator[];
+        using accessible_base::periodic;
+        using accessible_base::in_bounds;
+
+        template <class It>
+        reference element(It first, It last);
+
+        template <class It>
+        const_reference element(It first, It last) const;
+
+        data_type& value() noexcept;
+        const data_type& value() const noexcept;
+
+        mask_type& visible() noexcept;
+        const mask_type& visible() const noexcept;
+
+        using iterable_base::begin;
+        using iterable_base::end;
+        using iterable_base::cbegin;
+        using iterable_base::cend;
+        using iterable_base::rbegin;
+        using iterable_base::rend;
+        using iterable_base::crbegin;
+        using iterable_base::crend;
+
+        template <class S>
+        stepper stepper_begin(const S& shape) noexcept;
+        template <class S>
+        stepper stepper_end(const S& shape, layout_type l) noexcept;
+
+        template <class S>
+        const_stepper stepper_begin(const S& shape) const noexcept;
+        template <class S>
+        const_stepper stepper_end(const S& shape, layout_type l) const noexcept;
+
+        template <class E>
+        self_type& operator=(const xexpression<E>& e);
+
+        template <class E>
+        disable_xexpression<E, self_type>& operator=(const E& e);
+
+    private:
+
+        CTD m_data;
+        CTM m_mask;
+
+        void assign_temporary_impl(temporary_type&& tmp);
+
+        friend class xiterable<self_type>;
+        friend class xconst_iterable<self_type>;
+        friend class xview_semantic<self_type>;
+        friend class xaccessible<self_type>;
+        friend class xconst_accessible<self_type>;
+    };
+
+    template <class D, bool is_const>
+    class xmasked_view_stepper
+    {
+    public:
+
+        using self_type = xmasked_view_stepper<D, is_const>;
+        using masked_view_type = std::decay_t<D>;
+        using value_type = typename masked_view_type::value_type;
+        using reference = std::conditional_t<is_const,
+                                             typename masked_view_type::const_reference,
+                                             typename masked_view_type::reference>;
+        using pointer = std::conditional_t<is_const,
+                                           typename masked_view_type::const_pointer,
+                                           typename masked_view_type::pointer>;
+        using size_type = typename masked_view_type::size_type;
+        using difference_type = typename masked_view_type::difference_type;
+        using data_type = typename masked_view_type::data_type;
+        using mask_type = typename masked_view_type::mask_type;
+        using value_stepper = std::conditional_t<is_const,
+                                                 typename data_type::const_stepper,
+                                                 typename data_type::stepper>;
+        using mask_stepper = std::conditional_t<is_const,
+                                                typename mask_type::const_stepper,
+                                                typename mask_type::stepper>;
+
+        xmasked_view_stepper(value_stepper vs, mask_stepper fs) noexcept;
+
+
+        void step(size_type dim);
+        void step_back(size_type dim);
+        void step(size_type dim, size_type n);
+        void step_back(size_type dim, size_type n);
+        void reset(size_type dim);
+        void reset_back(size_type dim);
+
+        void to_begin();
+        void to_end(layout_type l);
+
+        reference operator*() const;
+
+    private:
+
+        value_stepper m_vs;
+        mask_stepper m_ms;
+    };
+
+    /*******************************
+     * xmasked_view implementation *
+     *******************************/
+
+    /**
+     * @name Constructors
+     */
+    //@{
+    /**
+     * Creates an xmasked_view, given the xoptional_assembly or
+     * xoptional_assembly_adaptor and the mask
+     *
+     * @param data the underlying xoptional_assembly or xoptional_assembly_adaptor
+     * @param mask the mask.
+     */
+    template <class CTD, class CTM>
+    template <class D, class M>
+    inline xmasked_view<CTD, CTM>::xmasked_view(D&& data, M&& mask)
+        : m_data(std::forward<D>(data)),
+          m_mask(std::forward<M>(mask))
+    {
+    }
+
+    /**
+     * @name Size and shape
+     */
+    //@{
+    /**
+     * Returns the number of elements in the xmasked_view.
+     */
+    template <class CTD, class CTM>
+    inline auto xmasked_view<CTD, CTM>::size() const noexcept -> size_type
+    {
+        return m_data.size();
+    }
+
+    /**
+     * Returns the shape of the xmasked_view.
+     */
+    template <class CTD, class CTM>
+    inline auto xmasked_view<CTD, CTM>::shape() const noexcept -> const inner_shape_type&
+    {
+        return m_data.shape();
+    }
+
+    /**
+     * Returns the strides of the xmasked_view.
+     */
+    template <class CTD, class CTM>
+    inline auto xmasked_view<CTD, CTM>::strides() const noexcept -> const inner_strides_type&
+    {
+        return m_data.strides();
+    }
+
+    /**
+     * Returns the backstrides of the xmasked_view.
+     */
+    template <class CTD, class CTM>
+    inline auto xmasked_view<CTD, CTM>::backstrides() const noexcept -> const inner_backstrides_type&
+    {
+        return m_data.backstrides();
+    }
+    //@}
+
+    /**
+     * Return the layout_type of the xmasked_view
+     * @return layout_type of the xmasked_view
+     */
+    template <class CTD, class CTM>
+    inline layout_type xmasked_view<CTD, CTM>::layout() const noexcept
+    {
+        return m_data.layout();
+    }
+
+    /**
+     * Fills the data with the given value.
+     * @param value the value to fill the data with.
+     */
+    template <class CTD, class CTM>
+    template <class T>
+    inline void xmasked_view<CTD, CTM>::fill(const T& value)
+    {
+        std::fill(this->begin(), this->end(), value);
+    }
+
+    /**
+     * @name Data
+     */
+    //@{
+    /**
+     * Returns a reference to the element at the specified position in the xmasked_view.
+     * @param args a list of indices specifying the position in the xmasked_view. Indices
+     * must be unsigned integers, the number of indices should be equal or greater than
+     * the number of dimensions of the xmasked_view.
+     */
+    template <class CTD, class CTM>
+    template <class... Args>
+    inline auto xmasked_view<CTD, CTM>::operator()(Args... args) -> reference
+    {
+        return reference(m_data(args...), m_mask(args...));
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the xmasked_view.
+     * @param args a list of indices specifying the position in the xmasked_view. Indices
+     * must be unsigned integers, the number of indices should be equal or greater than
+     * the number of dimensions of the xmasked_view.
+     */
+    template <class CTD, class CTM>
+    template <class... Args>
+    inline auto xmasked_view<CTD, CTM>::operator()(Args... args) const -> const_reference
+    {
+        return const_reference(m_data(args...), m_mask(args...));
+    }
+
+    /**
+     * Returns a reference to the element at the specified position in the  xmasked_view.
+     * @param args a list of indices specifying the position in the  xmasked_view. Indices
+     * must be unsigned integers, the number of indices must be equal to the number of
+     * dimensions of the  xmasked_view, else the behavior is undefined.
+     *
+     * @warning This method is meant for performance, for expressions with a dynamic
+     * number of dimensions (i.e. not known at compile time). Since it may have
+     * undefined behavior (see parameters), operator() should be prefered whenever
+     * it is possible.
+     * @warning This method is NOT compatible with broadcasting, meaning the following
+     * code has undefined behavior:
+     * \code{.cpp}
+     * xt::xarray<double> a = {{0, 1}, {2, 3}};
+     * xt::xarray<double> b = {0, 1};
+     * auto fd = a + b;
+     * double res = fd.uncheked(0, 1);
+     * \endcode
+     */
+    template <class CTD, class CTM>
+    template <class... Args>
+    inline auto xmasked_view<CTD, CTM>::unchecked(Args... args) -> reference
+    {
+        return reference(m_data.unchecked(args...), m_mask.unchecked(args...));
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the xmasked_view.
+     * @param args a list of indices specifying the position in the  xmasked_view. Indices
+     * must be unsigned integers, the number of indices must be equal to the number of
+     * dimensions of the  xmasked_view, else the behavior is undefined.
+     *
+     * @warning This method is meant for performance, for expressions with a dynamic
+     * number of dimensions (i.e. not known at compile time). Since it may have
+     * undefined behavior (see parameters), operator() should be prefered whenever
+     * it is possible.
+     * @warning This method is NOT compatible with broadcasting, meaning the following
+     * code has undefined behavior:
+     * \code{.cpp}
+     * xt::xarray<double> a = {{0, 1}, {2, 3}};
+     * xt::xarray<double> b = {0, 1};
+     * auto fd = a + b;
+     * double res = fd.uncheked(0, 1);
+     * \endcode
+     */
+    template <class CTD, class CTM>
+    template <class... Args>
+    inline auto xmasked_view<CTD, CTM>::unchecked(Args... args) const -> const_reference
+    {
+        return const_reference(m_data.unchecked(args...), m_mask.unchecked(args...));
+    }
+
+    /**
+     * Returns a reference to the element at the specified position in the xmasked_view.
+     * @param first iterator starting the sequence of indices
+     * @param last iterator ending the sequence of indices
+     * The number of indices in the sequence should be equal to or greater
+     * than the number of dimensions of the xmasked_view.
+     */
+    template <class CTD, class CTM>
+    template <class It>
+    inline auto xmasked_view<CTD, CTM>::element(It first, It last) -> reference
+    {
+        return reference(m_data.element(first, last), m_mask.element(first, last));
+    }
+
+    /**
+     * Returns a constant reference to the element at the specified position in the xmasked_view.
+     * @param first iterator starting the sequence of indices
+     * @param last iterator ending the sequence of indices
+     * The number of indices in the sequence should be equal to or greater
+     * than the number of dimensions of the xmasked_view.
+     */
+    template <class CTD, class CTM>
+    template <class It>
+    inline auto xmasked_view<CTD, CTM>::element(It first, It last) const -> const_reference
+    {
+        return const_reference(m_data.element(first, last), m_mask.element(first, last));
+    }
+    //@}
+
+    /**
+     * Return an expression for the values of the xmasked_view.
+     */
+    template <class CTD, class CTM>
+    inline auto xmasked_view<CTD, CTM>::value() noexcept -> data_type&
+    {
+        return m_data;
+    }
+
+    /**
+     * Return a constant expression for the values of the xmasked_view.
+     */
+    template <class CTD, class CTM>
+    inline auto xmasked_view<CTD, CTM>::value() const noexcept -> const data_type&
+    {
+        return m_data;
+    }
+
+    /**
+     * Return an expression for the mask of the xmasked_view.
+     */
+    template <class CTD, class CTM>
+    inline auto xmasked_view<CTD, CTM>::visible() noexcept -> mask_type&
+    {
+        return m_mask;
+    }
+
+    /**
+     * Return a constant expression for the mask of the xmasked_view.
+     */
+    template <class CTD, class CTM>
+    inline auto xmasked_view<CTD, CTM>::visible() const noexcept -> const mask_type&
+    {
+        return m_mask;
+    }
+
+    template <class CTD, class CTM>
+    template <class S>
+    inline auto xmasked_view<CTD, CTM>::stepper_begin(const S& shape) noexcept -> stepper
+    {
+        return stepper(value().stepper_begin(shape), visible().stepper_begin(shape));
+    }
+
+    template <class CTD, class CTM>
+    template <class S>
+    inline auto xmasked_view<CTD, CTM>::stepper_end(const S& shape, layout_type l) noexcept -> stepper
+    {
+        return stepper(value().stepper_end(shape, l), visible().stepper_end(shape, l));
+    }
+
+    template <class CTD, class CTM>
+    template <class S>
+    inline auto xmasked_view<CTD, CTM>::stepper_begin(const S& shape) const noexcept -> const_stepper
+    {
+        return const_stepper(value().stepper_begin(shape), visible().stepper_begin(shape));
+    }
+
+    template <class CTD, class CTM>
+    template <class S>
+    inline auto xmasked_view<CTD, CTM>::stepper_end(const S& shape, layout_type l) const noexcept -> const_stepper
+    {
+        return const_stepper(value().stepper_end(shape, l), visible().stepper_end(shape, l));
+    }
+
+    template <class CTD, class CTM>
+    template <class E>
+    inline auto xmasked_view<CTD, CTM>::operator=(const xexpression<E>& e) -> self_type&
+    {
+        return semantic_base::operator=(e);
+    }
+
+    template <class CTD, class CTM>
+    template <class E>
+    inline auto xmasked_view<CTD, CTM>::operator=(const E& e) -> disable_xexpression<E, self_type>&
+    {
+        std::fill(this->begin(), this->end(), e);
+        return *this;
+    }
+
+    template <class CTD, class CTM>
+    inline void xmasked_view<CTD, CTM>::assign_temporary_impl(temporary_type&& tmp)
+    {
+        std::copy(tmp.cbegin(), tmp.cend(), this->begin());
+    }
+
+    template <class CTD, class CTM>
+    inline xmasked_view<CTD, CTM> masked_view(CTD&& data, CTM&& mask)
+    {
+        return xmasked_view<CTD, CTM>(std::forward<CTD>(data), std::forward<CTM>(mask));
+    }
+
+    /***************************************
+     * xmasked_view_stepper implementation *
+     ***************************************/
+
+    template <class D, bool C>
+    inline xmasked_view_stepper<D, C>::xmasked_view_stepper(value_stepper vs, mask_stepper ms) noexcept
+        : m_vs(vs), m_ms(ms)
+    {
+    }
+
+    template <class D, bool C>
+    inline void xmasked_view_stepper<D, C>::step(size_type dim)
+    {
+        m_vs.step(dim);
+        m_ms.step(dim);
+    }
+
+    template <class D, bool C>
+    inline void xmasked_view_stepper<D, C>::step_back(size_type dim)
+    {
+        m_vs.step_back(dim);
+        m_ms.step_back(dim);
+    }
+
+    template <class D, bool C>
+    inline void xmasked_view_stepper<D, C>::step(size_type dim, size_type n)
+    {
+        m_vs.step(dim, n);
+        m_ms.step(dim, n);
+    }
+
+    template <class D, bool C>
+    inline void xmasked_view_stepper<D, C>::step_back(size_type dim, size_type n)
+    {
+        m_vs.step_back(dim, n);
+        m_ms.step_back(dim, n);
+    }
+
+    template <class D, bool C>
+    inline void xmasked_view_stepper<D, C>::reset(size_type dim)
+    {
+        m_vs.reset(dim);
+        m_ms.reset(dim);
+    }
+
+    template <class D, bool C>
+    inline void xmasked_view_stepper<D, C>::reset_back(size_type dim)
+    {
+        m_vs.reset_back(dim);
+        m_ms.reset_back(dim);
+    }
+
+    template <class D, bool C>
+    inline void xmasked_view_stepper<D, C>::to_begin()
+    {
+        m_vs.to_begin();
+        m_ms.to_begin();
+    }
+
+    template <class D, bool C>
+    inline void xmasked_view_stepper<D, C>::to_end(layout_type l)
+    {
+        m_vs.to_end(l);
+        m_ms.to_end(l);
+    }
+
+    template <class D, bool C>
+    inline auto xmasked_view_stepper<D, C>::operator*() const -> reference
+    {
+        return reference(*m_vs, *m_ms);
+    }
+}
+
+#endif

--- a/vendor/xtensor/include/xtensor/xmime.hpp
+++ b/vendor/xtensor/include/xtensor/xmime.hpp
@@ -1,0 +1,403 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_MIME_HPP
+#define XTENSOR_MIME_HPP
+
+#include <cstddef>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "xio.hpp"
+
+namespace xt
+{
+    template <class P, class T>
+    void compute_0d_table(std::stringstream& out, P& /*printer*/, const T& expr)
+    {
+        out << "<table style='border-style:solid;border-width:1px;'><tbody>";
+        out << "<tr><td style='font-family:monospace;'><pre>";
+        out << expr();
+        out << "</pre></td></tr>";
+        out << "</tbody></table>";
+    }
+
+    template <class P>
+    void compute_1d_row(std::stringstream& out, P& printer, const std::size_t& row_idx)
+    {
+        out << "<tr><td style='font-family:monospace;' title='" << row_idx << "'><pre>";
+        printer.print_next(out);
+        out << "</pre></td></tr>";
+    }
+
+    template <class P, class T>
+    void compute_1d_table(std::stringstream& out, P& printer, const T& expr,
+                          const std::size_t& edgeitems)
+    {
+        const auto& dim = expr.shape()[0];
+
+        out << "<table style='border-style:solid;border-width:1px;'><tbody>";
+        if (edgeitems == 0 || 2 * edgeitems >= dim)
+        {
+            for (std::size_t row_idx = 0; row_idx < dim; ++row_idx)
+            {
+                compute_1d_row(out, printer, row_idx);
+            }
+        }
+        else
+        {
+            for (std::size_t row_idx = 0; row_idx < edgeitems; ++row_idx)
+            {
+                compute_1d_row(out, printer, row_idx);
+            }
+            out << "<tr><td><center>\u22ee</center></td></tr>";
+            for (std::size_t row_idx = dim - edgeitems; row_idx < dim; ++row_idx)
+            {
+                compute_1d_row(out, printer, row_idx);
+            }
+        }
+        out << "</tbody></table>";
+    }
+
+    template <class P>
+    void compute_2d_element(std::stringstream& out, P& printer, const std::string& idx_str,
+                            const std::size_t& row_idx, const std::size_t& column_idx)
+    {
+        out << "<td style='font-family:monospace;' title='("
+            << idx_str << row_idx << ", " << column_idx << ")'><pre>";
+        printer.print_next(out);
+        out << "</pre></td>";
+    }
+
+    template <class P, class T>
+    void compute_2d_row(std::stringstream& out, P& printer, const T& expr,
+                        const std::size_t& edgeitems, const std::string& idx_str,
+                        const std::size_t& row_idx)
+    {
+        const auto& dim = expr.shape()[expr.dimension() - 1];
+
+        out << "<tr>";
+        if (edgeitems == 0 || 2 * edgeitems >= dim)
+        {
+            for (std::size_t column_idx = 0; column_idx < dim; ++column_idx)
+            {
+                compute_2d_element(out, printer, idx_str, row_idx, column_idx);
+            }
+        }
+        else
+        {
+            for (std::size_t column_idx = 0; column_idx < edgeitems; ++column_idx)
+            {
+                compute_2d_element(out, printer, idx_str, row_idx, column_idx);
+            }
+            out << "<td><center>\u22ef</center></td>";
+            for (std::size_t column_idx = dim - edgeitems; column_idx < dim; ++column_idx)
+            {
+                compute_2d_element(out, printer, idx_str, row_idx, column_idx);
+            }
+        }
+        out << "</tr>";
+    }
+
+    template <class P, class T, class I>
+    void compute_2d_table(std::stringstream& out, P& printer, const T& expr,
+                          const std::size_t& edgeitems, const std::vector<I>& idx)
+    {
+        const auto& dim = expr.shape()[expr.dimension() - 2];
+        const auto& last_dim = expr.shape()[expr.dimension() - 1];
+        std::string idx_str;
+        std::for_each(idx.cbegin(), idx.cend(), [&idx_str](const auto& i) {
+            idx_str += std::to_string(i) + ", ";
+        });
+
+        std::size_t nb_ellipsis = 2 * edgeitems + 1;
+        if (last_dim <= 2 * edgeitems + 1)
+        {
+            nb_ellipsis = last_dim;
+        }
+
+        out << "<table style='border-style:solid;border-width:1px;'><tbody>";
+        if (edgeitems == 0 || 2 * edgeitems >= dim)
+        {
+            for (std::size_t row_idx = 0; row_idx < dim; ++row_idx)
+            {
+                compute_2d_row(out, printer, expr, edgeitems, idx_str, row_idx);
+            }
+        }
+        else
+        {
+            for (std::size_t row_idx = 0; row_idx < edgeitems; ++row_idx)
+            {
+                compute_2d_row(out, printer, expr, edgeitems, idx_str, row_idx);
+            }
+            out << "<tr>";
+            for (std::size_t column_idx = 0; column_idx < nb_ellipsis; ++column_idx)
+            {
+                if (column_idx == edgeitems && nb_ellipsis != last_dim)
+                {
+                    out << "<td><center>\u22f1</center></td>";
+                }
+                else
+                {
+                    out << "<td><center>\u22ee</center></td>";
+                }
+            }
+            out << "</tr>";
+            for (std::size_t row_idx = dim - edgeitems; row_idx < dim; ++row_idx)
+            {
+                compute_2d_row(out, printer, expr, edgeitems, idx_str, row_idx);
+            }
+        }
+        out << "</tbody></table>";
+    }
+
+    template <class P, class T, class I>
+    void compute_nd_row(std::stringstream& out, P& printer, const T& expr,
+                        const std::size_t& edgeitems, const std::vector<I>& idx)
+    {
+        out << "<tr><td>";
+        compute_nd_table_impl(out, printer, expr, edgeitems, idx);
+        out << "</td></tr>";
+    }
+
+    template <class P, class T, class I>
+    void compute_nd_table_impl(std::stringstream& out, P& printer, const T& expr,
+                               const std::size_t& edgeitems, const std::vector<I>& idx)
+    {
+        const auto& displayed_dimension = idx.size();
+        const auto& expr_dim = expr.dimension();
+        const auto& dim = expr.shape()[displayed_dimension];
+
+        if (expr_dim - displayed_dimension == 2)
+        {
+            return compute_2d_table(out, printer, expr, edgeitems, idx);
+        }
+
+        std::vector<I> idx2 = idx;
+        idx2.resize(displayed_dimension + 1);
+
+        out << "<table style='border-style:solid;border-width:1px;'>";
+        if (edgeitems == 0 || 2 * edgeitems >= dim)
+        {
+            for (std::size_t i = 0; i < dim; ++i)
+            {
+                idx2[displayed_dimension] = i;
+                compute_nd_row(out, printer, expr, edgeitems, idx2);
+            }
+        }
+        else
+        {
+            for (std::size_t i = 0; i < edgeitems; ++i)
+            {
+                idx2[displayed_dimension] = i;
+                compute_nd_row(out, printer, expr, edgeitems, idx2);
+            }
+            out << "<tr><td><center>\u22ef</center></td></tr>";
+            for (std::size_t i = dim - edgeitems; i < dim; ++i)
+            {
+                idx2[displayed_dimension] = i;
+                compute_nd_row(out, printer, expr, edgeitems, idx2);
+            }
+        }
+        out << "</table>";
+    }
+
+    template <class P, class T>
+    void compute_nd_table(std::stringstream& out, P& printer, const T& expr,
+                          const std::size_t& edgeitems)
+    {
+        if (expr.dimension() == 0)
+        {
+            compute_0d_table(out, printer, expr);
+        }
+        else if (expr.dimension() == 1)
+        {
+            compute_1d_table(out, printer, expr, edgeitems);
+        }
+        else
+        {
+            std::vector<std::size_t> empty_vector;
+            compute_nd_table_impl(out, printer, expr, edgeitems, empty_vector);
+        }
+    }
+
+    template <class E>
+    nlohmann::json mime_bundle_repr_impl(const E& expr)
+    {
+        std::stringstream out;
+
+        std::size_t edgeitems = 0;
+        std::size_t size = compute_size(expr.shape());
+        if (size > print_options::print_options().threshold)
+        {
+            edgeitems = print_options::print_options().edge_items;
+        }
+
+        if (print_options::print_options().precision != -1)
+        {
+            out.precision(print_options::print_options().precision);
+        }
+
+        detail::printer<E> printer(out.precision());
+
+        xstrided_slice_vector slice_vector;
+        detail::recurser_run(printer, expr, slice_vector, edgeitems);
+        printer.init();
+
+        compute_nd_table(out, printer, expr, edgeitems);
+
+        auto bundle = nlohmann::json::object();
+        bundle["text/html"] = out.str();
+        return bundle;
+    }
+
+    template <class F, class CT>
+    class xfunctor_view;
+
+    template <class F, class CT>
+    nlohmann::json mime_bundle_repr(const xfunctor_view<F, CT>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class F, class... CT>
+    class xfunction;
+
+    template <class F, class... CT>
+    nlohmann::json mime_bundle_repr(const xfunction<F, CT...>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class EC, layout_type L, class SC, class Tag>
+    class xarray_container;
+
+    template <class EC, layout_type L, class SC, class Tag>
+    nlohmann::json mime_bundle_repr(const xarray_container<EC, L, SC, Tag>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    class xtensor_container;
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    nlohmann::json mime_bundle_repr(const xtensor_container<EC, N, L, Tag>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    class xfixed_container;
+
+    template <class ET, class S, layout_type L, bool SH, class Tag>
+    nlohmann::json mime_bundle_repr(const xfixed_container<ET, S, L, SH, Tag>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class F, class CT, class X, class O>
+    class xreducer;
+
+    template <class F, class CT, class X, class O>
+    nlohmann::json mime_bundle_repr(const xreducer<F, CT, X, O>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class VE, class FE>
+    class xoptional_assembly;
+
+    template <class VE, class FE>
+    nlohmann::json mime_bundle_repr(const xoptional_assembly<VE, FE>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class VEC, class FEC>
+    class xoptional_assembly_adaptor;
+
+    template <class VEC, class FEC>
+    nlohmann::json mime_bundle_repr(const xoptional_assembly_adaptor<VEC, FEC>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class CT>
+    class xscalar;
+
+    template <class CT>
+    nlohmann::json mime_bundle_repr(const xscalar<CT>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class CT, class X>
+    class xbroadcast;
+
+    template <class CT, class X>
+    nlohmann::json mime_bundle_repr(const xbroadcast<CT, X>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class F, class R, class S>
+    class xgenerator;
+
+    template <class F, class R, class S>
+    nlohmann::json mime_bundle_repr(const xgenerator<F, R, S>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class CT, class... S>
+    class xview;
+
+    template <class CT, class... S>
+    nlohmann::json mime_bundle_repr(const xview<CT, S...>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    class xstrided_view;
+
+    template <class CT, class S, layout_type L, class FST>
+    nlohmann::json mime_bundle_repr(const xstrided_view<CT, S, L, FST>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class CTD, class CTM>
+    class xmasked_view;
+
+    template <class CTD, class CTM>
+    nlohmann::json mime_bundle_repr(const xmasked_view<CTD, CTM>& expr)
+    {
+        return mime_bundle_repr_impl(expr);
+    }
+
+    template <class T, class B>
+    class xmasked_value;
+
+    template <class T, class B>
+    nlohmann::json mime_bundle_repr(const xmasked_value<T, B>& v)
+    {
+        auto bundle = nlohmann::json::object();
+        std::stringstream tmp;
+        tmp << v;
+        bundle["text/plain"] = tmp.str();
+        return bundle;
+    }
+}
+
+#endif

--- a/vendor/xtensor/include/xtensor/xnoalias.hpp
+++ b/vendor/xtensor/include/xtensor/xnoalias.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -20,90 +21,211 @@ namespace xt
 
     public:
 
-        noalias_proxy(A& a) noexcept;
+        noalias_proxy(A a) noexcept;
 
         template <class E>
-        A& operator=(const xexpression<E>& e);
+        disable_xexpression<E, A> operator=(const E&);
 
         template <class E>
-        A& operator+=(const xexpression<E>& e);
+        disable_xexpression<E, A> operator+=(const E&);
 
         template <class E>
-        A& operator-=(const xexpression<E>& e);
+        disable_xexpression<E, A> operator-=(const E&);
 
         template <class E>
-        A& operator*=(const xexpression<E>& e);
+        disable_xexpression<E, A> operator*=(const E&);
 
         template <class E>
-        A& operator/=(const xexpression<E>& e);
+        disable_xexpression<E, A> operator/=(const E&);
 
         template <class E>
-        A& operator%=(const xexpression<E>& e);
-        
+        disable_xexpression<E, A> operator%=(const E&);
+
+        template <class E>
+        disable_xexpression<E, A> operator&=(const E&);
+
+        template <class E>
+        disable_xexpression<E, A> operator|=(const E&);
+
+        template <class E>
+        disable_xexpression<E, A> operator^=(const E&);
+
+        template <class E>
+        A operator=(const xexpression<E>& e);
+
+        template <class E>
+        A operator+=(const xexpression<E>& e);
+
+        template <class E>
+        A operator-=(const xexpression<E>& e);
+
+        template <class E>
+        A operator*=(const xexpression<E>& e);
+
+        template <class E>
+        A operator/=(const xexpression<E>& e);
+
+        template <class E>
+        A operator%=(const xexpression<E>& e);
+
+        template <class E>
+        A operator&=(const xexpression<E>&);
+
+        template <class E>
+        A operator|=(const xexpression<E>&);
+
+        template <class E>
+        A operator^=(const xexpression<E>&);
+
     private:
 
-        A& m_array;
+        A m_array;
     };
 
     template <class A>
-    noalias_proxy<A> noalias(A& a) noexcept;
+    noalias_proxy<xtl::closure_type_t<A>> noalias(A&& a) noexcept;
 
     /********************************
      * noalias_proxy implementation *
      ********************************/
 
     template <class A>
-    inline noalias_proxy<A>::noalias_proxy(A& a) noexcept
-        : m_array(a)
+    inline noalias_proxy<A>::noalias_proxy(A a) noexcept
+        : m_array(std::forward<A>(a))
     {
     }
 
     template <class A>
     template <class E>
-    inline A& noalias_proxy<A>::operator=(const xexpression<E>& e)
+    inline auto noalias_proxy<A>::operator=(const E& e) -> disable_xexpression<E, A>
+    {
+        return m_array.assign(xscalar<E>(e));
+    }
+
+    template <class A>
+    template <class E>
+    inline auto noalias_proxy<A>::operator+=(const E& e) -> disable_xexpression<E, A>
+    {
+        return m_array.scalar_computed_assign(e, std::plus<>());
+    }
+
+    template <class A>
+    template <class E>
+    inline auto noalias_proxy<A>::operator-=(const E& e) -> disable_xexpression<E, A>
+    {
+        return m_array.scalar_computed_assign(e, std::minus<>());
+    }
+
+    template <class A>
+    template <class E>
+    inline auto noalias_proxy<A>::operator*=(const E& e) -> disable_xexpression<E, A>
+    {
+        return m_array.scalar_computed_assign(e, std::multiplies<>());
+    }
+
+    template <class A>
+    template <class E>
+    inline auto noalias_proxy<A>::operator/=(const E& e) -> disable_xexpression<E, A>
+    {
+        return m_array.scalar_computed_assign(e, std::divides<>());
+    }
+
+    template <class A>
+    template <class E>
+    inline auto noalias_proxy<A>::operator%=(const E& e) -> disable_xexpression<E, A>
+    {
+        return m_array.scalar_computed_assign(e, std::modulus<>());
+    }
+
+    template <class A>
+    template <class E>
+    inline auto noalias_proxy<A>::operator&=(const E& e) -> disable_xexpression<E, A>
+    {
+        return m_array.scalar_computed_assign(e, std::bit_and<>());
+    }
+
+    template <class A>
+    template <class E>
+    inline auto noalias_proxy<A>::operator|=(const E& e) -> disable_xexpression<E, A>
+    {
+        return m_array.scalar_computed_assign(e, std::bit_or<>());
+    }
+
+    template <class A>
+    template <class E>
+    inline auto noalias_proxy<A>::operator^=(const E& e) -> disable_xexpression<E, A>
+    {
+        return m_array.scalar_computed_assign(e, std::bit_xor<>());
+    }
+
+    template <class A>
+    template <class E>
+    inline A noalias_proxy<A>::operator=(const xexpression<E>& e)
     {
         return m_array.assign(e);
     }
 
     template <class A>
     template <class E>
-    inline A& noalias_proxy<A>::operator+=(const xexpression<E>& e)
+    inline A noalias_proxy<A>::operator+=(const xexpression<E>& e)
     {
         return m_array.plus_assign(e);
     }
 
     template <class A>
     template <class E>
-    inline A& noalias_proxy<A>::operator-=(const xexpression<E>& e)
+    inline A noalias_proxy<A>::operator-=(const xexpression<E>& e)
     {
         return m_array.minus_assign(e);
     }
 
     template <class A>
     template <class E>
-    inline A& noalias_proxy<A>::operator*=(const xexpression<E>& e)
+    inline A noalias_proxy<A>::operator*=(const xexpression<E>& e)
     {
         return m_array.multiplies_assign(e);
     }
 
     template <class A>
     template <class E>
-    inline A& noalias_proxy<A>::operator/=(const xexpression<E>& e)
+    inline A noalias_proxy<A>::operator/=(const xexpression<E>& e)
     {
         return m_array.divides_assign(e);
     }
 
     template <class A>
     template <class E>
-    inline A& noalias_proxy<A>::operator%=(const xexpression<E>& e)
+    inline A noalias_proxy<A>::operator%=(const xexpression<E>& e)
     {
         return m_array.modulus_assign(e);
     }
 
     template <class A>
-    inline noalias_proxy<A> noalias(A& a) noexcept
+    template <class E>
+    inline A noalias_proxy<A>::operator&=(const xexpression<E>& e)
     {
-        return noalias_proxy<A>(a);
+        return m_array.bit_and_assign(e);
+    }
+
+    template <class A>
+    template <class E>
+    inline A noalias_proxy<A>::operator|=(const xexpression<E>& e)
+    {
+        return m_array.bit_or_assign(e);
+    }
+
+    template <class A>
+    template <class E>
+    inline A noalias_proxy<A>::operator^=(const xexpression<E>& e)
+    {
+        return m_array.bit_xor_assign(e);
+    }
+
+    template <class A>
+    inline noalias_proxy<xtl::closure_type_t<A>>
+    noalias(A&& a) noexcept
+    {
+        return noalias_proxy<xtl::closure_type_t<A>>(a);
     }
 }
 

--- a/vendor/xtensor/include/xtensor/xnorm.hpp
+++ b/vendor/xtensor/include/xtensor/xnorm.hpp
@@ -1,5 +1,7 @@
 /***************************************************************************
-* Copyright (c) 2017, Ullrich Koethe                                       *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) Ullrich Koethe
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -14,43 +16,213 @@
 #include <complex>
 #include <cstdlib>
 
-#include "xconcepts.hpp"
+#include <xtl/xtype_traits.hpp>
+
 #include "xmath.hpp"
 #include "xoperation.hpp"
 #include "xutils.hpp"
 
 namespace xt
 {
-    template <class X>
-    using disable_evaluation_strategy = std::enable_if_t<!std::is_base_of<evaluation_strategy::base, std::decay_t<X>>::value, int>;
+    /********************************************
+     * type inference for norm and squared norm *
+     ********************************************/
+
+    template <class T>
+    struct norm_type;
+
+    template <class T>
+    struct squared_norm_type;
+
+    namespace traits_detail
+    {
+
+        template <class T, bool scalar = std::is_arithmetic<T>::value>
+        struct norm_of_scalar_impl;
+
+        template <class T>
+        struct norm_of_scalar_impl<T, false>
+        {
+            static const bool value = false;
+            using norm_type = void*;
+            using squared_norm_type = void*;
+        };
+
+        template <class T>
+        struct norm_of_scalar_impl<T, true>
+        {
+            static const bool value = true;
+            using norm_type = xtl::promote_type_t<T>;
+            using squared_norm_type = xtl::promote_type_t<T>;
+        };
+
+        template <class T, bool integral = std::is_integral<T>::value,
+                  bool floating = std::is_floating_point<T>::value>
+        struct norm_of_array_elements_impl;
+
+        template <>
+        struct norm_of_array_elements_impl<void*, false, false>
+        {
+            using norm_type = void*;
+            using squared_norm_type = void*;
+        };
+
+        template <class T>
+        struct norm_of_array_elements_impl<T, false, false>
+        {
+            using norm_type = typename norm_type<T>::type;
+            using squared_norm_type = typename squared_norm_type<T>::type;
+        };
+
+        template <class T>
+        struct norm_of_array_elements_impl<T, true, false>
+        {
+            static_assert(!std::is_same<T, char>::value,
+                          "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
+
+            using norm_type = double;
+            using squared_norm_type = uint64_t;
+        };
+
+        template <class T>
+        struct norm_of_array_elements_impl<T, false, true>
+        {
+            using norm_type = double;
+            using squared_norm_type = double;
+        };
+
+        template <>
+        struct norm_of_array_elements_impl<long double, false, true>
+        {
+            using norm_type = long double;
+            using squared_norm_type = long double;
+        };
+
+        template <class ARRAY>
+        struct norm_of_vector_impl
+        {
+            static void* test(...);
+
+            template <class U>
+            static typename U::value_type test(U*, typename U::value_type* = 0);
+
+            using T = decltype(test(std::declval<ARRAY*>()));
+
+            static const bool value = !std::is_same<T, void*>::value;
+
+            using norm_type = typename norm_of_array_elements_impl<T>::norm_type;
+            using squared_norm_type = typename norm_of_array_elements_impl<T>::squared_norm_type;
+        };
+
+        template <class U>
+        struct norm_type_base
+        {
+            using T = std::decay_t<U>;
+
+            static_assert(!std::is_same<T, char>::value,
+                          "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
+
+            using norm_of_scalar = norm_of_scalar_impl<T>;
+            using norm_of_vector = norm_of_vector_impl<T>;
+
+            static const bool value = norm_of_scalar::value || norm_of_vector::value;
+
+            static_assert(value, "norm_type<T> are undefined for type U.");
+        };
+    }  // namespace traits_detail
+
+    /**
+     * @brief Traits class for the result type of the <tt>norm_l2()</tt> function.
+     *
+     * Member 'type' defines the result of <tt>norm_l2(t)</tt>, where <tt>t</tt>
+     * is of type @tparam T. It implements the following rules designed to
+     * minimize the potential for overflow:
+     *   - @tparam T is an arithmetic type: 'type' is the result type of <tt>abs(t)</tt>.
+     *   - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
+     *   - @tparam T is a container of another arithmetic type: 'type' is <tt>double</tt>.
+     *   - @tparam T is a container of some other type: 'type' is the element's norm type,
+     *
+     * Containers are recognized by having an embedded typedef 'value_type'.
+     * To change the behavior for a case not covered here, specialize the
+     * <tt>traits_detail::norm_type_base</tt> template.
+     */
+    template <class T>
+    struct norm_type : traits_detail::norm_type_base<T>
+    {
+        using base_type = traits_detail::norm_type_base<T>;
+
+        using type =
+            typename std::conditional<base_type::norm_of_vector::value,
+                                      typename base_type::norm_of_vector::norm_type,
+                                      typename base_type::norm_of_scalar::norm_type>::type;
+    };
+
+    /**
+     * Abbreviation of 'typename norm_type<T>::type'.
+     */
+    template <class T>
+    using norm_type_t = typename norm_type<T>::type;
+
+    /**
+     * @brief Traits class for the result type of the <tt>norm_sq()</tt> function.
+     *
+     * Member 'type' defines the result of <tt>norm_sq(t)</tt>, where <tt>t</tt>
+     * is of type @tparam T. It implements the following rules designed to
+     * minimize the potential for overflow:
+     *   - @tparam T is an arithmetic type: 'type' is the result type of <tt>t*t</tt>.
+     *   - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
+     *   - @tparam T is a container of another floating-point type: 'type' is <tt>double</tt>.
+     *   - @tparam T is a container of integer elements: 'type' is <tt>uint64_t</tt>.
+     *   - @tparam T is a container of some other type: 'type' is the element's squared norm type,
+     *
+     *  Containers are recognized by having an embedded typedef 'value_type'.
+     *  To change the behavior for a case not covered here, specialize the
+     *  <tt>traits_detail::norm_type_base</tt> template.
+     */
+    template <class T>
+    struct squared_norm_type : traits_detail::norm_type_base<T>
+    {
+        using base_type = traits_detail::norm_type_base<T>;
+
+        using type =
+            typename std::conditional<base_type::norm_of_vector::value,
+                                      typename base_type::norm_of_vector::squared_norm_type,
+                                      typename base_type::norm_of_scalar::squared_norm_type>::type;
+    };
+
+    /**
+     * Abbreviation of 'typename squared_norm_type<T>::type'.
+     */
+    template <class T>
+    using squared_norm_type_t = typename squared_norm_type<T>::type;
 
     /*************************************
      * norm functions for built-in types *
      *************************************/
 
 ///@cond DOXYGEN_INCLUDE_SFINAE
-#define XTENSOR_DEFINE_SIGNED_NORMS(T)                          \
-    inline auto                                                 \
-    norm_lp(T t, double p) noexcept                             \
-    {                                                           \
-        using rt = decltype(std::abs(t));                       \
-        return p == 0.0                                         \
-            ? static_cast<rt>(t != 0)                           \
-            : std::abs(t);                                      \
-    }                                                           \
-    inline auto                                                 \
-    norm_lp_to_p(T t, double p) noexcept                        \
-    {                                                           \
-        using rt = real_promote_type_t<T>;                      \
-        return p == 0.0                                         \
-            ? static_cast<rt>(t != 0)                           \
-            : std::pow(static_cast<rt>(std::abs(t)),            \
-                       static_cast<rt>(p));                     \
-    }                                                           \
-    inline size_t norm_l0(T t) noexcept { return (t != 0); }    \
-    inline auto norm_l1(T t) noexcept { return std::abs(t); }   \
-    inline auto norm_l2(T t) noexcept { return std::abs(t); }   \
-    inline auto norm_linf(T t) noexcept { return std::abs(t); } \
+#define XTENSOR_DEFINE_SIGNED_NORMS(T)                            \
+    inline auto                                                   \
+    norm_lp(T t, double p) noexcept                               \
+    {                                                             \
+        using rt = decltype(std::abs(t));                         \
+        return p == 0.0                                           \
+            ? static_cast<rt>(t != 0)                             \
+            : std::abs(t);                                        \
+    }                                                             \
+    inline auto                                                   \
+    norm_lp_to_p(T t, double p) noexcept                          \
+    {                                                             \
+        using rt = xtl::real_promote_type_t<T>;                   \
+        return p == 0.0                                           \
+            ? static_cast<rt>(t != 0)                             \
+            : std::pow(static_cast<rt>(std::abs(t)),              \
+                       static_cast<rt>(p));                       \
+    }                                                             \
+    inline std::size_t norm_l0(T t) noexcept { return (t != 0); } \
+    inline auto norm_l1(T t) noexcept { return std::abs(t); }     \
+    inline auto norm_l2(T t) noexcept { return std::abs(t); }     \
+    inline auto norm_linf(T t) noexcept { return std::abs(t); }   \
     inline auto norm_sq(T t) noexcept { return t * t; }
 
     XTENSOR_DEFINE_SIGNED_NORMS(signed char)
@@ -74,7 +246,7 @@ namespace xt
     inline auto                                               \
     norm_lp_to_p(T t, double p) noexcept                      \
     {                                                         \
-        using rt = real_promote_type_t<T>;                    \
+        using rt = xtl::real_promote_type_t<T>;               \
         return p == 0.0                                       \
             ? static_cast<rt>(t != 0)                         \
             : std::pow(static_cast<rt>(t),                    \
@@ -135,7 +307,8 @@ namespace xt
     template <class T>
     inline auto norm_sq(const std::complex<T>& t) noexcept
     {
-        return std::norm(t);
+        // Does not use std::norm since it returns a std::complex on OSX
+        return t.real() * t.real() + t.imag() * t.imag();
     }
 
     /**
@@ -176,49 +349,66 @@ namespace xt
      ***********************************/
 
 #ifdef X_OLD_CLANG
-#define XTENSOR_NORM_FUNCTION_AXES(NAME)                                             \
-    template <class E, class I, class EVS = DEFAULT_STRATEGY_REDUCERS>               \
-    inline auto NAME(E&& e, std::initializer_list<I> axes, EVS es = EVS()) noexcept  \
-    {                                                                                \
-        using axes_type = std::vector<typename std::decay_t<E>::size_type>;          \
-        return NAME(std::forward<E>(e), xtl::forward_sequence<axes_type>(axes), es); \
+#define XTENSOR_NORM_FUNCTION_AXES(NAME)                                              \
+    template <class E, class I, class EVS = DEFAULT_STRATEGY_REDUCERS>                \
+    inline auto NAME(E&& e, std::initializer_list<I> axes, EVS es = EVS()) noexcept   \
+    {                                                                                 \
+        using axes_type = std::vector<typename std::decay_t<E>::size_type>;           \
+        return NAME(std::forward<E>(e),                                               \
+                xtl::forward_sequence<axes_type, decltype(axes)>(axes), es);          \
     }
 
 #else
-#define XTENSOR_NORM_FUNCTION_AXES(NAME)                                                \
-    template <class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>   \
-    inline auto NAME(E&& e, const I(&axes)[N], EVS es = EVS()) noexcept                 \
-    {                                                                                   \
-        using axes_type = std::array<typename std::decay_t<E>::size_type, N>;           \
-        return NAME(std::forward<E>(e), xtl::forward_sequence<axes_type>(axes), es);    \
+#define XTENSOR_NORM_FUNCTION_AXES(NAME)                                              \
+    template <class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS> \
+    inline auto NAME(E&& e, const I(&axes)[N], EVS es = EVS()) noexcept               \
+    {                                                                                 \
+        using axes_type = std::array<typename std::decay_t<E>::size_type, N>;         \
+        return NAME(std::forward<E>(e),                                               \
+                xtl::forward_sequence<axes_type, decltype(axes)>(axes), es);          \
     }
 #endif
 
+    namespace detail
+    {
+        template <class T>
+        struct norm_value_type
+        {
+            using type = T;
+        };
+
+        template <class T>
+        struct norm_value_type<std::complex<T>>
+        {
+            using type = T;
+        };
+
+        template <class T>
+        using norm_value_type_t = typename norm_value_type<T>::type;
+    }
 
 #define XTENSOR_EMPTY
 #define XTENSOR_COMMA ,
 #define XTENSOR_NORM_FUNCTION(NAME, RESULT_TYPE, REDUCE_EXPR, REDUCE_OP, MERGE_FUNC) \
     template <class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,               \
-              class = disable_evaluation_strategy<X>>                                \
+              XTL_REQUIRES(xtl::negation<is_reducer_options<X>>)>                    \
     inline auto NAME(E&& e, X&& axes, EVS es = EVS()) noexcept                       \
     {                                                                                \
         using value_type = typename std::decay_t<E>::value_type;                     \
-        using result_type = RESULT_TYPE;                                             \
+        using result_type = detail::norm_value_type_t<RESULT_TYPE>;                  \
                                                                                      \
         auto reduce_func = [](result_type const& r, value_type const& v) {           \
             return REDUCE_EXPR(r REDUCE_OP NAME(v));                                 \
         };                                                                           \
-        auto init_func = [](value_type const& v) {                                   \
-            return NAME(v);                                                          \
-        };                                                                           \
-        return reduce(make_xreducer_functor(std::move(reduce_func),                  \
-                                            std::move(init_func),                    \
-                                            MERGE_FUNC<result_type>()),              \
+                                                                                     \
+        return xt::reduce(make_xreducer_functor(std::move(reduce_func),              \
+                                                const_value<result_type>(0),                    \
+                                                MERGE_FUNC<result_type>()),          \
                       std::forward<E>(e), std::forward<X>(axes), es);                \
     }                                                                                \
                                                                                      \
     template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS,                        \
-              XTENSOR_REQUIRE<is_xexpression<E>::value>>                             \
+              XTL_REQUIRES(is_xexpression<E>)>                                       \
     inline auto NAME(E&& e, EVS es = EVS()) noexcept                                 \
     {                                                                                \
         return NAME(std::forward<E>(e), arange(e.dimension()), es);                  \
@@ -226,8 +416,8 @@ namespace xt
     XTENSOR_NORM_FUNCTION_AXES(NAME)
 
     XTENSOR_NORM_FUNCTION(norm_l0, unsigned long long, XTENSOR_EMPTY, +, std::plus)
-    XTENSOR_NORM_FUNCTION(norm_l1, big_promote_type_t<value_type>, XTENSOR_EMPTY, +, std::plus)
-    XTENSOR_NORM_FUNCTION(norm_sq, big_promote_type_t<value_type>, XTENSOR_EMPTY, +, std::plus)
+    XTENSOR_NORM_FUNCTION(norm_l1, xtl::big_promote_type_t<value_type>, XTENSOR_EMPTY, +, std::plus)
+    XTENSOR_NORM_FUNCTION(norm_sq, xtl::big_promote_type_t<value_type>, XTENSOR_EMPTY, +, std::plus)
     XTENSOR_NORM_FUNCTION(norm_linf, decltype(norm_linf(std::declval<value_type>())), (std::max<result_type>), XTENSOR_COMMA, math::maximum)
 
 #undef XTENSOR_EMPTY
@@ -288,7 +478,8 @@ namespace xt
      *  For scalar types: implemented as <tt>abs(t)</tt><br>
      *  otherwise: implemented as <tt>sqrt(norm_sq(t))</tt>.
     */
-    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS, XTENSOR_REQUIRE<is_xexpression<E>::value>>
+    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS,
+              XTL_REQUIRES(is_xexpression<E>)>
     inline auto norm_l2(E&& e, EVS es = EVS()) noexcept
     {
         using std::sqrt;
@@ -306,7 +497,7 @@ namespace xt
      * @return an \ref xreducer (specifically: <tt>sqrt(norm_sq(e, axes))</tt>) (or xcontainer, depending on evaluation strategy)
     */
     template <class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,
-              XTENSOR_REQUIRE<is_xexpression<E>::value>, class = disable_evaluation_strategy<X>>
+              XTL_REQUIRES(is_xexpression<E>, xtl::negation<is_reducer_options<X>>)>
     inline auto norm_l2(E&& e, X&& axes, EVS es = EVS()) noexcept
     {
         return sqrt(norm_sq(std::forward<E>(e), std::forward<X>(axes), es));
@@ -317,14 +508,14 @@ namespace xt
     inline auto norm_l2(E&& e, std::initializer_list<I> axes, EVS es = EVS()) noexcept
     {
         using axes_type = std::vector<typename std::decay_t<E>::size_type>;
-        return sqrt(norm_sq(std::forward<E>(e), xtl::forward_sequence<axes_type>(axes), es));
+        return sqrt(norm_sq(std::forward<E>(e), xtl::forward_sequence<axes_type, decltype(axes)>(axes), es));
     }
 #else
     template <class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>
     inline auto norm_l2(E&& e, const I (&axes)[N], EVS es = EVS()) noexcept
     {
         using axes_type = std::array<typename std::decay_t<E>::size_type, N>;
-        return sqrt(norm_sq(std::forward<E>(e), xtl::forward_sequence<axes_type>(axes), es));
+        return sqrt(norm_sq(std::forward<E>(e), xtl::forward_sequence<axes_type, decltype(axes)>(axes), es));
     }
 #endif
 
@@ -356,7 +547,8 @@ namespace xt
      * When no axes are provided, the norm is calculated over the entire array. In this case,
      * the reducer represents a scalar result, otherwise an array of appropriate dimension.
      */
-    template <class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS, class = disable_evaluation_strategy<X>>
+    template <class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,
+              XTL_REQUIRES(xtl::negation<is_reducer_options<X>>)>
     inline auto norm_lp_to_p(E&& e, double p, X&& axes, EVS es = EVS()) noexcept
     {
         using value_type = typename std::decay_t<E>::value_type;
@@ -365,15 +557,11 @@ namespace xt
         auto reduce_func = [p](result_type const& r, value_type const& v) {
             return r + norm_lp_to_p(v, p);
         };
-
-        auto init_func = [p](value_type const& v) {
-            return norm_lp_to_p(v, p);
-        };
-        return reduce(make_xreducer_functor(std::move(reduce_func), std::move(init_func), std::plus<result_type>()),
+        return xt::reduce(make_xreducer_functor(std::move(reduce_func), xt::const_value<result_type>(0), std::plus<result_type>()),
                       std::forward<E>(e), std::forward<X>(axes), es);
     }
 
-    template <class E, XTENSOR_REQUIRE<is_xexpression<E>::value>, class EVS = DEFAULT_STRATEGY_REDUCERS>
+    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS, XTL_REQUIRES(is_xexpression<E>)>
     inline auto norm_lp_to_p(E&& e, double p, EVS es = EVS()) noexcept
     {
         return norm_lp_to_p(std::forward<E>(e), p, arange(e.dimension()), es);
@@ -384,14 +572,14 @@ namespace xt
     inline auto norm_lp_to_p(E&& e, double p, std::initializer_list<I> axes, EVS es = EVS()) noexcept
     {
         using axes_type = std::vector<typename std::decay_t<E>::size_type>;
-        return norm_lp_to_p(std::forward<E>(e), p, xtl::forward_sequence<axes_type>(axes), es);
+        return norm_lp_to_p(std::forward<E>(e), p, xtl::forward_sequence<axes_type, decltype(axes)>(axes), es);
     }
 #else
     template <class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>
     inline auto norm_lp_to_p(E&& e, double p, const I (&axes)[N], EVS es = EVS()) noexcept
     {
         using axes_type = std::array<typename std::decay_t<E>::size_type, N>;
-        return norm_lp_to_p(std::forward<E>(e), p, xtl::forward_sequence<axes_type>(axes), es);
+        return norm_lp_to_p(std::forward<E>(e), p, xtl::forward_sequence<axes_type, decltype(axes)>(axes), es);
     }
 #endif
 
@@ -408,7 +596,8 @@ namespace xt
      * When no axes are provided, the norm is calculated over the entire array. In this case,
      * the reducer represents a scalar result, otherwise an array of appropriate dimension.
      */
-    template <class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS, class = disable_evaluation_strategy<X>>
+    template <class E, class X, class EVS = DEFAULT_STRATEGY_REDUCERS,
+              XTL_REQUIRES(xtl::negation<is_reducer_options<X>>)>
     inline auto norm_lp(E&& e, double p, X&& axes, EVS es = EVS())
     {
         XTENSOR_PRECONDITION(p != 0,
@@ -416,7 +605,8 @@ namespace xt
         return pow(norm_lp_to_p(std::forward<E>(e), p, std::forward<X>(axes), es), 1.0 / p);
     }
 
-    template <class E, XTENSOR_REQUIRE<is_xexpression<E>::value>, class EVS = DEFAULT_STRATEGY_REDUCERS>
+    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS,
+              XTL_REQUIRES(is_xexpression<E>)>
     inline auto norm_lp(E&& e, double p, EVS es = EVS())
     {
         return norm_lp(std::forward<E>(e), p, arange(e.dimension()), es);
@@ -427,14 +617,14 @@ namespace xt
     inline auto norm_lp(E&& e, double p, std::initializer_list<I> axes, EVS es = EVS())
     {
         using axes_type = std::vector<typename std::decay_t<E>::size_type>;
-        return norm_lp(std::forward<E>(e), p, xtl::forward_sequence<axes_type>(axes), es);
+        return norm_lp(std::forward<E>(e), p, xtl::forward_sequence<axes_type, decltype(axes)>(axes), es);
     }
 #else
     template <class E, class I, std::size_t N, class EVS = DEFAULT_STRATEGY_REDUCERS>
     inline auto norm_lp(E&& e, double p, const I (&axes)[N], EVS es = EVS())
     {
         using axes_type = std::array<typename std::decay_t<E>::size_type, N>;
-        return norm_lp(std::forward<E>(e), p, xtl::forward_sequence<axes_type>(axes), es);
+        return norm_lp(std::forward<E>(e), p, xtl::forward_sequence<axes_type, decltype(axes)>(axes), es);
     }
 #endif
 
@@ -447,7 +637,8 @@ namespace xt
      * @param es evaluation strategy to use (lazy (default), or immediate)
      * @return an \ref xreducer (or xcontainer, depending on evaluation strategy)
      */
-    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS, XTENSOR_REQUIRE<is_xexpression<E>::value>>
+    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS,
+              XTL_REQUIRES(is_xexpression<E>)>
     inline auto norm_induced_l1(E&& e, EVS es = EVS())
     {
         XTENSOR_PRECONDITION(e.dimension() == 2,
@@ -464,7 +655,8 @@ namespace xt
      * @param es evaluation strategy to use (lazy (default), or immediate)
      * @return an \ref xreducer (or xcontainer, depending on evaluation strategy)
      */
-    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS, XTENSOR_REQUIRE<is_xexpression<E>::value>>
+    template <class E, class EVS = DEFAULT_STRATEGY_REDUCERS,
+              XTL_REQUIRES(is_xexpression<E>)>
     inline auto norm_induced_linf(E&& e, EVS es = EVS())
     {
         XTENSOR_PRECONDITION(e.dimension() == 2,

--- a/vendor/xtensor/include/xtensor/xoffset_view.hpp
+++ b/vendor/xtensor/include/xtensor/xoffset_view.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -26,16 +27,57 @@ namespace xt
             using pointer = M*;
             using const_pointer = const M*;
 
+            using proxy = xtl::xproxy_wrapper<M>;
+
+            template <class value_type, class requested_type>
+            using simd_return_type = xt_simd::simd_return_type<value_type, requested_type>;
+
             template <class T>
             decltype(auto) operator()(T&& t) const
             {
-                return xtl::forward_offset<M, I>(t);
+                return xtl::forward_offset<M, I>(std::forward<T>(t));
+            }
+
+            template <class align, class requested_type, std::size_t N, class E, class MF = M,
+                      class = std::enable_if_t<(std::is_same<MF, double>::value || std::is_same<MF, float>::value) && I <= sizeof(MF), int>>
+            auto proxy_simd_load(const E& expr, std::size_t n) const
+            {
+                // TODO refactor using shuffle only
+                auto batch = expr.template load_simd<align, requested_type, N>(n);
+                if (I == 0)
+                {
+                    return batch.real();
+                }
+                else
+                {
+                    return batch.imag();
+                }
+            }
+
+            template <class align, class simd, class E, class MF = M,
+                      class = std::enable_if_t<(std::is_same<MF, double>::value || std::is_same<MF, float>::value) && I <= sizeof(MF), int>>
+            auto proxy_simd_store(E& expr, std::size_t n, const simd& batch) const
+            {
+                auto x = expr.template load_simd<align, double, simd::size>(n);
+                if (I == 0)
+                {
+                    x.real() = batch;
+                }
+                else
+                {
+                    x.imag() = batch;
+                }
+                expr.template store_simd<align>(n, x);
             }
         };
     }
 
     template <class CT, class M, std::size_t I>
     using xoffset_view = xfunctor_view<detail::offset_forwarder<M, I>, CT>;
+
+    template <class CT, class M, std::size_t I>
+    using xoffset_adaptor = xfunctor_adaptor<detail::offset_forwarder<M, I>, CT>;
 }
 
 #endif
+

--- a/vendor/xtensor/include/xtensor/xoptional.hpp
+++ b/vendor/xtensor/include/xtensor/xoptional.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -16,7 +17,16 @@
 #include <xtl/xoptional_sequence.hpp>
 
 #include "xarray.hpp"
+#include "xbroadcast.hpp"
+#include "xdynamic_view.hpp"
+#include "xfunctor_view.hpp"
+#include "xgenerator.hpp"
+#include "xindex_view.hpp"
+#include "xreducer.hpp"
+#include "xscalar.hpp"
+#include "xstrided_view.hpp"
 #include "xtensor.hpp"
+#include "xview.hpp"
 
 namespace xt
 {
@@ -25,14 +35,42 @@ namespace xt
      * Metafunction for splitting xoptional expressions *
      ****************************************************/
 
+    namespace extension
+    {
+
+        /**************************************
+         * get_expression_tag specializations *
+         **************************************/
+
+        template <class T, class B>
+        struct get_expression_tag<xtl::xoptional<T, B>>
+        {
+            using type = xoptional_expression_tag;
+        };
+
+        /************************
+         * xoptional_empty_base *
+         ************************/
+
+        template <class D>
+        class xoptional_empty_base
+        {
+        public:
+
+            using expression_tag = xoptional_expression_tag;
+
+        protected:
+
+            D& derived_cast() noexcept;
+            const D& derived_cast() const noexcept;
+        };
+    }
+
     namespace detail
     {
-        template <class CT, class CB>
-        struct functor_return_type<xtl::xoptional<CT, CB>, bool>
-        {
-            using type = xtl::xoptional<bool>;
-            using simd_type = xtl::xoptional<bool>;
-        };
+        /*****************************
+         * split_optional_expression *
+         *****************************/
 
         template <class T, class Tag>
         struct split_optional_expression_impl
@@ -72,68 +110,18 @@ namespace xt
             }
         };
 
-        template <class T, bool is_const, bool is_ref>
-        struct split_optional_scalar
-        {
-            using raw_value_closure = typename T::value_closure;
-            using raw_flag_closure = typename T::flag_closure;
-            using cst_value_closure = std::conditional_t<is_const,
-                                                         std::add_const_t<raw_value_closure>,
-                                                         raw_value_closure>;
-            using cst_flag_closure = std::conditional_t<is_const,
-                                                        std::add_const_t<raw_flag_closure>,
-                                                        raw_flag_closure>;
-            using value_closure = std::conditional_t<is_ref,
-                                                     std::add_lvalue_reference_t<cst_value_closure>,
-                                                     cst_value_closure>;
-            using flag_closure = std::conditional_t<is_ref,
-                                                    std::add_lvalue_reference_t<cst_flag_closure>,
-                                                    cst_flag_closure>;
-            using value_expression = xscalar<value_closure>;
-            using flag_expression = xscalar<flag_closure>;
-
-            template <class U>
-            static inline value_expression value(U&& arg)
-            {
-                return arg().value();
-            }
-
-            template <class U>
-            static inline flag_expression has_value(U&& arg)
-            {
-                return arg().has_value();
-            }
-        };
-
-        template <class T, class B, class Tag>
-        struct split_optional_expression_impl<xscalar<xtl::xoptional<T, B>>, Tag>
-            : split_optional_scalar<xtl::xoptional<T, B>, false, false>
-        {
-        };
-
-        template <class T, class B, class Tag>
-        struct split_optional_expression_impl<xscalar<xtl::xoptional<T, B>&>, Tag>
-            : split_optional_scalar<xtl::xoptional<T, B>, false, true>
-        {
-        };
-
-        template <class T, class B, class Tag>
-        struct split_optional_expression_impl<xscalar<const xtl::xoptional<T, B>&>, Tag>
-            : split_optional_scalar<xtl::xoptional<T, B>, true, true>
-        {
-        };
-
-        template <class T, class B, class Tag>
-        struct split_optional_expression_impl<xscalar<const xtl::xoptional<T, B>>, Tag>
-            : split_optional_scalar<xtl::xoptional<T, B>, true, false>
-        {
-        };
-
         template <class T>
-        struct split_optional_expression_impl<T, xoptional_expression_tag>
+        struct split_optional_expression_impl_base
         {
-            using value_expression = decltype(std::declval<T>().value());
-            using flag_expression = decltype(std::declval<T>().has_value());
+            static constexpr bool is_const = std::is_const<std::remove_reference_t<T>>::value;
+            using decay_type = std::decay_t<T>;
+
+            using value_expression = std::conditional_t<is_const,
+                                                        typename decay_type::const_value_expression,
+                                                        typename decay_type::value_expression>;
+            using flag_expression = std::conditional_t<is_const,
+                                                       typename decay_type::const_flag_expression,
+                                                       typename decay_type::flag_expression>;
 
             template <class U>
             static inline value_expression value(U&& arg)
@@ -149,135 +137,20 @@ namespace xt
         };
 
         template <class T>
+        struct split_optional_expression_impl<T, xoptional_expression_tag>
+            : split_optional_expression_impl_base<T>
+        {
+        };
+
+        template <class T>
+        struct split_optional_expression_impl<xscalar<T>, xoptional_expression_tag>
+            : split_optional_expression_impl_base<xscalar<T>>
+        {
+        };
+
+        template <class T>
         struct split_optional_expression
             : split_optional_expression_impl<T, xexpression_tag_t<std::decay_t<T>>>
-        {
-        };
-
-        template <class E>
-        struct optional_containers
-        {
-            using optional_expression = std::remove_const_t<E>;
-            using optional_container = typename optional_expression::storage_type;
-            using tmp_value_container = typename optional_container::base_container_type;
-            using tmp_flag_container = typename optional_container::flag_container_type;
-            using value_container = std::conditional_t<std::is_const<E>::value, const tmp_value_container, tmp_value_container>;
-            using flag_container = std::conditional_t<std::is_const<E>::value, const tmp_flag_container, tmp_flag_container>;
-        };
-
-        template <class OA, layout_type L>
-        struct split_optional_array
-        {
-            using optional_array = OA;
-            using value_container = typename optional_containers<optional_array>::value_container;
-            using flag_container = typename optional_containers<optional_array>::flag_container;
-            using value_expression = xarray_container<value_container, L>;
-            using flag_expression = xarray_container<flag_container, L>;
-
-            static inline value_expression value(OA arg)
-            {
-                return value_expression(std::move(arg.storage().value()), arg.shape());
-            }
-
-            static inline flag_expression has_value(OA arg)
-            {
-                return flag_expression(std::move(arg.storage().has_value()), arg.shape());
-            }
-        };
-
-        template <class OA, layout_type L>
-        struct split_optional_array_ref
-        {
-            using optional_array = OA;
-            using value_container = typename optional_containers<optional_array>::value_container;
-            using flag_container = typename optional_containers<optional_array>::flag_container;
-            using value_expression = xarray_adaptor<typename optional_containers<optional_array>::value_container, L>;
-            using flag_expression = xarray_adaptor<typename optional_containers<optional_array>::flag_container, L>;
-
-            static inline value_expression value(OA& arg)
-            {
-                return value_expression(arg.storage().value(), arg.shape());
-            }
-
-            static inline flag_expression has_value(OA& arg)
-            {
-                return flag_expression(arg.storage().has_value(), arg.shape());
-            }
-        };
-
-        template <class T, layout_type L, class A, class BC, class SA>
-        struct split_optional_expression<xarray_optional<T, L, A, BC, SA>>
-            : split_optional_array<xarray_optional<T, L, A, BC, SA>, L>
-        {
-        };
-
-        template <class T, layout_type L, class A, class BC, class SA>
-        struct split_optional_expression<xarray_optional<T, L, A, BC, SA>&>
-            : split_optional_array_ref<xarray_optional<T, L, A, BC, SA>, L>
-        {
-        };
-
-        template <class T, layout_type L, class A, class BC, class SA>
-        struct split_optional_expression<const xarray_optional<T, L, A, BC, SA>&>
-            : split_optional_array_ref<const xarray_optional<T, L, A, BC, SA>, L>
-        {
-        };
-
-        template <class OT, std::size_t N, layout_type L>
-        struct split_optional_tensor
-        {
-            using optional_tensor = OT;
-            using value_container = typename optional_containers<optional_tensor>::value_container;
-            using flag_container = typename optional_containers<optional_tensor>::flag_container;
-            using value_expression = xtensor_container<value_container, N, L>;
-            using flag_expression = xtensor_container<flag_container, N, L>;
-
-            static inline value_expression value(OT arg)
-            {
-                return value_expression(std::move(arg.storage().value()), arg.shape());
-            }
-
-            static inline flag_expression has_value(OT arg)
-            {
-                return flag_expression(std::move(arg.storage().has_value()), arg.shape());
-            }
-        };
-
-        template <class OT, std::size_t N, layout_type L>
-        struct split_optional_tensor_ref
-        {
-            using optional_tensor = OT;
-            using value_container = typename optional_containers<optional_tensor>::value_container;
-            using flag_container = typename optional_containers<optional_tensor>::flag_container;
-            using value_expression = xtensor_adaptor<value_container&, N, L>;
-            using flag_expression = xtensor_adaptor<flag_container&, N, L>;
-
-            static inline value_expression value(OT& arg)
-            {
-                return value_expression(arg.storage().value(), arg.shape());
-            }
-
-            static inline flag_expression has_value(OT& arg)
-            {
-                return flag_expression(arg.storage().has_value(), arg.shape());
-            }
-        };
-
-        template <class T, std::size_t N, layout_type L, class A, class BC>
-        struct split_optional_expression<xtensor_optional<T, N, L, A, BC>>
-            : split_optional_tensor<xtensor_optional<T, N, L, A, BC>, N, L>
-        {
-        };
-
-        template <class T, std::size_t N, layout_type L, class A, class BC>
-        struct split_optional_expression<xtensor_optional<T, N, L, A, BC>&>
-            : split_optional_tensor_ref<xtensor_optional<T, N, L, A, BC>, N, L>
-        {
-        };
-
-        template <class T, std::size_t N, layout_type L, class A, class BC>
-        struct split_optional_expression<const xtensor_optional<T, N, L, A, BC>&>
-            : split_optional_tensor_ref<const xtensor_optional<T, N, L, A, BC>, N, L>
         {
         };
 
@@ -287,24 +160,58 @@ namespace xt
         template <class T>
         using flag_expression_t = typename split_optional_expression<T>::flag_expression;
 
+        /********************
+         * optional_bitwise *
+         ********************/
+
         template <class T = bool>
-        struct optional_bitwise
+        class optional_bitwise
         {
+        public:
+
             using return_type = T;
             using first_argument_type = T;
             using second_argument_type = T;
             using result_type = T;
             using simd_value_type = bool;
             using simd_result_type = bool;
-            template <class T1, class T2>
-            constexpr result_type operator()(const T1& arg1, const T2& arg2) const
+            
+            template <class... Args>
+            constexpr result_type operator()(const Args&... args) const
             {
-                return (arg1 & arg2);
+                return apply_impl(args...);
             }
-            constexpr simd_result_type simd_apply(const simd_value_type& arg1,
-                                                  const simd_value_type& arg2) const
+
+            template <class B, class... Args>
+            constexpr B simd_apply(const B& b, const Args&... args) const
             {
-                return (arg1 & arg2);
+                return simd_apply_impl(b, args...);
+            }
+
+        private:
+
+            constexpr result_type apply_impl() const
+            {
+                return true;
+            }
+
+            template <class U, class... Args>
+            constexpr result_type apply_impl(const U& t, const Args&... args) const
+            {
+                return t & apply_impl(args...);
+            }
+
+
+            template <class B>
+            constexpr B simd_apply_impl(const B& b) const
+            {
+                return b;
+            }
+
+            template <class B1, class B2, class... Args>
+            constexpr B1 simd_apply_impl(const B1& b1, const B2& b2, const Args&... args) const
+            {
+                return b1 & simd_apply_impl(b2, args...);
             }
         };
     }
@@ -316,11 +223,11 @@ namespace xt
     template <class T, class B>
     auto sign(const xtl::xoptional<T, B>& e);
 
-    template <class E, XTENSOR_REQUIRE<is_xexpression<E>::value>>
+    /*template <class E, XTL_REQUIRES(is_xexpression<E>)>
     detail::value_expression_t<E> value(E&&);
 
-    template <class E, XTENSOR_REQUIRE<is_xexpression<E>::value>>
-    detail::flag_expression_t<E> has_value(E&&);
+    template <class E, XTL_REQUIRES(is_xexpression<E>)>
+    detail::flag_expression_t<E> has_value(E&&);*/
 
     template <>
     class xexpression_assigner_base<xoptional_expression_tag>
@@ -331,112 +238,918 @@ namespace xt
         static void assign_data(xexpression<E1>& e1, const xexpression<E2>& e2, bool trivial);
     };
 
-    /**********************
-     * xoptional_function *
-     **********************/
+    /**********************************
+     * xscalar extension for optional *
+     **********************************/
 
-#define DL XTENSOR_DEFAULT_LAYOUT
-
-    /**
-     * @class xoptional_function
-     * @brief Multidimensional function operating on
-     * xoptional expressions.
-     *
-     * The xoptional_function class implements a multidimensional function
-     * operating on xoptional expressions.
-     *
-     * @tparam F the function type
-     * @tparam R the return type of the function
-     * @tparam CT the closure types for arguments of the function
-     */
-    template <class F, class R, class... CT>
-    class xoptional_function : public xfunction_base<F, R, CT...>,
-                               public xexpression<xoptional_function<F, R, CT...>>
+    namespace extension
     {
-    public:
+       template <class CT>
+        struct xscalar_optional_traits
+        {
+            using closure_type = CT;
+            static constexpr bool is_ref = std::is_reference<closure_type>::value;
+            using unref_closure_type = std::remove_reference_t<closure_type>;
+            static constexpr bool is_const = std::is_const<unref_closure_type>::value;
+            using raw_closure_type = std::decay_t<CT>;
 
-        using self_type = xoptional_function<F, R, CT...>;
-        using base_type = xfunction_base<F, R, CT...>;
-        using expression_tag = xoptional_expression_tag;
-        using value_functor = typename F::template rebind<typename R::value_type>::type;
-        using flag_functor = detail::optional_bitwise<bool>;
+            using raw_value_closure = typename raw_closure_type::value_closure;
+            using raw_flag_closure = typename raw_closure_type::flag_closure;
+            using const_raw_value_closure = std::add_const_t<raw_value_closure>;
+            using const_raw_flag_closure = std::add_const_t<raw_flag_closure>;
 
-        template <class Func, class U = std::enable_if<!std::is_base_of<std::decay_t<Func>, self_type>::value>>
-        xoptional_function(Func&& func, CT... e) noexcept;
+            using value_closure = std::conditional_t<is_ref,
+                                                     std::add_lvalue_reference_t<raw_value_closure>,
+                                                     raw_value_closure>;
+            using flag_closure = std::conditional_t<is_ref,
+                                                    std::add_lvalue_reference_t<raw_flag_closure>,
+                                                    raw_flag_closure>;
+            using const_value_closure = std::conditional_t<is_ref,
+                                                           std::add_lvalue_reference_t<const_raw_value_closure>,
+                                                           raw_value_closure>;
+            using const_flag_closure = std::conditional_t<is_ref,
+                                                          std::add_lvalue_reference_t<const_raw_flag_closure>,
+                                                          raw_flag_closure>;
 
-        ~xoptional_function() = default;
+            using value_expression = xscalar<std::conditional_t<is_const, const_value_closure, value_closure>>;
+            using flag_expression = xscalar<std::conditional_t<is_const, const_flag_closure, flag_closure>>;
+            using const_value_expression = xscalar<const_value_closure>;
+            using const_flag_expression = xscalar<const_flag_closure>;
+        };
 
-        xoptional_function(const xoptional_function&) = default;
-        xoptional_function& operator=(const xoptional_function&) = default;
+        template <class CT>
+        class xscalar_optional_base : public xoptional_empty_base<xscalar<CT>>
+        {
+        public:
 
-        xoptional_function(xoptional_function&&) = default;
-        xoptional_function& operator=(xoptional_function&&) = default;
+            using traits = xscalar_optional_traits<CT>;
+            using value_expression = typename traits::value_expression;
+            using flag_expression = typename traits::flag_expression;
+            using const_value_expression = typename traits::const_value_expression;
+            using const_flag_expression = typename traits::const_flag_expression;
+            using expression_tag = xoptional_expression_tag;
 
-        using value_expression = xfunction<value_functor,
-                                           typename R::value_type,
-                                           detail::value_expression_t<CT>...>;
+            value_expression value();
+            const_value_expression value() const;
 
-        using flag_expression = xfunction<flag_functor,
-                                          bool,
-                                          detail::flag_expression_t<CT>...>;
+            flag_expression has_value();
+            const_flag_expression has_value() const;
+        };
 
-        value_expression value() const;
-        flag_expression has_value() const;
-
-    private:
-
-        template <std::size_t... I>
-        value_expression value_impl(std::index_sequence<I...>) const;
-
-        template <std::size_t... I>
-        flag_expression has_value_impl(std::index_sequence<I...>) const;
-    };
-
-#undef DL
+        template <class CT>
+        struct xscalar_base_impl<xoptional_expression_tag, CT>
+        {
+            using type = xscalar_optional_base<CT>;
+        };
+    }
 
     /*************************************
-     * xoptional_function implementation *
+     * xcontainer extension for optional *
      *************************************/
 
-    /**
-     * Constructs an xoptional_function applying the specified function to the given
-     * arguments.
-     * @param func the function to apply
-     * @param e the \ref xexpression arguments
-     */
-    template <class F, class R, class... CT>
-    template <class Func, class U>
-    inline xoptional_function<F, R, CT...>::xoptional_function(Func&& func, CT... e) noexcept
-        : base_type(std::forward<Func>(func), e...)
+    namespace extension
     {
+        template <class T>
+        class xcontainer_optional_base : public xoptional_empty_base<typename T::derived_type>
+        {
+        public:
+
+            using traits = T;
+            using value_expression = typename traits::value_expression;
+            using flag_expression = typename traits::flag_expression;
+            using const_value_expression = typename traits::const_value_expression;
+            using const_flag_expression = typename traits::const_flag_expression;
+            using expression_tag = xoptional_expression_tag;
+
+            value_expression value();
+            const_value_expression value() const;
+
+            flag_expression has_value();
+            const_flag_expression has_value() const;
+        };
     }
 
-    template <class F, class R, class... CT>
-    inline auto xoptional_function<F, R, CT...>::value() const -> value_expression
+    /*******************************************
+     * xarray_container extension for optional *
+     *******************************************/
+
+    namespace extension
     {
-        return value_impl(std::make_index_sequence<sizeof...(CT)>());
+        template <class EC, layout_type L, class SC>
+        struct xarray_optional_traits
+        {
+            using value_container = typename std::remove_reference_t<EC>::base_container_type;
+            using flag_container = typename std::remove_reference_t<EC>::flag_container_type;
+            using value_expression = xarray_adaptor<value_container&, L, SC>;
+            using flag_expression = xarray_adaptor<flag_container&, L, SC>;
+            using const_value_expression = xarray_adaptor<const value_container&, L, SC>;
+            using const_flag_expression = xarray_adaptor<const flag_container&, L, SC>;
+        };
+
+        template <class EC, layout_type L, class SC>
+        struct xarray_container_optional_traits : xarray_optional_traits<EC, L, SC>
+        {
+            using derived_type = xarray_container<EC, L, SC, xoptional_expression_tag>;
+        };
+
+        template <class EC, layout_type L, class SC>
+        struct xarray_container_base<EC, L, SC, xoptional_expression_tag>
+        {
+            using traits = xarray_container_optional_traits<EC, L, SC>;
+            using type = xcontainer_optional_base<traits>;
+        };
     }
 
-    template <class F, class R, class... CT>
-    inline auto xoptional_function<F, R, CT...>::has_value() const -> flag_expression
+    /*****************************************
+     * xarray_adaptor extension for optional *
+     *****************************************/
+
+    namespace extension
     {
-        return has_value_impl(std::make_index_sequence<sizeof...(CT)>());
+        template <class EC, layout_type L, class SC>
+        struct xarray_adaptor_optional_traits : xarray_optional_traits<EC, L, SC>
+        {
+            using derived_type = xarray_adaptor<EC, L, SC, xoptional_expression_tag>;
+        };
+
+        template <class EC, layout_type L, class SC>
+        struct xarray_adaptor_base<EC, L, SC, xoptional_expression_tag>
+        {
+            using traits = xarray_adaptor_optional_traits<EC, L, SC>;
+            using type = xcontainer_optional_base<traits>;
+        };
     }
 
-    template <class F, class R, class... CT>
-    template <std::size_t... I>
-    inline auto xoptional_function<F, R, CT...>::value_impl(std::index_sequence<I...>) const -> value_expression
+    /********************************************
+     * xtensor_container extension for optional *
+     ********************************************/
+
+    namespace extension
     {
-        return value_expression(value_functor(),
-            detail::split_optional_expression<CT>::value(std::get<I>(this->arguments()))...);
+        template <class EC, std::size_t N, layout_type L>
+        struct xtensor_optional_traits
+        {
+            using value_container = typename std::remove_reference_t<EC>::base_container_type;
+            using flag_container = typename std::remove_reference_t<EC>::flag_container_type;
+            using value_expression = xtensor_adaptor<value_container&, N, L>;
+            using flag_expression = xtensor_adaptor<flag_container&, N, L>;
+            using const_value_expression = xtensor_adaptor<const value_container&, N, L>;
+            using const_flag_expression = xtensor_adaptor<const flag_container&, N, L>;
+        };
+
+        template <class EC, std::size_t N, layout_type L>
+        struct xtensor_container_optional_traits : xtensor_optional_traits<EC, N, L>
+        {
+            using derived_type = xtensor_container<EC, N, L, xoptional_expression_tag>;
+        };
+
+        template <class EC, std::size_t N, layout_type L>
+        struct xtensor_container_base<EC, N, L, xoptional_expression_tag>
+        {
+            using traits = xtensor_container_optional_traits<EC, N, L>;
+            using type = xcontainer_optional_base<traits>;
+        };
     }
 
-    template <class F, class R, class... CT>
-    template <std::size_t... I>
-    inline auto xoptional_function<F, R, CT...>::has_value_impl(std::index_sequence<I...>) const -> flag_expression
+    /******************************************
+     * xtensor_adaptor extension for optional *
+     ******************************************/
+
+    namespace extension
     {
-        return flag_expression(flag_functor(),
-            detail::split_optional_expression<CT>::has_value(std::get<I>(this->arguments()))...);
+        template <class EC, std::size_t N, layout_type L>
+        struct xtensor_adaptor_optional_traits : xtensor_optional_traits<EC, N, L>
+        {
+            using derived_type = xtensor_adaptor<EC, N, L, xoptional_expression_tag>;
+        };
+
+        template <class EC, std::size_t N, layout_type L>
+        struct xtensor_adaptor_base<EC, N, L, xoptional_expression_tag>
+        {
+            using traits = xtensor_adaptor_optional_traits<EC, N, L>;
+            using type = xcontainer_optional_base<traits>;
+        };
+    }
+
+    /***************************************
+     * xtensor_view extension for optional *
+     ***************************************/
+
+    namespace extension
+    {
+        template <class EC, std::size_t N, layout_type L>
+        struct xtensor_view_optional_traits : xtensor_optional_traits<EC, N, L>
+        {
+            using derived_type = xtensor_view<EC, N, L, xoptional_expression_tag>;
+        };
+
+        template <class EC, std::size_t N, layout_type L>
+        struct xtensor_view_base<EC, N, L, xoptional_expression_tag>
+        {
+            using traits = xtensor_view_optional_traits<EC, N, L>;
+            using type = xcontainer_optional_base<traits>;
+        };
+    }
+
+    /************************************************
+     * xfunction extension for optional expressions *
+     ************************************************/
+
+    namespace extension
+    {
+        template <class F, class... CT>
+        class xfunction_optional_base : public xoptional_empty_base<xfunction<F, CT...>>
+        {
+        public:
+
+            using expression_tag = xoptional_expression_tag;
+            using value_functor = F;
+            using flag_functor = xt::detail::optional_bitwise<bool>;
+        
+            using value_expression = xfunction<value_functor, xt::detail::value_expression_t<CT>...>;
+            using flag_expression = xfunction<flag_functor, xt::detail::flag_expression_t<CT>...>;
+            using const_value_expression = value_expression;
+            using const_flag_expression = flag_expression;
+
+            const_value_expression value() const;
+            const_flag_expression has_value() const;
+            
+        private:
+
+            template <std::size_t... I>
+            const_value_expression value_impl(std::index_sequence<I...>) const;
+
+            template <std::size_t... I>
+            const_flag_expression has_value_impl(std::index_sequence<I...>) const;
+        };
+
+        template <class F, class... CT>
+        struct xfunction_base_impl<xoptional_expression_tag, F, CT...>
+        {
+            using type = xfunction_optional_base<F, CT...>;
+        };
+    }
+
+    /****************************************************
+     * xdynamic_view extension for optional expressions *
+     ****************************************************/
+
+    namespace extension
+    {
+        template <class CT, class S, layout_type L, class FST>
+        class xdynamic_view_optional : public xoptional_empty_base<xdynamic_view<CT, S, L, FST>>
+        {
+        public:
+
+            using expression_tag = xoptional_expression_tag;
+            using uvt = typename std::decay_t<CT>::value_expression;
+            using uft = typename std::decay_t<CT>::flag_expression;
+            using ucvt = typename std::decay_t<CT>::const_value_expression;
+            using ucft = typename std::decay_t<CT>::const_flag_expression;
+            using value_expression = xdynamic_view<uvt, S, L, typename FST::template rebind_t<uvt>>;
+            using flag_expression = xdynamic_view<uft, S, L, typename FST::template rebind_t<uft>>;
+            using const_value_expression = xdynamic_view<ucvt, S, L, typename FST::template rebind_t<ucvt>>;
+            using const_flag_expression = xdynamic_view<ucft, S, L, typename FST::template rebind_t<ucft>>;
+
+            value_expression value();
+            const_value_expression value() const;
+
+            flag_expression has_value();
+            const_flag_expression has_value() const;
+        };
+
+        template <class CT, class S, layout_type L, class FST>
+        struct xdynamic_view_base_impl<xoptional_expression_tag, CT, S, L, FST>
+        {
+            using type = xdynamic_view_optional<CT, S, L, FST>;
+        };
+    }
+
+    /*************************************************
+     * xbroadcast extension for optional expressions *
+     *************************************************/
+
+    namespace extension
+    {
+        template <class CT, class X>
+        class xbroadcast_optional : public xoptional_empty_base<xbroadcast<CT, X>>
+        {
+        public:
+
+            using expression_tag = xoptional_expression_tag;
+            using value_expression = xbroadcast<xt::detail::value_expression_t<CT>, X>;
+            using flag_expression = xbroadcast<xt::detail::flag_expression_t<CT>, X>;
+            using const_value_expression = value_expression;
+            using const_flag_expression = flag_expression;
+
+            const_value_expression value() const;
+            const_flag_expression has_value() const;
+        };
+
+        template <class CT, class X>
+        struct xbroadcast_base_impl<xoptional_expression_tag, CT, X>
+        {
+            using type = xbroadcast_optional<CT, X>;
+        };
+    }
+
+    /***************************************************
+     * xfunctor_view extension for optional expression *
+     ***************************************************/
+
+    namespace extension
+    {
+        template <class F, class CT>
+        class xfunctor_view_optional : public xoptional_empty_base<xfunctor_view<F, CT>>
+        {
+        public:
+
+            using expression_tag = xoptional_expression_tag;
+            using uvt = typename std::decay_t<CT>::value_expression;
+            using uft = typename std::decay_t<CT>::flag_expression;
+            using ucvt = typename std::decay_t<CT>::const_value_expression;
+            using ucft = typename std::decay_t<CT>::const_flag_expression;
+            using value_expression = xfunctor_view<F, uvt>;
+            using flag_expression = uft;
+            using const_value_expression = xfunctor_view<F, ucvt>;
+            using const_flag_expression = ucft;
+
+            value_expression value();
+            const_value_expression value() const;
+
+            flag_expression has_value();
+            const_flag_expression has_value() const;
+        };
+
+        template <class F, class CT>
+        struct xfunctor_view_base_impl<xoptional_expression_tag, F, CT>
+        {
+            using type = xfunctor_view_optional<F, CT>;
+        };
+    }
+
+    /**************************************************
+     * xindex_view extension for optional expressions *
+     **************************************************/
+
+    namespace extension
+    {
+        template <class CT, class I>
+        class xindex_view_optional : public xoptional_empty_base<xindex_view<CT, I>>
+        {
+        public:
+
+            using expression_tag = xoptional_expression_tag;
+            using uvt = typename std::decay_t<CT>::value_expression;
+            using ucvt = typename std::decay_t<CT>::const_value_expression;
+            using uft = typename std::decay_t<CT>::flag_expression;
+            using ucft = typename std::decay_t<CT>::const_flag_expression;
+            using value_expression = xindex_view<uvt, I>;
+            using flag_expression = xindex_view<uft, I>;
+            using const_value_expression = xindex_view<ucvt, I>;
+            using const_flag_expression = xindex_view<ucft, I>;
+
+            value_expression value();
+            const_value_expression value() const;
+
+            flag_expression has_value();
+            const_flag_expression has_value() const;
+        };
+
+        template <class CT, class I>
+        struct xindex_view_base_impl<xoptional_expression_tag, CT, I>
+        {
+            using type = xindex_view_optional<CT, I>;
+        };
+    }
+
+    /***********************************************
+     * xreducer extension for optional expressions *
+     ***********************************************/
+
+    namespace extension
+    {
+        template <class F, class CT, class X, class O>
+        class xreducer_optional : public xoptional_empty_base<xreducer<F, CT, X, O>>
+        {
+        public:
+
+            using expression_tag = xoptional_expression_tag;
+            using value_expression = xreducer<F, xt::detail::value_expression_t<CT>, X, O>;
+            using flag_reducer = xreducer_functors<xt::detail::optional_bitwise<bool>, xt::const_value<bool>>;
+            using rebound_flag_reduce_options = typename O::template rebind_t<bool>;
+            using flag_expression = xreducer<flag_reducer, xt::detail::flag_expression_t<CT>, X, rebound_flag_reduce_options>;
+            using const_value_expression = value_expression;
+            using const_flag_expression = flag_expression;
+
+            const_value_expression value() const;
+            const_flag_expression has_value() const;
+        };
+
+        template <class F, class CT, class X, class O>
+        struct xreducer_base_impl<xoptional_expression_tag, F, CT, X, O>
+        {
+            using type = xreducer_optional<F, CT, X, O>;
+        };
+    }
+
+    /****************************************************
+     * xstrided_view extension for optional expressions *
+     ****************************************************/
+
+    namespace extension
+    {
+        template <class CT, class S, layout_type L, class FST>
+        class xstrided_view_optional : public xoptional_empty_base<xstrided_view<CT, S, L, FST>>
+        {
+        public:
+
+            using expression_tag = xoptional_expression_tag;
+            using uvt = typename std::decay_t<CT>::value_expression;
+            using uft = typename std::decay_t<CT>::flag_expression;
+            using ucvt = typename std::decay_t<CT>::const_value_expression;
+            using ucft = typename std::decay_t<CT>::const_flag_expression;
+            using value_expression = xstrided_view<uvt, S, L, typename FST::template rebind_t<uvt>>;
+            using flag_expression = xstrided_view<uft, S, L, typename FST::template rebind_t<uft>>;
+            using const_value_expression = xstrided_view<ucvt, S, L, typename FST::template rebind_t<ucvt>>;
+            using const_flag_expression = xstrided_view<ucft, S, L, typename FST::template rebind_t<ucft>>;
+
+            value_expression value();
+            const_value_expression value() const;
+
+            flag_expression has_value();
+            const_flag_expression has_value() const;
+        };
+
+        template <class CT, class S, layout_type L, class FST>
+        struct xstrided_view_base_impl<xoptional_expression_tag, CT, S, L, FST>
+        {
+            using type = xstrided_view_optional<CT, S, L, FST>;
+        };
+    }
+
+    /********************************************
+     * xview extension for optional expressions *
+     ********************************************/
+
+    namespace extension
+    {
+        template <class CT, class... S>
+        class xview_optional : public xoptional_empty_base<xview<CT, S...>>
+        {
+        public:
+
+            using expression_tag = xoptional_expression_tag;
+            using uvt = typename std::decay_t<CT>::value_expression;
+            using uft = typename std::decay_t<CT>::flag_expression;
+            using ucvt = typename std::decay_t<CT>::const_value_expression;
+            using ucft = typename std::decay_t<CT>::const_flag_expression;
+            using value_expression = xview<uvt, S...>;
+            using flag_expression = xview<uft, S...>;
+            using const_value_expression = xview<ucvt, S...>;
+            using const_flag_expression = xview<ucft, S...>;
+
+            value_expression value();
+            const_value_expression value() const;
+
+            flag_expression has_value();
+            const_flag_expression has_value() const;
+        };
+
+        template <class CT, class... S>
+        struct xview_base_impl<xoptional_expression_tag, CT, S...>
+        {
+            using type = xview_optional<CT, S...>;
+        };
+    }
+
+    /*************************************************
+     * xgenerator extension for generator expression *
+     *************************************************/
+
+    namespace extension
+    {
+        namespace detail
+        {
+            template <class F, class = void_t<int>>
+            struct value_functor
+            {
+                using type = F;
+
+                static type get(const F& f)
+                {
+                    return f;
+                }
+            };
+
+            template <class F>
+            struct value_functor<F, void_t<typename F::value_functor_type>>
+            {
+                using type = typename F::value_functor_type;
+
+                static type get(const F& f)
+                {
+                    return f.value_functor();
+                }
+            };
+
+            template <class F>
+            using value_functor_t = typename value_functor<F>::type;
+
+            struct always_true
+            {
+                template <class... T>
+                bool operator()(T...) const
+                {
+                    return true;
+                }
+            };
+
+            template <class F, class = void_t<int>>
+            struct flag_functor
+            {
+                using type = always_true;
+
+                static type get(const F&)
+                {
+                    return type();
+                }
+            };
+
+            template <class F>
+            struct flag_functor<F, void_t<typename F::flag_functor_type>>
+            {
+                using type = typename F::flag_functor_type;
+
+                static type get(const F& f)
+                {
+                    return f.flag_functor();
+                }
+            };
+
+            template <class F>
+            using flag_functor_t = typename flag_functor<F>::type;
+        }
+
+        template <class F, class R, class S>
+        class xgenerator_optional : public xoptional_empty_base<xgenerator<F, R, S>>
+        {
+        public:
+
+            using expression_tag = xoptional_expression_tag;
+            using value_closure = typename R::value_closure;
+            using flag_closure = typename R::flag_closure;
+            using value_functor = detail::value_functor_t<F>;
+            using flag_functor = detail::flag_functor_t<F>;
+            using value_expression = xgenerator<value_functor, value_closure, S>;
+            using flag_expression = xgenerator<flag_functor, flag_closure, S>;
+            using const_value_expression = value_expression;
+            using const_flag_expression = flag_expression;
+
+            const_value_expression value() const;
+            const_flag_expression has_value() const;
+        };
+
+        template <class F, class R, class S>
+        struct xgenerator_base_impl<xoptional_expression_tag, F, R, S>
+        {
+            using type = xgenerator_optional<F, R, S>;
+        };
+    }
+
+    /***************************************
+     * xoptional_empty_base implementation *
+     ***************************************/
+
+    namespace extension
+    {
+        template <class D>
+        inline D& xoptional_empty_base<D>::derived_cast() noexcept
+        {
+            return *static_cast<D*>(this);
+        }
+
+        template <class D>
+        inline const D& xoptional_empty_base<D>::derived_cast() const noexcept
+        {
+            return *static_cast<const D*>(this);
+        }
+    }
+
+    /****************************************
+     * xscalar_optional_base implementation *
+     ****************************************/
+
+    namespace extension
+    {
+        template <class CT>
+        inline auto xscalar_optional_base<CT>::value() -> value_expression
+        {
+            return this->derived_cast().expression().value();
+        }
+
+        template <class CT>
+        inline auto xscalar_optional_base<CT>::value() const -> const_value_expression
+        {
+            return this->derived_cast().expression().value();
+        }
+
+        template <class CT>
+        inline auto xscalar_optional_base<CT>::has_value() -> flag_expression
+        {
+            return this->derived_cast().expression().has_value();
+        }
+
+        template <class CT>
+        inline auto xscalar_optional_base<CT>::has_value() const -> const_flag_expression
+        {
+            return this->derived_cast().expression().has_value();
+        }
+    }
+
+    /*******************************************
+     * xcontainer_optional_base implementation *
+     *******************************************/
+
+    namespace extension
+    {
+        template <class T>
+        inline auto xcontainer_optional_base<T>::value() -> value_expression
+        {
+            return value_expression(this->derived_cast().storage().value(), this->derived_cast().shape());
+        }
+
+        template <class T>
+        inline auto xcontainer_optional_base<T>::value() const -> const_value_expression
+        {
+            return const_value_expression(this->derived_cast().storage().value(), this->derived_cast().shape());
+        }
+
+        template <class T>
+        inline auto xcontainer_optional_base<T>::has_value() -> flag_expression
+        {
+            return flag_expression(this->derived_cast().storage().has_value(), this->derived_cast().shape());
+        }
+
+        template <class T>
+        inline auto xcontainer_optional_base<T>::has_value() const -> const_flag_expression
+        {
+            return const_flag_expression(this->derived_cast().storage().has_value(), this->derived_cast().shape());
+        }
+    }
+
+    /******************************************
+     * xfunction_optional_base implementation *
+     ******************************************/
+
+    namespace extension
+    {
+        template <class F, class... CT>
+        inline auto xfunction_optional_base<F, CT...>::value() const -> const_value_expression
+        {
+            return value_impl(std::make_index_sequence<sizeof...(CT)>());
+        }
+
+        template <class F, class... CT>
+        inline auto xfunction_optional_base<F, CT...>::has_value() const -> const_flag_expression
+        {
+            return has_value_impl(std::make_index_sequence<sizeof...(CT)>());
+        }
+
+        template <class F, class... CT>
+        template <std::size_t... I>
+        inline auto xfunction_optional_base<F, CT...>::value_impl(std::index_sequence<I...>) const -> const_value_expression
+        {
+            return value_expression(value_functor(),
+                xt::detail::split_optional_expression<CT>::value(std::get<I>(this->derived_cast().arguments()))...);
+        }
+
+        template <class F, class... CT>
+        template <std::size_t... I>
+        inline auto xfunction_optional_base<F, CT...>::has_value_impl(std::index_sequence<I...>) const -> const_flag_expression
+        {
+            return flag_expression(flag_functor(),
+                xt::detail::split_optional_expression<CT>::has_value(std::get<I>(this->derived_cast().arguments()))...);
+        }
+    }
+
+    /*****************************************
+     * xdynamic_view_optional implementation *
+     *****************************************/
+
+    namespace extension
+    {
+        template <class CT, class S, layout_type L, class FST>
+        inline auto xdynamic_view_optional<CT, S, L, FST>::value() -> value_expression
+        {
+            return this->derived_cast().build_view(this->derived_cast().expression().value());
+        }
+
+        template <class CT, class S, layout_type L, class FST>
+        inline auto xdynamic_view_optional<CT, S, L, FST>::value() const -> const_value_expression 
+        {
+            return this->derived_cast().build_view(this->derived_cast().expression().value());
+        }
+
+        template <class CT, class S, layout_type L, class FST>
+        inline auto xdynamic_view_optional<CT, S, L, FST>::has_value() -> flag_expression 
+        {
+            return this->derived_cast().build_view(this->derived_cast().expression().has_value());
+        }
+
+        template <class CT, class S, layout_type L, class FST>
+        inline auto xdynamic_view_optional<CT, S, L, FST>::has_value() const -> const_flag_expression 
+        {
+            return this->derived_cast().build_view(this->derived_cast().expression().has_value());
+        }
+    }
+
+    /**************************************
+     * xbroadcast_optional implementation *
+     **************************************/
+
+    namespace extension
+    {
+        template <class CT, class X>
+        inline auto xbroadcast_optional<CT, X>::value() const -> const_value_expression
+        {
+            return this->derived_cast().build_broadcast(this->derived_cast().expression().value());
+        }
+
+        template <class CT, class X>
+        inline auto xbroadcast_optional<CT, X>::has_value() const -> const_flag_expression
+        {
+            return this->derived_cast().build_broadcast(this->derived_cast().expression().has_value());
+        }
+    }
+
+    /*****************************************
+     * xfunctor_view_optional implementation *
+     *****************************************/
+
+    namespace extension
+    {
+        template <class F, class CT>
+        inline auto xfunctor_view_optional<F, CT>::value() -> value_expression
+        {
+            return this->derived_cast().build_functor_view(this->derived_cast().expression().value());
+        }
+
+        template <class F, class CT>
+        inline auto xfunctor_view_optional<F, CT>::value() const -> const_value_expression
+        {
+            return this->derived_cast().build_functor_view(this->derived_cast().expression().value());
+        }
+
+        template <class F, class CT>
+        inline auto xfunctor_view_optional<F, CT>::has_value() -> flag_expression
+        {
+            return this->derived_cast().expression().has_value();
+        }
+
+        template <class F, class CT>
+        inline auto xfunctor_view_optional<F, CT>::has_value() const -> const_flag_expression
+        {
+            return this->derived_cast().expression().has_value();
+        }
+    }
+
+    /***************************************
+     * xindex_view_optional implementation *
+     ***************************************/
+
+    namespace extension
+    {
+        template <class CT, class I>
+        inline auto xindex_view_optional<CT, I>::value() -> value_expression
+        {
+            return this->derived_cast().build_index_view(this->derived_cast().expression().value());
+        };
+
+        template <class CT, class I>
+        inline auto xindex_view_optional<CT, I>::value() const -> const_value_expression
+        {
+            return this->derived_cast().build_index_view(this->derived_cast().expression().value());
+        };
+
+        template <class CT, class I>
+        inline auto xindex_view_optional<CT, I>::has_value() -> flag_expression
+        {
+            return this->derived_cast().build_index_view(this->derived_cast().expression().has_value());
+        };
+
+        template <class CT, class I>
+        inline auto xindex_view_optional<CT, I>::has_value() const -> const_flag_expression
+        {
+            return this->derived_cast().build_index_view(this->derived_cast().expression().has_value());
+        };
+    }
+
+    /************************************
+     * xreducer_optional implementation *
+     ************************************/
+
+    namespace extension
+    {
+        template <class F, class CT, class X, class O>
+        inline auto xreducer_optional<F, CT, X, O>::value() const -> const_value_expression
+        {
+            return this->derived_cast().build_reducer(this->derived_cast().expression().value());
+        }
+
+        template <class F, class CT, class X, class O>
+        inline auto xreducer_optional<F, CT, X, O>::has_value() const -> const_flag_expression
+        {
+            auto opts = this->derived_cast().options().rebind(this->derived_cast().options().initial_value.has_value(),
+                                                              this->derived_cast().options());
+
+            return this->derived_cast().build_reducer(this->derived_cast().expression().has_value(),
+                                                        make_xreducer_functor(xt::detail::optional_bitwise<bool>(),
+                                                                              xt::const_value<bool>(true)), std::move(opts));
+        }
+    }
+
+    /*****************************************
+     * xstrided_view_optional implementation *
+     *****************************************/
+
+    namespace extension
+    {
+        template <class CT, class S, layout_type L, class FST>
+        inline auto xstrided_view_optional<CT, S, L, FST>::value() -> value_expression
+        {
+            return this->derived_cast().build_view(this->derived_cast().expression().value());
+        }
+
+        template <class CT, class S, layout_type L, class FST>
+        inline auto xstrided_view_optional<CT, S, L, FST>::value() const -> const_value_expression 
+        {
+            return this->derived_cast().build_view(this->derived_cast().expression().value());
+        }
+
+        template <class CT, class S, layout_type L, class FST>
+        inline auto xstrided_view_optional<CT, S, L, FST>::has_value() -> flag_expression 
+        {
+            return this->derived_cast().build_view(this->derived_cast().expression().has_value());
+        }
+
+        template <class CT, class S, layout_type L, class FST>
+        inline auto xstrided_view_optional<CT, S, L, FST>::has_value() const -> const_flag_expression 
+        {
+            return this->derived_cast().build_view(this->derived_cast().expression().has_value());
+        }
+    }
+
+    /*********************************
+     * xview_optional implementation *
+     *********************************/
+
+    namespace extension
+    {
+        template <class CT, class... S>
+        inline auto xview_optional<CT, S...>::value() -> value_expression
+        {
+            return this->derived_cast().build_view(this->derived_cast().expression().value());
+        }
+
+        template <class CT, class... S>
+        inline auto xview_optional<CT, S...>::value() const -> const_value_expression
+        {
+            return this->derived_cast().build_view(this->derived_cast().expression().value());
+        }
+
+        template <class CT, class... S>
+        inline auto xview_optional<CT, S...>::has_value() -> flag_expression
+        {
+            return this->derived_cast().build_view(this->derived_cast().expression().has_value());
+        }
+
+        template <class CT, class... S>
+        inline auto xview_optional<CT, S...>::has_value() const -> const_flag_expression
+        {
+            return this->derived_cast().build_view(this->derived_cast().expression().has_value());
+        }
+    }
+
+    /**************************************
+     * xgenerator_optional implementation *
+     **************************************/
+
+    namespace extension
+    {
+        template <class F, class R, class S>
+        inline auto xgenerator_optional<F, R, S>::value() const -> const_value_expression
+        {
+            return this->derived_cast().template build_generator<value_closure>(
+                    detail::value_functor<F>::get(this->derived_cast().functor()));
+        }
+
+        template <class F, class R, class S>
+        inline auto xgenerator_optional<F, R, S>::has_value() const -> const_flag_expression
+        {
+            return this->derived_cast().template build_generator<flag_closure>(
+                    detail::flag_functor<F>::get(this->derived_cast().functor()));
+        }
     }
 
     /********************************
@@ -446,42 +1159,33 @@ namespace xt
     namespace math
     {
         template <class T, class B>
-        struct sign_fun<xtl::xoptional<T, B>>
+        struct sign_impl<xtl::xoptional<T, B>>
         {
-            using argument_type = xtl::xoptional<T, B>;
-            using result_type = xtl::xoptional<std::decay_t<T>>;
-
-            constexpr result_type operator()(const xtl::xoptional<T, B>& x) const
+            static constexpr auto run(const xtl::xoptional<T, B>& x)
             {
-                return x.has_value() ? xtl::xoptional<T>(detail::sign_impl(x.value()))
-                                     : xtl::missing<std::decay_t<T>>();
+                return sign(x); // use overload declared above
             }
-
-            template <class U>
-            struct rebind
-            {
-                using type = sign_fun<U>;
-            };
         };
     }
 
     template <class T, class B>
     inline auto sign(const xtl::xoptional<T, B>& e)
     {
-        return e.has_value() ? math::detail::sign_impl(e.value()) : xtl::missing<std::decay_t<T>>();
+        using value_type = std::decay_t<T>;
+        return e.has_value() ? math::sign_impl<value_type>::run(e.value()) : xtl::missing<value_type>();
     }
 
     /******************************************
      * value() and has_value() implementation *
      ******************************************/
 
-    template <class E, class>
+    template <class E, XTL_REQUIRES(is_xexpression<E>)>
     inline auto value(E&& e) -> detail::value_expression_t<E>
     {
         return detail::split_optional_expression<E>::value(std::forward<E>(e));
     }
 
-    template <class E, class>
+    template <class E, XTL_REQUIRES(is_xexpression<E>)>
     inline auto has_value(E&& e) -> detail::flag_expression_t<E>
     {
         return detail::split_optional_expression<E>::has_value(std::forward<E>(e));

--- a/vendor/xtensor/include/xtensor/xoptional_assembly.hpp
+++ b/vendor/xtensor/include/xtensor/xoptional_assembly.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -9,7 +10,6 @@
 #ifndef XOPTIONAL_ASSEMBLY_HPP
 #define XOPTIONAL_ASSEMBLY_HPP
 
-#include "xconcepts.hpp"
 #include "xoptional.hpp"
 #include "xoptional_assembly_base.hpp"
 #include "xsemantic.hpp"
@@ -27,10 +27,10 @@ namespace xt
     template <class VE, class FE>
     struct xcontainer_inner_types<xoptional_assembly<VE, FE>>
     {
-        using value_expression = VE;
-        using value_storage_type = typename value_expression::storage_type&;
-        using flag_expression = FE;
-        using flag_storage_type = typename flag_expression::storage_type&;
+        using raw_value_expression = VE;
+        using value_storage_type = typename raw_value_expression::storage_type&;
+        using raw_flag_expression = FE;
+        using flag_storage_type = typename raw_flag_expression::storage_type&;
         using storage_type = xoptional_assembly_storage<value_storage_type, flag_storage_type>;
         using temporary_type = xoptional_assembly<VE, FE>;
     };
@@ -66,8 +66,12 @@ namespace xt
         using self_type = xoptional_assembly<VE, FE>;
         using base_type = xoptional_assembly_base<self_type>;
         using semantic_base = xcontainer_semantic<self_type>;
+        using raw_value_expression = typename base_type::raw_value_expression;
+        using raw_flag_expression = typename base_type::raw_flag_expression;
         using value_expression = typename base_type::value_expression;
         using flag_expression = typename base_type::flag_expression;
+        using const_value_expression = typename base_type::const_value_expression;
+        using const_flag_expression = typename base_type::const_flag_expression;
         using storage_type = typename base_type::storage_type;
         using value_type = typename base_type::value_type;
         using reference = typename base_type::reference;
@@ -88,7 +92,7 @@ namespace xt
         xoptional_assembly(const VE& ve);
         xoptional_assembly(VE&& ve);
 
-        template <class OVE, class OFE, XTENSOR_REQUIRE<is_xexpression<OVE>::value && is_xexpression<OFE>::value>>
+        template <class OVE, class OFE, typename = std::enable_if_t<is_xexpression<OVE>::value && is_xexpression<OFE>::value>>
         xoptional_assembly(OVE&& ove, OFE&& ofe);
 
         xoptional_assembly(const value_type& value);
@@ -120,14 +124,14 @@ namespace xt
         storage_type& storage_impl() noexcept;
         const storage_type& storage_impl() const noexcept;
 
-        value_expression& value_impl() noexcept;
-        const value_expression& value_impl() const noexcept;
+        value_expression value_impl() noexcept;
+        const_value_expression value_impl() const noexcept;
 
-        flag_expression& has_value_impl() noexcept;
-        const flag_expression& has_value_impl() const noexcept;
+        flag_expression has_value_impl() noexcept;
+        const_flag_expression has_value_impl() const noexcept;
 
-        value_expression m_value;
-        flag_expression m_has_value;
+        raw_value_expression m_value;
+        raw_flag_expression m_has_value;
         storage_type m_storage;
 
         friend class xoptional_assembly_base<xoptional_assembly<VE, FE>>;
@@ -143,16 +147,16 @@ namespace xt
     template <class VEC, class FEC>
     struct xcontainer_inner_types<xoptional_assembly_adaptor<VEC, FEC>>
     {
-        using value_expression = std::remove_reference_t<VEC>;
-        using value_storage_type = std::conditional_t<std::is_const<value_expression>::value,
-                                                      const typename value_expression::storage_type&,
-                                                      typename value_expression::storage_type&>;
-        using flag_expression = std::remove_reference_t<FEC>;
-        using flag_storage_type = std::conditional_t<std::is_const<flag_expression>::value,
-                                                     const typename flag_expression::storage_type&,
-                                                     typename flag_expression::storage_type&>;
+        using raw_value_expression = std::remove_reference_t<VEC>;
+        using value_storage_type = std::conditional_t<std::is_const<raw_value_expression>::value,
+                                                      const typename raw_value_expression::storage_type&,
+                                                      typename raw_value_expression::storage_type&>;
+        using raw_flag_expression = std::remove_reference_t<FEC>;
+        using flag_storage_type = std::conditional_t<std::is_const<raw_flag_expression>::value,
+                                                     const typename raw_flag_expression::storage_type&,
+                                                     typename raw_flag_expression::storage_type&>;
         using storage_type = xoptional_assembly_storage<value_storage_type, flag_storage_type>;
-        using temporary_type = xoptional_assembly<value_expression, flag_expression>;
+        using temporary_type = xoptional_assembly<raw_value_expression, raw_flag_expression>;
     };
 
     template <class VEC, class FEC>
@@ -188,6 +192,8 @@ namespace xt
         using storage_type = typename base_type::storage_type;
         using value_expression = typename base_type::value_expression;
         using flag_expression = typename base_type::flag_expression;
+        using const_value_expression = typename base_type::const_value_expression;
+        using const_flag_expression = typename base_type::const_flag_expression;
         using value_type = typename base_type::value_type;
         using reference = typename base_type::reference;
         using const_reference = typename base_type::const_reference;
@@ -219,11 +225,11 @@ namespace xt
         storage_type& storage_impl() noexcept;
         const storage_type& storage_impl() const noexcept;
 
-        value_expression& value_impl() noexcept;
-        const value_expression& value_impl() const noexcept;
+        value_expression value_impl() noexcept;
+        const_value_expression value_impl() const noexcept;
 
-        flag_expression& has_value_impl() noexcept;
-        const flag_expression& has_value_impl() const noexcept;
+        flag_expression has_value_impl() noexcept;
+        const_flag_expression has_value_impl() const noexcept;
 
         VEC m_value;
         FEC m_has_value;
@@ -450,7 +456,7 @@ namespace xt
     template <class S>
     inline xoptional_assembly<VE, FE> xoptional_assembly<VE, FE>::from_shape(S&& s)
     {
-        shape_type shape = xtl::forward_sequence<shape_type>(s);
+        shape_type shape = xtl::forward_sequence<shape_type, S>(s);
         return self_type(shape);
     }
 
@@ -523,25 +529,25 @@ namespace xt
     }
 
     template <class VE, class FE>
-    inline auto xoptional_assembly<VE, FE>::value_impl() noexcept -> value_expression&
+    inline auto xoptional_assembly<VE, FE>::value_impl() noexcept -> value_expression
     {
         return m_value;
     }
 
     template <class VE, class FE>
-    inline auto xoptional_assembly<VE, FE>::value_impl() const noexcept -> const value_expression&
+    inline auto xoptional_assembly<VE, FE>::value_impl() const noexcept -> const_value_expression
     {
         return m_value;
     }
 
     template <class VE, class FE>
-    inline auto xoptional_assembly<VE, FE>::has_value_impl() noexcept -> flag_expression&
+    inline auto xoptional_assembly<VE, FE>::has_value_impl() noexcept -> flag_expression
     {
         return m_has_value;
     }
 
     template <class VE, class FE>
-    inline auto xoptional_assembly<VE, FE>::has_value_impl() const noexcept -> const flag_expression&
+    inline auto xoptional_assembly<VE, FE>::has_value_impl() const noexcept -> const_flag_expression
     {
         return m_has_value;
     }
@@ -634,25 +640,25 @@ namespace xt
     }
 
     template <class VEC, class FEC>
-    inline auto xoptional_assembly_adaptor<VEC, FEC>::value_impl() noexcept -> value_expression&
+    inline auto xoptional_assembly_adaptor<VEC, FEC>::value_impl() noexcept -> value_expression
     {
         return m_value;
     }
 
     template <class VEC, class FEC>
-    inline auto xoptional_assembly_adaptor<VEC, FEC>::value_impl() const noexcept -> const value_expression&
+    inline auto xoptional_assembly_adaptor<VEC, FEC>::value_impl() const noexcept -> const_value_expression
     {
         return m_value;
     }
 
     template <class VEC, class FEC>
-    inline auto xoptional_assembly_adaptor<VEC, FEC>::has_value_impl() noexcept -> flag_expression&
+    inline auto xoptional_assembly_adaptor<VEC, FEC>::has_value_impl() noexcept -> flag_expression
     {
         return m_has_value;
     }
 
     template <class VEC, class FEC>
-    inline auto xoptional_assembly_adaptor<VEC, FEC>::has_value_impl() const noexcept -> const flag_expression&
+    inline auto xoptional_assembly_adaptor<VEC, FEC>::has_value_impl() const noexcept -> const_flag_expression
     {
         return m_has_value;
     }

--- a/vendor/xtensor/include/xtensor/xoptional_assembly_storage.hpp
+++ b/vendor/xtensor/include/xtensor/xoptional_assembly_storage.hpp
@@ -1,6 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay, Wolf Vollprecht and   *
-* Martin Renou                                                             *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -12,7 +12,6 @@
 
 #include "xtl/xiterator_base.hpp"
 
-#include "xconcepts.hpp"
 #include "xoptional.hpp"
 #include "xsemantic.hpp"
 
@@ -239,71 +238,71 @@ namespace xt
 
     template <class VE, class FE>
     inline xoptional_assembly_storage<VE, FE>::xoptional_assembly_storage(self_type&& rhs)
-        : m_value(rhs.m_value), m_has_value(rhs.m_has_value)
+        : m_value(std::forward<VE>(rhs.m_value)), m_has_value(std::forward<FE>(rhs.m_has_value))
     {
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::operator=(self_type&& rhs) -> self_type&
     {
-        m_value = rhs.m_value;
-        m_has_value = rhs.m_has_value;
+        m_value = std::forward<VE>(rhs.m_value);
+        m_has_value = std::forward<FE>(rhs.m_has_value);
         return *this;
     }
 
     template <class VE, class FE>
     inline bool xoptional_assembly_storage<VE, FE>::empty() const noexcept
     {
-        return m_value.empty();
+        return value().empty();
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::size() const noexcept -> size_type
     {
-        return m_value.size();
+        return value().size();
     }
 
     template <class VE, class FE>
     inline void xoptional_assembly_storage<VE, FE>::resize(size_type size)
     {
-        m_value.resize(size);
-        m_has_value.resize(size);
+        value().resize(size);
+        has_value().resize(size);
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::operator[](size_type i) -> reference
     {
-        return reference(m_value[i], m_has_value[i]);
+        return reference(value()[i], has_value()[i]);
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::operator[](size_type i) const -> const_reference
     {
-        return const_reference(m_value[i], m_has_value[i]);
+        return const_reference(value()[i], has_value()[i]);
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::front() -> reference
     {
-        return reference(m_value[0], m_has_value[0]);
+        return reference(value()[0], has_value()[0]);
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::front() const -> const_reference
     {
-        return const_reference(m_value[0], m_has_value[0]);
+        return const_reference(value()[0], has_value()[0]);
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::back() -> reference
     {
-        return reference(m_value[size() - 1], m_has_value[size() - 1]);
+        return reference(value()[size() - 1], has_value()[size() - 1]);
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::back() const -> const_reference
     {
-        return const_reference(m_value[size() - 1], m_has_value[size() - 1]);
+        return const_reference(value()[size() - 1], has_value()[size() - 1]);
     }
 
     template <class VE, class FE>
@@ -321,37 +320,37 @@ namespace xt
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::begin() noexcept -> iterator
     {
-        return iterator(m_value.begin(), m_has_value.begin());
+        return iterator(value().begin(), has_value().begin());
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::end() noexcept -> iterator
     {
-        return iterator(m_value.end(), m_has_value.end());
+        return iterator(value().end(), has_value().end());
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::begin() const noexcept -> const_iterator
     {
-        return const_iterator(m_value.begin(), m_has_value.begin());
+        return cbegin();
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::end() const noexcept -> const_iterator
     {
-        return const_iterator(m_value.end(), m_has_value.end());
+        return cend();
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::cbegin() const noexcept -> const_iterator
     {
-        return begin();
+        return const_iterator(value().begin(), has_value().begin());
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::cend() const noexcept -> const_iterator
     {
-        return end();
+        return const_iterator(value().end(), has_value().end());
     }
 
     template <class VE, class FE>
@@ -369,25 +368,25 @@ namespace xt
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::rbegin() const noexcept -> const_reverse_iterator
     {
-        return const_reverse_iterator(end());
+        return crbegin();
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::rend() const noexcept -> const_reverse_iterator
     {
-        return const_reverse_iterator(begin());
+        return crend();
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::crbegin() const noexcept -> const_reverse_iterator
     {
-        return rbegin();
+        return const_reverse_iterator(cend());
     }
 
     template <class VE, class FE>
     inline auto xoptional_assembly_storage<VE, FE>::crend() const noexcept -> const_reverse_iterator
     {
-        return rend();
+        return const_reverse_iterator(cbegin());
     }
 
     template <class VE, class FE>

--- a/vendor/xtensor/include/xtensor/xpad.hpp
+++ b/vendor/xtensor/include/xtensor/xpad.hpp
@@ -1,0 +1,209 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_PAD_HPP
+#define XTENSOR_PAD_HPP
+
+#include "xarray.hpp"
+#include "xtensor.hpp"
+#include "xview.hpp"
+#include "xstrided_view.hpp"
+
+using namespace xt::placeholders;  // to enable _ syntax
+
+namespace xt
+{
+    /**
+     * @brief Defines different algorithms to be used in ``xt::pad``:
+     * - ``constant``: Pads with a constant value.
+     * - ``symmetric``: Pads with the reflection of the vector mirrored along the edge of the array.
+     * - ``reflect``: Pads with the reflection of the vector mirrored on the first and last values
+     *   of the vector along each axis.
+     * - ``wrap``: Pads with the wrap of the vector along the axis. The first values are used to pad
+     *   the end and the end values are used to pad the beginning.
+     * - ``periodic`` : ``== wrap`` (pads with periodic repetitions of the vector).
+     *
+     * OpenCV to xtensor:
+     * - ``BORDER_CONSTANT == constant``
+     * - ``BORDER_REFLECT == symmetric``
+     * - ``BORDER_REFLECT_101 == reflect``
+     * - ``BORDER_WRAP == wrap``
+     */
+    enum class pad_mode
+    {
+        constant,
+        symmetric,
+        reflect,
+        wrap,
+        periodic
+    };
+
+    namespace detail
+    {
+        template <class S, class T>
+        inline bool check_pad_width(const std::vector<std::vector<S>>& pad_width, const T& shape)
+        {
+            if (pad_width.size() != shape.size())
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    /**
+     * @brief Pad an array.
+     *
+     * @param e The array.
+     * @param pad_width Number of values padded to the edges of each axis:
+     * `{{before_1, after_1}, ..., {before_N, after_N}}`.
+     * @param mode The type of algorithm to use. [default: `xt::pad_mode::constant`].
+     * @param constant_value The value to set the padded values for each axis
+     * (used in `xt::pad_mode::constant`).
+     * @return The padded array.
+     */
+    template <class E,
+              class S = typename std::decay_t<E>::size_type,
+              class V = typename std::decay_t<E>::value_type>
+    inline auto pad(E&& e,
+                    const std::vector<std::vector<S>>& pad_width,
+                    pad_mode mode = pad_mode::constant,
+                    V constant_value = 0)
+    {
+        XTENSOR_ASSERT(detail::check_pad_width(pad_width, e.shape()));
+
+        using size_type = typename std::decay_t<E>::size_type;
+        using value_type = typename std::decay_t<E>::value_type;
+
+        auto out = e;
+
+        for (size_type axis = 0; axis < e.shape().size(); ++axis)
+        {
+            size_type nb = static_cast<size_type>(pad_width[axis][0]);
+            size_type ne = static_cast<size_type>(pad_width[axis][1]);
+
+            if (mode == pad_mode::constant)
+            {
+                auto shape_bgn = out.shape();
+                auto shape_end = out.shape();
+                shape_bgn[axis] = nb;
+                shape_end[axis] = ne;
+                auto bgn = constant_value * xt::ones<value_type>(shape_bgn);
+                auto end = constant_value * xt::ones<value_type>(shape_end);
+                out = xt::concatenate(xt::xtuple(bgn, out, end), axis);
+            }
+            else
+            {
+                xt::xstrided_slice_vector sv_bgn(e.shape().size(), xt::all());
+                xt::xstrided_slice_vector sv_end(e.shape().size(), xt::all());
+
+                if (mode == pad_mode::wrap || mode == pad_mode::periodic)
+                {
+                    XTENSOR_ASSERT(nb <= out.shape()[axis]);
+                    XTENSOR_ASSERT(ne <= out.shape()[axis]);
+                    sv_bgn[axis] = xt::range(out.shape()[axis]-nb, out.shape()[axis]);
+                    sv_end[axis] = xt::range(0, ne);
+                }
+                else if (mode == pad_mode::symmetric)
+                {
+                    XTENSOR_ASSERT(nb <= out.shape()[axis]);
+                    XTENSOR_ASSERT(ne <= out.shape()[axis]);
+                    if (nb == size_type(0))
+                    {
+                        sv_bgn[axis] = xt::range(0, 0, -1);
+                    }
+                    else
+                    {
+                        sv_bgn[axis] = xt::range(nb-1, _, -1);
+                    }
+                    if (ne == out.shape()[axis])
+                    {
+                        sv_end[axis] = xt::range(out.shape()[axis], _, -1);
+                    }
+                    else
+                    {
+                        sv_end[axis] = xt::range(out.shape()[axis], out.shape()[axis]-ne-1, -1);
+                    }
+                }
+                else if (mode == pad_mode::reflect)
+                {
+                    XTENSOR_ASSERT(out.shape()[axis] > 1);
+                    XTENSOR_ASSERT(nb <= out.shape()[axis] - 1);
+                    XTENSOR_ASSERT(ne <= out.shape()[axis] - 1);
+                    sv_bgn[axis] = xt::range(nb, 0, -1);
+                    if (ne == out.shape()[axis] - 1)
+                    {
+                        sv_end[axis] = xt::range(out.shape()[axis]-2, _, -1);
+                    }
+                    else
+                    {
+                        sv_end[axis] = xt::range(out.shape()[axis]-2, out.shape()[axis]-ne-2, -1);
+                    }
+                }
+
+                auto bgn = xt::strided_view(out, sv_bgn);
+                auto end = xt::strided_view(out, sv_end);
+
+                out = xt::concatenate(xt::xtuple(bgn, out, end), axis);
+            }
+        }
+
+        return out;
+    }
+
+    /**
+     * @brief Pad an array.
+     *
+     * @param e The array.
+     * @param pad_width Number of values padded to the edges of each axis:
+     * `{before, after}`.
+     * @param mode The type of algorithm to use. [default: `xt::pad_mode::constant`].
+     * @param constant_value The value to set the padded values for each axis
+     * (used in `xt::pad_mode::constant`).
+     * @return The padded array.
+     */
+    template <class E,
+              class S = typename std::decay_t<E>::size_type,
+              class V = typename std::decay_t<E>::value_type>
+    inline auto pad(E&& e,
+                    const std::vector<S>& pad_width,
+                    pad_mode mode = pad_mode::constant,
+                    V constant_value = 0)
+    {
+        std::vector<std::vector<S>> pw(e.shape().size(), pad_width);
+
+        return pad(e, pw, mode, constant_value);
+    }
+
+    /**
+     * @brief Pad an array.
+     *
+     * @param e The array.
+     * @param pad_width Number of values padded to the edges of each axis.
+     * @param mode The type of algorithm to use. [default: `xt::pad_mode::constant`].
+     * @param constant_value The value to set the padded values for each axis
+     * (used in `xt::pad_mode::constant`).
+     * @return The padded array.
+     */
+    template <class E,
+              class S = typename std::decay_t<E>::size_type,
+              class V = typename std::decay_t<E>::value_type>
+    inline auto pad(E&& e,
+                    S pad_width,
+                    pad_mode mode = pad_mode::constant,
+                    V constant_value = 0)
+    {
+        std::vector<std::vector<S>> pw(e.shape().size(), {pad_width, pad_width});
+
+        return pad(e, pw, mode, constant_value);
+    }
+}
+
+#endif

--- a/vendor/xtensor/include/xtensor/xrandom.hpp
+++ b/vendor/xtensor/include/xtensor/xrandom.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -48,6 +49,57 @@ namespace xt
         auto randn(const S& shape, T mean = 0, T std_dev = 1,
                    E& engine = random::get_default_random_engine());
 
+        template <class T, class S, class D = double, class E = random::default_engine_type>
+        auto binomial(const S& shape, T trials = 1, D prob = 0.5,
+                      E& engine = random::get_default_random_engine());
+
+        template <class T, class S, class D = double, class E = random::default_engine_type>
+        auto geometric(const S& shape, D prob = 0.5, 
+                       E& engine = random::get_default_random_engine());
+
+        template <class T, class S, class D = double, class E = random::default_engine_type>
+        auto negative_binomial(const S& shape, T k = 1, D prob = 0.5,
+                               E& engine = random::get_default_random_engine()); 
+
+        template <class T, class S, class D = double, class E = random::default_engine_type>
+        auto poisson(const S& shape, D rate = 1.0,
+                     E& engine = random::get_default_random_engine());
+
+        template <class T, class S, class E = random::default_engine_type>
+        auto exponential(const S& shape, T rate = 1.0,
+                         E& engine = random::get_default_random_engine());
+
+        template <class T, class S, class E = random::default_engine_type>
+        auto gamma(const S& shape, T alpha = 1.0, T beta = 1.0,
+                   E& engine = random::get_default_random_engine());
+
+        template <class T, class S, class E = random::default_engine_type>
+        auto weibull(const S& shape, T a = 1.0, T b = 1.0, 
+                     E& engine = random::get_default_random_engine());
+
+        template <class T, class S, class E = random::default_engine_type>
+        auto extreme_value(const S& shape, T a = 0.0, T b = 1.0, 
+                           E& engine = random::get_default_random_engine());
+
+        template <class T, class S, class E = random::default_engine_type>
+        auto lognormal(const S& shape, T mean = 0, T std_dev = 1,
+                       E& engine = random::get_default_random_engine());
+
+        template <class T, class S, class E = random::default_engine_type>
+        auto chi_squared(const S& shape, T deg = 1.0,
+                         E& engine = random::get_default_random_engine());
+
+        template <class T, class S, class E = random::default_engine_type>
+        auto cauchy(const S& shape, T a = 0.0, T b = 1.0, 
+                           E& engine = random::get_default_random_engine());
+
+        template <class T, class S, class E = random::default_engine_type>
+        auto fisher_f(const S& shape, T m = 1.0, T n = 1.0,
+                      E& engine = random::get_default_random_engine());
+
+        template <class T, class S, class E = random::default_engine_type>
+        auto student_t(const S& shape, T n = 1.0,
+                       E& engine = random::get_default_random_engine());
 #ifdef X_OLD_CLANG
         template <class T, class I, class E = random::default_engine_type>
         auto rand(std::initializer_list<I> shape, T lower = 0, T upper = 1,
@@ -59,8 +111,63 @@ namespace xt
                      E& engine = random::get_default_random_engine());
 
         template <class T, class I, class E = random::default_engine_type>
-        auto randn(std::initializer_list<I>, T mean = 0, T std_dev = 1,
+        auto randn(std::initializer_list<I> shape, 
+                   T mean = 0, T std_dev = 1,
                    E& engine = random::get_default_random_engine());
+
+        template <class T, class I, class D = double, class E = random::default_engine_type>
+        auto binomial(std::initializer_list<I> shape, 
+                      T trials = 1, D prob = 0.5,
+                      E& engine = random::get_default_random_engine());
+
+        template <class T, class I, class D = double, class E = random::default_engine_type>
+        auto geometric(std::initializer_list<I> shape, D prob = 0.5, 
+                      E& engine = random::get_default_random_engine());
+
+        template <class T, class I, class D = double, class E = random::default_engine_type>
+        auto negative_binomial(std::initializer_list<I> shape, T k = 1, D prob = 0.5,
+                               E& engine = random::get_default_random_engine()); 
+
+        template <class T, class I, class D = double, class E = random::default_engine_type>
+        auto poisson(std::initializer_list<I> shape, D rate = 1.0, 
+                     E& engine = random::get_default_random_engine());
+
+        template <class T, class I, class E = random::default_engine_type>
+        auto exponential(std::initializer_list<I> shape, T rate = 1.0, 
+                         E& engine = random::get_default_random_engine());
+
+        template <class T, class I, class E = random::default_engine_type>
+        auto gamma(std::initializer_list<I> shape, T alpha = 1.0, T beta = 1.0,
+                   E& engine = random::get_default_random_engine());
+
+        template <class T, class I, class E = random::default_engine_type>
+        auto weibull(std::initializer_list<I> shape, T a = 1.0, T b = 1.0,
+                     E& engine = random::get_default_random_engine());
+
+        template <class T, class I, class E = random::default_engine_type>
+        auto extreme_value(std::initializer_list<I> shape, T a = 0.0, T b = 1.0,
+                           E& engine = random::get_default_random_engine());
+
+        template <class T, class I, class E = random::default_engine_type>
+        auto lognormal(std::initializer_list<I> shape, 
+                       T mean = 0, T std_dev = 1.0,
+                       E& engine = random::get_default_random_engine());
+
+        template <class T, class I, class E = random::default_engine_type>
+        auto chi_squared(std::initializer_list<I> shape, T deg = 1.0,
+                         E& engine = random::get_default_random_engine());  
+
+        template <class T, class I, class E = random::default_engine_type>
+        auto cauchy(std::initializer_list<I> shape, T a = 0.0, T b = 1.0,
+                    E& engine = random::get_default_random_engine());
+
+        template <class T, class I, class E = random::default_engine_type>
+        auto fisher_f(std::initializer_list<I> shape, T m = 1.0, T n = 1.0,
+                      E& engine = random::get_default_random_engine());
+
+        template < class T, class I, class E = random::default_engine_type>
+        auto student_t(std::initializer_list<I> shape, T n = 1.0,
+                       E& engine = random::get_default_random_engine());
 #else
         template <class T, class I, std::size_t L, class E = random::default_engine_type>
         auto rand(const I (&shape)[L], T lower = 0, T upper = 1,
@@ -73,13 +180,73 @@ namespace xt
         template <class T, class I, std::size_t L, class E = random::default_engine_type>
         auto randn(const I (&shape)[L], T mean = 0, T std_dev = 1,
                    E& engine = random::get_default_random_engine());
+
+        template <class T, class I, std::size_t L, class D = double, class E = random::default_engine_type>
+        auto binomial(const I (&shape)[L], T trials = 1, D prob = 0.5,
+                      E& engine = random::get_default_random_engine());
+
+        template <class T, class I, std::size_t L, class D = double, class E = random::default_engine_type>
+        auto geometric(const I (&shape)[L], D prob=0.5, 
+                       E& engine = random::get_default_random_engine());
+
+        template <class T, class I, std::size_t L, class D = double, class E = random::default_engine_type>
+        auto negative_binomial(const I (&shape)[L], T k = 1, D prob = 0.5,
+                               E& engine = random::get_default_random_engine()); 
+        
+        template <class T, class I, std::size_t L, class D = double, class E = random::default_engine_type>
+        auto poisson(const I (&shape)[L], D rate = 1.0, 
+                     E& engine = random::get_default_random_engine());
+
+        template <class T, class I, std::size_t L, class E = random::default_engine_type>
+        auto exponential(const I (&shape)[L], T rate = 1.0, 
+                         E& engine = random::get_default_random_engine());
+
+        template <class T, class I, std::size_t L, class E = random::default_engine_type>
+        auto gamma(const I (&shape)[L], T alpha = 1.0, T beta = 1.0,
+                   E& engine = random::get_default_random_engine());
+
+        template <class T, class I, std::size_t L, class E = random::default_engine_type>
+        auto weibull(const I (&shape)[L], T a = 1.0, T b = 1.0,
+                     E& engine = random::get_default_random_engine());
+
+        template <class T, class I, std::size_t L, class E = random::default_engine_type>
+        auto extreme_value(const I (&shape)[L], T a = 0.0, T b = 1.0,
+                           E& engine = random::get_default_random_engine());
+
+        template <class T, class I, std::size_t L, class E = random::default_engine_type>
+        auto lognormal(const I (&shape)[L], T mean = 0.0, T std_dev = 1.0,
+                       E& engine = random::get_default_random_engine());
+
+        template <class T, class I, std::size_t L, class E = random::default_engine_type>
+        auto chi_squared(const I (&shape)[L], T deg = 1.0,
+                         E& engine = random::get_default_random_engine());
+                         
+        template <class T, class I, std::size_t L, class E = random::default_engine_type>
+        auto cauchy(const I (&shape)[L], T a = 0.0, T b = 1.0,
+                    E& engine = random::get_default_random_engine());
+
+        template <class T, class I, std::size_t L, class E = random::default_engine_type>
+        auto fisher_f(const I (&shape)[L], T m = 1.0, T n = 1.0,
+                      E& engine = random::get_default_random_engine());
+
+        template <class T, class I, std::size_t L, class E = random::default_engine_type>
+        auto student_t(const I (&shape)[L], T n = 1.0,
+                       E& engine = random::get_default_random_engine());
 #endif
 
         template <class T, class E = random::default_engine_type>
         void shuffle(xexpression<T>& e, E& engine = random::get_default_random_engine());
 
         template <class T, class E = random::default_engine_type>
-        xtensor<typename T::value_type, 1> choice(const xexpression<T>& e, std::size_t n,
+        std::enable_if_t<std::is_integral<T>::value, xtensor<T, 1>>
+        permutation(T e, E& engine = random::get_default_random_engine());
+
+        template <class T, class E = random::default_engine_type>
+        std::enable_if_t<is_xexpression<std::decay_t<T>>::value, std::decay_t<T>>
+        permutation(T&& e, E& engine = random::get_default_random_engine());
+
+        template <class T, class E = random::default_engine_type>
+        xtensor<typename T::value_type, 1> choice(const xexpression<T>& e, std::size_t n, bool replace = true,
                                                   E& engine = random::get_default_random_engine());
     }
 
@@ -110,8 +277,9 @@ namespace xt
             template <class EX>
             inline void assign_to(xexpression<EX>& e) const noexcept
             {
+                // Note: we're not going row/col major here
                 auto& ed = e.derived_cast();
-                for (auto& el : ed.storage())
+                for (auto&& el : ed.storage())
                 {
                     el = m_dist(m_engine);
                 }
@@ -178,7 +346,7 @@ namespace xt
         template <class T, class S, class E>
         inline auto randint(const S& shape, T lower, T upper, E& engine)
         {
-            std::uniform_int_distribution<T> dist(lower, upper - 1);
+            std::uniform_int_distribution<T> dist(lower, T(upper - 1));
             return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
         }
 
@@ -202,6 +370,254 @@ namespace xt
             return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
         }
 
+        /**
+         * xexpression with specified @p shape containing numbers sampled from
+         * the binomial random number distribution for @p trials trials with
+         * probability of success equal to @p prob.
+         *
+         * Numbers are drawn from @c std::binomial_distribution.
+         *
+         * @param shape shape of resulting xexpression
+         * @param trials number of Bernoulli trials
+         * @param prob probability of success of each trial
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class D, class E>
+        inline auto binomial(const S& shape, T trials, D prob, E& engine)
+        {
+            std::binomial_distribution<T> dist(trials, prob);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+         /**
+         * xexpression with specified @p shape containing numbers sampled from
+         * a gemoetric random number distribution with
+         * probability of success equal to @p prob for each of the Bernoulli trials.
+         *
+         * Numbers are drawn from @c std::geometric_distribution.
+         *
+         * @param shape shape of resulting xexpression
+         * @param prob probability of success of each trial
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class D, class E>
+        inline auto geometric(const S& shape, D prob, E& engine)
+        {
+            std::geometric_distribution<T> dist(prob);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        /**
+         * xexpression with specified @p shape containing numbers sampled from
+         * a negative binomial random number distribution (also known as Pascal distribution)
+         * that returns the number of successes before @p k trials with probability of success 
+         * equal to @p prob for each of the Bernoulli trials.
+         * 
+         * Numbers are drawn from @c std::negative_binomial_distribution.
+         *
+         * @param shape shape of resulting xexpression
+         * @param k number of unsuccessful trials
+         * @param prob probability of success of each trial
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class D, class E>
+        inline auto negative_binomial(const S& shape, T k, D prob, E& engine)
+        {
+            std::negative_binomial_distribution<T> dist(k, prob);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);   
+        }
+
+        /**
+         * xexpression with specified @p shape containing numbers sampled from
+         * a Poisson random number distribution with rate @p rate
+         * 
+         * Numbers are drawn from @c std::poisson_distribution.
+         *
+         * @param shape shape of resulting xexpression
+         * @param rate rate of Poisson distribution
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class D, class E>
+        inline auto poisson(const S& shape, D rate, E& engine)
+        {
+            std::poisson_distribution<T> dist(rate);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);   
+        }
+
+        /**
+         * xexpression with specified @p shape containing numbers sampled from
+         * a exponential random number distribution with rate @p rate
+         * 
+         * Numbers are drawn from @c std::exponential_distribution.
+         *
+         * @param shape shape of resulting xexpression
+         * @param rate rate of exponential distribution
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class E>
+        inline auto exponential(const S& shape, T rate, E& engine)
+        {
+            std::exponential_distribution<T> dist(rate);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);   
+        }
+
+        /**
+         * xexpression with specified @p shape containing numbers sampled from
+         * a gamma random number distribution with shape @p alpha and scale @p beta
+         * 
+         * Numbers are drawn from @c std::gamma_distribution.
+         *
+         * @param shape shape of resulting xexpression
+         * @param alpha shape of the gamma distribution
+         * @param beta scale of the gamma distribution
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class E>
+        inline auto gamma(const S& shape, T alpha, T beta, E& engine)
+        {
+            std::gamma_distribution<T> dist(alpha, beta);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        /**
+         * xexpression with specified @p shape containing numbers sampled from
+         * a Weibull random number distribution with shape @p a and scale @p b
+         * 
+         * Numbers are drawn from @c std::weibull_distribution.
+         *
+         * @param shape shape of resulting xexpression
+         * @param a shape of the weibull distribution
+         * @param b scale of the weibull distribution
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class E>
+        inline auto weibull(const S& shape, T a, T b, E& engine)
+        {
+            std::weibull_distribution<T> dist(a, b);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        /**
+         * xexpression with specified @p shape containing numbers sampled from
+         * a extreme value random number distribution with shape @p a and scale @p b
+         * 
+         * Numbers are drawn from @c std::extreme_value_distribution.
+         *
+         * @param shape shape of resulting xexpression
+         * @param a shape of the extreme value distribution
+         * @param b scale of the extreme value distribution
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class E>
+        inline auto extreme_value(const S& shape, T a, T b, E& engine)
+        {
+            std::extreme_value_distribution<T> dist(a, b);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        /**
+         * xexpression with specified @p shape containing numbers sampled from
+         * the Log-Normal random number distribution with mean @p mean and
+         * standard deviation @p std_dev.
+         *
+         * Numbers are drawn from @c std::lognormal_distribution.
+         *
+         * @param shape shape of resulting xexpression
+         * @param mean mean of normal distribution
+         * @param std_dev standard deviation of normal distribution
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class E>
+        inline auto lognormal(const S& shape, T mean, T std_dev, E& engine)
+        {
+            std::lognormal_distribution<T> dist(mean, std_dev);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        /**
+         * xexpression with specified @p shape containing numbers sampled from
+         * the chi-squared random number distribution with @p deg degrees of freedom.
+         *
+         * Numbers are drawn from @c std::chi_squared_distribution.
+         *
+         * @param shape shape of resulting xexpression
+         * @param deg degrees of freedom
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class E>
+        inline auto chi_squared(const S& shape, T deg, E& engine)
+        {
+            std::chi_squared_distribution<T> dist(deg);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        /**
+         * xexpression with specified @p shape containing numbers sampled from
+         * a Cauchy random number distribution with peak @p a and scale @p b
+         * 
+         * Numbers are drawn from @c std::cauchy_distribution.
+         *
+         * @param shape shape of resulting xexpression
+         * @param a peak of the Cauchy distribution
+         * @param b scale of the Cauchy distribution
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class E>
+        inline auto cauchy(const S& shape, T a, T b, E& engine)
+        {
+            std::cauchy_distribution<T> dist(a, b);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        /**
+         * xexpression with specified @p shape containing numbers sampled from
+         * a Fisher-f random number distribution with numerator degrees of 
+         * freedom equal to @p m and denominator degrees of freedom equal to @p n
+         * 
+         * Numbers are drawn from @c std::fisher_f_distribution.
+         *
+         * @param shape shape of resulting xexpression
+         * @param m numerator degrees of freedom
+         * @param n denominator degrees of freedom
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class E>
+        inline auto fisher_f(const S& shape, T m, T n, E& engine)
+        {
+            std::fisher_f_distribution<T> dist(m, n);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        /**
+         * xexpression with specified @p shape containing numbers sampled from
+         * a Student-t random number distribution with degrees of 
+         * freedom equal to @p n 
+         * 
+         * Numbers are drawn from @c std::student_t_distribution.
+         *
+         * @param shape shape of resulting xexpression
+         * @param n degrees of freedom
+         * @param engine random number engine
+         * @tparam T number type to use
+         */
+        template <class T, class S, class E>
+        inline auto student_t(const S& shape, T n, E& engine)
+        {
+            std::student_t_distribution<T> dist(n);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
 #ifdef X_OLD_CLANG
         template <class T, class I, class E>
         inline auto rand(std::initializer_list<I> shape, T lower, T upper, E& engine)
@@ -213,7 +629,7 @@ namespace xt
         template <class T, class I, class E>
         inline auto randint(std::initializer_list<I> shape, T lower, T upper, E& engine)
         {
-            std::uniform_int_distribution<T> dist(lower, upper - 1);
+            std::uniform_int_distribution<T> dist(lower, T(upper - 1));
             return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
         }
 
@@ -221,6 +637,97 @@ namespace xt
         inline auto randn(std::initializer_list<I> shape, T mean, T std_dev, E& engine)
         {
             std::normal_distribution<T> dist(mean, std_dev);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, class D, class E>
+        inline auto binomial(std::initializer_list<I> shape, T trials, D prob, E& engine)
+        {
+            std::binomial_distribution<T> dist(trials, prob);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, class D, class E>
+        inline auto geometric(std::initializer_list<I> shape, D prob, E& engine)
+        {
+            std::geometric_distribution<T> dist(prob);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+        
+        template <class T, class I, class D, class E>
+        inline auto negative_binomial(std::initializer_list<I> shape, T k, D prob, E& engine)
+        {
+            std::negative_binomial_distribution<T> dist(k, prob);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);   
+        }
+
+        template <class T, class I, class D, class E>
+        inline auto poisson(std::initializer_list<I> shape, D rate, E& engine)
+        {
+            std::poisson_distribution<T> dist(rate);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);   
+        }
+
+        template <class T, class I, class E>
+        inline auto exponential(std::initializer_list<I> shape, T rate, E& engine)
+        {
+            std::exponential_distribution<T> dist(rate);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);   
+        }
+
+        template <class T, class I, class E>
+        inline auto gamma(std::initializer_list<I> shape, T alpha, T beta, E& engine)
+        {
+            std::gamma_distribution<T> dist(alpha, beta);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, class E>
+        inline auto weibull(std::initializer_list<I> shape, T a, T b, E& engine)
+        {
+            std::weibull_distribution<T> dist(a, b);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, class E>
+        inline auto extreme_value(std::initializer_list<I> shape, T a, T b, E& engine)
+        {
+            std::extreme_value_distribution<T> dist(a, b);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, class E>
+        inline auto lognormal(std::initializer_list<I> shape, T mean, T std_dev, E& engine)
+        {
+            std::lognormal_distribution<T> dist(mean, std_dev);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, class E>
+        inline auto chi_squared(std::initializer_list<I> shape, T deg, E& engine)
+        {
+            std::chi_squared_distribution<T> dist(deg);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, class E>
+        inline auto cauchy(std::initializer_list<I> shape, T a, T b, E& engine)
+        {
+            std::cauchy_distribution<T> dist(a, b);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, class E>
+        inline auto fisher_f(std::initializer_list<I> shape, T m, T n, E& engine)
+        {
+            std::fisher_f_distribution<T> dist(m, n);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, class E>
+        inline auto student_t(std::initializer_list<I> shape, T n, E& engine)
+        {
+            std::student_t_distribution<T> dist(n);
             return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
         }
 #else
@@ -234,7 +741,7 @@ namespace xt
         template <class T, class I, std::size_t L, class E>
         inline auto randint(const I (&shape)[L], T lower, T upper, E& engine)
         {
-            std::uniform_int_distribution<T> dist(lower, upper - 1);
+            std::uniform_int_distribution<T> dist(lower, T(upper - 1));
             return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
         }
 
@@ -242,6 +749,97 @@ namespace xt
         inline auto randn(const I (&shape)[L], T mean, T std_dev, E& engine)
         {
             std::normal_distribution<T> dist(mean, std_dev);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, std::size_t L, class D, class E>
+        inline auto binomial(const I (&shape)[L], T trials, D prob, E& engine)
+        {
+            std::binomial_distribution<T> dist(trials, prob);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, std::size_t L, class D, class E>
+        inline auto geometric(const I (&shape)[L], D prob, E& engine)
+        {
+            std::geometric_distribution<T> dist(prob);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, std::size_t L, class D , class E>
+        inline auto negative_binomial(const I (&shape)[L], T k, D prob, E& engine)
+        {
+            std::negative_binomial_distribution<T> dist(k, prob);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, std::size_t L, class D, class E>
+        inline auto poisson(const I (&shape)[L], D rate, E& engine)
+        {
+            std::poisson_distribution<T> dist(rate);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);   
+        }
+
+        template <class T, class I, std::size_t L, class E>
+        inline auto exponential(const I (&shape)[L], T rate, E& engine)
+        {
+            std::exponential_distribution<T> dist(rate);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);   
+        }
+
+        template <class T, class I, std::size_t L, class E>
+        inline auto gamma(const I (&shape)[L], T alpha, T beta, E& engine)
+        {
+            std::gamma_distribution<T> dist(alpha, beta);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, std::size_t L, class E>
+        inline auto weibull(const I (&shape)[L], T a, T b, E& engine)
+        {
+            std::weibull_distribution<T> dist(a, b);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, std::size_t L, class E>
+        inline auto extreme_value(const I (&shape)[L], T a, T b, E& engine)
+        {
+            std::extreme_value_distribution<T> dist(a, b);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, std::size_t L, class E>
+        inline auto lognormal(const I (&shape)[L], T mean, T std_dev, E& engine)
+        {
+            std::lognormal_distribution<T> dist(mean, std_dev);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, std::size_t L, class E>
+        inline auto chi_squared(const I (&shape)[L], T deg, E& engine)
+        {
+            std::chi_squared_distribution<T> dist(deg);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, std::size_t L, class E>
+        inline auto cauchy(const I (&shape)[L], T a, T b, E& engine)
+        {
+            std::cauchy_distribution<T> dist(a, b);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, std::size_t L, class E>
+        inline auto fisher_f(const I (&shape)[L], T m, T n, E& engine)
+        {
+            std::fisher_f_distribution<T> dist(m, n);
+            return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
+        }
+
+        template <class T, class I, std::size_t L, class E>
+        inline auto student_t(const I (&shape)[L], T n, E& engine)
+        {
+            std::student_t_distribution<T> dist(n);
             return detail::make_xgenerator(detail::random_impl<T, E, decltype(dist)>(engine, std::move(dist)), shape);
         }
 #endif
@@ -260,14 +858,24 @@ namespace xt
 
             if (de.dimension() == 1)
             {
-                std::shuffle(de.storage().begin(), de.storage().end(), engine);
+                using size_type = typename T::size_type;
+                auto first = de.begin();
+                auto last = de.end();
+
+                for (size_type i = std::size_t((last - first) - 1); i > 0; --i)
+                {
+                    std::uniform_int_distribution<size_type> dist(0, i);
+                    auto j = dist(engine);
+                    using std::swap;
+                    swap(first[i], first[j]);
+                }
             }
             else
             {
                 using size_type = typename T::size_type;
                 decltype(auto) buf = empty_like(view(de, 0));
 
-                for (std::size_t i = de.shape()[0] - 1; i > 0; --i)
+                for (size_type i = de.shape()[0] - 1; i > 0; --i)
                 {
                     std::uniform_int_distribution<size_type> dist(0, i);
                     size_type j = dist(engine);
@@ -280,33 +888,90 @@ namespace xt
         }
 
         /**
+         * Randomly permute a sequence, or return a permuted range.
+         *
+         * If the first parameter is an integer, this function creates a new
+         * ``arange(e)`` and returns it randomly permuted. Otherwise, this
+         * function creates a copy of the input, passes it to @sa shuffle and
+         * returns the result.
+         *
+         * @param e input xexpression or integer
+         * @param engine random number engine to use (optional)
+         *
+         * @return randomly permuted copy of container or arange.
+         */
+        template <class T, class E>
+        std::enable_if_t<std::is_integral<T>::value, xtensor<T, 1>>
+        permutation(T e, E& engine)
+        {
+            xt::xtensor<T, 1> res = xt::arange<T>(e);
+            shuffle(res, engine);
+            return res;
+        }
+
+        /// @cond DOXYGEN_INCLUDE_SFINAE
+        template <class T, class E>
+        std::enable_if_t<is_xexpression<std::decay_t<T>>::value, std::decay_t<T>>
+        permutation(T&& e, E& engine)
+        {
+            using copy_type = std::decay_t<T>;
+            copy_type res = e;
+            shuffle(res, engine);
+            return res;
+        }
+        /// @endcond
+
+        /**
          * Randomly select n unique elements from xexpression e.
          * Note: this function makes a copy of your data, and only 1D data is accepted.
          *
          * @param e expression to sample from
          * @param n number of elements to sample
+         * @param replace whether to sample with or without replacement
          * @param engine random number engine
          *
          * @return xtensor containing 1D container of sampled elements
          */
         template <class T, class E>
-        xtensor<typename T::value_type, 1> choice(const xexpression<T>& e, std::size_t n, E& engine)
+        xtensor<typename T::value_type, 1> choice(const xexpression<T>& e, std::size_t n, bool replace, E& engine)
         {
             const auto& de = e.derived_cast();
-            XTENSOR_ASSERT(de.dimension() == 1);
-            XTENSOR_ASSERT(de.size() >= n);
-            xtensor<typename T::value_type, 1> result;
+            if (de.dimension() != 1)
+            {
+                throw std::runtime_error("Sample expression must be 1 dimensional");
+            }
+            if (de.size() < n && !replace)
+            {
+                throw std::runtime_error("If replace is false, then the sample expression's size must be > n");
+            }
+            using result_type = xtensor<typename T::value_type, 1>;
+            using size_type = typename result_type::size_type;
+            result_type result;
             result.resize({n});
 
-            xtensor<typename T::value_type, 1> shuffled = de;
-            std::shuffle(shuffled.storage().begin(), shuffled.storage().end(), engine);
-
-            std::copy(shuffled.storage().begin(), shuffled.storage().begin() + n, result.begin());
-
+            if (replace)
+            {
+                auto dist = std::uniform_int_distribution<size_type>(0, de.size() - 1);
+                for (size_type i = 0; i < n; ++i)
+                {
+                    result[i] = de.storage()[dist(engine)];
+                }
+            }
+            else
+            {
+                // Naive resevoir sampling without weighting:
+                std::copy(de.storage().begin(), de.storage().begin() + n, result.begin());
+                size_type i = n;
+                for(auto it = de.storage().begin() + n; it != de.storage().end(); ++it, ++i)
+                {
+                    auto idx = std::uniform_int_distribution<size_type>(0, i)(engine);
+                    if (idx < n)
+                    {
+                        result.storage()[idx] = *it;
+                    }
+                }
+            }
             return result;
-
-            // Doesn't exist yet but would be much nicer as it probably prevent copies
-            // std::experimental::sample(de.begin(), de.end(), result.begin(), std::ref(engine));
         }
     }
 }

--- a/vendor/xtensor/include/xtensor/xscalar.hpp
+++ b/vendor/xtensor/include/xtensor/xscalar.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -15,6 +16,7 @@
 
 #include <xtl/xtype_traits.hpp>
 
+#include "xaccessible.hpp"
 #include "xexpression.hpp"
 #include "xiterable.hpp"
 #include "xlayout.hpp"
@@ -23,11 +25,37 @@
 namespace xt
 {
 
+    /*********************
+     * xscalar extension *
+     *********************/
+
+    namespace extension
+    {
+        template <class Tag, class CT>
+        struct xscalar_base_impl;
+
+        template <class CT>
+        struct xscalar_base_impl<xtensor_expression_tag, CT>
+        {
+            using type = xtensor_empty_base;
+        };
+
+        template <class CT>
+        struct xscalar_base : xscalar_base_impl<get_expression_tag_t<std::decay_t<CT>>, CT>
+        {
+        };
+
+        template <class CT>
+        using xscalar_base_t = typename xscalar_base<CT>::type;
+    }
+
     /***********
      * xscalar *
      ***********/
 
     // xscalar is a cheap wrapper for a scalar value as an xexpression.
+    template <class CT>
+    class xscalar;
 
     template <bool is_const, class CT>
     class xscalar_stepper;
@@ -36,39 +64,52 @@ namespace xt
     class xdummy_iterator;
 
     template <class CT>
-    class xscalar;
-
-    template <class CT>
     struct xiterable_inner_types<xscalar<CT>>
     {
         using value_type = std::decay_t<CT>;
         using inner_shape_type = std::array<std::size_t, 0>;
+        using shape_type = inner_shape_type;
         using const_stepper = xscalar_stepper<true, CT>;
         using stepper = xscalar_stepper<false, CT>;
     };
 
-#define DL XTENSOR_DEFAULT_LAYOUT
     template <class CT>
-    class xscalar : public xexpression<xscalar<CT>>,
-                    private xiterable<xscalar<CT>>
+    struct xcontainer_inner_types<xscalar<CT>>
+    {
+        using value_type = std::decay_t<CT>;
+        using reference = value_type&;
+        using const_reference = const value_type&;
+        using size_type = std::size_t;
+    };
+
+    template <class CT>
+    class xscalar : public xsharable_expression<xscalar<CT>>,
+                    private xiterable<xscalar<CT>>,
+                    private xaccessible<xscalar<CT>>,
+                    public extension::xscalar_base_t<CT>
     {
     public:
 
         using self_type = xscalar<CT>;
+        using xexpression_type = std::decay_t<CT>;
+        using extension_base = extension::xscalar_base_t<CT>;
+        using accessible_base = xaccessible<self_type>;
+        using expression_tag = typename extension_base::expression_tag;
+        using inner_types = xcontainer_inner_types<self_type>;
 
-        using value_type = std::decay_t<CT>;
-        using reference = value_type&;
-        using const_reference = const value_type&;
+        using value_type = typename inner_types::value_type;
+        using reference = typename inner_types::reference;
+        using const_reference = typename inner_types::const_reference;
         using pointer = value_type*;
         using const_pointer = const value_type*;
-        using size_type = std::size_t;
+        using size_type = typename inner_types::size_type;
         using difference_type = std::ptrdiff_t;
-        using simd_value_type = xsimd::simd_type<value_type>;
+        using simd_value_type = xt_simd::simd_type<value_type>;
+        using bool_load_type = xt::bool_load_type<value_type>;
 
         using iterable_base = xiterable<self_type>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
         using shape_type = inner_shape_type;
-        using expression_tag = xscalar_expression_tag;
 
         using stepper = typename iterable_base::stepper;
         using const_stepper = typename iterable_base::const_stepper;
@@ -111,33 +152,26 @@ namespace xt
         operator const value_type&() const noexcept;
 
         size_type size() const noexcept;
-        size_type dimension() const noexcept;
         const shape_type& shape() const noexcept;
+        size_type shape(size_type i) const noexcept;
         layout_type layout() const noexcept;
+        using accessible_base::dimension;
+        using accessible_base::shape;
 
         template <class... Args>
         reference operator()(Args...) noexcept;
         template <class... Args>
-        reference at(Args...);
-        template <class... Args>
         reference unchecked(Args...) noexcept;
-        template <class S>
-        disable_integral_t<S, reference> operator[](const S&) noexcept;
-        template <class I>
-        reference operator[](std::initializer_list<I>) noexcept;
-        reference operator[](size_type) noexcept;
 
         template <class... Args>
         const_reference operator()(Args...) const noexcept;
         template <class... Args>
-        const_reference at(Args...) const;
-        template <class... Args>
         const_reference unchecked(Args...) const noexcept;
-        template <class S>
-        disable_integral_t<S, const_reference> operator[](const S&) const noexcept;
-        template <class I>
-        const_reference operator[](std::initializer_list<I>) const noexcept;
-        const_reference operator[](size_type) const noexcept;
+
+        using accessible_base::at;
+        using accessible_base::operator[];
+        using accessible_base::periodic;
+        using accessible_base::in_bounds;
 
         template <class It>
         reference element(It, It) noexcept;
@@ -145,95 +179,86 @@ namespace xt
         template <class It>
         const_reference element(It, It) const noexcept;
 
+        xexpression_type& expression() noexcept;
+        const xexpression_type& expression() const noexcept;
+
         template <class S>
         bool broadcast_shape(S& shape, bool reuse_cache = false) const noexcept;
 
         template <class S>
-        bool is_trivial_broadcast(const S& strides) const noexcept;
+        bool has_linear_assign(const S& strides) const noexcept;
 
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         iterator begin() noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         iterator end() noexcept;
 
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_iterator begin() const noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_iterator end() const noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_iterator cbegin() const noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_iterator cend() const noexcept;
 
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         reverse_iterator rbegin() noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         reverse_iterator rend() noexcept;
 
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_reverse_iterator rbegin() const noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_reverse_iterator rend() const noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_reverse_iterator crbegin() const noexcept;
-        template <layout_type L = DL>
+        template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_reverse_iterator crend() const noexcept;
 
-        template <class S, layout_type L = DL>
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         broadcast_iterator<S, L> begin(const S& shape) noexcept;
-        template <class S, layout_type L = DL>
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         broadcast_iterator<S, L> end(const S& shape) noexcept;
 
-        template <class S, layout_type L = DL>
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_broadcast_iterator<S, L> begin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_broadcast_iterator<S, L> end(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_broadcast_iterator<S, L> cbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_broadcast_iterator<S, L> cend(const S& shape) const noexcept;
 
 
-        template <class S, layout_type L = DL>
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         reverse_broadcast_iterator<S, L> rbegin(const S& shape) noexcept;
-        template <class S, layout_type L = DL>
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         reverse_broadcast_iterator<S, L> rend(const S& shape) noexcept;
 
-        template <class S, layout_type L = DL>
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_reverse_broadcast_iterator<S, L> rbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_reverse_broadcast_iterator<S, L> rend(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_reverse_broadcast_iterator<S, L> crbegin(const S& shape) const noexcept;
-        template <class S, layout_type L = DL>
+        template <class S, layout_type L = XTENSOR_DEFAULT_TRAVERSAL>
         const_reverse_broadcast_iterator<S, L> crend(const S& shape) const noexcept;
 
-        template <layout_type L = DL>
         iterator storage_begin() noexcept;
-        template <layout_type L = DL>
         iterator storage_end() noexcept;
 
-        template <layout_type L = DL>
         const_iterator storage_begin() const noexcept;
-        template <layout_type L = DL>
         const_iterator storage_end() const noexcept;
-        template <layout_type L = DL>
         const_iterator storage_cbegin() const noexcept;
-        template <layout_type L = DL>
         const_iterator storage_cend() const noexcept;
 
-        template <layout_type L = DL>
         reverse_iterator storage_rbegin() noexcept;
-        template <layout_type L = DL>
         reverse_iterator storage_rend() noexcept;
 
-        template <layout_type L = DL>
         const_reverse_iterator storage_rbegin() const noexcept;
-        template <layout_type L = DL>
         const_reverse_iterator storage_rend() const noexcept;
-        template <layout_type L = DL>
         const_reverse_iterator storage_crbegin() const noexcept;
-        template <layout_type L = DL>
         const_reverse_iterator storage_crend() const noexcept;
 
         template <class S>
@@ -257,8 +282,10 @@ namespace xt
 
         template <class align, class simd = simd_value_type>
         void store_simd(size_type i, const simd& e);
-        template <class align, class simd = simd_value_type>
-        simd load_simd(size_type i) const;
+        template <class align, class requested_type = value_type,
+                  std::size_t N = xt_simd::simd_traits<requested_type>::size>
+        xt_simd::simd_return_type<value_type, requested_type>
+        load_simd(size_type i) const;
 
     private:
 
@@ -266,8 +293,9 @@ namespace xt
 
         friend class xconst_iterable<self_type>;
         friend class xiterable<self_type>;
+        friend class xaccessible<self_type>;
+        friend class xconst_accessible<self_type>;
     };
-#undef DL
 
     namespace detail
     {
@@ -335,6 +363,9 @@ namespace xt
         using size_type = typename storage_type::size_type;
         using difference_type = typename storage_type::difference_type;
 
+        template <class requested_type>
+        using simd_return_type = xt_simd::simd_return_type<value_type, requested_type>;
+
         xscalar_stepper(storage_type* c) noexcept;
 
         reference operator*() const noexcept;
@@ -347,10 +378,10 @@ namespace xt
         void to_begin() noexcept;
         void to_end(layout_type l) noexcept;
 
-        template <class R>
-        R step_simd();
+        template <class T>
+        simd_return_type<T> step_simd();
 
-        value_type step_leading();
+        void step_leading();
 
     private:
 
@@ -423,35 +454,42 @@ namespace xt
     bool operator<(const xdummy_iterator<is_const, CT>& lhs,
                    const xdummy_iterator<is_const, CT>& rhs) noexcept;
 
-    /*******************************
-     * trivial_begin / trivial_end *
-     *******************************/
-
-    namespace detail
+    template <class T>
+    struct is_not_xdummy_iterator : std::true_type
     {
-        template <class CT>
-        constexpr auto trivial_begin(xscalar<CT>& c) noexcept -> decltype(c.dummy_begin())
-        {
-            return c.dummy_begin();
-        }
+    };
 
-        template <class CT>
-        constexpr auto trivial_end(xscalar<CT>& c) noexcept -> decltype(c.dummy_end())
-        {
-            return c.dummy_end();
-        }
+    template <bool is_const, class CT>
+    struct is_not_xdummy_iterator<xdummy_iterator<is_const, CT>> : std::false_type
+    {
+    };
 
-        template <class CT>
-        constexpr auto trivial_begin(const xscalar<CT>& c) noexcept -> decltype(c.dummy_begin())
-        {
-            return c.dummy_begin();
-        }
+    /*****************************
+     * linear_begin / linear_end *
+     *****************************/
 
-        template <class CT>
-        constexpr auto trivial_end(const xscalar<CT>& c) noexcept -> decltype(c.dummy_end())
-        {
-            return c.dummy_end();
-        }
+    template <class CT>
+    XTENSOR_CONSTEXPR_RETURN auto linear_begin(xscalar<CT>& c) noexcept -> decltype(c.dummy_begin())
+    {
+        return c.dummy_begin();
+    }
+
+    template <class CT>
+    XTENSOR_CONSTEXPR_RETURN auto linear_end(xscalar<CT>& c) noexcept -> decltype(c.dummy_end())
+    {
+        return c.dummy_end();
+    }
+
+    template <class CT>
+    XTENSOR_CONSTEXPR_RETURN auto linear_begin(const xscalar<CT>& c) noexcept -> decltype(c.dummy_begin())
+    {
+        return c.dummy_begin();
+    }
+
+    template <class CT>
+    XTENSOR_CONSTEXPR_RETURN auto linear_end(const xscalar<CT>& c) noexcept -> decltype(c.dummy_end())
+    {
+        return c.dummy_end();
     }
 
     /**************************
@@ -490,16 +528,16 @@ namespace xt
     }
 
     template <class CT>
-    inline auto xscalar<CT>::dimension() const noexcept -> size_type
-    {
-        return 0;
-    }
-
-    template <class CT>
     inline auto xscalar<CT>::shape() const noexcept -> const shape_type&
     {
         static std::array<size_type, 0> zero_shape;
         return zero_shape;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::shape(size_type) const noexcept -> size_type
+    {
+        return 0;
     }
 
     template <class CT>
@@ -518,37 +556,7 @@ namespace xt
 
     template <class CT>
     template <class... Args>
-    inline auto xscalar<CT>::at(Args... args) -> reference
-    {
-        check_dimension(shape(), args...);
-        return this->operator()(args...);
-    }
-
-    template <class CT>
-    template <class... Args>
     inline auto xscalar<CT>::unchecked(Args...) noexcept -> reference
-    {
-        return m_value;
-    }
-
-    template <class CT>
-    template <class S>
-    inline auto xscalar<CT>::operator[](const S&) noexcept
-        -> disable_integral_t<S, reference>
-    {
-        return m_value;
-    }
-
-    template <class CT>
-    template <class I>
-    inline auto xscalar<CT>::operator[](std::initializer_list<I>) noexcept
-        -> reference
-    {
-        return m_value;
-    }
-
-    template <class CT>
-    inline auto xscalar<CT>::operator[](size_type) noexcept -> reference
     {
         return m_value;
     }
@@ -563,37 +571,7 @@ namespace xt
 
     template <class CT>
     template <class... Args>
-    inline auto xscalar<CT>::at(Args... args) const -> const_reference
-    {
-        check_dimension(shape(), args...);
-        return this->operator()(args...);
-    }
-
-    template <class CT>
-    template <class... Args>
     inline auto xscalar<CT>::unchecked(Args...) const noexcept -> const_reference
-    {
-        return m_value;
-    }
-
-    template <class CT>
-    template <class S>
-    inline auto xscalar<CT>::operator[](const S&) const noexcept
-        -> disable_integral_t<S, const_reference>
-    {
-        return m_value;
-    }
-
-    template <class CT>
-    template <class I>
-    inline auto xscalar<CT>::operator[](std::initializer_list<I>) const noexcept
-        -> const_reference
-    {
-        return m_value;
-    }
-
-    template <class CT>
-    inline auto xscalar<CT>::operator[](size_type) const noexcept -> const_reference
     {
         return m_value;
     }
@@ -613,6 +591,18 @@ namespace xt
     }
 
     template <class CT>
+    inline auto xscalar<CT>::expression() noexcept -> xexpression_type&
+    {
+        return m_value;
+    }
+
+    template <class CT>
+    inline auto xscalar<CT>::expression() const noexcept -> const xexpression_type&
+    {
+        return m_value;
+    }
+
+    template <class CT>
     template <class S>
     inline bool xscalar<CT>::broadcast_shape(S&, bool) const noexcept
     {
@@ -621,7 +611,7 @@ namespace xt
 
     template <class CT>
     template <class S>
-    inline bool xscalar<CT>::is_trivial_broadcast(const S&) const noexcept
+    inline bool xscalar<CT>::has_linear_assign(const S&) const noexcept
     {
         return true;
     }
@@ -672,14 +662,14 @@ namespace xt
     template <layout_type L>
     inline auto xscalar<CT>::rbegin() noexcept -> reverse_iterator
     {
-        return reverse_storage_iterator(end());
+        return reverse_iterator(end());
     }
 
     template <class CT>
     template <layout_type L>
     inline auto xscalar<CT>::rend() noexcept -> reverse_iterator
     {
-        return reverse_storage_iterator(begin());
+        return reverse_iterator(begin());
     }
 
     template <class CT>
@@ -700,14 +690,14 @@ namespace xt
     template <layout_type L>
     inline auto xscalar<CT>::crbegin() const noexcept -> const_reverse_iterator
     {
-        return const_reverse_storage_iterator(cend());
+        return const_reverse_iterator(cend());
     }
 
     template <class CT>
     template <layout_type L>
     inline auto xscalar<CT>::crend() const noexcept -> const_reverse_iterator
     {
-        return const_reverse_storage_iterator(cbegin());
+        return const_reverse_iterator(cbegin());
     }
 
     /*****************************
@@ -799,87 +789,75 @@ namespace xt
     }
 
     template <class CT>
-    template <layout_type L>
     inline auto xscalar<CT>::storage_begin() noexcept -> iterator
     {
-        return this->template begin<L>();
+        return this->template begin<XTENSOR_DEFAULT_LAYOUT>();
     }
 
     template <class CT>
-    template <layout_type L>
     inline auto xscalar<CT>::storage_end() noexcept -> iterator
     {
-        return this->template end<L>();
+        return this->template end<XTENSOR_DEFAULT_LAYOUT>();
     }
 
     template <class CT>
-    template <layout_type L>
     inline auto xscalar<CT>::storage_begin() const noexcept -> const_iterator
     {
-        return this->template begin<L>();
+        return this->template begin<XTENSOR_DEFAULT_LAYOUT>();
     }
 
     template <class CT>
-    template <layout_type L>
     inline auto xscalar<CT>::storage_end() const noexcept -> const_iterator
     {
-        return this->template end<L>();
+        return this->template end<XTENSOR_DEFAULT_LAYOUT>();
     }
 
     template <class CT>
-    template <layout_type L>
     inline auto xscalar<CT>::storage_cbegin() const noexcept -> const_iterator
     {
-        return this->template cbegin<L>();
+        return this->template cbegin<XTENSOR_DEFAULT_LAYOUT>();
     }
 
     template <class CT>
-    template <layout_type L>
     inline auto xscalar<CT>::storage_cend() const noexcept -> const_iterator
     {
-        return this->template cend<L>();
+        return this->template cend<XTENSOR_DEFAULT_LAYOUT>();
     }
 
     template <class CT>
-    template <layout_type L>
     inline auto xscalar<CT>::storage_rbegin() noexcept -> reverse_iterator
     {
-        return this->template rbegin<L>();
+        return this->template rbegin<XTENSOR_DEFAULT_LAYOUT>();
     }
 
     template <class CT>
-    template <layout_type L>
     inline auto xscalar<CT>::storage_rend() noexcept -> reverse_iterator
     {
-        return this->template rend<L>();
+        return this->template rend<XTENSOR_DEFAULT_LAYOUT>();
     }
 
     template <class CT>
-    template <layout_type L>
     inline auto xscalar<CT>::storage_rbegin() const noexcept -> const_reverse_iterator
     {
-        return this->template rbegin<L>();
+        return this->template rbegin<XTENSOR_DEFAULT_LAYOUT>();
     }
 
     template <class CT>
-    template <layout_type L>
     inline auto xscalar<CT>::storage_rend() const noexcept -> const_reverse_iterator
     {
-        return this->template rend<L>();
+        return this->template rend<XTENSOR_DEFAULT_LAYOUT>();
     }
 
     template <class CT>
-    template <layout_type L>
     inline auto xscalar<CT>::storage_crbegin() const noexcept -> const_reverse_iterator
     {
-        return this->template crbegin<L>();
+        return this->template crbegin<XTENSOR_DEFAULT_LAYOUT>();
     }
 
     template <class CT>
-    template <layout_type L>
     inline auto xscalar<CT>::storage_crend() const noexcept -> const_reverse_iterator
     {
-        return this->template crend<L>();
+        return this->template crend<XTENSOR_DEFAULT_LAYOUT>();
     }
 
     template <class CT>
@@ -954,10 +932,11 @@ namespace xt
     }
 
     template <class CT>
-    template <class align, class simd>
-    inline auto xscalar<CT>::load_simd(size_type) const -> simd
+    template <class align, class requested_type, std::size_t N>
+    inline auto xscalar<CT>::load_simd(size_type) const
+        -> xt_simd::simd_return_type<value_type, requested_type>
     {
-        return xsimd::set_simd<value_type, typename simd::value_type>(m_value);
+        return xt_simd::set_simd<value_type, requested_type>(m_value);
     }
 
     template <class T>
@@ -1019,17 +998,15 @@ namespace xt
     }
 
     template <bool is_const, class CT>
-    template <class R>
-    inline R xscalar_stepper<is_const, CT>::step_simd()
+    template <class T>
+    inline auto xscalar_stepper<is_const, CT>::step_simd() -> simd_return_type<T>
     {
-        return R(p_c->operator()());
+        return simd_return_type<T>(p_c->operator()());
     }
 
     template <bool is_const, class CT>
-    inline auto xscalar_stepper<is_const, CT>::step_leading()
-        -> value_type
+    inline void xscalar_stepper<is_const, CT>::step_leading()
     {
-        return p_c->operator()();
     }
 
     /**********************************

--- a/vendor/xtensor/include/xtensor/xsemantic.hpp
+++ b/vendor/xtensor/include/xtensor/xsemantic.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -13,10 +14,36 @@
 #include <utility>
 
 #include "xassign.hpp"
-#include "xexpression.hpp"
+#include "xexpression_traits.hpp"
 
 namespace xt
 {
+    namespace detail
+    {
+        template <class D>
+        struct is_sharable
+        {
+            static constexpr bool value = true;
+        };
+
+        template <class ET, class S, layout_type L, bool SH, class Tag>
+        struct is_sharable<xfixed_container<ET, S, L, SH, Tag>>
+        {
+            static constexpr bool value = SH;
+        };
+
+        template <class ET, class S, layout_type L, bool SH, class Tag>
+        struct is_sharable<xfixed_adaptor<ET, S, L, SH, Tag>>
+        {
+            static constexpr bool value = SH;
+        };
+    }
+
+    template <class D>
+    using select_expression_base_t = std::conditional_t<detail::is_sharable<D>::value,
+                                                        xsharable_expression<D>,
+                                                        xexpression<D>>;
+
     /**
      * @class xsemantic_base
      * @brief Base interface for assignable xexpressions.
@@ -28,11 +55,11 @@ namespace xt
      *           provides the interface.
      */
     template <class D>
-    class xsemantic_base : public xexpression<D>
+    class xsemantic_base : public select_expression_base_t<D>
     {
     public:
 
-        using base_type = xexpression<D>;
+        using base_type = select_expression_base_t<D>;
         using derived_type = typename base_type::derived_type;
 
         using temporary_type = typename xcontainer_inner_types<D>::temporary_type;
@@ -103,6 +130,15 @@ namespace xt
         template <class E>
         derived_type& modulus_assign(const xexpression<E>&);
 
+        template <class E>
+        derived_type& bit_and_assign(const xexpression<E>&);
+
+        template <class E>
+        derived_type& bit_or_assign(const xexpression<E>&);
+
+        template <class E>
+        derived_type& bit_xor_assign(const xexpression<E>&);
+
     protected:
 
         xsemantic_base() = default;
@@ -117,6 +153,15 @@ namespace xt
         template <class E>
         derived_type& operator=(const xexpression<E>&);
     };
+
+    template <class E>
+    using is_assignable = is_crtp_base_of<xsemantic_base, E>;
+
+    template <class E, class R = void>
+    using enable_assignable = typename std::enable_if<is_assignable<E>::value, R>::type;
+
+    template <class E, class R = void>
+    using disable_assignable = typename std::enable_if<!is_assignable<E>::value, R>::type;
 
     /**
      * @class xcontainer_semantic
@@ -164,21 +209,8 @@ namespace xt
         derived_type& operator=(const xexpression<E>&);
     };
 
-    namespace detail
-    {
-        template <class E>
-        struct has_container_semantics_impl : std::is_base_of<xcontainer_semantic<std::decay_t<E>>, std::decay_t<E>>
-        {
-        };
-
-        template <class E>
-        struct has_container_semantics_impl<xcontainer_semantic<E>> : std::true_type
-        {
-        };
-    }
-
     template <class E>
-    using has_container_semantics = detail::has_container_semantics_impl<E>;
+    using has_container_semantics = is_crtp_base_of<xcontainer_semantic, E>;
 
     template <class E, class R = void>
     using enable_xcontainer_semantics = typename std::enable_if<has_container_semantics<E>::value, R>::type;
@@ -231,21 +263,8 @@ namespace xt
         derived_type& operator=(const xexpression<E>&);
     };
 
-    namespace detail
-    {
-        template <class E>
-        struct has_view_semantics_impl : std::is_base_of<xview_semantic<std::decay_t<E>>, std::decay_t<E>>
-        {
-        };
-
-        template <class E>
-        struct has_view_semantics_impl<xview_semantic<E>> : std::true_type
-        {
-        };
-    }
-
     template <class E>
-    using has_view_semantics = detail::has_view_semantics_impl<E>;
+    using has_view_semantics = is_crtp_base_of<xview_semantic, E>;
 
     template <class E, class R = void>
     using enable_xview_semantics = typename std::enable_if<has_view_semantics<E>::value, R>::type;
@@ -535,6 +554,45 @@ namespace xt
         return this->derived_cast().computed_assign(this->derived_cast() % e.derived_cast());
     }
 
+    /**
+     * Computes the bitwise and of \c e to \c *this. Ensures no temporary
+     * will be used to perform the assignment.
+     * @param e the xexpression to add.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::bit_and_assign(const xexpression<E>& e) -> derived_type&
+    {
+        return this->derived_cast().computed_assign(this->derived_cast() & e.derived_cast());
+    }
+
+    /**
+     * Computes the bitwise or of \c e to \c *this. Ensures no temporary
+     * will be used to perform the assignment.
+     * @param e the xexpression to add.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::bit_or_assign(const xexpression<E>& e) -> derived_type&
+    {
+        return this->derived_cast().computed_assign(this->derived_cast() | e.derived_cast());
+    }
+
+    /**
+     * Computes the bitwise xor of \c e to \c *this. Ensures no temporary
+     * will be used to perform the assignment.
+     * @param e the xexpression to add.
+     * @return a reference to \c *this.
+     */
+    template <class D>
+    template <class E>
+    inline auto xsemantic_base<D>::bit_xor_assign(const xexpression<E>& e) -> derived_type&
+    {
+        return this->derived_cast().computed_assign(this->derived_cast() ^ e.derived_cast());
+    }
+
     template <class D>
     template <class E>
     inline auto xsemantic_base<D>::operator=(const xexpression<E>& e) -> derived_type&
@@ -605,12 +663,32 @@ namespace xt
         return this->derived_cast();
     }
 
+    namespace detail
+    {
+        template <class F>
+        bool get_rhs_triviality(const F&)
+        {
+            return true;
+        }
+
+        template <class F, class R, class... CT>
+        bool get_rhs_triviality(const xfunction<F, R, CT...>& rhs)
+        {
+            using index_type = xindex_type_t<typename xfunction<F, R, CT...>::shape_type>;
+            using size_type = typename index_type::size_type;
+            size_type size = rhs.dimension();
+            index_type shape = uninitialized_shape<index_type>(size);
+            bool trivial_broadcast = rhs.broadcast_shape(shape, true);
+            return trivial_broadcast;
+        }
+    }
+
     template <class D>
     template <class E>
     inline auto xview_semantic<D>::assign_xexpression(const xexpression<E>& e) -> derived_type&
     {
         xt::assert_compatible_shape(*this, e);
-        xt::assign_data(*this, e, false);
+        xt::assign_data(*this, e, detail::get_rhs_triviality(e.derived_cast()));
         return this->derived_cast();
     }
 
@@ -619,8 +697,23 @@ namespace xt
     inline auto xview_semantic<D>::computed_assign(const xexpression<E>& e) -> derived_type&
     {
         xt::assert_compatible_shape(*this, e);
-        xt::assign_data(*this, e, false);
+        xt::assign_data(*this, e, detail::get_rhs_triviality(e.derived_cast()));
         return this->derived_cast();
+    }
+
+    namespace xview_semantic_detail
+    {
+        template <class D>
+        auto get_begin(D&& lhs, std::true_type)
+        {
+            return lhs.storage_begin();
+        }
+
+        template <class D>
+        auto get_begin(D&& lhs, std::false_type)
+        {
+            return lhs.begin();
+        }
     }
 
     template <class D>
@@ -628,26 +721,33 @@ namespace xt
     inline auto xview_semantic<D>::scalar_computed_assign(const E& e, F&& f) -> derived_type&
     {
         D& d = this->derived_cast();
-        std::transform(d.begin(), d.end(), d.begin(),
-                       [e, &f](const auto& v) { return f(v, e); });
+
+        using size_type = typename D::size_type;
+        auto dst = xview_semantic_detail::get_begin(d, std::integral_constant<bool, D::contiguous_layout>());
+        for (size_type i = d.size(); i > 0; --i)
+        {
+            *dst = f(*dst, e);
+            ++dst;
+        }
         return this->derived_cast();
     }
 
     template <class D>
     template <class E>
-    inline auto xview_semantic<D>::operator=(const xexpression<E>& e) -> derived_type&
+    inline auto xview_semantic<D>::operator=(const xexpression<E>& rhs) -> derived_type&
     {
-        bool cond = (e.derived_cast().shape().size() == this->derived_cast().dimension()) &&
+        bool cond = (rhs.derived_cast().shape().size() == this->derived_cast().dimension()) &&
             std::equal(this->derived_cast().shape().begin(),
                        this->derived_cast().shape().end(),
-                       e.derived_cast().shape().begin());
+                       rhs.derived_cast().shape().begin());
+
         if (!cond)
         {
-            base_type::operator=(broadcast(e.derived_cast(), this->derived_cast().shape()));
+            base_type::operator=(broadcast(rhs.derived_cast(), this->derived_cast().shape()));
         }
         else
         {
-            base_type::operator=(e);
+            base_type::operator=(rhs);
         }
         return this->derived_cast();
     }

--- a/vendor/xtensor/include/xtensor/xshape.hpp
+++ b/vendor/xtensor/include/xtensor/xshape.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -18,8 +19,9 @@
 #include <iterator>
 #include <memory>
 
-#include "xexception.hpp"
+#include "xlayout.hpp"
 #include "xstorage.hpp"
+#include "xtensor_forward.hpp"
 
 namespace xt
 {
@@ -33,6 +35,185 @@ namespace xt
     class fixed_shape;
 
     using xindex = dynamic_shape<std::size_t>;
+    
+    template <class S1, class S2>
+    bool same_shape(const S1& s1, const S2& s2) noexcept;
+
+    template <class U>
+    struct initializer_dimension;
+
+    template <class R, class T>
+    constexpr R shape(T t);
+
+    template<class R = std::size_t, class T, std::size_t N>
+    xt::static_shape<R, N> shape(const T(&aList)[N]);
+
+    template <class S>
+    struct static_dimension;
+
+    template <layout_type L, class S>
+    struct select_layout;
+
+    template <class... S>
+    struct promote_shape;
+
+    template <class... S>
+    struct promote_strides;
+
+    template <class S>
+    struct index_from_shape;
+}
+
+namespace xtl
+{
+    namespace detail
+    {
+        template <class S>
+        struct sequence_builder;
+
+        template <std::size_t... I>
+        struct sequence_builder<xt::fixed_shape<I...>>
+        {
+            using sequence_type = xt::fixed_shape<I...>;
+            using value_type = typename sequence_type::value_type;
+
+            inline static sequence_type make(std::size_t /*size*/)
+            {
+                return sequence_type{};
+            }
+
+            inline static sequence_type make(std::size_t /*size*/, value_type /*v*/)
+            {
+                return sequence_type{};
+            }
+        };
+    }
+}
+
+namespace xt
+{
+    /**************
+     * same_shape *
+     **************/
+
+    template <class S1, class S2>
+    inline bool same_shape(const S1& s1, const S2& s2) noexcept
+    {
+        return s1.size() == s2.size() && std::equal(s1.begin(), s1.end(), s2.begin());
+    }
+
+    /*************************
+     * initializer_dimension *
+     *************************/
+
+    namespace detail
+    {
+        template <class U>
+        struct initializer_depth_impl
+        {
+            static constexpr std::size_t value = 0;
+        };
+
+        template <class T>
+        struct initializer_depth_impl<std::initializer_list<T>>
+        {
+            static constexpr std::size_t value = 1 + initializer_depth_impl<T>::value;
+        };
+    }
+
+    template <class U>
+    struct initializer_dimension
+    {
+        static constexpr std::size_t value = detail::initializer_depth_impl<U>::value;
+    };
+
+    /*********************
+     * initializer_shape *
+     *********************/
+
+    namespace detail
+    {
+        template <std::size_t I>
+        struct initializer_shape_impl
+        {
+            template <class T>
+            static constexpr std::size_t value(T t)
+            {
+                return t.size() == 0 ? 0 : initializer_shape_impl<I - 1>::value(*t.begin());
+            }
+        };
+
+        template <>
+        struct initializer_shape_impl<0>
+        {
+            template <class T>
+            static constexpr std::size_t value(T t)
+            {
+                return t.size();
+            }
+        };
+
+        template <class R, class U, std::size_t... I>
+        constexpr R initializer_shape(U t, std::index_sequence<I...>)
+        {
+            using size_type = typename R::value_type;
+            return {size_type(initializer_shape_impl<I>::value(t))...};
+        }
+    }
+
+    template <class R, class T>
+    constexpr R shape(T t)
+    {
+        return detail::initializer_shape<R, decltype(t)>(t, std::make_index_sequence<initializer_dimension<decltype(t)>::value>());
+    }
+
+    /** @brief Generate an xt::static_shape of the given size. */
+    template<class R, class T, std::size_t N>
+    xt::static_shape<R, N> shape(const T(&list)[N]) {
+        xt::static_shape<R, N> shape;
+        std::copy(std::begin(list), std::end(list), std::begin(shape));
+        return shape;
+    }
+
+    /********************
+     * static_dimension *
+     ********************/
+
+    namespace detail
+    {
+        template <class T, class E = void>
+        struct static_dimension_impl
+        {
+            static constexpr std::ptrdiff_t value = -1;
+        };
+
+        template <class T>
+        struct static_dimension_impl<T, void_t<decltype(std::tuple_size<T>::value)>>
+        {
+            static constexpr std::ptrdiff_t value = static_cast<std::ptrdiff_t>(std::tuple_size<T>::value);
+        };
+    }
+
+    template <class S>
+    struct static_dimension
+    {
+        static constexpr std::ptrdiff_t value = detail::static_dimension_impl<S>::value;
+    };
+
+    /**
+     * Compute a layout based on a layout and a shape type.
+     *
+     * The main functionality of this function is that it reduces vectors to
+     * ``layout_type::any`` so that assigning a row major 1D container to another
+     * row_major container becomes free.
+     */
+    template <layout_type L, class S>
+    struct select_layout
+    {
+        constexpr static std::ptrdiff_t static_dimension = xt::static_dimension<S>::value;
+        constexpr static bool is_any = static_dimension != -1 && static_dimension <= 1 && L != layout_type::dynamic;
+        constexpr static layout_type value = is_any ? layout_type::any : L;
+    };
 
     /*************************************
      * promote_shape and promote_strides *
@@ -61,6 +242,60 @@ namespace xt
         {
         };
 
+        // Broadcasting for fixed shapes
+        template <std::size_t IDX, std::size_t... X>
+        struct at
+        {
+            constexpr static std::size_t arr[sizeof...(X)] = {X...};
+            constexpr static std::size_t value = (IDX < sizeof...(X)) ? arr[IDX] : 0;
+        };
+
+        template <class S1, class S2>
+        struct broadcast_fixed_shape;
+
+        template <class IX, class A, class B>
+        struct broadcast_fixed_shape_impl;
+
+        template <std::size_t IX, class A, class B>
+        struct broadcast_fixed_shape_cmp_impl;
+
+        template <std::size_t JX, std::size_t... I, std::size_t... J>
+        struct broadcast_fixed_shape_cmp_impl<JX, fixed_shape<I...>, fixed_shape<J...>>
+        {
+            //We line the shapes up from the last index
+            //IX may underflow, thus being a very large number
+            static constexpr std::size_t IX = JX - (sizeof...(J) - sizeof...(I));
+
+            //Out of bounds access gives value 0
+            static constexpr std::size_t I_v = at<IX, I...>::value;
+            static constexpr std::size_t J_v = at<JX, J...>::value;
+
+            // we're statically checking if the broadcast shapes are either one on either of them or equal
+            static_assert(!I_v ||  I_v == 1 || J_v == 1 || J_v == I_v, "broadcast shapes do not match.");
+
+            static constexpr std::size_t ordinate = (I_v > J_v) ? I_v : J_v;
+            static constexpr bool value = (I_v == J_v);
+        };
+
+        template <std::size_t... JX, std::size_t... I, std::size_t... J>
+        struct broadcast_fixed_shape_impl<std::index_sequence<JX...>, fixed_shape<I...>, fixed_shape<J...>>
+        {
+            static_assert(sizeof... (J) >= sizeof... (I), "broadcast shapes do not match.");
+
+            using type = xt::fixed_shape<broadcast_fixed_shape_cmp_impl<JX, fixed_shape<I...>, fixed_shape<J...>>::ordinate...>;
+            static constexpr bool value = xtl::conjunction<broadcast_fixed_shape_cmp_impl<JX, fixed_shape<I...>, fixed_shape<J...>>...>::value;
+        };
+
+        /* broadcast_fixed_shape<fixed_shape<I...>, fixed_shape<J...>>
+         * Just like a call to broadcast_shape(cont S1& input, S2& output),
+         * except that the result shape is alised as type, and the returned
+         * bool is the member value. Asserts on an illegal broadcast, including
+         * the case where pack I is strictly longer than pack J. */
+
+        template <std::size_t... I, std::size_t... J>
+        struct broadcast_fixed_shape<fixed_shape<I...>, fixed_shape<J...>>
+            : broadcast_fixed_shape_impl<std::make_index_sequence<sizeof...(J)>, fixed_shape<I...>, fixed_shape<J...>> {};
+
         // Simple is_array and only_array meta-functions
         template <class S>
         struct is_array
@@ -74,46 +309,158 @@ namespace xt
             static constexpr bool value = true;
         };
 
+        template <class S>
+        struct is_fixed : std::false_type
+        {
+        };
+
+        template <std::size_t... N>
+        struct is_fixed<fixed_shape<N...>>
+            : std::true_type
+        {
+        };
+
+        template <class S>
+        struct is_scalar_shape
+        {
+            static constexpr bool value = false;
+        };
+
+        template <class T>
+        struct is_scalar_shape<std::array<T, 0>>
+        {
+            static constexpr bool value = true;
+        };
+
         template <class... S>
-        using only_array = xtl::conjunction<is_array<S>...>;
+        using only_array = xtl::conjunction<xtl::disjunction<is_array<S>, is_fixed<S>>...>;
+
+        // test that at least one argument is a fixed shape. If yes, then either argument has to be fixed or scalar
+        template <class... S>
+        using only_fixed = std::integral_constant<bool, xtl::disjunction<is_fixed<S>...>::value &&
+                                                        xtl::conjunction<xtl::disjunction<is_fixed<S>, is_scalar_shape<S>>...>::value>;
 
         // The promote_index meta-function returns std::vector<promoted_value_type> in the
         // general case and an array of the promoted value type and maximal size if all
         // arguments are of type std::array
 
-        template <bool A, class... S>
-        struct promote_index_impl;
-
         template <class... S>
-        struct promote_index_impl<false, S...>
-        {
-            using type = dynamic_shape<typename std::common_type<typename S::value_type...>::type>;
-        };
-
-        template <class... S>
-        struct promote_index_impl<true, S...>
+        struct promote_array
         {
             using type = std::array<typename std::common_type<typename S::value_type...>::type, max_array_size<S...>::value>;
         };
 
         template <>
-        struct promote_index_impl<true>
+        struct promote_array<>
         {
             using type = std::array<std::size_t, 0>;
         };
 
-        template <class... S>
-        struct promote_index
+        template <class S>
+        struct filter_scalar
         {
-            using type = typename promote_index_impl<only_array<S...>::value, S...>::type;
+            using type = S;
+        };
+
+        template <class T>
+        struct filter_scalar<std::array<T, 0>>
+        {
+            using type = fixed_shape<1>;
+        };
+
+        template <class S>
+        using filter_scalar_t = typename filter_scalar<S>::type;
+
+        template <class... S>
+        struct promote_fixed : promote_fixed<filter_scalar_t<S>...> {};
+
+        template <std::size_t... I>
+        struct promote_fixed<fixed_shape<I...>>
+        {
+            using type = fixed_shape<I...>;
+            static constexpr bool value = true;
+        };
+
+        template <std::size_t... I, std::size_t... J, class... S>
+        struct promote_fixed<fixed_shape<I...>, fixed_shape<J...>, S...>
+        {
+        private:
+
+            using intermediate = std::conditional_t< (sizeof... (I) > sizeof... (J)),
+                broadcast_fixed_shape<fixed_shape<J...>, fixed_shape<I...>>,
+                broadcast_fixed_shape<fixed_shape<I...>, fixed_shape<J...>>>;
+            using result = promote_fixed<typename intermediate::type, S...>;
+
+        public:
+
+            using type = typename result::type;
+            static constexpr bool value = xtl::conjunction<intermediate, result>::value;
+        };
+
+        template <bool all_index, bool all_array, class... S>
+        struct select_promote_index;
+
+        template <class... S>
+        struct select_promote_index<true, true, S...> : promote_fixed<S...> {};
+
+        template <>
+        struct select_promote_index<true, true>
+        {
+            // todo correct? used in xvectorize
+            using type = dynamic_shape<std::size_t>;
+        };
+
+        template <class... S>
+        struct select_promote_index<false, true, S...> : promote_array<S...> {};
+
+        template <class... S>
+        struct select_promote_index<false, false, S...>
+        {
+            using type = dynamic_shape<typename std::common_type<typename S::value_type...>::type>;
+        };
+
+        template <class... S>
+        struct promote_index : select_promote_index<only_fixed<S...>::value, only_array<S...>::value, S...> {};
+
+        template <class T>
+        struct index_from_shape_impl
+        {
+            using type = T;
+        };
+
+        template <std::size_t... N>
+        struct index_from_shape_impl<fixed_shape<N...>>
+        {
+            using type = std::array<std::size_t, sizeof...(N)>;
         };
     }
 
     template <class... S>
-    using promote_shape_t = typename detail::promote_index<S...>::type;
+    struct promote_shape
+    {
+        using type = typename detail::promote_index<S...>::type;
+    };
 
     template <class... S>
-    using promote_strides_t = typename detail::promote_index<S...>::type;
+    using promote_shape_t = typename promote_shape<S...>::type;
+
+    template <class... S>
+    struct promote_strides
+    {
+        using type = typename detail::promote_index<S...>::type;
+    };
+
+    template <class... S>
+    using promote_strides_t = typename promote_strides<S...>::type;
+
+    template <class S>
+    struct index_from_shape
+    {
+        using type = typename detail::index_from_shape_impl<S>::type;
+    };
+
+    template <class S>
+    using index_from_shape_t = typename index_from_shape<S>::type;
 }
 
 #endif

--- a/vendor/xtensor/include/xtensor/xslice.hpp
+++ b/vendor/xtensor/include/xtensor/xslice.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -12,11 +13,12 @@
 #include <cstddef>
 #include <type_traits>
 #include <utility>
+#include <map>
 
 #include <xtl/xtype_traits.hpp>
 
+#include "xstorage.hpp"
 #include "xutils.hpp"
-
 
 #ifndef XTENSOR_CONSTEXPR
     #if(defined(_MSC_VER) || __GNUC__ < 8)
@@ -30,91 +32,6 @@
 
 namespace xt
 {
-    struct xall_tag {};
-    struct xnewaxis_tag {};
-    struct xellipsis_tag {};
-
-    template <class A, class B, class C>
-    struct xrange_adaptor;
-
-    namespace placeholders
-    {
-        // xtensor universal placeholder
-        struct xtuph {};
-
-        template <class... Args>
-        struct rangemaker
-        {
-            ptrdiff_t rng[3];// = { 0, 0, 0 };
-        };
-
-        XTENSOR_CONSTEXPR xtuph get_tuph_or_val(std::ptrdiff_t /*val*/, std::true_type)
-        {
-            return xtuph();
-        }
-
-        XTENSOR_CONSTEXPR std::ptrdiff_t get_tuph_or_val(std::ptrdiff_t val, std::false_type)
-        {
-            return val;
-        }
-
-        template <class A, class B, class C>
-        struct rangemaker<A, B, C>
-        {
-            XTENSOR_CONSTEXPR operator xrange_adaptor<A, B, C>()
-            {
-                return {
-                    get_tuph_or_val(rng[0], std::is_same<A, xtuph>()),
-                    get_tuph_or_val(rng[1], std::is_same<B, xtuph>()),
-                    get_tuph_or_val(rng[2], std::is_same<C, xtuph>())
-                };
-            }
-
-            ptrdiff_t rng[3];// = { 0, 0, 0 };
-        };
-
-        template <class A, class B>
-        struct rangemaker<A, B>
-        {
-            XTENSOR_CONSTEXPR operator xrange_adaptor<A, B, xt::placeholders::xtuph>()
-            {
-                return {
-                    get_tuph_or_val(rng[0], std::is_same<A, xtuph>()),
-                    get_tuph_or_val(rng[1], std::is_same<B, xtuph>()),
-                    xtuph()
-                };
-            }
-
-            ptrdiff_t rng[3];// = { 0, 0, 0 };
-        };
-
-        template <class... OA>
-        XTENSOR_CONSTEXPR auto operator|(const rangemaker<OA...>& rng, const std::ptrdiff_t& t)
-        {
-            auto nrng = rangemaker<OA..., ptrdiff_t>{rng.rng[0], rng.rng[1], rng.rng[2]};
-            nrng.rng[sizeof...(OA)] = t;
-            return nrng; 
-        }
-
-        template <class... OA>
-        XTENSOR_CONSTEXPR auto operator|(const rangemaker<OA...>& rng, const xt::placeholders::xtuph& /*t*/)
-        {
-            auto nrng = rangemaker<OA..., xt::placeholders::xtuph>{rng.rng[0], rng.rng[1], rng.rng[2]};
-            return nrng;
-        }
-
-
-        XTENSOR_GLOBAL_CONSTEXPR xtuph _{};
-        XTENSOR_GLOBAL_CONSTEXPR rangemaker<> _r{0, 0, 0};
-        XTENSOR_GLOBAL_CONSTEXPR xall_tag _a{};
-        XTENSOR_GLOBAL_CONSTEXPR xnewaxis_tag _n{};
-        XTENSOR_GLOBAL_CONSTEXPR xellipsis_tag _e{};
-    }
-
-    inline auto xnone()
-    {
-        return placeholders::xtuph();
-    }
 
     /**********************
      * xslice declaration *
@@ -151,6 +68,23 @@ namespace xt
     template <class... E>
     using has_xslice = xtl::disjunction<is_xslice<E>...>;
 
+    /**************
+     * slice tags *
+     **************/
+
+#define DEFINE_TAG_CONVERSION(NAME)                 \
+    template <class T>                              \
+    XTENSOR_CONSTEXPR NAME convert() const noexcept \
+    {                                               \
+        return NAME();                              \
+    }
+
+    struct xall_tag { DEFINE_TAG_CONVERSION(xall_tag) };
+    struct xnewaxis_tag { DEFINE_TAG_CONVERSION(xnewaxis_tag) };
+    struct xellipsis_tag { DEFINE_TAG_CONVERSION(xellipsis_tag) };
+
+#undef DEFINE_TAG_CONVERSION
+
     /**********************
      * xrange declaration *
      **********************/
@@ -165,6 +99,14 @@ namespace xt
 
         xrange() = default;
         xrange(size_type start_val, size_type stop_val) noexcept;
+
+        template <class S, typename = std::enable_if_t<std::is_convertible<S, T>::value, void>>
+        operator xrange<S>() const noexcept;
+
+        // Same as implicit conversion operator but more convenient to call
+        // from a variant visitor
+        template <class S, typename = std::enable_if_t<std::is_convertible<S, T>::value, void>>
+        xrange<S> convert() const noexcept;
 
         size_type operator()(size_type i) const noexcept;
 
@@ -182,6 +124,9 @@ namespace xt
 
         size_type m_start;
         size_type m_size;
+
+        template <class S>
+        friend class xrange;
     };
 
     /******************************
@@ -198,6 +143,14 @@ namespace xt
 
         xstepped_range() = default;
         xstepped_range(size_type start_val, size_type stop_val, size_type step) noexcept;
+
+        template <class S, typename = std::enable_if_t<std::is_convertible<S, T>::value, void>>
+        operator xstepped_range<S>() const noexcept;
+
+        // Same as implicit conversion operator but more convenient to call
+        // from a variant visitor
+        template <class S, typename = std::enable_if_t<std::is_convertible<S, T>::value, void>>
+        xstepped_range<S> convert() const noexcept;
 
         size_type operator()(size_type i) const noexcept;
 
@@ -216,6 +169,9 @@ namespace xt
         size_type m_start;
         size_type m_size;
         size_type m_step;
+
+        template <class S>
+        friend class xstepped_range;
     };
 
     /********************
@@ -232,6 +188,14 @@ namespace xt
 
         xall() = default;
         explicit xall(size_type size) noexcept;
+
+        template <class S, typename = std::enable_if_t<std::is_convertible<S, T>::value, void>>
+        operator xall<S>() const noexcept;
+
+        // Same as implicit conversion operator but more convenient to call
+        // from a variant visitor
+        template <class S, typename = std::enable_if_t<std::is_convertible<S, T>::value, void>>
+        xall<S> convert() const noexcept;
 
         size_type operator()(size_type i) const noexcept;
 
@@ -291,8 +255,17 @@ namespace xt
     public:
 
         using size_type = T;
+        using self_type = xnewaxis<T>;
 
         xnewaxis() = default;
+
+        template <class S, typename = std::enable_if_t<std::is_convertible<S, T>::value, void>>
+        operator xnewaxis<S>() const noexcept;
+
+        // Same as implicit conversion operator but more convenient to call
+        // from a variant visitor
+        template <class S, typename = std::enable_if_t<std::is_convertible<S, T>::value, void>>
+        xnewaxis<S> convert() const noexcept;
 
         size_type operator()(size_type i) const noexcept;
 
@@ -302,6 +275,9 @@ namespace xt
         size_type revert_index(std::size_t i) const noexcept;
 
         bool contains(size_type i) const noexcept;
+
+        bool operator==(const self_type& rhs) const noexcept;
+        bool operator!=(const self_type& rhs) const noexcept;
     };
 
     /**
@@ -314,142 +290,261 @@ namespace xt
         return xnewaxis_tag();
     }
 
+    /***************************
+     * xkeep_slice declaration *
+     ***************************/
+
     template <class T>
-    class xislice : public xslice<xislice<T>>
+    class xkeep_slice;
+
+    namespace detail
+    {
+        template <class T>
+        struct is_xkeep_slice : std::false_type
+        {
+        };
+
+        template <class T>
+        struct is_xkeep_slice<xkeep_slice<T>> : std::true_type
+        {
+        };
+
+        template <class T>
+        using disable_xkeep_slice_t = std::enable_if_t<!is_xkeep_slice<std::decay_t<T>>::value, void>;
+
+        template <class T>
+        using enable_xkeep_slice_t = std::enable_if_t<is_xkeep_slice<std::decay_t<T>>::value, void>;
+    }
+
+    template <class T>
+    class xkeep_slice : public xslice<xkeep_slice<T>>
     {
     public:
 
-        using container_type = std::decay_t<T>;
+        using container_type = svector<T>;
         using size_type = typename container_type::value_type;
+        using self_type = xkeep_slice<T>;
 
-        explicit xislice(const container_type& cont)
-            : m_indices(cont)
-        {
-        }
+        template <class C, typename = detail::disable_xkeep_slice_t<C>>
+        explicit xkeep_slice(C& cont);
+        explicit xkeep_slice(container_type&& cont);
 
-        explicit xislice(container_type&& cont)
-            : m_indices(std::move(cont))
-        {
-        }
+        template <class S>
+        xkeep_slice(std::initializer_list<S> t);
 
-        size_type operator()(size_type i) const noexcept
-        {
-            return m_indices[i];
-        }
+        template <class S, typename = std::enable_if_t<std::is_convertible<S, T>::value, void>>
+        operator xkeep_slice<S>() const noexcept;
 
-        size_type size() const noexcept
-        {
-            // TODO change return type to container_type::size_type (e.g. size_t?)
-            return static_cast<size_type>(m_indices.size());
-        }
+        // Same as implicit conversion operator but more convenient to call
+        // from a variant visitor
+        template <class S, typename = std::enable_if_t<std::is_convertible<S, T>::value, void>>
+        xkeep_slice<S> convert() const noexcept;
 
-        size_type step_size(std::size_t i, std::size_t n = 1) const noexcept
-        {
-            // special case one-past-end step (should be removed soon)
-            if (i == static_cast<size_type>(m_indices.size()))
-            {
-                return 1;
-            }
-            else
-            {
-                --i;
-                return m_indices[i + n] - m_indices[i];
-            }
-        }
+        size_type operator()(size_type i) const noexcept;
+        size_type size() const noexcept;
 
-        size_type revert_index(std::size_t i) const
-        {
-            auto it = std::find(m_indices.begin(), m_indices.end(), i);
-            if (it != m_indices.end())
-            {
-                return std::distance(m_indices.begin(), it);
-            }
-            else
-            {
-                throw std::runtime_error("Index i (" + std::to_string(i) + ") not in indices of islice.");
-            }
-        }
+        void normalize(std::size_t s);
 
-        bool contains(size_type i) const noexcept
-        {
-            return (std::find(m_indices.begin(), m_indices.end(), i) == m_indices.end()) ? false : true;
-        }
+        size_type step_size(std::size_t i, std::size_t n = 1) const noexcept;
+        size_type revert_index(std::size_t i) const;
+
+        bool contains(size_type i) const noexcept;
+
+        bool operator==(const self_type& rhs) const noexcept;
+        bool operator!=(const self_type& rhs) const noexcept;
 
     private:
 
-        T m_indices;
+        xkeep_slice() = default;
+
+        container_type m_indices;
+        container_type m_raw_indices;
+
+        template <class S>
+        friend class xkeep_slice;
     };
 
+    namespace detail
+    {
+        template <class T>
+        using disable_integral_keep = std::enable_if_t<!std::is_integral<std::decay_t<T>>::value,
+            xkeep_slice<typename std::decay_t<T>::value_type>>;
+
+        template <class T, class R>
+        using enable_integral_keep = std::enable_if_t<std::is_integral<T>::value, xkeep_slice<R>>;
+    }
+
     /**
-     * Create a non-contigous slice from a container of indices.
-     * Note: this slice can **only** be used in the xview!
+     * Create a non-contigous slice from a container of indices to keep.
+     * Note: this slice cannot be used in the xstrided_view!
      *
      * \code{.cpp}
      * xt::xarray<double> a = xt::arange(9);
      * a.reshape({3, 3});
-     * xt::view(a, xt::islice({0, 2}); // => {{0, 1, 2}, {6, 7, 8}}
-     * xt::view(a, xt::islice({1, 1, 1}); // => {{3, 4, 5}, {3, 4, 5}, {3, 4, 5}}
+     * xt::view(a, xt::keep(0, 2); // => {{0, 1, 2}, {6, 7, 8}}
+     * xt::view(a, xt::keep(1, 1, 1); // => {{3, 4, 5}, {3, 4, 5}, {3, 4, 5}}
      * \endcode
      *
      * @param indices The indices container
-     * @return instance of xislice
+     * @return instance of xkeep_slice
      */
     template <class T>
-    inline auto islice(T&& indices)
+    inline detail::disable_integral_keep<T> keep(T&& indices)
     {
-        return xislice<T>(std::forward<T>(indices));
+        return xkeep_slice<typename std::decay_t<T>::value_type>(std::forward<T>(indices));
     }
 
-#ifndef X_OLD_CLANG
-    template <class T, std::size_t N>
-    inline auto islice(const T (&cont)[N])
+    template <class R = std::ptrdiff_t, class T>
+    inline detail::enable_integral_keep<T, R> keep(T i)
     {
-        return xislice<std::array<std::size_t, N>>(xtl::forward_sequence<std::array<std::size_t, N>>(cont));
+        using slice_type = xkeep_slice<R>;
+        using container_type = typename slice_type::container_type;
+        container_type tmp = { static_cast<R>(i) };
+        return slice_type(std::move(tmp));
     }
-#else
-    inline auto islice(std::initializer_list<std::size_t> cont)
+
+    template <class R = std::ptrdiff_t, class Arg0, class Arg1, class... Args>
+    inline xkeep_slice<R> keep(Arg0 i0, Arg1 i1, Args... args)
     {
-        return xislice<std::vector<std::size_t>>(cont);
+        using slice_type = xkeep_slice<R>;
+        using container_type = typename slice_type::container_type;
+        container_type tmp = { static_cast<R>(i0), static_cast<R>(i1), static_cast<R>(args)... };
+        return slice_type(std::move(tmp));
     }
-#endif
 
-    /******************
-     * xrange_adaptor *
-     ******************/
+    /***************************
+     * xdrop_slice declaration *
+     ***************************/
 
-    template <class A, class B, class C>
+    template <class T>
+    class xdrop_slice;
+
+    namespace detail
+    {
+        template <class T>
+        struct is_xdrop_slice : std::false_type
+        {
+        };
+
+        template <class T>
+        struct is_xdrop_slice<xdrop_slice<T>> : std::true_type
+        {
+        };
+
+        template <class T>
+        using disable_xdrop_slice_t = std::enable_if_t<!is_xdrop_slice<std::decay_t<T>>::value, void>;
+
+        template <class T>
+        using enable_xdrop_slice_t = std::enable_if_t<is_xdrop_slice<std::decay_t<T>>::value, void>;
+    }
+
+    template <class T>
+    class xdrop_slice : public xslice<xdrop_slice<T>>
+    {
+    public:
+
+        using container_type = svector<T>;
+        using size_type = typename container_type::value_type;
+        using self_type = xdrop_slice<T>;
+
+        template <class C, typename = detail::disable_xdrop_slice_t<C>>
+        explicit xdrop_slice(C& cont);
+        explicit xdrop_slice(container_type&& cont);
+
+        template <class S>
+        xdrop_slice(std::initializer_list<S> t);
+
+        template <class S, typename = std::enable_if_t<std::is_convertible<S, T>::value, void>>
+        operator xdrop_slice<S>() const noexcept;
+
+        // Same as implicit conversion operator but more convenient to call
+        // from a variant visitor
+        template <class S, typename = std::enable_if_t<std::is_convertible<S, T>::value, void>>
+        xdrop_slice<S> convert() const noexcept;
+
+        size_type operator()(size_type i) const noexcept;
+        size_type size() const noexcept;
+
+        void normalize(std::size_t s);
+
+        size_type step_size(std::size_t i, std::size_t n = 1) const noexcept;
+        size_type revert_index(std::size_t i) const;
+
+        bool contains(size_type i) const noexcept;
+
+        bool operator==(const self_type& rhs) const noexcept;
+        bool operator!=(const self_type& rhs) const noexcept;
+
+    private:
+
+        xdrop_slice() = default;
+
+        container_type m_indices;
+        container_type m_raw_indices;
+        std::map<size_type, size_type> m_inc;
+        size_type m_size;
+
+        template <class S>
+        friend class xdrop_slice;
+    };
+
+    namespace detail
+    {
+        template <class T>
+        using disable_integral_drop = std::enable_if_t<!std::is_integral<std::decay_t<T>>::value,
+                                     xdrop_slice<typename std::decay_t<T>::value_type>>;
+
+        template <class T, class R>
+        using enable_integral_drop = std::enable_if_t<std::is_integral<T>::value, xdrop_slice<R>>;
+    }
+
+    /**
+     * Create a non-contigous slice from a container of indices to drop.
+     * Note: this slice cannot be used in the xstrided_view!
+     *
+     * \code{.cpp}
+     * xt::xarray<double> a = xt::arange(9);
+     * a.reshape({3, 3});
+     * xt::view(a, xt::drop(0, 2); // => {{3, 4, 5}}
+     * \endcode
+     *
+     * @param indices The container of indices to drop
+     * @return instance of xdrop_slice
+     */
+    template <class T>
+    inline detail::disable_integral_drop<T> drop(T&& indices)
+    {
+        return xdrop_slice<typename std::decay_t<T>::value_type>(std::forward<T>(indices));
+    }
+
+    template <class R = std::ptrdiff_t, class T>
+    inline detail::enable_integral_drop<T, R> drop(T i)
+    {
+        using slice_type = xdrop_slice<R>;
+        using container_type = typename slice_type::container_type;
+        container_type tmp = { static_cast<R>(i) };
+        return slice_type(std::move(tmp));
+    }
+
+    template <class R = std::ptrdiff_t, class Arg0, class Arg1, class... Args>
+    inline xdrop_slice<R> drop(Arg0 i0, Arg1 i1, Args... args)
+    {
+        using slice_type = xdrop_slice<R>;
+        using container_type = typename slice_type::container_type;
+        container_type tmp = { static_cast<R>(i0), static_cast<R>(i1), static_cast<R>(args)... };
+        return slice_type(std::move(tmp));
+    }
+
+    /******************************
+     * xrange_adaptor declaration *
+     ******************************/
+
+    template <class A, class B = A, class C = A>
     struct xrange_adaptor
     {
         xrange_adaptor(A start_val, B stop_val, C step)
             : m_start(start_val), m_stop(stop_val), m_step(step)
         {
-        }
-
-        auto normalize(std::ptrdiff_t val, std::size_t ssize) const
-        {
-            std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
-            val = (val >= 0) ? val : val + size;
-            return std::max(std::ptrdiff_t(0), std::min(size, val));
-        }
-
-        auto get_stepped_range(std::ptrdiff_t start, std::ptrdiff_t stop, std::ptrdiff_t step, std::size_t ssize) const
-        {
-            std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
-            start = (start >= 0) ? start : start + size;
-            stop = (stop >= 0) ? stop : stop + size;
-
-            if(step > 0)
-            {
-                start = std::max(std::ptrdiff_t(0), std::min(size, start));
-                stop  = std::max(std::ptrdiff_t(0), std::min(size, stop));
-            }
-            else
-            {
-                start = std::max(std::ptrdiff_t(-1), std::min(size - 1, start));
-                stop  = std::max(std::ptrdiff_t(-1), std::min(size - 1, stop));
-            }
-
-            return xstepped_range<std::ptrdiff_t>(start, stop, step);
         }
 
         template <class MI = A, class MA = B, class STEP = C>
@@ -535,12 +630,126 @@ namespace xt
             return xall<std::ptrdiff_t>(static_cast<std::ptrdiff_t>(size));
         }
 
+        A start() const { return m_start; }
+        B stop()  const { return m_stop;  }
+        C step()  const { return m_step;  }
+
     private:
+
+        static auto normalize(std::ptrdiff_t val, std::size_t ssize)
+        {
+            std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
+            val = (val >= 0) ? val : val + size;
+            return (std::max)(std::ptrdiff_t(0), (std::min)(size, val));
+        }
+
+        static auto get_stepped_range(std::ptrdiff_t start, std::ptrdiff_t stop, std::ptrdiff_t step, std::size_t ssize)
+        {
+            std::ptrdiff_t size = static_cast<std::ptrdiff_t>(ssize);
+            start = (start >= 0) ? start : start + size;
+            stop = (stop >= 0) ? stop : stop + size;
+
+            if (step > 0)
+            {
+                start = (std::max)(std::ptrdiff_t(0), (std::min)(size, start));
+                stop  = (std::max)(std::ptrdiff_t(0), (std::min)(size, stop));
+            }
+            else
+            {
+                start = (std::max)(std::ptrdiff_t(-1), (std::min)(size - 1, start));
+                stop  = (std::max)(std::ptrdiff_t(-1), (std::min)(size - 1, stop));
+            }
+
+            return xstepped_range<std::ptrdiff_t>(start, stop, step);
+        }
 
         A m_start;
         B m_stop;
         C m_step;
     };
+
+    /*******************************
+     * Placeholders and rangemaker *
+     *******************************/
+
+    namespace placeholders
+    {
+        // xtensor universal placeholder
+        struct xtuph {};
+
+        template <class... Args>
+        struct rangemaker
+        {
+            std::ptrdiff_t rng[3]; // = { 0, 0, 0 };
+        };
+
+        XTENSOR_CONSTEXPR xtuph get_tuph_or_val(std::ptrdiff_t /*val*/, std::true_type)
+        {
+            return xtuph();
+        }
+
+        XTENSOR_CONSTEXPR std::ptrdiff_t get_tuph_or_val(std::ptrdiff_t val, std::false_type)
+        {
+            return val;
+        }
+
+        template <class A, class B, class C>
+        struct rangemaker<A, B, C>
+        {
+            XTENSOR_CONSTEXPR operator xrange_adaptor<A, B, C>()
+            {
+                return xrange_adaptor<A, B, C>({
+                    get_tuph_or_val(rng[0], std::is_same<A, xtuph>()),
+                    get_tuph_or_val(rng[1], std::is_same<B, xtuph>()),
+                    get_tuph_or_val(rng[2], std::is_same<C, xtuph>())
+                });
+            }
+
+            std::ptrdiff_t rng[3];// = { 0, 0, 0 };
+        };
+
+        template <class A, class B>
+        struct rangemaker<A, B>
+        {
+            XTENSOR_CONSTEXPR operator xrange_adaptor<A, B, xt::placeholders::xtuph>()
+            {
+                return xrange_adaptor<A, B, xt::placeholders::xtuph>({
+                    get_tuph_or_val(rng[0], std::is_same<A, xtuph>()),
+                    get_tuph_or_val(rng[1], std::is_same<B, xtuph>()),
+                    xtuph()
+                });
+            }
+
+            std::ptrdiff_t rng[3];  // = { 0, 0, 0 };
+        };
+
+        template <class... OA>
+        XTENSOR_CONSTEXPR auto operator|(const rangemaker<OA...>& rng, const std::ptrdiff_t& t)
+        {
+            auto nrng = rangemaker<OA..., std::ptrdiff_t>({ rng.rng[0], rng.rng[1], rng.rng[2] });
+            nrng.rng[sizeof...(OA)] = t;
+            return nrng;
+        }
+
+        template <class... OA>
+        XTENSOR_CONSTEXPR auto operator|(const rangemaker<OA...>& rng, const xt::placeholders::xtuph& /*t*/)
+        {
+            auto nrng = rangemaker<OA..., xt::placeholders::xtuph>({ rng.rng[0], rng.rng[1], rng.rng[2] });
+            return nrng;
+        }
+
+
+        XTENSOR_GLOBAL_CONSTEXPR xtuph _{};
+        XTENSOR_GLOBAL_CONSTEXPR rangemaker<> _r = rangemaker<>({ 0, 0, 0 });
+        XTENSOR_GLOBAL_CONSTEXPR xall_tag _a{};
+        XTENSOR_GLOBAL_CONSTEXPR xnewaxis_tag _n{};
+        XTENSOR_GLOBAL_CONSTEXPR xellipsis_tag _e{};
+    }
+
+    inline auto xnone()
+    {
+        return placeholders::xtuph();
+    }
 
     namespace detail
     {
@@ -571,14 +780,14 @@ namespace xt
     }
 
     /**
-     * Select a range from start_val to stop_val.
+     * Select a range from start_val to stop_val (excluded).
      * You can use the shorthand `_` syntax to select from the start or until the end.
      *
      * \code{.cpp}
      * using namespace xt::placeholders;  // to enable _ syntax
      *
      * range(3, _)  // select from index 3 to the end
-     * range(_, 5)  // select from index o to 5
+     * range(_, 5)  // select from index 0 to 5 (excluded)
      * range(_, _)  // equivalent to `all()`
      * \endcode
      *
@@ -592,7 +801,7 @@ namespace xt
     }
 
     /**
-     * Select a range from start_val to stop_val with step
+     * Select a range from start_val to stop_val (excluded) with step
      * You can use the shorthand `_` syntax to select from the start or until the end.
      *
      * \code{.cpp}
@@ -608,7 +817,6 @@ namespace xt
         return xrange_adaptor<detail::cast_if_integer_t<A>, detail::cast_if_integer_t<B>, detail::cast_if_integer_t<C>>(
             detail::cast_if_integer<A>{}(start_val), detail::cast_if_integer<B>{}(stop_val), detail::cast_if_integer<C>{}(step));
     }
-
 
     /******************************************************
      * homogeneous get_size for integral types and slices *
@@ -675,28 +883,82 @@ namespace xt
      * homogeneous get_slice_implementation *
      ****************************************/
 
+    namespace detail
+    {
+        template <class T>
+        struct slice_implementation_getter
+        {
+            template <class E, class SL>
+            inline decltype(auto) operator()(E&, SL&& slice, std::size_t) const
+            {
+                return std::forward<SL>(slice);
+            }
+        };
+
+        struct keep_drop_getter
+        {
+            template <class E, class SL>
+            inline decltype(auto) operator()(E& e, SL&& slice, std::size_t index) const
+            {
+                slice.normalize(e.shape()[index]);
+                return std::forward<SL>(slice);
+            }
+
+            template <class E, class SL>
+            inline auto operator()(E& e, const SL& slice, std::size_t index) const
+            {
+                return this->operator()(e, SL(slice), index);
+            }
+        };
+
+        template <class T>
+        struct slice_implementation_getter<xkeep_slice<T>>
+            : keep_drop_getter
+        {
+        };
+
+        template <class T>
+        struct slice_implementation_getter<xdrop_slice<T>>
+            : keep_drop_getter
+        {
+        };
+
+        template <>
+        struct slice_implementation_getter<xall_tag>
+        {
+            template <class E, class SL>
+            inline auto operator()(E& e, SL&&, std::size_t index) const
+            {
+                return xall<typename E::size_type>(e.shape()[index]);
+            }
+        };
+
+        template <>
+        struct slice_implementation_getter<xnewaxis_tag>
+        {
+            template <class E, class SL>
+            inline auto operator()(E&, SL&&, std::size_t) const
+            {
+                return xnewaxis<typename E::size_type>();
+            }
+        };
+
+        template <class A, class B, class C>
+        struct slice_implementation_getter<xrange_adaptor<A, B, C>>
+        {
+            template <class E, class SL>
+            inline auto operator()(E& e, SL&& adaptor, std::size_t index) const
+            {
+                return adaptor.get(e.shape()[index]);
+            }
+        };
+    }
+
     template <class E, class SL>
-    inline auto get_slice_implementation(E& /*e*/, SL&& slice, std::size_t /*index*/)
+    inline auto get_slice_implementation(E& e, SL&& slice, std::size_t index)
     {
-        return std::forward<SL>(slice);
-    }
-
-    template <class E>
-    inline auto get_slice_implementation(E& e, xall_tag, std::size_t index)
-    {
-        return xall<typename E::size_type>(e.shape()[index]);
-    }
-
-    template <class E>
-    inline auto get_slice_implementation(E& /*e*/, xnewaxis_tag, std::size_t /*index*/)
-    {
-        return xnewaxis<typename E::size_type>();
-    }
-
-    template <class E, class A, class B, class C>
-    inline auto get_slice_implementation(E& e, xrange_adaptor<A, B, C> adaptor, std::size_t index)
-    {
-        return adaptor.get(e.shape()[index]);
+        detail::slice_implementation_getter<std::decay_t<SL>> getter;
+        return getter(e, std::forward<SL>(slice), index);
     }
 
     /******************************
@@ -760,6 +1022,23 @@ namespace xt
     }
 
     template <class T>
+    template <class S, typename>
+    inline xrange<T>::operator xrange<S>() const noexcept
+    {
+        xrange<S> ret;
+        ret.m_start = static_cast<S>(m_start);
+        ret.m_size = static_cast<S>(m_size);
+        return ret;
+    }
+
+    template <class T>
+    template <class S, typename>
+    inline xrange<S> xrange<T>::convert() const noexcept
+    {
+        return xrange<S>(*this);
+    }
+
+    template <class T>
     inline auto xrange<T>::operator()(size_type i) const noexcept -> size_type
     {
         return m_start + i;
@@ -813,10 +1092,29 @@ namespace xt
 
     template <class T>
     inline xstepped_range<T>::xstepped_range(size_type start_val, size_type stop_val, size_type step) noexcept
-        : m_start(start_val), m_size(size_type(std::ceil(double(stop_val - start_val) / double(step)))), m_step(step)
+        : m_start(start_val), m_size(size_type(0)), m_step(step)
     {
+        size_type n = stop_val - start_val;
+        m_size = n / step + (((n < 0) ^ (step > 0)) && (n % step));
     }
 
+    template <class T>
+    template <class S, typename>
+    inline xstepped_range<T>::operator xstepped_range<S>() const noexcept
+    {
+        xstepped_range<S> ret;
+        ret.m_start = static_cast<S>(m_start);
+        ret.m_size = static_cast<S>(m_size);
+        ret.m_step = static_cast<S>(m_step);
+        return ret;
+    }
+
+    template <class T>
+    template <class S, typename>
+    inline xstepped_range<S> xstepped_range<T>::convert() const noexcept
+    {
+        return xstepped_range<S>(*this);
+    }
 
     template <class T>
     inline auto xstepped_range<T>::operator()(size_type i) const noexcept -> size_type
@@ -877,6 +1175,20 @@ namespace xt
     }
 
     template <class T>
+    template <class S, typename>
+    inline xall<T>::operator xall<S>() const noexcept
+    {
+        return xall<S>(static_cast<S>(m_size));
+    }
+
+    template <class T>
+    template <class S, typename>
+    inline xall<S> xall<T>::convert() const noexcept
+    {
+        return xall<S>(*this);
+    }
+
+    template <class T>
     inline auto xall<T>::operator()(size_type i) const noexcept -> size_type
     {
         return i;
@@ -929,6 +1241,20 @@ namespace xt
      ***************************/
 
     template <class T>
+    template <class S, typename>
+    inline xnewaxis<T>::operator xnewaxis<S>() const noexcept
+    {
+        return xnewaxis<S>();
+    }
+
+    template <class T>
+    template <class S, typename>
+    inline xnewaxis<S> xnewaxis<T>::convert() const noexcept
+    {
+        return xnewaxis<S>(*this);
+    }
+
+    template <class T>
     inline auto xnewaxis<T>::operator()(size_type) const noexcept -> size_type
     {
         return 0;
@@ -962,6 +1288,280 @@ namespace xt
     inline bool xnewaxis<T>::contains(size_type i) const noexcept
     {
         return i == 0;
+    }
+
+    template <class T>
+    inline bool xnewaxis<T>::operator==(const self_type& /*rhs*/) const noexcept
+    {
+        return true;
+    }
+
+    template <class T>
+    inline bool xnewaxis<T>::operator!=(const self_type& /*rhs*/) const noexcept
+    {
+        return true;
+    }
+
+    /******************************
+     * xkeep_slice implementation *
+     ******************************/
+
+    template <class T>
+    template <class C, typename>
+    inline xkeep_slice<T>::xkeep_slice(C& cont)
+        : m_raw_indices(cont.begin(), cont.end())
+    {
+    }
+
+    template <class T>
+    inline xkeep_slice<T>::xkeep_slice(container_type&& cont)
+        : m_raw_indices(std::move(cont))
+    {
+    }
+
+    template <class T>
+    template <class S>
+    inline xkeep_slice<T>::xkeep_slice(std::initializer_list<S> t)
+        : m_raw_indices(t.size())
+    {
+        std::transform(t.begin(), t.end(), m_raw_indices.begin(),
+            [](auto t) { return static_cast<size_type>(t); });
+    }
+
+    template <class T>
+    template <class S, typename>
+    inline xkeep_slice<T>::operator xkeep_slice<S>() const noexcept
+    {
+        xkeep_slice<S> ret;
+        using us_type = typename container_type::size_type;
+        us_type sz = static_cast<us_type>(size());
+        ret.m_raw_indices.resize(sz);
+        ret.m_indices.resize(sz);
+        std::transform(m_raw_indices.cbegin(), m_raw_indices.cend(), ret.m_raw_indices.begin(),
+                       [](const T& val) { return static_cast<S>(val); });
+        std::transform(m_indices.cbegin(), m_indices.cend(), ret.m_indices.begin(),
+                       [](const T& val) { return static_cast<S>(val); });
+        return ret;
+    }
+
+    template <class T>
+    template <class S, typename>
+    inline xkeep_slice<S> xkeep_slice<T>::convert() const noexcept
+    {
+        return xkeep_slice<S>(*this);
+    }
+
+    template <class T>
+    inline void xkeep_slice<T>::normalize(std::size_t shape)
+    {
+        m_indices.resize(m_raw_indices.size());
+        std::size_t sz = m_indices.size();
+        for (std::size_t i = 0; i < sz; ++i)
+        {
+            m_indices[i] = m_raw_indices[i] < 0 ? static_cast<std::ptrdiff_t>(shape) + m_raw_indices[i] : m_raw_indices[i];
+        }
+    }
+
+    template <class T>
+    inline auto xkeep_slice<T>::operator()(size_type i) const noexcept -> size_type
+    {
+        return m_indices[static_cast<std::size_t>(i)];
+    }
+
+    template <class T>
+    inline auto xkeep_slice<T>::size() const noexcept -> size_type
+    {
+        return static_cast<size_type>(m_raw_indices.size());
+    }
+
+    template <class T>
+    inline auto xkeep_slice<T>::step_size(std::size_t i, std::size_t n) const noexcept -> size_type
+    {
+        if (i + n >= m_indices.size())
+        {
+            return m_indices.back() - m_indices[i] + 1;
+        }
+        else
+        {
+            return m_indices[i + n] - m_indices[i];
+        }
+    }
+
+    template <class T>
+    inline auto xkeep_slice<T>::revert_index(std::size_t i) const -> size_type
+    {
+        auto it = std::find(m_indices.begin(), m_indices.end(), i);
+        if (it != m_indices.end())
+        {
+            return std::distance(m_indices.begin(), it);
+        }
+        else
+        {
+            throw std::runtime_error("Index i (" + std::to_string(i) + ") not in indices of islice.");
+        }
+    }
+
+    template <class T>
+    inline bool xkeep_slice<T>::contains(size_type i) const noexcept
+    {
+        return (std::find(m_indices.begin(), m_indices.end(), i) == m_indices.end()) ? false : true;
+    }
+
+    template <class T>
+    inline bool xkeep_slice<T>::operator==(const self_type& rhs) const noexcept
+    {
+        return m_indices == rhs.m_indices;
+    }
+
+    template <class T>
+    inline bool xkeep_slice<T>::operator!=(const self_type& rhs) const noexcept
+    {
+        return !(*this == rhs);
+    }
+
+    /******************************
+     * xdrop_slice implementation *
+     ******************************/
+
+    template <class T>
+    template <class C, typename>
+    inline xdrop_slice<T>::xdrop_slice(C& cont)
+        : m_raw_indices(cont.begin(), cont.end())
+    {
+    }
+
+    template <class T>
+    inline xdrop_slice<T>::xdrop_slice(container_type&& cont)
+        : m_raw_indices(std::move(cont))
+    {
+    }
+
+    template <class T>
+    template <class S>
+    inline xdrop_slice<T>::xdrop_slice(std::initializer_list<S> t)
+        : m_raw_indices(t.size())
+    {
+        std::transform(t.begin(), t.end(), m_raw_indices.begin(),
+            [](auto t) { return static_cast<size_type>(t); });
+    }
+
+    template <class T>
+    template <class S, typename>
+    inline xdrop_slice<T>::operator xdrop_slice<S>() const noexcept
+    {
+        xdrop_slice<S> ret;
+        ret.m_raw_indices.resize(m_raw_indices.size());
+        ret.m_indices.resize(m_indices.size());
+        std::transform(m_raw_indices.cbegin(), m_raw_indices.cend(), ret.m_raw_indices.begin(),
+                       [](const T& val) { return static_cast<S>(val); });
+        std::transform(m_indices.cbegin(), m_indices.cend(), ret.m_indices.begin(),
+                       [](const T& val) { return static_cast<S>(val); });
+        std::transform(m_inc.cbegin(), m_inc.cend(), std::inserter(ret.m_inc, ret.m_inc.begin()),
+            [](const auto& val) { return std::make_pair(static_cast<S>(val.first), static_cast<S>(val.second)); });
+        ret.m_size = static_cast<S>(m_size);
+        return ret;
+    }
+
+    template <class T>
+    template <class S, typename>
+    inline xdrop_slice<S> xdrop_slice<T>::convert() const noexcept
+    {
+        return xdrop_slice<S>(*this);
+    }
+
+    template <class T>
+    inline void xdrop_slice<T>::normalize(std::size_t shape)
+    {
+        m_size = static_cast<size_type>(shape - m_raw_indices.size());
+
+        m_indices.resize(m_raw_indices.size());
+        std::size_t sz = m_indices.size();
+        for (std::size_t i = 0; i < sz; ++i)
+        {
+            m_indices[i] = m_raw_indices[i] < 0 ? static_cast<std::ptrdiff_t>(shape) + m_raw_indices[i] : m_raw_indices[i];
+        }
+        size_type cum = size_type(0);
+        size_type prev_cum = cum;
+        for (std::size_t i = 0; i < sz; ++i)
+        {
+            std::size_t ind = i;
+            size_type d = m_indices[i];
+            while (i + 1 < sz && m_indices[i + 1] == m_indices[i] + 1)
+            {
+                ++i;
+            }
+            cum += (static_cast<size_type>(i) - static_cast<size_type>(ind)) + 1;
+            m_inc[d - prev_cum] = cum;
+            prev_cum = cum;
+        }
+    }
+
+    template <class T>
+    inline auto xdrop_slice<T>::operator()(size_type i) const noexcept -> size_type
+    {
+        if (i < m_inc.begin()->first)
+        {
+            return i;
+        }
+        else
+        {
+            auto iter = --m_inc.upper_bound(i);
+            return i + iter->second;
+        }
+    }
+
+    template <class T>
+    inline auto xdrop_slice<T>::size() const noexcept -> size_type
+    {
+        return m_size;
+    }
+
+    template <class T>
+    inline auto xdrop_slice<T>::step_size(std::size_t i, std::size_t n) const noexcept -> size_type
+    {
+        if (i + n >= static_cast<std::size_t>(m_size))
+        {
+            return (*this)(static_cast<size_type>(m_size-1)) - (*this)(static_cast<size_type>(i)) + 1;
+        }
+        else
+        {
+            return (*this)(static_cast<size_type>(i + n)) - (*this)(static_cast<size_type>(i));
+        }
+    }
+
+    template <class T>
+    inline auto xdrop_slice<T>::revert_index(std::size_t i) const -> size_type
+    {
+        if (i < m_inc.begin()->first)
+        {
+            return i;
+        }
+        else
+        {
+            auto iter = --m_inc.lower_bound(i);
+            auto check = iter->first + iter->second;
+            if (check > i)
+                --iter;
+            return i - iter->second;
+        }
+    }
+
+    template <class T>
+    inline bool xdrop_slice<T>::contains(size_type i) const noexcept
+    {
+        return (std::find(m_indices.begin(), m_indices.end(), i) == m_indices.end()) ? true : false;
+    }
+
+    template <class T>
+    inline bool xdrop_slice<T>::operator==(const self_type& rhs) const noexcept
+    {
+        return m_indices == rhs.m_indices;
+    }
+
+    template <class T>
+    inline bool xdrop_slice<T>::operator!=(const self_type& rhs) const noexcept
+    {
+        return !(*this == rhs);
     }
 }
 

--- a/vendor/xtensor/include/xtensor/xsort.hpp
+++ b/vendor/xtensor/include/xtensor/xsort.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -10,48 +11,43 @@
 #define XTENSOR_SORT_HPP
 
 #include <algorithm>
+#include <utility>
 
 #include "xarray.hpp"
 #include "xeval.hpp"
 #include "xslice.hpp"  // for xnone
-#include "xstrided_view.hpp"
+#include "xmanipulation.hpp"
 #include "xtensor.hpp"
 
 namespace xt
 {
-    template <class E>
-    auto sort(const xexpression<E>& e, placeholders::xtuph /*t*/)
-    {
-        using value_type = typename E::value_type;
-        const auto de = e.derived_cast();
-        E ev;
-        ev.resize({de.size()});
-
-        std::copy(de.cbegin(), de.cend(), ev.begin());
-        std::sort(ev.begin(), ev.end());
-
-        return ev;
-    }
-
     namespace detail
     {
-        template <class E, class F>
-        void call_over_leading_axis(E& ev, F&& fct)
+        template <class T>
+        std::ptrdiff_t adjust_secondary_stride(std::ptrdiff_t stride, T shape)
         {
-            using value_type = typename E::value_type;
+            return stride != 0 ? stride : static_cast<std::ptrdiff_t>(shape);
+        }
+
+        template <class E, class F>
+        inline void call_over_leading_axis(E& ev, F&& fct)
+        {
             std::size_t n_iters = 1;
             std::ptrdiff_t secondary_stride;
+
             if (ev.layout() == layout_type::row_major)
             {
                 n_iters = std::accumulate(ev.shape().begin(), ev.shape().end() - 1,
                                           std::size_t(1), std::multiplies<>());
-                secondary_stride = static_cast<std::ptrdiff_t>(ev.strides()[ev.dimension() - 2]);
+                secondary_stride = adjust_secondary_stride(ev.strides()[ev.dimension() - 2],
+                                                           *(ev.shape().end() - 1));
             }
             else
             {
                 n_iters = std::accumulate(ev.shape().begin() + 1, ev.shape().end(),
                                           std::size_t(1), std::multiplies<>());
-                secondary_stride = static_cast<std::ptrdiff_t>(ev.strides()[1]);
+                secondary_stride = adjust_secondary_stride(ev.strides()[1],
+                                                           *(ev.shape().begin()));
             }
 
             std::ptrdiff_t offset = 0;
@@ -75,6 +71,114 @@ namespace xt
             }
             throw std::runtime_error("Layout not supported.");
         }
+
+        // get permutations to transpose and reverse-transpose array
+        inline std::pair<dynamic_shape<std::size_t>, dynamic_shape<std::size_t>>
+        get_permutations(std::size_t dim, std::size_t ax, layout_type layout)
+        {
+            dynamic_shape<std::size_t> permutation(dim);
+            std::iota(permutation.begin(), permutation.end(), std::size_t(0));
+            permutation.erase(permutation.begin() + std::ptrdiff_t(ax));
+
+            if (layout == layout_type::row_major)
+            {
+                permutation.push_back(ax);
+            }
+            else
+            {
+                permutation.insert(permutation.begin(), ax);
+            }
+
+            // TODO find a more clever way to get reverse permutation?
+            dynamic_shape<std::size_t> reverse_permutation;
+            for (std::size_t i = 0; i < dim; ++i)
+            {
+                auto it = std::find(permutation.begin(), permutation.end(), i);
+                reverse_permutation.push_back(std::size_t(std::distance(permutation.begin(), it)));
+            }
+
+            return std::make_pair(std::move(permutation), std::move(reverse_permutation));
+        }
+
+        template <class E, class R, class F>
+        inline auto run_lambda_over_axis(const E& e, R& res, std::size_t axis, F&& lambda)
+        {
+            if (axis != detail::leading_axis(res))
+            {
+                dynamic_shape<std::size_t> permutation, reverse_permutation;
+                std::tie(permutation, reverse_permutation) = get_permutations(e.dimension(), axis, e.layout());
+
+                res = transpose(e, permutation);
+                detail::call_over_leading_axis(res, std::forward<F>(lambda));
+                res = transpose(res, reverse_permutation);
+            }
+            else
+            {
+                res = e;
+                detail::call_over_leading_axis(res, std::forward<F>(lambda));
+            }
+        }
+
+        template <class VT>
+        struct flatten_sort_result_type_impl
+        {
+            using type = VT;
+        };
+
+        template <class VT, std::size_t N, layout_type L>
+        struct flatten_sort_result_type_impl<xtensor<VT, N, L>>
+        {
+            using type = xtensor<VT, 1, L>;
+        };
+
+        template <class VT, class S, layout_type L>
+        struct flatten_sort_result_type_impl<xtensor_fixed<VT, S, L>>
+        {
+            using type = xtensor_fixed<VT, xshape<fixed_compute_size<S>::value>, L>;
+        };
+
+        template <class VT>
+        struct flatten_sort_result_type
+            : flatten_sort_result_type_impl<common_tensor_type_t<VT>>
+        {
+        };
+
+        template <class VT>
+        using flatten_sort_result_type_t = typename flatten_sort_result_type<VT>::type;
+
+        template <class E, class R = flatten_sort_result_type_t<E>>
+        inline auto flat_sort_impl(const xexpression<E>& e)
+        {
+            const auto& de = e.derived_cast();
+            R ev;
+            ev.resize({de.size()});
+
+            std::copy(de.cbegin(), de.cend(), ev.begin());
+            std::sort(ev.begin(), ev.end());
+
+            return ev;
+        }
+    }
+
+    template <class E>
+    inline auto sort(const xexpression<E>& e, placeholders::xtuph /*t*/)
+    {
+        return detail::flat_sort_impl(e);
+    }
+
+    namespace detail
+    {
+        template <class T>
+        struct sort_eval_type
+        {
+            using type = typename T::temporary_type;
+        };
+
+        template <class T, std::size_t... I, layout_type L>
+        struct sort_eval_type<xtensor_fixed<T, fixed_shape<I...>, L>>
+        {
+            using type = xtensor<T, sizeof...(I), L>;
+        };
     }
 
     /**
@@ -88,60 +192,596 @@ namespace xt
      * @return sorted array (copy)
      */
     template <class E>
-    auto sort(const xexpression<E>& e, std::size_t axis)
+    inline auto sort(const xexpression<E>& e, std::ptrdiff_t axis = -1)
     {
-        using eval_type = typename E::temporary_type;
-        using value_type = typename E::value_type;
+        using eval_type = typename detail::sort_eval_type<E>::type;
 
         const auto& de = e.derived_cast();
 
         if (de.dimension() == 1)
         {
-            return sort(de, xnone());
+            return detail::flat_sort_impl<std::decay_t<decltype(de)>, eval_type>(de);
         }
 
-        eval_type ev;
+        std::size_t ax = normalize_axis(de.dimension(), axis);
 
-        if (axis != detail::leading_axis(ev))
+        eval_type res;
+        detail::run_lambda_over_axis(de, res, ax, [](auto begin, auto end) { std::sort(begin, end); });
+        return res;
+    }
+
+    namespace detail
+    {
+        template <class VT, class T>
+        struct rebind_value_type
         {
-            auto axis_numbers = arange<std::size_t>(de.shape().size());
-            std::vector<std::size_t> permutation(axis_numbers.begin(), axis_numbers.end());
-            permutation.erase(permutation.begin() + std::ptrdiff_t(axis));
-            if (de.layout() == layout_type::row_major)
+            using type = xarray<VT, xt::layout_type::dynamic>;
+        };
+
+        template <class VT, class EC, layout_type L>
+        struct rebind_value_type<VT, xarray<EC, L>>
+        {
+            using type = xarray<VT, L>;
+        };
+
+        template <class VT, class EC, std::size_t N, layout_type L>
+        struct rebind_value_type<VT, xtensor<EC, N, L>>
+        {
+            using type = xtensor<VT, N, L>;
+        };
+
+        template <class VT, class ET, class S, layout_type L>
+        struct rebind_value_type<VT, xtensor_fixed<ET, S, L>>
+        {
+            using type = xtensor_fixed<VT, S, L>;
+        };
+
+        template <class VT, class T>
+        struct flatten_rebind_value_type
+        {
+            using type = typename rebind_value_type<VT, T>::type;
+        };
+
+        template <class VT, class EC, std::size_t N, layout_type L>
+        struct flatten_rebind_value_type<VT, xtensor<EC, N, L>>
+        {
+            using type = xtensor<VT, 1, L>;
+        };
+
+        template <class VT, class ET, class S, layout_type L>
+        struct flatten_rebind_value_type<VT, xtensor_fixed<ET, S, L>>
+        {
+            using type = xtensor_fixed<VT, xshape<fixed_compute_size<S>::value>, L>;
+        };
+
+        template <class T>
+        struct argsort_result_type
+        {
+            using type = typename rebind_value_type<typename T::temporary_type::size_type,
+                                                    typename T::temporary_type>::type;
+        };
+
+        template <class T>
+        struct linear_argsort_result_type
+        {
+            using type = typename flatten_rebind_value_type<typename T::temporary_type::size_type,
+                                                            typename T::temporary_type>::type;
+        };
+
+        template <class Ed, class Ei>
+        inline void argsort_over_leading_axis(const Ed& data, Ei& inds)
+        {
+            std::size_t n_iters = 1;
+            std::ptrdiff_t data_secondary_stride, inds_secondary_stride;
+
+            if (data.layout() == layout_type::row_major)
             {
-                permutation.push_back(axis);
+                n_iters = std::accumulate(data.shape().begin(), data.shape().end() - 1,
+                                          std::size_t(1), std::multiplies<>());
+                data_secondary_stride = data.strides()[data.dimension() - 2];
+                inds_secondary_stride = inds.strides()[inds.dimension() - 2];
             }
             else
             {
-                permutation.insert(permutation.begin(), axis);
+                n_iters = std::accumulate(data.shape().begin() + 1, data.shape().end(),
+                                          std::size_t(1), std::multiplies<>());
+                data_secondary_stride = data.strides()[1];
+                inds_secondary_stride = inds.strides()[1];
             }
 
-            // TODO find a more clever way to get reverse permutation?
-            std::vector<std::size_t> reverse_permutation;
-            for (auto el : axis_numbers)
+            auto ptr = data.data();
+            auto indices_ptr = inds.data();
+
+            for (std::size_t i = 0; i < n_iters; ++i, ptr += data_secondary_stride, indices_ptr += inds_secondary_stride)
             {
-                auto it = std::find(permutation.begin(), permutation.end(), el);
-                reverse_permutation.push_back(std::size_t(std::distance(permutation.begin(), it)));
+                auto comp = [&ptr](std::size_t x, std::size_t y) {
+                    return *(ptr + x) < *(ptr + y);
+                };
+                std::iota(indices_ptr, indices_ptr + inds_secondary_stride, 0);
+                std::sort(indices_ptr, indices_ptr + inds_secondary_stride, comp);
             }
-
-            ev = transpose(de, permutation);
-            detail::call_over_leading_axis(ev, [](auto begin, auto end) { std::sort(begin, end); });
-            ev = transpose(ev, reverse_permutation);
-            return ev;
         }
-        else
+
+        template <class E, class R = typename detail::linear_argsort_result_type<E>::type>
+        inline auto flatten_argsort_impl(const xexpression<E>& e)
         {
-            ev = de;
-            detail::call_over_leading_axis(ev, [](auto begin, auto end) { std::sort(begin, end); });
-            return ev;
+            const auto& de = e.derived_cast();
+
+            auto cit = de.template begin<layout_type::row_major>();
+            using const_iterator = decltype(cit);
+            auto ad = xiterator_adaptor<const_iterator, const_iterator>(cit, cit, de.size());
+
+            using result_type = R;
+            result_type result;
+            result.resize({de.size()});
+            auto comp = [&ad](std::size_t x, std::size_t y) {
+                return ad[x] < ad[y];
+            };
+            std::iota(result.begin(), result.end(), 0);
+            std::sort(result.begin(), result.end(), comp);
+
+            return result;
         }
     }
 
     template <class E>
-    auto sort(const xexpression<E>& e)
+    inline auto argsort(const xexpression<E>& e, placeholders::xtuph /*t*/)
+    {
+        return detail::flatten_argsort_impl(e);
+    }
+
+    /**
+     * Argsort xexpression (optionally along axis)
+     * Performs an indirect sort along the given axis. Returns an xarray
+     * of indices of the same shape as e that index data along the given axis in
+     * sorted order.
+     *
+     * @param e xexpression to argsort
+     * @param axis axis along which argsort is performed
+     *
+     * @return argsorted index array
+     */
+    template <class E>
+    inline auto argsort(const xexpression<E>& e, std::ptrdiff_t axis = -1)
+    {
+        using eval_type = typename detail::sort_eval_type<E>::type;
+        using result_type = typename detail::argsort_result_type<eval_type>::type;
+
+        const auto& de = e.derived_cast();
+
+        std::size_t ax = normalize_axis(de.dimension(), axis);
+
+        if (de.dimension() == 1)
+        {
+            return detail::flatten_argsort_impl<E, result_type>(e);
+        }
+
+        if (ax != detail::leading_axis(de))
+        {
+            dynamic_shape<std::size_t> permutation, reverse_permutation;
+            std::tie(permutation, reverse_permutation) = detail::get_permutations(de.dimension(), ax, de.layout());
+
+            eval_type ev = transpose(de, permutation);
+            result_type res = result_type::from_shape(ev.shape());
+            detail::argsort_over_leading_axis(ev, res);
+            res = transpose(res, reverse_permutation);
+            return res;
+        }
+        else
+        {
+            result_type res = result_type::from_shape(de.shape());
+            detail::argsort_over_leading_axis(de, res);
+            return res;
+        }
+    }
+
+    /************************************************
+     * Implementation of partition and argpartition *
+     ************************************************/
+
+    /**
+     * Partially sort xexpression
+     *
+     * Partition shuffles the xexpression in a way so that the kth element
+     * in the returned xexpression is in the place it would appear in a sorted
+     * array and all elements smaller than this entry are placed (unsorted) before.
+     *
+     * The optional third parameter can either be an axis or ``xnone()`` in which case
+     * the xexpression will be flattened.
+     *
+     * This function uses ``std::nth_element`` internally.
+     *
+     * \code{cpp}
+     * xt::xarray<float> a = {1, 10, -10, 123};
+     * std::cout << xt::partition(a, 0) << std::endl; // {-10, 1, 123, 10} the correct entry at index 0
+     * std::cout << xt::partition(a, 3) << std::endl; // {1, 10, -10, 123} the correct entry at index 3
+     * std::cout << xt::partition(a, {0, 3}) << std::endl; // {-10, 1, 10, 123} the correct entries at index 0 and 3
+     * \endcode
+     *
+     * @param e input xexpression
+     * @param kth_container a container of ``indices`` that should contain the correctly sorted value
+     * @param axis either integer (default = -1) to sort along last axis or ``xnone()`` to flatten before sorting
+     *
+     * @return partially sorted xcontainer
+     */
+    template <class E, class C, class R = detail::flatten_sort_result_type_t<E>,
+              class = std::enable_if_t<!std::is_integral<C>::value, int>>
+    inline R partition(const xexpression<E>& e, const C& kth_container, placeholders::xtuph /*ax*/)
     {
         const auto& de = e.derived_cast();
-        return sort(de, de.dimension() - 1);
+
+        R ev = R::from_shape({ de.size() });
+        C kth_copy = kth_container;
+        if (kth_copy.size() > 1)
+        {
+            std::sort(kth_copy.begin(), kth_copy.end());
+        }
+
+        std::copy(de.storage_cbegin(), de.storage_cend(), ev.storage_begin()); // flatten
+        std::size_t k_last = kth_copy.back();
+        std::nth_element(ev.storage_begin(), ev.storage_begin() + k_last, ev.storage_end());
+
+        for (auto it = (kth_copy.rbegin() + 1); it != kth_copy.rend(); ++it)
+        {
+            std::nth_element(ev.storage_begin(), ev.storage_begin() + *it, ev.storage_begin() + k_last);
+            k_last = *it;
+        }
+
+        return ev;
+    }
+
+#ifdef X_OLD_CLANG
+    template <class E, class I, class R = detail::flatten_sort_result_type_t<E>>
+    inline R partition(const xexpression<E>& e, std::initializer_list<I> kth_container, placeholders::xtuph tag)
+    {
+        return partition(e, xtl::forward_sequence<std::vector<std::size_t>, decltype(kth_container)>(kth_container), tag);
+    }
+#else
+    template <class E, class I, std::size_t N, class R = detail::flatten_sort_result_type_t<E>>
+    inline R partition(const xexpression<E>& e, const I(&kth_container)[N], placeholders::xtuph tag)
+    {
+        return partition(e, xtl::forward_sequence<std::array<std::size_t, N>, decltype(kth_container)>(kth_container), tag);
+    }
+#endif
+
+    template <class E, class R = detail::flatten_sort_result_type_t<E>>
+    inline R partition(const xexpression<E>& e, std::size_t kth, placeholders::xtuph tag)
+    {
+        return partition(e, std::array<std::size_t, 1>({kth}), tag);
+    }
+
+    template <class E, class C, class = std::enable_if_t<!std::is_integral<C>::value, int>>
+    inline auto partition(const xexpression<E>& e, const C& kth_container, std::ptrdiff_t axis = -1)
+    {
+        using eval_type = typename detail::sort_eval_type<E>::type;
+
+        const auto& de = e.derived_cast();
+
+        if (de.dimension() == 1)
+        {
+            return partition<E, C, eval_type>(de, kth_container, xnone());
+        }
+
+        C kth_copy = kth_container;
+        if (kth_copy.size() > 1)
+        {
+            std::sort(kth_copy.begin(), kth_copy.end());
+        }
+
+        std::size_t ax = normalize_axis(de.dimension(), axis);
+
+        eval_type res;
+
+        std::size_t kth = kth_copy.back();
+
+        dynamic_shape<std::size_t> permutation, reverse_permutation;
+        bool is_leading_axis = (ax == detail::leading_axis(res));
+
+        if (!is_leading_axis)
+        {
+            std::tie(permutation, reverse_permutation) = detail::get_permutations(de.dimension(), ax, de.layout());
+            res = transpose(de, permutation);
+        }
+        else
+        {
+            res = de;
+        }
+
+        auto lambda = [&kth](auto begin, auto end) {
+            std::nth_element(begin, begin + kth, end);
+        };
+        detail::call_over_leading_axis(res, lambda);
+
+        for (auto it = kth_copy.rbegin() + 1; it != kth_copy.rend(); ++it)
+        {
+            kth = *it;
+            detail::call_over_leading_axis(res, lambda);
+        }
+
+        if (!is_leading_axis)
+        {
+            res = transpose(res, reverse_permutation);
+        }
+
+        return res;
+    }
+
+#ifdef X_OLD_CLANG
+    template <class E, class I>
+    inline auto partition(const xexpression<E>& e, std::initializer_list<I> kth_container, std::ptrdiff_t axis = -1)
+    {
+        return partition(e, xtl::forward_sequence<std::vector<std::size_t>, decltype(kth_container)>(kth_container), axis);
+    }
+#else
+    template <class E, class T, std::size_t N>
+    inline auto partition(const xexpression<E>& e, const T(&kth_container)[N], std::ptrdiff_t axis = -1)
+    {
+        return partition(e, xtl::forward_sequence<std::array<std::size_t, N>, decltype(kth_container)>(kth_container), axis);
+    }
+#endif
+    template <class E>
+    inline auto partition(const xexpression<E>& e, std::size_t kth, std::ptrdiff_t axis = -1)
+    {
+        return partition(e, std::array<std::size_t, 1>({kth}), axis);
+    }
+
+    /**
+     * Partially sort arguments
+     *
+     * Argpartition shuffles the indices to a xexpression in a way so that the index for the
+     * kth element in the returned xexpression is in the place it would appear in a sorted
+     * array and all elements smaller than this entry are placed (unsorted) before.
+     *
+     * The optional third parameter can either be an axis or ``xnone()`` in which case
+     * the xexpression will be flattened.
+     *
+     * This function uses ``std::nth_element`` internally.
+     *
+     * \code{cpp}
+     * xt::xarray<float> a = {1, 10, -10, 123};
+     * std::cout << xt::argpartition(a, 0) << std::endl; // {2, 0, 3, 1} the correct entry at index 0
+     * std::cout << xt::argpartition(a, 3) << std::endl; // {0, 1, 2, 3} the correct entry at index 3
+     * std::cout << xt::argpartition(a, {0, 3}) << std::endl; // {2, 0, 1, 3} the correct entries at index 0 and 3
+     * \endcode
+     *
+     * @param e input xexpression
+     * @param kth_container a container of ``indices`` that should contain the correctly sorted value
+     * @param axis either integer (default = -1) to sort along last axis or ``xnone()`` to flatten before sorting
+     *
+     * @return xcontainer with indices of partial sort of input
+     */
+    template <class E, class C,
+              class R = typename detail::linear_argsort_result_type<typename detail::sort_eval_type<E>::type>::type,
+              class = std::enable_if_t<!std::is_integral<C>::value, int>>
+    inline R argpartition(const xexpression<E>& e, const C& kth_container, placeholders::xtuph)
+    {
+        using eval_type = typename detail::sort_eval_type<E>::type;
+        using result_type = typename detail::linear_argsort_result_type<eval_type>::type;
+
+        const auto& de = e.derived_cast();
+
+        result_type ev = result_type::from_shape({ de.size() });
+
+        C kth_copy = kth_container;
+        if (kth_copy.size() > 1)
+        {
+            std::sort(kth_copy.begin(), kth_copy.end());
+        }
+
+        auto arg_lambda = [&de](std::size_t a, std::size_t b) {
+            return de[a] < de[b];
+        };
+
+        std::iota(ev.storage_begin(), ev.storage_end(), 0);
+        std::size_t k_last = kth_copy.back();
+        std::nth_element(ev.storage_begin(), ev.storage_begin() + k_last, ev.storage_end(), arg_lambda);
+
+        for (auto it = (kth_copy.rbegin() + 1); it != kth_copy.rend(); ++it)
+        {
+            std::nth_element(ev.storage_begin(), ev.storage_begin() + *it, ev.storage_begin() + k_last, arg_lambda);
+            k_last = *it;
+        }
+
+        return ev;
+    }
+
+#ifdef X_OLD_CLANG
+    template <class E, class I>
+    inline auto argpartition(const xexpression<E>& e, std::initializer_list<I> kth_container, placeholders::xtuph tag)
+    {
+        return argpartition(e, xtl::forward_sequence<std::vector<std::size_t>, decltype(kth_container)>(kth_container), tag);
+    }
+#else
+    template <class E, class I, std::size_t N>
+    inline auto argpartition(const xexpression<E>& e, const I(&kth_container)[N], placeholders::xtuph tag)
+    {
+        return argpartition(e, xtl::forward_sequence<std::array<std::size_t, N>, decltype(kth_container)>(kth_container), tag);
+    }
+#endif
+
+    template <class E>
+    inline auto argpartition(const xexpression<E>& e, std::size_t kth, placeholders::xtuph tag)
+    {
+        return argpartition(e, std::array<std::size_t, 1>({kth}), tag);
+    }
+
+    namespace detail
+    {
+        template <class Ed, class Ei>
+        inline void argpartition_over_leading_axis(const Ed& data, Ei& inds, std::size_t kth, std::ptrdiff_t last)
+        {
+            std::size_t n_iters = 1;
+            std::ptrdiff_t data_secondary_stride, inds_secondary_stride;
+
+            if (data.layout() == layout_type::row_major)
+            {
+                n_iters = std::accumulate(data.shape().begin(), data.shape().end() - 1,
+                                          std::size_t(1), std::multiplies<>());
+                data_secondary_stride = data.strides()[data.dimension() - 2];
+                inds_secondary_stride = inds.strides()[inds.dimension() - 2];
+            }
+            else
+            {
+                n_iters = std::accumulate(data.shape().begin() + 1, data.shape().end(),
+                                          std::size_t(1), std::multiplies<>());
+                data_secondary_stride = data.strides()[1];
+                inds_secondary_stride = inds.strides()[1];
+            }
+
+            auto ptr = data.data();
+            auto indices_ptr = inds.data();
+            auto comp = [&ptr](std::size_t x, std::size_t y) {
+                return *(ptr + x) < *(ptr + y);
+            };
+
+            if (last == -1) // initialize
+            {
+                for (std::size_t i = 0; i < n_iters; ++i, ptr += data_secondary_stride, indices_ptr += inds_secondary_stride)
+                {
+                    std::iota(indices_ptr, indices_ptr + inds_secondary_stride, 0);
+                    std::nth_element(indices_ptr, indices_ptr + kth, indices_ptr + inds_secondary_stride, comp);
+                }
+            }
+            else
+            {
+                for (std::size_t i = 0; i < n_iters; ++i, ptr += data_secondary_stride, indices_ptr += inds_secondary_stride)
+                {
+                    std::nth_element(indices_ptr, indices_ptr + kth, indices_ptr + last, comp);
+                }
+            }
+        }
+    }
+
+    template <class E, class C, class = std::enable_if_t<!std::is_integral<C>::value, int>>
+    inline auto argpartition(const xexpression<E>& e, const C& kth_container, std::ptrdiff_t axis = -1)
+    {
+        using eval_type = typename detail::sort_eval_type<E>::type;
+        using result_type = typename detail::argsort_result_type<eval_type>::type;
+
+        const auto& de = e.derived_cast();
+
+        std::size_t ax = normalize_axis(de.dimension(), axis);
+
+        if (de.dimension() == 1)
+        {
+            return argpartition<E, C, result_type>(e, kth_container, xnone());
+        }
+
+        C kth_copy = kth_container;
+        if (kth_copy.size() > 1)
+        {
+            std::sort(kth_copy.begin(), kth_copy.end());
+        }
+
+        eval_type ev;
+        result_type res;
+
+        dynamic_shape<std::size_t> permutation, reverse_permutation;
+        bool is_leading_axis = (ax == detail::leading_axis(res));
+
+        if (!is_leading_axis)
+        {
+            std::tie(permutation, reverse_permutation) = detail::get_permutations(de.dimension(), ax, de.layout());
+            ev = transpose(de, permutation);
+        }
+        else
+        {
+            ev = de;
+        }
+        res.resize(ev.shape());
+
+        std::size_t kth = kth_copy.back();
+        detail::argpartition_over_leading_axis(ev, res, kth, -1);
+
+        for (auto it = (kth_copy.rbegin() + 1); it != kth_copy.rend(); ++it)
+        {
+            detail::argpartition_over_leading_axis(ev, res, *it, static_cast<std::ptrdiff_t>(kth));
+            kth = *it;
+        }
+
+        if (!is_leading_axis)
+        {
+            res = transpose(res, reverse_permutation);
+        }
+
+        return res;
+    }
+
+#ifdef X_OLD_CLANG
+    template <class E, class I>
+    inline auto argpartition(const xexpression<E>& e, std::initializer_list<I> kth_container, std::ptrdiff_t axis = -1)
+    {
+        return argpartition(e, xtl::forward_sequence<std::vector<std::size_t>, decltype(kth_container)>(kth_container), axis);
+    }
+#else
+    template <class E, class I, std::size_t N>
+    inline auto argpartition(const xexpression<E>& e, const I(&kth_container)[N], std::ptrdiff_t axis = -1)
+    {
+        return argpartition(e, xtl::forward_sequence<std::array<std::size_t, N>, decltype(kth_container)>(kth_container), axis);
+    }
+#endif
+
+    template <class E>
+    inline auto argpartition(const xexpression<E>& e, std::size_t kth, std::ptrdiff_t axis = -1)
+    {
+        return argpartition(e, std::array<std::size_t, 1>({kth}), axis);
+    }
+
+    template <class E>
+    inline typename std::decay_t<E>::value_type median(E&& e)
+    {
+        using value_type = typename std::decay_t<E>::value_type;
+        auto sz = e.size();
+        if (sz % 2 == 0)
+        {
+            std::size_t szh = sz / 2; // integer floor div
+            std::array<std::size_t, 2> kth = {szh - 1, szh};
+            auto values = xt::partition(xt::flatten(e), kth);
+            return (values[kth[0]] + values[kth[1]]) / value_type(2);
+        }
+        else
+        {
+            std::array<std::size_t, 1> kth = {(sz - 1) / 2};
+            auto values = xt::partition(xt::flatten(e), kth);
+            return values[kth[0]];
+        }
+    }
+
+    /**
+     * Find the median along the specified axis
+     *
+     * Given a vector V of length N, the median of V is the middle value of a
+     * sorted copy of V, V_sorted - i e., V_sorted[(N-1)/2], when N is odd,
+     * and the average of the two middle values of V_sorted when N is even.
+     *
+     * @param axis axis along which the medians are computed.
+     *             If not set, computes the median along a flattened version of the input.
+     * @param e input xexpression
+     * @return median value
+     */
+    template <class E>
+    inline auto median(E&& e, std::ptrdiff_t axis)
+    {
+        std::size_t ax = normalize_axis(e.dimension(), axis);
+        std::size_t sz = e.shape()[ax];
+        xstrided_slice_vector sv(e.dimension(), xt::all());
+
+        if (sz % 2 == 0)
+        {
+            std::size_t szh = sz / 2; // integer floor div
+            std::array<std::size_t, 2> kth = {szh - 1, szh};
+            auto values = xt::partition(std::forward<E>(e), kth, static_cast<ptrdiff_t>(ax));
+            sv[ax] = xt::range(szh - 1, szh + 1);
+            return xt::mean(xt::strided_view(std::move(values), std::move(sv)), {ax});
+        }
+        else
+        {
+            std::size_t szh = (sz - 1) / 2;
+            std::array<std::size_t, 1> kth = {(sz - 1) / 2};
+            auto values = xt::partition(std::forward<E>(e), kth, static_cast<ptrdiff_t>(ax));
+            sv[ax] = xt::range(szh, szh + 1);
+            return xt::mean(xt::strided_view(std::move(values), std::move(sv)), {ax});
+        }
     }
 
     namespace detail
@@ -162,7 +802,7 @@ namespace xt
         inline std::size_t cmp_idx(IT iter, IT end, std::ptrdiff_t inc, F&& cmp)
         {
             std::size_t idx = 0;
-            double min = *iter;
+            auto min = *iter;
             iter += inc;
             for (std::size_t i = 1; iter < end; iter += inc, ++i)
             {
@@ -175,31 +815,37 @@ namespace xt
             return idx;
         }
 
-        template <class E, class F>
-        xtensor<std::size_t, 0> arg_func_impl(const E& e, F&& f)
+        template <layout_type L, class E, class F>
+        inline xtensor<std::size_t, 0> arg_func_impl(const E& e, F&& f)
         {
-            return cmp_idx(e.template begin<XTENSOR_DEFAULT_LAYOUT>(),
-                           e.template end<XTENSOR_DEFAULT_LAYOUT>(), 1,
+            return cmp_idx(e.template begin<L>(),
+                           e.template end<L>(), 1,
                            std::forward<F>(f));
         }
 
-        template <class E, class F>
-        typename argfunc_result_type<E>::type
+        template <layout_type L, class E, class F>
+        inline typename argfunc_result_type<E>::type
         arg_func_impl(const E& e, std::size_t axis, F&& cmp)
         {
+            using eval_type = typename detail::sort_eval_type<E>::type;
             using value_type = typename E::value_type;
             using result_type = typename argfunc_result_type<E>::type;
+            using result_shape_type = typename result_type::shape_type;
 
             if (e.dimension() == 1)
             {
-                return arg_func_impl(e, std::forward<F>(cmp));
+                return arg_func_impl<L>(e, std::forward<F>(cmp));
             }
 
-            xt::dynamic_shape<std::size_t> new_shape = e.shape();
-            new_shape.erase(new_shape.begin() + std::ptrdiff_t(axis));
+            result_shape_type alt_shape;
+            xt::resize_container(alt_shape, e.dimension() - 1);
 
-            result_type result(new_shape);
-            auto result_iter = result.begin();
+            // Excluding copy, copy all of shape except for axis
+            std::copy(e.shape().cbegin(), e.shape().cbegin() + std::ptrdiff_t(axis), alt_shape.begin());
+            std::copy(e.shape().cbegin() + std::ptrdiff_t(axis) + 1, e.shape().cend(), alt_shape.begin() + std::ptrdiff_t(axis));
+
+            result_type result = result_type::from_shape(std::move(alt_shape));
+            auto result_iter = result.template begin<L>();
 
             auto arg_func_lambda = [&result_iter, &cmp](auto begin, auto end) {
                 std::size_t idx = 0;
@@ -219,21 +865,11 @@ namespace xt
 
             if (axis != detail::leading_axis(e))
             {
-                E input;
-                auto axis_numbers = arange<std::size_t>(e.shape().size());
-                std::vector<std::size_t> permutation(axis_numbers.cbegin(), axis_numbers.cend());
-                permutation.erase(permutation.begin() + std::ptrdiff_t(axis));
-                if (input.layout() == layout_type::row_major)
-                {
-                    permutation.push_back(axis);
-                }
-                else
-                {
-                    permutation.insert(permutation.begin(), axis);
-                }
-                // Note we create a copy
-                input = transpose(e, permutation);
+                dynamic_shape<std::size_t> permutation, reverse_permutation;
+                std::tie(permutation, reverse_permutation) = detail::get_permutations(e.dimension(), axis, e.layout());
 
+                // note: creating copy
+                eval_type input = transpose(e, permutation);
                 detail::call_over_leading_axis(input, arg_func_lambda);
                 return result;
             }
@@ -246,12 +882,12 @@ namespace xt
         }
     }
 
-    template <class E>
-    auto argmin(const xexpression<E>& e)
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E>
+    inline auto argmin(const xexpression<E>& e)
     {
         using value_type = typename E::value_type;
         auto&& ed = eval(e.derived_cast());
-        return detail::arg_func_impl(ed, std::less<value_type>());
+        return detail::arg_func_impl<L>(ed, std::less<value_type>());
     }
 
     /**
@@ -262,20 +898,21 @@ namespace xt
      *
      * @return returns xarray with positions of minimal value
      */
-    template <class E>
-    auto argmin(const xexpression<E>& e, std::size_t axis)
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E>
+    inline auto argmin(const xexpression<E>& e, std::ptrdiff_t axis)
     {
         using value_type = typename E::value_type;
         auto&& ed = eval(e.derived_cast());
-        return detail::arg_func_impl(ed, axis, std::less<value_type>());
+        std::size_t ax = normalize_axis(ed.dimension(), axis);
+        return detail::arg_func_impl<L>(ed, ax, std::less<value_type>());
     }
 
-    template <class E>
-    auto argmax(const xexpression<E>& e)
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E>
+    inline auto argmax(const xexpression<E>& e)
     {
         using value_type = typename E::value_type;
         auto&& ed = eval(e.derived_cast());
-        return detail::arg_func_impl(ed, std::greater<value_type>());
+        return detail::arg_func_impl<L>(ed, std::greater<value_type>());
     }
 
     /**
@@ -286,12 +923,13 @@ namespace xt
      *
      * @return returns xarray with positions of maximal value
      */
-    template <class E>
-    auto argmax(const xexpression<E>& e, std::size_t axis)
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E>
+    inline auto argmax(const xexpression<E>& e, std::ptrdiff_t axis)
     {
         using value_type = typename E::value_type;
         auto&& ed = eval(e.derived_cast());
-        return detail::arg_func_impl(ed, axis, std::greater<value_type>());
+        std::size_t ax = normalize_axis(ed.dimension(), axis);
+        return detail::arg_func_impl<L>(ed, ax, std::greater<value_type>());
     }
 
     /**
@@ -301,14 +939,47 @@ namespace xt
      * @param e input xexpression (will be flattened)
      */
     template <class E>
-    auto unique(const xexpression<E>& e)
+    inline auto unique(const xexpression<E>& e)
     {
         auto sorted = sort(e, xnone());
         auto end = std::unique(sorted.begin(), sorted.end());
         std::size_t sz = static_cast<std::size_t>(std::distance(sorted.begin(), end));
         // TODO check if we can shrink the vector without reallocation
-        auto result = xtensor<typename E::value_type, 1>::from_shape({sz});
+        using value_type = typename E::value_type;
+        auto result = xtensor<value_type, 1>::from_shape({sz});
         std::copy(sorted.begin(), end, result.begin());
+        return result;
+    }
+
+    /**
+     * Find the set difference of two xexpressions. This returns a flattened xtensor with
+     * the sorted, unique values in ar1 that are not in ar2.
+     *
+     * @param ar1 input xexpression (will be flattened)
+     * @param ar2 input xexpression
+     */
+    template <class E1, class E2>
+    inline auto setdiff1d(const xexpression<E1>& ar1, const xexpression<E2>& ar2)
+    {
+        using value_type = typename E1::value_type;
+
+        auto unique1 = unique(ar1);
+        auto unique2 = unique(ar2);
+
+        auto tmp = xtensor<value_type, 1>::from_shape({unique1.size()});
+
+        auto end = std::set_difference(
+            unique1.begin(), unique1.end(),
+            unique2.begin(), unique2.end(),
+            tmp.begin()
+        );
+
+        std::size_t sz = static_cast<std::size_t>(std::distance(tmp.begin(), end));
+
+        auto result = xtensor<value_type, 1>::from_shape({sz});
+
+        std::copy(tmp.begin(), end, result.begin());
+
         return result;
     }
 }

--- a/vendor/xtensor/include/xtensor/xstrided_view.hpp
+++ b/vendor/xtensor/include/xtensor/xstrided_view.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -22,10 +23,37 @@
 #include "xiterable.hpp"
 #include "xlayout.hpp"
 #include "xsemantic.hpp"
+#include "xstorage.hpp"
 #include "xstrided_view_base.hpp"
+#include "xutils.hpp"
 
 namespace xt
 {
+    /***************************
+     * xstrided_view extension *
+     ***************************/
+
+    namespace extension
+    {
+        template <class Tag, class CT, class S, layout_type L, class FST>
+        struct xstrided_view_base_impl;
+
+        template <class CT, class S, layout_type L, class FST>
+        struct xstrided_view_base_impl<xtensor_expression_tag, CT, S, L, FST>
+        {
+            using type = xtensor_empty_base;
+        };
+
+        template <class CT, class S, layout_type L, class FST>
+        struct xstrided_view_base
+            : xstrided_view_base_impl<xexpression_tag_t<CT>, CT, S, L, FST>
+        {
+        };
+
+        template <class CT, class S, layout_type L, class FST>
+        using xstrided_view_base_t = typename xstrided_view_base<CT, S, L, FST>::type;
+    }
+
     template <class CT, class S, layout_type L, class FST>
     class xstrided_view;
 
@@ -33,15 +61,24 @@ namespace xt
     struct xcontainer_inner_types<xstrided_view<CT, S, L, FST>>
     {
         using xexpression_type = std::decay_t<CT>;
-        using temporary_type = xarray<std::decay_t<typename xexpression_type::value_type>>;
+        using undecay_expression = CT;
+        using reference = inner_reference_t<undecay_expression>;
+        using const_reference = typename xexpression_type::const_reference;
+        using size_type = typename xexpression_type::size_type;
+        using shape_type = std::decay_t<S>;
+        using undecay_shape = S;
+        using storage_getter = FST;
+        using inner_storage_type = typename storage_getter::type;
+        using temporary_type = temporary_type_t<typename xexpression_type::value_type, S, L>;
+        static constexpr layout_type layout = L;
     };
 
     template <class CT, class S, layout_type L, class FST>
     struct xiterable_inner_types<xstrided_view<CT, S, L, FST>>
     {
-        using inner_shape_type = S;
-        using inner_strides_type = inner_shape_type;
-        using inner_backstrides_type = inner_shape_type;
+        using inner_shape_type = std::decay_t<S>;
+        using inner_strides_type = get_strides_t<inner_shape_type>;
+        using inner_backstrides_type_type = inner_strides_type;
 
         using const_stepper = std::conditional_t<
             is_indexed_stepper<typename std::decay_t<CT>::stepper>::value,
@@ -66,21 +103,25 @@ namespace xt
      * and strides.
      *
      * @tparam CT the closure type of the \ref xexpression type underlying this view
+     * @tparam L the layout of the strided view
      * @tparam S the strides type of the strided view
-     * @tparam FST the flat storage type used for the strided view.
+     * @tparam FST the flat storage type used for the strided view
      *
      * @sa strided_view, transpose
      */
-    template <class CT, class S, layout_type L = layout_type::dynamic, class FST = typename detail::flat_storage_type<CT>::type>
+    template <class CT, class S, layout_type L = layout_type::dynamic, class FST = detail::flat_storage_getter<CT, XTENSOR_DEFAULT_TRAVERSAL>>
     class xstrided_view : public xview_semantic<xstrided_view<CT, S, L, FST>>,
                           public xiterable<xstrided_view<CT, S, L, FST>>,
-                          private xstrided_view_base<CT, S, L, FST>
+                          private xstrided_view_base<xstrided_view<CT, S, L, FST>>,
+                          public extension::xstrided_view_base_t<CT, S, L, FST>
     {
     public:
 
         using self_type = xstrided_view<CT, S, L, FST>;
-        using base_type = xstrided_view_base<CT, S, L, FST>;
+        using base_type = xstrided_view_base<self_type>;
         using semantic_base = xview_semantic<self_type>;
+        using extension_base = extension::xstrided_view_base_t<CT, S, L, FST>;
+        using expression_tag = typename extension_base::expression_tag;
 
         using xexpression_type = typename base_type::xexpression_type;
         using base_type::is_const;
@@ -95,12 +136,16 @@ namespace xt
 
         using inner_storage_type = typename base_type::inner_storage_type;
         using storage_type = typename base_type::storage_type;
+        using storage_iterator = typename storage_type::iterator;
+        using const_storage_iterator = typename storage_type::const_iterator;
 
         using iterable_base = xiterable<self_type>;
         using inner_shape_type = typename iterable_base::inner_shape_type;
+        using inner_strides_type = typename base_type::inner_strides_type;
+        using inner_backstrides_type = typename base_type::inner_backstrides_type;
         using shape_type = typename base_type::shape_type;
-        using strides_type = typename base_type::strides_type;;
-        using backstrides_type = typename base_type::backstrides_type;;
+        using strides_type = typename base_type::strides_type;
+        using backstrides_type = typename base_type::backstrides_type;
 
         using stepper = typename iterable_base::stepper;
         using const_stepper = typename iterable_base::const_stepper;
@@ -111,13 +156,14 @@ namespace xt
         using temporary_type = typename xcontainer_inner_types<self_type>::temporary_type;
         using base_index_type = xindex_type_t<shape_type>;
 
-        using simd_value_type = xsimd::simd_type<value_type>;
+        using simd_value_type = typename base_type::simd_value_type;
+        using bool_load_type = typename base_type::bool_load_type;
 
-        template <class CTA>
-        xstrided_view(CTA&& e, S&& shape, S&& strides, std::size_t offset, layout_type layout) noexcept;
+        template <class CTA, class SA>
+        xstrided_view(CTA&& e, SA&& shape, strides_type&& strides, std::size_t offset, layout_type layout) noexcept;
 
-        template <class CTA, class FLS>
-        xstrided_view(CTA&& e, S&& shape, S&& strides, std::size_t offset, layout_type layout, FLS&& flatten_strides, layout_type flatten_layout) noexcept;
+        xstrided_view(const xstrided_view& rhs) = default;
+        xstrided_view& operator=(const xstrided_view& rhs);
 
         template <class E>
         self_type& operator=(const xexpression<E>& e);
@@ -143,10 +189,15 @@ namespace xt
         using base_type::expression;
 
         using base_type::broadcast_shape;
-        using base_type::is_trivial_broadcast;
+        using base_type::has_linear_assign;
 
         template <class T>
         void fill(const T& value);
+
+        storage_iterator storage_begin();
+        storage_iterator storage_end();
+        const_storage_iterator storage_cbegin() const;
+        const_storage_iterator storage_cend() const;
 
         template <class ST>
         stepper stepper_begin(const ST& shape);
@@ -172,27 +223,32 @@ namespace xt
                                                       typename storage_type::iterator>;
         using const_container_iterator = typename storage_type::const_iterator;
 
-    protected:
+        template <class E>
+        using rebind_t = xstrided_view<E, S, L, typename FST::template rebind_t<E>>;
 
-        container_iterator data_xbegin() noexcept;
-        const_container_iterator data_xbegin() const noexcept;
-        container_iterator data_xend(layout_type l) noexcept;
-        const_container_iterator data_xend(layout_type l) const noexcept;
+        template <class E>
+        rebind_t<E> build_view(E&& e) const;
 
     private:
 
-        template <class C>
-        friend class xstepper;
+        container_iterator data_xbegin() noexcept;
+        const_container_iterator data_xbegin() const noexcept;
+        container_iterator data_xend(layout_type l, size_type offset) noexcept;
+        const_container_iterator data_xend(layout_type l, size_type offset) const noexcept;
 
         template <class It>
         It data_xbegin_impl(It begin) const noexcept;
 
         template <class It>
-        It data_xend_impl(It end, layout_type l) const noexcept;
+        It data_xend_impl(It end, layout_type l, size_type offset) const noexcept;
 
         void assign_temporary_impl(temporary_type&& tmp);
 
-        friend class xview_semantic<xstrided_view<CT, S, L, FST>>;
+        template <class C>
+        friend class xstepper;
+        friend class xview_semantic<self_type>;
+        friend class xaccessible<self_type>;
+        friend class xconst_accessible<self_type>;
     };
 
     /**************************
@@ -214,46 +270,25 @@ namespace xt
         xrange_adaptor<T, T, T>,
         xrange_adaptor<placeholders::xtuph, placeholders::xtuph, placeholders::xtuph>,
 
+        xrange<T>,
+        xstepped_range<T>,
+
         xall_tag,
         xellipsis_tag,
         xnewaxis_tag
     >;
 
     /**
-     * @typedef xstrided_slice_vector
-     * @brief vector of slices used to build a `xstrided_view`
-     */
+    * @typedef xstrided_slice_vector
+    * @brief vector of slices used to build a `xstrided_view`
+    */
     using xstrided_slice_vector = std::vector<xstrided_slice<std::ptrdiff_t>>;
 
-    // TODO: remove this type used for backward compatibility only
-    using slice_vector = xstrided_slice_vector;
-
-    template <layout_type L = layout_type::dynamic, class E, class I>
-    auto strided_view(E&& e, I&& shape, I&& strides, std::size_t offset = 0, layout_type layout = layout_type::dynamic) noexcept;
+    template <layout_type L = layout_type::dynamic, class E, class S, class X>
+    auto strided_view(E&& e, S&& shape, X&& stride, std::size_t offset = 0, layout_type layout = L) noexcept;
 
     template <class E>
     auto strided_view(E&& e, const xstrided_slice_vector& slices);
-
-    template <class E>
-    auto transpose(E&& e) noexcept;
-
-    template <class E, class S, class Tag = check_policy::none>
-    auto transpose(E&& e, S&& permutation, Tag check_policy = Tag());
-
-    template <layout_type L, class E>
-    auto ravel(E&& e);
-
-    template <class E>
-    auto flatten(E&& e);
-
-    template <class E>
-    auto trim_zeros(E&& e, const std::string& direction = "fb");
-
-    template <class E>
-    auto squeeze(E&& e);
-
-    template <class E, class S, class Tag = check_policy::none, std::enable_if_t<!std::is_integral<S>::value, int> = 0>
-    auto squeeze(E&& e, S&& axis, Tag check_policy = Tag());
 
     /********************************
      * xstrided_view implementation *
@@ -273,20 +308,19 @@ namespace xt
      * @param layout the layout of the view
      */
     template <class CT, class S, layout_type L, class FST>
-    template <class CTA>
-    inline xstrided_view<CT, S, L, FST>::xstrided_view(CTA&& e, S&& shape, S&& strides, std::size_t offset, layout_type layout) noexcept
-        : base_type(std::forward<CTA>(e), std::move(shape), std::move(strides), offset, layout)
-    {
-    }
-
-    template <class CT, class S, layout_type L, class FST>
-    template <class CTA, class FLS>
-    inline xstrided_view<CT, S, L, FST>::xstrided_view(CTA&& e, S&& shape, S&& strides, std::size_t offset,
-                                                       layout_type layout, FLS&& flatten_strides, layout_type flatten_layout) noexcept
-        : base_type(std::forward<CTA>(e), std::move(shape), std::move(strides), offset, layout, std::forward<FLS>(flatten_strides), flatten_layout)
+    template <class CTA, class SA>
+    inline xstrided_view<CT, S, L, FST>::xstrided_view(CTA&& e, SA&& shape, strides_type&& strides, std::size_t offset, layout_type layout) noexcept
+        : base_type(std::forward<CTA>(e), std::forward<SA>(shape), std::move(strides), offset, layout)
     {
     }
     //@}
+
+    template <class CT, class S, layout_type L, class FST>
+    inline xstrided_view<CT, S, L, FST>& xstrided_view<CT, S, L, FST>::operator=(const xstrided_view<CT, S, L, FST>& rhs)
+    {
+        temporary_type tmp(rhs);
+        return this->assign_temporary(std::move(tmp));
+    }
 
     /**
      * @name Extended copy semantic
@@ -307,7 +341,7 @@ namespace xt
     template <class E>
     inline auto xstrided_view<CT, S, L, FST>::operator=(const E& e) -> disable_xexpression<E, self_type>&
     {
-        std::fill(this->begin(), this->end(), e);
+        this->fill(e);
         return *this;
     }
 
@@ -316,7 +350,7 @@ namespace xt
         template <class V, class T>
         inline void run_assign_temporary_impl(V& v, const T& t, std::true_type /* enable strided assign */)
         {
-            strided_assign(v, t, std::true_type{});
+            strided_loop_assigner<true>::run(v, t);
         }
 
         template <class V, class T>
@@ -329,7 +363,7 @@ namespace xt
     template <class CT, class S, layout_type L, class FST>
     inline void xstrided_view<CT, S, L, FST>::assign_temporary_impl(temporary_type&& tmp)
     {
-        constexpr bool fast_assign = xassign_traits<xstrided_view<CT, S, L, FST>, temporary_type>::simd_strided_loop();
+        constexpr bool fast_assign = xassign_traits<xstrided_view<CT, S, L, FST>, temporary_type>::simd_strided_assign();
         xstrided_view_detail::run_assign_temporary_impl(*this, tmp, std::integral_constant<bool, fast_assign>{});
     }
 
@@ -346,9 +380,40 @@ namespace xt
     template <class T>
     inline void xstrided_view<CT, S, L, FST>::fill(const T& value)
     {
-        return std::fill(this->storage_begin(), this->storage_end(), value);
+        if (layout() != layout_type::dynamic)
+        {
+            std::fill(this->storage_begin(), this->storage_end(), value);
+        }
+        else
+        {
+            std::fill(this->begin(), this->end(), value);
+        }
     }
     //@}
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::storage_begin() -> storage_iterator
+    {
+        return this->storage().begin() + static_cast<std::ptrdiff_t>(data_offset());
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::storage_end() -> storage_iterator
+    {
+        return this->storage().begin() + static_cast<std::ptrdiff_t>(data_offset() + size());
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::storage_cbegin() const -> const_storage_iterator
+    {
+        return this->storage().cbegin() + static_cast<std::ptrdiff_t>(data_offset());
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    inline auto xstrided_view<CT, S, L, FST>::storage_cend() const -> const_storage_iterator
+    {
+        return this->storage().cbegin() + static_cast<std::ptrdiff_t>(data_offset() + size());
+    }
 
     /***************
      * stepper api *
@@ -367,7 +432,7 @@ namespace xt
     inline auto xstrided_view<CT, S, L, FST>::stepper_end(const ST& shape, layout_type l) -> stepper
     {
         size_type offset = shape.size() - dimension();
-        return stepper(this, data_xend(l), offset);
+        return stepper(this, data_xend(l, offset), offset);
     }
 
     template <class CT, class S, layout_type L, class FST>
@@ -383,7 +448,7 @@ namespace xt
     inline auto xstrided_view<CT, S, L, FST>::stepper_end(const ST& shape, layout_type l) const -> std::enable_if_t<!is_indexed_stepper<STEP>::value, STEP>
     {
         size_type offset = shape.size() - dimension();
-        return const_stepper(this, data_xend(l), offset);
+        return const_stepper(this, data_xend(l, offset), offset);
     }
 
     template <class CT, class S, layout_type L, class FST>
@@ -411,10 +476,9 @@ namespace xt
 
     template <class CT, class S, layout_type L, class FST>
     template <class It>
-    inline It xstrided_view<CT, S, L, FST>::data_xend_impl(It begin, layout_type l) const noexcept
+    inline It xstrided_view<CT, S, L, FST>::data_xend_impl(It begin, layout_type l, size_type offset) const noexcept
     {
-        std::ptrdiff_t end_offset = static_cast<std::ptrdiff_t>(std::accumulate(this->backstrides().begin(), this->backstrides().end(), std::size_t(0)));
-        return strided_data_end(*this, begin + std::ptrdiff_t(this->data_offset()) + end_offset + 1, l);
+        return strided_data_end(*this, begin + std::ptrdiff_t(this->data_offset()), l, offset);
     }
 
     template <class CT, class S, layout_type L, class FST>
@@ -430,15 +494,24 @@ namespace xt
     }
 
     template <class CT, class S, layout_type L, class FST>
-    inline auto xstrided_view<CT, S, L, FST>::data_xend(layout_type l) noexcept -> container_iterator
+    inline auto xstrided_view<CT, S, L, FST>::data_xend(layout_type l, size_type offset) noexcept -> container_iterator
     {
-        return data_xend_impl(this->storage().begin(), l);
+        return data_xend_impl(this->storage().begin(), l, offset);
     }
 
     template <class CT, class S, layout_type L, class FST>
-    inline auto xstrided_view<CT, S, L, FST>::data_xend(layout_type l) const noexcept -> const_container_iterator
+    inline auto xstrided_view<CT, S, L, FST>::data_xend(layout_type l, size_type offset) const noexcept -> const_container_iterator
     {
-        return data_xend_impl(this->storage().cbegin(), l);
+        return data_xend_impl(this->storage().cbegin(), l, offset);
+    }
+
+    template <class CT, class S, layout_type L, class FST>
+    template <class E>
+    inline auto xstrided_view<CT, S, L, FST>::build_view(E&& e) const -> rebind_t<E>
+    {
+        inner_shape_type sh(this->shape());
+        inner_strides_type str(this->strides());
+        return rebind_t<E>(std::forward<E>(e), std::move(sh), std::move(str), base_type::data_offset(), this->layout());
     }
 
     /*****************************************
@@ -456,177 +529,36 @@ namespace xt
      *
      * @tparam L the static layout type of the view (default: dynamic)
      * @tparam E type of xexpression
-     * @tparam I shape and strides type
+     * @tparam S strides type
+     * @tparam X strides type
      *
      * @return the view
      */
-    template <layout_type L, class E, class I>
-    inline auto strided_view(E&& e, I&& shape, I&& strides, std::size_t offset, layout_type layout) noexcept
+    template <layout_type L, class E, class S, class X>
+    inline auto strided_view(E&& e, S&& shape, X&& strides, std::size_t offset, layout_type layout) noexcept
     {
-        using view_type = xstrided_view<xclosure_t<E>, I, L>;
-        return view_type(std::forward<E>(e), std::forward<I>(shape), std::forward<I>(strides), offset, layout);
+        using view_type = xstrided_view<xclosure_t<E>, S, L>;
+        return view_type(std::forward<E>(e), std::forward<S>(shape), std::forward<X>(strides), offset, layout);
     }
 
     namespace detail
     {
-        template <class S>
-        struct slice_getter_impl
+        struct no_adj_strides_policy
         {
-            const S& m_shape;
-            mutable std::size_t idx;
+        protected:
 
-            slice_getter_impl(const S& shape)
-                : m_shape(shape), idx(0)
-            {
-            }
+            inline void resize(std::size_t) {}
+            inline void set_fake_slice(std::size_t) {}
 
-            template <class T>
-            std::array<std::ptrdiff_t, 3> operator()(const T& /*t*/) const
+            template <class ST, class S>
+            bool fill_args(const xstrided_slice_vector& /*slices*/, std::size_t /*sl_idx*/,
+                           std::size_t /*i*/, std::size_t /*old_shape*/,
+                           const ST& /*old_stride*/,
+                           S& /*shape*/, get_strides_t<S>& /*strides*/)
             {
-                return {0, 0, 0};
-            }
-
-            template <class A, class B, class C>
-            std::array<std::ptrdiff_t, 3> operator()(const xrange_adaptor<A, B, C>& range) const
-            {
-                auto sl = range.get(static_cast<std::size_t>(m_shape[idx]));
-                return {sl(0), sl.size(), sl.step_size()};
+                return false;
             }
         };
-    }
-
-    template <class T>
-    struct select_strided_view
-    {
-        template <class CT, class S, layout_type L = layout_type::dynamic>
-        using type = xstrided_view<CT, S, L>;
-    };
-
-    template <class T>
-    using select_strided_view_t = typename select_strided_view<T>::type;
-
-    namespace detail
-    {
-        template <class S, class ST>
-        inline auto get_strided_view_args(const S& shape, ST&& strides, std::size_t base_offset, layout_type layout, const xstrided_slice_vector& slices)
-        {
-            // Compute dimension
-            std::size_t dimension = shape.size(), n_newaxis = 0, n_add_all = 0;
-            std::ptrdiff_t dimension_check = static_cast<std::ptrdiff_t>(shape.size());
-
-            bool has_ellipsis = false;
-            for (const auto& el : slices)
-            {
-                if (xtl::get_if<xt::xnewaxis_tag>(&el) != nullptr)
-                {
-                    ++dimension;
-                    ++n_newaxis;
-                }
-                else if (xtl::get_if<std::ptrdiff_t>(&el) != nullptr)
-                {
-                    --dimension;
-                    --dimension_check;
-                }
-                else if (xtl::get_if<xt::xellipsis_tag>(&el) != nullptr)
-                {
-                    if (has_ellipsis == true)
-                    {
-                        throw std::runtime_error("Ellipsis can only appear once.");
-                    }
-                    has_ellipsis = true;
-                }
-                else
-                {
-                    --dimension_check;
-                }
-            }
-
-            if (dimension_check < 0)
-            {
-                throw std::runtime_error("Too many slices for view.");
-            }
-
-            if (has_ellipsis)
-            {
-                // replace ellipsis with N * xt::all
-                // remove -1 because of the ellipsis slize itself
-                n_add_all = shape.size() - (slices.size() - 1 - n_newaxis);
-            }
-
-            // Compute strided view
-            std::size_t offset = base_offset;
-            using shape_type = dynamic_shape<std::ptrdiff_t>;
-
-            shape_type new_shape(dimension);
-            shape_type new_strides(dimension);
-
-            auto old_shape = shape;
-            auto&& old_strides = strides;
-
-            using old_strides_vt = std::decay_t<decltype(old_strides[0])>;
-
-    #define XTENSOR_MS(v) static_cast<std::ptrdiff_t>(v)
-    #define XTENSOR_MU(v) static_cast<std::size_t>(v)
-
-            std::ptrdiff_t i = 0, axis_skip = 0;
-            std::size_t idx = 0;
-
-            auto slice_getter = detail::slice_getter_impl<S>(shape);
-
-            for (; i < XTENSOR_MS(slices.size()); ++i)
-            {
-                auto ptr = xtl::get_if<std::ptrdiff_t>(&slices[XTENSOR_MU(i)]);
-                if (ptr != nullptr)
-                {
-                    auto slice0 = static_cast<old_strides_vt>(*ptr);
-                    offset += static_cast<std::size_t>(slice0 * old_strides[XTENSOR_MU(i - axis_skip)]);
-                }
-                else if (xtl::get_if<xt::xnewaxis_tag>(&slices[XTENSOR_MU(i)]) != nullptr)
-                {
-                    new_shape[idx] = 1;
-                    ++axis_skip, ++idx;
-                }
-                else if (xtl::get_if<xt::xellipsis_tag>(&slices[XTENSOR_MU(i)]) != nullptr)
-                {
-                    for (std::size_t j = 0; j < n_add_all; ++j)
-                    {
-                        new_shape[idx] = XTENSOR_MS(old_shape[XTENSOR_MU(i - axis_skip)]);
-                        new_strides[idx] = XTENSOR_MS(old_strides[XTENSOR_MU(i - axis_skip)]);
-                        --axis_skip, ++idx;
-                    }
-                    ++axis_skip;  // because i++
-                }
-                else if (xtl::get_if<xt::xall_tag>(&slices[XTENSOR_MU(i)]) != nullptr)
-                {
-                    new_shape[idx] = XTENSOR_MS(old_shape[XTENSOR_MU(i - axis_skip)]);
-                    new_strides[idx] = XTENSOR_MS(old_strides[XTENSOR_MU(i - axis_skip)]);
-                    ++idx;
-                }
-                else
-                {
-                    slice_getter.idx = XTENSOR_MU(i - axis_skip);
-                    auto info = xtl::visit(slice_getter, slices[XTENSOR_MU(i)]);
-                    offset += XTENSOR_MU(static_cast<old_strides_vt>(info[0]) * old_strides[XTENSOR_MU(i - axis_skip)]);
-                    new_shape[idx] = std::ptrdiff_t(info[1]);
-                    new_strides[idx] = std::ptrdiff_t(info[2]) * XTENSOR_MS(old_strides[XTENSOR_MU(i - axis_skip)]);
-                    ++idx;
-                }
-            }
-
-            for (; XTENSOR_MU(i - axis_skip) < old_shape.size(); ++i)
-            {
-                new_shape[idx] = XTENSOR_MS(old_shape[XTENSOR_MU(i - axis_skip)]);
-                new_strides[idx] = XTENSOR_MS(old_strides[XTENSOR_MU(i - axis_skip)]);
-                ++idx;
-            }
-
-            layout_type new_layout = do_strides_match(new_shape, new_strides, layout) ? layout : layout_type::dynamic;
-
-            return std::make_tuple(std::move(new_shape), std::move(new_strides), offset, new_layout);
-
-    #undef XTENSOR_MU
-    #undef XTENSOR_MS
-        }
     }
 
     /**
@@ -657,599 +589,26 @@ namespace xt
     template <class E>
     inline auto strided_view(E&& e, const xstrided_slice_vector& slices)
     {
-        auto args = detail::get_strided_view_args(e.shape(), detail::get_strides(e), detail::get_offset(e), e.layout(), slices);
-        using view_type = xstrided_view<xclosure_t<E>, std::decay_t<decltype(std::get<0>(args))>>;
-        return view_type(std::forward<E>(e), std::move(std::get<0>(args)), std::move(std::get<1>(args)), std::get<2>(args), std::get<3>(args));
+        detail::strided_view_args<detail::no_adj_strides_policy> args;
+        args.fill_args(e.shape(), detail::get_strides<XTENSOR_DEFAULT_TRAVERSAL>(e), detail::get_offset<XTENSOR_DEFAULT_TRAVERSAL>(e), e.layout(), slices);
+        using view_type = xstrided_view<xclosure_t<E>, decltype(args.new_shape)>;
+        return view_type(std::forward<E>(e), std::move(args.new_shape), std::move(args.new_strides), args.new_offset, args.new_layout);
     }
 
-    template <class CT, class S, layout_type L, class FST>
-    auto strided_view(const xstrided_view<CT, S, L, FST>& e, const xstrided_slice_vector& slices)
-    {
-        auto args = detail::get_strided_view_args(e.shape(), detail::get_strides(e), detail::get_offset(e), e.layout(), slices);
-        using view_type = xstrided_view<xclosure_t<decltype(e.expression())>, std::decay_t<decltype(std::get<0>(args))>>;
-        return view_type(e.expression(), std::move(std::get<0>(args)), std::move(std::get<1>(args)), std::get<2>(args), std::get<3>(args));
-    }
-
-    template <class CT, class S, layout_type L, class FST>
-    auto strided_view(xstrided_view<CT, S, L, FST>& e, const xstrided_slice_vector& slices)
-    {
-        auto args = detail::get_strided_view_args(e.shape(), detail::get_strides(e), detail::get_offset(e), e.layout(), slices);
-        using view_type = xstrided_view<xclosure_t<decltype(e.expression())>, std::decay_t<decltype(std::get<0>(args))>>;
-        return view_type(e.expression(), std::move(std::get<0>(args)), std::move(std::get<1>(args)), std::get<2>(args), std::get<3>(args));
-    }
-
-    /****************************
-     * transpose implementation *
-     ****************************/
-
-    namespace detail
-    {
-        inline layout_type transpose_layout_noexcept(layout_type l) noexcept
-        {
-            layout_type result = l;
-            if (l == layout_type::row_major)
-            {
-                result = layout_type::column_major;
-            }
-            else if (l == layout_type::column_major)
-            {
-                result = layout_type::row_major;
-            }
-            return result;
-        }
-
-        inline layout_type transpose_layout(layout_type l)
-        {
-            if (l != layout_type::row_major && l != layout_type::column_major)
-            {
-                throw transpose_error("cannot compute transposed layout of dynamic layout");
-            }
-            return transpose_layout_noexcept(l);
-        }
-
-        template <class E, class S>
-        inline auto transpose_impl(E&& e, S&& permutation, check_policy::none)
-        {
-            if (sequence_size(permutation) != e.dimension())
-            {
-                throw transpose_error("Permutation does not have the same size as shape");
-            }
-
-            // permute stride and shape
-            using strides_type = typename std::decay_t<E>::strides_type;
-            strides_type temp_strides;
-            resize_container(temp_strides, e.strides().size());
-
-            using shape_type = typename std::decay_t<E>::shape_type;
-            shape_type temp_shape;
-            resize_container(temp_shape, e.shape().size());
-
-            using size_type = typename std::decay_t<E>::size_type;
-            for (std::size_t i = 0; i < e.shape().size(); ++i)
-            {
-                if (std::size_t(permutation[i]) >= e.dimension())
-                {
-                    throw transpose_error("Permutation contains wrong axis");
-                }
-                size_type perm = static_cast<size_type>(permutation[i]);
-                temp_shape[i] = e.shape()[perm];
-                temp_strides[i] = e.strides()[perm];
-            }
-
-            layout_type new_layout = layout_type::dynamic;
-            if (std::is_sorted(std::begin(permutation), std::end(permutation)))
-            {
-                // keep old layout
-                new_layout = e.layout();
-            }
-            else if (std::is_sorted(std::begin(permutation), std::end(permutation), std::greater<>()))
-            {
-                new_layout = transpose_layout_noexcept(e.layout());
-            }
-
-            using view_type = typename select_strided_view<std::decay_t<E>>::template type<xclosure_t<E>, shape_type>;
-            return view_type(std::forward<E>(e), std::move(temp_shape), std::move(temp_strides), 0, new_layout);
-        }
-
-        template <class E, class S>
-        inline auto transpose_impl(E&& e, S&& permutation, check_policy::full)
-        {
-            // check if axis appears twice in permutation
-            for (std::size_t i = 0; i < sequence_size(permutation); ++i)
-            {
-                for (std::size_t j = i + 1; j < sequence_size(permutation); ++j)
-                {
-                    if (permutation[i] == permutation[j])
-                    {
-                        throw transpose_error("Permutation contains axis more than once");
-                    }
-                }
-            }
-            return transpose_impl(std::forward<E>(e), std::forward<S>(permutation), check_policy::none());
-        }
-
-        template <class E, class S, std::enable_if_t<has_data_interface<std::decay_t<E>>::value>* = nullptr>
-        inline void compute_transposed_strides(E&& e, const S&, S& strides)
-        {
-            std::copy(e.strides().crbegin(), e.strides().crend(), strides.begin());
-        }
-
-        template <class E, class S, std::enable_if_t<!has_data_interface<std::decay_t<E>>::value>* = nullptr>
-        inline void compute_transposed_strides(E&&, const S& shape, S& strides)
-        {
-            layout_type l = transpose_layout(std::decay_t<E>::static_layout);
-            compute_strides(shape, l, strides);
-        }
-    }
-
-    /**
-     * Returns a transpose view by reversing the dimensions of xexpression e
-     * @param e the input expression
-     */
-    template <class E>
-    inline auto transpose(E&& e) noexcept
-    {
-        using shape_type = typename std::decay_t<E>::shape_type;
-        shape_type shape;
-        resize_container(shape, e.shape().size());
-        std::copy(e.shape().crbegin(), e.shape().crend(), shape.begin());
-
-        shape_type strides;
-        resize_container(strides, e.shape().size());
-        detail::compute_transposed_strides(e, shape, strides);
-
-        layout_type new_layout = detail::transpose_layout_noexcept(e.layout());
-
-        using view_type = typename select_strided_view<std::decay_t<E>>::template type<xclosure_t<E>, shape_type>;
-        return view_type(std::forward<E>(e), std::move(shape), std::move(strides), 0, new_layout);
-    }
-
-    /**
-     * Returns a transpose view by permuting the xexpression e with @p permutation.
-     * @param e the input expression
-     * @param permutation the sequence containing permutation
-     * @param check_policy the check level (check_policy::full() or check_policy::none())
-     * @tparam Tag selects the level of error checking on permutation vector defaults to check_policy::none.
-     */
-    template <class E, class S, class Tag>
-    inline auto transpose(E&& e, S&& permutation, Tag check_policy)
-    {
-        return detail::transpose_impl(std::forward<E>(e), std::forward<S>(permutation), check_policy);
-    }
-
-    /// @cond DOXYGEN_INCLUDE_SFINAE
-#ifdef X_OLD_CLANG
-    template <class E, class I, class Tag = check_policy::none>
-    inline auto transpose(E&& e, std::initializer_list<I> permutation, Tag check_policy = Tag())
-    {
-        dynamic_shape<I> perm(permutation);
-        return detail::transpose_impl(std::forward<E>(e), std::move(perm), check_policy);
-    }
-#else
-    template <class E, class I, std::size_t N, class Tag = check_policy::none>
-    inline auto transpose(E&& e, const I(&permutation)[N], Tag check_policy = Tag())
-    {
-        return detail::transpose_impl(std::forward<E>(e), permutation, check_policy);
-    }
-#endif
-    /// @endcond
-
-    /***************************
-     * ravel and flatten views *
-     ***************************/
-
-    namespace detail
-    {
-        template <class E>
-        inline auto build_ravel_view(E&& e)
-        {
-            using shape_type = static_shape<std::size_t, 1>;
-            using view_type = xstrided_view<xclosure_t<E>, shape_type>;
-
-            shape_type new_shape, new_strides;
-            new_shape[0] = e.size();
-            new_strides[0] = std::size_t(1);
-            std::size_t offset = detail::get_offset(e);
-
-            return view_type(std::forward<E>(e),
-                             std::move(new_shape),
-                             std::move(new_strides),
-                             offset,
-                             layout_type::dynamic);
-        }
-
-        template <class E, class S>
-        inline auto build_ravel_view(E&& e, S&& flatten_strides, layout_type l)
-        {
-            using shape_type = static_shape<std::size_t, 1>;
-            using view_type = xstrided_view<xclosure_t<E>, shape_type, layout_type::dynamic, detail::flat_expression_adaptor<xclosure_t<E>>>;
-
-            shape_type new_shape, new_strides;
-            new_shape[0] = e.size();
-            new_strides[0] = std::size_t(1);
-            std::size_t offset = detail::get_offset(e);
-
-            return view_type(std::forward<E>(e),
-                             std::move(new_shape),
-                             std::move(new_strides),
-                             offset,
-                             layout_type::dynamic,
-                             std::move(flatten_strides),
-                             l);
-        }
-
-        template <bool same_layout>
-        struct ravel_impl
-        {
-            template <class E>
-            inline static auto run(E&& e)
-            {
-                return build_ravel_view(std::forward<E>(e));
-            }
-        };
-
-        template <>
-        struct ravel_impl<false>
-        {
-            template <class E>
-            inline static auto run(E&& e)
-            {
-                // Case where the static layout is either row_major or column major.
-                using shape_type = typename std::decay_t<E>::shape_type;
-                shape_type strides;
-                resize_container(strides, e.shape().size());
-                layout_type l = detail::transpose_layout(e.layout());
-                compute_strides(e.shape(), l, strides);
-                return build_ravel_view(std::forward<E>(e), std::move(strides), l);
-            }
-        };
-    }
-
-    /**
-     * Returns a flatten view of the given expression. No copy is made.
-     * @param e the input expression
-     * @tparam L the layout used to read the elements of e
-     * @tparam E the type of the expression
-     */
-    template <layout_type L, class E>
-    inline auto ravel(E&& e)
-    {
-        return detail::ravel_impl<std::decay_t<E>::static_layout == L>::run(std::forward<E>(e));
-    }
-
-    /**
-     * Returns a flatten view of the given expression. No copy is made.
-     * The layout used to read the elements is the one of e.
-     * @param e the input expression
-     * @tparam E the type of the expression
-     */
-    template <class E>
-    inline auto flatten(E&& e)
-    {
-        return ravel<std::decay_t<E>::static_layout>(std::forward<E>(e));
-    }
-
-    /**
-     * Trim zeros at beginning, end or both of 1D sequence.
-     *
-     * @param e input xexpression
-     * @param direction string of either 'f' for trim from beginning, 'b' for trim from end
-     *                  or 'fb' (default) for both.
-     * @return returns a view without zeros at the beginning and end
-     */
-    template <class E>
-    inline auto trim_zeros(E&& e, const std::string& direction)
-    {
-        XTENSOR_ASSERT_MSG(e.dimension() == 1, "Dimension for trim_zeros has to be 1.");
-
-        std::ptrdiff_t begin = 0, end = static_cast<std::ptrdiff_t>(e.size());
-
-        auto find_fun = [](const auto& i) {
-            return i != 0;
-        };
-
-        if (direction.find("f") != std::string::npos)
-        {
-            begin = std::find_if(e.cbegin(), e.cend(), find_fun) - e.cbegin();
-        }
-
-        if (direction.find("b") != std::string::npos && begin != end)
-        {
-            end -= std::find_if(e.crbegin(), e.crend(), find_fun) - e.crbegin();
-        }
-
-        return strided_view(std::forward<E>(e), { range(begin, end) });
-    }
-
-    /**
-     * Returns a squeeze view of the given expression. No copy is made.
-     * Squeezing an expression removes dimensions of extent 1.
-     *
-     * @param e the input expression
-     * @tparam E the type of the expression
-     */
-    template <class E>
-    inline auto squeeze(E&& e)
-    {
-        xt::dynamic_shape<std::size_t> new_shape, new_strides;
-        std::copy_if(e.shape().cbegin(), e.shape().cend(), std::back_inserter(new_shape),
-                     [](std::size_t i) { return i != 1; });
-        auto&& old_strides = detail::get_strides(e);
-        std::copy_if(old_strides.cbegin(), old_strides.cend(), std::back_inserter(new_strides),
-                     [](std::size_t i) { return i != 0; });
-
-        using view_type = xstrided_view<xclosure_t<E>, xt::dynamic_shape<std::size_t>>;
-        return view_type(std::forward<E>(e), std::move(new_shape), std::move(new_strides), 0, e.layout());
-    }
-
-    namespace detail
-    {
-        template <class E, class S>
-        inline auto squeeze_impl(E&& e, S&& axis, check_policy::none)
-        {
-            std::size_t new_dim = e.dimension() - axis.size();
-            xt::dynamic_shape<std::size_t> new_shape(new_dim), new_strides(new_dim);
-
-            decltype(auto) old_strides = detail::get_strides(e);
-
-            for (std::size_t i = 0, ix = 0; i < e.dimension(); ++i)
-            {
-                if (axis.cend() == std::find(axis.cbegin(), axis.cend(), i))
-                {
-                    new_shape[ix] = e.shape()[i];
-                    new_strides[ix++] = old_strides[i];
-                }
-            }
-
-            using view_type = xstrided_view<xclosure_t<E>, xt::dynamic_shape<std::size_t>>;
-            return view_type(std::forward<E>(e), std::move(new_shape), std::move(new_strides), 0, e.layout());
-        }
-
-        template <class E, class S>
-        inline auto squeeze_impl(E&& e, S&& axis, check_policy::full)
-        {
-            for (auto ix : axis)
-            {
-                if (static_cast<std::size_t>(ix) > e.dimension())
-                {
-                    throw std::runtime_error("Axis argument to squeeze > dimension of expression");
-                }
-                if (e.shape()[static_cast<std::size_t>(ix)] != 1)
-                {
-                    throw std::runtime_error("Trying to squeeze axis != 1");
-                }
-            }
-            return squeeze_impl(std::forward<E>(e), std::forward<S>(axis), check_policy::none());
-        }
-    }
-
-    /**
-     * @brief Remove single-dimensional entries from the shape of an xexpression
-     *
-     * @param e input xexpression
-     * @param axis integer or container of integers, select a subset of single-dimensional
-     *        entries of the shape.
-     * @param check_policy select check_policy. With check_policy::full(), selecting an axis
-     *        which is greater than one will throw a runtime_error.
-     */
-    template <class E, class S, class Tag, std::enable_if_t<!std::is_integral<S>::value, int>>
-    inline auto squeeze(E&& e, S&& axis, Tag check_policy)
-    {
-        return detail::squeeze_impl(std::forward<E>(e), std::forward<S>(axis), check_policy);
-    }
-
-    /// @cond DOXYGEN_INCLUDE_SFINAE
-#ifdef X_OLD_CLANG
-    template <class E, class I, class Tag = check_policy::none>
-    inline auto squeeze(E&& e, std::initializer_list<I> axis, Tag check_policy = Tag())
-    {
-        dynamic_shape<I> ax(axis);
-        return detail::squeeze_impl(std::forward<E>(e), std::move(ax), check_policy);
-    }
-#else
-    template <class E, class I, std::size_t N, class Tag = check_policy::none>
-    inline auto squeeze(E&& e, const I(&axis)[N], Tag check_policy = Tag())
-    {
-        using arr_t = std::array<I, N>;
-        return detail::squeeze_impl(std::forward<E>(e), xtl::forward_sequence<arr_t>(axis), check_policy);
-    }
-#endif
-
-    template <class E, class Tag = check_policy::none>
-    inline auto squeeze(E&& e, std::size_t axis, Tag check_policy = Tag())
-    {
-        return squeeze(std::forward<E>(e), std::array<std::size_t, 1>{ axis }, check_policy);
-    }
-    /// @endcond
-
-    /**
-     * @brief Expand the shape of an xexpression.
-     *
-     * Insert a new axis that will appear at the axis position in the expanded array shape.
-     * This will return a ``strided_view`` with a ``xt::newaxis()`` at the indicated axis.
-     *
-     * @param e input xexpression
-     * @param axis axis to expand
-     * @return returns a ``strided_view`` with expanded dimension
-     */
-    template <class E>
-    auto expand_dims(E&& e, std::size_t axis)
-    {
-        xstrided_slice_vector sv(e.dimension() + 1, xt::all());
-        sv[axis] = xt::newaxis();
-        return strided_view(std::forward<E>(e), std::move(sv));
-    }
-
-    /**
-     * Expand dimensions of xexpression to at least `N`
-     *
-     * This adds ``newaxis()`` slices to a ``strided_view`` until
-     * the dimension of the view reaches at least `N`.
-     * Note: dimensions are added equally at the beginning and the end.
-     * For example, a 1-D array of shape (N,) becomes a view of shape (1, N, 1).
-     *
-     * @param e input xexpression
-     * @tparam N the number of requested dimensions
-     * @return ``strided_view`` with expanded dimensions
-     */
-    template <std::size_t N, class E>
-    auto atleast_Nd(E&& e)
-    {
-        xstrided_slice_vector sv((std::max)(e.dimension(), N), xt::all());
-        if (e.dimension() < N)
-        {
-            std::size_t i = 0;
-            std::size_t end = static_cast<std::size_t>(std::round(double(N - e.dimension()) / double(N)));
-            for (; i < end; ++i)
-            {
-                sv[i] = xt::newaxis();
-            }
-            i += e.dimension();
-            for (; i < N; ++i)
-            {
-                sv[i] = xt::newaxis();
-            }
-        }
-        return strided_view(std::forward<E>(e), std::move(sv));
-    }
-
-    /**
-     * Expand to at least 1D
-     * @sa atleast_Nd
-     */
-    template <class E>
-    auto atleast_1d(E&& e)
-    {
-        return atleast_Nd<1>(std::forward<E>(e));
-    }
-
-    /**
-     * Expand to at least 2D
-     * @sa atleast_Nd
-     */
-    template <class E>
-    auto atleast_2d(E&& e)
-    {
-        return atleast_Nd<2>(std::forward<E>(e));
-    }
-
-    /**
-     * Expand to at least 3D
-     * @sa atleast_Nd
-     */
-    template <class E>
-    auto atleast_3d(E&& e)
-    {
-        return atleast_Nd<3>(std::forward<E>(e));
-    }
-
-    /**
-     * @brief Split xexpression along axis into subexpressions
-     *
-     * This splits an xexpression along the axis in `n` equal parts and
-     * returns a vector of ``strided_view``.
-     * Calling split with axis > dimension of e or a `n` that does not result in
-     * an equal division of the xexpression will throw a runtime_error.
-     *
-     * @param e input xexpression
-     * @param n number of elements to return
-     * @param axis axis along which to split the expression
-     */
-    template <class E>
-    auto split(E& e, std::size_t n, std::size_t axis = 0)
-    {
-        if (axis >= e.dimension())
-        {
-            throw std::runtime_error("Split along axis > dimension.");
-        }
-
-        std::size_t ax_sz = e.shape()[axis];
-        xstrided_slice_vector sv(e.dimension(), xt::all());
-        std::size_t step = ax_sz / n;
-        std::size_t rest = ax_sz % n;
-
-        if (rest)
-        {
-            throw std::runtime_error("Split does not result in equal division.");
-        }
-
-        std::vector<decltype(strided_view(e, sv))> result;
-        for (std::size_t i = 0; i < n; ++i)
-        {
-            sv[axis] = range(i * step, (i + 1) * step);
-            result.emplace_back(strided_view(e, sv));
-        }
-        return result;
-    }
-
-    template <class T>
-    struct make_signed_shape;
-
-    template <class E, std::size_t N>
-    struct make_signed_shape<std::array<E, N>>
-    {
-        using type = std::array<typename std::make_signed<E>::type, N>;
-    };
-
-    template <class E>
-    struct make_signed_shape<std::vector<E>>
-    {
-        using type = std::vector<typename std::make_signed<E>::type>;
-    };
-
-    template <class E>
-    struct make_signed_shape<xt::svector<E>>
-    {
-        using type = xt::svector<typename std::make_signed<E>::type>;
-    };
-
-    template <class T>
-    using make_signed_shape_t = typename make_signed_shape<T>::type;
-
-    /**
-     * @brief Reverse the order of elements in an xexpression along the given axis.
-     * Note: A NumPy/Matlab style `flipud(arr)` is equivalent to `xt::flip(arr, 0)`,
-     * `fliplr(arr)` to `xt::flip(arr, 1)`.
-     *
-     * @param e the input xexpression
-     * @param axis the axis along which elements should be reversed
-     *
-     * @return returns a view with the result of the flip
-     */
-    template <class E>
-    inline auto flip(E&& e, std::size_t axis)
-    {
-        using shape_type = typename std::decay_t<E>::shape_type;
-        using signed_shape_type = make_signed_shape_t<shape_type>;
-
-        signed_shape_type shape;
-        resize_container(shape, e.shape().size());
-        std::copy(e.shape().cbegin(), e.shape().cend(), shape.begin());
-
-        signed_shape_type strides;
-        auto&& old_strides = detail::get_strides(e);
-        resize_container(strides, old_strides.size());
-        std::copy(old_strides.cbegin(), old_strides.cend(), strides.begin());
-
-        strides[axis] *= -1;
-        std::size_t offset = old_strides[axis] * (e.shape()[axis] - 1);
-
-        return strided_view(std::forward<E>(e), std::move(shape), std::move(strides), offset);
-    }
-
-    template <class E, class S>
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E, class S>
     inline auto reshape_view(E&& e, S&& shape)
     {
-        using shape_type = S;
+        using shape_type = std::decay_t<S>;
+        get_strides_t<shape_type> strides;
 
-        shape_type strides;
         xt::resize_container(strides, shape.size());
-        compute_strides(shape, default_assignable_layout(std::decay_t<E>::static_layout), strides);
-
-        return strided_view<std::decay_t<E>::static_layout>(std::forward<E>(e), std::forward<S>(shape), std::move(strides), 0);
+        compute_strides(shape, L, strides);
+        using view_type = xstrided_view<xclosure_t<E>, shape_type, layout_type::dynamic, detail::flat_adaptor_getter<xclosure_t<E>, L>>;
+        return view_type(std::forward<E>(e), std::forward<S>(shape), std::move(strides), 0, e.layout());
     }
 
     /**
+     * @deprecated
      * @brief Return a view on a container with a new shape
      *
      * Note: if you resize the underlying container, this view becomes
@@ -1257,49 +616,43 @@ namespace xt
      *
      * @param e xexpression to reshape
      * @param shape new shape
-     * @param layout new layout (optional)
+     * @param order traversal order (optional)
      *
      * @return view on xexpression with new shape
      */
-    template <class E, class S>
-    inline auto reshape_view(E&& e, S&& shape, layout_type layout)
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E, class S>
+    inline auto reshape_view(E&& e, S&& shape, layout_type /*order*/)
     {
-        using shape_type = S;
-
-        shape_type strides;
-        xt::resize_container(strides, shape.size());
-        compute_strides(shape, layout, strides);
-
-        return strided_view(std::forward<E>(e), std::forward<S>(shape), std::move(strides), 0);
+        return reshape_view<L>(std::forward<E>(e), std::forward<S>(shape));
     }
 
 #if !defined(X_OLD_CLANG)
-    template <class E, class I, std::size_t N>
-    inline auto reshape_view(E&& e, const I(&shape)[N], layout_type l)
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E, class I, std::size_t N>
+    inline auto reshape_view(E&& e, const I(&shape)[N], layout_type order)
     {
         using shape_type = std::array<std::size_t, N>;
-        return reshape_view(std::forward<E>(e), xtl::forward_sequence<shape_type>(shape), l);
+        return reshape_view<L>(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(shape)>(shape), order);
     }
 
-    template <class E, class I, std::size_t N>
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E, class I, std::size_t N>
     inline auto reshape_view(E&& e, const I(&shape)[N])
     {
         using shape_type = std::array<std::size_t, N>;
-        return reshape_view(std::forward<E>(e), xtl::forward_sequence<shape_type>(shape));
+        return reshape_view<L>(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
     }
 #else
-    template <class E, class I>
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E, class I>
     inline auto reshape_view(E&& e, const std::initializer_list<I>& shape)
     {
         using shape_type = xt::dynamic_shape<std::size_t>;
-        return reshape_view(std::forward<E>(e), xtl::forward_sequence<shape_type>(shape));
+        return reshape_view<L>(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(shape)>(shape));
     }
 
-    template <class E, class I>
-    inline auto reshape_view(E&& e, const std::initializer_list<I>& shape, layout_type l)
+    template <layout_type L = XTENSOR_DEFAULT_TRAVERSAL, class E, class I>
+    inline auto reshape_view(E&& e, const std::initializer_list<I>& shape, layout_type order)
     {
         using shape_type = xt::dynamic_shape<std::size_t>;
-        return reshape_view(std::forward<E>(e), xtl::forward_sequence<shape_type>(shape), l);
+        return reshape_view<L>(std::forward<E>(e), xtl::forward_sequence<shape_type, decltype(shape)>(shape), order);
     }
 #endif
 }

--- a/vendor/xtensor/include/xtensor/xstrides.hpp
+++ b/vendor/xtensor/include/xtensor/xstrides.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -11,9 +12,13 @@
 
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <numeric>
 
+#include <xtl/xsequence.hpp>
+
 #include "xexception.hpp"
+#include "xshape.hpp"
 #include "xtensor_forward.hpp"
 
 namespace xt
@@ -26,26 +31,26 @@ namespace xt
      * data offset *
      ***************/
 
-    template <class size_type, class S>
-    size_type data_offset(const S& strides) noexcept;
+    template <class offset_type, class S>
+    offset_type data_offset(const S& strides) noexcept;
 
-    template <class size_type, class S, class Arg, class... Args>
-    size_type data_offset(const S& strides, Arg arg, Args... args) noexcept;
+    template <class offset_type, class S, class Arg, class... Args>
+    offset_type data_offset(const S& strides, Arg arg, Args... args) noexcept;
 
-    template <class size_type, class S, class... Args>
-    size_type unchecked_data_offset(const S& strides, Args... args) noexcept;
+    template <class offset_type, layout_type L = layout_type::dynamic, class S, class... Args>
+    offset_type unchecked_data_offset(const S& strides, Args... args) noexcept;
 
-    template <class size_type, class S, class It>
-    size_type element_offset(const S& strides, It first, It last) noexcept;
+    template <class offset_type, class S, class It>
+    offset_type element_offset(const S& strides, It first, It last) noexcept;
 
     /*******************
      * strides builder *
      *******************/
 
-    template <class shape_type, class strides_type>
+    template <layout_type L = layout_type::dynamic, class shape_type, class strides_type>
     std::size_t compute_strides(const shape_type& shape, layout_type l, strides_type& strides);
 
-    template <class shape_type, class strides_type, class backstrides_type>
+    template <layout_type L = layout_type::dynamic, class shape_type, class strides_type, class backstrides_type>
     std::size_t compute_strides(const shape_type& shape, layout_type l,
                                 strides_type& strides, backstrides_type& backstrides);
 
@@ -61,14 +66,20 @@ namespace xt
      *****************/
 
     template <class S>
-    S unravel_from_strides(typename S::value_type index, const S& strides, layout_type l);
+    S unravel_from_strides(typename S::value_type index, const S& strides, layout_type l=layout_type::row_major);
 
     template <class S>
-    S unravel_index(typename S::value_type index, const S& shape, layout_type l);
+    get_strides_t<S> unravel_index(typename S::value_type index, const S& shape, layout_type l=layout_type::row_major);
+
+    template <class S, class T>
+    std::vector<get_strides_t<S>> unravel_indices(const T& indices, const S& shape, layout_type l=layout_type::row_major);
 
     /***********************
      * broadcast functions *
      ***********************/
+
+    template <class S, class size_type>
+    S uninitialized_shape(size_type size);
 
     template <class S1, class S2>
     bool broadcast_shape(const S1& input, S2& output);
@@ -83,92 +94,201 @@ namespace xt
     template <layout_type L>
     struct check_strides_overlap;
 
+    /**********************************
+     * check bounds, without throwing *
+     **********************************/
+
+    template <class S, class... Args>
+    bool in_bounds(const S& shape, Args&... args);
+
+    /********************************
+     * apply periodicity to indices *
+     *******************************/
+
+    template <class S, class... Args>
+    void normalize_periodic(const S& shape, Args&... args);
+
     /********************************************
      * utility functions for strided containers *
      ********************************************/
 
-    template <class C, class It>
-    It strided_data_end(const C& c, It end, layout_type l)
+    template <class C, class It, class size_type>
+    It strided_data_end(const C& c, It begin, layout_type l, size_type offset)
     {
         using difference_type = typename std::iterator_traits<It>::difference_type;
         if (c.dimension() == 0)
         {
-            return end;
+            ++begin;
         }
         else
         {
-            auto leading_stride = (l == layout_type::row_major ? c.strides().back() : c.strides().front());
-            return end + difference_type(leading_stride - 1);
+            for (std::size_t i = 0; i != c.dimension(); ++i)
+            {
+                begin += c.strides()[i] * difference_type(c.shape()[i] - 1);
+            }
+            if (l == layout_type::row_major)
+            {
+                begin += c.strides().back();
+            }
+            else
+            {
+                if (offset == 0)
+                {
+                    begin += c.strides().front();
+                }
+            }
         }
+        return begin;
     }
 
     /******************
      * Implementation *
      ******************/
 
+    namespace detail
+    {
+        template <class shape_type>
+        inline std::size_t compute_size_impl(const shape_type& shape, std::true_type /* is signed */) {
+            using size_type = std::decay_t<typename shape_type::value_type>;
+            return static_cast<std::size_t>(std::abs(std::accumulate(shape.cbegin(), shape.cend(), size_type(1), std::multiplies<size_type>())));
+        }
+
+        template <class shape_type>
+        inline std::size_t compute_size_impl(const shape_type& shape, std::false_type /* is not signed */) {
+            using size_type = std::decay_t<typename shape_type::value_type>;
+            return static_cast<std::size_t>(std::accumulate(shape.cbegin(), shape.cend(), size_type(1), std::multiplies<size_type>()));
+        }
+    }
+
     template <class shape_type>
     inline std::size_t compute_size(const shape_type& shape) noexcept
     {
-        using size_type = std::decay_t<typename shape_type::value_type>;
-        return static_cast<std::size_t>(std::accumulate(shape.cbegin(), shape.cend(), size_type(1), std::multiplies<size_type>()));
+        return detail::compute_size_impl(shape, std::is_signed<std::decay_t<typename std::decay_t<shape_type>::value_type>>());
     }
 
     namespace detail
     {
-        template <class size_type, std::size_t dim, class S>
-        inline size_type raw_data_offset(const S&) noexcept
+        template <std::size_t dim, class S>
+        inline auto raw_data_offset(const S&) noexcept
         {
-            return 0;
+            using strides_value_type = std::decay_t<decltype(std::declval<S>()[0])>;
+            return strides_value_type(0);
         }
 
-        template <class size_type, std::size_t dim, class S, class Arg, class... Args>
-        inline size_type raw_data_offset(const S& strides, Arg arg, Args... args) noexcept
+        template <std::size_t dim, class S, class Arg, class... Args>
+        inline auto raw_data_offset(const S& strides, Arg arg, Args... args) noexcept
         {
-            using strides_type = decltype(strides[0]);
-            return strides_type(arg) * strides[dim] + raw_data_offset<size_type, dim + 1>(strides, args...);
+            return arg * strides[dim] + raw_data_offset<dim + 1>(strides, args...);
         }
+
+        template <layout_type L, std::ptrdiff_t static_dim>
+        struct layout_data_offset
+        {
+            template <std::size_t dim, class S, class Arg, class... Args>
+            static inline auto run(const S& strides, Arg arg, Args... args) noexcept
+            {
+                return raw_data_offset<dim>(strides, arg, args...);
+            }
+        };
+
+        template <std::ptrdiff_t static_dim>
+        struct layout_data_offset<layout_type::row_major, static_dim>
+        {
+            using self_type = layout_data_offset<layout_type::row_major, static_dim>;
+
+            template <std::size_t dim, class S, class Arg>
+            static inline auto run(const S& strides, Arg arg) noexcept
+            {
+                if (std::ptrdiff_t(dim) + 1 == static_dim)
+                {
+                    return arg;
+                }
+                else
+                {
+                    return arg * strides[dim];
+                }
+            }
+
+            template <std::size_t dim, class S, class Arg, class... Args>
+            static inline auto run(const S& strides, Arg arg, Args... args) noexcept
+            {
+                return arg * strides[dim] + self_type::template run<dim + 1>(strides, args...);
+            }
+        };
+
+        template <std::ptrdiff_t static_dim>
+        struct layout_data_offset<layout_type::column_major, static_dim>
+        {
+            using self_type = layout_data_offset<layout_type::column_major, static_dim>;
+
+            template <std::size_t dim, class S, class Arg>
+            static inline auto run(const S& strides, Arg arg) noexcept
+            {
+                if (dim == 0)
+                {
+                    return arg;
+                }
+                else
+                {
+                    return arg * strides[dim];
+                }
+            }
+
+            template <std::size_t dim, class S, class Arg, class... Args>
+            static inline auto run(const S& strides, Arg arg, Args... args) noexcept
+            {
+                if (dim == 0)
+                {
+                    return arg + self_type::template run<dim + 1>(strides, args...);
+                }
+                else
+                {
+                    return arg * strides[dim] + self_type::template run<dim + 1>(strides, args...);
+                }
+            }
+        };
     }
 
-    template <class size_type, class S>
-    inline size_type data_offset(const S&) noexcept
+    template <class offset_type, class S>
+    inline offset_type data_offset(const S&) noexcept
     {
-        return 0;
+        return offset_type(0);
     }
 
-    template <class size_type, class S, class Arg, class... Args>
-    inline size_type data_offset(const S& strides, Arg arg, Args... args) noexcept
+    template <class offset_type, class S, class Arg, class... Args>
+    inline offset_type data_offset(const S& strides, Arg arg, Args... args) noexcept
     {
         constexpr std::size_t nargs = sizeof...(Args) + 1;
         if (nargs == strides.size())
         {
             // Correct number of arguments: iterate
-            return detail::raw_data_offset<size_type, 0>(strides, arg, args...);
+            return static_cast<offset_type>(detail::raw_data_offset<0>(strides, arg, args...));
         }
         else if (nargs > strides.size())
         {
             // Too many arguments: drop the first
-            return data_offset<size_type, S>(strides, args...);
+            return data_offset<offset_type, S>(strides, args...);
         }
         else
         {
             // Too few arguments: right to left scalar product
             auto view = strides.cend() - nargs;
-            return detail::raw_data_offset<size_type, 0>(view, arg, args...);
+            return static_cast<offset_type>(detail::raw_data_offset<0>(view, arg, args...));
         }
     }
 
-    template <class size_type, class S, class... Args>
-    inline size_type unchecked_data_offset(const S& strides, Args... args) noexcept
+    template <class offset_type, layout_type L, class S, class... Args>
+    inline offset_type unchecked_data_offset(const S& strides, Args... args) noexcept
     {
-        return detail::raw_data_offset<size_type, 0>(strides.cbegin(), args...);
+        return static_cast<offset_type>(detail::layout_data_offset<L, static_dimension<S>::value>::template run<0>(strides.cbegin(), args...));
     }
 
-    template <class size_type, class S, class It>
-    inline size_type element_offset(const S& strides, It first, It last) noexcept
+    template <class offset_type, class S, class It>
+    inline offset_type element_offset(const S& strides, It first, It last) noexcept
     {
         using difference_type = typename std::iterator_traits<It>::difference_type;
         auto size = static_cast<difference_type>((std::min)(static_cast<typename S::size_type>(std::distance(first, last)), strides.size()));
-        return std::inner_product(last - size, last, strides.cend() - size, size_type(0));
+        return std::inner_product(last - size, last, strides.cend() - size, offset_type(0));
     }
 
     namespace detail
@@ -181,7 +301,7 @@ namespace xt
             {
                 strides[i] = 0;
             }
-            (*backstrides)[i] = strides[i] * (shape[i] - 1);
+            (*backstrides)[i] = strides[i] * std::ptrdiff_t(shape[i] - 1);
         }
 
         template <class shape_type, class strides_type>
@@ -194,61 +314,70 @@ namespace xt
             }
         }
 
-        template <class shape_type, class strides_type, class bs_ptr>
+        template <layout_type L, class shape_type, class strides_type, class bs_ptr>
         inline std::size_t compute_strides(const shape_type& shape, layout_type l,
                                            strides_type& strides, bs_ptr bs)
         {
-            std::size_t data_size = 1;
-            if (l == layout_type::row_major)
+            using strides_value_type = typename std::decay_t<strides_type>::value_type;
+            strides_value_type data_size = 1;
+            if (L == layout_type::row_major || l == layout_type::row_major)
             {
-                for (std::size_t i = strides.size(); i != 0; --i)
+                for (std::size_t i = shape.size(); i != 0; --i)
                 {
                     strides[i - 1] = data_size;
-                    data_size = strides[i - 1] * shape[i - 1];
+                    data_size = strides[i - 1] * static_cast<strides_value_type>(shape[i - 1]);
                     adapt_strides(shape, strides, bs, i - 1);
                 }
             }
             else
             {
-                for (std::size_t i = 0; i < strides.size(); ++i)
+                for (std::size_t i = 0; i < shape.size(); ++i)
                 {
                     strides[i] = data_size;
-                    data_size = strides[i] * shape[i];
+                    data_size = strides[i] * static_cast<strides_value_type>(shape[i]);
                     adapt_strides(shape, strides, bs, i);
                 }
             }
-            return data_size;
+            return static_cast<std::size_t>(data_size);
         }
     }
 
-    template <class shape_type, class strides_type>
+    template <layout_type L, class shape_type, class strides_type>
     inline std::size_t compute_strides(const shape_type& shape, layout_type l, strides_type& strides)
     {
-        return detail::compute_strides(shape, l, strides, nullptr);
+        return detail::compute_strides<L>(shape, l, strides, nullptr);
     }
 
-    template <class shape_type, class strides_type, class backstrides_type>
+    template <layout_type L, class shape_type, class strides_type, class backstrides_type>
     inline std::size_t compute_strides(const shape_type& shape, layout_type l,
                                        strides_type& strides,
                                        backstrides_type& backstrides)
     {
-        return detail::compute_strides(shape, l, strides, &backstrides);
+        return detail::compute_strides<L>(shape, l, strides, &backstrides);
     }
 
-    template <class shape_type, class strides_type>
-    inline bool do_strides_match(const shape_type& shape, const strides_type& strides, layout_type l)
+    template <class T1, class T2>
+    inline bool stride_match_condition(const T1& stride, const T2& shape, const T1& data_size, bool zero_strides)
     {
-        using shape_value_type = typename shape_type::value_type;
-        shape_value_type data_size = 1;
+        return (shape == T2(1) && stride == T1(0) && zero_strides) || (stride == data_size);
+    }
+
+    // zero_strides should be true when strides are set to 0 if the corresponding dimensions are 1
+    template <class shape_type, class strides_type>
+    inline bool do_strides_match(const shape_type& shape, const strides_type& strides,
+                                 layout_type l, bool zero_strides)
+    {
+        using value_type = typename strides_type::value_type;
+        value_type data_size = 1;
         if (l == layout_type::row_major)
         {
             for (std::size_t i = strides.size(); i != 0; --i)
             {
-                if ((shape[i - 1] == 1 && strides[i - 1] != 0) || (shape[i - 1] != 1 && strides[i - 1] != data_size))
+                if (!stride_match_condition(strides[i - 1], shape[i - 1], data_size, zero_strides))
                 {
                     return false;
                 }
-                data_size *= shape[i - 1];
+                data_size *= static_cast<value_type>(shape[i - 1]);
             }
             return true;
         }
@@ -256,11 +385,11 @@ namespace xt
         {
             for (std::size_t i = 0; i < strides.size(); ++i)
             {
-                if ((shape[i] != 1 && strides[i] != data_size) || (shape[i] == 1 && strides[i] != 0))
+                if (!stride_match_condition(strides[i], shape[i], data_size, zero_strides))
                 {
                     return false;
                 }
-                data_size *= shape[i];
+                data_size *= static_cast<value_type>(shape[i]);
             }
             return true;
         }
@@ -332,11 +461,54 @@ namespace xt
     }
 
     template <class S>
-    inline S unravel_index(typename S::value_type index, const S& shape, layout_type l)
+    inline get_strides_t<S> ravel_from_strides(const S& index, const S& strides)
     {
-        S strides = xtl::make_sequence<S>(shape.size(), 0);
+        return element_offset<get_strides_t<S>>(strides, index.begin(), index.end());
+    }
+
+    template <class S>
+    inline get_strides_t<S> unravel_index(typename S::value_type index, const S& shape, layout_type l)
+    {
+        using strides_type = get_strides_t<S>;
+        using strides_value_type = typename strides_type::value_type;
+        strides_type strides = xtl::make_sequence<strides_type>(shape.size(), 0);
         compute_strides(shape, l, strides);
-        return unravel_from_strides(index, strides, l);
+        return unravel_from_strides(static_cast<strides_value_type>(index), strides, l);
+    }
+
+    template <class S, class T>
+    inline std::vector<get_strides_t<S>> unravel_indices(const T& idx, const S& shape, layout_type l)
+    {
+        using strides_type = get_strides_t<S>;
+        using strides_value_type = typename strides_type::value_type;
+        strides_type strides = xtl::make_sequence<strides_type>(shape.size(), 0);
+        compute_strides(shape, l, strides);
+        std::vector<get_strides_t<S>> out(idx.size());
+        auto out_iter = out.begin();
+        auto idx_iter = idx.begin();
+        for ( ; out_iter != out.end(); ++out_iter, ++idx_iter )
+        {
+            *out_iter = unravel_from_strides(static_cast<strides_value_type>(*idx_iter), strides, l);
+        }
+        return out;
+    }
+
+    template <class S>
+    inline get_value_type<S> ravel_index(const S& index, const S& shape, layout_type l)
+    {
+        using strides_type = get_strides_t<S>;
+        using strides_value_type = typename strides_type::value_type;
+        strides_type strides = xtl::make_sequence<strides_type>(shape.size(), 0);
+        compute_strides(shape, l, strides);
+        return ravel_from_strides(static_cast<strides_value_type>(index), strides);
+    }
+
+    template <class S, class stype>
+    inline S uninitialized_shape(stype size)
+    {
+        using value_type = typename S::value_type;
+        using size_type = typename S::size_type;
+        return xtl::make_sequence<S>(static_cast<size_type>(size), std::numeric_limits<value_type>::max());
     }
 
     template <class S1, class S2>
@@ -347,20 +519,21 @@ namespace xt
         using value_type = typename S2::value_type;
         auto output_index = output.size();
         auto input_index = input.size();
+
         if (output_index < input_index)
         {
             throw_broadcast_error(output, input);
         }
         for (; input_index != 0; --input_index, --output_index)
         {
-            // First case: output = (0, 0, ...., 0)
+            // First case: output = (MAX, MAX, ...., MAX)
             // output is a new shape that has not been through
             // the broadcast process yet; broadcast is trivial
-            if (output[output_index - 1] == 0)
+            if (output[output_index - 1] == std::numeric_limits<value_type>::max())
             {
                 output[output_index - 1] = static_cast<value_type>(input[input_index - 1]);
             }
-            // Second case: output has been initialized to 1. Broacast is trivial
+            // Second case: output has been initialized to 1. Broadcast is trivial
             // only if input is 1 to.
             else if (output[output_index - 1] == 1)
             {
@@ -430,7 +603,7 @@ namespace xt
             size_type index = 0;
 
             // This check is necessary as column major "broadcasting" is still
-            // peformed in a row major fashion
+            // performed in a row major fashion
             if (s1.size() != s2.size())
                 return 0;
 
@@ -446,6 +619,64 @@ namespace xt
             return index;
         }
     };
+
+    namespace detail
+    {
+        template <class S, std::size_t dim>
+        inline bool check_in_bounds_impl(const S&)
+        {
+            return true;
+        }
+
+        template <class S, std::size_t dim, class T, class... Args>
+        inline bool check_in_bounds_impl(const S& shape, T& arg, Args&... args)
+        {
+            if (sizeof...(Args) + 1 > shape.size())
+            {
+                return check_in_bounds_impl<S, dim>(shape, args...);
+            }
+            else
+            {
+                return arg >= T(0) && arg < static_cast<T>(shape[dim]) && check_in_bounds_impl<S, dim + 1>(shape, args...);
+            }
+        }
+    }
+
+    template <class S, class... Args>
+    inline bool check_in_bounds(const S& shape, Args&... args)
+    {
+        return detail::check_in_bounds_impl<S, 0>(shape, args...);
+    }
+
+    namespace detail
+    {
+        template <class S, std::size_t dim>
+        inline void normalize_periodic_impl(const S&)
+        {
+        }
+
+        template <class S, std::size_t dim, class T, class... Args>
+        inline void normalize_periodic_impl(const S& shape, T& arg, Args&... args)
+        {
+            if (sizeof...(Args) + 1 > shape.size())
+            {
+                normalize_periodic_impl<S, dim>(shape, args...);
+            }
+            else
+            {
+                T n = static_cast<T>(shape[dim]);
+                arg = (n + (arg%n)) % n;
+                normalize_periodic_impl<S, dim + 1>(shape, args...);
+            }
+        }
+    }
+
+    template <class S, class... Args>
+    inline void normalize_periodic(const S& shape, Args&... args)
+    {
+        check_dimension(shape, args...);
+        detail::normalize_periodic_impl<S, 0>(shape, args...);
+    }
 }
 
 #endif

--- a/vendor/xtensor/include/xtensor/xtensor.hpp
+++ b/vendor/xtensor/include/xtensor/xtensor.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -26,13 +27,31 @@ namespace xt
      * xtensor declaration *
      ***********************/
 
+    namespace extension
+    {
+        template <class EC, std::size_t N, layout_type L, class Tag>
+        struct xtensor_container_base;
+
+        template <class EC, std::size_t N, layout_type L>
+        struct xtensor_container_base<EC, N, L, xtensor_expression_tag>
+        {
+            using type = xtensor_empty_base;
+        };
+
+        template <class EC, std::size_t N, layout_type L, class Tag>
+        using xtensor_container_base_t = typename xtensor_container_base<EC, N, L, Tag>::type;
+    }
+
     template <class EC, std::size_t N, layout_type L, class Tag>
     struct xcontainer_inner_types<xtensor_container<EC, N, L, Tag>>
     {
         using storage_type = EC;
+        using reference = inner_reference_t<storage_type>;
+        using const_reference = typename storage_type::const_reference;
+        using size_type = typename storage_type::size_type;
         using shape_type = std::array<typename storage_type::size_type, N>;
-        using strides_type = shape_type;
-        using backstrides_type = shape_type;
+        using strides_type = get_strides_t<shape_type>;
+        using backstrides_type = get_strides_t<shape_type>;
         using inner_shape_type = shape_type;
         using inner_strides_type = strides_type;
         using inner_backstrides_type = backstrides_type;
@@ -52,23 +71,25 @@ namespace xt
      * dimension.
      *
      * The xtensor_container class implements a dense multidimensional container
-     * with tensor semantic and fixed dimension
+     * with tensor semantics and fixed dimension
      *
      * @tparam EC The type of the container holding the elements.
      * @tparam N The dimension of the container.
      * @tparam L The layout_type of the tensor.
      * @tparam Tag The expression tag.
-     * @sa xtensor
+     * @sa xtensor, xstrided_container, xcontainer
      */
-    template <class EC, size_t N, layout_type L, class Tag>
+    template <class EC, std::size_t N, layout_type L, class Tag>
     class xtensor_container : public xstrided_container<xtensor_container<EC, N, L, Tag>>,
-                              public xcontainer_semantic<xtensor_container<EC, N, L, Tag>>
+                              public xcontainer_semantic<xtensor_container<EC, N, L, Tag>>,
+                              public extension::xtensor_container_base_t<EC, N, L, Tag>
     {
     public:
 
         using self_type = xtensor_container<EC, N, L, Tag>;
         using base_type = xstrided_container<self_type>;
         using semantic_base = xcontainer_semantic<self_type>;
+        using extension_base = extension::xtensor_container_base_t<EC, N, L, Tag>;
         using storage_type = typename base_type::storage_type;
         using allocator_type = typename base_type::allocator_type;
         using value_type = typename base_type::value_type;
@@ -80,6 +101,7 @@ namespace xt
         using inner_shape_type = typename base_type::inner_shape_type;
         using strides_type = typename base_type::strides_type;
         using backstrides_type = typename base_type::backstrides_type;
+        using inner_backstrides_type = typename base_type::inner_backstrides_type;
         using inner_strides_type = typename base_type::inner_strides_type;
         using temporary_type = typename semantic_base::temporary_type;
         using expression_tag = Tag;
@@ -103,6 +125,11 @@ namespace xt
         xtensor_container(xtensor_container&&) = default;
         xtensor_container& operator=(xtensor_container&&) = default;
 
+        template <class SC>
+        explicit xtensor_container(xarray_container<EC, L, SC, Tag>&&);
+        template <class SC>
+        xtensor_container& operator=(xarray_container<EC, L, SC, Tag>&&);
+
         template <class E>
         xtensor_container(const xexpression<E>& e);
 
@@ -123,13 +150,31 @@ namespace xt
      * xtensor_container_adaptor declaration *
      *****************************************/
 
+    namespace extension
+    {
+        template <class EC, std::size_t N, layout_type L, class Tag>
+        struct xtensor_adaptor_base;
+
+        template <class EC, std::size_t N, layout_type L>
+        struct xtensor_adaptor_base<EC, N, L, xtensor_expression_tag>
+        {
+            using type = xtensor_empty_base;
+        };
+
+        template <class EC, std::size_t N, layout_type L, class Tag>
+        using xtensor_adaptor_base_t = typename xtensor_adaptor_base<EC, N, L, Tag>::type;
+    }
+
     template <class EC, std::size_t N, layout_type L, class Tag>
     struct xcontainer_inner_types<xtensor_adaptor<EC, N, L, Tag>>
     {
         using storage_type = std::remove_reference_t<EC>;
+        using reference = inner_reference_t<storage_type>;
+        using const_reference = typename storage_type::const_reference;
+        using size_type = typename storage_type::size_type;
         using shape_type = std::array<typename storage_type::size_type, N>;
-        using strides_type = shape_type;
-        using backstrides_type = shape_type;
+        using strides_type = get_strides_t<shape_type>;
+        using backstrides_type = get_strides_t<shape_type>;
         using inner_shape_type = shape_type;
         using inner_strides_type = strides_type;
         using inner_backstrides_type = backstrides_type;
@@ -137,19 +182,19 @@ namespace xt
         static constexpr layout_type layout = L;
     };
 
-    template <class EC, std::size_t N, layout_type L>
-    struct xiterable_inner_types<xtensor_adaptor<EC, N, L>>
-        : xcontainer_iterable_types<xtensor_adaptor<EC, N, L>>
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    struct xiterable_inner_types<xtensor_adaptor<EC, N, L, Tag>>
+        : xcontainer_iterable_types<xtensor_adaptor<EC, N, L, Tag>>
     {
     };
 
     /**
      * @class xtensor_adaptor
-     * @brief Dense multidimensional container adaptor with tensor semantic
-     * and fixed dimension.
+     * @brief Dense multidimensional container adaptor with tensor
+     * semantics and fixed dimension.
      *
      * The xtensor_adaptor class implements a dense multidimensional
-     * container adaptor with tensor semantic and fixed dimension. It
+     * container adaptor with tensor semantics and fixed dimension. It
      * is used to provide a multidimensional container semantic and a
      * tensor semantic to stl-like containers.
      *
@@ -157,10 +202,12 @@ namespace xt
      * @tparam N The dimension of the adaptor.
      * @tparam L The layout_type of the adaptor.
      * @tparam Tag The expression tag.
+     * @sa xstrided_container, xcontainer
      */
     template <class EC, std::size_t N, layout_type L, class Tag>
     class xtensor_adaptor : public xstrided_container<xtensor_adaptor<EC, N, L, Tag>>,
-                            public xcontainer_semantic<xtensor_adaptor<EC, N, L, Tag>>
+                            public xcontainer_semantic<xtensor_adaptor<EC, N, L, Tag>>,
+                            public extension::xtensor_adaptor_base_t<EC, N, L, Tag>
     {
     public:
 
@@ -169,6 +216,7 @@ namespace xt
         using self_type = xtensor_adaptor<EC, N, L, Tag>;
         using base_type = xstrided_container<self_type>;
         using semantic_base = xcontainer_semantic<self_type>;
+        using extension_base = extension::xtensor_adaptor_base_t<EC, N, L, Tag>;
         using storage_type = typename base_type::storage_type;
         using allocator_type = typename base_type::allocator_type;
         using shape_type = typename base_type::shape_type;
@@ -208,6 +256,124 @@ namespace xt
         friend class xcontainer<xtensor_adaptor<EC, N, L, Tag>>;
     };
 
+    /****************************
+     * xtensor_view declaration *
+     ****************************/
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    class xtensor_view;
+
+    namespace extension
+    {
+        template <class EC, std::size_t N, layout_type L, class Tag>
+        struct xtensor_view_base;
+
+        template <class EC, std::size_t N, layout_type L>
+        struct xtensor_view_base<EC, N, L, xtensor_expression_tag>
+        {
+            using type = xtensor_empty_base;
+        };
+
+        template <class EC, std::size_t N, layout_type L, class Tag>
+        using xtensor_view_base_t = typename xtensor_view_base<EC, N, L, Tag>::type;
+    }
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    struct xcontainer_inner_types<xtensor_view<EC, N, L, Tag>>
+    {
+        using storage_type = std::remove_reference_t<EC>;
+        using reference = inner_reference_t<storage_type>;
+        using const_reference = typename storage_type::const_reference;
+        using size_type = typename storage_type::size_type;
+        using shape_type = std::array<typename storage_type::size_type, N>;
+        using strides_type = get_strides_t<shape_type>;
+        using backstrides_type = get_strides_t<shape_type>;
+        using inner_shape_type = shape_type;
+        using inner_strides_type = strides_type;
+        using inner_backstrides_type = backstrides_type;
+        using temporary_type = xtensor_container<temporary_container_t<storage_type>, N, L, Tag>;
+        static constexpr layout_type layout = L;
+    };
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    struct xiterable_inner_types<xtensor_view<EC, N, L, Tag>>
+        : xcontainer_iterable_types<xtensor_view<EC, N, L, Tag>>
+    {
+    };
+
+    /**
+     * @class xtensor_view
+     * @brief Dense multidimensional container adaptor with view
+     * semantics and fixed dimension.
+     *
+     * The xtensor_view class implements a dense multidimensional
+     * container adaptor with viewsemantics and fixed dimension. It
+     * is used to provide a multidimensional container semantic and a
+     * view semantic to stl-like containers.
+     *
+     * @tparam EC The closure for the container type to adapt.
+     * @tparam N The dimension of the view.
+     * @tparam L The layout_type of the view.
+     * @tparam Tag The expression tag.
+     * @sa xstrided_container, xcontainer
+     */
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    class xtensor_view : public xstrided_container<xtensor_view<EC, N, L, Tag>>,
+                         public xview_semantic<xtensor_view<EC, N, L, Tag>>,
+                         public extension::xtensor_view_base_t<EC, N, L, Tag>
+    {
+    public:
+
+        using container_closure_type = EC;
+
+        using self_type = xtensor_view<EC, N, L, Tag>;
+        using base_type = xstrided_container<self_type>;
+        using semantic_base = xview_semantic<self_type>;
+        using extension_base = extension::xtensor_adaptor_base_t<EC, N, L, Tag>;
+        using storage_type = typename base_type::storage_type;
+        using allocator_type = typename base_type::allocator_type;
+        using shape_type = typename base_type::shape_type;
+        using strides_type = typename base_type::strides_type;
+        using backstrides_type = typename base_type::backstrides_type;
+        using temporary_type = typename semantic_base::temporary_type;
+        using expression_tag = Tag;
+
+        xtensor_view(storage_type&& storage);
+        xtensor_view(const storage_type& storage);
+
+        template <class D>
+        xtensor_view(D&& storage, const shape_type& shape, layout_type l = L);
+
+        template <class D>
+        xtensor_view(D&& storage, const shape_type& shape, const strides_type& strides);
+
+        ~xtensor_view() = default;
+
+        xtensor_view(const xtensor_view&) = default;
+        xtensor_view& operator=(const xtensor_view&);
+
+        xtensor_view(xtensor_view&&) = default;
+        xtensor_view& operator=(xtensor_view&&);
+
+        template <class E>
+        self_type& operator=(const xexpression<E>& e);
+
+        template <class E>
+        disable_xexpression<E, self_type>& operator=(const E& e);
+
+    private:
+
+        container_closure_type m_storage;
+
+        storage_type& storage_impl() noexcept;
+        const storage_type& storage_impl() const noexcept;
+
+        void assign_temporary_impl(temporary_type&& tmp);
+
+        friend class xcontainer<xtensor_view<EC, N, L, Tag>>;
+        friend class xview_semantic<xtensor_view<EC, N, L, Tag>>;
+    };
+
     /************************************
      * xtensor_container implementation *
      ************************************/
@@ -217,11 +383,11 @@ namespace xt
      */
     //@{
     /**
-     * Allocates an uninitialized xtensor_container that holds 0 element.
+     * Allocates an uninitialized xtensor_container that holds 0 elements.
      */
     template <class EC, std::size_t N, layout_type L, class Tag>
     inline xtensor_container<EC, N, L, Tag>::xtensor_container()
-        : base_type(), m_storage(1, value_type())
+        : base_type(), m_storage(N == 0 ? 1 : 0, value_type())
     {
     }
 
@@ -305,14 +471,36 @@ namespace xt
     }
 
     template <class EC, std::size_t N, layout_type L, class Tag>
+    template <class SC>
+    inline xtensor_container<EC, N, L, Tag>::xtensor_container(xarray_container<EC, L, SC, Tag>&& rhs)
+        : base_type(xtl::forward_sequence<inner_shape_type, decltype(rhs.shape())>(rhs.shape()),
+                    xtl::forward_sequence<inner_strides_type, decltype(rhs.strides())>(rhs.strides()),
+                    xtl::forward_sequence<inner_backstrides_type, decltype(rhs.backstrides())>(rhs.backstrides()),
+                    std::move(rhs.layout())),
+          m_storage(std::move(rhs.storage()))
+    {
+    }
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    template <class SC>
+    inline xtensor_container<EC, N, L, Tag>& xtensor_container<EC, N, L, Tag>::operator=(xarray_container<EC, L, SC, Tag>&& rhs)
+    {
+        XTENSOR_ASSERT_MSG(N == rhs.dimension(), "Cannot change dimension of xtensor.");
+        std::copy(rhs.shape().begin(), rhs.shape().end(), this->shape_impl().begin());
+        std::copy(rhs.strides().cbegin(), rhs.strides().cend(), this->strides_impl().begin());
+        std::copy(rhs.backstrides().cbegin(), rhs.backstrides().cend(), this->backstrides_impl().begin());
+        this->mutable_layout() = std::move(rhs.layout());
+        m_storage = std::move(std::move(rhs.storage()));
+        return *this;
+    }
+
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
     template <class S>
     inline xtensor_container<EC, N, L, Tag> xtensor_container<EC, N, L, Tag>::from_shape(S&& s)
     {
-        if (s.size() != N)
-        {
-            throw std::runtime_error("Cannot change dimension of xtensor.");
-        }
-        shape_type shape = xtl::forward_sequence<shape_type>(s);
+        XTENSOR_ASSERT_MSG(s.size() == N, "Cannot change dimension of xtensor.");
+        shape_type shape = xtl::forward_sequence<shape_type, S>(s);
         return self_type(shape);
     }
     //@}
@@ -329,11 +517,10 @@ namespace xt
     inline xtensor_container<EC, N, L, Tag>::xtensor_container(const xexpression<E>& e)
         : base_type()
     {
-        // Avoids unintialized data because of (m_shape == shape) condition
-        // in resize (called by assign), which is always true when size() == 1.
-        // The condition dimension() == 0 as in xarray is not sufficient because
-        // the shape is always initialized since it has a static number of dimensions.
-        if (e.derived_cast().size() == 1)
+        XTENSOR_ASSERT_MSG(N == e.derived_cast().dimension(), "Cannot change dimension of xtensor.");
+        // Avoids uninitialized data because of (m_shape == shape) condition
+        // in resize (called by assign), which is always true when dimension() == 0.
+        if (e.derived_cast().dimension() == 0)
         {
             detail::resize_data_container(m_storage, std::size_t(1));
         }
@@ -363,9 +550,9 @@ namespace xt
         return m_storage;
     }
 
-    /*******************
-     * xtensor_adaptor *
-     *******************/
+    /**********************************
+     * xtensor_adaptor implementation *
+     **********************************/
 
     /**
      * @name Constructors
@@ -473,6 +660,246 @@ namespace xt
     inline auto xtensor_adaptor<EC, N, L, Tag>::storage_impl() const noexcept -> const storage_type&
     {
         return m_storage;
+    }
+
+    /*******************************
+     * xtensor_view implementation *
+     *******************************/
+
+    /**
+     * @name Constructors
+     */
+    //@{
+    /**
+     * Constructs an xtensor_view of the given stl-like container.
+     * @param storage the container to adapt
+     */
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    inline xtensor_view<EC, N, L, Tag>::xtensor_view(storage_type&& storage)
+        : base_type(), m_storage(std::move(storage))
+    {
+    }
+
+    /**
+     * Constructs an xtensor_view of the given stl-like container.
+     * @param storage the container to adapt
+     */
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    inline xtensor_view<EC, N, L, Tag>::xtensor_view(const storage_type& storage)
+        : base_type(), m_storage(storage)
+    {
+    }
+
+    /**
+     * Constructs an xtensor_view of the given stl-like container,
+     * with the specified shape and layout_type.
+     * @param storage the container to adapt
+     * @param shape the shape of the xtensor_view
+     * @param l the layout_type of the xtensor_view
+     */
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    template <class D>
+    inline xtensor_view<EC, N, L, Tag>::xtensor_view(D&& storage, const shape_type& shape, layout_type l)
+        : base_type(), m_storage(std::forward<D>(storage))
+    {
+        base_type::resize(shape, l);
+    }
+
+    /**
+     * Constructs an xtensor_view of the given stl-like container,
+     * with the specified shape and strides.
+     * @param storage the container to adapt
+     * @param shape the shape of the xtensor_view
+     * @param strides the strides of the xtensor_view
+     */
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    template <class D>
+    inline xtensor_view<EC, N, L, Tag>::xtensor_view(D&& storage, const shape_type& shape, const strides_type& strides)
+        : base_type(), m_storage(std::forward<D>(storage))
+    {
+        base_type::resize(shape, strides);
+    }
+    //@}
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    inline auto xtensor_view<EC, N, L, Tag>::operator=(const xtensor_view& rhs) -> self_type&
+    {
+        base_type::operator=(rhs);
+        m_storage = rhs.m_storage;
+        return *this;
+    }
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    inline auto xtensor_view<EC, N, L, Tag>::operator=(xtensor_view&& rhs) -> self_type&
+    {
+        base_type::operator=(std::move(rhs));
+        m_storage = rhs.m_storage;
+        return *this;
+    }
+
+    /**
+     * @name Extended copy semantic
+     */
+    //@{
+    /**
+     * The extended assignment operator.
+     */
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    template <class E>
+    inline auto xtensor_view<EC, N, L, Tag>::operator=(const xexpression<E>& e) -> self_type&
+    {
+        return semantic_base::operator=(e);
+    }
+    //@}
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    template <class E>
+    inline auto xtensor_view<EC, N, L, Tag>::operator=(const E& e) -> disable_xexpression<E, self_type>&
+    {
+        std::fill(m_storage.begin(), m_storage.end(), e);
+        return *this;
+    }
+    
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    inline auto xtensor_view<EC, N, L, Tag>::storage_impl() noexcept -> storage_type&
+    {
+        return m_storage;
+    }
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    inline auto xtensor_view<EC, N, L, Tag>::storage_impl() const noexcept -> const storage_type&
+    {
+        return m_storage;
+    }
+
+    template <class EC, std::size_t N, layout_type L, class Tag>
+    inline void xtensor_view<EC, N, L, Tag>::assign_temporary_impl(temporary_type&& tmp)
+    {
+        std::copy(tmp.cbegin(), tmp.cend(), m_storage.begin());
+    }
+
+    /**
+     * Converts ``std::vector<index_type>`` (returned e.g. from ``xt::argwhere``) to ``xtensor``.
+     *
+     * @param idx vector of indices
+     *
+     * @return ``xt::xtensor<typename index_type::value_type, 2>`` (e.g. ``xt::xtensor<size_t, 2>``)
+     */
+    template <class T>
+    inline auto from_indices(const std::vector<T> &idx)
+    {
+        using return_type = xtensor<typename T::value_type, 2>;
+        using size_type = typename return_type::size_type;
+
+        if (idx.size() == 0)
+        {
+            return return_type::from_shape({size_type(0), size_type(0)});
+        }
+
+        return_type out = return_type::from_shape({idx.size(), idx[0].size()});
+
+        for (size_type i = 0; i < out.shape()[0]; ++i)
+        {
+            for (size_type j = 0; j < out.shape()[1]; ++j)
+            {
+                out(i, j) = idx[i][j];
+            }
+        }
+
+        return out;
+    }
+
+    /**
+     * Converts ``std::vector<index_type>`` (returned e.g. from ``xt::argwhere``) to a flattened
+     * ``xtensor``.
+     *
+     * @param vector of indices
+     *
+     * @return ``xt::xtensor<typename index_type::value_type, 1>`` (e.g. ``xt::xtensor<size_t, 1>``)
+     */
+    template <class T>
+    inline auto flatten_indices(const std::vector<T> &idx)
+    {
+        auto n = idx.size();
+        if (n != 0)
+        {
+            n *= idx[0].size();
+        }
+
+        using return_type = xtensor<typename T::value_type, 1>;
+        return_type out = return_type::from_shape({n});
+        auto iter = out.begin();
+        for_each(idx.begin(), idx.end(), [&iter](const auto& t) { iter = std::copy(t.cbegin(), t.cend(), iter); });
+
+        return out;
+    }
+
+    struct ravel_vector_tag;
+    struct ravel_tensor_tag;
+
+    namespace detail
+    {
+        template <class C, class Tag>
+        struct ravel_return_type;
+
+        template <class C>
+        struct ravel_return_type<C, ravel_vector_tag>
+        {
+            using index_type = typename C::value_type;
+            using value_type = typename index_type::value_type;
+            using type = std::vector<value_type>;
+
+            template <class T>
+            static std::vector<value_type> init(T n)
+            {
+                return std::vector<value_type>(n);
+            }
+        };
+
+        template <class C>
+        struct ravel_return_type<C, ravel_tensor_tag>
+        {
+            using index_type = typename C::value_type;
+            using value_type = typename index_type::value_type;
+            using type = xt::xtensor<value_type, 1>;
+
+            template <class T>
+            static xt::xtensor<value_type, 1> init(T n)
+            {
+                return xtensor<value_type, 1>::from_shape({n});
+            }
+        };
+    }
+
+    template <class C, class Tag>
+    using ravel_return_type_t = typename detail::ravel_return_type<C, Tag>::type;
+
+    /**
+     * Converts ``std::vector<index_type>`` (returned e.g. from ``xt::argwhere``) to ``xtensor``
+     * whereby the indices are ravelled. For 1-d input there is no conversion.
+     *
+     * @param idx vector of indices
+     * @param shape the shape of the original array
+     * @param l the layout type (row-major or column-major)
+     *
+     * @return ``xt::xtensor<typename index_type::value_type, 1>`` (e.g. ``xt::xtensor<size_t, 1>``)
+     */
+    template <class Tag = ravel_tensor_tag, class C, class S>
+    ravel_return_type_t<C, Tag> ravel_indices(const C& idx, const S& shape, layout_type l = layout_type::row_major)
+    {
+        using return_type = typename detail::ravel_return_type<C, Tag>::type;
+        using value_type = typename detail::ravel_return_type<C, Tag>::value_type;
+        using strides_type = get_strides_t<S>;
+        strides_type strides = xtl::make_sequence<strides_type>(shape.size(), 0);
+        compute_strides(shape, l, strides);
+        return_type out = detail::ravel_return_type<C, Tag>::init(idx.size());
+        auto out_iter = out.begin();
+        auto idx_iter = idx.begin();
+        for (; out_iter != out.end(); ++out_iter, ++idx_iter)
+        {
+            *out_iter = element_offset<value_type>(strides, (*idx_iter).cbegin(), (*idx_iter).cend());
+        }
+        return out;
     }
 }
 

--- a/vendor/xtensor/include/xtensor/xtensor_config.hpp
+++ b/vendor/xtensor/include/xtensor/xtensor_config.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -10,8 +11,8 @@
 #define XTENSOR_CONFIG_HPP
 
 #define XTENSOR_VERSION_MAJOR 0
-#define XTENSOR_VERSION_MINOR 16
-#define XTENSOR_VERSION_PATCH 4
+#define XTENSOR_VERSION_MINOR 20
+#define XTENSOR_VERSION_PATCH 10
 
 // DETECT 3.6 <= clang < 3.8 for compiler bug workaround.
 #ifdef __clang__
@@ -22,13 +23,28 @@
     #endif
 #endif
 
+// Workaround for some missing constexpr functionality in MSVC 2015 and MSVC 2017 x86
+#if defined(_MSC_VER)
+    #define XTENSOR_CONSTEXPR_ENHANCED const
+    // The following must not be defined to const, otherwise
+    // it prevents generation of copy operators of classes
+    // containing XTENSOR_CONSTEXPR_ENHANCED_STATIC members
+    #define XTENSOR_CONSTEXPR_ENHANCED_STATIC
+    #define XTENSOR_CONSTEXPR_RETURN inline
+#else
+    #define XTENSOR_CONSTEXPR_ENHANCED constexpr
+    #define XTENSOR_CONSTEXPR_RETURN constexpr
+    #define XTENSOR_CONSTEXPR_ENHANCED_STATIC constexpr static
+    #define XTENSOR_HAS_CONSTEXPR_ENHANCED
+#endif
+
 #ifndef XTENSOR_DEFAULT_DATA_CONTAINER
 #define XTENSOR_DEFAULT_DATA_CONTAINER(T, A) uvector<T, A>
 #endif
 
 #ifndef XTENSOR_DEFAULT_SHAPE_CONTAINER
 #define XTENSOR_DEFAULT_SHAPE_CONTAINER(T, EA, SA) \
-    xt::svector<typename XTENSOR_DEFAULT_DATA_CONTAINER(T, EA)::size_type, 4, SA>
+    xt::svector<typename XTENSOR_DEFAULT_DATA_CONTAINER(T, EA)::size_type, 4, SA, true>
 #endif
 
 #ifndef XTENSOR_DEFAULT_ALLOCATOR
@@ -46,18 +62,46 @@
     #endif
 #else
     #ifdef XTENSOR_USE_XSIMD
-    #include <xsimd/xsimd.hpp>
-    #define XTENSOR_DEFAULT_ALLOCATOR(T) \
-        xsimd::aligned_allocator<T, XSIMD_DEFAULT_ALIGNMENT>
+        #include <xsimd/xsimd.hpp>
+        #define XTENSOR_DEFAULT_ALLOCATOR(T) \
+            xsimd::aligned_allocator<T, XSIMD_DEFAULT_ALIGNMENT>
     #else
-    #define XTENSOR_DEFAULT_ALLOCATOR(T) \
-        std::allocator<T>
+        #define XTENSOR_DEFAULT_ALLOCATOR(T) \
+            std::allocator<T>
     #endif
 #endif
 #endif
 
+#ifndef XTENSOR_DEFAULT_ALIGNMENT
+    #ifdef XTENSOR_USE_XSIMD
+        #define XTENSOR_DEFAULT_ALIGNMENT XSIMD_DEFAULT_ALIGNMENT
+    #else
+        #define XTENSOR_DEFAULT_ALIGNMENT 0
+    #endif
+#endif
+
 #ifndef XTENSOR_DEFAULT_LAYOUT
 #define XTENSOR_DEFAULT_LAYOUT ::xt::layout_type::row_major
+#endif
+
+#ifndef XTENSOR_DEFAULT_TRAVERSAL
+#define XTENSOR_DEFAULT_TRAVERSAL ::xt::layout_type::row_major
+#endif
+
+#ifdef IN_DOXYGEN
+namespace xtl
+{
+    template <class... T>
+    struct conjunction
+    {
+        constexpr bool value = true;
+    };
+
+    template <class... C>
+    using check_concept = std::enable_if_t<conjunction<C...>::value, int>;
+
+#define XTL_REQUIRES(...) xtl::check_concept<__VA_ARGS__> = 0
+}
 #endif
 
 #endif

--- a/vendor/xtensor/include/xtensor/xtensor_forward.hpp
+++ b/vendor/xtensor/include/xtensor/xtensor_forward.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -9,25 +10,42 @@
 #ifndef XTENSOR_FORWARD_HPP
 #define XTENSOR_FORWARD_HPP
 
+// This file contains forward declarations and
+// alias types to solve the problem of circular
+// includes. It should not contain anything else
+// and should not bring additional dependencies to
+// the files that include it. So:
+// - do NOT define classes of metafunctions here
+// - do NOT include other headers
+//
+// If you need to do so, something is probably
+// going wrong (either your change, or xtensor
+// needs to be refactored).
+
 #include <memory>
 #include <vector>
 
 #include <xtl/xoptional_sequence.hpp>
 
-#include "xexpression.hpp"
 #include "xlayout.hpp"
-#include "xshape.hpp"
-#include "xstorage.hpp"
 #include "xtensor_config.hpp"
-#include "xtensor_simd.hpp"
 
 namespace xt
 {
+    struct xtensor_expression_tag;
+    struct xoptional_expression_tag;
+
     template <class C>
     struct xcontainer_inner_types;
 
     template <class D>
     class xcontainer;
+
+    template <class T, class A>
+    class uvector;
+
+    template <class T, std::size_t N, class A, bool Init>
+    class svector;
 
     template <class EC,
               layout_type L = XTENSOR_DEFAULT_LAYOUT,
@@ -53,7 +71,7 @@ namespace xt
      * \endcode
      *
      * @tparam T The value type of the elements.
-     * @tparam L The layout_type of the xarray_container (default: row_major).
+     * @tparam L The layout_type of the xarray_container (default: XTENSOR_DEFAULT_LAYOUT).
      * @tparam A The allocator of the container holding the elements.
      * @tparam SA The allocator of the containers holding the shape and the strides.
      */
@@ -76,7 +94,7 @@ namespace xt
      * Alias template on xarray_container for handling missing values
      *
      * @tparam T The value type of the elements.
-     * @tparam L The layout_type of the container (default: row_major).
+     * @tparam L The layout_type of the container (default: XTENSOR_DEFAULT_LAYOUT).
      * @tparam A The allocator of the container holding the elements.
      * @tparam BA The allocator of the container holding the missing flags.
      * @tparam SA The allocator of the containers holding the shape and the strides.
@@ -108,7 +126,7 @@ namespace xt
      *
      * @tparam T The value type of the elements.
      * @tparam N The dimension of the tensor.
-     * @tparam L The layout_type of the tensor (default: row_major).
+     * @tparam L The layout_type of the tensor (default: XTENSOR_DEFAULT_LAYOUT).
      * @tparam A The allocator of the containers holding the elements.
      */
     template <class T,
@@ -120,6 +138,9 @@ namespace xt
     template <class EC, std::size_t N, layout_type L = XTENSOR_DEFAULT_LAYOUT, class Tag = xtensor_expression_tag>
     class xtensor_adaptor;
 
+    template <class EC, std::size_t N, layout_type L = XTENSOR_DEFAULT_LAYOUT, class Tag = xtensor_expression_tag>
+    class xtensor_view;
+
     template <std::size_t... N>
     class fixed_shape;
 
@@ -130,10 +151,10 @@ namespace xt
     template <std::size_t... N>
     using xshape = fixed_shape<N...>;
 
-    template <class ET, class S, layout_type L = XTENSOR_DEFAULT_LAYOUT, class Tag = xtensor_expression_tag>
+    template <class ET, class S, layout_type L = XTENSOR_DEFAULT_LAYOUT, bool Sharable = true, class Tag = xtensor_expression_tag>
     class xfixed_container;
 
-    template <class ET, class S, layout_type L = XTENSOR_DEFAULT_LAYOUT, class Tag = xtensor_expression_tag>
+    template <class ET, class S, layout_type L = XTENSOR_DEFAULT_LAYOUT, bool Sharable = true, class Tag = xtensor_expression_tag>
     class xfixed_adaptor;
 
     /**
@@ -153,13 +174,14 @@ namespace xt
      *
      * @tparam T The value type of the elements.
      * @tparam FSH A xshape template shape.
-     * @tparam L The layout_type of the tensor (default: row_major).
-     * @tparam A The allocator of the containers holding the elements.
+     * @tparam L The layout_type of the tensor (default: XTENSOR_DEFAULT_LAYOUT).
+     * @tparam Sharable Wether the tnesor can be used in shared expression.
      */
     template <class T,
               class FSH,
-              layout_type L = XTENSOR_DEFAULT_LAYOUT>
-    using xtensor_fixed = xfixed_container<T, FSH, L>;
+              layout_type L = XTENSOR_DEFAULT_LAYOUT,
+              bool Sharable = true>
+    using xtensor_fixed = xfixed_container<T, FSH, L, Sharable>;
 
     /**
      * @typedef xtensor_optional
@@ -167,7 +189,7 @@ namespace xt
      *
      * @tparam T The value type of the elements.
      * @tparam N The dimension of the tensor.
-     * @tparam L The layout_type of the container (default: row_major).
+     * @tparam L The layout_type of the container (default: XTENSOR_DEFAULT_LAYOUT).
      * @tparam A The allocator of the containers holding the elements.
      * @tparam BA The allocator of the container holding the missing flags.
      */
@@ -181,36 +203,8 @@ namespace xt
     template <class CT, class... S>
     class xview;
 
-    template <class F, class R, class... CT>
+    template <class F, class... CT>
     class xfunction;
-
-    namespace check_policy
-    {
-        struct none
-        {
-        };
-        struct full
-        {
-        };
-    }
-
-    namespace evaluation_strategy
-    {
-        struct base
-        {
-        };
-        struct immediate : base
-        {
-        };
-        struct lazy : base
-        {
-        };
-        /*
-        struct cached
-        {
-        };
-        */
-    }
 }
 
 #endif

--- a/vendor/xtensor/include/xtensor/xtensor_simd.hpp
+++ b/vendor/xtensor/include/xtensor/xtensor_simd.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -10,16 +11,76 @@
 #define XTENSOR_SIMD_HPP
 
 #include <vector>
+#include <xtl/xdynamic_bitset.hpp>
 
-#include "xstorage.hpp"
+#include "xutils.hpp"
 
 #ifdef XTENSOR_USE_XSIMD
 
 #include <xsimd/xsimd.hpp>
 
+#if defined(_MSV_VER) && (_MSV_VER < 1910)
+template <class T, std::size_t N>
+inline xsimd::batch_bool<T, N> isnan(const xsimd::batch<T, N>& b)
+{
+    return xsimd::isnan(b);
+}
+#endif
+
+namespace xt_simd
+{
+    template <class T, std::size_t A>
+    using aligned_allocator = xsimd::aligned_allocator<T, A>;
+
+    using aligned_mode = xsimd::aligned_mode;
+    using unaligned_mode = xsimd::unaligned_mode;
+
+    template <class A>
+    using allocator_alignment = xsimd::allocator_alignment<A>;
+
+    template <class A>
+    using allocator_alignment_t = xsimd::allocator_alignment_t<A>;
+
+    template <class C>
+    using container_alignment = xsimd::container_alignment<C>;
+
+    template <class C>
+    using container_alignment_t = xsimd::container_alignment_t<C>;
+
+    template <class T>
+    using simd_traits = xsimd::simd_traits<T>;
+
+    template <class T>
+    using revert_simd_traits = xsimd::revert_simd_traits<T>;
+
+    template <class T>
+    using simd_type = xsimd::simd_type<T>;
+
+    template <class T>
+    using simd_bool_type = xsimd::simd_bool_type<T>;
+
+    template <class T>
+    using revert_simd_type = xsimd::revert_simd_type<T>;
+
+    using xsimd::set_simd;
+    using xsimd::load_simd;
+    using xsimd::store_simd;
+    using xsimd::select;
+    using xsimd::get_alignment_offset;
+
+    template <class T1, class T2>
+    using simd_return_type = xsimd::simd_return_type<T1, T2>;
+
+    template <class V>
+    using is_batch_bool = xsimd::is_batch_bool<V>;
+
+    template <class V>
+    using is_batch_complex = xsimd::is_batch_complex<V>;
+}
+
 #else  // XTENSOR_USE_XSIMD
 
-namespace xsimd
+namespace xt_simd
 {
     template <class T, std::size_t A>
     class aligned_allocator;
@@ -56,14 +117,14 @@ namespace xsimd
         using type = T;
         using bool_type = bool;
         using batch_bool = bool;
-        static constexpr size_t size = 1;
+        static constexpr std::size_t size = 1;
     };
 
     template <class T>
     struct revert_simd_traits
     {
         using type = T;
-        static constexpr size_t size = simd_traits<type>::size;
+        static constexpr std::size_t size = simd_traits<type>::size;
     };
 
     template <class T>
@@ -75,19 +136,19 @@ namespace xsimd
     template <class T>
     using revert_simd_type = typename revert_simd_traits<T>::type;
 
-    template <class T>
+    template <class T, class V>
     inline simd_type<T> set_simd(const T& value)
     {
         return value;
     }
 
-    template <class T>
+    template <class T, class V>
     inline simd_type<T> load_simd(const T* src, aligned_mode)
     {
         return *src;
     }
 
-    template <class T>
+    template <class T, class V>
     inline simd_type<T> load_simd(const T* src, unaligned_mode)
     {
         return *src;
@@ -119,14 +180,24 @@ namespace xsimd
 
     template <class T1, class T2>
     using simd_return_type = simd_type<T2>;
+
+    template <class V>
+    struct is_batch_bool : std::false_type
+    {
+    };
+
+    template <class V>
+    struct is_batch_complex : std::false_type
+    {
+    };
 }
 
 #endif  // XTENSOR_USE_XSIMD
 
 namespace xt
 {
-    using xsimd::aligned_mode;
-    using xsimd::unaligned_mode;
+    using xt_simd::aligned_mode;
+    using xt_simd::unaligned_mode;
 
     struct inner_aligned_mode
     {
@@ -137,7 +208,7 @@ namespace xt
         template <class A1, class A2>
         struct driven_align_mode_impl
         {
-            using type = std::conditional_t<std::is_same<A1, A2>::value, A1, ::xsimd::unaligned_mode>;
+            using type = std::conditional_t<std::is_same<A1, A2>::value, A1, ::xt_simd::unaligned_mode>;
         };
 
         template <class A>
@@ -155,6 +226,85 @@ namespace xt
 
     template <class A1, class A2>
     using driven_align_mode_t = typename detail::driven_align_mode_impl<A1, A2>::type;
+
+    namespace detail
+    {
+        template <class E, class T, class = void>
+        struct has_simd_interface_impl : std::false_type
+        {
+        };
+
+        template <class E, class T>
+        struct has_simd_interface_impl<E, T, void_t<decltype(std::declval<E>().template load_simd<aligned_mode, T>(typename E::size_type(0)))>>
+            : std::true_type
+        {
+        };
+    }
+
+    template <class E, class T = typename std::decay_t<E>::value_type>
+    struct has_simd_interface : detail::has_simd_interface_impl<E, T>
+    {
+    };
+
+    template <class T>
+    struct has_simd_type
+        : std::integral_constant<bool, !std::is_same<T, xt_simd::simd_type<T>>::value>
+    {
+    };
+
+    namespace detail
+    {
+        template <class F, class B, class = void>
+        struct has_simd_apply_impl : std::false_type {};
+
+        template <class F, class B>
+        struct has_simd_apply_impl<F, B, void_t<decltype(&F::template simd_apply<B>)>>
+            : std::true_type
+        {
+        };
+    }
+
+    template <class F, class B>
+    struct has_simd_apply : detail::has_simd_apply_impl<F, B>
+    {
+    };
+
+    template <class T>
+    using bool_load_type = std::conditional_t<std::is_same<T, bool>::value, uint8_t, T>;
+
+    template <class T>
+    struct forbid_simd : std::false_type
+    {
+    };
+
+    template <class A>
+    struct forbid_simd<std::vector<bool, A>> : std::true_type
+    {
+    };
+
+    template <class A>
+    struct forbid_simd<const std::vector<bool, A>> : std::true_type
+    {
+    };
+
+    template <class B, class A>
+    struct forbid_simd<xtl::xdynamic_bitset<B, A>> : std::true_type
+    {
+    };
+
+    template <class B, class A>
+    struct forbid_simd<const xtl::xdynamic_bitset<B, A>> : std::true_type
+    {
+    };
+
+    template <class C, class T1, class T2>
+    struct container_simd_return_type
+        : std::enable_if<!forbid_simd<C>::value, xt_simd::simd_return_type<T1, bool_load_type<T2>>>
+    {
+    };
+
+    template <class C, class T1, class T2>
+    using container_simd_return_type_t = typename container_simd_return_type<C, T1, T2>::type;
 }
 
 #endif

--- a/vendor/xtensor/include/xtensor/xutils.hpp
+++ b/vendor/xtensor/include/xtensor/xutils.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -22,9 +23,17 @@
 #include <vector>
 
 #include <xtl/xfunctional.hpp>
+#include <xtl/xsequence.hpp>
+#include <xtl/xmeta_utils.hpp>
 #include <xtl/xtype_traits.hpp>
 
 #include "xtensor_config.hpp"
+
+#if (_MSC_VER >= 1910)
+    #define NOEXCEPT(T)
+#else
+    #define NOEXCEPT(T) noexcept(T)
+#endif
 
 namespace xt
 {
@@ -35,17 +44,17 @@ namespace xt
     template <class T>
     struct remove_class;
 
-    template <class F, class... T>
-    void for_each(F&& f, std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()));
+    /*template <class F, class... T>
+    void for_each(F&& f, std::tuple<T...>& t) noexcept(implementation_dependent);*/
 
-    template <class F, class R, class... T>
-    R accumulate(F&& f, R init, const std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()));
+    /*template <class F, class R, class... T>
+    R accumulate(F&& f, R init, const std::tuple<T...>& t) noexcept(implementation_dependent);*/
 
     template <std::size_t I, class... Args>
     constexpr decltype(auto) argument(Args&&... args) noexcept;
 
     template <class R, class F, class... S>
-    R apply(std::size_t index, F&& func, const std::tuple<S...>& s) noexcept(noexcept(std::declval<F>()));
+    R apply(std::size_t index, F&& func, const std::tuple<S...>& s) NOEXCEPT(noexcept(func(std::get<0>(s))));
 
     template <class T, class S>
     void nested_copy(T&& iter, const S& s);
@@ -53,20 +62,25 @@ namespace xt
     template <class T, class S>
     void nested_copy(T&& iter, std::initializer_list<S> s);
 
-    template <class U>
-    struct initializer_dimension;
-
-    template <class R, class T>
-    constexpr R shape(T t);
-
-    template <class T, class S>
-    constexpr bool check_shape(T t, S first, S last);
-
     template <class C>
     bool resize_container(C& c, typename C::size_type size);
 
     template <class T, std::size_t N>
     bool resize_container(std::array<T, N>& a, typename std::array<T, N>::size_type size);
+
+    template <std::size_t... I>
+    class fixed_shape;
+
+    template <std::size_t... I>
+    bool resize_container(fixed_shape<I...>& a, std::size_t size);
+
+    template <class X, class C>
+    struct rebind_container;
+
+    template <class X, class C>
+    using rebind_container_t = typename rebind_container<X, C>::type;
+
+    std::size_t normalize_axis(std::size_t dim, std::ptrdiff_t axis);
 
     // gcc 4.9 is affected by C++14 defect CGW 1558
     // see http://open-std.org/JTC1/SC22/WG21/docs/cwg_defects.html#1558
@@ -79,8 +93,30 @@ namespace xt
     template <class... T>
     using void_t = typename make_void<T...>::type;
 
+    // This is used for non existent types (e.g. storage for some expressions
+    // like generators)
+    struct invalid_type
+    {
+    };
+
+    template <class... T>
+    struct make_invalid_type
+    {
+        using type = invalid_type;
+    };
+
     template <class T, class R>
     using disable_integral_t = std::enable_if_t<!std::is_integral<T>::value, R>;
+
+    /********************************
+     * meta identity implementation *
+     ********************************/
+
+    template <class T>
+    struct meta_identity
+    {
+        using type = T;
+    };
 
     /*******************************
      * remove_class implementation *
@@ -114,13 +150,14 @@ namespace xt
     {
         template <std::size_t I, class F, class... T>
         inline typename std::enable_if<I == sizeof...(T), void>::type
-        for_each_impl(F&& /*f*/, std::tuple<T...>& /*t*/) noexcept(noexcept(std::declval<F>()))
+        for_each_impl(F&& /*f*/, std::tuple<T...>& /*t*/) noexcept
         {
         }
 
         template <std::size_t I, class F, class... T>
         inline typename std::enable_if<I < sizeof...(T), void>::type
-        for_each_impl(F&& f, std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()))
+        for_each_impl(F&& f, std::tuple<T...>& t)
+            noexcept(noexcept(f(std::get<I>(t))))
         {
             f(std::get<I>(t));
             for_each_impl<I + 1, F, T...>(std::forward<F>(f), t);
@@ -128,7 +165,8 @@ namespace xt
     }
 
     template <class F, class... T>
-    inline void for_each(F&& f, std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()))
+    inline void for_each(F&& f, std::tuple<T...>& t)
+        noexcept(noexcept(detail::for_each_impl<0, F, T...>(std::forward<F>(f), t)))
     {
         detail::for_each_impl<0, F, T...>(std::forward<F>(f), t);
     }
@@ -137,13 +175,14 @@ namespace xt
     {
         template <std::size_t I, class F, class... T>
         inline typename std::enable_if<I == sizeof...(T), void>::type
-        for_each_impl(F&& /*f*/, const std::tuple<T...>& /*t*/) noexcept(noexcept(std::declval<F>()))
+        for_each_impl(F&& /*f*/, const std::tuple<T...>& /*t*/) noexcept
         {
         }
 
         template <std::size_t I, class F, class... T>
         inline typename std::enable_if<I < sizeof...(T), void>::type
-        for_each_impl(F&& f, const std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()))
+        for_each_impl(F&& f, const std::tuple<T...>& t)
+            noexcept(noexcept(f(std::get<I>(t))))
         {
             f(std::get<I>(t));
             for_each_impl<I + 1, F, T...>(std::forward<F>(f), t);
@@ -151,7 +190,8 @@ namespace xt
     }
 
     template <class F, class... T>
-    inline void for_each(F&& f, const std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()))
+    inline void for_each(F&& f, const std::tuple<T...>& t)
+        noexcept(noexcept(detail::for_each_impl<0, F, T...>(std::forward<F>(f), t)))
     {
         detail::for_each_impl<0, F, T...>(std::forward<F>(f), t);
     }
@@ -164,14 +204,15 @@ namespace xt
     {
         template <std::size_t I, class F, class R, class... T>
         inline std::enable_if_t<I == sizeof...(T), R>
-        accumulate_impl(F&& /*f*/, R init, const std::tuple<T...>& /*t*/) noexcept(noexcept(std::declval<F>()))
+        accumulate_impl(F&& /*f*/, R init, const std::tuple<T...>& /*t*/) noexcept
         {
             return init;
         }
 
         template <std::size_t I, class F, class R, class... T>
         inline std::enable_if_t<I < sizeof...(T), R>
-        accumulate_impl(F&& f, R init, const std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()))
+        accumulate_impl(F&& f, R init, const std::tuple<T...>& t)
+            noexcept(noexcept(f(init, std::get<I>(t))))
         {
             R res = f(init, std::get<I>(t));
             return accumulate_impl<I + 1, F, R, T...>(std::forward<F>(f), res, t);
@@ -179,9 +220,10 @@ namespace xt
     }
 
     template <class F, class R, class... T>
-    inline R accumulate(F&& f, R init, const std::tuple<T...>& t) noexcept(noexcept(std::declval<F>()))
+    inline R accumulate(F&& f, R init, const std::tuple<T...>& t)
+        noexcept(noexcept(detail::accumulate_impl<0, F, R, T...>(std::forward<F>(f), init, t)))
     {
-        return detail::accumulate_impl<0, F, R, T...>(f, init, t);
+        return detail::accumulate_impl<0, F, R, T...>(std::forward<F>(f), init, t);
     }
 
     /***************************
@@ -225,13 +267,14 @@ namespace xt
     namespace detail
     {
         template <class R, class F, std::size_t I, class... S>
-        R apply_one(F&& func, const std::tuple<S...>& s) noexcept(noexcept(std::declval<F>()))
+        R apply_one(F&& func, const std::tuple<S...>& s) NOEXCEPT(noexcept(func(std::get<I>(s))))
         {
             return static_cast<R>(func(std::get<I>(s)));
         }
 
         template <class R, class F, std::size_t... I, class... S>
-        R apply(std::size_t index, F&& func, std::index_sequence<I...> /*seq*/, const std::tuple<S...>& s) noexcept(noexcept(std::declval<F>()))
+        R apply(std::size_t index, F&& func, std::index_sequence<I...> /*seq*/, const std::tuple<S...>& s)
+            NOEXCEPT(noexcept(func(std::get<0>(s))))
         {
             using FT = std::add_pointer_t<R(F&&, const std::tuple<S...>&)>;
             static const std::array<FT, sizeof...(I)> ar = {{&apply_one<R, F, I, S...>...}};
@@ -240,7 +283,7 @@ namespace xt
     }
 
     template <class R, class F, class... S>
-    inline R apply(std::size_t index, F&& func, const std::tuple<S...>& s) noexcept(noexcept(std::declval<F>()))
+    inline R apply(std::size_t index, F&& func, const std::tuple<S...>& s) NOEXCEPT(noexcept(func(std::get<0>(s))))
     {
         return detail::apply<R>(index, std::forward<F>(func), std::make_index_sequence<sizeof...(S)>(), s);
     }
@@ -283,118 +326,6 @@ namespace xt
         }
     }
 
-    /****************************************
-     * initializer_dimension implementation *
-     ****************************************/
-
-    namespace detail
-    {
-        template <class U>
-        struct initializer_depth_impl
-        {
-            static constexpr std::size_t value = 0;
-        };
-
-        template <class T>
-        struct initializer_depth_impl<std::initializer_list<T>>
-        {
-            static constexpr std::size_t value = 1 + initializer_depth_impl<T>::value;
-        };
-    }
-
-    template <class U>
-    struct initializer_dimension
-    {
-        static constexpr std::size_t value = detail::initializer_depth_impl<U>::value;
-    };
-
-    /************************************
-     * initializer_shape implementation *
-     ************************************/
-
-    namespace detail
-    {
-        template <std::size_t I>
-        struct initializer_shape_impl
-        {
-            template <class T>
-            static constexpr std::size_t value(T t)
-            {
-                return t.size() == 0 ? 0 : initializer_shape_impl<I - 1>::value(*t.begin());
-            }
-        };
-
-        template <>
-        struct initializer_shape_impl<0>
-        {
-            template <class T>
-            static constexpr std::size_t value(T t)
-            {
-                return t.size();
-            }
-        };
-
-        template <class R, class U, std::size_t... I>
-        constexpr R initializer_shape(U t, std::index_sequence<I...>)
-        {
-            using size_type = typename R::value_type;
-            return {size_type(initializer_shape_impl<I>::value(t))...};
-        }
-    }
-
-    template <class R, class T>
-    constexpr R shape(T t)
-    {
-        return detail::initializer_shape<R, decltype(t)>(t, std::make_index_sequence<initializer_dimension<decltype(t)>::value>());
-    }
-
-    /******************************
-     * check_shape implementation *
-     ******************************/
-
-    namespace detail
-    {
-        template <class T, class S>
-        struct predshape
-        {
-            constexpr predshape(S first, S last)
-                : m_first(first), m_last(last)
-            {
-            }
-
-            constexpr bool operator()(const T&) const
-            {
-                return m_first == m_last;
-            }
-
-            S m_first;
-            S m_last;
-        };
-
-        template <class T, class S>
-        struct predshape<std::initializer_list<T>, S>
-        {
-            constexpr predshape(S first, S last)
-                : m_first(first), m_last(last)
-            {
-            }
-
-            constexpr bool operator()(std::initializer_list<T> t) const
-            {
-                return *m_first == t.size() && std::all_of(t.begin(), t.end(), predshape<T, S>(m_first + 1, m_last));
-            }
-
-            S m_first;
-            S m_last;
-        };
-    }
-
-    template <class T, class S>
-    constexpr bool check_shape(T t, S first, S last)
-    {
-        return detail::predshape<decltype(t), S>(first, last)(t);
-    }
-
     /***********************************
      * resize_container implementation *
      ***********************************/
@@ -410,6 +341,88 @@ namespace xt
     inline bool resize_container(std::array<T, N>& /*a*/, typename std::array<T, N>::size_type size)
     {
         return size == N;
+    }
+
+    template <std::size_t... I>
+    inline bool resize_container(xt::fixed_shape<I...>&, std::size_t size)
+    {
+        return sizeof...(I) == size;
+    }
+
+    /*********************************
+     * normalize_axis implementation *
+     *********************************/
+
+    // scalar normalize axis
+    inline std::size_t normalize_axis(std::size_t dim, std::ptrdiff_t axis)
+    {
+        return axis < 0 ? static_cast<std::size_t>(static_cast<std::ptrdiff_t>(dim) + axis) : static_cast<std::size_t>(axis);
+    }
+
+    template <class E, class C>
+    inline std::enable_if_t<!std::is_integral<std::decay_t<C>>::value &&
+                     std::is_signed<typename std::decay_t<C>::value_type>::value,
+                     rebind_container_t<std::size_t, std::decay_t<C>>>
+    normalize_axis(E& expr, C&& axes)
+    {
+        rebind_container_t<std::size_t, std::decay_t<C>> res;
+        resize_container(res, axes.size());
+
+        for (std::size_t i = 0; i < axes.size(); ++i)
+        {
+            res[i] = normalize_axis(expr.dimension(), axes[i]);
+        }
+
+        XTENSOR_ASSERT(std::all_of(res.begin(), res.end(), [&expr](auto ax_el) { return ax_el < expr.dimension(); }));
+
+        return res;
+    }
+
+    template <class C, class E>
+    inline std::enable_if_t<!std::is_integral<std::decay_t<C>>::value && std::is_unsigned<typename std::decay_t<C>::value_type>::value, C&&>
+    normalize_axis(E& expr, C&& axes)
+    {
+        static_cast<void>(expr);
+        XTENSOR_ASSERT(std::all_of(axes.begin(), axes.end(), [&expr](auto ax_el) { return ax_el < expr.dimension(); }));
+        return std::forward<C>(axes);
+    }
+
+    template <class R, class E, class C>
+    inline auto forward_normalize(E& expr, C&& axes)
+        -> std::enable_if_t<std::is_signed<std::decay_t<decltype(*std::begin(axes))>>::value, R>
+    {
+        R res;
+        xt::resize_container(res, xtl::sequence_size(axes));
+        auto dim = expr.dimension();
+        std::transform(std::begin(axes), std::end(axes), std::begin(res), [&dim](auto ax_el) {
+            return normalize_axis(dim, ax_el);
+        });
+
+        XTENSOR_ASSERT(std::all_of(res.begin(), res.end(), [&expr](auto ax_el) { return ax_el < expr.dimension(); }));
+
+        return res;
+    }
+
+    template <class R, class E, class C>
+    inline auto forward_normalize(E& expr, C&& axes)
+        -> std::enable_if_t<!std::is_signed<std::decay_t<decltype(*std::begin(axes))>>::value && !std::is_same<R, std::decay_t<C>>::value, R>
+    {
+        static_cast<void>(expr);
+
+        R res;
+        xt::resize_container(res, xtl::sequence_size(axes));
+        std::copy(std::begin(axes), std::end(axes), std::begin(res));
+        XTENSOR_ASSERT(std::all_of(res.begin(), res.end(), [&expr](auto ax_el) { return ax_el < expr.dimension(); }));
+        return res;
+    }
+
+    template <class R, class E, class C>
+    inline auto forward_normalize(E& expr, C&& axes)
+        -> std::enable_if_t<!std::is_signed<std::decay_t<decltype(*std::begin(axes))>>::value && std::is_same<R, std::decay_t<C>>::value, R&&>
+    {
+        static_cast<void>(expr);
+        XTENSOR_ASSERT(std::all_of(std::begin(axes), std::end(axes), [&expr](auto ax_el) { return ax_el < expr.dimension(); }));
+        return std::move(axes);
     }
 
     /******************
@@ -430,6 +443,30 @@ namespace xt
 
     template <class T>
     using get_value_type_t = typename get_value_type<T>::type;
+
+    /**********************
+     * get implementation *
+     **********************/
+
+    // When subclassing from std::tuple not all compilers are able to correctly instantiate get
+    // See here: https://stackoverflow.com/a/37188019/2528668
+    template <std::size_t I, template <typename... Args> class T, typename ...Args>
+    decltype(auto) get(T<Args...>&& v)
+    {
+      return std::get<I>(static_cast<std::tuple<Args...>&&>(v));
+    }
+
+    template <std::size_t I, template <typename... Args> class T, typename ...Args>
+    decltype(auto) get(T<Args...>& v)
+    {
+      return std::get<I>(static_cast<std::tuple<Args...>&>(v));
+    }
+
+    template <std::size_t I, template <typename... Args> class T, typename ...Args>
+    decltype(auto) get(const T<Args...> & v)
+    {
+      return std::get<I>(static_cast<const std::tuple<Args...> &>(v));
+    }
 
     /***************************
      * apply_cv implementation *
@@ -534,24 +571,19 @@ namespace xt
         return N;
     }
 
-    /*****************************************
+    /*************************************
      * has_data_interface implementation *
-     *****************************************/
+     *************************************/
 
-    template <class T>
-    class has_data_interface
+    template <class E, class = void>
+    struct has_data_interface : std::false_type
     {
-        // the test function has one argument -- the return type of the function we're searching if it exists
-        template <class C>
-        static std::true_type test(decltype(std::declval<C>().data()));
+    };
 
-        template <class C>
-        static std::false_type test(...);
-
-    public:
-
-        // we try to call the test function with the return type and report the result
-        constexpr static bool value = decltype(test<T>(std::declval<const std::add_pointer_t<typename T::value_type>>()))::value == true;
+    template <class E>
+    struct has_data_interface<E, void_t<decltype(std::declval<E>().data())>>
+        : std::true_type
+    {
     };
 
     template <class E, class = void>
@@ -565,14 +597,15 @@ namespace xt
     {
     };
 
-    /******************
-     * enable_if_type *
-     ******************/
-
-    template <class T>
-    struct enable_if_type
+    template <class E, class = void>
+    struct has_iterator_interface : std::false_type
     {
-        using type = void;
+    };
+
+    template <class E>
+    struct has_iterator_interface<E, void_t<decltype(std::declval<E>().begin())>>
+        : std::true_type
+    {
     };
 
     /********************************************
@@ -625,326 +658,11 @@ namespace xt
     inline auto conditional_cast(U&& u)
     {
         return conditional_cast_functor<condition, T>()(std::forward<U>(u));
-    };
-
-    /************************************
-     * arithmetic type promotion traits *
-     ************************************/
-
-    /**
-     * @brief Traits class for the result type of mixed arithmetic expressions.
-     * For example, <tt>promote_type<unsigned char, unsigned char>::type</tt> tells
-     * the user that <tt>unsigned char + unsigned char => int</tt>.
-     */
-    template <class... T>
-    struct promote_type;
-
-    template <>
-    struct promote_type<>
-    {
-        using type = void;
-    };
-
-    template <class T>
-    struct promote_type<T>
-    {
-        using type = typename promote_type<T, T>::type;
-    };
-
-    template <class T0, class T1>
-    struct promote_type<T0, T1>
-    {
-        using type = decltype(std::declval<std::decay_t<T0>>() + std::declval<std::decay_t<T1>>());
-    };
-
-    template <class T0, class... REST>
-    struct promote_type<T0, REST...>
-    {
-        using type = decltype(std::declval<std::decay_t<T0>>() + std::declval<typename promote_type<REST...>::type>());
-    };
-
-    template <>
-    struct promote_type<bool>
-    {
-        using type = bool;
-    };
-
-    template <class T>
-    struct promote_type<bool, T>
-    {
-        using type = T;
-    };
-
-    template <class... REST>
-    struct promote_type<bool, REST...>
-    {
-        using type = typename promote_type<bool, typename promote_type<REST...>::type>::type;
-    };
-
-    /** 
-     * @brief Abbreviation of 'typename promote_type<T>::type'.
-     */
-    template <class... T>
-    using promote_type_t = typename promote_type<T...>::type;
-
-    /**
-     * @brief Traits class to find the biggest type of the same kind.
-     *
-     * For example, <tt>big_promote_type<unsigned char>::type</tt> is <tt>unsigned long long</tt>.
-     * The default implementation only supports built-in types and <tt>std::complex</tt>. All
-     * other types remain unchanged unless <tt>big_promote_type</tt> gets specialized for them.
-     */
-    template <class T>
-    struct big_promote_type
-    {
-    private:
-        
-        using V = std::decay_t<T>;
-        static constexpr bool is_arithmetic = std::is_arithmetic<V>::value;
-        static constexpr bool is_signed = std::is_signed<V>::value;
-        static constexpr bool is_integral = std::is_integral<V>::value;
-        static constexpr bool is_long_double = std::is_same<V, long double>::value;
-
-    public:
-
-        using type = std::conditional_t<is_arithmetic,
-                        std::conditional_t<is_integral,
-                            std::conditional_t<is_signed, long long, unsigned long long>,
-                            std::conditional_t<is_long_double, long double, double>
-                        >,
-                        V
-                     >;
-    };
-
-    template <class T>
-    struct big_promote_type<std::complex<T>>
-    {
-        using type = std::complex<typename big_promote_type<T>::type>;
-    };
-
-    /**
-     * @brief Abbreviation of 'typename big_promote_type<T>::type'.
-     */
-    template <class T>
-    using big_promote_type_t = typename big_promote_type<T>::type;
-
-    namespace traits_detail
-    {
-        using std::sqrt;
-
-        template <class T>
-        using real_promote_type_t = decltype(sqrt(std::declval<std::decay_t<T>>()));
     }
 
-    /**
-     * @brief Result type of algebraic expressions.
-     *
-     * For example, <tt>real_promote_type<int>::type</tt> tells the
-     * user that <tt>sqrt(int) => double</tt>.
-     */
-    template <class T>
-    struct real_promote_type
-    {
-        using type = traits_detail::real_promote_type_t<T>;
-    };
-
-    /**
-     * @brief Abbreviation of 'typename real_promote_type<T>::type'.
-     */
-    template <class T>
-    using real_promote_type_t = typename real_promote_type<T>::type;
-
-    /**
-     * @brief Traits class to replace 'bool' with 'uint8_t' and keep everything else.
-     *
-     * This is useful for scientific computing, where a boolean mask array is
-     * usually implemented as an array of bytes.
-     */
-    template <class T>
-    struct bool_promote_type
-    {
-        using type = typename std::conditional<std::is_same<T, bool>::value, uint8_t, T>::type;
-    };
-
-    /**
-     * @brief Abbreviation for typename bool_promote_type<T>::type
-     */
-    template <class T>
-    using bool_promote_type_t = typename bool_promote_type<T>::type;
-
-    /********************************************
-     * type inference for norm and squared norm *
-     ********************************************/
-
-    template <class T>
-    struct norm_type;
-
-    template <class T>
-    struct squared_norm_type;
-
-    namespace traits_detail
-    {
-
-        template <class T, bool scalar = std::is_arithmetic<T>::value>
-        struct norm_of_scalar_impl;
-
-        template <class T>
-        struct norm_of_scalar_impl<T, false>
-        {
-            static const bool value = false;
-            using norm_type = void*;
-            using squared_norm_type = void*;
-        };
-
-        template <class T>
-        struct norm_of_scalar_impl<T, true>
-        {
-            static const bool value = true;
-            using norm_type = promote_type_t<T>;
-            using squared_norm_type = promote_type_t<T>;
-        };
-
-        template <class T, bool integral = std::is_integral<T>::value,
-                  bool floating = std::is_floating_point<T>::value>
-        struct norm_of_array_elements_impl;
-
-        template <>
-        struct norm_of_array_elements_impl<void*, false, false>
-        {
-            using norm_type = void*;
-            using squared_norm_type = void*;
-        };
-
-        template <class T>
-        struct norm_of_array_elements_impl<T, false, false>
-        {
-            using norm_type = typename norm_type<T>::type;
-            using squared_norm_type = typename squared_norm_type<T>::type;
-        };
-
-        template <class T>
-        struct norm_of_array_elements_impl<T, true, false>
-        {
-            static_assert(!std::is_same<T, char>::value,
-                          "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
-
-            using norm_type = double;
-            using squared_norm_type = uint64_t;
-        };
-
-        template <class T>
-        struct norm_of_array_elements_impl<T, false, true>
-        {
-            using norm_type = double;
-            using squared_norm_type = double;
-        };
-
-        template <>
-        struct norm_of_array_elements_impl<long double, false, true>
-        {
-            using norm_type = long double;
-            using squared_norm_type = long double;
-        };
-
-        template <class ARRAY>
-        struct norm_of_vector_impl
-        {
-            static void* test(...);
-
-            template <class U>
-            static typename U::value_type test(U*, typename U::value_type* = 0);
-
-            using T = decltype(test(std::declval<ARRAY*>()));
-
-            static const bool value = !std::is_same<T, void*>::value;
-
-            using norm_type = typename norm_of_array_elements_impl<T>::norm_type;
-            using squared_norm_type = typename norm_of_array_elements_impl<T>::squared_norm_type;
-        };
-
-        template <class U>
-        struct norm_type_base
-        {
-            using T = std::decay_t<U>;
-
-            static_assert(!std::is_same<T, char>::value,
-                          "'char' is not a numeric type, use 'signed char' or 'unsigned char'.");
-
-            using norm_of_scalar = norm_of_scalar_impl<T>;
-            using norm_of_vector = norm_of_vector_impl<T>;
-
-            static const bool value = norm_of_scalar::value || norm_of_vector::value;
-
-            static_assert(value, "norm_type<T> are undefined for type U.");
-        };
-    }  // namespace traits_detail
-
-    /**
-     * @brief Traits class for the result type of the <tt>norm_l2()</tt> function.
-     *
-     * Member 'type' defines the result of <tt>norm_l2(t)</tt>, where <tt>t</tt>
-     * is of type @tparam T. It implements the following rules designed to
-     * minimize the potential for overflow:
-     *   - @tparam T is an arithmetic type: 'type' is the result type of <tt>abs(t)</tt>.
-     *   - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
-     *   - @tparam T is a container of another arithmetic type: 'type' is <tt>double</tt>.
-     *   - @tparam T is a container of some other type: 'type' is the element's norm type,
-     *
-     * Containers are recognized by having an embedded typedef 'value_type'.
-     * To change the behavior for a case not covered here, specialize the
-     * <tt>traits_detail::norm_type_base</tt> template.
-     */
-    template <class T>
-    struct norm_type
-        : public traits_detail::norm_type_base<T>
-    {
-        using base_type = traits_detail::norm_type_base<T>;
-
-        using type =
-            typename std::conditional<base_type::norm_of_vector::value,
-                                      typename base_type::norm_of_vector::norm_type,
-                                      typename base_type::norm_of_scalar::norm_type>::type;
-    };
-
-    /**
-     * Abbreviation of 'typename norm_type<T>::type'.
-     */
-    template <class T>
-    using norm_type_t = typename norm_type<T>::type;
-
-    /**
-     * @brief Traits class for the result type of the <tt>norm_sq()</tt> function.
-     *
-     * Member 'type' defines the result of <tt>norm_sq(t)</tt>, where <tt>t</tt>
-     * is of type @tparam T. It implements the following rules designed to
-     * minimize the potential for overflow:
-     *   - @tparam T is an arithmetic type: 'type' is the result type of <tt>t*t</tt>.
-     *   - @tparam T is a container of 'long double' elements: 'type' is <tt>long double</tt>.
-     *   - @tparam T is a container of another floating-point type: 'type' is <tt>double</tt>.
-     *   - @tparam T is a container of integer elements: 'type' is <tt>uint64_t</tt>.
-     *   - @tparam T is a container of some other type: 'type' is the element's squared norm type,
-     *
-     *  Containers are recognized by having an embedded typedef 'value_type'.
-     *  To change the behavior for a case not covered here, specialize the
-     *  <tt>traits_detail::norm_type_base</tt> template.
-     */
-    template <class T>
-    struct squared_norm_type
-        : public traits_detail::norm_type_base<T>
-    {
-        using base_type = traits_detail::norm_type_base<T>;
-
-        using type =
-            typename std::conditional<base_type::norm_of_vector::value,
-                                      typename base_type::norm_of_vector::squared_norm_type,
-                                      typename base_type::norm_of_scalar::squared_norm_type>::type;
-    };
-
-    /**
-     * Abbreviation of 'typename squared_norm_type<T>::type'.
-     */
-    template <class T>
-    using squared_norm_type_t = typename squared_norm_type<T>::type;
+    /**********************
+     * tracking allocator *
+     **********************/
 
     namespace alloc_tracking
     {
@@ -952,7 +670,7 @@ namespace xt
         {
             static bool enabled;
             return enabled;
-        };
+        }
 
         inline void enable()
         {
@@ -1025,6 +743,10 @@ namespace xt
       return !(a == b);
     }
 
+    /*****************
+     * has_assign_to *
+     *****************/
+
     template <class E1, class E2, class = void>
     struct has_assign_to : std::false_type
     {
@@ -1035,6 +757,69 @@ namespace xt
         : std::true_type
     {
     };
+
+    /********************
+     * rebind_container *
+     ********************/
+
+    template <class X, template <class, class> class C, class T, class A>
+    struct rebind_container<X, C<T, A>>
+    {
+        using allocator = typename A::template rebind<X>::other;
+        using type = C<X, allocator>;
+    };
+
+#if defined(__GNUC__) && __GNUC__ > 6 && !defined(__clang__) && __cplusplus >= 201703L
+    template <class X, class T, std::size_t N>
+    struct rebind_container<X, std::array<T, N>>
+    {
+        using type = std::array<X, N>;
+    };
+#else
+    template <class X, template <class, std::size_t> class C, class T, std::size_t N>
+    struct rebind_container<X, C<T, N>>
+    {
+        using type = C<X, N>;
+    };
+#endif
+
+    /********************
+     * get_strides_type *
+     ********************/
+
+    template <class S>
+    struct get_strides_type
+    {
+        using type = typename rebind_container<std::ptrdiff_t, S>::type;
+    };
+
+    template <std::size_t... I>
+    struct get_strides_type<fixed_shape<I...>>
+    {
+        // TODO we could compute the strides statically here.
+        //  But we'll need full constexpr support to have a
+        //  homogenous ``compute_strides`` method
+        using type = std::array<std::ptrdiff_t, sizeof...(I)>;
+    };
+
+    template <class C>
+    using get_strides_t = typename get_strides_type<C>::type;
+
+    /*******************
+     * inner_reference *
+     *******************/
+
+    template <class ST>
+    struct inner_reference
+    {
+        using storage_type = std::decay_t<ST>;
+        using type = std::conditional_t<std::is_const<std::remove_reference_t<ST>>::value,
+                                        typename storage_type::const_reference,
+                                        typename storage_type::reference>;
+    };
+
+    template <class ST>
+    using inner_reference_t = typename inner_reference<ST>::type;
 }
 
 #endif

--- a/vendor/xtensor/include/xtensor/xvectorize.hpp
+++ b/vendor/xtensor/include/xtensor/xvectorize.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -28,7 +29,7 @@ namespace xt
     public:
 
         template <class... E>
-        using xfunction_type = xfunction<F, R, xclosure_t<E>...>;
+        using xfunction_type = xfunction<F, xclosure_t<E>...>;
 
         template <class Func, class = std::enable_if_t<!std::is_same<std::decay_t<Func>, xvectorizer>::value>>
         xvectorizer(Func&& f);

--- a/vendor/xtensor/include/xtensor/xview_utils.hpp
+++ b/vendor/xtensor/include/xtensor/xview_utils.hpp
@@ -1,5 +1,6 @@
 /***************************************************************************
-* Copyright (c) 2016, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
 *                                                                          *
 * Distributed under the terms of the BSD 3-Clause License.                 *
 *                                                                          *
@@ -36,7 +37,7 @@ namespace xt
     template <class... S>
     constexpr std::size_t newaxis_count();
 
-// number of newaxis types in the specified sequence of types before specified index
+    // number of newaxis types in the specified sequence of types before specified index
     template <class... S>
     constexpr std::size_t newaxis_count_before(std::size_t i);
 
@@ -44,7 +45,6 @@ namespace xt
     template <class... S>
     constexpr std::size_t newaxis_skip(std::size_t i);
 
-    // return slice evaluation and increment iterator
     template <class S, class It>
     inline disable_xslice<S, std::size_t> get_slice_value(const S& s, It&) noexcept
     {
@@ -54,7 +54,7 @@ namespace xt
     template <class S, class It>
     inline auto get_slice_value(const xslice<S>& slice, It& it) noexcept
     {
-        return slice.derived_cast()(typename S::size_type(*it++));
+        return slice.derived_cast()(typename S::size_type(*it));
     }
 
     /***********************
@@ -66,13 +66,13 @@ namespace xt
         template <class T, class S, layout_type L, class... SL>
         struct view_temporary_type_impl
         {
-            using type = xarray<T, L>;
+            using type = xt::xarray<T, L>;
         };
 
         template <class T, class I, std::size_t N, layout_type L, class... SL>
         struct view_temporary_type_impl<T, std::array<I, N>, L, SL...>
         {
-            using type = xtensor<T, N + newaxis_count<SL...>() - integral_count<SL...>(), L>;
+            using type = xt::xtensor<T, N + newaxis_count<SL...>() - integral_count<SL...>(), L>;
         };
     }
 

--- a/vendor/xtensor/xtensorConfig.cmake.in
+++ b/vendor/xtensor/xtensorConfig.cmake.in
@@ -1,5 +1,6 @@
 ############################################################################
-# Copyright (c) 2016, Johan Mabille and Sylvain Corlay                     #
+# Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          #
+# Copyright (c) QuantStack
 #                                                                          #
 # Distributed under the terms of the BSD 3-Clause License.                 #
 #                                                                          #
@@ -14,6 +15,17 @@
 #   xtensor_LIBRARY - empty
 
 @PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(xtl @xtl_REQUIRED_VERSION@)
+
+if(XTENSOR_USE_XSIMD)
+    find_dependency(xsimd @xsimd_REQUIRED_VERSION@)
+endif()
+
+if(XTENSOR_USE_TBB)
+    find_dependency(TBB)
+endif()
 
 if(NOT TARGET @PROJECT_NAME@)
   include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/vendor/xtl/CMakeLists.txt
+++ b/vendor/xtl/CMakeLists.txt
@@ -9,9 +9,11 @@
 cmake_minimum_required(VERSION 3.1)
 project(xtl)
 
+enable_testing()
+
 set(XTL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-# Versionning
+# Versioning
 # ===========
 
 file(STRINGS "${XTL_INCLUDE_DIR}/xtl/xtl_config.hpp" xtl_version_defines
@@ -28,7 +30,7 @@ message(STATUS "xtl v${${PROJECT_NAME}_VERSION}")
 # Dependencies
 # ============
 
-#find_package(nlohmann_json)
+find_package(nlohmann_json QUIET)
 
 # Build
 # =====
@@ -40,13 +42,18 @@ set(XTL_HEADERS
     ${XTL_INCLUDE_DIR}/xtl/xclosure.hpp
     ${XTL_INCLUDE_DIR}/xtl/xcomplex.hpp
     ${XTL_INCLUDE_DIR}/xtl/xcomplex_sequence.hpp
+    ${XTL_INCLUDE_DIR}/xtl/xspan.hpp
+    ${XTL_INCLUDE_DIR}/xtl/xspan_impl.hpp
     ${XTL_INCLUDE_DIR}/xtl/xdynamic_bitset.hpp
     ${XTL_INCLUDE_DIR}/xtl/xfunctional.hpp
     ${XTL_INCLUDE_DIR}/xtl/xhash.hpp
     ${XTL_INCLUDE_DIR}/xtl/xhierarchy_generator.hpp
     ${XTL_INCLUDE_DIR}/xtl/xiterator_base.hpp
     ${XTL_INCLUDE_DIR}/xtl/xjson.hpp
+    ${XTL_INCLUDE_DIR}/xtl/xmasked_value_meta.hpp
+    ${XTL_INCLUDE_DIR}/xtl/xmasked_value.hpp
     ${XTL_INCLUDE_DIR}/xtl/xmeta_utils.hpp
+    ${XTL_INCLUDE_DIR}/xtl/xoptional_meta.hpp
     ${XTL_INCLUDE_DIR}/xtl/xoptional.hpp
     ${XTL_INCLUDE_DIR}/xtl/xoptional_sequence.hpp
     ${XTL_INCLUDE_DIR}/xtl/xproxy_wrapper.hpp
@@ -61,9 +68,13 @@ add_library(xtl INTERFACE)
 target_include_directories(xtl INTERFACE $<BUILD_INTERFACE:${XTL_INCLUDE_DIR}>
                                          $<INSTALL_INTERFACE:include>)
 
+# xtl requires C++14 support!
+target_compile_features(xtl INTERFACE cxx_std_14)
 
-OPTION(BUILD_TESTS "xtl test suite" OFF)
-OPTION(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
+
+option(BUILD_TESTS "xtl test suite" OFF)
+option(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
+option(XTL_DISABLE_EXCEPTIONS "Disable C++ exceptions" OFF)
 
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
     set(BUILD_TESTS ON)
@@ -111,3 +122,9 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
 install(EXPORT ${PROJECT_NAME}-targets
         FILE ${PROJECT_NAME}Targets.cmake
         DESTINATION ${XTL_CMAKECONFIG_INSTALL_DIR})
+
+configure_file(${PROJECT_NAME}.pc.in
+               "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+                @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")

--- a/vendor/xtl/include/xtl/xany.hpp
+++ b/vendor/xtl/include/xtl/xany.hpp
@@ -36,6 +36,19 @@ namespace xtl
         }
     };
 
+    namespace detail {
+        inline static void check_any_cast(const void* p) {
+            if (p == nullptr) {
+#if defined(XTL_NO_EXCEPTIONS)
+                std::fprintf(stderr, "bad_any_cast\n");
+                std::terminate();        
+#else
+                throw bad_any_cast();
+#endif
+            }
+        }
+    } // namespace detail
+
     class any final
     {
     public:
@@ -378,8 +391,7 @@ namespace xtl
     inline ValueType any_cast(const any& operand)
     {
         auto p = any_cast<typename std::add_const<typename std::remove_reference<ValueType>::type>::type>(&operand);
-        if (p == nullptr)
-            throw bad_any_cast();
+        detail::check_any_cast(p);
         return *p;
     }
 
@@ -388,8 +400,7 @@ namespace xtl
     inline ValueType any_cast(any& operand)
     {
         auto p = any_cast<typename std::remove_reference<ValueType>::type>(&operand);
-        if (p == nullptr)
-            throw bad_any_cast();
+        detail::check_any_cast(p);
         return *p;
     }
 
@@ -414,8 +425,7 @@ namespace xtl
 #endif
 
         auto p = any_cast<typename std::remove_reference<ValueType>::type>(&operand);
-        if (p == nullptr)
-            throw bad_any_cast();
+        detail::check_any_cast(p);
         return detail::any_cast_move_if_true<ValueType>(p, can_move());
     }
 

--- a/vendor/xtl/include/xtl/xbase64.hpp
+++ b/vendor/xtl/include/xtl/xbase64.hpp
@@ -51,8 +51,9 @@ namespace xtl
         std::string output;
         int val = 0;
         int valb = -6;
-        for (unsigned char c : input)
+        for (char sc : input)
         {
+            unsigned char c = static_cast<unsigned char>(sc);
             val = (val << 8) + c;
             valb += 8;
             while (valb >= 0)

--- a/vendor/xtl/include/xtl/xbasic_fixed_string.hpp
+++ b/vendor/xtl/include/xtl/xbasic_fixed_string.hpp
@@ -16,7 +16,12 @@
 #include <stdexcept>
 #include <string>
 
+#ifdef __CLING__
+#include <nlohmann/json.hpp>
+#endif
+
 #include "xhash.hpp"
+#include "xtl_config.hpp"
 
 namespace xtl
 {
@@ -30,15 +35,136 @@ namespace xtl
         struct throwing_error;
     }
 
-
     /***********************
      * xbasic_fixed_string *
      ***********************/
 
+    enum storage_options
+    {
+        buffer = 1 << 0,
+        pointer = 1 << 1,
+        store_size = 1 << 2,
+        is_const = 1 << 3
+    };
+
+    template <class CT, std::size_t N = 55, int ST = buffer | store_size, template <std::size_t> class EP = string_policy::silent_error, class TR = std::char_traits<CT>>
+    class xbasic_fixed_string;
+
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    std::basic_ostream<CT, TR>& operator<<(std::basic_ostream<CT, TR>& os,
+                                           const xbasic_fixed_string<CT, N, ST, EP, TR>& str);
+
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    std::basic_istream<CT, TR>& operator>>(std::basic_istream<CT, TR>& is,
+                                           xbasic_fixed_string<CT, N, ST, EP, TR>& str);
+
+    template <class CT>
+    using xbasic_string_view = xbasic_fixed_string<const CT, 0, pointer | store_size | is_const>;
+
+    namespace detail
+    {
+        template <int selector>
+        struct select_storage;
+
+        template <class T, std::size_t N>
+        struct fixed_string_storage_impl
+        {
+            fixed_string_storage_impl() = default;
+
+            fixed_string_storage_impl(T ptr, std::size_t size)
+                : m_buffer(ptr), m_size(size)
+            {
+            }
+
+            T& buffer()
+            {
+                return m_buffer;
+            }
+
+            const T& buffer() const
+            {
+                return m_buffer;
+            }
+
+            std::size_t size() const
+            {
+                return m_size;
+            }
+
+            void set_size(std::size_t sz)
+            {
+                m_size = sz;
+                m_buffer[sz] = '\0';
+            }
+
+            void adjust_size(std::ptrdiff_t val)
+            {
+                m_size += std::size_t(val);
+                m_buffer[m_size] = '\0';
+            }
+
+            T m_buffer;
+            std::size_t m_size;
+        };
+
+        template <class T, std::size_t N>
+        struct fixed_string_external_storage_impl
+        {
+            fixed_string_external_storage_impl() = default;
+
+            fixed_string_external_storage_impl(T ptr, std::ptrdiff_t/*size*/)
+            {
+                m_buffer = ptr;
+            }
+
+            T& buffer()
+            {
+                return m_buffer;
+            }
+
+            const T& buffer() const
+            {
+                return m_buffer;
+            }
+
+            void set_size(std::size_t sz)
+            {
+                m_buffer[sz] = '\0';
+            }
+
+            void adjust_size(std::ptrdiff_t val)
+            {
+                m_buffer[size() + val] = '\0';
+            }
+
+            std::size_t size() const
+            {
+                return std::strlen(m_buffer);
+            }
+
+            T m_buffer;
+        };
+
+        template <>
+        struct select_storage<buffer | store_size>
+        {
+            template <class T, std::size_t N>
+            using type = fixed_string_storage_impl<T[N + 1], N>;
+        };
+
+        template <>
+        struct select_storage<buffer>
+        {
+            template <class T, std::size_t N>
+            using type = fixed_string_external_storage_impl<T[N + 1], N>;
+        };
+    }
+
     template <class CT,
-              std::size_t N = 55,
-              template <std::size_t> class EP = string_policy::silent_error,
-              class TR = std::char_traits<CT>>
+              std::size_t N,
+              int ST,
+              template <std::size_t> class EP,
+              class TR>
     class xbasic_fixed_string
     {
     public:
@@ -47,6 +173,9 @@ namespace xtl
         using value_type = CT;
         using size_type = std::size_t;
         using difference_type = std::ptrdiff_t;
+
+        using storage_type = typename detail::select_storage<ST>::template type<CT, N>;
+
         using reference = value_type&;
         using const_reference = const value_type&;
         using pointer = value_type*;
@@ -55,6 +184,7 @@ namespace xtl
         using const_iterator = const_pointer;
         using reverse_iterator = std::reverse_iterator<iterator>;
         using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
 
         static const size_type npos;
 
@@ -65,14 +195,15 @@ namespace xtl
         using error_policy = EP<N>;
 
         xbasic_fixed_string();
-        xbasic_fixed_string(size_type count, value_type ch);
-        xbasic_fixed_string(const self_type& other,
+
+        explicit xbasic_fixed_string(size_type count, value_type ch);
+        explicit xbasic_fixed_string(const self_type& other,
                             size_type pos,
                             size_type count = npos);
-        xbasic_fixed_string(const string_type& other);
-        xbasic_fixed_string(const string_type& other,
-                            size_type pos,
-                            size_type count = npos);
+        explicit xbasic_fixed_string(const string_type& other);
+        explicit xbasic_fixed_string(const string_type& other,
+                                     size_type pos,
+                                     size_type count = npos);
         xbasic_fixed_string(const_pointer s, size_type count);
         xbasic_fixed_string(const_pointer s);
         xbasic_fixed_string(initializer_type ilist);
@@ -266,12 +397,11 @@ namespace xtl
         void check_index(size_type pos, size_type size, const char* what) const;
         void check_index_strict(size_type pos, size_type size, const char* what) const;
 
-        value_type m_buffer[N + 1];
-        size_type m_size;
+        storage_type m_storage;
     };
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    const typename xbasic_fixed_string<CT, N, EP, TR>::size_type xbasic_fixed_string<CT, N, EP, TR>::npos
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    const typename xbasic_fixed_string<CT, N, ST, EP, TR>::size_type xbasic_fixed_string<CT, N, ST, EP, TR>::npos
         = std::basic_string<value_type, traits_type>::npos;
 
     template <std::size_t N>
@@ -290,232 +420,224 @@ namespace xtl
      * Concatenation operator *
      **************************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>& rhs);
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+              const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
               const CT* rhs);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
               CT rhs);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    xbasic_fixed_string<CT, N, EP, TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    xbasic_fixed_string<CT, N, ST, EP, TR>
     operator+(const CT* lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>& rhs);
+              const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    xbasic_fixed_string<CT, N, EP, TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    xbasic_fixed_string<CT, N, ST, EP, TR>
     operator+(CT lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>& rhs);
+              const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>&& lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>& rhs);
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>&& lhs,
+              const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>&& rhs);
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+              const xbasic_fixed_string<CT, N, ST, EP, TR>&& rhs);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>&& lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>&& rhs);
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>&& lhs,
+              const xbasic_fixed_string<CT, N, ST, EP, TR>&& rhs);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>&& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>&& lhs,
               const CT* rhs);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>&& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>&& lhs,
               CT rhs);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    xbasic_fixed_string<CT, N, EP, TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    xbasic_fixed_string<CT, N, ST, EP, TR>
     operator+(const CT* lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>&& rhs);
+              const xbasic_fixed_string<CT, N, ST, EP, TR>&& rhs);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    xbasic_fixed_string<CT, N, EP, TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    xbasic_fixed_string<CT, N, ST, EP, TR>
     operator+(CT lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>&& rhs);
+              const xbasic_fixed_string<CT, N, ST, EP, TR>&& rhs);
 
     /************************
      * Comparison operators *
      ************************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator==(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-                    const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator==(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+                    const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator==(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator==(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                     const CT* rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     bool operator==(const CT* lhs,
-                    const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+                    const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator==(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator==(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                     const std::basic_string<CT, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     bool operator==(const std::basic_string<CT, TR>& lhs,
-                    const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+                    const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator!=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-                    const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator!=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+                    const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator!=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator!=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                     const CT* rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     bool operator!=(const CT* lhs,
-                    const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+                    const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator!=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator!=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                     const std::basic_string<CT, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     bool operator!=(const std::basic_string<CT, TR>& lhs,
-                    const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+                    const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator<(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-                   const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator<(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+                   const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator<(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator<(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                    const CT* rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     bool operator<(const CT* lhs,
-                   const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+                   const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator<(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator<(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                    const std::basic_string<CT, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     bool operator<(const std::basic_string<CT, TR>& lhs,
-                   const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+                   const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator<=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-                    const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator<=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+                    const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator<=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator<=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                     const CT* rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     bool operator<=(const CT* lhs,
-                    const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+                    const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator<=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator<=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                     const std::basic_string<CT, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     bool operator<=(const std::basic_string<CT, TR>& lhs,
-                    const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+                    const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator>(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-                   const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator>(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+                   const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator>(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator>(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                    const CT* rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     bool operator>(const CT* lhs,
-                   const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+                   const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator>(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator>(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                    const std::basic_string<CT, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     bool operator>(const std::basic_string<CT, TR>& lhs,
-                   const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+                   const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator>=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-                    const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator>=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+                    const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator>=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator>=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                     const CT* rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     bool operator>=(const CT* lhs,
-                    const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+                    const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    bool operator>=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    bool operator>=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                     const std::basic_string<CT, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     bool operator>=(const std::basic_string<CT, TR>& lhs,
-                    const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept;
+                    const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept;
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    void swap(xbasic_fixed_string<CT, N, EP, TR>& lhs,
-              xbasic_fixed_string<CT, N, EP, TR>& rhs);
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    void swap(xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+              xbasic_fixed_string<CT, N, ST, EP, TR>& rhs);
 
     /******************************
      * Input / output declaration *
      ******************************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    std::basic_ostream<CT, TR>& operator<<(std::basic_ostream<CT, TR>& os,
-                                           const xbasic_fixed_string<CT, N, EP, TR>& str);
-
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    std::basic_istream<CT, TR>& operator>>(std::basic_istream<CT, TR>& is,
-                                           xbasic_fixed_string<CT, N, EP, TR>& str);
-
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     std::basic_istream<CT, TR>& getline(std::basic_istream<CT, TR>& input,
-                                        xbasic_fixed_string<CT, N, EP, TR>& str,
+                                        xbasic_fixed_string<CT, N, ST, EP, TR>& str,
                                         CT delim);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     std::basic_istream<CT, TR>& getline(std::basic_istream<CT, TR>&& input,
-                                        xbasic_fixed_string<CT, N, EP, TR>& str,
+                                        xbasic_fixed_string<CT, N, ST, EP, TR>& str,
                                         CT delim);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     std::basic_istream<CT, TR>& getline(std::basic_istream<CT, TR>& input,
-                                        xbasic_fixed_string<CT, N, EP, TR>& str);
+                                        xbasic_fixed_string<CT, N, ST, EP, TR>& str);
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     std::basic_istream<CT, TR>& getline(std::basic_istream<CT, TR>&& input,
-                                        xbasic_fixed_string<CT, N, EP, TR>& str);
+                                        xbasic_fixed_string<CT, N, ST, EP, TR>& str);
 
 }  // namespace xtl
 
 namespace std
 {
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    struct hash<::xtl::xbasic_fixed_string<CT, N, EP, TR>>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    struct hash<::xtl::xbasic_fixed_string<CT, N, ST, EP, TR>>
     {
-        using argument_type = ::xtl::xbasic_fixed_string<CT, N, EP, TR>;
+        using argument_type = ::xtl::xbasic_fixed_string<CT, N, ST, EP, TR>;
         using result_type = std::size_t;
         inline result_type operator()(const argument_type& arg) const
         {
@@ -554,7 +676,12 @@ namespace xtl
                 {
                     std::ostringstream oss;
                     oss << "Invalid size (" << size << ") for xbasic_fixed_string - maximal size: " << N;
+#if defined(XTL_NO_EXCEPTIONS)
+                    std::fprintf(stderr, "%s\n", oss.str().c_str());
+                    std::terminate();
+#else
                     throw std::length_error(oss.str());
+#endif
                 }
                 return size;
             }
@@ -574,76 +701,75 @@ namespace xtl
      * Constructors *
      ****************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>::xbasic_fixed_string()
-        : m_size(0)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>::xbasic_fixed_string()
+        : m_storage()
     {
-        update_null_termination();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>::xbasic_fixed_string(size_type count, value_type ch)
-        : m_size(0)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>::xbasic_fixed_string(size_type count, value_type ch)
+        : m_storage()
     {
         assign(count, ch);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>::xbasic_fixed_string(const self_type& other,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>::xbasic_fixed_string(const self_type& other,
                                                                    size_type pos,
                                                                    size_type count)
-        : m_size(0)
+        : m_storage()
     {
         assign(other, pos, count);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>::xbasic_fixed_string(const string_type& other)
-        : m_size(0)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>::xbasic_fixed_string(const string_type& other)
+        : m_storage()
     {
         assign(other);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>::xbasic_fixed_string(const string_type& other,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>::xbasic_fixed_string(const string_type& other,
                                                                    size_type pos,
                                                                    size_type count)
-        : m_size(0)
+        : m_storage()
     {
         assign(other, pos, count);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>::xbasic_fixed_string(const_pointer s, size_type count)
-        : m_size(0)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>::xbasic_fixed_string(const_pointer s, size_type count)
+        : m_storage()
     {
         assign(s, count);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>::xbasic_fixed_string(const_pointer s)
-        : m_size(0)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>::xbasic_fixed_string(const_pointer s)
+        : m_storage()
     {
         assign(s);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>::xbasic_fixed_string(initializer_type ilist)
-        : m_size(0)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>::xbasic_fixed_string(initializer_type ilist)
+        : m_storage()
     {
         assign(ilist);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     template <class InputIt>
-    inline xbasic_fixed_string<CT, N, EP, TR>::xbasic_fixed_string(InputIt first, InputIt last)
-        : m_size(0)
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>::xbasic_fixed_string(InputIt first, InputIt last)
+        : m_storage()
     {
         assign(first, last);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>::operator string_type() const
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>::operator string_type() const
     {
         return string_type(data());
     }
@@ -652,116 +778,110 @@ namespace xtl
      * Assignment *
      **************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::operator=(const_pointer s) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::operator=(const_pointer s) -> self_type&
     {
         return assign(s);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::operator=(value_type ch) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::operator=(value_type ch) -> self_type&
     {
         return assign(size_type(1), ch);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::operator=(initializer_type ilist) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::operator=(initializer_type ilist) -> self_type&
     {
         return assign(ilist);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::operator=(const string_type& str) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::operator=(const string_type& str) -> self_type&
     {
         return assign(str);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::assign(size_type count, value_type ch) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::assign(size_type count, value_type ch) -> self_type&
     {
-        m_size = error_policy::check_size(count);
+        m_storage.set_size(error_policy::check_size(count));
         traits_type::assign(data(), count, ch);
-        update_null_termination();
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::assign(const self_type& other,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::assign(const self_type& other,
                                                            size_type pos,
                                                            size_type count) -> self_type&
     {
         check_index_strict(pos, other.size(), "xbasic_fixed_string::assign");
         size_type copy_count = std::min(other.size() - pos, count);
-        m_size = error_policy::check_size(copy_count);
+        m_storage.set_size(error_policy::check_size(copy_count));
         traits_type::copy(data(), other.data() + pos, copy_count);
-        update_null_termination();
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::assign(const_pointer s, size_type count) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::assign(const_pointer s, size_type count) -> self_type&
     {
-        m_size = error_policy::check_size(count);
+        m_storage.set_size(error_policy::check_size(count));
         traits_type::copy(data(), s, count);
-        update_null_termination();
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::assign(const_pointer s) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::assign(const_pointer s) -> self_type&
     {
         std::size_t ssize = traits_type::length(s);
         return assign(s, ssize);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::assign(initializer_type ilist) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::assign(initializer_type ilist) -> self_type&
     {
         return assign(ilist.begin(), ilist.end());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     template <class InputIt>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::assign(InputIt first, InputIt last) -> self_type&
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::assign(InputIt first, InputIt last) -> self_type&
     {
-        m_size = error_policy::check_size(static_cast<size_type>(std::distance(first, last)));
+        m_storage.set_size(error_policy::check_size(static_cast<size_type>(std::distance(first, last))));
         std::copy(first, last, data());
-        update_null_termination();
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::assign(const self_type& rhs) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::assign(const self_type& rhs) -> self_type&
     {
         if (this != &rhs)
         {
-            m_size = rhs.size();
+            m_storage.set_size(rhs.size());
             traits_type::copy(data(), rhs.data(), rhs.size());
-            update_null_termination();
         }
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::assign(self_type&& rhs) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::assign(self_type&& rhs) -> self_type&
     {
         if (this != &rhs)
         {
-            m_size = rhs.size();
+            m_storage.set_size(rhs.size());
             traits_type::copy(data(), rhs.data(), rhs.size());
-            update_null_termination();
         }
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::assign(const string_type& other) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::assign(const string_type& other) -> self_type&
     {
         return assign(other.c_str());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::assign(const string_type& other,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::assign(const string_type& other,
                                                            size_type pos,
                                                            size_type count) -> self_type&
     {
@@ -772,145 +892,145 @@ namespace xtl
      * Element access *
      ******************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::at(size_type pos) -> reference
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::at(size_type pos) -> reference
     {
         check_index(pos, size(), "basic_fixed_string::at");
         return this->operator[](pos);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::at(size_type pos) const -> const_reference
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::at(size_type pos) const -> const_reference
     {
         check_index(pos, size(), "basic_fixed_string::at");
         return this->operator[](pos);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::operator[](size_type pos) -> reference
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::operator[](size_type pos) -> reference
     {
         return data()[pos];
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::operator[](size_type pos) const -> const_reference
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::operator[](size_type pos) const -> const_reference
     {
         return data()[pos];
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::front() -> reference
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::front() -> reference
     {
         return this->operator[](0);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::front() const -> const_reference
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::front() const -> const_reference
     {
         return this->operator[](0);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::back() -> reference
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::back() -> reference
     {
         return this->operator[](size() - 1);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::back() const -> const_reference
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::back() const -> const_reference
     {
         return this->operator[](size() - 1);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::data() noexcept -> pointer
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::data() noexcept -> pointer
     {
-        return m_buffer;
+        return m_storage.buffer();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::data() const noexcept -> const_pointer
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::data() const noexcept -> const_pointer
     {
-        return m_buffer;
+        return m_storage.buffer();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::c_str() const noexcept -> const_pointer
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::c_str() const noexcept -> const_pointer
     {
-        return m_buffer;
+        return m_storage.buffer();
     }
 
     /*************
      * Iterators *
      *************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::begin() noexcept -> iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::begin() noexcept -> iterator
     {
         return data();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::end() noexcept -> iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::end() noexcept -> iterator
     {
         return data() + size();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::begin() const noexcept -> const_iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::begin() const noexcept -> const_iterator
     {
         return cbegin();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::end() const noexcept -> const_iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::end() const noexcept -> const_iterator
     {
         return cend();
     }
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::cbegin() const noexcept -> const_iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::cbegin() const noexcept -> const_iterator
     {
         return data();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::cend() const noexcept -> const_iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::cend() const noexcept -> const_iterator
     {
         return data() + size();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::rbegin() noexcept -> reverse_iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::rbegin() noexcept -> reverse_iterator
     {
         return reverse_iterator(end());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::rend() noexcept -> reverse_iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::rend() noexcept -> reverse_iterator
     {
         return reverse_iterator(begin());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::rbegin() const noexcept -> const_reverse_iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::rbegin() const noexcept -> const_reverse_iterator
     {
         return const_reverse_iterator(end());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::rend() const noexcept -> const_reverse_iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::rend() const noexcept -> const_reverse_iterator
     {
         return const_reverse_iterator(begin());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::crbegin() const noexcept -> const_reverse_iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::crbegin() const noexcept -> const_reverse_iterator
     {
         return const_reverse_iterator(end());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::crend() const noexcept -> const_reverse_iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::crend() const noexcept -> const_reverse_iterator
     {
         return const_reverse_iterator(begin());
     }
@@ -919,26 +1039,26 @@ namespace xtl
      * Capacity *
      ************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool xbasic_fixed_string<CT, N, EP, TR>::empty() const noexcept
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool xbasic_fixed_string<CT, N, ST, EP, TR>::empty() const noexcept
     {
         return size() == 0;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::size() const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::size() const noexcept -> size_type
     {
-        return m_size;
+        return m_storage.size();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::length() const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::length() const noexcept -> size_type
     {
-        return m_size;
+        return m_storage.size();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::max_size() const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::max_size() const noexcept -> size_type
     {
         return N;
     }
@@ -947,37 +1067,34 @@ namespace xtl
      * Operations *
      **************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline void xbasic_fixed_string<CT, N, EP, TR>::clear() noexcept
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline void xbasic_fixed_string<CT, N, ST, EP, TR>::clear() noexcept
     {
-        m_size = 0;
-        update_null_termination();
+        m_storage.set_size(0);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline void xbasic_fixed_string<CT, N, EP, TR>::push_back(value_type ch)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline void xbasic_fixed_string<CT, N, ST, EP, TR>::push_back(value_type ch)
     {
         error_policy::check_add(size(), size_type(1));
-        data()[m_size] = ch;
-        ++m_size;
-        update_null_termination();
+        data()[size()] = ch;
+        m_storage.adjust_size(+1);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline void xbasic_fixed_string<CT, N, EP, TR>::pop_back()
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline void xbasic_fixed_string<CT, N, ST, EP, TR>::pop_back()
     {
-        --m_size;
-        update_null_termination();
+        m_storage.adjust_size(-1);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::substr(size_type pos, size_type count) const -> self_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::substr(size_type pos, size_type count) const -> self_type
     {
         return self_type(*this, pos, count);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::copy(pointer dest, size_type count, size_type pos) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::copy(pointer dest, size_type count, size_type pos) const -> size_type
     {
         check_index_strict(pos, size(), "xbasic_fixed_string::copy");
         size_type nb_copied = std::min(count, size() - pos);
@@ -985,26 +1102,25 @@ namespace xtl
         return nb_copied;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline void xbasic_fixed_string<CT, N, EP, TR>::resize(size_type count)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline void xbasic_fixed_string<CT, N, ST, EP, TR>::resize(size_type count)
     {
-        resize(count, value_type());
+        resize(count, value_type(' '));  // need to initialize with some value != \0
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline void xbasic_fixed_string<CT, N, EP, TR>::resize(size_type count, value_type ch)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline void xbasic_fixed_string<CT, N, ST, EP, TR>::resize(size_type count, value_type ch)
     {
         size_type old_size = size();
-        m_size = error_policy::check_size(count);
-        if (old_size < m_size)
+        m_storage.set_size(error_policy::check_size(count));
+        if (old_size < size())
         {
-            traits_type::assign(data() + old_size, m_size - old_size, ch);
+            traits_type::assign(data() + old_size, size() - old_size, ch);
         }
-        update_null_termination();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline void xbasic_fixed_string<CT, N, EP, TR>::swap(self_type& rhs) noexcept
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline void xbasic_fixed_string<CT, N, ST, EP, TR>::swap(self_type& rhs) noexcept
     {
         self_type tmp(std::move(rhs));
         rhs = std::move(*this);
@@ -1015,72 +1131,70 @@ namespace xtl
      * insert *
      **********/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    auto xbasic_fixed_string<CT, N, EP, TR>::insert(size_type index, size_type count, value_type ch) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    auto xbasic_fixed_string<CT, N, ST, EP, TR>::insert(size_type index, size_type count, value_type ch) -> self_type&
     {
         check_index_strict(index, size(), "xbasic_fixed_string::insert");
-        size_type old_size = m_size;
-        m_size = error_policy::check_add(m_size, count);
+        size_type old_size = size();
+        m_storage.set_size(error_policy::check_add(size(), count));
         std::copy_backward(data() + index, data() + old_size, end());
         traits_type::assign(data() + index, count, ch);
-        update_null_termination();
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::insert(size_type index, const_pointer s) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::insert(size_type index, const_pointer s) -> self_type&
     {
         return insert(index, s, traits_type::length(s));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    auto xbasic_fixed_string<CT, N, EP, TR>::insert(size_type index, const_pointer s, size_type count) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    auto xbasic_fixed_string<CT, N, ST, EP, TR>::insert(size_type index, const_pointer s, size_type count) -> self_type&
     {
         check_index_strict(index, size(), "xbasic_fixed_string::insert");
-        size_type old_size = m_size;
-        m_size = error_policy::check_add(m_size, count);
+        size_type old_size = size();
+        m_storage.set_size(error_policy::check_add(size(), count));
         std::copy_backward(data() + index, data() + old_size, end());
         traits_type::copy(data() + index, s, count);
-        update_null_termination();
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::insert(size_type index, const self_type& str) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::insert(size_type index, const self_type& str) -> self_type&
     {
         return insert(index, str.data(), str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::insert(size_type index, const self_type& str,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::insert(size_type index, const self_type& str,
                                                            size_type index_str, size_type count) -> self_type&
     {
         check_index_strict(index_str, str.size(), "xbasic_fixed_string::insert");
         return insert(index, str.data() + index_str, std::min(count, str.size() - index_str));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::insert(size_type index, const string_type& str) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::insert(size_type index, const string_type& str) -> self_type&
     {
         return insert(index, str.c_str(), str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::insert(size_type index, const string_type& str,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::insert(size_type index, const string_type& str,
                                                            size_type index_str, size_type count) -> self_type&
     {
         check_index_strict(index_str, str.size(), "xbasic_fixed_string::insert");
         return insert(index, str.c_str() + index_str, std::min(count, str.size() - index_str));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::insert(const_iterator pos, value_type ch) -> iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::insert(const_iterator pos, value_type ch) -> iterator
     {
         return insert(pos, size_type(1), ch);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::insert(const_iterator pos, size_type count, value_type ch) -> iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::insert(const_iterator pos, size_type count, value_type ch) -> iterator
     {
         if (cbegin() <= pos && pos < cend())
         {
@@ -1091,25 +1205,24 @@ namespace xtl
         return end();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::insert(const_iterator pos, initializer_type ilist) -> iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::insert(const_iterator pos, initializer_type ilist) -> iterator
     {
         return insert(pos, ilist.begin(), ilist.end());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     template <class InputIt>
-    auto xbasic_fixed_string<CT, N, EP, TR>::insert(const_iterator pos, InputIt first, InputIt last) -> iterator
+    auto xbasic_fixed_string<CT, N, ST, EP, TR>::insert(const_iterator pos, InputIt first, InputIt last) -> iterator
     {
         if (cbegin() <= pos && pos < cend())
         {
             size_type index = static_cast<size_type>(pos - cbegin());
             size_type count = static_cast<size_type>(std::distance(first, last));
-            size_type old_size = m_size;
-            m_size = error_policy::check_add(m_size, count);
+            size_type old_size = size();
+            m_storage.set_size(error_policy::check_add(size(), count));
             std::copy_backward(data() + index, data() + old_size, end());
             std::copy(first, last, data() + index);
-            update_null_termination();
             return begin() + index;
         }
         return end();
@@ -1119,26 +1232,25 @@ namespace xtl
      * erase *
      *********/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    auto xbasic_fixed_string<CT, N, EP, TR>::erase(size_type index, size_type count) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    auto xbasic_fixed_string<CT, N, ST, EP, TR>::erase(size_type index, size_type count) -> self_type&
     {
         check_index_strict(index, size(), "xbasic_fixed_string::erase");
         size_type erase_count = std::min(count, size() - index);
         // cannot use traits_type::copy because of overlapping
-        std::copy(data() + index + erase_count, data() + m_size, data() + index);
-        m_size -= erase_count;
-        update_null_termination();
+        std::copy(data() + index + erase_count, data() + size(), data() + index);
+        m_storage.adjust_size(-static_cast<std::ptrdiff_t>(erase_count));
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::erase(const_iterator position) -> iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::erase(const_iterator position) -> iterator
     {
         return erase(position, position + 1);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    auto xbasic_fixed_string<CT, N, EP, TR>::erase(const_iterator first, const_iterator last) -> iterator
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    auto xbasic_fixed_string<CT, N, ST, EP, TR>::erase(const_iterator first, const_iterator last) -> iterator
     {
         if (cbegin() <= first && first < cend())
         {
@@ -1146,8 +1258,7 @@ namespace xtl
             size_type erase_count = static_cast<size_type>(adapted_last - first);
             // cannot use traits_type::copy because of overlapping
             std::copy(adapted_last, cend(), iterator(first));
-            m_size -= erase_count;
-            update_null_termination();
+            m_storage.adjust_size(-static_cast<std::ptrdiff_t>(erase_count));
             return const_cast<iterator>(first);
         }
         return end();
@@ -1157,104 +1268,101 @@ namespace xtl
      * append *
      **********/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::append(size_type count, value_type ch) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::append(size_type count, value_type ch) -> self_type&
     {
-        size_type old_size = m_size;
-        m_size = error_policy::check_add(size(), count);
+        size_type old_size = m_storage.size();
+        m_storage.set_size(error_policy::check_add(size(), count));
         traits_type::assign(data() + old_size, count, ch);
-        update_null_termination();
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::append(const self_type& str) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::append(const self_type& str) -> self_type&
     {
         return append(str.data(), str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::append(const self_type& str,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::append(const self_type& str,
                                                            size_type pos, size_type count) -> self_type&
     {
         check_index_strict(pos, str.size(), "xbasic_fixed_string::append");
         return append(str.data() + pos, std::min(count, str.size() - pos));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::append(const string_type& str) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::append(const string_type& str) -> self_type&
     {
         return append(str.c_str(), str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::append(const string_type& str,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::append(const string_type& str,
                                                            size_type pos, size_type count) -> self_type&
     {
         check_index_strict(pos, str.size(), "xbasic_fixed_string::append");
         return append(str.c_str() + pos, std::min(count, str.size() - pos));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::append(const_pointer s, size_type count) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::append(const_pointer s, size_type count) -> self_type&
     {
-        size_type old_size = m_size;
-        m_size = error_policy::check_add(size(), count);
+        size_type old_size = m_storage.size();
+        m_storage.set_size(error_policy::check_add(size(), count));
         traits_type::copy(data() + old_size, s, count);
-        update_null_termination();
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::append(const_pointer s) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::append(const_pointer s) -> self_type&
     {
         return append(s, traits_type::length(s));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::append(initializer_type ilist) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::append(initializer_type ilist) -> self_type&
     {
         return append(ilist.begin(), ilist.end());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     template <class InputIt>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::append(InputIt first, InputIt last) -> self_type&
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::append(InputIt first, InputIt last) -> self_type&
     {
         size_type count = static_cast<size_type>(std::distance(first, last));
-        size_type old_size = m_size;
-        m_size = error_policy::check_add(size(), count);
+        size_type old_size = m_storage.size();
+        m_storage.set_size(error_policy::check_add(size(), count));
         std::copy(first, last, data() + old_size);
-        update_null_termination();
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::operator+=(const self_type& str) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::operator+=(const self_type& str) -> self_type&
     {
         return append(str);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::operator+=(const string_type& str) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::operator+=(const string_type& str) -> self_type&
     {
         return append(str);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::operator+=(value_type ch) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::operator+=(value_type ch) -> self_type&
     {
         return append(size_type(1), ch);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::operator+=(const_pointer s) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::operator+=(const_pointer s) -> self_type&
     {
         return append(s);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::operator+=(initializer_type ilist) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::operator+=(initializer_type ilist) -> self_type&
     {
         return append(ilist);
     }
@@ -1263,21 +1371,21 @@ namespace xtl
      * compare *
      ***********/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline int xbasic_fixed_string<CT, N, EP, TR>::compare(const self_type& str) const noexcept
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline int xbasic_fixed_string<CT, N, ST, EP, TR>::compare(const self_type& str) const noexcept
     {
         return compare_impl(data(), size(), str.data(), str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline int xbasic_fixed_string<CT, N, EP, TR>::compare(size_type pos1, size_type count1, const self_type& str) const
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline int xbasic_fixed_string<CT, N, ST, EP, TR>::compare(size_type pos1, size_type count1, const self_type& str) const
     {
         check_index_strict(pos1, size(), "xbasic_fixed_string::compare");
         return compare_impl(data() + pos1, std::min(count1, size() - pos1), str.data(), str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline int xbasic_fixed_string<CT, N, EP, TR>::compare(size_type pos1, size_type count1, const self_type& str,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline int xbasic_fixed_string<CT, N, ST, EP, TR>::compare(size_type pos1, size_type count1, const self_type& str,
                                                            size_type pos2, size_type count2) const
     {
         check_index_strict(pos1, size(), "xbasic_fixed_string::compare");
@@ -1286,21 +1394,21 @@ namespace xtl
                             str.data() + pos2, std::min(count2, str.size() - pos2));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline int xbasic_fixed_string<CT, N, EP, TR>::compare(const string_type& str) const noexcept
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline int xbasic_fixed_string<CT, N, ST, EP, TR>::compare(const string_type& str) const noexcept
     {
         return compare_impl(data(), size(), str.data(), str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline int xbasic_fixed_string<CT, N, EP, TR>::compare(size_type pos1, size_type count1, const string_type& str) const
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline int xbasic_fixed_string<CT, N, ST, EP, TR>::compare(size_type pos1, size_type count1, const string_type& str) const
     {
         check_index_strict(pos1, size(), "xbasic_fixed_string::compare");
         return compare_impl(data() + pos1, std::min(count1, size() - pos1), str.data(), str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline int xbasic_fixed_string<CT, N, EP, TR>::compare(size_type pos1, size_type count1, const string_type& str,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline int xbasic_fixed_string<CT, N, ST, EP, TR>::compare(size_type pos1, size_type count1, const string_type& str,
                                                            size_type pos2, size_type count2) const
     {
         check_index_strict(pos1, size(), "xbasic_fixed_string::compare");
@@ -1309,20 +1417,20 @@ namespace xtl
                             str.data() + pos2, std::min(count2, str.size() - pos2));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline int xbasic_fixed_string<CT, N, EP, TR>::compare(const_pointer s) const noexcept
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline int xbasic_fixed_string<CT, N, ST, EP, TR>::compare(const_pointer s) const noexcept
     {
         return compare_impl(data(), size(), s, traits_type::length(s));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    int xbasic_fixed_string<CT, N, EP, TR>::compare(size_type pos1, size_type count1, const_pointer s) const
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    int xbasic_fixed_string<CT, N, ST, EP, TR>::compare(size_type pos1, size_type count1, const_pointer s) const
     {
         return compare(pos1, count1, s, traits_type::length(s));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    int xbasic_fixed_string<CT, N, EP, TR>::compare(size_type pos1, size_type count1, const_pointer s, size_type count2) const
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    int xbasic_fixed_string<CT, N, ST, EP, TR>::compare(size_type pos1, size_type count1, const_pointer s, size_type count2) const
     {
         check_index_strict(pos1, size(), "xbasic_fixed_string::compare");
         return compare_impl(data() + pos1, std::min(count1, size() - pos1),
@@ -1333,50 +1441,50 @@ namespace xtl
      * replace *
      ***********/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::replace(size_type pos, size_type count, const self_type& str) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(size_type pos, size_type count, const self_type& str) -> self_type&
     {
         return replace(pos, count, str.data(), str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::replace(const_iterator first, const_iterator last,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(const_iterator first, const_iterator last,
                                                             const self_type& str) -> self_type&
     {
         return replace(first, last, str.data(), str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::replace(size_type pos1, size_type count1, const self_type& str,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(size_type pos1, size_type count1, const self_type& str,
                                                             size_type pos2, size_type count2) -> self_type&
     {
         check_index_strict(pos2, str.size(), "xbasic_fixed_string::replace");
         return replace(pos1, count1, str.data() + pos2, std::min(count2, str.size() - pos2));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::replace(size_type pos, size_type count, const string_type& str) -> self_type&
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(size_type pos, size_type count, const string_type& str) -> self_type&
     {
         return replace(pos, count, str.data(), str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::replace(const_iterator first, const_iterator last,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(const_iterator first, const_iterator last,
                                                             const string_type& str) -> self_type&
     {
         return replace(first, last, str.data(), str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::replace(size_type pos1, size_type count1, const string_type& str,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(size_type pos1, size_type count1, const string_type& str,
                                                             size_type pos2, size_type count2) -> self_type&
     {
         check_index_strict(pos2, str.size(), "xbasic_fixed_string::replace");
         return replace(pos1, count1, str.data() + pos2, std::min(count2, str.size() - pos2));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    auto xbasic_fixed_string<CT, N, EP, TR>::replace(size_type pos, size_type count,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(size_type pos, size_type count,
                                                      const_pointer cstr, size_type count2) -> self_type&
     {
         check_index_strict(pos, size(), "xbasic_fixed_string::replace");
@@ -1386,15 +1494,13 @@ namespace xtl
         {
             traits_type::copy(data() + pos, cstr, count2);
             std::copy(cbegin() + pos + erase_count, cend(), data() + pos + count2);
-            m_size = new_size;
-            update_null_termination();
+            m_storage.set_size(new_size);
         }
         else if (erase_count < count2)
         {
             std::copy_backward(cbegin() + pos + erase_count, cend(), data() + new_size);
             traits_type::copy(data() + pos, cstr, count2);
-            m_size = new_size;
-            update_null_termination();
+            m_storage.set_size(new_size);
         }
         else
         {
@@ -1403,8 +1509,8 @@ namespace xtl
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::replace(const_iterator first, const_iterator last,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(const_iterator first, const_iterator last,
                                                             const_pointer cstr, size_type count2) -> self_type&
     {
         if (cbegin() <= first && first < last && last <= cend())
@@ -1416,22 +1522,22 @@ namespace xtl
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::replace(size_type pos, size_type count,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(size_type pos, size_type count,
                                                             const_pointer cstr) -> self_type&
     {
         return replace(pos, count, cstr, traits_type::length(cstr));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::replace(const_iterator first, const_iterator last,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(const_iterator first, const_iterator last,
                                                             const_pointer cstr) -> self_type&
     {
         return replace(first, last, cstr, traits_type::length(cstr));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::replace(size_type pos, size_type count,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(size_type pos, size_type count,
                                                             size_type count2, value_type ch) -> self_type&
     {
         check_index_strict(pos, size(), "xbasic_fixed_string::replace");
@@ -1441,15 +1547,13 @@ namespace xtl
         {
             traits_type::assign(data() + pos, count2, ch);
             std::copy(cbegin() + pos + erase_count, cend(), data() + pos + count2);
-            m_size = new_size;
-            update_null_termination();
+            m_storage.set_size(new_size);
         }
         else if (erase_count < count2)
         {
             std::copy_backward(cbegin() + pos + erase_count, cend(), data() + new_size);
             traits_type::assign(data() + pos, count2, ch);
-            m_size = new_size;
-            update_null_termination();
+            m_storage.set_size(new_size);
         }
         else
         {
@@ -1458,8 +1562,8 @@ namespace xtl
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::replace(const_iterator first, const_iterator last,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(const_iterator first, const_iterator last,
                                                             size_type count2, value_type ch) -> self_type&
     {
         if (cbegin() <= first && first < last && last <= cend())
@@ -1471,16 +1575,16 @@ namespace xtl
         return *this;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::replace(const_iterator first, const_iterator last,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(const_iterator first, const_iterator last,
                                                             initializer_type ilist) -> self_type&
     {
         return replace(first, last, ilist.begin(), ilist.end());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     template <class InputIt>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::replace(const_iterator first, const_iterator last,
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::replace(const_iterator first, const_iterator last,
                                                             InputIt first2, InputIt last2) -> self_type&
     {
         if (cbegin() <= first && first < last && last <= cend())
@@ -1493,15 +1597,13 @@ namespace xtl
             {
                 std::copy(first2, last2, data() + pos);
                 std::copy(cbegin() + pos + erase_count, cend(), data() + pos + count2);
-                m_size = new_size;
-                update_null_termination();
+                m_storage.set_size(new_size);
             }
             else if (erase_count < count2)
             {
                 std::copy_backward(cbegin() + pos + erase_count, cend(), data() + new_size);
                 std::copy(first2, last2, data() + pos);
-                m_size = new_size;
-                update_null_termination();
+                m_storage.set_size(new_size);
             }
             else
             {
@@ -1515,20 +1617,20 @@ namespace xtl
      * find *
      ********/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find(const self_type& str, size_type pos) const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find(const self_type& str, size_type pos) const noexcept -> size_type
     {
         return find(str.data(), pos, str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find(const string_type& str, size_type pos) const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find(const string_type& str, size_type pos) const noexcept -> size_type
     {
         return find(str.data(), pos, str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    auto xbasic_fixed_string<CT, N, EP, TR>::find(const_pointer s, size_type pos, size_type count) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    auto xbasic_fixed_string<CT, N, ST, EP, TR>::find(const_pointer s, size_type pos, size_type count) const -> size_type
     {
         if (count == size_type(0) && pos <= size())
         {
@@ -1541,25 +1643,25 @@ namespace xtl
             const_pointer uptr, vptr;
             for (nm -= count - 1, vptr = data() + pos;
                  (uptr = traits_type::find(vptr, nm, *s)) != 0;
-                 nm -= uptr - vptr + 1, vptr = uptr + 1)
+                 nm -= size_type(uptr - vptr) + 1ul, vptr = uptr + 1ul)
             {
                 if (traits_type::compare(uptr, s, count) == 0)
                 {
-                    return (uptr - data());
+                    return size_type(uptr - data());
                 }
             }
         }
         return npos;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find(const_pointer s, size_type pos) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find(const_pointer s, size_type pos) const -> size_type
     {
         return find(s, pos, traits_type::length(s));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find(value_type ch, size_type pos) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find(value_type ch, size_type pos) const -> size_type
     {
         return find((const_pointer)(&ch), pos, size_type(1));
     }
@@ -1568,20 +1670,20 @@ namespace xtl
      * rfind *
      *********/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::rfind(const self_type& str, size_type pos) const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::rfind(const self_type& str, size_type pos) const noexcept -> size_type
     {
         return rfind(str.data(), pos, str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::rfind(const string_type& str, size_type pos) const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::rfind(const string_type& str, size_type pos) const noexcept -> size_type
     {
         return rfind(str.data(), pos, str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    auto xbasic_fixed_string<CT, N, EP, TR>::rfind(const_pointer s, size_type pos, size_type count) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    auto xbasic_fixed_string<CT, N, ST, EP, TR>::rfind(const_pointer s, size_type pos, size_type count) const -> size_type
     {
         if (count == 0)
         {
@@ -1595,7 +1697,7 @@ namespace xtl
             {
                 if (traits_type::eq(*uptr, *s) && traits_type::compare(uptr, s, count) == 0)
                 {
-                    return uptr - data();
+                    return size_type(uptr - data());
                 }
                 else if (uptr == data())
                 {
@@ -1606,14 +1708,14 @@ namespace xtl
         return npos;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::rfind(const_pointer s, size_type pos) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::rfind(const_pointer s, size_type pos) const -> size_type
     {
         return rfind(s, pos, traits_type::length(s));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::rfind(value_type ch, size_type pos) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::rfind(value_type ch, size_type pos) const -> size_type
     {
         return rfind((const_pointer)(&ch), pos, size_type(1));
     }
@@ -1622,20 +1724,20 @@ namespace xtl
      * find_first_of *
      *****************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_first_of(const self_type& str, size_type pos) const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_first_of(const self_type& str, size_type pos) const noexcept -> size_type
     {
         return find_first_of(str.data(), pos, str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_first_of(const string_type& str, size_type pos) const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_first_of(const string_type& str, size_type pos) const noexcept -> size_type
     {
         return find_first_of(str.data(), pos, str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    auto xbasic_fixed_string<CT, N, EP, TR>::find_first_of(const_pointer s, size_type pos, size_type count) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_first_of(const_pointer s, size_type pos, size_type count) const -> size_type
     {
         if (size_type(0) < count && pos < size())
         {
@@ -1644,21 +1746,21 @@ namespace xtl
             {
                 if (traits_type::find(s, count, *uptr) != 0)
                 {
-                    return uptr - data();
+                    return size_type(uptr - data());
                 }
             }
         }
         return npos;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_first_of(const_pointer s, size_type pos) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_first_of(const_pointer s, size_type pos) const -> size_type
     {
         return find_first_of(s, pos, traits_type::length(s));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_first_of(value_type ch, size_type pos) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_first_of(value_type ch, size_type pos) const -> size_type
     {
         return find_first_of((const_pointer)(&ch), pos, size_type(1));
     }
@@ -1667,20 +1769,20 @@ namespace xtl
      * find_first_not_of *
      *********************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_first_not_of(const self_type& str, size_type pos) const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_first_not_of(const self_type& str, size_type pos) const noexcept -> size_type
     {
         return find_first_not_of(str.data(), pos, str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_first_not_of(const string_type& str, size_type pos) const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_first_not_of(const string_type& str, size_type pos) const noexcept -> size_type
     {
         return find_first_not_of(str.data(), pos, str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    auto xbasic_fixed_string<CT, N, EP, TR>::find_first_not_of(const_pointer s, size_type pos, size_type count) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_first_not_of(const_pointer s, size_type pos, size_type count) const -> size_type
     {
         if (pos < size())
         {
@@ -1689,21 +1791,21 @@ namespace xtl
             {
                 if (traits_type::find(s, count, *uptr) == 0)
                 {
-                    return uptr - data();
+                    return size_type(uptr - data());
                 }
             }
         }
         return npos;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_first_not_of(const_pointer s, size_type pos) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_first_not_of(const_pointer s, size_type pos) const -> size_type
     {
         return find_first_not_of(s, pos, traits_type::length(s));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_first_not_of(value_type ch, size_type pos) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_first_not_of(value_type ch, size_type pos) const -> size_type
     {
         return find_first_not_of((const_pointer)(&ch), pos, size_type(1));
     }
@@ -1712,20 +1814,20 @@ namespace xtl
      * find_last_of *
      ****************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_last_of(const self_type& str, size_type pos) const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_last_of(const self_type& str, size_type pos) const noexcept -> size_type
     {
         return find_last_of(str.data(), pos, str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_last_of(const string_type& str, size_type pos) const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_last_of(const string_type& str, size_type pos) const noexcept -> size_type
     {
         return find_last_of(str.data(), pos, str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    auto xbasic_fixed_string<CT, N, EP, TR>::find_last_of(const_pointer s, size_type pos, size_type count) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_last_of(const_pointer s, size_type pos, size_type count) const -> size_type
     {
         if (size_type(0) < count && size_type(0) < size())
         {
@@ -1734,7 +1836,7 @@ namespace xtl
             {
                 if (traits_type::find(s, count, *uptr) != 0)
                 {
-                    return uptr - data();
+                    return size_type(uptr - data());
                 }
                 else if (uptr == data())
                 {
@@ -1745,14 +1847,14 @@ namespace xtl
         return npos;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_last_of(const_pointer s, size_type pos) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_last_of(const_pointer s, size_type pos) const -> size_type
     {
         return find_last_of(s, pos, traits_type::length(s));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_last_of(value_type ch, size_type pos) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_last_of(value_type ch, size_type pos) const -> size_type
     {
         return find_last_of((const_pointer)(&ch), pos, size_type(1));
     }
@@ -1761,20 +1863,20 @@ namespace xtl
      * find_last_not_of *
      ********************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_last_not_of(const self_type& str, size_type pos) const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_last_not_of(const self_type& str, size_type pos) const noexcept -> size_type
     {
         return find_last_not_of(str.data(), pos, str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_last_not_of(const string_type& str, size_type pos) const noexcept -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_last_not_of(const string_type& str, size_type pos) const noexcept -> size_type
     {
         return find_last_not_of(str.data(), pos, str.size());
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    auto xbasic_fixed_string<CT, N, EP, TR>::find_last_not_of(const_pointer s, size_type pos, size_type count) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_last_not_of(const_pointer s, size_type pos, size_type count) const -> size_type
     {
         if (size_type(0) < size())
         {
@@ -1783,7 +1885,7 @@ namespace xtl
             {
                 if (traits_type::find(s, count, *uptr) == 0)
                 {
-                    return uptr - data();
+                    return size_type(uptr - data());
                 }
                 else if (uptr == data())
                 {
@@ -1794,14 +1896,14 @@ namespace xtl
         return npos;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_last_not_of(const_pointer s, size_type pos) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_last_not_of(const_pointer s, size_type pos) const -> size_type
     {
         return find_last_not_of(s, pos, traits_type::length(s));
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline auto xbasic_fixed_string<CT, N, EP, TR>::find_last_not_of(value_type ch, size_type pos) const -> size_type
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline auto xbasic_fixed_string<CT, N, ST, EP, TR>::find_last_not_of(value_type ch, size_type pos) const -> size_type
     {
         return find_last_not_of((const_pointer)(&ch), pos, size_type(1));
     }
@@ -1810,8 +1912,8 @@ namespace xtl
      * Private methods *
      *******************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    int xbasic_fixed_string<CT, N, EP, TR>::compare_impl(const_pointer s1, size_type count1,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    int xbasic_fixed_string<CT, N, ST, EP, TR>::compare_impl(const_pointer s1, size_type count1,
                                                          const_pointer s2, size_type count2) const noexcept
     {
         size_type rlen = std::min(count1, count2);
@@ -1826,23 +1928,28 @@ namespace xtl
         }
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline void xbasic_fixed_string<CT, N, EP, TR>::update_null_termination() noexcept
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline void xbasic_fixed_string<CT, N, ST, EP, TR>::update_null_termination() noexcept
     {
         data()[size()] = '\0';
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    void xbasic_fixed_string<CT, N, EP, TR>::check_index(size_type pos, size_type size, const char* what) const
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    void xbasic_fixed_string<CT, N, ST, EP, TR>::check_index(size_type pos, size_type size, const char* what) const
     {
         if (pos >= size)
         {
+#if defined(XTL_NO_EXCEPTIONS)
+            std::fprintf(stderr, "%s\n", what);
+            std::terminate();
+#else
             throw std::out_of_range(what);
+#endif
         }
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    void xbasic_fixed_string<CT, N, EP, TR>::check_index_strict(size_type pos, size_type size, const char* what) const
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    void xbasic_fixed_string<CT, N, ST, EP, TR>::check_index_strict(size_type pos, size_type size, const char* what) const
     {
         check_index(pos, size + 1, what);
     }
@@ -1851,113 +1958,113 @@ namespace xtl
      * Concatenation operator *
      **************************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>& rhs)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+              const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs)
     {
-        xbasic_fixed_string<CT, N, EP, TR> res(lhs);
+        xbasic_fixed_string<CT, N, ST, EP, TR> res(lhs);
         return res += rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
               const CT* rhs)
     {
-        xbasic_fixed_string<CT, N, EP, TR> res(lhs);
+        xbasic_fixed_string<CT, N, ST, EP, TR> res(lhs);
         return res += rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
               CT rhs)
     {
-        xbasic_fixed_string<CT, N, EP, TR> res(lhs);
+        xbasic_fixed_string<CT, N, ST, EP, TR> res(lhs);
         return res += rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>
     operator+(const CT* lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>& rhs)
+              const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs)
     {
-        xbasic_fixed_string<CT, N, EP, TR> res(lhs);
+        xbasic_fixed_string<CT, N, ST, EP, TR> res(lhs);
         return res += rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>
     operator+(CT lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>& rhs)
+              const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs)
     {
-        using size_type = typename xbasic_fixed_string<CT, N, EP, TR>::size_type;
-        xbasic_fixed_string<CT, N, EP, TR> res(size_type(1), lhs);
+        using size_type = typename xbasic_fixed_string<CT, N, ST, EP, TR>::size_type;
+        xbasic_fixed_string<CT, N, ST, EP, TR> res(size_type(1), lhs);
         return res += rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>&& lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>& rhs)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>&& lhs,
+              const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs)
     {
-        xbasic_fixed_string<CT, N, EP, TR> res(std::move(lhs));
+        xbasic_fixed_string<CT, N, ST, EP, TR> res(std::move(lhs));
         return res += rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>&& rhs)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+              const xbasic_fixed_string<CT, N, ST, EP, TR>&& rhs)
     {
-        xbasic_fixed_string<CT, N, EP, TR> res(lhs);
+        xbasic_fixed_string<CT, N, ST, EP, TR> res(lhs);
         return res += std::move(rhs);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>&& lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>&& rhs)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>&& lhs,
+              const xbasic_fixed_string<CT, N, ST, EP, TR>&& rhs)
     {
-        xbasic_fixed_string<CT, N, EP, TR> res(std::move(lhs));
+        xbasic_fixed_string<CT, N, ST, EP, TR> res(std::move(lhs));
         return res += std::move(rhs);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>&& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>&& lhs,
               const CT* rhs)
     {
-        xbasic_fixed_string<CT, N, EP, TR> res(std::move(lhs));
+        xbasic_fixed_string<CT, N, ST, EP, TR> res(std::move(lhs));
         return res += rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>
-    operator+(const xbasic_fixed_string<CT, N, EP, TR>&& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>
+    operator+(const xbasic_fixed_string<CT, N, ST, EP, TR>&& lhs,
               CT rhs)
     {
-        xbasic_fixed_string<CT, N, EP, TR> res(std::move(lhs));
+        xbasic_fixed_string<CT, N, ST, EP, TR> res(std::move(lhs));
         return res += rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>
     operator+(const CT* lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>&& rhs)
+              const xbasic_fixed_string<CT, N, ST, EP, TR>&& rhs)
     {
-        xbasic_fixed_string<CT, N, EP, TR> res(lhs);
+        xbasic_fixed_string<CT, N, ST, EP, TR> res(lhs);
         return res += std::move(rhs);
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline xbasic_fixed_string<CT, N, EP, TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline xbasic_fixed_string<CT, N, ST, EP, TR>
     operator+(CT lhs,
-              const xbasic_fixed_string<CT, N, EP, TR>&& rhs)
+              const xbasic_fixed_string<CT, N, ST, EP, TR>&& rhs)
     {
-        using size_type = typename xbasic_fixed_string<CT, N, EP, TR>::size_type;
-        xbasic_fixed_string<CT, N, EP, TR> res(size_type(1), lhs);
+        using size_type = typename xbasic_fixed_string<CT, N, ST, EP, TR>::size_type;
+        xbasic_fixed_string<CT, N, ST, EP, TR> res(size_type(1), lhs);
         return res += std::move(rhs);
     }
 
@@ -1965,218 +2072,218 @@ namespace xtl
     * Comparison operators *
     ************************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator==(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-                           const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator==(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+                           const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return lhs.compare(rhs) == 0;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator==(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator==(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                            const CT* rhs) noexcept
     {
         return lhs.compare(rhs) == 0;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline bool operator==(const CT* lhs,
-                           const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+                           const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return rhs == lhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator==(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator==(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                            const std::basic_string<CT, TR>& rhs) noexcept
     {
         return lhs == rhs.c_str();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline bool operator==(const std::basic_string<CT, TR>& lhs,
-                           const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+                           const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return lhs.c_str() == rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator!=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-                           const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator!=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+                           const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return lhs.compare(rhs) != 0;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator!=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator!=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                            const CT* rhs) noexcept
     {
         return lhs.compare(rhs) != 0;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline bool operator!=(const CT* lhs,
-                           const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+                           const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return rhs != lhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator!=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator!=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                            const std::basic_string<CT, TR>& rhs) noexcept
     {
         return lhs != rhs.c_str();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline bool operator!=(const std::basic_string<CT, TR>& lhs,
-                           const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+                           const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return lhs.c_str() != rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator<(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-                          const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator<(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+                          const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return lhs.compare(rhs) < 0;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator<(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator<(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                           const CT* rhs) noexcept
     {
         return lhs.compare(rhs) < 0;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline bool operator<(const CT* lhs,
-                          const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+                          const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return rhs > lhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator<(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator<(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                           const std::basic_string<CT, TR>& rhs) noexcept
     {
         return lhs < rhs.c_str();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline bool operator<(const std::basic_string<CT, TR>& lhs,
-                          const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+                          const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return lhs.c_str() < rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator<=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-                           const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator<=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+                           const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return lhs.compare(rhs) <= 0;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator<=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator<=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                            const CT* rhs) noexcept
     {
         return lhs.compare(rhs) <= 0;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline bool operator<=(const CT* lhs,
-                           const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+                           const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return rhs >= lhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator<=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator<=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                            const std::basic_string<CT, TR>& rhs) noexcept
     {
         return lhs <= rhs.c_str();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline bool operator<=(const std::basic_string<CT, TR>& lhs,
-                           const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+                           const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return lhs.c_str() <= rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator>(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-                          const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator>(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+                          const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return lhs.compare(rhs) > 0;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator>(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator>(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                           const CT* rhs) noexcept
     {
         return lhs.compare(rhs) > 0;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline bool operator>(const CT* lhs,
-                          const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+                          const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return rhs < lhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator>(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator>(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                           const std::basic_string<CT, TR>& rhs) noexcept
     {
         return lhs > rhs.c_str();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline bool operator>(const std::basic_string<CT, TR>& lhs,
-                          const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+                          const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return lhs.c_str() > rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator>=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
-                           const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator>=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
+                           const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return lhs.compare(rhs) >= 0;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator>=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator>=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                            const CT* rhs) noexcept
     {
         return lhs.compare(rhs) >= 0;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline bool operator>=(const CT* lhs,
-                           const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+                           const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return rhs <= lhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline bool operator>=(const xbasic_fixed_string<CT, N, EP, TR>& lhs,
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline bool operator>=(const xbasic_fixed_string<CT, N, ST, EP, TR>& lhs,
                            const std::basic_string<CT, TR>& rhs) noexcept
     {
         return lhs >= rhs.c_str();
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline bool operator>=(const std::basic_string<CT, TR>& lhs,
-                           const xbasic_fixed_string<CT, N, EP, TR>& rhs) noexcept
+                           const xbasic_fixed_string<CT, N, ST, EP, TR>& rhs) noexcept
     {
         return lhs.c_str() >= rhs;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
-    inline void swap(xbasic_fixed_string<CT, N, EP, TR>& lhs, xbasic_fixed_string<CT, N, EP, TR>& rhs)
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    inline void swap(xbasic_fixed_string<CT, N, ST, EP, TR>& lhs, xbasic_fixed_string<CT, N, ST, EP, TR>& rhs)
     {
         lhs.swap(rhs);
     }
@@ -2185,17 +2292,27 @@ namespace xtl
      * Input / output *
      ******************/
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline std::basic_ostream<CT, TR>& operator<<(std::basic_ostream<CT, TR>& os,
-                                                  const xbasic_fixed_string<CT, N, EP, TR>& str)
+                                                  const xbasic_fixed_string<CT, N, ST, EP, TR>& str)
     {
         os << str.c_str();
         return os;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+#ifdef __CLING__
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    nlohmann::json mime_bundle_repr(const xbasic_fixed_string<CT, N, ST, EP, TR>& str)
+    {
+        auto bundle = nlohmann::json::object();
+        bundle["text/plain"] = str.c_str();
+        return bundle;
+    }
+#endif
+
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline std::basic_istream<CT, TR>& operator>>(std::basic_istream<CT, TR>& is,
-                                                  xbasic_fixed_string<CT, N, EP, TR>& str)
+                                                  xbasic_fixed_string<CT, N, ST, EP, TR>& str)
     {
         // Not optimal
         std::string tmp;
@@ -2204,9 +2321,9 @@ namespace xtl
         return is;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline std::basic_istream<CT, TR>& getline(std::basic_istream<CT, TR>& input,
-                                               xbasic_fixed_string<CT, N, EP, TR>& str,
+                                               xbasic_fixed_string<CT, N, ST, EP, TR>& str,
                                                CT delim)
     {
         std::string tmp;
@@ -2215,9 +2332,9 @@ namespace xtl
         return ret;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline std::basic_istream<CT, TR>& getline(std::basic_istream<CT, TR>&& input,
-                                               xbasic_fixed_string<CT, N, EP, TR>& str,
+                                               xbasic_fixed_string<CT, N, ST, EP, TR>& str,
                                                CT delim)
     {
         std::string tmp;
@@ -2226,9 +2343,9 @@ namespace xtl
         return ret;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline std::basic_istream<CT, TR>& getline(std::basic_istream<CT, TR>& input,
-                                               xbasic_fixed_string<CT, N, EP, TR>& str)
+                                               xbasic_fixed_string<CT, N, ST, EP, TR>& str)
     {
         std::string tmp;
         auto& ret = std::getline(input, tmp);
@@ -2236,9 +2353,9 @@ namespace xtl
         return ret;
     }
 
-    template <class CT, std::size_t N, template <std::size_t> class EP, class TR>
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
     inline std::basic_istream<CT, TR>& getline(std::basic_istream<CT, TR>&& input,
-                                               xbasic_fixed_string<CT, N, EP, TR>& str)
+                                               xbasic_fixed_string<CT, N, ST, EP, TR>& str)
     {
         std::string tmp;
         auto& ret = std::getline(std::move(input), tmp);

--- a/vendor/xtl/include/xtl/xcomplex.hpp
+++ b/vendor/xtl/include/xtl/xcomplex.hpp
@@ -9,11 +9,22 @@
 #ifndef XTL_COMPLEX_HPP
 #define XTL_COMPLEX_HPP
 
+#if !defined(_MSC_VER)
+#include <cmath>
+using std::copysign;
+#endif
+
 #include <complex>
 #include <cstddef>
 #include <limits>
 #include <type_traits>
 #include <utility>
+#include <sstream>
+#include <string>
+
+#ifdef __CLING__
+#include <nlohmann/json.hpp>
+#endif
 
 #include "xclosure.hpp"
 #include "xtl_config.hpp"
@@ -150,8 +161,8 @@ namespace xtl
             : m_real(), m_imag()
         {
         }
-        
-        template <class OCTR, 
+
+        template <class OCTR,
             std::enable_if_t<
                 conjunction<
                     negation<is_gen_complex<OCTR>>,
@@ -184,7 +195,7 @@ namespace xtl
             : m_real(std::forward<OCTR>(re)), m_imag(std::forward<OCTI>(im))
         {
         }
-        
+
         template <class OCTR, class OCTI, bool OB>
         explicit constexpr xcomplex(const xcomplex<OCTR, OCTI, OB>& rhs) noexcept
             : m_real(rhs.real()), m_imag(rhs.imag())
@@ -280,7 +291,7 @@ namespace xtl
     template <class CTR1, class CTI1, bool B1, class CTR2, class CTI2, bool B2>
     common_xcomplex_t<CTR1, CTI1, B1, CTR2, CTI2, B2>
     operator+(const xcomplex<CTR1, CTI1, B1>& lhs, const xcomplex<CTR2, CTI2, B2>& rhs) noexcept;
-    
+
     template <class CTR, class CTI, bool B, class T>
     enable_scalar<T, temporary_xcomplex_t<CTR, CTI, B>>
     operator+(const xcomplex<CTR, CTI, B>& lhs, const T& rhs) noexcept;
@@ -536,7 +547,7 @@ namespace xtl
                 return return_type((c*a + d*b) / e, (c*b - d*a) / e);
             }
         };
-        
+
         template <>
         struct xcomplex_multiplier<true>
         {
@@ -560,29 +571,29 @@ namespace xtl
                     bool recalc = false;
                     if (std::isinf(a) || std::isinf(b))
                     {
-                        a = std::copysign(std::isinf(a) ? value_type(1) : value_type(0), a);
-                        b = std::copysign(std::isinf(b) ? value_type(1) : value_type(0), b);
+                        a = copysign(std::isinf(a) ? value_type(1) : value_type(0), a);
+                        b = copysign(std::isinf(b) ? value_type(1) : value_type(0), b);
                         if (std::isnan(c))
                         {
-                            c = std::copysign(value_type(0), c);
+                            c = copysign(value_type(0), c);
                         }
                         if (std::isnan(d))
                         {
-                            d = std::copysign(value_type(0), d);
+                            d = copysign(value_type(0), d);
                         }
                         recalc = true;
                     }
                     if (std::isinf(c) || std::isinf(d))
                     {
-                        c = std::copysign(std::isinf(c) ? value_type(1) : value_type(0), c);
-                        d = std::copysign(std::isinf(c) ? value_type(1) : value_type(0), d);
+                        c = copysign(std::isinf(c) ? value_type(1) : value_type(0), c);
+                        d = copysign(std::isinf(c) ? value_type(1) : value_type(0), d);
                         if (std::isnan(a))
                         {
-                            a = std::copysign(value_type(0), a);
+                            a = copysign(value_type(0), a);
                         }
                         if (std::isnan(b))
                         {
-                            b = std::copysign(value_type(0), b);
+                            b = copysign(value_type(0), b);
                         }
                         recalc = true;
                     }
@@ -590,19 +601,19 @@ namespace xtl
                     {
                         if (std::isnan(a))
                         {
-                            a = std::copysign(value_type(0), a);
+                            a = copysign(value_type(0), a);
                         }
                         if (std::isnan(b))
                         {
-                            b = std::copysign(value_type(0), b);
+                            b = copysign(value_type(0), b);
                         }
                         if (std::isnan(c))
                         {
-                            c = std::copysign(value_type(0), c);
+                            c = copysign(value_type(0), c);
                         }
                         if (std::isnan(d))
                         {
-                            d = std::copysign(value_type(0), d);
+                            d = copysign(value_type(0), d);
                         }
                         recalc = true;
                     }
@@ -639,20 +650,20 @@ namespace xtl
                 {
                     if ((denom == value_type(0)) && (!std::isnan(a) || !std::isnan(b)))
                     {
-                        x = std::copysign(std::numeric_limits<value_type>::infinity(), c) * a;
-                        y = std::copysign(std::numeric_limits<value_type>::infinity(), c) * b;
+                        x = copysign(std::numeric_limits<value_type>::infinity(), c) * a;
+                        y = copysign(std::numeric_limits<value_type>::infinity(), c) * b;
                     }
                     else if ((std::isinf(a) || std::isinf(b)) && std::isfinite(c) && std::isfinite(d))
                     {
-                        a = std::copysign(std::isinf(a) ? value_type(1) : value_type(0), a);
-                        b = std::copysign(std::isinf(b) ? value_type(1) : value_type(0), b);
+                        a = copysign(std::isinf(a) ? value_type(1) : value_type(0), a);
+                        b = copysign(std::isinf(b) ? value_type(1) : value_type(0), b);
                         x = std::numeric_limits<value_type>::infinity() * (a*c + b*d);
                         y = std::numeric_limits<value_type>::infinity() * (b*c - a*d);
                     }
                     else if (std::isinf(logbw) && logbw > value_type(0) && std::isfinite(a) && std::isfinite(b))
                     {
-                        c = std::copysign(std::isinf(c) ? value_type(1) : value_type(0), c);
-                        d = std::copysign(std::isinf(d) ? value_type(1) : value_type(0), d);
+                        c = copysign(std::isinf(c) ? value_type(1) : value_type(0), c);
+                        d = copysign(std::isinf(d) ? value_type(1) : value_type(0), d);
                         x = value_type(0) * (a*c + b*d);
                         y = value_type(0) * (b*c - a*d);
                     }
@@ -741,7 +752,7 @@ namespace xtl
     {
         return m_imag;
     }
-    
+
     template <class CTR, class CTI, bool B>
     auto xcomplex<CTR, CTI, B>::imag() && noexcept -> imag_rvalue_reference
     {
@@ -753,7 +764,7 @@ namespace xtl
     {
         return m_imag;
     }
-    
+
     template <class CTR, class CTI, bool B>
     constexpr auto xcomplex<CTR, CTI, B>::imag() const && noexcept -> imag_rvalue_const_reference
     {
@@ -800,6 +811,18 @@ namespace xtl
         out << "(" << c.real() << "," << c.imag() << ")";
         return out;
     }
+
+#ifdef __CLING__
+    template <class CTR, class CTI, bool B>
+    nlohmann::json mime_bundle_repr(const xcomplex<CTR, CTI, B>& c)
+    {
+        auto bundle = nlohmann::json::object();
+        std::stringstream tmp;
+        tmp << c;
+        bundle["text/plain"] = tmp.str();
+        return bundle;
+    }
+#endif
 
     template <class CTR, class CTI, bool B>
     inline temporary_xcomplex_t<CTR, CTI, B>
@@ -1146,7 +1169,7 @@ namespace xtl
         template <class T, class M>
         struct forward_type
         {
-            using type = apply_cv_t<T, M>&&;
+            using type = apply_cv_t<T, M>;
         };
 
         template <class T, class M>

--- a/vendor/xtl/include/xtl/xcomplex_sequence.hpp
+++ b/vendor/xtl/include/xtl/xcomplex_sequence.hpp
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <vector>
+#include <algorithm>
 
 #include "xclosure.hpp"
 #include "xcomplex.hpp"

--- a/vendor/xtl/include/xtl/xfunctional.hpp
+++ b/vendor/xtl/include/xtl/xfunctional.hpp
@@ -12,9 +12,14 @@
 #include <utility>
 
 #include "xtl_config.hpp"
+#include "xtype_traits.hpp"
 
 namespace xtl
 {
+    /***************************
+     * identity implementation *
+     ***************************/
+
     struct identity
     {
         template <class T>
@@ -23,6 +28,16 @@ namespace xtl
             return std::forward<T>(x);
         }
     };
-}
-#endif
 
+    /*************************
+     * select implementation *
+     *************************/
+
+    template <class B, class T1, class T2, XTL_REQUIRES(all_scalar<B, T1, T2>)>
+    inline std::common_type_t<T1, T2> select(const B& cond, const T1& v1, const T2& v2) noexcept
+    {
+        return cond ? v1 : v2;
+    }
+}
+
+#endif

--- a/vendor/xtl/include/xtl/xhash.hpp
+++ b/vendor/xtl/include/xtl/xhash.hpp
@@ -34,7 +34,7 @@ namespace xtl
             const char* data = static_cast<const char*>(buffer);
             for (; length != 0; --length)
             {
-                hash = (hash * 131) + *data++;
+                hash = (hash * 131) + static_cast<std::size_t>(*data++);
             }
             return hash;
         }
@@ -65,11 +65,11 @@ namespace xtl
             switch (length)
             {
             case 3:
-                hash ^= data[2] << 16;
+                hash ^= static_cast<std::size_t>(data[2] << 16);
             case 2:
-                hash ^= data[1] << 8;
+                hash ^= static_cast<std::size_t>(data[1] << 8);
             case 1:
-                hash ^= data[0];
+                hash ^= static_cast<std::size_t>(data[0]);
                 hash *= m;
             }
 
@@ -102,7 +102,7 @@ namespace xtl
                 static_cast<std::size_t>(0x5bd1e995UL);
             constexpr int r = 47;
             const char* data = static_cast<const char*>(buffer);
-            const char* end = data + (length & ~0x7);
+            const char* end = data + (length & std::size_t(~0x7));
             std::size_t hash = seed ^ (length * m);
             while (data != end)
             {

--- a/vendor/xtl/include/xtl/xiterator_base.hpp
+++ b/vendor/xtl/include/xtl/xiterator_base.hpp
@@ -49,22 +49,7 @@ namespace xtl
         {
             return !(lhs == rhs);
         }
-
-        inline friend bool operator<=(const derived_type& lhs, const derived_type& rhs)
-        {
-            return !(rhs < lhs);
-        }
-
-        inline friend bool operator>=(const derived_type& lhs, const derived_type& rhs)
-        {
-            return !(lhs < rhs);
-        }
-
-        inline friend bool operator>(const derived_type& lhs, const derived_type& rhs)
-        {
-            return rhs < lhs;
-        }
-    };
+   };
 
     template <class T>
     using xbidirectional_iterator_base2 = xbidirectional_iterator_base<typename T::iterator_type,
@@ -111,6 +96,22 @@ namespace xtl
             derived_type tmp(it);
             return tmp -= n;
         }
+
+        inline friend bool operator<=(const derived_type& lhs, const derived_type& rhs)
+        {
+            return !(rhs < lhs);
+        }
+
+        inline friend bool operator>=(const derived_type& lhs, const derived_type& rhs)
+        {
+            return !(lhs < rhs);
+        }
+
+        inline friend bool operator>(const derived_type& lhs, const derived_type& rhs)
+        {
+            return rhs < lhs;
+        }
+ 
     };
 
     template <class T>
@@ -119,6 +120,45 @@ namespace xtl
                                                                        typename T::difference_type,
                                                                        typename T::pointer,
                                                                        typename T::reference>;
+
+    /*******************************
+     * xrandom_access_iterator_ext *
+     *******************************/
+
+    // Extension for random access iterators defining operator[] and operator+ overloads
+    // accepting size_t arguments.
+    template <class I, class R>
+    class xrandom_access_iterator_ext
+    {
+    public:
+
+        using derived_type = I;
+        using reference = R;
+        using size_type = std::size_t;
+
+        inline reference operator[](size_type n) const
+        {
+            return *(*static_cast<const derived_type*>(this) + n);
+        }
+
+        inline friend derived_type operator+(const derived_type& it, size_type n)
+        {
+            derived_type tmp(it);
+            return tmp += n;
+        }
+
+        inline friend derived_type operator+(size_type n, const derived_type& it)
+        {
+            derived_type tmp(it);
+            return tmp += n;
+        }
+
+        inline friend derived_type operator-(const derived_type& it, size_type n)
+        {
+            derived_type tmp(it);
+            return tmp -= n;
+        }
+    };
 
     /*****************
      * xkey_iterator *
@@ -168,11 +208,6 @@ namespace xtl
         inline bool operator==(const self_type& rhs) const
         {
             return m_it == rhs.m_it;
-        }
-
-        inline bool operator<(const self_type& rhs) const
-        {
-            return m_it < rhs.m_it;
         }
 
     private:

--- a/vendor/xtl/include/xtl/xjson.hpp
+++ b/vendor/xtl/include/xtl/xjson.hpp
@@ -1,8 +1,15 @@
 #ifndef XTL_JSON_HPP
 #define XTL_JSON_HPP
 
+// WARNING:
+// All the code in this file and in the
+// files it includes must be C++11 compliant,
+// otherwise it breaks xeus-cling C++11 kernel
+
+#include <cstddef>
+#include <string>
+
 #include "nlohmann/json.hpp"
-#include "xoptional.hpp"
 
 namespace xtl
 {
@@ -10,8 +17,16 @@ namespace xtl
      * to_json and from_json specialization for xtl::xoptional *
      ***********************************************************/
 
-    template <class D>
-    void to_json(nlohmann::json& j, const xoptional<D>& o)
+    // xoptional forward declaration.
+    template <class D, class B>
+    class xoptional;
+
+    template <class T>
+    xoptional<T, bool> missing() noexcept;
+
+    // to_json and from_json ADL overload
+    template <class D, class B>
+    void to_json(nlohmann::json& j, const xoptional<D, B>& o)
     {
         if (!o.has_value())
         {
@@ -23,8 +38,8 @@ namespace xtl
         }
     }
 
-    template <class D>
-    void from_json(const nlohmann::json& j, xoptional<D>& o)
+    template <class D, class B>
+    void from_json(const nlohmann::json& j, xoptional<D, B>& o)
     {
         if (j.is_null())
         {
@@ -34,6 +49,27 @@ namespace xtl
         {
             o = j.get<D>();
         }
+    }
+
+    /********************************************************************
+     * to_json and from_json specialization for xtl::basic_fixed_string *
+     ********************************************************************/
+
+    // xbasic_fixed_string forward declaration.
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    class xbasic_fixed_string;
+
+    // to_json and from_json ADL overload
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    void to_json(::nlohmann::json& j, const xbasic_fixed_string<CT, N, ST, EP, TR>& str)
+    {
+        j = str.c_str();
+    }
+
+    template <class CT, std::size_t N, int ST, template <std::size_t> class EP, class TR>
+    void from_json(const ::nlohmann::json& j, xbasic_fixed_string<CT, N, ST, EP, TR>& str)
+    {
+        str = j.get<std::string>();
     }
 }
 

--- a/vendor/xtl/include/xtl/xmasked_value.hpp
+++ b/vendor/xtl/include/xtl/xmasked_value.hpp
@@ -1,0 +1,545 @@
+/***************************************************************************
+* Copyright (c) 2017, Johan Mabille, Sylvain Corlay, Wolf Vollprecht and   *
+* Martin Renou                                                             *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTL_XMASKED_VALUE_HPP
+#define XTL_XMASKED_VALUE_HPP
+
+#include "xmasked_value_meta.hpp"
+#include "xtype_traits.hpp"
+
+namespace xtl
+{
+    template <class T>
+    inline xmasked_value<T, bool> masked() noexcept
+    {
+        return xmasked_value<T, bool>(T(0), false);
+    }
+
+    /****************************
+    * xmasked_value declaration *
+    *****************************/
+
+    template <class T, class B>
+    class xmasked_value
+    {
+    public:
+
+        using self_type = xmasked_value<T, B>;
+
+        using value_type = T;
+        using flag_type = B;
+
+        template <class T1, class B1>
+        constexpr xmasked_value(T1&& value, B1&& flag);
+
+        template <class T1>
+        constexpr xmasked_value(T1&& value);
+
+        explicit constexpr xmasked_value();
+
+        inline operator value_type() {
+            return m_value;
+        }
+
+        std::add_lvalue_reference_t<T> value() & noexcept;
+        std::add_lvalue_reference_t<std::add_const_t<T>> value() const & noexcept;
+        std::conditional_t<std::is_reference<T>::value, apply_cv_t<T, std::decay_t<T>>&, std::decay_t<T>> value() && noexcept;
+        std::conditional_t<std::is_reference<T>::value, const std::decay_t<T>&, std::decay_t<T>> value() const && noexcept;
+
+        std::add_lvalue_reference_t<B> visible() & noexcept;
+        std::add_lvalue_reference_t<std::add_const_t<B>> visible() const & noexcept;
+        std::conditional_t<std::is_reference<B>::value, apply_cv_t<B, std::decay_t<B>>&, std::decay_t<B>> visible() && noexcept;
+        std::conditional_t<std::is_reference<B>::value, const std::decay_t<B>&, std::decay_t<B>> visible() const && noexcept;
+
+        template <class T1, class B1>
+        bool equal(const xmasked_value<T1, B1>& rhs) const noexcept;
+
+        template <class T1, XTL_DISALLOW(is_xmasked_value<T1>)>
+        bool equal(const T1& rhs) const noexcept;
+
+        template <class T1, class B1>
+        void swap(xmasked_value<T1, B1>& other);
+
+#define DEFINE_ASSIGN_OPERATOR(OP)                                                            \
+        template <class T1>                                                                   \
+        inline xmasked_value& operator OP(const T1& rhs)                                      \
+        {                                                                                     \
+            if (m_visible)                                                                    \
+            {                                                                                 \
+                m_value OP rhs;                                                               \
+            }                                                                                 \
+            return *this;                                                                     \
+        }                                                                                     \
+                                                                                              \
+        template <class T1, class B1>                                                         \
+        inline xmasked_value& operator OP(const xmasked_value<T1, B1>& rhs)                   \
+        {                                                                                     \
+            m_visible = m_visible && rhs.visible();                                           \
+            if (m_visible)                                                                    \
+            {                                                                                 \
+                m_value OP rhs.value();                                                       \
+            }                                                                                 \
+            return *this;                                                                     \
+        }
+
+        DEFINE_ASSIGN_OPERATOR(=);
+        DEFINE_ASSIGN_OPERATOR(+=);
+        DEFINE_ASSIGN_OPERATOR(-=);
+        DEFINE_ASSIGN_OPERATOR(*=);
+        DEFINE_ASSIGN_OPERATOR(/=);
+        DEFINE_ASSIGN_OPERATOR(%=);
+        DEFINE_ASSIGN_OPERATOR(&=);
+        DEFINE_ASSIGN_OPERATOR(|=);
+        DEFINE_ASSIGN_OPERATOR(^=);
+#undef DEFINE_ASSIGN_OPERATOR
+
+    private:
+
+        value_type m_value;
+        flag_type m_visible;
+    };
+
+    /********************************
+     * xmasked_value implementation *
+     ********************************/
+
+    template <class T, class B>
+    template <class T1, class B1>
+    inline constexpr xmasked_value<T, B>::xmasked_value(T1&& value, B1&& flag)
+        : m_value(std::forward<T1>(value)), m_visible(std::forward<B1>(flag))
+    {
+    }
+
+    template <class T, class B>
+    template <class T1>
+    inline constexpr xmasked_value<T, B>::xmasked_value(T1&& value)
+        : m_value(std::forward<T1>(value)), m_visible(true)
+    {
+    }
+
+    template <class T, class B>
+    inline constexpr xmasked_value<T, B>::xmasked_value()
+        : m_value(0), m_visible(true)
+    {
+    }
+
+    template <class T>
+    inline auto masked_value(T&& val)
+    {
+        return xmasked_value<T>(std::forward<T>(val));
+    }
+
+    template <class T, class B>
+    inline auto masked_value(T&& val, B&& mask)
+    {
+        return xmasked_value<T, B>(std::forward<T>(val), std::forward<B>(mask));
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::value() & noexcept -> std::add_lvalue_reference_t<T>
+    {
+        return m_value;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::value() const & noexcept -> std::add_lvalue_reference_t<std::add_const_t<T>>
+    {
+        return m_value;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::value() && noexcept -> std::conditional_t<std::is_reference<T>::value, apply_cv_t<T, std::decay_t<T>>&, std::decay_t<T>>
+    {
+        return m_value;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::value() const && noexcept -> std::conditional_t<std::is_reference<T>::value, const std::decay_t<T>&, std::decay_t<T>>
+    {
+        return m_value;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::visible() & noexcept -> std::add_lvalue_reference_t<B>
+    {
+        return m_visible;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::visible() const & noexcept -> std::add_lvalue_reference_t<std::add_const_t<B>>
+    {
+        return m_visible;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::visible() && noexcept -> std::conditional_t<std::is_reference<B>::value, apply_cv_t<B, std::decay_t<B>>&, std::decay_t<B>>
+    {
+        return m_visible;
+    }
+
+    template <class T, class B>
+    inline auto xmasked_value<T, B>::visible() const && noexcept -> std::conditional_t<std::is_reference<B>::value, const std::decay_t<B>&, std::decay_t<B>>
+    {
+        return m_visible;
+    }
+
+    template <class T, class B>
+    template <class T1, class B1>
+    inline bool xmasked_value<T, B>::equal(const xmasked_value<T1, B1>& rhs) const noexcept
+    {
+        return (!m_visible && !rhs.visible()) || (m_value == rhs.value() && (m_visible && rhs.visible()));
+    }
+
+    template <class T, class B>
+    template <class T1, check_disallow<is_xmasked_value<T1>>>
+    inline bool xmasked_value<T, B>::equal(const T1& rhs) const noexcept
+    {
+        return m_visible && m_value == rhs;
+    }
+
+    template <class T, class B>
+    template <class T1, class B1>
+    inline void xmasked_value<T, B>::swap(xmasked_value<T1, B1>& other)
+    {
+        using std::swap;
+        swap(m_value, other.m_value);
+        swap(m_visible, other.m_visible);
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline bool operator==(const xmasked_value<T1, B1>& lhs, const xmasked_value<T2, B2>& rhs) noexcept
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class T1, class T2, class B2, XTL_REQUIRES(negation<is_xmasked_value<T1>>)>
+    inline bool operator==(const T1& lhs, const xmasked_value<T2, B2>& rhs) noexcept
+    {
+        return rhs.equal(lhs);
+    }
+
+    template <class T1, class B1, class T2, XTL_REQUIRES(negation<is_xmasked_value<T2>>)>
+    inline bool operator==(const xmasked_value<T1, B1>& lhs, const T2& rhs) noexcept
+    {
+        return lhs.equal(rhs);
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline bool operator!=(const xmasked_value<T1, B1>& lhs, const xmasked_value<T2, B2>& rhs) noexcept
+    {
+        return !lhs.equal(rhs);
+    }
+
+    template <class T1, class T2, class B2, XTL_REQUIRES(negation<is_xmasked_value<T1>>)>
+    inline bool operator!=(const T1& lhs, const xmasked_value<T2, B2>& rhs) noexcept
+    {
+        return !rhs.equal(lhs);
+    }
+
+    template <class T1, class B1, class T2, XTL_REQUIRES(negation<is_xmasked_value<T2>>)>
+    inline bool operator!=(const xmasked_value<T1, B1>& lhs, const T2& rhs) noexcept
+    {
+        return !lhs.equal(rhs);
+    }
+
+    template <class T, class B>
+    inline auto operator+(const xmasked_value<T, B>& e) noexcept
+        -> xmasked_value<std::decay_t<T>, std::decay_t<B>>
+    {
+        return xmasked_value<std::decay_t<T>, std::decay_t<B>>(e.value(), e.visible());
+    }
+
+    template <class T, class B>
+    inline auto operator-(const xmasked_value<T, B>& e) noexcept
+        -> xmasked_value<std::decay_t<T>, std::decay_t<B>>
+    {
+        return xmasked_value<std::decay_t<T>, std::decay_t<B>>(-e.value(), e.visible());
+    }
+
+    template <class T, class B>
+    inline auto operator~(const xmasked_value<T, B>& e) noexcept
+        -> xmasked_value<std::decay_t<T>>
+    {
+        using value_type = std::decay_t<T>;
+        return e.visible() ? masked_value(~e.value()) : masked<value_type>();
+    }
+
+    template <class T, class B>
+    inline auto operator!(const xmasked_value<T, B>& e) noexcept -> xmasked_value<decltype(!e.value())>
+    {
+        using return_type = xmasked_value<decltype(!e.value())>;
+        using value_type = typename return_type::value_type;
+        return e.visible() ? return_type(!e.value()) : masked<value_type>();
+    }
+
+    template <class T, class B, class OC, class OT>
+    inline std::basic_ostream<OC, OT>& operator<<(std::basic_ostream<OC, OT>& out, xmasked_value<T, B> v)
+    {
+        if (v.visible())
+        {
+            out << v.value();
+        }
+        else
+        {
+            out << "masked";
+        }
+        return out;
+    }
+
+    template <class T1, class B1, class T2, class B2>
+    inline void swap(xmasked_value<T1, B1>& lhs, xmasked_value<T2, B2>& rhs)
+    {
+        lhs.swap(rhs);
+    }
+
+#define DEFINE_OPERATOR(OP)                                                                                   \
+    template <class T1, class B1, class T2, class B2>                                                         \
+    inline auto operator OP(const xmasked_value<T1, B1>& e1, const xmasked_value<T2, B2>& e2) noexcept        \
+        -> xmasked_value<promote_type_t<std::decay_t<T1>, std::decay_t<T2>>>                                  \
+    {                                                                                                         \
+        using value_type = promote_type_t<std::decay_t<T1>, std::decay_t<T2>>;                                \
+        return e1.visible() && e2.visible() ? masked_value(e1.value() OP e2.value()) : masked<value_type>();  \
+    }                                                                                                         \
+                                                                                                              \
+    template <class T1, class B1, class T2, XTL_REQUIRES(negation<is_xmasked_value<T2>>)>                     \
+    inline auto operator OP(const xmasked_value<T1, B1>& e1, const T2& e2) noexcept                           \
+        -> xmasked_value<promote_type_t<std::decay_t<T1>, std::decay_t<T2>>>                                  \
+    {                                                                                                         \
+        using value_type = promote_type_t<std::decay_t<T1>, std::decay_t<T2>>;                                \
+        return e1.visible() ? masked_value(e1.value() OP e2) : masked<value_type>();                          \
+    }                                                                                                         \
+                                                                                                              \
+    template <class T1, class T2, class B2, XTL_REQUIRES(negation<is_xmasked_value<T1>>)>                     \
+    inline auto operator OP(const T1& e1, const xmasked_value<T2, B2>& e2) noexcept                           \
+        -> xmasked_value<promote_type_t<std::decay_t<T1>, std::decay_t<T2>>>                                  \
+    {                                                                                                         \
+        using value_type = promote_type_t<std::decay_t<T1>, std::decay_t<T2>>;                                \
+        return e2.visible() ? masked_value(e1 OP e2.value()) : masked<value_type>();                          \
+    }
+
+#define DEFINE_BOOL_OPERATOR(OP)                                                                           \
+    template <class T1, class B1, class T2, class B2>                                                      \
+    inline auto operator OP(const xmasked_value<T1, B1>& e1, const xmasked_value<T2, B2>& e2) noexcept     \
+        -> xmasked_value<decltype(e1.value() OP e2.value())>                                               \
+    {                                                                                                      \
+        return e1.visible() && e2.visible() ?                                                              \
+            masked_value(e1.value() OP e2.value()) :                                                       \
+            masked<decltype(e1.value() OP e2.value())>();                                                  \
+    }                                                                                                      \
+                                                                                                           \
+    template <class T1, class B1, class T2, XTL_REQUIRES(negation<is_xmasked_value<T2>>)>                  \
+    inline auto operator OP(const xmasked_value<T1, B1>& e1, const T2& e2) noexcept                        \
+        -> xmasked_value<decltype(e1.value() OP e2)>                                                       \
+    {                                                                                                      \
+        return e1.visible() ? masked_value(e1.value() OP e2) : masked<decltype(e1.value() OP e2)>();       \
+    }                                                                                                      \
+                                                                                                           \
+    template <class T1, class T2, class B2, XTL_REQUIRES(negation<is_xmasked_value<T1>>)>                  \
+    inline auto operator OP(const T1& e1, const xmasked_value<T2, B2>& e2) noexcept                        \
+        -> xmasked_value<decltype(e1 OP e2.value())>                                                       \
+    {                                                                                                      \
+        return e2.visible() ? masked_value(e1 OP e2.value()) : masked<decltype(e1 OP e2.value())>();       \
+    }
+
+#define DEFINE_UNARY_OPERATOR(OP)                                                     \
+    template <class T, class B>                                                       \
+    inline xmasked_value<std::decay_t<T>> OP(const xmasked_value<T, B>& e)            \
+    {                                                                                 \
+        using std::OP;                                                                \
+        return e.visible() ? masked_value(OP(e.value())) : masked<std::decay_t<T>>(); \
+    }
+
+#define DEFINE_UNARY_BOOL_OPERATOR(OP)                                                        \
+    template <class T, class B>                                                               \
+    inline auto OP(const xmasked_value<T, B>& e)                                              \
+    {                                                                                         \
+        using std::OP;                                                                        \
+        return e.visible() ? masked_value(OP(e.value())) : masked<decltype(OP(e.value()))>(); \
+    }
+
+#define DEFINE_BINARY_OPERATOR(OP)                                                                       \
+    template <class T1, class B1, class T2, class B2>                                                    \
+    inline auto OP(const xmasked_value<T1, B1>& e1, const xmasked_value<T2, B2>& e2)                     \
+    {                                                                                                    \
+        using std::OP;                                                                                   \
+        return e1.visible() && e2.visible() ?                                                            \
+            masked_value(OP(e1.value(), e2.value())) :                                                   \
+            masked<decltype(OP(e1.value(), e2.value()))>();                                              \
+    }                                                                                                    \
+                                                                                                         \
+    template <class T1, class B1, class T2>                                                              \
+    inline auto OP(const xmasked_value<T1, B1>& e1, const T2& e2)                                        \
+    {                                                                                                    \
+        using std::OP;                                                                                   \
+        return e1.visible() ? masked_value(OP(e1.value(), e2)) : masked<decltype(OP(e1.value(), e2))>(); \
+    }                                                                                                    \
+                                                                                                         \
+    template <class T1, class T2, class B2>                                                              \
+    inline auto OP(const T1& e1, const xmasked_value<T2, B2>& e2)                                        \
+    {                                                                                                    \
+        using std::OP;                                                                                   \
+        return e2.visible() ? masked_value(OP(e1, e2.value())) : masked<decltype(OP(e1, e2.value()))>(); \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_MMM(OP)                                                                               \
+    template <class T1, class B1, class T2, class B2, class T3, class B3>                                             \
+    inline auto OP(const xmasked_value<T1, B1>& e1, const xmasked_value<T2, B2>& e2, const xmasked_value<T3, B3>& e3) \
+    {                                                                                                                 \
+        using std::OP;                                                                                                \
+        return (e1.visible() && e2.visible() && e3.visible()) ?                                                       \
+                masked_value(OP(e1.value(), e2.value(), e3.value())) :                                                \
+                masked<decltype(OP(e1.value(), e2.value(), e3.value()))>();                                           \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_MMT(OP)                                                              \
+    template <class T1, class B1, class T2, class B2, class T3>                                      \
+    inline auto OP(const xmasked_value<T1, B1>& e1, const xmasked_value<T2, B2>& e2, const T3& e3)   \
+    {                                                                                                \
+        using std::OP;                                                                               \
+        return (e1.visible() && e2.visible()) ?                                                      \
+                masked_value(OP(e1.value(), e2.value(), e3)) :                                       \
+                masked<decltype(OP(e1.value(), e2.value(), e3))>();                                  \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_MTM(OP)                                                            \
+    template <class T1, class B1, class T2, class T3, class B3>                                    \
+    inline auto OP(const xmasked_value<T1, B1>& e1, const T2& e2, const xmasked_value<T3, B3>& e3) \
+    {                                                                                              \
+        using std::OP;                                                                             \
+        return (e1.visible() && e3.visible()) ?                                                    \
+                masked_value(OP(e1.value(), e2, e3.value())) :                                     \
+                masked<decltype(OP(e1.value(), e2, e3.value()))>();                                \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_TMM(OP)                                                            \
+    template <class T1, class T2, class B2, class T3, class B3>                                    \
+    inline auto OP(const T1& e1, const xmasked_value<T2, B2>& e2, const xmasked_value<T3, B3>& e3) \
+    {                                                                                              \
+        using std::OP;                                                                             \
+        return (e2.visible() && e3.visible()) ?                                                    \
+                masked_value(OP(e1, e2.value(), e3.value())) :                                     \
+                masked<decltype(OP(e1, e2.value(), e3.value()))>();                                \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_TTM(OP)                                         \
+    template <class T1, class T2, class T3, class B3>                           \
+    inline auto OP(const T1& e1, const T2& e2, const xmasked_value<T3, B3>& e3) \
+    {                                                                           \
+        using std::OP;                                                          \
+        return e3.visible() ?                                                   \
+            masked_value(OP(e1, e2, e3.value())) :                              \
+            masked<decltype(OP(e1, e2, e3.value()))>();                         \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_TMT(OP)                                         \
+    template <class T1, class T2, class B2, class T3>                           \
+    inline auto OP(const T1& e1, const xmasked_value<T2, B2>& e2, const T3& e3) \
+    {                                                                           \
+        using std::OP;                                                          \
+        return e2.visible() ?                                                   \
+            masked_value(OP(e1, e2.value(), e3)) :                              \
+            masked<decltype(OP(e1, e2.value(), e3))>();                         \
+    }
+
+#define DEFINE_TERNARY_OPERATOR_MTT(OP)                                         \
+    template <class T1, class B1, class T2, class T3>                           \
+    inline auto OP(const xmasked_value<T1, B1>& e1, const T2& e2, const T3& e3) \
+    {                                                                           \
+        using std::OP;                                                          \
+        return e1.visible() ?                                                   \
+            masked_value(OP(e1.value(), e2, e3)) :                              \
+            masked<decltype(OP(e1.value(), e2, e3))>();                         \
+    }
+
+#define DEFINE_TERNARY_OPERATOR(OP) \
+    DEFINE_TERNARY_OPERATOR_MMM(OP) \
+                                    \
+    DEFINE_TERNARY_OPERATOR_MMT(OP) \
+    DEFINE_TERNARY_OPERATOR_MTM(OP) \
+    DEFINE_TERNARY_OPERATOR_TMM(OP) \
+    DEFINE_TERNARY_OPERATOR_TTM(OP) \
+    DEFINE_TERNARY_OPERATOR_TMT(OP) \
+    DEFINE_TERNARY_OPERATOR_MTT(OP)
+
+    DEFINE_OPERATOR(+);
+    DEFINE_OPERATOR(-);
+    DEFINE_OPERATOR(*);
+    DEFINE_OPERATOR(/);
+    DEFINE_OPERATOR(%);
+    DEFINE_BOOL_OPERATOR(||);
+    DEFINE_BOOL_OPERATOR(&&);
+    DEFINE_OPERATOR(&);
+    DEFINE_OPERATOR(|);
+    DEFINE_OPERATOR(^);
+    DEFINE_BOOL_OPERATOR(<);
+    DEFINE_BOOL_OPERATOR(<=);
+    DEFINE_BOOL_OPERATOR(>);
+    DEFINE_BOOL_OPERATOR(>=);
+    DEFINE_UNARY_OPERATOR(abs)
+    DEFINE_UNARY_OPERATOR(fabs)
+    DEFINE_UNARY_OPERATOR(exp)
+    DEFINE_UNARY_OPERATOR(exp2)
+    DEFINE_UNARY_OPERATOR(expm1)
+    DEFINE_UNARY_OPERATOR(log)
+    DEFINE_UNARY_OPERATOR(log10)
+    DEFINE_UNARY_OPERATOR(log2)
+    DEFINE_UNARY_OPERATOR(log1p)
+    DEFINE_UNARY_OPERATOR(sqrt)
+    DEFINE_UNARY_OPERATOR(cbrt)
+    DEFINE_UNARY_OPERATOR(sin)
+    DEFINE_UNARY_OPERATOR(cos)
+    DEFINE_UNARY_OPERATOR(tan)
+    DEFINE_UNARY_OPERATOR(acos)
+    DEFINE_UNARY_OPERATOR(asin)
+    DEFINE_UNARY_OPERATOR(atan)
+    DEFINE_UNARY_OPERATOR(sinh)
+    DEFINE_UNARY_OPERATOR(cosh)
+    DEFINE_UNARY_OPERATOR(tanh)
+    DEFINE_UNARY_OPERATOR(acosh)
+    DEFINE_UNARY_OPERATOR(asinh)
+    DEFINE_UNARY_OPERATOR(atanh)
+    DEFINE_UNARY_OPERATOR(erf)
+    DEFINE_UNARY_OPERATOR(erfc)
+    DEFINE_UNARY_OPERATOR(tgamma)
+    DEFINE_UNARY_OPERATOR(lgamma)
+    DEFINE_UNARY_OPERATOR(ceil)
+    DEFINE_UNARY_OPERATOR(floor)
+    DEFINE_UNARY_OPERATOR(trunc)
+    DEFINE_UNARY_OPERATOR(round)
+    DEFINE_UNARY_OPERATOR(nearbyint)
+    DEFINE_UNARY_OPERATOR(rint)
+    DEFINE_UNARY_BOOL_OPERATOR(isfinite)
+    DEFINE_UNARY_BOOL_OPERATOR(isinf)
+    DEFINE_UNARY_BOOL_OPERATOR(isnan)
+    DEFINE_BINARY_OPERATOR(fmod)
+    DEFINE_BINARY_OPERATOR(remainder)
+    DEFINE_BINARY_OPERATOR(fmax)
+    DEFINE_BINARY_OPERATOR(fmin)
+    DEFINE_BINARY_OPERATOR(fdim)
+    DEFINE_BINARY_OPERATOR(pow)
+    DEFINE_BINARY_OPERATOR(hypot)
+    DEFINE_BINARY_OPERATOR(atan2)
+    DEFINE_TERNARY_OPERATOR(fma)
+
+#undef DEFINE_TERNARY_OPERATOR
+#undef DEFINE_TERNARY_OPERATOR_MMM
+#undef DEFINE_TERNARY_OPERATOR_MMT
+#undef DEFINE_TERNARY_OPERATOR_MTM
+#undef DEFINE_TERNARY_OPERATOR_TMM
+#undef DEFINE_TERNARY_OPERATOR_TTM
+#undef DEFINE_TERNARY_OPERATOR_TMT
+#undef DEFINE_TERNARY_OPERATOR_MTT
+#undef DEFINE_BINARY_OPERATOR
+#undef DEFINE_UNARY_OPERATOR
+#undef DEFINE_UNARY_BOOL_OPERATOR
+#undef DEFINE_OPERATOR
+#undef DEFINE_BOOL_OPERATOR
+}
+
+#endif

--- a/vendor/xtl/include/xtl/xmasked_value_meta.hpp
+++ b/vendor/xtl/include/xtl/xmasked_value_meta.hpp
@@ -1,0 +1,40 @@
+/***************************************************************************
+* Copyright (c) 2019, Johan Mabille, Sylvain Corlay, Wolf Vollprecht and   *
+* Martin Renou                                                             *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTL_XMASKED_VALUE_META_HPP
+#define XTL_XMASKED_VALUE_META_HPP
+
+#include <type_traits>
+
+namespace xtl
+{
+    template <class T, class B = bool>
+    class xmasked_value;
+
+    namespace detail
+    {
+        template <class E>
+        struct is_xmasked_value_impl : std::false_type
+        {
+        };
+
+        template <class T, class B>
+        struct is_xmasked_value_impl<xmasked_value<T, B>> : std::true_type
+        {
+        };
+    }
+
+    template <class E>
+    using is_xmasked_value = detail::is_xmasked_value_impl<E>;
+
+    template <class E, class R>
+    using disable_xmasked_value = std::enable_if_t<!is_xmasked_value<E>::value, R>;
+}
+
+#endif

--- a/vendor/xtl/include/xtl/xoptional.hpp
+++ b/vendor/xtl/include/xtl/xoptional.hpp
@@ -14,143 +14,25 @@
 #include <type_traits>
 #include <utility>
 
+#ifdef __CLING__
+#include <nlohmann/json.hpp>
+#endif
+
+#include "xoptional_meta.hpp"
 #include "xclosure.hpp"
+#include "xfunctional.hpp"
 #include "xmeta_utils.hpp"
 #include "xtl_config.hpp"
 #include "xtype_traits.hpp"
 
 namespace xtl
 {
-    /********************
-     * optional helpers *
-     ********************/
-
     template <class T, class B>
     auto optional(T&& t, B&& b) noexcept;
 
-    template <class T>
-    auto missing() noexcept;
-
-    /*************************
-     * xoptional declaration *
-     *************************/
-
-    template <class CT, class CB = bool>
-    class xoptional;
-
-    namespace detail
-    {
-        template <class E>
-        struct is_xoptional_impl : std::false_type
-        {
-        };
-
-        template <class CT, class CB>
-        struct is_xoptional_impl<xoptional<CT, CB>> : std::true_type
-        {
-        };
-
-        template <class CT, class CTO, class CBO>
-        using converts_from_xoptional = disjunction<
-            std::is_constructible<CT, const xoptional<CTO, CBO>&>,
-            std::is_constructible<CT, xoptional<CTO, CBO>&>,
-            std::is_constructible<CT, const xoptional<CTO, CBO>&&>,
-            std::is_constructible<CT, xoptional<CTO, CBO>&&>,
-            std::is_convertible<const xoptional<CTO, CBO>&, CT>,
-            std::is_convertible<xoptional<CTO, CBO>&, CT>,
-            std::is_convertible<const xoptional<CTO, CBO>&&, CT>,
-            std::is_convertible<xoptional<CTO, CBO>&&, CT>
-        >;
-
-        template <class CT, class CTO, class CBO>
-        using assigns_from_xoptional = disjunction<
-            std::is_assignable<std::add_lvalue_reference_t<CT>, const xoptional<CTO, CBO>&>,
-            std::is_assignable<std::add_lvalue_reference_t<CT>, xoptional<CTO, CBO>&>,
-            std::is_assignable<std::add_lvalue_reference_t<CT>, const xoptional<CTO, CBO>&&>,
-            std::is_assignable<std::add_lvalue_reference_t<CT>, xoptional<CTO, CBO>&&>
-        >;
-
-        template <class... Args>
-        struct common_optional_impl;
-
-        template <class T>
-        struct common_optional_impl<T>
-        {
-            using type = std::conditional_t < is_xoptional_impl<T>::value , T, xoptional<T >> ;
-        };
-
-        template <class T>
-        struct identity
-        {
-            using type = T;
-        };
-
-        template <class T>
-        struct get_value_type
-        {
-            using type = typename T::value_type;
-        };
-
-        template<class T1, class T2>
-        struct common_optional_impl<T1, T2>
-        {
-            using decay_t1 = std::decay_t<T1>;
-            using decay_t2 = std::decay_t<T2>;
-            using type1 = xtl::mpl::eval_if_t<std::is_fundamental<decay_t1>, identity<decay_t1>, get_value_type<decay_t1>>;
-            using type2 = xtl::mpl::eval_if_t<std::is_fundamental<decay_t2>, identity<decay_t2>, get_value_type<decay_t2>>;
-            using type = xoptional<std::common_type_t<type1, type2>>;
-        };
-
-        template <class T1, class T2, class B2>
-        struct common_optional_impl<T1, xoptional<T2, B2>>
-            : common_optional_impl<T1, T2>
-        {
-        };
-
-        template <class T1, class B1, class T2>
-        struct common_optional_impl<xoptional<T1, B1>, T2>
-            : common_optional_impl<T2, xoptional<T1, B1>>
-        {
-        };
-
-        template <class T1, class B1, class T2, class B2>
-        struct common_optional_impl<xoptional<T1, B1>, xoptional<T2, B2>>
-            : common_optional_impl<T1, T2>
-        {
-        };
-
-        template <class T1, class T2, class... Args>
-        struct common_optional_impl<T1, T2, Args...>
-        {
-            using type = typename common_optional_impl<
-                             typename common_optional_impl<T1, T2>::type,
-                             Args...
-                         >::type;
-        };
-    }
-
-    template <class E>
-    using is_xoptional = detail::is_xoptional_impl<E>;
-
-    template <class E, class R = void>
-    using disable_xoptional = std::enable_if_t<!is_xoptional<E>::value, R>;
-
-    template <class E1, class E2, class R = void>
-    using disable_both_xoptional = std::enable_if_t<!is_xoptional<E1>::value && !is_xoptional<E2>::value, R>;
-
-    template <class E, class R = void>
-    using enable_xoptional = std::enable_if_t<is_xoptional<E>::value, R>;
-
-    template <class E1, class E2, class R = void>
-    using enable_both_xoptional = std::enable_if_t<is_xoptional<E1>::value && is_xoptional<E2>::value, R>;
-
-    template <class... Args>
-    struct common_optional : detail::common_optional_impl<Args...>
-    {
-    };
-
-    template <class... Args>
-    using common_optional_t = typename common_optional<Args...>::type;
+    /************************
+     * optional declaration *
+     ************************/
 
     /**
      * @class xoptional
@@ -312,8 +194,8 @@ namespace xtl
          xoptional&>
         inline operator=(T&& rhs)
         {
-            m_flag = true;
             m_value = std::forward<T>(rhs);
+            m_flag = true;
             return *this;
         }
 
@@ -327,8 +209,8 @@ namespace xtl
         xoptional&>
         inline operator=(const xoptional<CTO, CBO>& rhs)
         {
-            m_flag = rhs.has_value();
             m_value = rhs.value();
+            m_flag = rhs.has_value();
             return *this;
         }
 
@@ -342,8 +224,8 @@ namespace xtl
         xoptional&>
         inline operator=(xoptional<CTO, CBO>&& rhs)
         {
-            m_flag = std::move(rhs).has_value();
             m_value = std::move(rhs).value();
+            m_flag = std::move(rhs).has_value();
             return *this;
         }
 
@@ -365,22 +247,22 @@ namespace xtl
         template <class CTO, class CBO>
         xoptional& operator^=(const xoptional<CTO, CBO>&);
 
-        template <class T>
-        disable_xoptional<T, xoptional&> operator+=(const T&);
-        template <class T>
-        disable_xoptional<T, xoptional&> operator-=(const T&);
-        template <class T>
-        disable_xoptional<T, xoptional&> operator*=(const T&);
-        template <class T>
-        disable_xoptional<T, xoptional&> operator/=(const T&);
-        template <class T>
-        disable_xoptional<T, xoptional&> operator%=(const T&);
-        template <class T>
-        disable_xoptional<T, xoptional&> operator&=(const T&);
-        template <class T>
-        disable_xoptional<T, xoptional&> operator|=(const T&);
-        template <class T>
-        disable_xoptional<T, xoptional&> operator^=(const T&);
+        template <class T, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T>)>
+        xoptional& operator+=(const T&);
+        template <class T, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T>)>
+        xoptional& operator-=(const T&);
+        template <class T, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T>)>
+        xoptional& operator*=(const T&);
+        template <class T, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T>)>
+        xoptional& operator/=(const T&);
+        template <class T, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T>)>
+        xoptional& operator%=(const T&);
+        template <class T, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T>)>
+        xoptional& operator&=(const T&);
+        template <class T, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T>)>
+        xoptional& operator|=(const T&);
+        template <class T, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T>)>
+        xoptional& operator^=(const T&);
 
         // Access
         std::add_lvalue_reference_t<CT> value() & noexcept;
@@ -406,8 +288,8 @@ namespace xtl
         template <class CTO, class CBO>
         bool equal(const xoptional<CTO, CBO>& rhs) const noexcept;
 
-        template <class CTO>
-        disable_xoptional<CTO, bool> equal(const CTO& rhs) const noexcept;
+        template <class CTO, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<CTO>)>
+        bool equal(const CTO& rhs) const noexcept;
 
         xclosure_pointer<self_type&> operator&() &;
         xclosure_pointer<const self_type&> operator&() const &;
@@ -495,7 +377,7 @@ namespace xtl
      * @brief Returns an \ref xoptional for a missig value
      */
     template <class T>
-    auto missing() noexcept
+    xoptional<T, bool> missing() noexcept
     {
         return xoptional<T, bool>(T(), false);
     }
@@ -627,8 +509,8 @@ namespace xtl
     }
 
     template <class CT, class CB>
-    template <class T>
-    auto xoptional<CT, CB>::operator+=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    template <class T, check_requires<is_not_xoptional_nor_xmasked_value<T>>>
+    auto xoptional<CT, CB>::operator+=(const T& rhs) -> xoptional&
     {
         if (m_flag)
         {
@@ -638,8 +520,8 @@ namespace xtl
     }
 
     template <class CT, class CB>
-    template <class T>
-    auto xoptional<CT, CB>::operator-=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    template <class T, check_requires<is_not_xoptional_nor_xmasked_value<T>>>
+    auto xoptional<CT, CB>::operator-=(const T& rhs) -> xoptional&
     {
         if (m_flag)
         {
@@ -649,8 +531,8 @@ namespace xtl
     }
 
     template <class CT, class CB>
-    template <class T>
-    auto xoptional<CT, CB>::operator*=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    template <class T, check_requires<is_not_xoptional_nor_xmasked_value<T>>>
+    auto xoptional<CT, CB>::operator*=(const T& rhs) -> xoptional&
     {
         if (m_flag)
         {
@@ -660,8 +542,8 @@ namespace xtl
     }
 
     template <class CT, class CB>
-    template <class T>
-    auto xoptional<CT, CB>::operator/=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    template <class T, check_requires<is_not_xoptional_nor_xmasked_value<T>>>
+    auto xoptional<CT, CB>::operator/=(const T& rhs) -> xoptional&
     {
         if (m_flag)
         {
@@ -671,8 +553,8 @@ namespace xtl
     }
 
     template <class CT, class CB>
-    template <class T>
-    auto xoptional<CT, CB>::operator%=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    template <class T, check_requires<is_not_xoptional_nor_xmasked_value<T>>>
+    auto xoptional<CT, CB>::operator%=(const T& rhs) -> xoptional&
     {
         if (m_flag)
         {
@@ -682,8 +564,8 @@ namespace xtl
     }
 
     template <class CT, class CB>
-    template <class T>
-    auto xoptional<CT, CB>::operator&=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    template <class T, check_requires<is_not_xoptional_nor_xmasked_value<T>>>
+    auto xoptional<CT, CB>::operator&=(const T& rhs) -> xoptional&
     {
         if (m_flag)
         {
@@ -693,8 +575,8 @@ namespace xtl
     }
 
     template <class CT, class CB>
-    template <class T>
-    auto xoptional<CT, CB>::operator|=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    template <class T, check_requires<is_not_xoptional_nor_xmasked_value<T>>>
+    auto xoptional<CT, CB>::operator|=(const T& rhs) -> xoptional&
     {
         if (m_flag)
         {
@@ -704,8 +586,8 @@ namespace xtl
     }
 
     template <class CT, class CB>
-    template <class T>
-    auto xoptional<CT, CB>::operator^=(const T& rhs) -> disable_xoptional<T, xoptional&>
+    template <class T, check_requires<is_not_xoptional_nor_xmasked_value<T>>>
+    auto xoptional<CT, CB>::operator^=(const T& rhs) -> xoptional&
     {
         if (m_flag)
         {
@@ -782,7 +664,7 @@ namespace xtl
     template <class CT, class CB>
     void xoptional<CT, CB>::swap(xoptional& other)
     {
-        std::swap(m_value, other.m_flag);
+        std::swap(m_value, other.m_value);
         std::swap(m_flag, other.m_flag);
     }
 
@@ -795,8 +677,8 @@ namespace xtl
     }
 
     template <class CT, class CB>
-    template <class CTO>
-    auto xoptional<CT, CB>::equal(const CTO& rhs) const noexcept -> disable_xoptional<CTO, bool>
+    template <class CTO, check_requires<is_not_xoptional_nor_xmasked_value<CTO>>>
+    bool xoptional<CT, CB>::equal(const CTO& rhs) const noexcept
     {
         return m_flag ? (m_value == rhs) : false;
     }
@@ -834,6 +716,18 @@ namespace xtl
         return out;
     }
 
+#ifdef __CLING__
+    template <class T, class B>
+    nlohmann::json mime_bundle_repr(const xoptional<T, B>& v)
+    {
+        auto bundle = nlohmann::json::object();
+        std::stringstream tmp;
+        tmp << v;
+        bundle["text/plain"] = tmp.str();
+        return bundle;
+    }
+#endif
+
     template <class T1, class B1, class T2, class B2>
     inline auto operator==(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2) noexcept
         -> bool
@@ -841,16 +735,14 @@ namespace xtl
         return e1.equal(e2);
     }
 
-    template <class T1, class B1, class T2>
-    inline auto operator==(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> disable_xoptional<T2, bool>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
+    inline bool operator==(const xoptional<T1, B1>& e1, const T2& e2) noexcept
     {
         return e1.equal(e2);
     }
 
-    template <class T1, class T2, class B2>
-    inline auto operator==(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> disable_xoptional<T1, bool>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
+    inline bool operator==(const T1& e1, const xoptional<T2, B2>& e2) noexcept
     {
         return e2.equal(e1);
     }
@@ -869,16 +761,14 @@ namespace xtl
         return !e1.equal(e2);
     }
 
-    template <class T1, class B1, class T2>
-    inline auto operator!=(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> disable_xoptional<T2, bool>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
+    inline bool operator!=(const xoptional<T1, B1>& e1, const T2& e2) noexcept
     {
         return !e1.equal(e2);
     }
 
-    template <class T1, class T2, class B2>
-    inline auto operator!=(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> disable_xoptional<T1, bool>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
+    inline bool operator!=(const T1& e1, const xoptional<T2, B2>& e2) noexcept
     {
         return !e2.equal(e1);
     }
@@ -900,17 +790,17 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() + e2.value() : missing<value_type>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator+(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> disable_xoptional<T1, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 + e2.value() : missing<value_type>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator+(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> disable_xoptional<T2, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() + e2 : missing<value_type>();
@@ -924,17 +814,17 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() - e2.value() : missing<value_type>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator-(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> disable_xoptional<T1, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 - e2.value() : missing<value_type>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator-(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> disable_xoptional<T2, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() - e2 : missing<value_type>();
@@ -948,17 +838,17 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() * e2.value() : missing<value_type>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator*(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> disable_xoptional<T1, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 * e2.value() : missing<value_type>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator*(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> disable_xoptional<T2, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() * e2 : missing<value_type>();
@@ -972,17 +862,17 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() / e2.value() : missing<value_type>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator/(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> disable_xoptional<T1, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 / e2.value() : missing<value_type>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator/(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> disable_xoptional<T2, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() / e2 : missing<value_type>();
@@ -996,17 +886,17 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() % e2.value() : missing<value_type>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator%(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> disable_xoptional<T1, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 % e2.value() : missing<value_type>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator%(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> disable_xoptional<T2, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() % e2 : missing<value_type>();
@@ -1028,17 +918,17 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() & e2.value() : missing<value_type>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator&(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> disable_xoptional<T1, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 & e2.value() : missing<value_type>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator&(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> disable_xoptional<T2, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() & e2 : missing<value_type>();
@@ -1052,17 +942,17 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() | e2.value() : missing<value_type>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator|(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> disable_xoptional<T1, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 | e2.value() : missing<value_type>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator|(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> disable_xoptional<T2, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() | e2 : missing<value_type>();
@@ -1076,17 +966,17 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() ^ e2.value() : missing<value_type>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator^(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> disable_xoptional<T1, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 ^ e2.value() : missing<value_type>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator^(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> disable_xoptional<T2, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() ^ e2 : missing<value_type>();
@@ -1100,17 +990,17 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() || e2.value() : missing<value_type>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator||(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> disable_xoptional<T1, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 || e2.value() : missing<value_type>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator||(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> disable_xoptional<T2, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() || e2 : missing<value_type>();
@@ -1125,17 +1015,17 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() && e2.value() : missing<value_type>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator&&(const T1& e1, const xoptional<T2, B2>& e2) noexcept
-        -> disable_xoptional<T1, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e2.has_value() ? e1 && e2.value() : missing<value_type>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator&&(const xoptional<T1, B1>& e1, const T2& e2) noexcept
-        -> disable_xoptional<T2, common_optional_t<T1, T2>>
+        -> common_optional_t<T1, T2>
     {
         using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
         return e1.has_value() ? e1.value() && e2 : missing<value_type>();
@@ -1155,14 +1045,14 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() < e2.value() : missing<bool>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator<(const T1& e1, const xoptional<T2, B2>& e2) noexcept
         -> xoptional<bool>
     {
         return e2.has_value() ? e1 < e2.value() : missing<bool>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator<(const xoptional<T1, B1>& e1, const T2& e2) noexcept
         -> xoptional<bool>
     {
@@ -1176,14 +1066,14 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() <= e2.value() : missing<bool>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator<=(const T1& e1, const xoptional<T2, B2>& e2) noexcept
         -> xoptional<bool>
     {
         return e2.has_value() ? e1 <= e2.value() : missing<bool>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator<=(const xoptional<T1, B1>& e1, const T2& e2) noexcept
         -> xoptional<bool>
     {
@@ -1197,14 +1087,14 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() > e2.value() : missing<bool>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator>(const T1& e1, const xoptional<T2, B2>& e2) noexcept
         -> xoptional<bool>
     {
         return e2.has_value() ? e1 > e2.value() : missing<bool>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator>(const xoptional<T1, B1>& e1, const T2& e2) noexcept
         -> xoptional<bool>
     {
@@ -1218,14 +1108,14 @@ namespace xtl
         return e1.has_value() && e2.has_value() ? e1.value() >= e2.value() : missing<bool>();
     }
 
-    template <class T1, class T2, class B2>
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)>
     inline auto operator>=(const T1& e1, const xoptional<T2, B2>& e2) noexcept
         -> xoptional<bool>
     {
         return e2.has_value() ? e1 >= e2.value() : missing<bool>();
     }
 
-    template <class T1, class B1, class T2>
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)>
     inline auto operator>=(const xoptional<T1, B1>& e1, const T2& e2) noexcept
         -> xoptional<bool>
     {
@@ -1248,25 +1138,25 @@ namespace xtl
         return e.has_value() ? bool(NAME(e.value())) : missing<bool>(); \
     }
 
-#define BINARY_OPTIONAL_1(NAME)                                                    \
-    template <class T1, class B1, class T2>                                        \
-    inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2)                    \
-        -> disable_xoptional<T2, common_optional_t<T1, T2>>                        \
-    {                                                                              \
-        using std::NAME;                                                           \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>; \
-        return e1.has_value() ? NAME(e1.value(), e2) : missing<value_type>();      \
+#define BINARY_OPTIONAL_1(NAME)                                                                   \
+    template <class T1, class B1, class T2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)> \
+    inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2)                                   \
+        -> common_optional_t<T1, T2>                                                              \
+    {                                                                                             \
+        using std::NAME;                                                                          \
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;                \
+        return e1.has_value() ? NAME(e1.value(), e2) : missing<value_type>();                     \
     }
 
 
-#define BINARY_OPTIONAL_2(NAME)                                                    \
-    template <class T1, class T2, class B2>                                        \
-    inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2)                    \
-        -> disable_xoptional<T1, common_optional_t<T1, T2>>                        \
-    {                                                                              \
-        using std::NAME;                                                           \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>; \
-        return e2.has_value() ? NAME(e1, e2.value()) : missing<value_type>();      \
+#define BINARY_OPTIONAL_2(NAME)                                                                   \
+    template <class T1, class T2, class B2, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)> \
+    inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2)                                   \
+        -> common_optional_t<T1, T2>                                                              \
+    {                                                                                             \
+        using std::NAME;                                                                          \
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;                \
+        return e2.has_value() ? NAME(e1, e2.value()) : missing<value_type>();                     \
     }
 
 #define BINARY_OPTIONAL_12(NAME)                                                                        \
@@ -1283,64 +1173,64 @@ namespace xtl
     BINARY_OPTIONAL_2(NAME)   \
     BINARY_OPTIONAL_12(NAME)
 
-#define TERNARY_OPTIONAL_1(NAME)                                                                     \
-    template <class T1, class B1, class T2, class T3>                                                \
-    inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2, const T3& e3)                        \
-        -> disable_both_xoptional<T2, T3, common_optional_t<T1, T2, T3>>                             \
-    {                                                                                                \
-        using std::NAME;                                                                             \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>; \
-        return e1.has_value() ? NAME(e1.value(), e2, e3) : missing<value_type>();                    \
+#define TERNARY_OPTIONAL_1(NAME)                                                                                                                    \
+    template <class T1, class B1, class T2, class T3, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>, is_not_xoptional_nor_xmasked_value<T3>)> \
+    inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2, const T3& e3)                                                                       \
+        -> common_optional_t<T1, T2, T3>                                                                                                            \
+    {                                                                                                                                               \
+        using std::NAME;                                                                                                                            \
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;                                                \
+        return e1.has_value() ? NAME(e1.value(), e2, e3) : missing<value_type>();                                                                   \
     }
 
-#define TERNARY_OPTIONAL_2(NAME)                                                                     \
-    template <class T1, class T2, class B2, class T3>                                                \
-    inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2, const T3& e3)                        \
-        -> disable_both_xoptional<T1, T3, common_optional_t<T1, T2, T3>>                             \
-    {                                                                                                \
-        using std::NAME;                                                                             \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>; \
-        return e2.has_value() ? NAME(e1, e2.value(), e3) : missing<value_type>();                    \
+#define TERNARY_OPTIONAL_2(NAME)                                                                                                                    \
+    template <class T1, class T2, class B2, class T3, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>, is_not_xoptional_nor_xmasked_value<T3>)> \
+    inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2, const T3& e3)                                                                       \
+        -> common_optional_t<T1, T2, T3>                                                                                                            \
+    {                                                                                                                                               \
+        using std::NAME;                                                                                                                            \
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;                                                \
+        return e2.has_value() ? NAME(e1, e2.value(), e3) : missing<value_type>();                                                                   \
     }
 
-#define TERNARY_OPTIONAL_3(NAME)                                                                     \
-    template <class T1, class T2, class T3, class B3>                                                \
-    inline auto NAME(const T1& e1, const T2& e2, const xoptional<T3, B3>& e3)                        \
-        -> disable_both_xoptional<T1, T2, common_optional_t<T1, T2, T3>>                             \
-    {                                                                                                \
-        using std::NAME;                                                                             \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>; \
-        return e3.has_value() ? NAME(e1, e2, e3.value()) : missing<value_type>();                    \
+#define TERNARY_OPTIONAL_3(NAME)                                                                                                                    \
+    template <class T1, class T2, class T3, class B3, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>, is_not_xoptional_nor_xmasked_value<T2>)> \
+    inline auto NAME(const T1& e1, const T2& e2, const xoptional<T3, B3>& e3)                                                                       \
+        -> common_optional_t<T1, T2, T3>                                                                                                            \
+    {                                                                                                                                               \
+        using std::NAME;                                                                                                                            \
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;                                                \
+        return e3.has_value() ? NAME(e1, e2, e3.value()) : missing<value_type>();                                                                   \
     }
 
-#define TERNARY_OPTIONAL_12(NAME)                                                                             \
-    template <class T1, class B1, class T2, class B2, class T3>                                               \
-    inline auto NAME(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2, const T3& e3)                  \
-        -> disable_xoptional<T3, common_optional_t<T1, T2, T3>>                                               \
-    {                                                                                                         \
-        using std::NAME;                                                                                      \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;          \
-        return (e1.has_value() && e2.has_value()) ? NAME(e1.value(), e2.value(), e3) : missing<value_type>(); \
+#define TERNARY_OPTIONAL_12(NAME)                                                                                     \
+    template <class T1, class B1, class T2, class B2, class T3, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T3>)> \
+    inline auto NAME(const xoptional<T1, B1>& e1, const xoptional<T2, B2>& e2, const T3& e3)                          \
+        -> common_optional_t<T1, T2, T3>                                                                              \
+    {                                                                                                                 \
+        using std::NAME;                                                                                              \
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;                  \
+        return (e1.has_value() && e2.has_value()) ? NAME(e1.value(), e2.value(), e3) : missing<value_type>();         \
     }
 
-#define TERNARY_OPTIONAL_13(NAME)                                                                             \
-    template <class T1, class B1, class T2, class T3, class B3>                                               \
-    inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2, const xoptional<T3, B3>& e3)                  \
-        -> disable_xoptional<T2, common_optional_t<T1, T2, T3>>                                               \
-    {                                                                                                         \
-        using std::NAME;                                                                                      \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;          \
-        return (e1.has_value() && e3.has_value()) ? NAME(e1.value(), e2, e3.value()) : missing<value_type>(); \
+#define TERNARY_OPTIONAL_13(NAME)                                                                                     \
+    template <class T1, class B1, class T2, class T3, class B3, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T2>)> \
+    inline auto NAME(const xoptional<T1, B1>& e1, const T2& e2, const xoptional<T3, B3>& e3)                          \
+        -> common_optional_t<T1, T2, T3>                                                                              \
+    {                                                                                                                 \
+        using std::NAME;                                                                                              \
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;                  \
+        return (e1.has_value() && e3.has_value()) ? NAME(e1.value(), e2, e3.value()) : missing<value_type>();         \
     }
 
-#define TERNARY_OPTIONAL_23(NAME)                                                                             \
-    template <class T1, class T2, class B2, class T3, class B3>                                               \
-    inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2, const xoptional<T3, B3>& e3)                  \
-        -> disable_xoptional<T1, common_optional_t<T1, T2, T3>>                                               \
-    {                                                                                                         \
-        using std::NAME;                                                                                      \
-        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;          \
-        return (e2.has_value() && e3.has_value()) ? NAME(e1, e2.value(), e3.value()) : missing<value_type>(); \
+#define TERNARY_OPTIONAL_23(NAME)                                                                                     \
+    template <class T1, class T2, class B2, class T3, class B3, XTL_REQUIRES(is_not_xoptional_nor_xmasked_value<T1>)> \
+    inline auto NAME(const T1& e1, const xoptional<T2, B2>& e2, const xoptional<T3, B3>& e3)                          \
+        -> common_optional_t<T1, T2, T3>                                                                              \
+    {                                                                                                                 \
+        using std::NAME;                                                                                              \
+        using value_type = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>, std::decay_t<T3>>;                  \
+        return (e2.has_value() && e3.has_value()) ? NAME(e1, e2.value(), e3.value()) : missing<value_type>();         \
     }
 
 #define TERNARY_OPTIONAL_123(NAME)                                                                                                      \
@@ -1420,6 +1310,21 @@ namespace xtl
 #undef BINARY_OPTIONAL_2
 #undef BINARY_OPTIONAL_1
 #undef UNARY_OPTIONAL
+
+    /*************************
+     * select implementation *
+     *************************/
+
+    template <class B, class T1, class T2, XTL_REQUIRES(at_least_one_xoptional<B, T1, T2>)>
+    inline common_optional_t<T1, T2> select(const B& cond, const T1& v1, const T2& v2) noexcept
+    {
+        using bool_type = common_optional_t<B>;
+        using return_type = common_optional_t<T1, T2>;
+        bool_type opt_cond(cond);
+        return opt_cond.has_value() ?
+            opt_cond.value() ? return_type(v1) : return_type(v2) :
+            missing<typename return_type::value_type>();
+    }
 }
 
 #endif

--- a/vendor/xtl/include/xtl/xoptional_meta.hpp
+++ b/vendor/xtl/include/xtl/xoptional_meta.hpp
@@ -1,0 +1,140 @@
+/***************************************************************************
+* Copyright (c) 2016, Johan Mabille, Sylvain Corlay, Wolf Vollprecht and   *
+* Martin Renou                                                             *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTL_OPTIONAL_META_HPP
+#define XTL_OPTIONAL_META_HPP
+
+#include <type_traits>
+
+#include "xmasked_value_meta.hpp"
+#include "xmeta_utils.hpp"
+#include "xtype_traits.hpp"
+
+namespace xtl
+{
+    template <class CT, class CB = bool>
+    class xoptional;
+
+    namespace detail
+    {
+        template <class E>
+        struct is_xoptional_impl : std::false_type
+        {
+        };
+
+        template <class CT, class CB>
+        struct is_xoptional_impl<xoptional<CT, CB>> : std::true_type
+        {
+        };
+
+        template <class CT, class CTO, class CBO>
+        using converts_from_xoptional = disjunction<
+            std::is_constructible<CT, const xoptional<CTO, CBO>&>,
+            std::is_constructible<CT, xoptional<CTO, CBO>&>,
+            std::is_constructible<CT, const xoptional<CTO, CBO>&&>,
+            std::is_constructible<CT, xoptional<CTO, CBO>&&>,
+            std::is_convertible<const xoptional<CTO, CBO>&, CT>,
+            std::is_convertible<xoptional<CTO, CBO>&, CT>,
+            std::is_convertible<const xoptional<CTO, CBO>&&, CT>,
+            std::is_convertible<xoptional<CTO, CBO>&&, CT>
+        >;
+
+        template <class CT, class CTO, class CBO>
+        using assigns_from_xoptional = disjunction<
+            std::is_assignable<std::add_lvalue_reference_t<CT>, const xoptional<CTO, CBO>&>,
+            std::is_assignable<std::add_lvalue_reference_t<CT>, xoptional<CTO, CBO>&>,
+            std::is_assignable<std::add_lvalue_reference_t<CT>, const xoptional<CTO, CBO>&&>,
+            std::is_assignable<std::add_lvalue_reference_t<CT>, xoptional<CTO, CBO>&&>
+        >;
+
+        template <class... Args>
+        struct common_optional_impl;
+
+        template <class T>
+        struct common_optional_impl<T>
+        {
+            using type = std::conditional_t<is_xoptional_impl<T>::value, T, xoptional<T>>;
+        };
+
+        template <class T>
+        struct identity
+        {
+            using type = T;
+        };
+
+        template <class T>
+        struct get_value_type
+        {
+            using type = typename T::value_type;
+        };
+
+        template<class T1, class T2>
+        struct common_optional_impl<T1, T2>
+        {
+            using decay_t1 = std::decay_t<T1>;
+            using decay_t2 = std::decay_t<T2>;
+            using type1 = xtl::mpl::eval_if_t<std::is_fundamental<decay_t1>, identity<decay_t1>, get_value_type<decay_t1>>;
+            using type2 = xtl::mpl::eval_if_t<std::is_fundamental<decay_t2>, identity<decay_t2>, get_value_type<decay_t2>>;
+            using type = xoptional<std::common_type_t<type1, type2>>;
+        };
+
+        template <class T1, class T2, class B2>
+        struct common_optional_impl<T1, xoptional<T2, B2>>
+            : common_optional_impl<T1, T2>
+        {
+        };
+
+        template <class T1, class B1, class T2>
+        struct common_optional_impl<xoptional<T1, B1>, T2>
+            : common_optional_impl<T1, T2>
+        {
+        };
+
+        template <class T1, class B1, class T2, class B2>
+        struct common_optional_impl<xoptional<T1, B1>, xoptional<T2, B2>>
+            : common_optional_impl<T1, T2>
+        {
+        };
+
+        template <class T1, class T2, class... Args>
+        struct common_optional_impl<T1, T2, Args...>
+        {
+            using type = typename common_optional_impl<
+                             typename common_optional_impl<T1, T2>::type,
+                             Args...
+                         >::type;
+        };
+    }
+
+    template <class E>
+    using is_xoptional = detail::is_xoptional_impl<E>;
+
+    template <class E, class R = void>
+    using disable_xoptional = std::enable_if_t<!is_xoptional<E>::value, R>;
+
+    template <class... Args>
+    struct at_least_one_xoptional : disjunction<is_xoptional<Args>...>
+    {
+    };
+
+    template <class... Args>
+    struct common_optional : detail::common_optional_impl<Args...>
+    {
+    };
+
+    template <class... Args>
+    using common_optional_t = typename common_optional<Args...>::type;
+
+    template <class E>
+    struct is_not_xoptional_nor_xmasked_value : negation<disjunction<is_xoptional<E>, is_xmasked_value<E>>>
+    {
+    };
+}
+
+#endif

--- a/vendor/xtl/include/xtl/xsequence.hpp
+++ b/vendor/xtl/include/xtl/xsequence.hpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "xtl_config.hpp"
+#include "xmeta_utils.hpp"
 
 namespace xtl
 {
@@ -24,6 +25,9 @@ namespace xtl
 
     template <class S>
     S make_sequence(typename S::size_type size, typename S::value_type v);
+
+    template <class S>
+    S make_sequence(std::initializer_list<typename S::value_type> init);
 
     template <class R, class A>
     decltype(auto) forward_sequence(A&& s);
@@ -48,7 +52,6 @@ namespace xtl
             using value_type = typename S::value_type;
             using size_type = typename S::size_type;
 
-
             inline static S make(size_type size)
             {
                 return S(size);
@@ -57,6 +60,11 @@ namespace xtl
             inline static S make(size_type size, value_type v)
             {
                 return S(size, v);
+            }
+
+            inline static S make(std::initializer_list<value_type> init)
+            {
+                return S(init);
             }
         };
 
@@ -78,6 +86,13 @@ namespace xtl
                 s.fill(v);
                 return s;
             }
+
+            inline static sequence_type make(std::initializer_list<value_type> init)
+            {
+                sequence_type s;
+                std::copy(init.begin(), init.end(), s.begin());
+                return s;
+            }
         };
     }
     
@@ -93,6 +108,12 @@ namespace xtl
         return detail::sequence_builder<S>::make(size, v);
     }
 
+    template <class S>
+    inline S make_sequence(std::initializer_list<typename S::value_type> init)
+    {
+        return detail::sequence_builder<S>::make(init);
+    }
+
     /***********************************
      * forward_sequence implementation *
      ***********************************/
@@ -100,21 +121,8 @@ namespace xtl
     namespace detail
     {
         template <class R, class A, class E = void>
-        struct sequence_forwarder
+        struct sequence_forwarder_impl
         {
-            template <class T>
-            static inline R forward(const T& r)
-            {
-                return R(std::begin(r), std::end(r));
-            }
-        };
-
-        template <class I, std::size_t L, class A>
-        struct sequence_forwarder<std::array<I, L>, A,
-                                  std::enable_if_t<!std::is_same<std::array<I, L>, A>::value>>
-        {
-            using R = std::array<I, L>;
-
             template <class T>
             static inline R forward(const T& r)
             {
@@ -123,32 +131,54 @@ namespace xtl
                 return ret;
             }
         };
+        
+        template <class R, class A>
+        struct sequence_forwarder_impl<R, A, void_t<decltype(std::declval<R>().resize(std::size_t()))>>
+        {
+            template <class T>
+            static inline auto forward(const T& r)
+            {
+                return R(std::begin(r), std::end(r));
+            }
+        };
+
+        template <class R, class A>
+        struct sequence_forwarder
+            : sequence_forwarder_impl<R, A>
+        {
+        };
 
         template <class R>
         struct sequence_forwarder<R, R>
         {
             template <class T>
-            static inline T&& forward(typename std::remove_reference<T>::type& t) noexcept
+            static inline T&& forward(T&& t) noexcept
             {
-                return static_cast<T&&>(t);
-            }
-
-            template <class T>
-            static inline T&& forward(typename std::remove_reference<T>::type&& t) noexcept
-            {
-                return static_cast<T&&>(t);
+                return std::forward<T>(t);
             }
         };
-    }
 
-    template <class R, class A>
-    inline decltype(auto) forward_sequence(A&& s)
-    {
-        using forwarder = detail::sequence_forwarder<
+        template <class R, class A>
+        using forwarder_type = detail::sequence_forwarder<
             std::decay_t<R>,
             std::remove_cv_t<std::remove_reference_t<A>>
         >;
-        return forwarder::template forward<A>(s);
+    }
+
+    template <class R, class A>
+    inline decltype(auto) forward_sequence(typename std::remove_reference<A>::type& s)
+    {
+        using forwarder = detail::forwarder_type<R, A>;
+        return forwarder::forward(std::forward<A>(s));
+    }
+
+    template <class R, class A>
+    inline decltype(auto) forward_sequence(typename std::remove_reference<A>::type&& s)
+    {
+        using forwarder = detail::forwarder_type<R, A>;
+        static_assert(!std::is_lvalue_reference<A>::value,
+                      "Can not forward an rvalue as an lvalue.");
+        return forwarder::forward(std::move(s));
     }
 
     /********************************

--- a/vendor/xtl/include/xtl/xspan.hpp
+++ b/vendor/xtl/include/xtl/xspan.hpp
@@ -1,0 +1,20 @@
+/***************************************************************************
+* Copyright (c) 2016, Sylvain Corlay and Johan Mabille                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTL_XSPAN_HPP
+#define XTL_XSPAN_HPP
+
+#include "xspan_impl.hpp"
+
+namespace xtl
+{
+	using tcb::span;
+	constexpr std::ptrdiff_t dynamic_extent = tcb::dynamic_extent;
+}
+
+#endif

--- a/vendor/xtl/include/xtl/xspan_impl.hpp
+++ b/vendor/xtl/include/xtl/xspan_impl.hpp
@@ -1,0 +1,778 @@
+// https://github.com/tcbrindle/span/blob/master/include/tcb/span.hpp
+// TCP SPAN @commit cd0c6d0
+
+/*
+This is an implementation of std::span from P0122R7
+http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0122r7.pdf
+*/
+
+//          Copyright Tristan Brindle 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../../LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef TCB_SPAN_HPP_INCLUDED
+#define TCB_SPAN_HPP_INCLUDED
+
+#include <array>
+#include <cstddef>
+#include <type_traits>
+
+#ifndef TCB_SPAN_NO_EXCEPTIONS
+// Attempt to discover whether we're being compiled with exception support
+#if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
+#define TCB_SPAN_NO_EXCEPTIONS
+#endif
+#endif
+
+#ifndef TCB_SPAN_NO_EXCEPTIONS
+#include <cstdio>
+#include <stdexcept>
+#endif
+
+// Various feature test macros
+
+#ifndef TCB_SPAN_NAMESPACE_NAME
+#define TCB_SPAN_NAMESPACE_NAME tcb
+#endif
+
+#ifdef TCB_SPAN_STD_COMPLIANT_MODE
+#define TCB_SPAN_NO_DEPRECATION_WARNINGS
+#endif
+
+#ifndef TCB_SPAN_NO_DEPRECATION_WARNINGS
+#define TCB_SPAN_DEPRECATED_FOR(msg) [[deprecated(msg)]]
+#else
+#define TCB_SPAN_DEPRECATED_FOR(msg)
+#endif
+
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#define TCB_SPAN_HAVE_CPP17
+#endif
+
+#if __cplusplus >= 201402L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
+#define TCB_SPAN_HAVE_CPP14
+#endif
+
+namespace TCB_SPAN_NAMESPACE_NAME {
+
+// Establish default contract checking behavior
+#if !defined(TCB_SPAN_THROW_ON_CONTRACT_VIOLATION) &&                          \
+    !defined(TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION) &&                      \
+    !defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#if defined(NDEBUG) || !defined(TCB_SPAN_HAVE_CPP14)
+#define TCB_SPAN_NO_CONTRACT_CHECKING
+#else
+#define TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION
+#endif
+#endif
+
+#if defined(TCB_SPAN_THROW_ON_CONTRACT_VIOLATION)
+struct contract_violation_error : std::logic_error {
+    explicit contract_violation_error(const char* msg) : std::logic_error(msg)
+    {}
+};
+
+inline void contract_violation(const char* msg)
+{
+    throw contract_violation_error(msg);
+}
+
+#elif defined(TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION)
+[[noreturn]] inline void contract_violation(const char* /*unused*/)
+{
+    std::terminate();
+}
+#endif
+
+#if !defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#define TCB_SPAN_STRINGIFY(cond) #cond
+#define TCB_SPAN_EXPECT(cond)                                                  \
+    cond ? (void) 0 : contract_violation("Expected " TCB_SPAN_STRINGIFY(cond))
+#else
+#define TCB_SPAN_EXPECT(cond)
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_inline_variables)
+#define TCB_SPAN_INLINE_VAR inline
+#else
+#define TCB_SPAN_INLINE_VAR
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14) ||                                                 \
+    (defined(__cpp_constexpr) && __cpp_constexpr >= 201304)
+#define TCB_SPAN_CONSTEXPR14 constexpr
+#else
+#define TCB_SPAN_CONSTEXPR14
+#endif
+
+#if defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#define TCB_SPAN_CONSTEXPR11 constexpr
+#else
+#define TCB_SPAN_CONSTEXPR11 TCB_SPAN_CONSTEXPR14
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_deduction_guides)
+#define TCB_SPAN_HAVE_DEDUCTION_GUIDES
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_byte)
+#define TCB_SPAN_HAVE_STD_BYTE
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_array_constexpr)
+#define TCB_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC
+#endif
+
+#if defined(TCB_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC)
+#define TCB_SPAN_ARRAY_CONSTEXPR constexpr
+#else
+#define TCB_SPAN_ARRAY_CONSTEXPR
+#endif
+
+#ifdef TCB_SPAN_HAVE_STD_BYTE
+using byte = std::byte;
+#else
+using byte = unsigned char;
+#endif
+
+TCB_SPAN_INLINE_VAR constexpr std::ptrdiff_t dynamic_extent = -1;
+
+template <typename ElementType, std::ptrdiff_t Extent = dynamic_extent>
+class span;
+
+namespace detail {
+
+template <typename E, std::ptrdiff_t S>
+struct span_storage {
+    constexpr span_storage() noexcept = default;
+
+    constexpr span_storage(E* ptr, std::ptrdiff_t /*unused*/) noexcept
+        : ptr(ptr)
+    {}
+
+    E* ptr = nullptr;
+    static constexpr std::ptrdiff_t size = S;
+};
+
+template <typename E>
+struct span_storage<E, dynamic_extent> {
+    constexpr span_storage() noexcept = default;
+
+    constexpr span_storage(E* ptr, std::size_t size) noexcept
+        : ptr(ptr), size(size)
+    {}
+
+    E* ptr = nullptr;
+    std::size_t size = 0;
+};
+
+// Reimplementation of C++17 std::size() and std::data()
+#if defined(TCB_SPAN_HAVE_CPP17) ||                                            \
+    defined(__cpp_lib_nonmember_container_access)
+using std::data;
+using std::size;
+#else
+template <class C>
+constexpr auto size(const C& c) -> decltype(c.size())
+{
+    return c.size();
+}
+
+template <class T, std::size_t N>
+constexpr std::size_t size(const T (&)[N]) noexcept
+{
+    return N;
+}
+
+template <class C>
+constexpr auto data(C& c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class C>
+constexpr auto data(const C& c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class T, std::size_t N>
+constexpr T* data(T (&array)[N]) noexcept
+{
+    return array;
+}
+
+template <class E>
+constexpr const E* data(std::initializer_list<E> il) noexcept
+{
+    return il.begin();
+}
+#endif // TCB_SPAN_HAVE_CPP17
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_void_t)
+using std::void_t;
+#else
+template <typename...>
+using void_t = void;
+#endif
+
+template <typename T>
+using uncvref_t =
+    typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+
+template <typename>
+struct is_span : std::false_type {};
+
+template <typename T, std::ptrdiff_t S>
+struct is_span<span<T, S>> : std::true_type {};
+
+template <typename>
+struct is_std_array : std::false_type {};
+
+template <typename T, std::size_t N>
+struct is_std_array<std::array<T, N>> : std::true_type {};
+
+template <typename, typename = void>
+struct has_size_and_data : std::false_type {};
+
+template <typename T>
+struct has_size_and_data<T, void_t<decltype(detail::size(std::declval<T>())),
+                                   decltype(detail::data(std::declval<T>()))>>
+    : std::true_type {};
+
+template <typename C, typename U = uncvref_t<C>>
+struct is_container {
+    static constexpr bool value =
+        !is_span<U>::value && !is_std_array<U>::value &&
+        !std::is_array<U>::value && has_size_and_data<C>::value;
+};
+
+template <typename T>
+using remove_pointer_t = typename std::remove_pointer<T>::type;
+
+template <typename, typename, typename = void>
+struct is_container_element_type_compatible : std::false_type {};
+
+template <typename T, typename E>
+struct is_container_element_type_compatible<
+    T, E, void_t<decltype(detail::data(std::declval<T>()))>>
+    : std::is_convertible<
+          remove_pointer_t<decltype(detail::data(std::declval<T>()))> (*)[],
+          E (*)[]> {};
+
+template <typename, typename = size_t>
+struct is_complete : std::false_type {};
+
+template <typename T>
+struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
+
+} // namespace detail
+
+template <typename ElementType, std::ptrdiff_t Extent>
+class span {
+    static_assert(Extent == dynamic_extent || Extent >= 0,
+                  "A span must have an extent greater than or equal to zero, "
+                  "or a dynamic extent");
+    static_assert(std::is_object<ElementType>::value,
+                  "A span's ElementType must be an object type (not a "
+                  "reference type or void)");
+    static_assert(detail::is_complete<ElementType>::value,
+                  "A span's ElementType must be a complete type (not a forward "
+                  "declaration)");
+    static_assert(!std::is_abstract<ElementType>::value,
+                  "A span's ElementType cannot be an abstract class type");
+
+    using storage_type = detail::span_storage<ElementType, Extent>;
+
+public:
+    // constants and types
+    using element_type = ElementType;
+    using value_type = typename std::remove_cv<ElementType>::type;
+    using index_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = ElementType*;
+    using reference = ElementType&;
+    using iterator = pointer;
+    using const_iterator = const ElementType*;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    static constexpr index_type extent = static_cast<index_type>(Extent);
+
+    // [span.cons], span constructors, copy, assignment, and destructor
+    template <std::ptrdiff_t E = Extent,
+              typename std::enable_if<E <= 0, int>::type = 0>
+    constexpr span() noexcept
+    {}
+
+    TCB_SPAN_CONSTEXPR11 span(pointer ptr, index_type count)
+        : storage_(ptr, count)
+    {
+        TCB_SPAN_EXPECT(extent == dynamic_extent || count == extent);
+    }
+
+    TCB_SPAN_CONSTEXPR11 span(pointer first_elem, pointer last_elem)
+        : storage_(first_elem, last_elem - first_elem)
+    {
+        TCB_SPAN_EXPECT(extent == dynamic_extent ||
+                        last_elem - first_elem == extent);
+    }
+
+    template <
+        std::size_t N, std::ptrdiff_t E = Extent,
+        typename std::enable_if<
+            (E == dynamic_extent || static_cast<std::ptrdiff_t>(N) == E) &&
+                detail::is_container_element_type_compatible<
+                    element_type (&)[N], ElementType>::value,
+            int>::type = 0>
+    constexpr span(element_type (&arr)[N]) noexcept : storage_(arr, N)
+    {}
+
+    template <
+        std::size_t N, std::ptrdiff_t E = Extent,
+        typename std::enable_if<
+            (E == dynamic_extent || static_cast<std::ptrdiff_t>(N) == E) &&
+                detail::is_container_element_type_compatible<
+                    std::array<value_type, N>&, ElementType>::value,
+            int>::type = 0>
+    TCB_SPAN_ARRAY_CONSTEXPR span(std::array<value_type, N>& arr) noexcept
+        : storage_(arr.data(), N)
+    {}
+
+    template <
+        std::size_t N, std::ptrdiff_t E = Extent,
+        typename std::enable_if<
+            (E == dynamic_extent || static_cast<std::ptrdiff_t>(N) == E) &&
+                detail::is_container_element_type_compatible<
+                    const std::array<value_type, N>&, ElementType>::value,
+            int>::type = 0>
+    TCB_SPAN_ARRAY_CONSTEXPR span(const std::array<value_type, N>& arr) noexcept
+        : storage_(arr.data(), N)
+    {}
+
+    template <typename Container,
+              typename std::enable_if<
+                  detail::is_container<Container>::value &&
+                      detail::is_container_element_type_compatible<
+                          Container&, ElementType>::value,
+                  int>::type = 0>
+    TCB_SPAN_CONSTEXPR11 span(Container& cont)
+        : storage_(detail::data(cont), detail::size(cont))
+    {
+        TCB_SPAN_EXPECT(extent == dynamic_extent ||
+                        static_cast<std::ptrdiff_t>(detail::size(cont)) ==
+                            extent);
+    }
+
+    template <typename Container,
+              typename std::enable_if<
+                  detail::is_container<Container>::value &&
+                      detail::is_container_element_type_compatible<
+                          const Container&, ElementType>::value,
+                  int>::type = 0>
+    TCB_SPAN_CONSTEXPR11 span(const Container& cont)
+        : storage_(detail::data(cont), detail::size(cont))
+    {
+        TCB_SPAN_EXPECT(extent == dynamic_extent ||
+                        static_cast<std::ptrdiff_t>(detail::size(cont)) ==
+                            extent);
+    }
+
+    constexpr span(const span& other) noexcept = default;
+
+    template <typename OtherElementType, std::ptrdiff_t OtherExtent,
+              typename std::enable_if<
+                  (Extent == OtherExtent || Extent == dynamic_extent) &&
+                      std::is_convertible<OtherElementType (*)[],
+                                          ElementType (*)[]>::value,
+                  int>::type = 0>
+    constexpr span(const span<OtherElementType, OtherExtent>& other) noexcept
+        : storage_(other.data(), other.size())
+    {}
+
+    ~span() noexcept = default;
+
+    span& operator=(const span& other) noexcept = default;
+
+    // [span.sub], span subviews
+    template <std::ptrdiff_t Count>
+    TCB_SPAN_CONSTEXPR11 span<element_type, Count> first() const
+    {
+        TCB_SPAN_EXPECT(Count >= 0 && Count <= size());
+        return {data(), Count};
+    }
+
+    template <std::ptrdiff_t Count>
+    TCB_SPAN_CONSTEXPR11 span<element_type, Count> last() const
+    {
+        TCB_SPAN_EXPECT(Count >= 0 && Count <= size());
+        return {data() + (size() - Count), Count};
+    }
+
+    template <std::ptrdiff_t Offset, std::ptrdiff_t Count = dynamic_extent>
+    using subspan_return_t =
+        span<ElementType, Count != dynamic_extent
+                              ? Count
+                              : (Extent != dynamic_extent ? Extent - Offset
+                                                          : dynamic_extent)>;
+
+    template <std::ptrdiff_t Offset, std::ptrdiff_t Count = dynamic_extent>
+    TCB_SPAN_CONSTEXPR11 subspan_return_t<Offset, Count> subspan() const
+    {
+        TCB_SPAN_EXPECT((Offset >= 0 && Offset <= size()) &&
+                        (Count == dynamic_extent ||
+                         (Count >= 0 && Offset + Count <= size())));
+        return {data() + Offset,
+                Count != dynamic_extent
+                    ? Count
+                    : (Extent != dynamic_extent ? Extent - Offset
+                                                : size() - Offset)};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    first(index_type count) const
+    {
+        TCB_SPAN_EXPECT(count >= 0 && count <= size());
+        return {data(), count};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    last(index_type count) const
+    {
+        TCB_SPAN_EXPECT(count >= 0 && count <= size());
+        return {data() + (size() - count), count};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    subspan(index_type offset, index_type count = static_cast<index_type>(dynamic_extent)) const
+    {
+        TCB_SPAN_EXPECT((offset >= 0 && offset <= size()) &&
+                        (count == dynamic_extent ||
+                         (count >= 0 && offset + count <= size())));
+        return {data() + offset,
+                count == dynamic_extent ? size() - offset : count};
+    }
+
+    // [span.obs], span observers
+    constexpr index_type size() const noexcept { return storage_.size; }
+
+    constexpr index_type size_bytes() const noexcept
+    {
+        return size() * sizeof(element_type);
+    }
+
+    constexpr bool empty() const noexcept { return size() == 0; }
+
+    // [span.elem], span element access
+    TCB_SPAN_CONSTEXPR11 reference operator[](index_type idx) const
+    {
+        TCB_SPAN_EXPECT(idx >= 0 && idx < size());
+        return *(data() + idx);
+    }
+
+    /* Extension: not in P0122 */
+#ifndef TCB_SPAN_STD_COMPLIANT_MODE
+    TCB_SPAN_CONSTEXPR14 reference at(index_type idx) const
+    {
+#ifndef TCB_SPAN_NO_EXCEPTIONS
+        if (idx < 0 || idx >= size()) {
+            char msgbuf[64] = {
+                0,
+            };
+            std::snprintf(msgbuf, sizeof(msgbuf),
+                          "Index %td is out of range for span of size %td", idx,
+                          size());
+            throw std::out_of_range{msgbuf};
+        }
+#endif // TCB_SPAN_NO_EXCEPTIONS
+        return this->operator[](idx);
+    }
+
+    TCB_SPAN_CONSTEXPR11 reference front() const
+    {
+        TCB_SPAN_EXPECT(!empty());
+        return *data();
+    }
+
+    TCB_SPAN_CONSTEXPR11 reference back() const
+    {
+        TCB_SPAN_EXPECT(!empty());
+        return *(data() + (size() - 1));
+    }
+
+#endif // TCB_SPAN_STD_COMPLIANT_MODE
+
+#ifndef TCB_SPAN_NO_FUNCTION_CALL_OPERATOR
+    TCB_SPAN_DEPRECATED_FOR("Use operator[] instead")
+    constexpr reference operator()(index_type idx) const
+    {
+        return this->operator[](idx);
+    }
+#endif // TCB_SPAN_NO_FUNCTION_CALL_OPERATOR
+
+    constexpr pointer data() const noexcept { return storage_.ptr; }
+
+    // [span.iterators], span iterator support
+    constexpr iterator begin() const noexcept { return data(); }
+
+    constexpr iterator end() const noexcept { return data() + size(); }
+
+    constexpr const_iterator cbegin() const noexcept { return begin(); }
+
+    constexpr const_iterator cend() const noexcept { return end(); }
+
+    TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rbegin() const noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rend() const noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    TCB_SPAN_ARRAY_CONSTEXPR const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(cend());
+    }
+
+    TCB_SPAN_ARRAY_CONSTEXPR const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(cbegin());
+    }
+
+private:
+    storage_type storage_{};
+};
+
+#ifdef TCB_SPAN_HAVE_DEDUCTION_GUIDES
+
+/* Deduction Guides */
+template <class T, size_t N>
+span(T (&)[N])->span<T, N>;
+
+template <class T, size_t N>
+span(std::array<T, N>&)->span<T, N>;
+
+template <class T, size_t N>
+span(const std::array<T, N>&)->span<const T, N>;
+
+template <class Container>
+span(Container&)->span<typename Container::value_type>;
+
+template <class Container>
+span(const Container&)->span<const typename Container::value_type>;
+
+#endif // TCB_HAVE_DEDUCTION_GUIDES
+
+template <typename ElementType, std::ptrdiff_t Extent>
+constexpr span<ElementType, Extent>
+make_span(span<ElementType, Extent> s) noexcept
+{
+    return s;
+}
+
+#define AS_SIGNED(N) static_cast<std::ptrdiff_t>(N)
+
+template <typename T, std::size_t N>
+constexpr span<T, AS_SIGNED(N)> make_span(T (&arr)[N]) noexcept
+{
+    return {arr};
+}
+
+template <typename T, std::size_t N>
+TCB_SPAN_ARRAY_CONSTEXPR span<T, AS_SIGNED(N)> make_span(std::array<T, N>& arr) noexcept
+{
+    return {arr};
+}
+
+template <typename T, std::size_t N>
+TCB_SPAN_ARRAY_CONSTEXPR span<const T, AS_SIGNED(N)>
+make_span(const std::array<T, N>& arr) noexcept
+{
+    return {arr};
+}
+
+#undef AS_SIGNED
+
+template <typename Container>
+constexpr span<typename Container::value_type> make_span(Container& cont)
+{
+    return {cont};
+}
+
+template <typename Container>
+constexpr span<const typename Container::value_type>
+make_span(const Container& cont)
+{
+    return {cont};
+}
+
+/* Comparison operators */
+// Implementation note: the implementations of == and < are equivalent to
+// 4-legged std::equal and std::lexicographical_compare respectively
+
+template <typename T, std::ptrdiff_t X, typename U, std::ptrdiff_t Y>
+TCB_SPAN_CONSTEXPR14 bool operator==(span<T, X> lhs, span<U, Y> rhs)
+{
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+
+    for (std::ptrdiff_t i = 0; i < lhs.size(); i++) {
+        if (lhs[i] != rhs[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+template <typename T, std::ptrdiff_t X, typename U, std::ptrdiff_t Y>
+TCB_SPAN_CONSTEXPR14 bool operator!=(span<T, X> lhs, span<U, Y> rhs)
+{
+    return !(lhs == rhs);
+}
+
+template <typename T, std::ptrdiff_t X, typename U, std::ptrdiff_t Y>
+TCB_SPAN_CONSTEXPR14 bool operator<(span<T, X> lhs, span<U, Y> rhs)
+{
+    // No std::min to avoid dragging in <algorithm>
+    const std::ptrdiff_t size =
+        lhs.size() < rhs.size() ? lhs.size() : rhs.size();
+
+    for (std::ptrdiff_t i = 0; i < size; i++) {
+        if (lhs[i] < rhs[i]) {
+            return true;
+        }
+        if (lhs[i] > rhs[i]) {
+            return false;
+        }
+    }
+    return lhs.size() < rhs.size();
+}
+
+template <typename T, std::ptrdiff_t X, typename U, std::ptrdiff_t Y>
+TCB_SPAN_CONSTEXPR14 bool operator<=(span<T, X> lhs, span<U, Y> rhs)
+{
+    return !(rhs < lhs);
+}
+
+template <typename T, std::ptrdiff_t X, typename U, std::ptrdiff_t Y>
+TCB_SPAN_CONSTEXPR14 bool operator>(span<T, X> lhs, span<U, Y> rhs)
+{
+    return rhs < lhs;
+}
+
+template <typename T, std::ptrdiff_t X, typename U, std::ptrdiff_t Y>
+TCB_SPAN_CONSTEXPR14 bool operator>=(span<T, X> lhs, span<U, Y> rhs)
+{
+    return !(lhs < rhs);
+}
+
+template <typename ElementType, std::ptrdiff_t Extent>
+span<const byte, ((Extent == dynamic_extent)
+                      ? dynamic_extent
+                      : (static_cast<ptrdiff_t>(sizeof(ElementType)) * Extent))>
+as_bytes(span<ElementType, Extent> s) noexcept
+{
+    return {reinterpret_cast<const byte*>(s.data()), s.size_bytes()};
+}
+
+template <
+    class ElementType, ptrdiff_t Extent,
+    typename std::enable_if<!std::is_const<ElementType>::value, int>::type = 0>
+span<byte, ((Extent == dynamic_extent)
+                ? dynamic_extent
+                : (static_cast<ptrdiff_t>(sizeof(ElementType)) * Extent))>
+as_writable_bytes(span<ElementType, Extent> s) noexcept
+{
+    return {reinterpret_cast<byte*>(s.data()), s.size_bytes()};
+}
+
+/* Extension: nonmember subview operations */
+
+#ifndef TCB_SPAN_STD_COMPLIANT_MODE
+
+template <std::ptrdiff_t Count, typename T>
+TCB_SPAN_CONSTEXPR11 auto first(T& t)
+    -> decltype(make_span(t).template first<Count>())
+{
+    return make_span(t).template first<Count>();
+}
+
+template <std::ptrdiff_t Count, typename T>
+TCB_SPAN_CONSTEXPR11 auto last(T& t)
+    -> decltype(make_span(t).template last<Count>())
+{
+    return make_span(t).template last<Count>();
+}
+
+template <std::ptrdiff_t Offset, std::ptrdiff_t Count = dynamic_extent,
+          typename T>
+TCB_SPAN_CONSTEXPR11 auto subspan(T& t)
+    -> decltype(make_span(t).template subspan<Offset, Count>())
+{
+    return make_span(t).template subspan<Offset, Count>();
+}
+
+template <typename T>
+TCB_SPAN_CONSTEXPR11 auto first(T& t, std::ptrdiff_t count)
+    -> decltype(make_span(t).first(count))
+{
+    return make_span(t).first(count);
+}
+
+template <typename T>
+TCB_SPAN_CONSTEXPR11 auto last(T& t, std::ptrdiff_t count)
+    -> decltype(make_span(t).last(count))
+{
+    return make_span(t).last(count);
+}
+
+template <typename T>
+TCB_SPAN_CONSTEXPR11 auto subspan(T& t, std::ptrdiff_t offset,
+                                  std::ptrdiff_t count = dynamic_extent)
+    -> decltype(make_span(t).subspan(offset, count))
+{
+    return make_span(t).subspan(offset, count);
+}
+
+#endif // TCB_SPAN_STD_COMPLIANT_MODE
+
+} // namespace TCB_SPAN_NAMESPACE_NAME
+
+/* Extension: support for C++17 structured bindings */
+
+#ifndef TCB_SPAN_STD_COMPLIANT_MODE
+
+namespace TCB_SPAN_NAMESPACE_NAME {
+
+template <std::ptrdiff_t N, typename E, std::ptrdiff_t S>
+constexpr auto get(span<E, S> s) -> decltype(s[N])
+{
+    return s[N];
+}
+
+} // namespace TCB_SPAN_NAMESPACE_NAME
+
+namespace std {
+
+template <typename E, ptrdiff_t S>
+class tuple_size<tcb::span<E, S>> : public integral_constant<size_t, static_cast<size_t>(S)> {};
+
+template <typename E>
+class tuple_size<tcb::span<E, tcb::dynamic_extent>>; // not defined
+
+template <size_t N, typename E, ptrdiff_t S>
+class tuple_element<N, tcb::span<E, S>> {
+public:
+    using type = E;
+};
+
+} // end namespace std
+
+#endif // TCB_SPAN_STD_COMPLIANT_MODE
+
+#endif // TCB_SPAN_HPP_INCLUDED

--- a/vendor/xtl/include/xtl/xtl_config.hpp
+++ b/vendor/xtl/include/xtl/xtl_config.hpp
@@ -10,7 +10,19 @@
 #define XTL_CONFIG_HPP
 
 #define XTL_VERSION_MAJOR 0
-#define XTL_VERSION_MINOR 4
-#define XTL_VERSION_PATCH 12
+#define XTL_VERSION_MINOR 6
+#define XTL_VERSION_PATCH 7
+
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
+// Attempt to discover whether we're being compiled with exception support
+#if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)) && !defined(XTL_NO_EXCEPTIONS)
+// Exceptions are enabled.
+#else
+// Exceptions are disabled.
+#define XTL_NO_EXCEPTIONS
+#endif
 
 #endif

--- a/vendor/xtl/include/xtl/xtype_traits.hpp
+++ b/vendor/xtl/include/xtl/xtype_traits.hpp
@@ -9,12 +9,189 @@
 #ifndef XTL_TYPE_TRAITS_HPP
 #define XTL_TYPE_TRAITS_HPP
 
+#include <complex>
+#include <chrono>
 #include <type_traits>
 
 #include "xtl_config.hpp"
 
 namespace xtl
 {
+    /************************************
+     * arithmetic type promotion traits *
+     ************************************/
+
+    /**
+     * Traits class for the result type of mixed arithmetic expressions.
+     * For example, <tt>promote_type<unsigned char, unsigned char>::type</tt> tells
+     * the user that <tt>unsigned char + unsigned char => int</tt>.
+     */
+    template <class... T>
+    struct promote_type;
+
+    template <>
+    struct promote_type<>
+    {
+        using type = void;
+    };
+
+    template <class T>
+    struct promote_type<T>
+    {
+        using type = typename promote_type<T, T>::type;
+    };
+
+    template <class C, class D1, class D2>
+    struct promote_type<std::chrono::time_point<C, D1>, std::chrono::time_point<C, D2>>
+    {
+        using type = std::chrono::time_point<C, typename promote_type<D1, D2>::type>;
+    };
+
+    template <class T0, class T1>
+    struct promote_type<T0, T1>
+    {
+        using type = decltype(std::declval<std::decay_t<T0>>() + std::declval<std::decay_t<T1>>());
+    };
+
+    template <class T0, class... REST>
+    struct promote_type<T0, REST...>
+    {
+        using type = decltype(std::declval<std::decay_t<T0>>() + std::declval<typename promote_type<REST...>::type>());
+    };
+
+    template <>
+    struct promote_type<bool>
+    {
+        using type = bool;
+    };
+
+    template <class T>
+    struct promote_type<bool, T>
+    {
+        using type = T;
+    };
+
+    template <class T>
+    struct promote_type<bool, std::complex<T>>
+    {
+        using type = std::complex<T>;
+    };
+
+    template <class T1, class T2>
+    struct promote_type<T1, std::complex<T2>>
+    {
+        using type = std::complex<typename promote_type<T1, T2>::type>;
+    };
+
+    template <class T1, class T2>
+    struct promote_type<std::complex<T1>, T2>
+        : promote_type<T2, std::complex<T1>>
+    {
+    };
+
+    template <class T>
+    struct promote_type<std::complex<T>, std::complex<T>>
+    {
+        using type = std::complex<T>;
+    };
+
+    template <class... REST>
+    struct promote_type<bool, REST...>
+    {
+        using type = typename promote_type<bool, typename promote_type<REST...>::type>::type;
+    };
+
+    /**
+     * Abbreviation of 'typename promote_type<T>::type'.
+     */
+    template <class... T>
+    using promote_type_t = typename promote_type<T...>::type;
+
+    /**
+     * Traits class to find the biggest type of the same kind.
+     *
+     * For example, <tt>big_promote_type<unsigned char>::type</tt> is <tt>unsigned long long</tt>.
+     * The default implementation only supports built-in types and <tt>std::complex</tt>. All
+     * other types remain unchanged unless <tt>big_promote_type</tt> gets specialized for them.
+     */
+    template <class T>
+    struct big_promote_type
+    {
+    private:
+
+        using V = std::decay_t<T>;
+        static constexpr bool is_arithmetic = std::is_arithmetic<V>::value;
+        static constexpr bool is_signed = std::is_signed<V>::value;
+        static constexpr bool is_integral = std::is_integral<V>::value;
+        static constexpr bool is_long_double = std::is_same<V, long double>::value;
+
+    public:
+
+        using type = std::conditional_t<is_arithmetic,
+                        std::conditional_t<is_integral,
+                            std::conditional_t<is_signed, long long, unsigned long long>,
+                            std::conditional_t<is_long_double, long double, double>
+                        >,
+                        V
+                     >;
+    };
+
+    template <class T>
+    struct big_promote_type<std::complex<T>>
+    {
+        using type = std::complex<typename big_promote_type<T>::type>;
+    };
+
+    /**
+     * Abbreviation of 'typename big_promote_type<T>::type'.
+     */
+    template <class T>
+    using big_promote_type_t = typename big_promote_type<T>::type;
+
+    namespace traits_detail
+    {
+        using std::sqrt;
+
+        template <class T>
+        using real_promote_type_t = decltype(sqrt(std::declval<std::decay_t<T>>()));
+    }
+
+    /**
+     * Result type of algebraic expressions.
+     *
+     * For example, <tt>real_promote_type<int>::type</tt> tells the
+     * user that <tt>sqrt(int) => double</tt>.
+     */
+    template <class T>
+    struct real_promote_type
+    {
+        using type = traits_detail::real_promote_type_t<T>;
+    };
+
+    /**
+     * Abbreviation of 'typename real_promote_type<T>::type'.
+     */
+    template <class T>
+    using real_promote_type_t = typename real_promote_type<T>::type;
+
+    /**
+     * Traits class to replace 'bool' with 'uint8_t' and keep everything else.
+     *
+     * This is useful for scientific computing, where a boolean mask array is
+     * usually implemented as an array of bytes.
+     */
+    template <class T>
+    struct bool_promote_type
+    {
+        using type = typename std::conditional<std::is_same<T, bool>::value, uint8_t, T>::type;
+    };
+
+    /**
+     * Abbreviation for typename bool_promote_type<T>::type
+     */
+    template <class T>
+    using bool_promote_type_t = typename bool_promote_type<T>::type;
+
     /************
      * apply_cv *
      ************/
@@ -129,13 +306,112 @@ namespace xtl
     };
 
     /******************
-     * negation - and *
+     * negation - not *
      ******************/
 
     template <class Arg>
     struct negation : std::integral_constant<bool, !Arg::value>
     {
     };
+
+    /************
+     * concepts *
+     ************/
+
+#if !defined(__GNUC__) || (defined(__GNUC__) && (__GNUC__ >= 5))
+
+    template <class... C>
+    constexpr bool requires = conjunction<C...>::value;
+
+    template <class... C>
+    constexpr bool either = disjunction<C...>::value;
+
+    template <class... C>
+    constexpr bool disallow = xtl::negation<xtl::conjunction<C...>>::value;
+
+    template <class... C>
+    constexpr bool disallow_one = xtl::negation<xtl::disjunction<C...>>::value;
+
+    template <class... C>
+    using check_requires = std::enable_if_t<requires<C...>, int>;
+
+    template <class... C>
+    using check_either = std::enable_if_t<either<C...>, int>;
+
+    template <class... C>
+    using check_disallow = std::enable_if_t<disallow<C...>, int>;
+
+    template <class... C>
+    using check_disallow_one = std::enable_if_t<disallow_one<C...>, int>;
+
+#else
+
+    template <class... C>
+    using check_requires = std::enable_if_t<conjunction<C...>::value, int>;
+
+    template <class... C>
+    using check_either = std::enable_if_t<disjunction<C...>::value, int>;
+
+    template <class... C>
+    using check_disallow = std::enable_if_t<xtl::negation<xtl::conjunction<C...>>::value, int>;
+
+    template <class... C>
+    using check_disallow_one = std::enable_if_t<xtl::negation<xtl::disjunction<C...>>::value, int>;
+
+#endif
+
+#define XTL_REQUIRES_IMPL(...) xtl::check_requires<__VA_ARGS__>
+#define XTL_REQUIRES(...) XTL_REQUIRES_IMPL(__VA_ARGS__) = 0
+
+#define XTL_EITHER_IMPL(...) xtl::check_either<__VA_ARGS__>
+#define XTL_EITHER(...) XTL_EITHER_IMPL(__VA_ARGS__) = 0
+
+#define XTL_DISALLOW_IMPL(...) xtl::check_disallow<__VA_ARGS__>
+#define XTL_DISALLOW(...) XTL_DISALLOW_IMPL(__VA_ARGS__) = 0
+
+#define XTL_DISALLOW_ONE_IMPL(...) xtl::check_disallow_one<__VA_ARGS__>
+#define XTL_DISALLOW_ONE(...) XTL_DISALLOW_ONE_IMPL(__VA_ARGS__) = 0
+
+    // For backward compatibility
+    template <class... C>
+    using check_concept = check_requires<C...>;
+
+    /**************
+     * all_scalar *
+     **************/
+
+    template <class... Args>
+    struct all_scalar : conjunction<std::is_scalar<Args>...>
+    {
+    };
+
+    /************
+     * constify *
+     ************/
+
+    // Adds const to the underlying type of a reference or pointer, or to the type itself
+    // if it's not a reference nor a pointer
+
+    template <class T>
+    struct constify
+    {
+        using type = std::add_const_t<T>;
+    };
+
+    template <class T>
+    struct constify<T*>
+    {
+        using type = std::add_const_t<T>*;
+    };
+
+    template <class T>
+    struct constify<T&>
+    {
+        using type = std::add_const_t<T>&;
+    };
+
+    template <class T>
+    using constify_t = typename constify<T>::type;
 }
 
 #endif

--- a/vendor/xtl/include/xtl/xvariant.hpp
+++ b/vendor/xtl/include/xtl/xvariant.hpp
@@ -9,15 +9,9 @@
 #ifndef XTL_XVARIANT_HPP
 #define XTL_XVARIANT_HPP
 
-#ifndef __cpp_exceptions
-    #define __cpp_exceptions
-    #include "xvariant_impl.hpp"
-    #undef __cpp_exceptions
-#else
-    #include "xvariant_impl.hpp"
-#endif
-
+#include "xvariant_impl.hpp"
 #include "xclosure.hpp"
+#include "xmeta_utils.hpp"
 
 namespace xtl
 {
@@ -43,25 +37,25 @@ namespace xtl
         struct xgetter
         {
             template <class... Ts>
-            static inline constexpr T& get(xtl::variant<Ts...>& v)
+            static constexpr T& get(xtl::variant<Ts...>& v)
             {
                 return xtl::get<T>(v);
             }
 
             template <class... Ts>
-            static inline constexpr T&& get(xtl::variant<Ts...>&& v)
+            static constexpr T&& get(xtl::variant<Ts...>&& v)
             {
                 return xtl::get<T>(std::move(v));
             }
 
             template <class... Ts>
-            static inline constexpr const T& get(const xtl::variant<Ts...>& v)
+            static constexpr const T& get(const xtl::variant<Ts...>& v)
             {
                 return xtl::get<T>(v);
             }
 
             template <class... Ts>
-            static inline constexpr const T&& get(const xtl::variant<Ts...>&& v)
+            static constexpr const T&& get(const xtl::variant<Ts...>&& v)
             {
                 return xtl::get<T>(std::move(v));
             }
@@ -71,51 +65,107 @@ namespace xtl
         struct xgetter<T&>
         {
             template <class... Ts>
-            static inline constexpr T& get(xtl::variant<Ts...>& v)
+            static constexpr T& get(xtl::variant<Ts...>& v)
             {
                 return xtl::get<xtl::xclosure_wrapper<T&>>(v).get();
             }
 
             template <class... Ts>
-            static inline constexpr T&& get(xtl::variant<Ts...>&& v)
+            static constexpr T& get(xtl::variant<Ts...>&& v)
             {
                 return xtl::get<xtl::xclosure_wrapper<T&>>(std::move(v)).get();
             }
 
             template <class... Ts>
-            static inline constexpr const T& get(const xtl::variant<Ts...>& v)
+            static constexpr const T& get(const xtl::variant<Ts...>& v)
             {
                 return xtl::get<xtl::xclosure_wrapper<T&>>(v).get();
             }
 
             template <class... Ts>
-            static inline constexpr const T&& get(const xtl::variant<Ts...>&& v)
+            static constexpr const T& get(const xtl::variant<Ts...>&& v)
             {
                 return xtl::get<xtl::xclosure_wrapper<T&>>(std::move(v)).get();
+            }
+        };
+
+        template <class T>
+        struct xgetter<const T&>
+        {
+            template <class... Ts>
+            static constexpr const T& get(const xtl::variant<Ts...>& v)
+            {
+                using cl_type = xtl::xclosure_wrapper<const T&>;
+                return get_impl(v, xtl::mpl::contains<xtl::mpl::vector<Ts...>, cl_type>());
+            }
+
+            template <class... Ts>
+            static constexpr const T& get(const xtl::variant<Ts...>&& v)
+            {
+                using cl_type = xtl::xclosure_wrapper<const T&>;
+                return get_impl(std::move(v), xtl::mpl::contains<xtl::mpl::vector<Ts...>, cl_type>());
+            }
+
+            template <class... Ts>
+            static constexpr const T& get(xtl::variant<Ts...>& v)
+            {
+                return get(static_cast<const xtl::variant<Ts...>&>(v));
+            }
+
+            template <class... Ts>
+            static constexpr const T& get(xtl::variant<Ts...>&& v)
+            {
+                return get(static_cast<const xtl::variant<Ts...>&&>(v));
+            }
+
+        private:
+
+            template <class... Ts>
+            static constexpr const T& get_impl(const xtl::variant<Ts...>& v, xtl::mpl::bool_<true>)
+            {
+                return xtl::get<xtl::xclosure_wrapper<const T&>>(v).get();
+            }
+
+            template <class... Ts>
+            static constexpr const T& get_impl(const xtl::variant<Ts...>& v, xtl::mpl::bool_<false>)
+            {
+                return static_cast<const xtl::xclosure_wrapper<T&>&>(xtl::get<xtl::xclosure_wrapper<T&>>(v)).get();
+            }
+
+            template <class... Ts>
+            static constexpr const T& get_impl(const xtl::variant<Ts...>&& v, xtl::mpl::bool_<true>)
+            {
+                return xtl::get<xtl::closure_wrapper<const T&>>(std::move(v)).get();
+            }
+
+            template <class... Ts>
+            static constexpr const T& get_impl(const xtl::variant<Ts...>&& v, xtl::mpl::bool_<false>)
+            {
+                return static_cast<const xtl::xclosure_wrapper<T&>&&>(xtl::get<xtl::xclosure_wrapper<T&>>(std::move(v))).get();
             }
         };
     }
 
     template <class T, class... Ts>
-    inline constexpr decltype(auto) xget(xtl::variant<Ts...>& v)
+    constexpr decltype(auto) xget(xtl::variant<Ts...>& v)
     {
         return detail::xgetter<T>::get(v);
     }
 
     template <class T, class... Ts>
-    inline constexpr decltype(auto) xget(xtl::variant<Ts...>&& v)
+    constexpr decltype(auto) xget(xtl::variant<Ts...>&& v)
     {
         return detail::xgetter<T>::get(std::move(v));
     }
 
     template <class T, class... Ts>
-    inline constexpr decltype(auto) xget(const xtl::variant<Ts...>& v)
+    constexpr decltype(auto) xget(const xtl::variant<Ts...>& v)
     {
         return detail::xgetter<T>::get(v);
     }
 
     template <class T, class... Ts>
-    inline constexpr decltype(auto) xget(const xtl::variant<Ts...>&& v)
+    constexpr decltype(auto) xget(const xtl::variant<Ts...>&& v)
     {
         return detail::xgetter<T>::get(std::move(v));
     }

--- a/vendor/xtl/include/xtl/xvariant_impl.hpp
+++ b/vendor/xtl/include/xtl/xvariant_impl.hpp
@@ -217,6 +217,10 @@ namespace std {
 #error "MPark.Variant requires C++11 support."
 #endif
 
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
 #ifndef __has_builtin
 #define __has_builtin(x) 0
 #endif
@@ -229,12 +233,24 @@ namespace std {
 #define __has_feature(x) 0
 #endif
 
+#if __has_attribute(always_inline) || defined(__GNUC__)
+#define MPARK_ALWAYS_INLINE __attribute__((__always_inline__)) inline
+#elif defined(_MSC_VER)
+#define MPARK_ALWAYS_INLINE __forceinline
+#else
+#define MPARK_ALWAYS_INLINE inline
+#endif
+
 #if __has_builtin(__builtin_addressof) || \
     (defined(__GNUC__) && __GNUC__ >= 7) || defined(_MSC_VER)
 #define MPARK_BUILTIN_ADDRESSOF
 #endif
 
-#if __has_builtin(__builtin_unreachable)
+#if __has_builtin(__builtin_unreachable) || defined(__GNUC__)
+#define MPARK_BUILTIN_UNREACHABLE __builtin_unreachable()
+#elif defined(_MSC_VER)
+#define MPARK_BUILTIN_UNREACHABLE __assume(false)
+#else
 #define MPARK_BUILTIN_UNREACHABLE
 #endif
 
@@ -242,12 +258,19 @@ namespace std {
 #define MPARK_TYPE_PACK_ELEMENT
 #endif
 
+#if defined(__cpp_constexpr) && __cpp_constexpr >= 200704 && \
+    !(defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ == 9)
+#define MPARK_CPP11_CONSTEXPR
+#endif
+
 #if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
 #define MPARK_CPP14_CONSTEXPR
 #endif
 
-#if __has_feature(cxx_exceptions) || defined(__cpp_exceptions) || \
-    (defined(_MSC_VER) && defined(_CPPUNWIND))
+#if !defined(MPARK_NO_EXCEPTIONS) && \
+    (__has_feature(cxx_exceptions) || defined(__cpp_exceptions) || \
+    defined(__EXCEPTIONS) || (defined(_MSC_VER) && defined(_CPPUNWIND)))
+// Exceptions are enabled.
 #define MPARK_EXCEPTIONS
 #endif
 
@@ -273,6 +296,7 @@ namespace std {
 
 #if !defined(__GLIBCXX__) || __has_include(<codecvt>)  // >= libstdc++-5
 #define MPARK_TRIVIALITY_TYPE_TRAITS
+#define MPARK_INCOMPLETE_TYPE_TRAITS
 #endif
 
 #endif  // MPARK_CONFIG_HPP
@@ -328,10 +352,8 @@ namespace mpark {
 #include <utility>
 
 
-#define RETURN(...)                                          \
-  noexcept(noexcept(__VA_ARGS__)) -> decltype(__VA_ARGS__) { \
-    return __VA_ARGS__;                                      \
-  }
+#define MPARK_RETURN(...) \
+  noexcept(noexcept(__VA_ARGS__)) -> decltype(__VA_ARGS__) { return __VA_ARGS__; }
 
 namespace mpark {
   namespace lib {
@@ -434,7 +456,7 @@ namespace mpark {
       struct equal_to {
         template <typename Lhs, typename Rhs>
         inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          RETURN(lib::forward<Lhs>(lhs) == lib::forward<Rhs>(rhs))
+          MPARK_RETURN(lib::forward<Lhs>(lhs) == lib::forward<Rhs>(rhs))
       };
 #endif
 
@@ -444,7 +466,7 @@ namespace mpark {
       struct not_equal_to {
         template <typename Lhs, typename Rhs>
         inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          RETURN(lib::forward<Lhs>(lhs) != lib::forward<Rhs>(rhs))
+          MPARK_RETURN(lib::forward<Lhs>(lhs) != lib::forward<Rhs>(rhs))
       };
 #endif
 
@@ -454,7 +476,7 @@ namespace mpark {
       struct less {
         template <typename Lhs, typename Rhs>
         inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          RETURN(lib::forward<Lhs>(lhs) < lib::forward<Rhs>(rhs))
+          MPARK_RETURN(lib::forward<Lhs>(lhs) < lib::forward<Rhs>(rhs))
       };
 #endif
 
@@ -464,7 +486,7 @@ namespace mpark {
       struct greater {
         template <typename Lhs, typename Rhs>
         inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          RETURN(lib::forward<Lhs>(lhs) > lib::forward<Rhs>(rhs))
+          MPARK_RETURN(lib::forward<Lhs>(lhs) > lib::forward<Rhs>(rhs))
       };
 #endif
 
@@ -474,7 +496,7 @@ namespace mpark {
       struct less_equal {
         template <typename Lhs, typename Rhs>
         inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          RETURN(lib::forward<Lhs>(lhs) <= lib::forward<Rhs>(rhs))
+          MPARK_RETURN(lib::forward<Lhs>(lhs) <= lib::forward<Rhs>(rhs))
       };
 #endif
 
@@ -484,7 +506,7 @@ namespace mpark {
       struct greater_equal {
         template <typename Lhs, typename Rhs>
         inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
-          RETURN(lib::forward<Lhs>(lhs) >= lib::forward<Rhs>(rhs))
+          MPARK_RETURN(lib::forward<Lhs>(lhs) >= lib::forward<Rhs>(rhs))
       };
 #endif
     }  // namespace cpp14
@@ -521,48 +543,107 @@ namespace mpark {
             static constexpr bool value = decltype(test<T>(0))::value;
           };
 
-          template <typename T, bool = is_swappable<T>::value>
+          template <bool IsSwappable, typename T>
           struct is_nothrow_swappable {
             static constexpr bool value =
                 noexcept(swap(std::declval<T &>(), std::declval<T &>()));
           };
 
           template <typename T>
-          struct is_nothrow_swappable<T, false> : std::false_type {};
+          struct is_nothrow_swappable<false, T> : std::false_type {};
 
         }  // namespace swappable
       }  // namespace detail
 
       using detail::swappable::is_swappable;
-      using detail::swappable::is_nothrow_swappable;
+
+      template <typename T>
+      using is_nothrow_swappable =
+          detail::swappable::is_nothrow_swappable<is_swappable<T>::value, T>;
 
       // <functional>
+      namespace detail {
+
+        template <typename T>
+        struct is_reference_wrapper : std::false_type {};
+
+        template <typename T>
+        struct is_reference_wrapper<std::reference_wrapper<T>>
+            : std::true_type {};
+
+        template <bool, int>
+        struct Invoke;
+
+        template <>
+        struct Invoke<true /* pmf */, 0 /* is_base_of */> {
+          template <typename R, typename T, typename Arg, typename... Args>
+          inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
+            MPARK_RETURN((lib::forward<Arg>(arg).*pmf)(lib::forward<Args>(args)...))
+        };
+
+        template <>
+        struct Invoke<true /* pmf */, 1 /* is_reference_wrapper */> {
+          template <typename R, typename T, typename Arg, typename... Args>
+          inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
+            MPARK_RETURN((lib::forward<Arg>(arg).get().*pmf)(lib::forward<Args>(args)...))
+        };
+
+        template <>
+        struct Invoke<true /* pmf */, 2 /* otherwise */> {
+          template <typename R, typename T, typename Arg, typename... Args>
+          inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
+            MPARK_RETURN(((*lib::forward<Arg>(arg)).*pmf)(lib::forward<Args>(args)...))
+        };
+
+        template <>
+        struct Invoke<false /* pmo */, 0 /* is_base_of */> {
+          template <typename R, typename T, typename Arg>
+          inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
+            MPARK_RETURN(lib::forward<Arg>(arg).*pmo)
+        };
+
+        template <>
+        struct Invoke<false /* pmo */, 1 /* is_reference_wrapper */> {
+          template <typename R, typename T, typename Arg>
+          inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
+            MPARK_RETURN(lib::forward<Arg>(arg).get().*pmo)
+        };
+
+        template <>
+        struct Invoke<false /* pmo */, 2 /* otherwise */> {
+          template <typename R, typename T, typename Arg>
+          inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
+              MPARK_RETURN((*lib::forward<Arg>(arg)).*pmo)
+        };
+
+        template <typename R, typename T, typename Arg, typename... Args>
+        inline constexpr auto invoke(R T::*f, Arg &&arg, Args &&... args)
+          MPARK_RETURN(
+              Invoke<std::is_function<R>::value,
+                     (std::is_base_of<T, lib::decay_t<Arg>>::value
+                          ? 0
+                          : is_reference_wrapper<lib::decay_t<Arg>>::value
+                                ? 1
+                                : 2)>::invoke(f,
+                                              lib::forward<Arg>(arg),
+                                              lib::forward<Args>(args)...))
+
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4100)
 #endif
-      template <typename F, typename... As>
-      inline constexpr auto invoke(F &&f, As &&... as)
-          RETURN(lib::forward<F>(f)(lib::forward<As>(as)...))
+        template <typename F, typename... Args>
+        inline constexpr auto invoke(F &&f, Args &&... args)
+          MPARK_RETURN(lib::forward<F>(f)(lib::forward<Args>(args)...))
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
+      }  // namespace detail
 
-      template <typename B, typename T, typename D>
-      inline constexpr auto invoke(T B::*pmv, D &&d)
-          RETURN(lib::forward<D>(d).*pmv)
-
-      template <typename Pmv, typename Ptr>
-      inline constexpr auto invoke(Pmv pmv, Ptr &&ptr)
-          RETURN((*lib::forward<Ptr>(ptr)).*pmv)
-
-      template <typename B, typename T, typename D, typename... As>
-      inline constexpr auto invoke(T B::*pmf, D &&d, As &&... as)
-          RETURN((lib::forward<D>(d).*pmf)(lib::forward<As>(as)...))
-
-      template <typename Pmf, typename Ptr, typename... As>
-      inline constexpr auto invoke(Pmf pmf, Ptr &&ptr, As &&... as)
-          RETURN(((*lib::forward<Ptr>(ptr)).*pmf)(lib::forward<As>(as)...))
+      template <typename F, typename... Args>
+      inline constexpr auto invoke(F &&f, Args &&... args)
+        MPARK_RETURN(detail::invoke(lib::forward<F>(f),
+                                    lib::forward<Args>(args)...))
 
       namespace detail {
 
@@ -612,10 +693,48 @@ namespace mpark {
       template <typename R, typename F, typename... Args>
       using is_invocable_r = detail::is_invocable_r<void, R, F, Args...>;
 
+      namespace detail {
+
+        template <bool Invocable, typename F, typename... Args>
+        struct is_nothrow_invocable {
+          static constexpr bool value =
+              noexcept(lib::invoke(std::declval<F>(), std::declval<Args>()...));
+        };
+
+        template <typename F, typename... Args>
+        struct is_nothrow_invocable<false, F, Args...> : std::false_type {};
+
+        template <bool Invocable, typename R, typename F, typename... Args>
+        struct is_nothrow_invocable_r {
+          private:
+          inline static R impl() {
+            return lib::invoke(std::declval<F>(), std::declval<Args>()...);
+          }
+
+          public:
+          static constexpr bool value = noexcept(impl());
+        };
+
+        template <typename R, typename F, typename... Args>
+        struct is_nothrow_invocable_r<false, R, F, Args...> : std::false_type {};
+
+      }  // namespace detail
+
+      template <typename F, typename... Args>
+      using is_nothrow_invocable = detail::
+          is_nothrow_invocable<is_invocable<F, Args...>::value, F, Args...>;
+
+      template <typename R, typename F, typename... Args>
+      using is_nothrow_invocable_r =
+          detail::is_nothrow_invocable_r<is_invocable_r<R, F, Args...>::value,
+                                         R,
+                                         F,
+                                         Args...>;
+
       // <memory>
 #ifdef MPARK_BUILTIN_ADDRESSOF
       template <typename T>
-      inline constexpr T *addressof(T &arg) {
+      inline constexpr T *addressof(T &arg) noexcept {
         return __builtin_addressof(arg);
       }
 #else
@@ -640,19 +759,19 @@ namespace mpark {
         using has_addressof = bool_constant<has_addressof_impl::impl<T>()>;
 
         template <typename T>
-        inline constexpr T *addressof(T &arg, std::true_type) {
+        inline constexpr T *addressof(T &arg, std::true_type) noexcept {
           return std::addressof(arg);
         }
 
         template <typename T>
-        inline constexpr T *addressof(T &arg, std::false_type) {
+        inline constexpr T *addressof(T &arg, std::false_type) noexcept {
           return &arg;
         }
 
       }  // namespace detail
 
       template <typename T>
-      inline constexpr T *addressof(T &arg) {
+      inline constexpr T *addressof(T &arg) noexcept {
         return detail::addressof(arg, detail::has_addressof<T>{});
       }
 #endif
@@ -675,7 +794,7 @@ namespace mpark {
     using size_constant = std::integral_constant<std::size_t, N>;
 
     template <std::size_t I, typename T>
-    struct indexed_type : size_constant<I>, identity<T> {};
+    struct indexed_type : size_constant<I> { using type = T; };
 
     template <bool... Bs>
     using all = std::is_same<integer_sequence<bool, true, Bs...>,
@@ -750,7 +869,7 @@ namespace mpark {
   }  // namespace lib
 }  // namespace mpark
 
-#undef RETURN
+#undef MPARK_RETURN
 
 #endif  // MPARK_LIB_HPP
 
@@ -789,7 +908,7 @@ namespace mpark {
 
   class bad_variant_access : public std::exception {
     public:
-    virtual const char *what() const noexcept { return "bad_variant_access"; }
+    virtual const char *what() const noexcept override { return "bad_variant_access"; }
   };
 
   [[noreturn]] inline void throw_bad_variant_access() {
@@ -797,9 +916,7 @@ namespace mpark {
     throw bad_variant_access{};
 #else
     std::terminate();
-#ifdef MPARK_BUILTIN_UNREACHABLE
-    __builtin_unreachable();
-#endif
+    MPARK_BUILTIN_UNREACHABLE;
 #endif
   }
 
@@ -847,7 +964,7 @@ namespace mpark {
   template <std::size_t I, typename... Ts>
   struct variant_alternative<I, variant<Ts...>> {
     static_assert(I < sizeof...(Ts),
-                  "Index out of bounds in std::variant_alternative<>");
+                  "index out of bounds in `std::variant_alternative<>`");
     using type = lib::type_pack_element_t<I, Ts...>;
   };
 
@@ -930,9 +1047,11 @@ namespace mpark {
 
 #ifdef MPARK_CPP14_CONSTEXPR
     template <typename... Traits>
-    inline constexpr Trait common_trait(Traits... traits) {
+    inline constexpr Trait common_trait(Traits... traits_) {
       Trait result = Trait::TriviallyAvailable;
-      for (Trait t : {traits...}) {
+      lib::array<Trait, sizeof...(Traits)> traits = {{traits_...}};
+      for (std::size_t i = 0; i < sizeof...(Traits); ++i) {
+        Trait t = traits[i];
         if (static_cast<int>(t) > static_cast<int>(result)) {
           result = t;
         }
@@ -1024,8 +1143,13 @@ namespace mpark {
       struct base {
         template <std::size_t I, typename V>
         inline static constexpr AUTO_REFREF get_alt(V &&v)
+#ifdef _MSC_VER
+          AUTO_REFREF_RETURN(recursive_union::get_alt(
+              lib::forward<V>(v).data_, in_place_index_t<I>{}))
+#else
           AUTO_REFREF_RETURN(recursive_union::get_alt(
               data(lib::forward<V>(v)), in_place_index_t<I>{}))
+#endif
       };
 
       struct variant {
@@ -1038,106 +1162,259 @@ namespace mpark {
 
     namespace visitation {
 
+#if defined(MPARK_CPP14_CONSTEXPR) && !defined(_MSC_VER)
+#define MPARK_VARIANT_SWITCH_VISIT
+#endif
+
       struct base {
+        template <typename Visitor, typename... Vs>
+        using dispatch_result_t = decltype(
+            lib::invoke(std::declval<Visitor>(),
+                        access::base::get_alt<0>(std::declval<Vs>())...));
+
+        template <typename Expected>
+        struct expected {
+          template <typename Actual>
+          inline static constexpr bool but_got() {
+            return std::is_same<Expected, Actual>::value;
+          }
+        };
+
+        template <typename Expected, typename Actual>
+        struct visit_return_type_check {
+          static_assert(
+              expected<Expected>::template but_got<Actual>(),
+              "`visit` requires the visitor to have a single return type");
+
+          template <typename Visitor, typename... Alts>
+          inline static constexpr DECLTYPE_AUTO invoke(Visitor &&visitor,
+                                                       Alts &&... alts)
+            DECLTYPE_AUTO_RETURN(lib::invoke(lib::forward<Visitor>(visitor),
+                                             lib::forward<Alts>(alts)...))
+        };
+
+#ifdef MPARK_VARIANT_SWITCH_VISIT
+        template <bool B, typename R, typename... ITs>
+        struct dispatcher;
+
+        template <typename R, typename... ITs>
+        struct dispatcher<false, R, ITs...> {
+          template <std::size_t B, typename F, typename... Vs>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch(
+              F &&, typename ITs::type &&..., Vs &&...) {
+            MPARK_BUILTIN_UNREACHABLE;
+          }
+
+          template <std::size_t I, typename F, typename... Vs>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch_case(F &&, Vs &&...) {
+            MPARK_BUILTIN_UNREACHABLE;
+          }
+
+          template <std::size_t B, typename F, typename... Vs>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch_at(std::size_t,
+                                                             F &&,
+                                                             Vs &&...) {
+            MPARK_BUILTIN_UNREACHABLE;
+          }
+        };
+
+        template <typename R, typename... ITs>
+        struct dispatcher<true, R, ITs...> {
+          template <std::size_t B, typename F>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch(
+              F &&f, typename ITs::type &&... visited_vs) {
+            using Expected = R;
+            using Actual = decltype(lib::invoke(
+                lib::forward<F>(f),
+                access::base::get_alt<ITs::value>(
+                    lib::forward<typename ITs::type>(visited_vs))...));
+            return visit_return_type_check<Expected, Actual>::invoke(
+                lib::forward<F>(f),
+                access::base::get_alt<ITs::value>(
+                    lib::forward<typename ITs::type>(visited_vs))...);
+          }
+
+          template <std::size_t B, typename F, typename V, typename... Vs>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch(
+              F &&f, typename ITs::type &&... visited_vs, V &&v, Vs &&... vs) {
+#define MPARK_DISPATCH(I)                                                   \
+  dispatcher<(I < lib::decay_t<V>::size()),                                 \
+             R,                                                             \
+             ITs...,                                                        \
+             lib::indexed_type<I, V>>::                                     \
+      template dispatch<0>(lib::forward<F>(f),                              \
+                           lib::forward<typename ITs::type>(visited_vs)..., \
+                           lib::forward<V>(v),                              \
+                           lib::forward<Vs>(vs)...)
+
+#define MPARK_DEFAULT(I)                                                      \
+  dispatcher<(I < lib::decay_t<V>::size()), R, ITs...>::template dispatch<I>( \
+      lib::forward<F>(f),                                                     \
+      lib::forward<typename ITs::type>(visited_vs)...,                        \
+      lib::forward<V>(v),                                                     \
+      lib::forward<Vs>(vs)...)
+
+            switch (v.index()) {
+              case B + 0: return MPARK_DISPATCH(B + 0);
+              case B + 1: return MPARK_DISPATCH(B + 1);
+              case B + 2: return MPARK_DISPATCH(B + 2);
+              case B + 3: return MPARK_DISPATCH(B + 3);
+              case B + 4: return MPARK_DISPATCH(B + 4);
+              case B + 5: return MPARK_DISPATCH(B + 5);
+              case B + 6: return MPARK_DISPATCH(B + 6);
+              case B + 7: return MPARK_DISPATCH(B + 7);
+              case B + 8: return MPARK_DISPATCH(B + 8);
+              case B + 9: return MPARK_DISPATCH(B + 9);
+              case B + 10: return MPARK_DISPATCH(B + 10);
+              case B + 11: return MPARK_DISPATCH(B + 11);
+              case B + 12: return MPARK_DISPATCH(B + 12);
+              case B + 13: return MPARK_DISPATCH(B + 13);
+              case B + 14: return MPARK_DISPATCH(B + 14);
+              case B + 15: return MPARK_DISPATCH(B + 15);
+              case B + 16: return MPARK_DISPATCH(B + 16);
+              case B + 17: return MPARK_DISPATCH(B + 17);
+              case B + 18: return MPARK_DISPATCH(B + 18);
+              case B + 19: return MPARK_DISPATCH(B + 19);
+              case B + 20: return MPARK_DISPATCH(B + 20);
+              case B + 21: return MPARK_DISPATCH(B + 21);
+              case B + 22: return MPARK_DISPATCH(B + 22);
+              case B + 23: return MPARK_DISPATCH(B + 23);
+              case B + 24: return MPARK_DISPATCH(B + 24);
+              case B + 25: return MPARK_DISPATCH(B + 25);
+              case B + 26: return MPARK_DISPATCH(B + 26);
+              case B + 27: return MPARK_DISPATCH(B + 27);
+              case B + 28: return MPARK_DISPATCH(B + 28);
+              case B + 29: return MPARK_DISPATCH(B + 29);
+              case B + 30: return MPARK_DISPATCH(B + 30);
+              case B + 31: return MPARK_DISPATCH(B + 31);
+              default: return MPARK_DEFAULT(B + 32);
+            }
+
+#undef MPARK_DEFAULT
+#undef MPARK_DISPATCH
+          }
+
+          template <std::size_t I, typename F, typename... Vs>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch_case(F &&f,
+                                                               Vs &&... vs) {
+            using Expected = R;
+            using Actual = decltype(
+                lib::invoke(lib::forward<F>(f),
+                            access::base::get_alt<I>(lib::forward<Vs>(vs))...));
+            return visit_return_type_check<Expected, Actual>::invoke(
+                lib::forward<F>(f),
+                access::base::get_alt<I>(lib::forward<Vs>(vs))...);
+          }
+
+          template <std::size_t B, typename F, typename V, typename... Vs>
+          MPARK_ALWAYS_INLINE static constexpr R dispatch_at(std::size_t index,
+                                                             F &&f,
+                                                             V &&v,
+                                                             Vs &&... vs) {
+            static_assert(lib::all<(lib::decay_t<V>::size() ==
+                                    lib::decay_t<Vs>::size())...>::value,
+                          "all of the variants must be the same size.");
+#define MPARK_DISPATCH_AT(I)                                               \
+  dispatcher<(I < lib::decay_t<V>::size()), R>::template dispatch_case<I>( \
+      lib::forward<F>(f), lib::forward<V>(v), lib::forward<Vs>(vs)...)
+
+#define MPARK_DEFAULT(I)                                                 \
+  dispatcher<(I < lib::decay_t<V>::size()), R>::template dispatch_at<I>( \
+      index, lib::forward<F>(f), lib::forward<V>(v), lib::forward<Vs>(vs)...)
+
+            switch (index) {
+              case B + 0: return MPARK_DISPATCH_AT(B + 0);
+              case B + 1: return MPARK_DISPATCH_AT(B + 1);
+              case B + 2: return MPARK_DISPATCH_AT(B + 2);
+              case B + 3: return MPARK_DISPATCH_AT(B + 3);
+              case B + 4: return MPARK_DISPATCH_AT(B + 4);
+              case B + 5: return MPARK_DISPATCH_AT(B + 5);
+              case B + 6: return MPARK_DISPATCH_AT(B + 6);
+              case B + 7: return MPARK_DISPATCH_AT(B + 7);
+              case B + 8: return MPARK_DISPATCH_AT(B + 8);
+              case B + 9: return MPARK_DISPATCH_AT(B + 9);
+              case B + 10: return MPARK_DISPATCH_AT(B + 10);
+              case B + 11: return MPARK_DISPATCH_AT(B + 11);
+              case B + 12: return MPARK_DISPATCH_AT(B + 12);
+              case B + 13: return MPARK_DISPATCH_AT(B + 13);
+              case B + 14: return MPARK_DISPATCH_AT(B + 14);
+              case B + 15: return MPARK_DISPATCH_AT(B + 15);
+              case B + 16: return MPARK_DISPATCH_AT(B + 16);
+              case B + 17: return MPARK_DISPATCH_AT(B + 17);
+              case B + 18: return MPARK_DISPATCH_AT(B + 18);
+              case B + 19: return MPARK_DISPATCH_AT(B + 19);
+              case B + 20: return MPARK_DISPATCH_AT(B + 20);
+              case B + 21: return MPARK_DISPATCH_AT(B + 21);
+              case B + 22: return MPARK_DISPATCH_AT(B + 22);
+              case B + 23: return MPARK_DISPATCH_AT(B + 23);
+              case B + 24: return MPARK_DISPATCH_AT(B + 24);
+              case B + 25: return MPARK_DISPATCH_AT(B + 25);
+              case B + 26: return MPARK_DISPATCH_AT(B + 26);
+              case B + 27: return MPARK_DISPATCH_AT(B + 27);
+              case B + 28: return MPARK_DISPATCH_AT(B + 28);
+              case B + 29: return MPARK_DISPATCH_AT(B + 29);
+              case B + 30: return MPARK_DISPATCH_AT(B + 30);
+              case B + 31: return MPARK_DISPATCH_AT(B + 31);
+              default: return MPARK_DEFAULT(B + 32);
+            }
+
+#undef MPARK_DEFAULT
+#undef MPARK_DISPATCH_AT
+          }
+        };
+#else
         template <typename T>
-        inline static constexpr const T &at(const T &elem) {
+        inline static constexpr const T &at(const T &elem) noexcept {
           return elem;
         }
 
         template <typename T, std::size_t N, typename... Is>
         inline static constexpr const lib::remove_all_extents_t<T> &at(
-            const lib::array<T, N> &elems, std::size_t i, Is... is) {
+            const lib::array<T, N> &elems, std::size_t i, Is... is) noexcept {
           return at(elems[i], is...);
         }
 
         template <typename F, typename... Fs>
-        inline static constexpr int visit_visitor_return_type_check() {
-          static_assert(lib::all<std::is_same<F, Fs>::value...>::value,
-                        "`mpark::visit` requires the visitor to have a single "
-                        "return type.");
-          return 0;
+        inline static constexpr lib::array<lib::decay_t<F>, sizeof...(Fs) + 1>
+        make_farray(F &&f, Fs &&... fs) {
+          return {{lib::forward<F>(f), lib::forward<Fs>(fs)...}};
         }
 
-        template <typename... Fs>
-        inline static constexpr lib::array<
-            lib::common_type_t<lib::decay_t<Fs>...>,
-            sizeof...(Fs)>
-        make_farray(Fs &&... fs) {
-          using result = lib::array<lib::common_type_t<lib::decay_t<Fs>...>,
-                                    sizeof...(Fs)>;
-          return visit_visitor_return_type_check<lib::decay_t<Fs>...>(),
-                 result{{lib::forward<Fs>(fs)...}};
-        }
-
-        template <std::size_t... Is>
-        struct dispatcher {
-          template <typename F, typename... Vs>
-          struct impl {
-            inline static constexpr DECLTYPE_AUTO dispatch(F f, Vs... vs)
-              DECLTYPE_AUTO_RETURN(lib::invoke(
-                  static_cast<F>(f),
-                  access::base::get_alt<Is>(static_cast<Vs>(vs))...))
-          };
-        };
-
-        template <typename F, typename... Vs, std::size_t... Is>
-        inline static constexpr AUTO make_dispatch(lib::index_sequence<Is...>)
-          AUTO_RETURN(&dispatcher<Is...>::template impl<F, Vs...>::dispatch)
-
-        template <std::size_t I, typename F, typename... Vs>
-        inline static constexpr AUTO make_fdiagonal_impl()
-          AUTO_RETURN(make_dispatch<F, Vs...>(
-              lib::index_sequence<lib::indexed_type<I, Vs>::value...>{}))
-
-        template <typename F, typename... Vs, std::size_t... Is>
-        inline static constexpr AUTO make_fdiagonal_impl(
-            lib::index_sequence<Is...>)
-          AUTO_RETURN(make_farray(make_fdiagonal_impl<Is, F, Vs...>()...))
-
-        template <typename F, typename V, typename... Vs>
-        inline static constexpr /* auto * */ auto make_fdiagonal()
-            -> decltype(make_fdiagonal_impl<F, V, Vs...>(
-                lib::make_index_sequence<lib::decay_t<V>::size()>{})) {
-          static_assert(lib::all<(lib::decay_t<V>::size() ==
-                                  lib::decay_t<Vs>::size())...>::value,
-                        "all of the variants must be the same size.");
-          return make_fdiagonal_impl<F, V, Vs...>(
-              lib::make_index_sequence<lib::decay_t<V>::size()>{});
-        }
-
-#ifdef MPARK_RETURN_TYPE_DEDUCTION
-        template <typename F, typename... Vs, typename Is>
-        inline static constexpr auto make_fmatrix_impl(Is is) {
-          return make_dispatch<F, Vs...>(is);
-        }
-
-        template <typename F,
-                  typename... Vs,
-                  typename Is,
-                  std::size_t... Js,
-                  typename... Ls>
-        inline static constexpr auto make_fmatrix_impl(
-            Is, lib::index_sequence<Js...>, Ls... ls) {
-          return make_farray(make_fmatrix_impl<F, Vs...>(
-              lib::push_back_t<Is, Js>{}, ls...)...);
-        }
-
-        template <typename F, typename... Vs>
-        inline static constexpr auto make_fmatrix() {
-          return make_fmatrix_impl<F, Vs...>(
-              lib::index_sequence<>{},
-              lib::make_index_sequence<lib::decay_t<Vs>::size()>{}...);
-        }
-#else
         template <typename F, typename... Vs>
         struct make_fmatrix_impl {
+
+          template <std::size_t... Is>
+          inline static constexpr dispatch_result_t<F, Vs...> dispatch(
+              F &&f, Vs &&... vs) {
+            using Expected = dispatch_result_t<F, Vs...>;
+            using Actual = decltype(lib::invoke(
+                lib::forward<F>(f),
+                access::base::get_alt<Is>(lib::forward<Vs>(vs))...));
+            return visit_return_type_check<Expected, Actual>::invoke(
+                lib::forward<F>(f),
+                access::base::get_alt<Is>(lib::forward<Vs>(vs))...);
+          }
+
+#ifdef MPARK_RETURN_TYPE_DEDUCTION
+          template <std::size_t... Is>
+          inline static constexpr auto impl(lib::index_sequence<Is...>) {
+            return &dispatch<Is...>;
+          }
+
+          template <typename Is, std::size_t... Js, typename... Ls>
+          inline static constexpr auto impl(Is,
+                                            lib::index_sequence<Js...>,
+                                            Ls... ls) {
+            return make_farray(impl(lib::push_back_t<Is, Js>{}, ls...)...);
+          }
+#else
           template <typename...>
           struct impl;
 
-          template <typename Is>
-          struct impl<Is> {
+          template <std::size_t... Is>
+          struct impl<lib::index_sequence<Is...>> {
             inline constexpr AUTO operator()() const
-              AUTO_RETURN(make_dispatch<F, Vs...>(Is{}))
+              AUTO_RETURN(&dispatch<Is...>)
           };
 
           template <typename Is, std::size_t... Js, typename... Ls>
@@ -1146,8 +1423,17 @@ namespace mpark {
               AUTO_RETURN(
                   make_farray(impl<lib::push_back_t<Is, Js>, Ls...>{}()...))
           };
+#endif
         };
 
+#ifdef MPARK_RETURN_TYPE_DEDUCTION
+        template <typename F, typename... Vs>
+        inline static constexpr auto make_fmatrix() {
+          return make_fmatrix_impl<F, Vs...>::impl(
+              lib::index_sequence<>{},
+              lib::make_index_sequence<lib::decay_t<Vs>::size()>{}...);
+        }
+#else
         template <typename F, typename... Vs>
         inline static constexpr AUTO make_fmatrix()
           AUTO_RETURN(
@@ -1155,86 +1441,141 @@ namespace mpark {
                   lib::index_sequence<>,
                   lib::make_index_sequence<lib::decay_t<Vs>::size()>...>{}())
 #endif
-      };  // namespace base
 
-      template <typename F, typename... Vs>
-      using FDiagonal = decltype(base::make_fdiagonal<F, Vs...>());
+        template <typename F, typename... Vs>
+        struct make_fdiagonal_impl {
+          template <std::size_t I>
+          inline static constexpr dispatch_result_t<F, Vs...> dispatch(
+              F &&f, Vs &&... vs) {
+            using Expected = dispatch_result_t<F, Vs...>;
+            using Actual = decltype(
+                lib::invoke(lib::forward<F>(f),
+                            access::base::get_alt<I>(lib::forward<Vs>(vs))...));
+            return visit_return_type_check<Expected, Actual>::invoke(
+                lib::forward<F>(f),
+                access::base::get_alt<I>(lib::forward<Vs>(vs))...);
+          }
 
-      template <typename F, typename... Vs>
-      struct fdiagonal {
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4268)
-#endif
-        static constexpr FDiagonal<F, Vs...> value =
-            base::make_fdiagonal<F, Vs...>();
-#ifdef _MSC_VER
-#pragma warning(pop)
+          template <std::size_t... Is>
+          inline static constexpr AUTO impl(lib::index_sequence<Is...>)
+            AUTO_RETURN(make_farray(&dispatch<Is>...))
+        };
+
+        template <typename F, typename V, typename... Vs>
+        inline static constexpr auto make_fdiagonal()
+            -> decltype(make_fdiagonal_impl<F, V, Vs...>::impl(
+                lib::make_index_sequence<lib::decay_t<V>::size()>{})) {
+          static_assert(lib::all<(lib::decay_t<V>::size() ==
+                                  lib::decay_t<Vs>::size())...>::value,
+                        "all of the variants must be the same size.");
+          return make_fdiagonal_impl<F, V, Vs...>::impl(
+              lib::make_index_sequence<lib::decay_t<V>::size()>{});
+        }
 #endif
       };
 
+#if !defined(MPARK_VARIANT_SWITCH_VISIT) && \
+    (!defined(_MSC_VER) || _MSC_VER >= 1910)
       template <typename F, typename... Vs>
-      constexpr FDiagonal<F, Vs...> fdiagonal<F, Vs...>::value;
-
-      template <typename F, typename... Vs>
-      using FMatrix = decltype(base::make_fmatrix<F, Vs...>());
+      using fmatrix_t = decltype(base::make_fmatrix<F, Vs...>());
 
       template <typename F, typename... Vs>
       struct fmatrix {
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4268)
-#endif
-        static constexpr FMatrix<F, Vs...> value =
+        static constexpr fmatrix_t<F, Vs...> value =
             base::make_fmatrix<F, Vs...>();
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
       };
 
       template <typename F, typename... Vs>
-      constexpr FMatrix<F, Vs...> fmatrix<F, Vs...>::value;
+      constexpr fmatrix_t<F, Vs...> fmatrix<F, Vs...>::value;
+
+      template <typename F, typename... Vs>
+      using fdiagonal_t = decltype(base::make_fdiagonal<F, Vs...>());
+
+      template <typename F, typename... Vs>
+      struct fdiagonal {
+        static constexpr fdiagonal_t<F, Vs...> value =
+            base::make_fdiagonal<F, Vs...>();
+      };
+
+      template <typename F, typename... Vs>
+      constexpr fdiagonal_t<F, Vs...> fdiagonal<F, Vs...>::value;
+#endif
 
       struct alt {
         template <typename Visitor, typename... Vs>
-        inline static constexpr DECLTYPE_AUTO visit_alt_at(std::size_t index,
-                                                           Visitor &&visitor,
-                                                           Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(base::at(
-              fdiagonal<Visitor &&,
-                        decltype(as_base(lib::forward<Vs>(vs)))...>::value,
-              index)(lib::forward<Visitor>(visitor),
-                     as_base(lib::forward<Vs>(vs))...))
-
-        template <typename Visitor, typename... Vs>
         inline static constexpr DECLTYPE_AUTO visit_alt(Visitor &&visitor,
                                                         Vs &&... vs)
+#ifdef MPARK_VARIANT_SWITCH_VISIT
+          DECLTYPE_AUTO_RETURN(
+              base::dispatcher<
+                  true,
+                  base::dispatch_result_t<Visitor,
+                                          decltype(as_base(
+                                              lib::forward<Vs>(vs)))...>>::
+                  template dispatch<0>(lib::forward<Visitor>(visitor),
+                                       as_base(lib::forward<Vs>(vs))...))
+#elif !defined(_MSC_VER) || _MSC_VER >= 1910
           DECLTYPE_AUTO_RETURN(base::at(
               fmatrix<Visitor &&,
                       decltype(as_base(lib::forward<Vs>(vs)))...>::value,
               vs.index()...)(lib::forward<Visitor>(visitor),
                              as_base(lib::forward<Vs>(vs))...))
+#else
+          DECLTYPE_AUTO_RETURN(base::at(
+              base::make_fmatrix<Visitor &&,
+                      decltype(as_base(lib::forward<Vs>(vs)))...>(),
+              vs.index()...)(lib::forward<Visitor>(visitor),
+                             as_base(lib::forward<Vs>(vs))...))
+#endif
+
+        template <typename Visitor, typename... Vs>
+        inline static constexpr DECLTYPE_AUTO visit_alt_at(std::size_t index,
+                                                           Visitor &&visitor,
+                                                           Vs &&... vs)
+#ifdef MPARK_VARIANT_SWITCH_VISIT
+          DECLTYPE_AUTO_RETURN(
+              base::dispatcher<
+                  true,
+                  base::dispatch_result_t<Visitor,
+                                          decltype(as_base(
+                                              lib::forward<Vs>(vs)))...>>::
+                  template dispatch_at<0>(index,
+                                          lib::forward<Visitor>(visitor),
+                                          as_base(lib::forward<Vs>(vs))...))
+#elif !defined(_MSC_VER) || _MSC_VER >= 1910
+          DECLTYPE_AUTO_RETURN(base::at(
+              fdiagonal<Visitor &&,
+                        decltype(as_base(lib::forward<Vs>(vs)))...>::value,
+              index)(lib::forward<Visitor>(visitor),
+                     as_base(lib::forward<Vs>(vs))...))
+#else
+          DECLTYPE_AUTO_RETURN(base::at(
+              base::make_fdiagonal<Visitor &&,
+                        decltype(as_base(lib::forward<Vs>(vs)))...>(),
+              index)(lib::forward<Visitor>(visitor),
+                     as_base(lib::forward<Vs>(vs))...))
+#endif
       };
 
       struct variant {
         private:
-        template <typename Visitor, typename... Values>
-        struct visit_exhaustive_visitor_check {
-          static_assert(
-              lib::is_invocable<Visitor, Values...>::value,
-              "`mpark::visit` requires the visitor to be exhaustive.");
+        template <typename Visitor>
+        struct visitor {
+          template <typename... Values>
+          inline static constexpr bool does_not_handle() {
+            return lib::is_invocable<Visitor, Values...>::value;
+          }
+        };
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4100)
-#endif
-          inline constexpr DECLTYPE_AUTO operator()(Visitor &&visitor,
-                                                    Values &&... values) const
+        template <typename Visitor, typename... Values>
+        struct visit_exhaustiveness_check {
+          static_assert(visitor<Visitor>::template does_not_handle<Values...>(),
+                        "`visit` requires the visitor to be exhaustive.");
+
+          inline static constexpr DECLTYPE_AUTO invoke(Visitor &&visitor,
+                                                       Values &&... values)
             DECLTYPE_AUTO_RETURN(lib::invoke(lib::forward<Visitor>(visitor),
                                              lib::forward<Values>(values)...))
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
         };
 
         template <typename Visitor>
@@ -1244,11 +1585,11 @@ namespace mpark {
           template <typename... Alts>
           inline constexpr DECLTYPE_AUTO operator()(Alts &&... alts) const
             DECLTYPE_AUTO_RETURN(
-                visit_exhaustive_visitor_check<
+                visit_exhaustiveness_check<
                     Visitor,
-                    decltype((lib::forward<Alts>(alts).value))...>{}(
-                    lib::forward<Visitor>(visitor_),
-                    lib::forward<Alts>(alts).value...))
+                    decltype((lib::forward<Alts>(alts).value))...>::
+                    invoke(lib::forward<Visitor>(visitor_),
+                           lib::forward<Alts>(alts).value...))
         };
 
         template <typename Visitor>
@@ -1256,6 +1597,12 @@ namespace mpark {
           AUTO_RETURN(value_visitor<Visitor>{lib::forward<Visitor>(visitor)})
 
         public:
+        template <typename Visitor, typename... Vs>
+        inline static constexpr DECLTYPE_AUTO visit_alt(Visitor &&visitor,
+                                                        Vs &&... vs)
+          DECLTYPE_AUTO_RETURN(alt::visit_alt(lib::forward<Visitor>(visitor),
+                                              lib::forward<Vs>(vs).impl_...))
+
         template <typename Visitor, typename... Vs>
         inline static constexpr DECLTYPE_AUTO visit_alt_at(std::size_t index,
                                                            Visitor &&visitor,
@@ -1266,10 +1613,11 @@ namespace mpark {
                                 lib::forward<Vs>(vs).impl_...))
 
         template <typename Visitor, typename... Vs>
-        inline static constexpr DECLTYPE_AUTO visit_alt(Visitor &&visitor,
-                                                        Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(alt::visit_alt(lib::forward<Visitor>(visitor),
-                                              lib::forward<Vs>(vs).impl_...))
+        inline static constexpr DECLTYPE_AUTO visit_value(Visitor &&visitor,
+                                                          Vs &&... vs)
+          DECLTYPE_AUTO_RETURN(
+              visit_alt(make_value_visitor(lib::forward<Visitor>(visitor)),
+                        lib::forward<Vs>(vs)...))
 
         template <typename Visitor, typename... Vs>
         inline static constexpr DECLTYPE_AUTO visit_value_at(std::size_t index,
@@ -1279,13 +1627,6 @@ namespace mpark {
               visit_alt_at(index,
                            make_value_visitor(lib::forward<Visitor>(visitor)),
                            lib::forward<Vs>(vs)...))
-
-        template <typename Visitor, typename... Vs>
-        inline static constexpr DECLTYPE_AUTO visit_value(Visitor &&visitor,
-                                                          Vs &&... vs)
-          DECLTYPE_AUTO_RETURN(
-              visit_alt(make_value_visitor(lib::forward<Visitor>(visitor)),
-                        lib::forward<Vs>(vs)...))
       };
 
     }  // namespace visitation
@@ -1411,13 +1752,13 @@ namespace mpark {
 #endif
     };
 
-#if defined(_MSC_VER) && _MSC_VER < 1910
-#define INHERITING_CTOR(type, base)               \
+#if !defined(_MSC_VER) || _MSC_VER >= 1910
+#define MPARK_INHERITING_CTOR(type, base) using base::base;
+#else
+#define MPARK_INHERITING_CTOR(type, base)         \
   template <typename... Args>                     \
   inline explicit constexpr type(Args &&... args) \
       : base(lib::forward<Args>(args)...) {}
-#else
-#define INHERITING_CTOR(type, base) using base::base;
 #endif
 
     template <typename Traits, Trait = Traits::destructible_trait>
@@ -1430,7 +1771,7 @@ namespace mpark {
     using super = base<destructible_trait, Ts...>;                        \
                                                                           \
     public:                                                               \
-    INHERITING_CTOR(destructor, super)                                    \
+    MPARK_INHERITING_CTOR(destructor, super)                              \
     using super::operator=;                                               \
                                                                           \
     destructor(const destructor &) = default;                             \
@@ -1472,7 +1813,7 @@ namespace mpark {
       using super = destructor<Traits>;
 
       public:
-      INHERITING_CTOR(constructor, super)
+      MPARK_INHERITING_CTOR(constructor, super)
       using super::operator=;
 
       protected:
@@ -1488,9 +1829,9 @@ namespace mpark {
 
       template <std::size_t I, typename T, typename... Args>
       inline static T &construct_alt(alt<I, T> &a, Args &&... args) {
-        ::new (static_cast<void *>(lib::addressof(a)))
+        auto *result = ::new (static_cast<void *>(lib::addressof(a)))
             alt<I, T>(in_place_t{}, lib::forward<Args>(args)...);
-        return a.value;
+        return result->value;
       }
 
       template <typename Rhs>
@@ -1525,7 +1866,7 @@ namespace mpark {
     using super = constructor<traits<Ts...>>;                                \
                                                                              \
     public:                                                                  \
-    INHERITING_CTOR(move_constructor, super)                                 \
+    MPARK_INHERITING_CTOR(move_constructor, super)                           \
     using super::operator=;                                                  \
                                                                              \
     move_constructor(const move_constructor &) = default;                    \
@@ -1563,7 +1904,7 @@ namespace mpark {
     using super = move_constructor<traits<Ts...>>;                           \
                                                                              \
     public:                                                                  \
-    INHERITING_CTOR(copy_constructor, super)                                 \
+    MPARK_INHERITING_CTOR(copy_constructor, super)                           \
     using super::operator=;                                                  \
                                                                              \
     definition                                                               \
@@ -1595,7 +1936,7 @@ namespace mpark {
       using super = copy_constructor<Traits>;
 
       public:
-      INHERITING_CTOR(assignment, super)
+      MPARK_INHERITING_CTOR(assignment, super)
       using super::operator=;
 
       template <std::size_t I, typename... Args>
@@ -1683,7 +2024,7 @@ namespace mpark {
     using super = assignment<traits<Ts...>>;                             \
                                                                          \
     public:                                                              \
-    INHERITING_CTOR(move_assignment, super)                              \
+    MPARK_INHERITING_CTOR(move_assignment, super)                        \
     using super::operator=;                                              \
                                                                          \
     move_assignment(const move_assignment &) = default;                  \
@@ -1723,7 +2064,7 @@ namespace mpark {
     using super = move_assignment<traits<Ts...>>;                        \
                                                                          \
     public:                                                              \
-    INHERITING_CTOR(copy_assignment, super)                              \
+    MPARK_INHERITING_CTOR(copy_assignment, super)                        \
     using super::operator=;                                              \
                                                                          \
     copy_assignment(const copy_assignment &) = default;                  \
@@ -1755,7 +2096,7 @@ namespace mpark {
       using super = copy_assignment<traits<Ts...>>;
 
       public:
-      INHERITING_CTOR(impl, super)
+      MPARK_INHERITING_CTOR(impl, super)
       using super::operator=;
 
       template <std::size_t I, typename Arg>
@@ -1825,6 +2166,8 @@ namespace mpark {
                }[this->index()];
       }
     };
+
+#undef MPARK_INHERITING_CTOR
 
     template <std::size_t I, typename T>
     struct overload_leaf {
@@ -2069,7 +2412,7 @@ namespace mpark {
   namespace detail {
     template <std::size_t I, typename V>
     struct generic_get_impl {
-      constexpr generic_get_impl(int) {}
+      constexpr generic_get_impl(int) noexcept {}
 
       constexpr AUTO_REFREF operator()(V &&v) const
         AUTO_REFREF_RETURN(
@@ -2162,11 +2505,26 @@ namespace mpark {
     return get_if<detail::find_index_checked<T, Ts...>::value>(v);
   }
 
+  namespace detail {
+    template <typename RelOp>
+    struct convert_to_bool {
+      template <typename Lhs, typename Rhs>
+      inline constexpr bool operator()(Lhs &&lhs, Rhs &&rhs) const {
+        static_assert(std::is_convertible<lib::invoke_result_t<RelOp, Lhs, Rhs>,
+                                          bool>::value,
+                      "relational operators must return a type"
+                      " implicitly convertible to bool");
+        return lib::invoke(
+            RelOp{}, lib::forward<Lhs>(lhs), lib::forward<Rhs>(rhs));
+      }
+    };
+  }  // namespace detail
+
   template <typename... Ts>
   inline constexpr bool operator==(const variant<Ts...> &lhs,
                                    const variant<Ts...> &rhs) {
     using detail::visitation::variant;
-    using lib::equal_to;
+    using equal_to = detail::convert_to_bool<lib::equal_to>;
 #ifdef MPARK_CPP14_CONSTEXPR
     if (lhs.index() != rhs.index()) return false;
     if (lhs.valueless_by_exception()) return true;
@@ -2182,7 +2540,7 @@ namespace mpark {
   inline constexpr bool operator!=(const variant<Ts...> &lhs,
                                    const variant<Ts...> &rhs) {
     using detail::visitation::variant;
-    using lib::not_equal_to;
+    using not_equal_to = detail::convert_to_bool<lib::not_equal_to>;
 #ifdef MPARK_CPP14_CONSTEXPR
     if (lhs.index() != rhs.index()) return true;
     if (lhs.valueless_by_exception()) return false;
@@ -2198,7 +2556,7 @@ namespace mpark {
   inline constexpr bool operator<(const variant<Ts...> &lhs,
                                   const variant<Ts...> &rhs) {
     using detail::visitation::variant;
-    using lib::less;
+    using less = detail::convert_to_bool<lib::less>;
 #ifdef MPARK_CPP14_CONSTEXPR
     if (rhs.valueless_by_exception()) return false;
     if (lhs.valueless_by_exception()) return true;
@@ -2217,7 +2575,7 @@ namespace mpark {
   inline constexpr bool operator>(const variant<Ts...> &lhs,
                                   const variant<Ts...> &rhs) {
     using detail::visitation::variant;
-    using lib::greater;
+    using greater = detail::convert_to_bool<lib::greater>;
 #ifdef MPARK_CPP14_CONSTEXPR
     if (lhs.valueless_by_exception()) return false;
     if (rhs.valueless_by_exception()) return true;
@@ -2236,7 +2594,7 @@ namespace mpark {
   inline constexpr bool operator<=(const variant<Ts...> &lhs,
                                    const variant<Ts...> &rhs) {
     using detail::visitation::variant;
-    using lib::less_equal;
+    using less_equal = detail::convert_to_bool<lib::less_equal>;
 #ifdef MPARK_CPP14_CONSTEXPR
     if (lhs.valueless_by_exception()) return true;
     if (rhs.valueless_by_exception()) return false;
@@ -2256,7 +2614,7 @@ namespace mpark {
   inline constexpr bool operator>=(const variant<Ts...> &lhs,
                                    const variant<Ts...> &rhs) {
     using detail::visitation::variant;
-    using lib::greater_equal;
+    using greater_equal = detail::convert_to_bool<lib::greater_equal>;
 #ifdef MPARK_CPP14_CONSTEXPR
     if (rhs.valueless_by_exception()) return true;
     if (lhs.valueless_by_exception()) return false;
@@ -2363,14 +2721,14 @@ namespace mpark {
     namespace hash {
 
       template <typename H, typename K>
-      constexpr bool meets_requirements() {
+      constexpr bool meets_requirements() noexcept {
         return std::is_copy_constructible<H>::value &&
                std::is_move_constructible<H>::value &&
                lib::is_invocable_r<std::size_t, H, const K &>::value;
       }
 
       template <typename K>
-      constexpr bool is_enabled() {
+      constexpr bool is_enabled() noexcept {
         using H = std::hash<K>;
         return meets_requirements<H, K>() &&
                std::is_default_constructible<H>::value &&

--- a/vendor/xtl/xtl.pc.in
+++ b/vendor/xtl/xtl.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: xtl
+Description: Basic tools (containers, algorithms) used by other quantstack packages.
+Version: @xtl_VERSION@
+Cflags: -I${includedir}


### PR DESCRIPTION
This PR updates xtensor/xtl in the `vendor` directory and makes accompanying code changes so that everything works accordingly. The one nice cosmetic change is that an uninitialized xtensor now has `size() == 0` rather than the strange `size() == 1` before.

The miscellaneous fixes/changes included:
- Wrong location for a symlink in `examples/jupyter` (discovered by @cliffdugal)
- Added an error check for a cell that is filled by the same universe that it's in (inspired by a user's group message)
- Added one publication in list in documentation