### PR TITLE
fix mesh plotter energy filter bins

### DIFF
--- a/scripts/openmc-plot-mesh-tally
+++ b/scripts/openmc-plot-mesh-tally
@@ -176,8 +176,8 @@ class MeshPlotter(tk.Frame):
 
             # Set combobox items
             if filterType in ['Energy', 'Energyout']:
-                combobox['values'] = ['{} to {}'.format(bin)
-                                      for bin in f.bins)]
+                combobox['values'] = ['{} to {}'.format(*ebin)
+                                      for ebin in f.bins]
             else:
                 combobox['values'] = [str(i) for i in f.bins]
 

--- a/scripts/openmc-plot-mesh-tally
+++ b/scripts/openmc-plot-mesh-tally
@@ -176,8 +176,8 @@ class MeshPlotter(tk.Frame):
 
             # Set combobox items
             if filterType in ['Energy', 'Energyout']:
-                combobox['values'] = ['{0} to {1}'.format(*f.bins[i:i+2])
-                                      for i in range(len(f.bins) - 1)]
+                combobox['values'] = ['{0} to {1}'.format(*f.bins[i])
+                                      for i in range(len(f.bins))]
             else:
                 combobox['values'] = [str(i) for i in f.bins]
 
@@ -210,7 +210,7 @@ class MeshPlotter(tk.Frame):
                 continue
             elif f.short_name in ['Energy', 'Energyout']:
                 index = self.filterBoxes[f.short_name].current()
-                ebin = (f.bins[index], f.bins[index + 1])
+                ebin = f.bins[index]
                 spec_list.append((type(f), (ebin,)))
             else:
                 index = self.filterBoxes[f.short_name].current()

--- a/scripts/openmc-plot-mesh-tally
+++ b/scripts/openmc-plot-mesh-tally
@@ -176,8 +176,8 @@ class MeshPlotter(tk.Frame):
 
             # Set combobox items
             if filterType in ['Energy', 'Energyout']:
-                combobox['values'] = ['{0} to {1}'.format(*f.bins[i])
-                                      for i in range(len(f.bins))]
+                combobox['values'] = ['{} to {}'.format(bin)
+                                      for bin in f.bins)]
             else:
                 combobox['values'] = [str(i) for i in f.bins]
 


### PR DESCRIPTION
Hi all,
It seems that at some point, the format of energy filter bins in statepoint files was changed from being a list of bin endpoints to a list of 2-tuples of bin boundaries for each bin. This causes the mesh plotter to misinterpret the true number of bins and give clearly incorrect bin names to be available in the mesh plotter, vis. below for examples/python/pincell:

![meshplotter-before](https://user-images.githubusercontent.com/18088906/68886129-88768400-06e4-11ea-94a4-080c72751169.png)

With this tiny PR, the reading in of bins is now fixed, so that both of the energy groups in this problem are now able to be plotted. Before, only the first one appeared in the GUI with an incorrect label. The new result is below:

![fixed_ene_bins](https://user-images.githubusercontent.com/18088906/68886179-ac39ca00-06e4-11ea-9951-10dc7aea3183.png)
