### PR TITLE
Surface rotations and geometry enhancements

### DIFF
--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from numbers import Real, Integral
 from xml.etree import ElementTree as ET
 from warnings import warn
+import math
 
 import numpy as np
 
@@ -477,6 +478,42 @@ class Plane(Surface):
         else:
             return type(self)(a=self.a, b=self.b, c=self.c, d=d)
 
+    def rotate(self, rotation, frame='lab'):
+        """Rotate surface by given Tait-Bryan angles
+
+        Parameters
+        ----------
+        rotation : iterable of float
+            Intrinsic Tait-Bryan angles in degrees used to rotate the surface
+
+        frame : str, one of 'lab' or 'body'
+
+        Returns
+        -------
+        openmc.Plane
+            Rotated surface
+
+        """
+
+        check_type('surface rotation', rotation, Iterable, Real)
+        check_length('surface rotation', rotation, 3)
+
+        # Calculate rotation matrix Rmat from angles phi, theta, psi
+        phi, theta, psi = rotation*(-np.pi/180.)
+        c3, s3 = np.cos(phi), np.sin(phi)
+        c2, s2 = np.cos(theta), np.sin(theta)
+        c1, s1 = np.cos(psi), np.sin(psi)
+        Rmat = np.array([[c1*c2, c1*s2*s3 - c3*s1, s1*s3 + c1*c3*s2],
+                         [c2*s1, c1*c3 + s1*s2*s3, c3*s1*s2 - c1*s3],
+                         [-s2, c2*s3, c2*c3]])
+        bvec = np.array([self.a, self.b, self.c])
+
+        # Compute new rotated coefficients a, b, c
+        a, b, c = np.dot(bvec.T, Rmat.T)
+
+        return type(self)(a=a, b=b, c=c, d=self.d)
+
+
     def to_xml_element(self):
         """Return XML representation of the surface
 
@@ -651,6 +688,42 @@ class XPlane(Plane):
         else:
             return type(self)(x0=self.x0 + vx)
 
+    def rotate(self, rotation, frame='lab'):
+        """Rotate surface by given Tait-Bryan angles
+
+        Parameters
+        ----------
+        rotation : iterable of float
+            Intrinsic Tait-Bryan angles in degrees used to rotate the surface
+
+        frame : str, one of 'lab' or 'body'
+
+        Returns
+        -------
+        openmc.Plane
+            Rotated surface
+
+        """
+
+        check_type('surface rotation', rotation, Iterable, Real)
+        check_length('surface rotation', rotation, 3)
+
+        # Calculate rotation matrix Rmat from angles phi, theta, psi
+        phi, theta, psi = rotation*(-np.pi/180.)
+        c3, s3 = np.cos(phi), np.sin(phi)
+        c2, s2 = np.cos(theta), np.sin(theta)
+        c1, s1 = np.cos(psi), np.sin(psi)
+        Rmat = np.array([[c1*c2, c1*s2*s3 - c3*s1, s1*s3 + c1*c3*s2],
+                         [c2*s1, c1*c3 + s1*s2*s3, c3*s1*s2 - c1*s3],
+                         [-s2, c2*s3, c2*c3]])
+        bvec = np.array([1., 0., 0.])
+
+        # Compute new rotated coefficients a, b, c
+        a, b, c = np.dot(bvec.T, Rmat.T)
+        d = self.x0
+
+        return Plane(a=a, b=b, c=c, d=d)
+
 
 class YPlane(Plane):
     """A plane perpendicular to the y axis of the form :math:`y - y_0 = 0`
@@ -775,6 +848,42 @@ class YPlane(Plane):
             return self
         else:
             return type(self)(y0=self.y0 + vy)
