### PR TITLE
Support pre-evaluated data in Chain.from_endf

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -189,7 +189,7 @@ class Chain(object):
         return len(self.nuclides)
 
     @classmethod
-    def from_endf(cls, decay_files, fpy_files, neutron_files):
+    def from_endf(cls, decay_files, fpy_files, neutron_files, progress=True):
         """Create a depletion chain from ENDF files.
 
         Parameters
@@ -200,12 +200,20 @@ class Chain(object):
             List of ENDF neutron-induced fission product yield sub-library files
         neutron_files : list of str
             List of ENDF neutron reaction sub-library files
+        progress : bool, optional
+            Flag to print status messages during processing. Does not
+            effect warning messages
+
+        Returns
+        -------
+        Chain
 
         """
         chain = cls()
 
         # Create dictionary mapping target to filename
-        print('Processing neutron sub-library files...')
+        if progress:
+            print('Processing neutron sub-library files...')
         reactions = {}
         for f in neutron_files:
             evaluation = openmc.data.endf.Evaluation(f)
@@ -219,7 +227,8 @@ class Chain(object):
                     reactions[name][mt] = q_value
 
         # Determine what decay and FPY nuclides are available
-        print('Processing decay sub-library files...')
+        if progress:
+            print('Processing decay sub-library files...')
         decay_data = {}
         for f in decay_files:
             data = openmc.data.Decay(f)
@@ -228,13 +237,15 @@ class Chain(object):
                 continue
             decay_data[data.nuclide['name']] = data
 
-        print('Processing fission product yield sub-library files...')
+        if progress:
+            print('Processing fission product yield sub-library files...')
         fpy_data = {}
         for f in fpy_files:
             data = openmc.data.FissionProductYields(f)
             fpy_data[data.nuclide['name']] = data
 
-        print('Creating depletion_chain...')
+        if progress:
+            print('Creating depletion_chain...')
         missing_daughter = []
         missing_rx_product = []
         missing_fpy = []

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -192,13 +192,18 @@ class Chain(object):
     def from_endf(cls, decay_files, fpy_files, neutron_files, progress=True):
         """Create a depletion chain from ENDF files.
 
+        String arguments in ``decay_files``, ``fpy_files``, and
+        ``neutron_files`` will be treated as file names to be read.
+        Alternatively, :class:`openmc.data.endf.Evaluation` instances
+        can be included in these arguments.
+
         Parameters
         ----------
-        decay_files : list of str
+        decay_files : list of str or openmc.data.endf.Evaluation
             List of ENDF decay sub-library files
-        fpy_files : list of str
+        fpy_files : list of str or openmc.data.endf.Evaluation
             List of ENDF neutron-induced fission product yield sub-library files
-        neutron_files : list of str
+        neutron_files : list of str or openmc.data.endf.Evaluation
             List of ENDF neutron reaction sub-library files
         progress : bool, optional
             Flag to print status messages during processing. Does not


### PR DESCRIPTION
~~Companion to the `from_endf` method, but acts on instances of `Evaluation`, `Decay`, and `FissionProductYields` objects. The `from_endf` method reads the appropriate files and passes the instances off to from_evaluation for internal processing.~~

This is the first part in what I hope will be a two PR process allowing users to create equivalent depletion chains to what Serpent uses. I'm working on a ~~hack~~script know that will come up later after some more development. The goal is that the script will produce the evaluations by reading the `.dec` and `.nfy` files that usually ship with Serpent, and then create chain using `from_evaluations`

## Edit

The `from_evaluations` method has been removed. Instead, users can pass pre-evaluated ~`Decay`, `FissionProductYields` and/or~ `Evaluation` instances in place of file names