### PR TITLE
fixing normal distribution

### DIFF
--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -448,7 +448,6 @@ class Normal(Univariate):
     @mean_value.setter
     def mean_value(self, mean_value):
         cv.check_type('Normal mean_value', mean_value, Real)
-        cv.check_greater_than('Normal mean_value', mean_value, 0.0)
         self._mean_value = mean_value
 
     @std_dev.setter


### PR DESCRIPTION
The mean of a normal distribution doesn't have to be positive. This PR simply removes that check when creating a Normal distribution object. It makes sense for energy distributions, but not for spatial ones, which is where I'm using it.