+
+    def rotate(self, rotation, frame='lab'):
+        """Rotate surface by given Tait-Bryan angles
+
+        Parameters
+        ----------
+        rotation : iterable of float
+            Intrinsic Tait-Bryan angles in degrees used to rotate the surface
+
+        frame : str, one of 'lab' or 'body'
+
+        Returns
+        -------
+        openmc.Plane
+            Rotated surface
+
+        """
+
+        check_type('surface rotation', rotation, Iterable, Real)
+        check_length('surface rotation', rotation, 3)
+
+        # Calculate rotation matrix Rmat from angles phi, theta, psi
+        phi, theta, psi = rotation*(-np.pi/180.)
+        c3, s3 = np.cos(phi), np.sin(phi)
+        c2, s2 = np.cos(theta), np.sin(theta)
+        c1, s1 = np.cos(psi), np.sin(psi)
+        Rmat = np.array([[c1*c2, c1*s2*s3 - c3*s1, s1*s3 + c1*c3*s2],
+                         [c2*s1, c1*c3 + s1*s2*s3, c3*s1*s2 - c1*s3],
+                         [-s2, c2*s3, c2*c3]])
+        bvec = np.array([0., 1., 0.])
+
+        # Compute new rotated coefficients a, b, c
+        a, b, c = np.dot(bvec.T, Rmat.T)
+        d = self.y0
+
+        return Plane(a=a, b=b, c=c, d=d)
 
 
 class ZPlane(Plane):
@@ -901,6 +1010,42 @@ class ZPlane(Plane):
         else:
             return type(self)(z0=self.z0 + vz)
 
+    def rotate(self, rotation, frame='lab'):
+        """Rotate surface by given Tait-Bryan angles
+
+        Parameters
+        ----------
+        rotation : iterable of float
+            Intrinsic Tait-Bryan angles in degrees used to rotate the surface
+
+        frame : str, one of 'lab' or 'body'
+
+        Returns
+        -------
+        openmc.Plane
+            Rotated surface
+
+        """
+
+        check_type('surface rotation', rotation, Iterable, Real)
+        check_length('surface rotation', rotation, 3)
+
+        # Calculate rotation matrix Rmat from angles phi, theta, psi
+        phi, theta, psi = rotation*(-np.pi/180.)
+        c3, s3 = np.cos(phi), np.sin(phi)
+        c2, s2 = np.cos(theta), np.sin(theta)
+        c1, s1 = np.cos(psi), np.sin(psi)
+        Rmat = np.array([[c1*c2, c1*s2*s3 - c3*s1, s1*s3 + c1*c3*s2],
+                         [c2*s1, c1*c3 + s1*s2*s3, c3*s1*s2 - c1*s3],
+                         [-s2, c2*s3, c2*c3]])
+        bvec = np.array([0., 0., 1.])
+
+        # Compute new rotated coefficients a, b, c
+        a, b, c = np.dot(bvec.T, Rmat.T)
+        d = self.z0
+
+        return Plane(a=a, b=b, c=c, d=d)
+
 
 class Cylinder(Surface):
     """A cylinder whose length is parallel to the x-, y-, or z-axis.
@@ -950,6 +1095,48 @@ class Cylinder(Surface):
     def r(self, r):
         check_type('r coefficient', r, Real)
         self._coefficients['r'] = r
+
+    @classmethod
+    def from_points(cls, p1, p2, r=1., **kwargs):
+        """Return a cylinder given points that define the axis and a radius.
+
+        Parameters
+        ----------
+        p1, p2 : 3-tuples
+            Points that pass through the plane
+        r : float, optional
+            Radius of the culinder. Defaults to 1.
+        kwargs : dict
+            Keyword arguments passed to the :class:`Quadric` constructor
+
+        Returns
+        -------
+        Quadric
+            Quadric that passes through the three points
+
+        """
+        # Convert to numpy arrays
+        p1 = np.asarray(p1)
+        p2 = np.asarray(p2)
+        x1, y1, z1 = p1
+        x2, y2, z2 = p2
+        dx, dy, dz = p2 - p1
+
+        # Set coefficients for Quadric surface that represents a cylinder of
+        # radius r whose axis is the line defined by p1 and p2
+        a = dy**2 + dz**2
+        b = dx**2 + dz**2
+        c = dx**2 + dy**2
+        d = -2*dx*dy
+        e = -2*dy*dz
+        f = -2*dx*dz
+        g = -2*((z2 - z1)*(x1*z2 - x2*z1) + (y2 - y1)*(x1*y2-x2*y1))
+        h = 2*((x2 - x1)*(x1*y2 - x2*y1) - (z2 - z1)*(y1*z2 - y2*z1))
+        j = 2*((x2 - x1)*(x1*z2 - x2*z1) + (y2 - y1)*(y1*z2 - y2*z1))
+        k = (y1*z2 - y2*z1)**2 + (x1*z2 - x2*z1)**2 + (x1*y2 - x2*y1)**2 \
+            - r**2*(dx**2 + dy**2 + dz**2)
+
+        return Quadric(a=a, b=b, c=c, d=d, e=e, f=f, g=g, h=h, j=j, k=k, **kwargs)
 
 
 class XCylinder(Cylinder):
@@ -1098,6 +1285,28 @@ class XCylinder(Cylinder):
             z0 = self.z0 + vz
             return type(self)(y0=y0, z0=z0, r=self.r)
 
+    def rotate(self, rotation, frame='lab'):
+        """Rotate surface by given Tait-Bryan angles
+
+        Parameters
+        ----------
+        rotation : iterable of float
+            Intrinsic Tait-Bryan angles in degrees used to rotate the surface
+
+        frame : str, one of 'lab' or 'body'
+
+        Returns
+        -------
+        openmc.Quadric
+            Rotated surface
+
+        """
+
+        q_cyl = Cylinder.from_points((0., self.y0, self.z0),
+                                     (1., self.y0, self.z0), r=self.r)
+
+        return q_cyl.rotate(rotation, frame=frame)
+
 
 class YCylinder(Cylinder):
     """An infinite cylinder whose length is parallel to the y-axis of the form
