### PR TITLE
Update generated input filename in test harness.

### DIFF
--- a/tests/testing_harness.py
+++ b/tests/testing_harness.py
@@ -348,9 +348,9 @@ class PyAPITestHarness(TestHarness):
         compare = filecmp.cmp('inputs_test.dat', 'inputs_true.dat')
         if not compare:
             expected = open('inputs_true.dat', 'r').readlines()
-            actual = open('inputs_error.dat', 'r').readlines()
+            actual = open('inputs_test.dat', 'r').readlines()
             diff = unified_diff(expected, actual, 'inputs_true.dat',
-                                'inputs_error.dat')
+                                'inputs_test.dat')
             print('Input differences:')
             print(''.join(colorize(diff)))
             os.rename('inputs_test.dat', 'inputs_error.dat')


### PR DESCRIPTION
Found a problem with how incorrect test input is currently being reported. The filename for reporting the diff doesn't exist yet so we just see a `FileNotFoundError` instead of the diff.

```python

../../../testing_harness.py:294: in main
    self.execute_test()
../../../testing_harness.py:302: in execute_test
    self._compare_inputs()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <tests.regression_tests.dagmc.uwuw.test.UWUWTest object at 0x7fd33159ab70>
    def _compare_inputs(self):
        """Make sure the current inputs agree with the _true standard."""
        compare = filecmp.cmp('inputs_test.dat', 'inputs_true.dat')
        if not compare:
            expected = open('inputs_true.dat', 'r').readlines()
>           actual = open('inputs_error.dat', 'r').readlines()
E           FileNotFoundError: [Errno 2] No such file or directory: 'inputs_error.dat'

../../../testing_harness.py:351: FileNotFoundError
```

