### PR TITLE
fix a typo bug in SIIntegrator class

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -815,11 +815,11 @@ class SIIntegrator(Integrator):
         reset_particles = False
         if step_index == 0 and hasattr(self.operator, "settings"):
             reset_particles = True
-            self.operator.settings.particles *= self.n_stages
+            self.operator.settings.particles *= self.n_steps
         inherited = super()._get_bos_data_from_operator(
             step_index, step_power, bos_conc)
         if reset_particles:
-            self.operator.settings.particles //= self.n_stages
+            self.operator.settings.particles //= self.n_steps
         return inherited
 
     def integrate(self):

--- a/tests/dummy_operator.py
+++ b/tests/dummy_operator.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from unittest.mock import Mock
 
 import numpy as np
 import scipy.sparse as sp
@@ -133,6 +134,8 @@ class DummyOperator(TransportOperator):
         self.prev_res = previous_results
         self.chain = TestChain()
         self.output_dir = "."
+        self.settings = Mock()
+        self.settings.particles = 10
 
     def __call__(self, vec, power, print_out=False):
         """Evaluates F(y)


### PR DESCRIPTION
This PR is to fix the typo bug existed in deplete/abc.py when I tried to test the SI-CE/LIIntegrator and SI-LEQIIntegrator. 
