### PR TITLE
Adding data_type kwarg to DataLibrary.get_by_material

### DIFF
--- a/openmc/data/library.py
+++ b/openmc/data/library.py
@@ -23,13 +23,16 @@ class DataLibrary(EqualityMixin):
     def __init__(self):
         self.libraries = []
 
-    def get_by_material(self, name):
+    def get_by_material(self, name, data_type='neutron'):
         """Return the library dictionary containing a given material.
 
         Parameters
         ----------
         name : str
             Name of material, e.g. 'Am241'
+        data_type : str
+            Name of data type, e.g. 'neutron', 'photon', 'wmp',
+            or 'thermal'
 
         Returns
         -------
@@ -39,7 +42,7 @@ class DataLibrary(EqualityMixin):
 
         """
         for library in self.libraries:
-            if name in library['materials']:
+            if name in library['materials'] and data_type in library['type']:
                 return library
         return None
 

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -562,14 +562,16 @@ def _calculate_cexs_elem_mat(this, types, temperature=294.,
     if isinstance(this, openmc.Material):
         for sab_name in this._sab:
             sab = openmc.data.ThermalScattering.from_hdf5(
-                library.get_by_material(sab_name)['path'])
+                library.get_by_material(sab_name, data_type='thermal')['path'])
             for nuc in sab.nuclides:
-                sabs[nuc] = library.get_by_material(sab_name)['path']
+                sabs[nuc] = library.get_by_material(sab_name,
+                        data_type='thermal')['path']
     else:
         if sab_name:
             sab = openmc.data.ThermalScattering.from_hdf5(sab_name)
             for nuc in sab.nuclides:
-                sabs[nuc] = library.get_by_material(sab_name)['path']
+                sabs[nuc] = library.get_by_material(sab_name,
+                        data_type='thermal')['path']
 
     # Now we can create the data sets to be plotted
     xs = {}

--- a/tests/unit_tests/test_data_misc.py
+++ b/tests/unit_tests/test_data_misc.py
@@ -18,7 +18,7 @@ def test_data_library(tmpdir):
     assert f['type'] == 'neutron'
     assert 'U235' in f['materials']
 
-    f = lib.get_by_material('c_H_in_H2O')
+    f = lib.get_by_material('c_H_in_H2O', data_type='thermal')
     assert f['type'] == 'thermal'
     assert 'c_H_in_H2O' in f['materials']
 


### PR DESCRIPTION
Currently the DataLibrary.get_by_material method returns the first library it finds for a material regardless of whether or not that cross section library file is for neutrons, photons, wmp, or thermal scattering data. Simply adding an optional keyword that defaults to neutrons should fix this.