### PR TITLE
Prevent segfault when destructors are called

### DIFF
--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -25,8 +25,8 @@ class Material;
 
 namespace model {
 
-extern std::vector<std::unique_ptr<Material>> materials;
 extern std::unordered_map<int32_t, int32_t> material_map;
+extern std::vector<std::unique_ptr<Material>> materials;
 
 } // namespace model
 

--- a/include/openmc/tallies/filter.h
+++ b/include/openmc/tallies/filter.h
@@ -108,8 +108,8 @@ private:
 
 namespace model {
   extern "C" int32_t n_filters;
-  extern std::vector<std::unique_ptr<Filter>> tally_filters;
   extern std::unordered_map<int, int> filter_map;
+  extern std::vector<std::unique_ptr<Filter>> tally_filters;
 }
 
 //==============================================================================

--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -141,6 +141,7 @@ private:
 //==============================================================================
 
 namespace model {
+  extern std::unordered_map<int, int> tally_map;
   extern std::vector<std::unique_ptr<Tally>> tallies;
   extern std::vector<int> active_tallies;
   extern std::vector<int> active_analog_tallies;
@@ -148,8 +149,6 @@ namespace model {
   extern std::vector<int> active_collision_tallies;
   extern std::vector<int> active_meshsurf_tallies;
   extern std::vector<int> active_surface_tallies;
-
-  extern std::unordered_map<int, int> tally_map;
 }
 
 namespace simulation {

--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -98,10 +98,10 @@ public:
   //! True if this tally has a bin for every nuclide in the problem
   bool all_nuclides_ {false};
 
-  //! Results for each bin -- the first dimension of the array is for scores
-  //! (e.g. flux, total reaction rate, fission reaction rate, etc.) and the
-  //! second dimension of the array is for the combination of filters
-  //! (e.g. specific cell, specific energy group, etc.)
+  //! Results for each bin -- the first dimension of the array is for the
+  //! combination of filters (e.g. specific cell, specific energy group, etc.)
+  //! and the second dimension of the array is for scores (e.g. flux, total
+  //! reaction rate, fission reaction rate, etc.)
   xt::xtensor<double, 3> results_;
 
   //! True if this tally should be written to statepoint files

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -37,8 +37,8 @@ namespace openmc {
 
 namespace model {
 
-std::vector<std::unique_ptr<Material>> materials;
 std::unordered_map<int32_t, int32_t> material_map;
+std::vector<std::unique_ptr<Material>> materials;
 
 } // namespace model
 

--- a/src/tallies/filter.cpp
+++ b/src/tallies/filter.cpp
@@ -40,8 +40,8 @@ namespace openmc {
 //==============================================================================
 
 namespace model {
-  std::vector<std::unique_ptr<Filter>> tally_filters;
   std::unordered_map<int, int> filter_map;
+  std::vector<std::unique_ptr<Filter>> tally_filters;
 }
 
 //==============================================================================

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -45,6 +45,7 @@ namespace openmc {
 //==============================================================================
 
 namespace model {
+  std::unordered_map<int, int> tally_map;
   std::vector<std::unique_ptr<Tally>> tallies;
   std::vector<int> active_tallies;
   std::vector<int> active_analog_tallies;
@@ -52,7 +53,6 @@ namespace model {
   std::vector<int> active_collision_tallies;
   std::vector<int> active_meshsurf_tallies;
   std::vector<int> active_surface_tallies;
-  std::unordered_map<int, int> tally_map;
 }
 
 namespace simulation {


### PR DESCRIPTION
The destructors for `Filter`, `Tally`, and `Material` attempt to clean things up by erasing their ID from the corresponding unordered map (`filter_map`, `tally_map`, and `material_map`). However, this currently can cause problems if the executable exits and `openmc_finalize` was never called. For global variables, destructors are called in the reverse order that objects were created in, which is the order of declaration for variables in the same translation unit. Right now we declare, e.g., `filters` first and _then_ `filter_map`, which means `filter_map` gets deleted first and then `filters`. Ergo, when the destructor of `Filter` is called (which calls `filter_map.erase(id_)`, `filter_map` doesn't exist anymore, which unpredictably leads to a segfault. This PR simply reverses the order so that these unordered maps are guaranteed to still exist at the time the `Filter`, `Tally`, and `Material` destructors are called.