### PR TITLE
Use collective MPI I/O for reading and writing tally results to statepoint

### DIFF
--- a/include/openmc/hdf5_interface.h
+++ b/include/openmc/hdf5_interface.h
@@ -26,13 +26,17 @@ namespace openmc {
 //==============================================================================
 
 void read_attr(hid_t obj_id, const char* name, hid_t mem_type_id,
-               void* buffer);
+  void* buffer);
+
 void write_attr(hid_t obj_id, int ndim, const hsize_t* dims, const char* name,
-                hid_t mem_type_id, const void* buffer);
-void read_dataset(hid_t obj_id, const char* name, hid_t mem_type_id,
-                  void* buffer, bool indep);
-void write_dataset(hid_t group_id, int ndim, const hsize_t* dims, const char* name,
-                   hid_t mem_type_id, const void* buffer, bool indep);
+  hid_t mem_type_id, const void* buffer);
+
+void read_dataset_lowlevel(hid_t obj_id, const char* name, hid_t mem_type_id,
+  void* buffer, bool indep);
+
+void write_dataset_lowlevel(hid_t group_id, int ndim, const hsize_t* dims,
+  const char* name, hid_t mem_type_id, const void* buffer, bool indep);
+
 bool using_mpio_device(hid_t obj_id);
 
 //==============================================================================
@@ -86,34 +90,32 @@ extern "C" {
   void read_attr_string(hid_t obj_id, const char* name, size_t slen,
                         char* buffer);
   void read_complex(hid_t obj_id, const char* name,
-                             std::complex<double>* buffer, bool indep);
-  void read_double(hid_t obj_id, const char* name, double* buffer,
-                            bool indep);
-  void read_int(hid_t obj_id, const char* name, int* buffer,
-                         bool indep);
+                    std::complex<double>* buffer, bool indep);
+  void read_double(hid_t obj_id, const char* name, double* buffer, bool indep);
+  void read_int(hid_t obj_id, const char* name, int* buffer, bool indep);
   void read_llong(hid_t obj_id, const char* name, long long* buffer,
-                           bool indep);
-  void read_string(hid_t obj_id, const char* name, size_t slen,
-                            char* buffer, bool indep);
+                  bool indep);
+  void read_string(hid_t obj_id, const char* name, size_t slen, char* buffer,
+                   bool indep);
 
 
-  void read_tally_results(hid_t group_id, hsize_t n_filter,
-                                   hsize_t n_score, double* results);
+  void read_tally_results(hid_t group_id, hsize_t n_filter, hsize_t n_score,
+                          double* results);
   void write_attr_double(hid_t obj_id, int ndim, const hsize_t* dims,
-                                  const char* name, const double* buffer);
+                         const char* name, const double* buffer);
   void write_attr_int(hid_t obj_id, int ndim, const hsize_t* dims,
-                               const char* name, const int* buffer);
+                      const char* name, const int* buffer);
   void write_attr_string(hid_t obj_id, const char* name, const char* buffer);
   void write_double(hid_t group_id, int ndim, const hsize_t* dims,
-                             const char* name, const double* buffer, bool indep);
+                    const char* name, const double* buffer, bool indep);
   void write_int(hid_t group_id, int ndim, const hsize_t* dims,
-                          const char* name, const int* buffer, bool indep);
+                 const char* name, const int* buffer, bool indep);
   void write_llong(hid_t group_id, int ndim, const hsize_t* dims,
-                            const char* name, const long long* buffer, bool indep);
+                   const char* name, const long long* buffer, bool indep);
   void write_string(hid_t group_id, int ndim, const hsize_t* dims, size_t slen,
-                             const char* name, char const* buffer, bool indep);
+                    const char* name, char const* buffer, bool indep);
   void write_tally_results(hid_t group_id, hsize_t n_filter, hsize_t n_score,
-                                    const double* results);
+                           const double* results);
 } // extern "C"
 
 //==============================================================================
@@ -233,7 +235,7 @@ template<typename T> inline
 std::enable_if_t<std::is_scalar<std::decay_t<T>>::value>
 read_dataset(hid_t obj_id, const char* name, T& buffer, bool indep=false)
 {
-  read_dataset(obj_id, name, H5TypeMap<T>::type_id, &buffer, indep);
+  read_dataset_lowlevel(obj_id, name, H5TypeMap<T>::type_id, &buffer, indep);
 }
 
 // overload for std::string