@@ -1245,6 +1454,28 @@ class YCylinder(Cylinder):
             z0 = self.z0 + vz
             return type(self)(x0=x0, z0=z0, r=self.r)
 
+    def rotate(self, rotation, frame='lab'):
+        """Rotate surface by given Tait-Bryan angles
+
+        Parameters
+        ----------
+        rotation : iterable of float
+            Intrinsic Tait-Bryan angles in degrees used to rotate the surface
+
+        frame : str, one of 'lab' or 'body'
+
+        Returns
+        -------
+        openmc.Quadric
+            Rotated surface
+
+        """
+
+        q_cyl = Cylinder.from_points((self.x0, 0., self.z0),
+                                     (self.x0, 1., self.z0), r=self.r)
+
+        return q_cyl.rotate(rotation, frame=frame)
+
 
 class ZCylinder(Cylinder):
     """An infinite cylinder whose length is parallel to the z-axis of the form
@@ -1391,6 +1622,28 @@ class ZCylinder(Cylinder):
             x0 = self.x0 + vx
             y0 = self.y0 + vy
             return type(self)(x0=x0, y0=y0, r=self.r)
+
+    def rotate(self, rotation, frame='lab'):
+        """Rotate surface by given Tait-Bryan angles
+
+        Parameters
+        ----------
+        rotation : iterable of float
+            Intrinsic Tait-Bryan angles in degrees used to rotate the surface
+
+        frame : str, one of 'lab' or 'body'
+
+        Returns
+        -------
+        openmc.Quadric
+            Rotated surface
+
+        """
+
+        q_cyl = Cylinder.from_points((self.x0, self.y0, 0.),
+                                     (self.x0, self.y0, 1.), r=self.r)
+
+        return q_cyl.rotate(rotation, frame=frame)
 
 
 class Sphere(Surface):
@@ -2105,8 +2358,8 @@ class Quadric(Surface):
 
         """
 
-        check_type('cell rotation', rotation, Iterable, Real)
-        check_length('cell rotation', rotation, 3)
+        check_type('surface rotation', rotation, Iterable, Real)
+        check_length('surface rotation', rotation, 3)
 
         # Calculate rotation matrix Rmat from angles phi, theta, psi
         phi, theta, psi = rotation*(-np.pi/180.)


