### PR TITLE
Fix cosine "smearing" for S(a,b) and update documentation

### DIFF
--- a/src/secondary_thermal.cpp
+++ b/src/secondary_thermal.cpp
@@ -255,22 +255,9 @@ IncoherentInelasticAE::sample(double E_in, double& E_out, double& mu) const
   // Pick closer energy based on interpolation factor
   int l = f > 0.5 ? i + 1 : i;
 
-  // Determine endpoints on grid i
-  auto n = distribution_[i].e_out.size();
-  double E_i_1 = distribution_[i].e_out[0];
-  double E_i_J = distribution_[i].e_out[n - 1];
-
-  // Determine endpoints on grid i + 1
-  n = distribution_[i + 1].e_out.size();
-  double E_i1_1 = distribution_[i + 1].e_out[0];
-  double E_i1_J = distribution_[i + 1].e_out[n - 1];
-
-  double E_1 = E_i_1 + f * (E_i1_1 - E_i_1);
-  double E_J = E_i_J + f * (E_i1_J - E_i_J);
-
   // Determine outgoing energy bin
   // (First reset n_energy_out to the right value)
-  n = distribution_[l].n_e_out;
+  auto n = distribution_[l].n_e_out;
   double r1 = prn();
   double c_j = distribution_[l].e_out_cdf[0];
   double c_j1;

--- a/src/secondary_thermal.cpp
+++ b/src/secondary_thermal.cpp
@@ -252,8 +252,8 @@ IncoherentInelasticAE::sample(double E_in, double& E_out, double& mu) const
   double f;
   get_energy_index(energy_, E_in, i, f);
 
-  // Sample between ith and [i+1]th bin
-  int l = f > prn() ? i + 1 : i;
+  // Pick closer energy based on interpolation factor
+  int l = f > 0.5 ? i + 1 : i;
 
   // Determine endpoints on grid i
   auto n = distribution_[i].e_out.size();
@@ -301,11 +301,12 @@ IncoherentInelasticAE::sample(double E_in, double& E_out, double& mu) const
           2.0*frac*(r1 - c_j))) - p_l_j) / frac;
   }
 
-  // Now interpolate between incident energy bins i and i + 1
-  if (l == i) {
-    E_out = E_1 + (E_out - E_i_1) * (E_J - E_1) / (E_i_J - E_i_1);
+  // Adjustment of outgoing energy
+  double E_l = energy_[l];
+  if (E_out < 0.5*E_l) {
+    E_out *= 2.0*E_in/E_l - 1.0;
   } else {
-    E_out = E_1 + (E_out - E_i1_1) * (E_J - E_1) / (E_i1_J - E_i1_1);
+    E_out += E_in - E_l;
   }
 
   // Sample outgoing cosine bin


### PR DESCRIPTION
Jaakko Leppanen and I have been doing some comparisons of between OpenMC, Serpent 2, and MCNP6 on a simple broomstick problem to assess how the codes treat continuous S(a,b) data. These comparisons have uncovered a few issues in OpenMC:

1. The discrete cosines incoherent inelastic scattering were not being "[smeared](https://github.com/openmc-dev/openmc/pull/777)" correctly for the first and last bins. This is now fixed.
2. MCNP also applies smearing to discrete cosines for incoherent elastic scattering, whereas we were not. I've added this in.
3. MCNP uses a slightly different way of adjusting the outgoing energies in incoherent inelastic scattering (rather than using unit base interpolation) that was causing some differences between the codes. I've changed our treatment to match MCNP in this regard.
4. Jaakko was a bit confused by what we were doing because our documentation is out of date. It has now been updated and should agree with what's actually in the code.