@@ -251,9 +253,11 @@ read_dataset(hid_t obj_id, const char* name, std::string& str, bool indep=false)
 
 // array version
 template<typename T, std::size_t N> inline void
-read_dataset(hid_t dset, const char* name, std::array<T, N>& buffer, bool indep=false)
+read_dataset(hid_t dset, const char* name, std::array<T, N>& buffer,
+             bool indep=false)
 {
-  read_dataset(dset, name, H5TypeMap<T>::type_id, buffer.data(), indep);
+  read_dataset_lowlevel(dset, name, H5TypeMap<T>::type_id, buffer.data(),
+                        indep);
 }
 
 // vector version
@@ -267,11 +271,13 @@ void read_dataset(hid_t dset, std::vector<T>& vec, bool indep=false)
   vec.resize(shape[0]);
 
   // Read data into vector
-  read_dataset(dset, nullptr, H5TypeMap<T>::type_id, vec.data(), indep);
+  read_dataset_lowlevel(dset, nullptr, H5TypeMap<T>::type_id, vec.data(),
+                        indep);
 }
 
 template <typename T>
-void read_dataset(hid_t obj_id, const char* name, std::vector<T>& vec, bool indep=false)
+void read_dataset(hid_t obj_id, const char* name, std::vector<T>& vec,
+                  bool indep=false)
 {
   hid_t dset = open_dataset(obj_id, name);
   read_dataset(dset, vec, indep);
@@ -291,14 +297,17 @@ void read_dataset(hid_t dset, xt::xarray<T>& arr, bool indep=false)
   arr.resize(shape);
 
   // Read data from attribute
-  read_dataset(dset, nullptr, H5TypeMap<T>::type_id, arr.data(), indep);
+  read_dataset_lowlevel(dset, nullptr, H5TypeMap<T>::type_id, arr.data(),
+                        indep);
 }
 
 template<>
-void read_dataset(hid_t dset, xt::xarray<std::complex<double>>& arr, bool indep);
+void read_dataset(hid_t dset, xt::xarray<std::complex<double>>& arr,
+                  bool indep);
 
 template <typename T>