### PR DESCRIPTION
This is a draft of a PR I'm working on to allow for rotations to be applied to surfaces and to add the ability to create cylinders with arbitrary axes specified by two points (rather than only having X, Y, Z cylinders). I think this could be pretty useful for model building and for translating MCNP geometries into OpenMC. 

Generally speaking we can represent quadric surfaces in the form:

<img src="https://render.githubusercontent.com/render/math?math=\bf{x}^TA\bf{x} %2B \bf{b}^T\bf{x} %2B c = 0">

where A, b, c represent all the coefficients A-K that define the surface. In this formalism performing transformations on surfaces is pretty straightforward. If you want to translate a surface by the vector <img src="https://render.githubusercontent.com/render/math?math=\bf{v}">, just substitute <img src="https://render.githubusercontent.com/render/math?math=\bf{x}-\bf{v}"> in for <img src="https://render.githubusercontent.com/render/math?math=\bf{x}"> in the equation above and the equation for the new surface becomes (after a little math) 

<img src="https://render.githubusercontent.com/render/math?math=\bf{x}^TA\bf{x} %2B (\bf{b}^T - 2\bf{v}^TA)\bf{x} %2B \bf{v}^TA\bf{v} - \bf{b}^T\bf{v} %2B c = 0">
which gives a new representation for the linear and constant terms, but not the quadratic ones.

Similarly, if you want to perform a rotation <img src="https://render.githubusercontent.com/render/math?math=R"> then the equation for the rotated surface becomes 

<img src="https://render.githubusercontent.com/render/math?math=\bf{x}^TRAR^T\bf{x} %2B \bf{b}^TR^T\bf{x} %2B c = 0">

Working through this math I believe I found an error in the Quadric surface translate function which is corrected in this PR (although certainly correct me if I'm mistaken). I'm also working on applying this logic to the rest of the surfaces and perhaps regions (just through calls to all the surfaces in the region). 

On a related note, I realized when working through PR #1444 that the same surface can have different coefficients (if they are all scaled by the same factor for example) and currently there is no way to know they are the same. Is it worth thinking about a surface simplify method to cover our bases here? When this comes to mind it brings up questions about the abstraction of surfaces and the geometry in general that might be worth talking about if people like.

Update: As this PR seems to become more involved I decided I'd write down an outline here. This is what I'm thinking of doing right now and, of course, any and all feedback is appreciated as always:

1.) Refactor the code such that only Plane, Quadric, and a new class Quartic are subclasses of Surface, this means all Cylinders, Cones, and Spheres are subclasses of Quadric.
2.) Include checks of dimensionality in constructors for Plane, Quadric, and Quartic to return simplified geometries if a bunch of 0 coefficients are passed in. i.e. if for some reason somebody created a quadric surface with a=b=c=d=e=f=0 it should return a Plane and a Plane should return an XPlane if b=c=0
3.) Add classes for EllipticCylinder and (X,Y,Z)EllipticCylinder (subclasses of Quadric) as well as Torus and EllipticTorus classes (subclasses of Quartic) (@makeclean I looked at your add_torus branch are you interested in adding that to this PR?) This part also involves modifying the C++ source to accept new surface types and I'd want to make sure this PR doesn't break how things currently work.
4.) Implement surface rotations in a similar fashion to cell rotations (maybe region rotations too?)
5.) Implement surface normalization method (possibly leading non-zero coefficient = 1) in order to determine for sure if two surfaces are equivalent
6.) Perhaps override setters for subclasses of Plane, Quadric, and Quartic to prevent people from messing with inherited coefficients that would make a Cylinder no longer a cylinder for example. This helps address issue #1475 
7.) Implement Cylinder and EllipticCylinder from_points class methods to specify an arbitrary axis for the cylinder

My ultimate hope is that this leads to the idea that for any given model there is one (and really only one) representation of it in xml format and that this format is as simple as possible with as few coefficients as possible (as I assume this affects performance to some degree), while also giving the user the power to perform arbitrary rotations and translations to any surface during the model building process.