### PR TITLE
Removing duplicate surfaces from geometry

### DIFF
--- a/openmc/region.py
+++ b/openmc/region.py
@@ -45,8 +45,7 @@ class Region(metaclass=ABCMeta):
         return not self == other
 
     def get_surfaces(self, surfaces=None):
-        """
-        Recursively find all the surfaces referenced by a region and return them
+        """Recursively find all surfaces referenced by a region and return them
 
         Parameters
         ----------
@@ -64,6 +63,19 @@ class Region(metaclass=ABCMeta):
         for region in self:
             surfaces = region.get_surfaces(surfaces)
         return surfaces
+
+    def remove_redundant_surfaces(self, redundant_surfaces):
+        """Recursively remove all redundant surfaces referenced by this region
+
+        Parameters
+        ----------
+        redundant_surfaces : dict
+            Dictionary mapping redundant surface IDs to class:`openmc.Surface`
+            instances that should replace them.
+
+        """
+        for region in self:
+            region.remove_redundant_surfaces(redundant_surfaces)
 
     @staticmethod
     def from_expression(expression, surfaces):
@@ -597,8 +609,7 @@ class Complement(Region):
         return temp_region.bounding_box
 
     def get_surfaces(self, surfaces=None):
-        """
-        Recursively find and return all the surfaces referenced by the node
+        """Recursively find and return all the surfaces referenced by the node
 
         Parameters
         ----------
@@ -616,6 +627,19 @@ class Complement(Region):
         for region in self.node:
             surfaces = region.get_surfaces(surfaces)
         return surfaces
+
+    def remove_redundant_surfaces(self, redundant_surfaces):
+        """Recursively remove all redundant surfaces referenced by this region
+
+        Parameters
+        ----------
+        redundant_surfaces : dict
+            Dictionary mapping redundant surface IDs to class:`openmc.Surface`
+            instances that should replace them.
+
+        """
+        for region in self.node:
+            region.remove_redundant_surfaces(redundant_surfaces)
 
     def clone(self, memo=None):
         """Create a copy of this region - each of the surfaces in the

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -2209,6 +2209,21 @@ class Halfspace(Region):
         surfaces[self.surface.id] = self.surface
         return surfaces
 
+    def remove_redundant_surfaces(self, redundant_surfaces):
+        """Recursively remove all redundant surfaces referenced by this region
+
+        Parameters
+        ----------
+        redundant_surfaces : dict
+            Dictionary mapping redundant surface IDs to surface IDs for the 
+            :class:`openmc.Surface` instances that should replace them.
+
+        """
+
+        surf = redundant_surfaces.get(self.surface.id)
+        if surf is not None:
+            self.surface = surf
+
     def clone(self, memo=None):
         """Create a copy of this halfspace, with a cloned surface with a
         unique ID.


### PR DESCRIPTION
I just wanted to open a PR to let people see what I was thinking about solving issue #1443. By adding a key and hash method to the surface class we can compare surfaces easily for topological equality by comparing, surface type, boundary_type and coefficients and throwing out the name and id number. This means you can take sets of surfaces to get only the unique ones. Then it should be pretty straight-forward to check surfaces in a universe for equality and reduce them to a single surface by replacing the duplicated surfaces in a Regions node list.

I still need to implement the duplicate checking in a universe or geometry, but I wanted to get feedback before going further.