-void read_dataset(hid_t obj_id, const char* name, xt::xarray<T>& arr, bool indep=false)
+void read_dataset(hid_t obj_id, const char* name, xt::xarray<T>& arr,
+                  bool indep=false)
 {
   // Open dataset and read array
   hid_t dset = open_dataset(obj_id, name);
@@ -308,7 +317,8 @@ void read_dataset(hid_t obj_id, const char* name, xt::xarray<T>& arr, bool indep
 
 
 template <typename T, std::size_t N>
-void read_dataset(hid_t obj_id, const char* name, xt::xtensor<T, N>& arr, bool indep=false)
+void read_dataset(hid_t obj_id, const char* name, xt::xtensor<T, N>& arr,
+                  bool indep=false)
 {
   // Open dataset and read array
   hid_t dset = open_dataset(obj_id, name);
@@ -346,7 +356,7 @@ read_dataset(hid_t obj_id, const char* name, Position& r, bool indep=false)
 
 template <typename T, std::size_t N>
 inline void read_dataset_as_shape(hid_t obj_id, const char* name,
-                           xt::xtensor<T, N>& arr, bool indep=false)
+                                  xt::xtensor<T, N>& arr, bool indep=false)
 {
   hid_t dset = open_dataset(obj_id, name);
 
@@ -357,7 +367,8 @@ inline void read_dataset_as_shape(hid_t obj_id, const char* name,
   std::vector<T> buffer(size);
 
   // Read data from attribute
-  read_dataset(dset, nullptr, H5TypeMap<T>::type_id, buffer.data(), indep);
+  read_dataset_lowlevel(dset, nullptr, H5TypeMap<T>::type_id, buffer.data(),
+                        indep);
 
   // Adapt into xarray
   arr = xt::adapt(buffer, arr.shape());
@@ -367,8 +378,8 @@ inline void read_dataset_as_shape(hid_t obj_id, const char* name,
 
 
 template <typename T, std::size_t N>
-inline void read_nd_vector(hid_t obj_id, const char* name, xt::xtensor<T, N>& result,
-     bool must_have=false)
+inline void read_nd_vector(hid_t obj_id, const char* name,
+                           xt::xtensor<T, N>& result, bool must_have=false)
 {
   if (object_exists(obj_id, name)) {
     read_dataset_as_shape(obj_id, name, result, true);
@@ -431,7 +442,8 @@ template<typename T> inline
 std::enable_if_t<std::is_scalar<std::decay_t<T>>::value>
 write_dataset(hid_t obj_id, const char* name, T buffer)
 {
-  write_dataset(obj_id, 0, nullptr, name, H5TypeMap<T>::type_id, &buffer, false);
+  write_dataset_lowlevel(obj_id, 0, nullptr, name, H5TypeMap<T>::type_id,
+                         &buffer, false);
 }
 
 inline void
@@ -444,11 +456,13 @@ template<typename T, std::size_t N> inline void
 write_dataset(hid_t obj_id, const char* name, const std::array<T, N>& buffer)
 {
   hsize_t dims[] {N};
-  write_dataset(obj_id, 1, dims, name, H5TypeMap<T>::type_id, buffer.data(), false);
+  write_dataset_lowlevel(obj_id, 1, dims, name, H5TypeMap<T>::type_id,
+                         buffer.data(), false);
 }
 
 inline void
-write_dataset(hid_t obj_id, const char* name, const std::vector<std::string>& buffer)
+write_dataset(hid_t obj_id, const char* name,
+              const std::vector<std::string>& buffer)
 {
   auto n {buffer.size()};
   hsize_t dims[] {n};
@@ -477,7 +491,8 @@ template<typename T> inline void
 write_dataset(hid_t obj_id, const char* name, const std::vector<T>& buffer)
 {
   hsize_t dims[] {buffer.size()};
-  write_dataset(obj_id, 1, dims, name, H5TypeMap<T>::type_id, buffer.data(), false);
+  write_dataset_lowlevel(obj_id, 1, dims, name, H5TypeMap<T>::type_id,
+                         buffer.data(), false);
 }
 
 // Template for xarray, xtensor, etc.
@@ -487,8 +502,8 @@ write_dataset(hid_t obj_id, const char* name, const xt::xcontainer<D>& arr)
   using T = typename D::value_type;
   auto s = arr.shape();
   std::vector<hsize_t> dims {s.cbegin(), s.cend()};
-  write_dataset(obj_id, dims.size(), dims.data(), name, H5TypeMap<T>::type_id,
-                arr.data(), false);
+  write_dataset_lowlevel(obj_id, dims.size(), dims.data(), name,
+                         H5TypeMap<T>::type_id, arr.data(), false);
 }
 
 inline void

--- a/src/hdf5_interface.cpp
+++ b/src/hdf5_interface.cpp
@@ -49,7 +49,8 @@ get_shape(hid_t obj_id, hsize_t* dims)
   } else if (type == H5I_ATTR) {
     dspace = H5Aget_space(obj_id);
   } else {
-    throw std::runtime_error{"Expected dataset or attribute in call to get_shape."};
+    throw std::runtime_error{
+      "Expected dataset or attribute in call to get_shape."};
   }
   H5Sget_simple_extent_dims(dspace, dims, nullptr);
   H5Sclose(dspace);
@@ -74,7 +75,8 @@ std::vector<hsize_t> object_shape(hid_t obj_id)
   } else if (type == H5I_ATTR) {
     dspace = H5Aget_space(obj_id);
   } else {
-    throw std::runtime_error{"Expected dataset or attribute in call to object_shape."};
+    throw std::runtime_error{
+      "Expected dataset or attribute in call to object_shape."};
   }
   int n = H5Sget_simple_extent_ndims(dspace);
 
@@ -471,8 +473,8 @@ read_attr_string(hid_t obj_id, const char* name, size_t slen, char* buffer)
 
 
 void
-read_dataset(hid_t obj_id, const char* name, hid_t mem_type_id,
-             void* buffer, bool indep)
+read_dataset_lowlevel(hid_t obj_id, const char* name, hid_t mem_type_id,
+                      void* buffer, bool indep)
 {
   hid_t dset = obj_id;
   if (name) dset = open_dataset(obj_id, name);
@@ -520,26 +522,27 @@ void read_dataset(hid_t dset, xt::xarray<std::complex<double>>& arr, bool indep)
 void
 read_double(hid_t obj_id, const char* name, double* buffer, bool indep)
 {
-  read_dataset(obj_id, name, H5T_NATIVE_DOUBLE, buffer, indep);
+  read_dataset_lowlevel(obj_id, name, H5T_NATIVE_DOUBLE, buffer, indep);
 }
 
 
 void
 read_int(hid_t obj_id, const char* name, int* buffer, bool indep)
 {
-  read_dataset(obj_id, name, H5T_NATIVE_INT, buffer, indep);
+  read_dataset_lowlevel(obj_id, name, H5T_NATIVE_INT, buffer, indep);
 }
 
 
 void
 read_llong(hid_t obj_id, const char* name, long long* buffer, bool indep)
 {
-  read_dataset(obj_id, name, H5T_NATIVE_LLONG, buffer, indep);
+  read_dataset_lowlevel(obj_id, name, H5T_NATIVE_LLONG, buffer, indep);
 }
 
 
 void
-read_string(hid_t obj_id, const char* name, size_t slen, char* buffer, bool indep)
+read_string(hid_t obj_id, const char* name, size_t slen, char* buffer,
+            bool indep)
 {
   // Create datatype for a string
   hid_t datatype = H5Tcopy(H5T_C_S1);
@@ -548,7 +551,7 @@ read_string(hid_t obj_id, const char* name, size_t slen, char* buffer, bool inde
   H5Tset_strpad(datatype, H5T_STR_NULLPAD);
 
   // Read data into buffer
-  read_dataset(obj_id, name, datatype, buffer, indep);
+  read_dataset_lowlevel(obj_id, name, datatype, buffer, indep);
 
   // Free resources
   H5Tclose(datatype);
@@ -556,7 +559,8 @@ read_string(hid_t obj_id, const char* name, size_t slen, char* buffer, bool inde
 
 
 void
-read_complex(hid_t obj_id, const char* name, std::complex<double>* buffer, bool indep)
+read_complex(hid_t obj_id, const char* name, std::complex<double>* buffer,
+             bool indep)
 {
   // Create compound datatype for complex numbers
   struct complex_t {
@@ -569,7 +573,7 @@ read_complex(hid_t obj_id, const char* name, std::complex<double>* buffer, bool 
   H5Tinsert(complex_id, "i", HOFFSET(complex_t, im), H5T_NATIVE_DOUBLE);
 
   // Read data
-  read_dataset(obj_id, name, complex_id, buffer, indep);
+  read_dataset_lowlevel(obj_id, name, complex_id, buffer, indep);
 
   // Free resources
   H5Tclose(complex_id);
@@ -577,7 +581,8 @@ read_complex(hid_t obj_id, const char* name, std::complex<double>* buffer, bool 
 
 
 void
-read_tally_results(hid_t group_id, hsize_t n_filter, hsize_t n_score, double* results)
+read_tally_results(hid_t group_id, hsize_t n_filter, hsize_t n_score,
+                   double* results)
 {
   // Create dataspace for hyperslab in memory
   hsize_t dims[] {n_filter, n_score, 3};
@@ -654,8 +659,8 @@ write_attr_string(hid_t obj_id, const char* name, const char* buffer)
 
 
 void
-write_dataset(hid_t group_id, int ndim, const hsize_t* dims, const char* name,
-              hid_t mem_type_id, const void* buffer, bool indep)
+write_dataset_lowlevel(hid_t group_id, int ndim, const hsize_t* dims,
+  const char* name, hid_t mem_type_id, const void* buffer, bool indep)
 {
   // If array is given, create a simple dataspace. Otherwise, create a scalar
   // datascape.
@@ -696,7 +701,8 @@ void
 write_double(hid_t group_id, int ndim, const hsize_t* dims, const char* name,
              const double* buffer, bool indep)
 {
-  write_dataset(group_id, ndim, dims, name, H5T_NATIVE_DOUBLE, buffer, indep);
+  write_dataset_lowlevel(group_id, ndim, dims, name, H5T_NATIVE_DOUBLE, buffer,
+                         indep);
 }
 
 
@@ -704,7 +710,8 @@ void
 write_int(hid_t group_id, int ndim, const hsize_t* dims, const char* name,
           const int* buffer, bool indep)
 {
-  write_dataset(group_id, ndim, dims, name, H5T_NATIVE_INT, buffer, indep);
+  write_dataset_lowlevel(group_id, ndim, dims, name, H5T_NATIVE_INT, buffer,
+                         indep);
 }
 
 
@@ -712,7 +719,8 @@ void
 write_llong(hid_t group_id, int ndim, const hsize_t* dims, const char* name,
             const long long* buffer, bool indep)
 {
-  write_dataset(group_id, ndim, dims, name, H5T_NATIVE_LLONG, buffer, indep);
+  write_dataset_lowlevel(group_id, ndim, dims, name, H5T_NATIVE_LLONG, buffer,
+                         indep);
 }
 
 
@@ -725,7 +733,7 @@ write_string(hid_t group_id, int ndim, const hsize_t* dims, size_t slen,
     hid_t datatype = H5Tcopy(H5T_C_S1);
     H5Tset_size(datatype, slen);
 
-    write_dataset(group_id, ndim, dims, name, datatype, buffer, indep);
+    write_dataset_lowlevel(group_id, ndim, dims, name, datatype, buffer, indep);
 
     // Free resources
     H5Tclose(datatype);
@@ -734,14 +742,17 @@ write_string(hid_t group_id, int ndim, const hsize_t* dims, size_t slen,
 
 
 void
-write_string(hid_t group_id, const char* name, const std::string& buffer, bool indep)
+write_string(hid_t group_id, const char* name, const std::string& buffer,
+             bool indep)
 {
-  write_string(group_id, 0, nullptr, buffer.length(), name, buffer.c_str(), indep);
+  write_string(group_id, 0, nullptr, buffer.length(), name, buffer.c_str(),
+               indep);
 }
 
 
 void
-write_tally_results(hid_t group_id, hsize_t n_filter, hsize_t n_score, const double* results)
+write_tally_results(hid_t group_id, hsize_t n_filter, hsize_t n_score,
+                    const double* results)
 {
   // Set dimensions of sum/sum_sq hyperslab to store
   hsize_t count[] {n_filter, n_score, 2};

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -418,7 +418,7 @@ void load_state_point()
   if (mpi::master) {
 #endif
     // Read global tally data
-    read_dataset(file_id, "global_tallies", H5T_NATIVE_DOUBLE,
+    read_dataset_lowlevel(file_id, "global_tallies", H5T_NATIVE_DOUBLE,
       simulation::global_tallies.data(), false);
 
     // Check if tally results are present

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -419,7 +419,7 @@ void load_state_point()
 #endif
     // Read global tally data
     read_dataset_lowlevel(file_id, "global_tallies", H5T_NATIVE_DOUBLE,
-      simulation::global_tallies.data(), false);
+      H5S_ALL, false, simulation::global_tallies.data());
 
     // Check if tally results are present
     bool present;


### PR DESCRIPTION
This PR updates the `read_tally_results` and `write_tally_results` functions to use collective MPI I/O operations with PHDF5. This makes a huge difference in how long it takes to read the statepoint in a restart run. For one case I was running, I waited for more than an hour to read the statepoint with 256 procs before canceling the job. I don't have precise timing, but it looks like it takes just a few seconds using the changes in this PR.

Rather than adding PHDF5 code to `read_tally_results`/`write_tally_results`, I modified them to use the `read_dataset`/`write_dataset` functions which already had the MPI I/O stuff.

Also, I thought the `read_dataset`/`write_dataset` names were getting a little too crowded with overloads, so I renamed the relevant functions `read_dataset_lowlevel`/`write_dataset_lowelevel` to be more explicit about when the most low-level functions were being called. There are also some other changes for readability here like breaking many lines so they fit within 80 characters.