### PR TITLE
use relative distances for coincidence test in hex lattice

### DIFF
--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -895,8 +895,12 @@ HexLattice::get_indices(Position r, Direction u) const
       Position r_t = get_local_position(r, i_xyz);
       // calculate distance
       double d = r_t.x*r_t.x + r_t.y*r_t.y;
-      // check for coincidence
-      bool on_boundary = coincident(d, d_min);
+      // check for coincidence. Because the numerical error incurred
+      // in hex geometry is higher than other geometries, the relative
+      // coincidence is checked here so that coincidence is successfully
+      // detected on large hex lattice with particles far from the origin
+      // which have rounding errors larger than the FP_COINCIDENT thresdhold.
+      bool on_boundary = coincident(1.0, d_min/d);
       if (d < d_min || on_boundary) {
         // normalize r_t and find dot product
         r_t /= std::sqrt(d);


### PR DESCRIPTION
This fixes #1383 

Currently, it seems that for large hex lattices, particles get leaked in cells near the boundary. This issue can be reproduced with the input in #1383, where I had the impression that the materials were influencing the particle tracker's ability to move through a hex lattice. It ended up being the case that one of the material files simply had an optically thinner material dominating the lattice, which allowed particles to reach the lattice periphery more quickly. In fact, both configurations give this error after a few particle batches. This only happens if the cells in that periphery are defined using the "outer" keyword, which means that they are registered as invalid lattice indices in OpenMC, triggering a find_cell call.

I have found that particles get leaked in this case because find_cell ends up calling HexLattice::get_indices, which fails to put a particle in the correct cell for lattices of sufficiently large pitch or extent if the particle is crossing a lattice cell boundary far from the origin (>~100cm or so). Ordinarily, get_indices would determine that the particle is "on" a boundary if two distances calculated to cell centers are within FP_COINCIDENT; this fails for large lattices. For the hex lattices I was running, this difference ends up being around 5e-12 after the particle has been advanced to a lattice boundary, and would presumably be larger for larger lattices. This can be probably attributed to the less well-conditioned math of the hex lattices' non-orthogonal coordinates.

So, to fix this, I propose that in checking whether a particle is coincident with a lattice boundary, the relative distance to cell center is used rather than the actual distance.

This took me forever to figure out, and I can't believe it has such a tiny fix! BTW, I have tried re-ordering some arithmetic in hex lattice routines to get better results here, but haven't had much luck. I think this is pretty much unavoidable since non-orthogonal coordinates are intrinsically prone to larger numerical errors.