### PR TITLE
add some getters to 1D distributions (needed for my research project)

### DIFF
--- a/include/openmc/distribution.h
+++ b/include/openmc/distribution.h
@@ -62,6 +62,9 @@ public:
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
   double sample(uint64_t* seed) const;
+
+  double a() const { return a_; }
+  double b() const { return a_; }
 private:
   double a_; //!< Lower bound of distribution
   double b_; //!< Upper bound of distribution
@@ -80,6 +83,8 @@ public:
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
   double sample(uint64_t* seed) const;
+
+  double theta() const { return theta_; }
 private:
   double theta_; //!< Factor in exponential [eV]
 };
@@ -97,6 +102,9 @@ public:
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
   double sample(uint64_t* seed) const;
+
+  double a() const { return a_; }
+  double b() const { return b_; }
 private:
   double a_; //!< Factor in exponential [eV]
   double b_; //!< Factor in square root [1/eV]
@@ -115,6 +123,9 @@ public:
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
   double sample(uint64_t* seed) const;
+
+  double mean_value() const { return mean_value_; }
+  double std_dev() const { return std_dev_; }
 private:
   double mean_value_;    //!< middle of distribution [eV]
   double std_dev_; //!< standard deviation [eV]
@@ -134,6 +145,10 @@ public:
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
   double sample(uint64_t* seed) const;
+
+  double e0() const { return e0_; }
+  double m_rat() const { return m_rat_; }
+  double kt() const { return kt_; }
 private:
   // example DT fusion m_rat = 5 (D = 2 + T = 3)
   // ion temp = 20000 eV
@@ -161,6 +176,8 @@ public:
   // x property
   std::vector<double>& x() { return x_; }
   const std::vector<double>& x() const { return x_; }
+  const std::vector<double>& p() const { return p_; }
+  Interpolation interp() const { return interp_; }
 private:
   std::vector<double> x_; //!< tabulated independent variable
   std::vector<double> p_; //!< tabulated probability density
@@ -188,6 +205,8 @@ public:
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
   double sample(uint64_t* seed) const;
+
+  const std::vector<double>& x() const { return x_; }
 private:
   std::vector<double> x_; //! Possible outcomes
 };

--- a/include/openmc/distribution.h
+++ b/include/openmc/distribution.h
@@ -64,7 +64,7 @@ public:
   double sample(uint64_t* seed) const;
 
   double a() const { return a_; }
-  double b() const { return a_; }
+  double b() const { return b_; }
 private:
   double a_; //!< Lower bound of distribution
   double b_; //!< Upper bound of distribution


### PR DESCRIPTION
Hey,

So, here is a **very small** change that will allow some of my research code to work, and should not change the execution of normally running OpenMC in any way. In short, I need this because I'm writing GPU code that links to libopenmc, and to get data to the GPU, I need to access a few private members of some things because I'm not directly copying this data, and rather copying to other data structures which are optimized for the GPU.