### PR TITLE
Small fixes for MG mode

### DIFF
--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -999,6 +999,11 @@ class Library(object):
             xsdata.set_total_mgxs(mymgxs, xs_type=xs_type, nuclide=[nuclide],
                                   subdomain=subdomain)
 
+        elif 'transport' in self.mgxs_types and self.correction == 'P0':
+            mymgxs = self.get_mgxs(domain, 'transport')
+            xsdata.set_total_mgxs(mymgxs, xs_type=xs_type, nuclide=[nuclide],
+                                  subdomain=subdomain)
+
         elif 'total' in self.mgxs_types:
             mymgxs = self.get_mgxs(domain, 'total')
             xsdata.set_total_mgxs(mymgxs, xs_type=xs_type, nuclide=[nuclide],
@@ -1170,7 +1175,7 @@ class Library(object):
             # if only scatter matrices have been tallied, multiplicity cannot
             # be accounted for
             else:
-                msg = 'Scatter multiplicity (such as (n,xn) reactions) ' \
+                msg = 'Scatter multiplicity (such as (n,xn) reactions) '\
                       'are ignored since multiplicity or nu-scatter matrices '\
                       'were not tallied for ' + xsdata_name
                 warn(msg, RuntimeWarning)

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -1172,7 +1172,7 @@ class Library(object):
             else:
                 msg = 'Scatter multiplicity (such as (n,xn) reactions) ' \
                       'are ignored since multiplicity or nu-scatter matrices '\
-                      'were not tallied for '+xsdata_name
+                      'were not tallied for ' + xsdata_name
                 warn(msg, RuntimeWarning)
                 xsdata.set_scatter_matrix_mgxs(scatt_mgxs, xs_type=xs_type,
                                                nuclide=[nuclide],
@@ -1420,8 +1420,9 @@ class Library(object):
           fixed source problem could be the target.
         - Fission and kappa-fission are not required as they are only
           needed to support tallies the user may wish to request.
-        - Scattering multiplicity should have been tallied, either using a
-        multiplicity or scatter and nu-scatter matrix tally.
+        - Scattering multiplicity should have been tallied for increased model
+          accuracy, either using a multiplicity or scatter and nu-scatter matrix
+          tally.
 
         See also
         --------
@@ -1478,9 +1479,8 @@ class Library(object):
              'nu-scatter matrix' not in self.mgxs_types) and\
             ('consistent scatter matrix' not in self.mgxs_types or
              'consistent nu-scatter matrix' not in self.mgxs_types):
-            error_flag = True
             warn('A "multiplicity matrix" or both a "scatter" and "nu-scatter" '
-                 'matrix MGXS type(s) is/are required.')
+                 'matrix MGXS type(s) should be provided.')
 
         # Ensure absorption is present
         if 'absorption' not in self.mgxs_types:

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -1420,6 +1420,8 @@ class Library(object):
           fixed source problem could be the target.
         - Fission and kappa-fission are not required as they are only
           needed to support tallies the user may wish to request.
+        - Scattering multiplicity should have been tallied, either using a
+        multiplicity or scatter and nu-scatter matrix tally.
 
         See also
         --------
@@ -1469,6 +1471,16 @@ class Library(object):
             warn('A "nu-scatter matrix", "consistent nu-scatter matrix", '
                  '"scatter matrix", or "consistent scatter matrix" MGXS '
                  'type is required.')
+
+        # Make sure there is some kind of a scattering multiplicity matrix data
+        if 'multiplicity matrix' not in self.mgxs_types and \
+            ('scatter matrix' not in self.mgxs_types or
+             'nu-scatter matrix' not in self.mgxs_types) and\
+            ('consistent scatter matrix' not in self.mgxs_types or
+             'consistent nu-scatter matrix' not in self.mgxs_types):
+            error_flag = True
+            warn('A "multiplicity matrix" or both a "scatter" and "nu-scatter" '
+                 'matrix MGXS type(s) is/are required.')
 
         # Ensure absorption is present
         if 'absorption' not in self.mgxs_types:

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -1167,6 +1167,16 @@ class Library(object):
                                     np.subtract(xsdata._total[i], np.sum(np.sum(
                                         xsdata._scatter_matrix[i][:, :, :, :, :],
                                         axis=4), axis=3))
+            # if only scatter matrices have been tallied, multiplicity cannot
+            # be accounted for
+            else:
+                msg = 'Scatter multiplicity (such as (n,xn) reactions) ' \
+                      'are ignored since multiplicity or nu-scatter matrices '\
+                      'were not tallied for '+xsdata_name
+                warn(msg, RuntimeWarning)
+                xsdata.set_scatter_matrix_mgxs(scatt_mgxs, xs_type=xs_type,
+                                               nuclide=[nuclide],
+                                               subdomain=subdomain)
 
         return xsdata
 

--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -1638,9 +1638,9 @@ class XSdata(object):
                                    xs_type=xs_type, moment=0,
                                    subdomains=subdomain)
             if scatter.scatter_format == 'histogram':
-                scatt = np.sum(scatt, axis=0)
+                scatt = np.sum(scatt, axis=2)
             if nuscatter.scatter_format == 'histogram':
-                nuscatt = np.sum(nuscatt, axis=0)
+                nuscatt = np.sum(nuscatt, axis=2)
             self._multiplicity_matrix[i] = np.divide(nuscatt, scatt)
 
         self._multiplicity_matrix[i] = \


### PR DESCRIPTION
I tried running the MG mode to look at self-shielding errors and I forgot to tally scattering multiplicities (n, xn) in an initial continuous energy run. 
When I tried converting then exporting the MG mgxs library to hdf5, it was telling me that I was missing a scattering matrix, which I had included.

This will catch the problem sooner and more explicitly.

An indexing issue also arised. The test suite only covers converting to mg mode for legendre representations not histogram. I'm still thinking about how to add this in without creating a full new regression test.