### PR TITLE
Fix a number of problems related to photoatomic data

### DIFF
--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -110,6 +110,11 @@ PhotonInteraction::PhotonInteraction(hid_t group, int i_element)
   std::vector<std::string> designators;
   read_attribute(rgroup, "designators", designators);
   auto n_shell = designators.size();
+  if (n_shell == 0) {
+    throw std::runtime_error{"Photoatomic data for " + name_ +
+      " does not have subshell data."};
+  }
+
   for (int i = 0; i < n_shell; ++i) {
     const auto& designator {designators[i]};
 


### PR DESCRIPTION
This pull request fixes a number of issues related to photon transport that @pshriwise helped to uncover. There are actually four separate issues:

- `IncidentPhoton.from_ace` should not work with older MCNP libraries like mcplib84 because they don't contain photoelectric subshell cross sections, which OpenMC needs. There is now an explicit check for this data and if it's not present, an exception is raised.
- Using mcplib84 before and writing the data to HDF5 resulted in a file that was missing data, which caused OpenMC to segfault. Although this shouldn't happen in the future, I've put in a check for the subshell data on the C++ side too in case someone encounters one of these invalid files to at least avoid the segfault.
- When looking into the above issues, I found that `IncidentPhoton.from_ace` was not setting thresholds for photoelectric subshell cross sections correctly. That is now fixed.
- I also discovered that trying to run `IncidentPhoton.from_endf()` with just a photoatomic library file (no atomic relaxation file) resulted in an exception due to an assumption in `_compute_heating` that atomic relaxation data is already present. I've added a check so that this case doesn't result in an exception.

Requesting a review from @amandalund as our photon expert, but @pshriwise feel free to chime in too.