### PR TITLE
Ensure a valid bin is picked for short tracks in tally meshes

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -530,9 +530,11 @@ void RegularMesh::bins_crossed(const Particle* p, std::vector<int>& bins,
   // The TINY_BIT offsets above mean that the preceding logic cannot always find
   // the correct ijk0 and ijk1 indices. For tracks shorter than 2*TINY_BIT, just
   // assume the track lies in only one mesh bin. These tracks are very short so
-  // any error caused by this assumption will be small.
+  // any error caused by this assumption will be small. It is important that
+  // ijk0 values are used rather than ijk1 because the previous logic guarantees
+  // ijk0 is a valid mesh bin.
   if (total_distance < 2*TINY_BIT) {
-    for (int i = 0; i < n; ++i) ijk0[i] = ijk1[i];
+    for (int i = 0; i < n; ++i) ijk1[i] = ijk0[i];
   }
 
   // ========================================================================
@@ -917,9 +919,11 @@ void RectilinearMesh::bins_crossed(const Particle* p, std::vector<int>& bins,
   // The TINY_BIT offsets above mean that the preceding logic cannot always find
   // the correct ijk0 and ijk1 indices. For tracks shorter than 2*TINY_BIT, just
   // assume the track lies in only one mesh bin. These tracks are very short so
-  // any error caused by this assumption will be small.
+  // any error caused by this assumption will be small. It is important that
+  // ijk0 values are used rather than ijk1 because the previous logic guarantees
+  // ijk0 is a valid mesh bin.
   if (total_distance < 2*TINY_BIT) {
-    for (int i = 0; i < 3; ++i) ijk0[i] = ijk1[i];
+    for (int i = 0; i < 3; ++i) ijk1[i] = ijk0[i];
   }
 
   // ========================================================================


### PR DESCRIPTION
#1387 fixed one type of bug related to very short tracks, but added another. With that change the tally mesh code can sometimes give an invalid bin with subtle side-effects. This PR fixes that error.

#1387 was aimed at tricky cases where we were tallying a track that is shorter than `2*TINY_BIT` and crosses from mesh bin `ijk0` to a different mesh bin `ijk1`. Since the track is short it's okay to just pick one of those mesh bins and return, but it matters which one. Previously, I went with the values for `ijk1`, but those indices are not guaranteed to actually be in the mesh. This PR switches that to `ijk0` which should always be valid as far as I can tell.

This was a nasty little bug! Its effect was to sometimes cause `score_general_ce` to try updating a tally result in an invalid chunk of memory, but that memory chunk was always somewhere else in the heap and didn't cause a segfault. It would manifest by causing segfaults in some unrelated cross section code.