### PR TITLE
Unresolved Resonance Parameters

### DIFF
--- a/openmc/data/resonance.py
+++ b/openmc/data/resonance.py
@@ -998,7 +998,6 @@ class Unresolved(ResonanceRange):
                 items, values = get_list_record(file_obj)
                 awri = items[0]
                 l = items[2]
-
                 NJS = items[5]
                 for j in range(NJS):
                     d, j, amun, gn0, gg = values[6*j:6*j + 5]
@@ -1021,7 +1020,6 @@ class Unresolved(ResonanceRange):
                 items = get_cont_record(file_obj)
                 awri = items[0]
                 l = items[2]
-
                 NJS = items[4]
                 for j in range(NJS):
                     items, values = get_list_record(file_obj)
@@ -1046,7 +1044,6 @@ class Unresolved(ResonanceRange):
                 items = get_cont_record(file_obj)
                 awri = items[0]
                 l = items[2]
-
                 NJS = items[4]
                 for j in range(NJS):
                     items, values = get_list_record(file_obj)

--- a/openmc/data/resonance.py
+++ b/openmc/data/resonance.py
@@ -1121,6 +1121,7 @@ class Unresolved(ResonanceRange):
                     amux = values[2]
                     amun = values[3]
                     amuf = values[5]
+                    energies = []
                     for k in range(1, ne + 1):
                         E = values[6*k]
                         d = values[6*k + 1]
@@ -1128,10 +1129,10 @@ class Unresolved(ResonanceRange):
                         gn0 = values[6*k + 3]
                         gg = values[6*k + 4]
                         gf = values[6*k + 5]
+                        energies.append(E)
                         records.append([l, j, E, d, amux, amun, amuf, gx, gn0,
                                         gg, gf])
             parameters = pd.DataFrame.from_records(records, columns=columns)
-            energies = None
 
         urr = cls(target_spin, energy_min, energy_max, channel_radius,
                   scattering_radius)


### PR DESCRIPTION
This PR modifies the `Unresolved.from_endf` method to store a few additional unresolved resonance parameters (e.g. degrees of freedom) that are necessary for generating resonance ladders.