### PR TITLE
Use fmtlib in place of iostreams

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "vendor/xtl"]
 	path = vendor/xtl
 	url = https://github.com/xtensor-stack/xtl.git
+[submodule "vendor/fmt"]
+	path = vendor/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,13 @@ endif()
 add_subdirectory(vendor/pugixml)
 
 #===============================================================================
+# {fmt} library
+#===============================================================================
+
+set(FMT_INSTALL ON CACHE BOOL "Generate the install target.")
+add_subdirectory(vendor/fmt)
+
+#===============================================================================
 # xtensor header-only library
 #===============================================================================
 
@@ -346,7 +353,7 @@ endif()
 # target_link_libraries treats any arguments starting with - but not -l as
 # linker flags. Thus, we can pass both linker flags and libraries together.
 target_link_libraries(libopenmc ${ldflags} ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES}
-                      pugixml faddeeva xtensor gsl-lite-v1)
+                      pugixml faddeeva xtensor gsl-lite-v1 fmt::fmt)
 
 if(dagmc)
   target_compile_definitions(libopenmc PRIVATE DAGMC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,8 @@ target_link_libraries(xtensor INTERFACE xtl)
 add_subdirectory(vendor/gsl-lite)
 
 # Make sure contract violations throw exceptions
-target_compile_definitions(gsl-lite INTERFACE GSL_THROW_ON_CONTRACT_VIOLATION)
+target_compile_definitions(gsl-lite-v1 INTERFACE GSL_THROW_ON_CONTRACT_VIOLATION)
+target_compile_definitions(gsl-lite-v1 INTERFACE gsl_CONFIG_ALLOWS_NONSTRICT_SPAN_COMPARISON=1)
 
 #===============================================================================
 # RPATH information
@@ -345,7 +346,7 @@ endif()
 # target_link_libraries treats any arguments starting with - but not -l as
 # linker flags. Thus, we can pass both linker flags and libraries together.
 target_link_libraries(libopenmc ${ldflags} ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES}
-                      pugixml faddeeva xtensor gsl-lite)
+                      pugixml faddeeva xtensor gsl-lite-v1)
 
 if(dagmc)
   target_compile_definitions(libopenmc PRIVATE DAGMC)

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -11,6 +11,7 @@
 #include "openmc/position.h"
 #include "openmc/constants.h"
 #include "openmc/cell.h"
+#include "openmc/error.h"
 #include "openmc/geometry.h"
 #include "openmc/particle.h"
 #include "openmc/xml_interface.h"
@@ -154,10 +155,8 @@ T PlotBase::get_map() const {
     in_i = 1;
     out_i = 2;
     break;
-#ifdef __GNUC__
   default:
-    __builtin_unreachable();
-#endif
+    UNREACHABLE();
   }
 
   // set initial position

--- a/include/openmc/volume_calc.h
+++ b/include/openmc/volume_calc.h
@@ -7,6 +7,7 @@
 #include "pugixml.hpp"
 #include "xtensor/xtensor.hpp"
 
+#include <array>
 #include <string>
 #include <vector>
 #include <gsl/gsl>

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -9,9 +9,8 @@
 #include <set>
 #include <string>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include <gsl/gsl>
-#include <fmt/format.h>
 
 #include "openmc/capi.h"
 #include "openmc/constants.h"

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -9,7 +9,7 @@
 #include <set>
 #include <string>
 
-
+#include <fmt/format.h>
 #include <gsl/gsl>
 #include <fmt/format.h>
 
@@ -158,10 +158,8 @@ generate_rpn(int32_t cell_id, std::vector<int32_t> infix)
         // If we run out of operators without finding a left parenthesis, it
         // means there are mismatched parentheses.
         if (it == stack.rend()) {
-          std::stringstream err_msg;
-          err_msg << "Mismatched parentheses in region specification for cell "
-                  << cell_id;
-          fatal_error(err_msg);
+          fatal_error(fmt::format(
+            "Mismatched parentheses in region specification for cell {}", cell_id));
         }
         rpn.push_back(stack.back());
         stack.pop_back();
@@ -177,10 +175,8 @@ generate_rpn(int32_t cell_id, std::vector<int32_t> infix)
 
     // If the operator is a parenthesis it is mismatched.
     if (op >= OP_RIGHT_PAREN) {
-      std::stringstream err_msg;
-      err_msg << "Mismatched parentheses in region specification for cell "
-              << cell_id;
-      fatal_error(err_msg);
+      fatal_error(fmt::format(
+        "Mismatched parentheses in region specification for cell {}", cell_id));
     }
 
     rpn.push_back(stack.back());
@@ -198,9 +194,7 @@ void
 Universe::to_hdf5(hid_t universes_group) const
 {
   // Create a group for this universe.
-  std::stringstream group_name;
-  group_name << "universe " << id_;
-  auto group = create_group(universes_group, group_name);
+  auto group = create_group(universes_group, fmt::format("universe {}", id_));
 
   // Write the contained cells.
   if (cells_.size() > 0) {
@@ -301,22 +295,19 @@ CSGCell::CSGCell(pugi::xml_node cell_node)
   bool fill_present = check_for_node(cell_node, "fill");
   bool material_present = check_for_node(cell_node, "material");
   if (!(fill_present || material_present)) {
-    std::stringstream err_msg;
-    err_msg << "Neither material nor fill was specified for cell " << id_;
-    fatal_error(err_msg);
+    fatal_error(fmt::format(
+      "Neither material nor fill was specified for cell {}", id_));
   }
   if (fill_present && material_present) {
-    std::stringstream err_msg;
-    err_msg << "Cell " << id_ << " has both a material and a fill specified; "
-            << "only one can be specified per cell";
-    fatal_error(err_msg);
+    fatal_error(fmt::format("Cell {} has both a material and a fill specified; "
+      "only one can be specified per cell", id_));
   }
 
   if (fill_present) {
     fill_ = std::stoi(get_node_value(cell_node, "fill"));
     if (fill_ == universe_) {
-      fatal_error("Cell " + std::to_string(id_) +
-        " is filled with the same universe that it is contained in.");
+      fatal_error(fmt::format("Cell {} is filled with the same universe that"
+        "it is contained in.", id_));
     }
   } else {
     fill_ = C_NONE;
@@ -338,9 +329,8 @@ CSGCell::CSGCell(pugi::xml_node cell_node)
         }
       }
     } else {
-      std::stringstream err_msg;
-      err_msg << "An empty material element was specified for cell " << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format("An empty material element was specified for cell {}",
+        id_));
     }
   }
 
@@ -351,20 +341,16 @@ CSGCell::CSGCell(pugi::xml_node cell_node)
 
     // Make sure this is a material-filled cell.
     if (material_.size() == 0) {
-      std::stringstream err_msg;
-      err_msg << "Cell " << id_ << " was specified with a temperature but "
-           "no material. Temperature specification is only valid for cells "
-           "filled with a material.";
-      fatal_error(err_msg);
+      fatal_error(fmt::format(
+        "Cell {} was specified with a temperature but no material. Temperature"
+        "specification is only valid for cells filled with a material.", id_));
     }
 
     // Make sure all temperatures are non-negative.
     for (auto T : sqrtkT_) {
       if (T < 0) {
-        std::stringstream err_msg;
-        err_msg << "Cell " << id_
-                << " was specified with a negative temperature";
-        fatal_error(err_msg);
+        fatal_error(fmt::format(
+          "Cell {} was specified with a negative temperature", id_));
       }
     }
 
@@ -426,17 +412,14 @@ CSGCell::CSGCell(pugi::xml_node cell_node)
   // Read the translation vector.
   if (check_for_node(cell_node, "translation")) {
     if (fill_ == C_NONE) {
-      std::stringstream err_msg;
-      err_msg << "Cannot apply a translation to cell " << id_
-              << " because it is not filled with another universe";
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Cannot apply a translation to cell {}"
+        " because it is not filled with another universe", id_));
     }
 
     auto xyz {get_node_array<double>(cell_node, "translation")};
     if (xyz.size() != 3) {
-      std::stringstream err_msg;
-      err_msg << "Non-3D translation vector applied to cell " << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format(
+        "Non-3D translation vector applied to cell {}", id_));
     }
     translation_ = xyz;
   }
@@ -444,17 +427,14 @@ CSGCell::CSGCell(pugi::xml_node cell_node)
   // Read the rotation transform.
   if (check_for_node(cell_node, "rotation")) {
     if (fill_ == C_NONE) {
-      std::stringstream err_msg;
-      err_msg << "Cannot apply a rotation to cell " << id_
-              << " because it is not filled with another universe";
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Cannot apply a rotation to cell {}"
+        " because it is not filled with another universe", id_));
     }
 
     auto rot {get_node_array<double>(cell_node, "rotation")};
     if (rot.size() != 3 && rot.size() != 9) {
-      std::stringstream err_msg;
-      err_msg << "Non-3D rotation vector applied to cell " << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format(
+        "Non-3D rotation vector applied to cell {}", id_));
     }
 
     // Compute and store the rotation matrix.
@@ -534,9 +514,7 @@ void
 CSGCell::to_hdf5(hid_t cell_group) const
 {
   // Create a group for this cell.
-  std::stringstream group_name;
-  group_name << "cell " << id_;
-  auto group = create_group(cell_group, group_name);
+  auto group = create_group(cell_group, fmt::format("cell {}", id_));
 
   if (!name_.empty()) {
     write_string(group, "name", name_, false);
@@ -1013,9 +991,7 @@ void read_cells(pugi::xml_node node)
     if (search == model::cell_map.end()) {
       model::cell_map[id] = i;
     } else {
-      std::stringstream err_msg;
-      err_msg << "Two or more cells use the same unique ID: " << id;
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Two or more cells use the same unique ID: {}", id));
     }
   }
 

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -8,7 +8,10 @@
 #include <sstream>
 #include <set>
 #include <string>
+
+
 #include <gsl/gsl>
+#include <fmt/format.h>
 
 #include "openmc/capi.h"
 #include "openmc/constants.h"
@@ -83,9 +86,8 @@ tokenize(const std::string region_spec) {
       i++;
 
     } else {
-      std::stringstream err_msg;
-      err_msg << "Region specification contains invalid character, \""
-              << region_spec[i] << "\"";
+      auto err_msg = fmt::format(
+        "Region specification contains invalid character, \"{}\"", region_spec[i]);
       fatal_error(err_msg);
     }
   }

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -12,11 +12,10 @@
 #include "openmc/surface.h"
 
 #ifdef DAGMC
-
 #include "uwuw.hpp"
 #include "dagmcmetadata.hpp"
-
 #endif
+#include <fmt/format.h>
 
 #include <string>
 #include <sstream>
@@ -110,11 +109,10 @@ void legacy_assign_material(const std::string& mat_string, DAGCell* c)
         c->material_.push_back(m->id_);
       // report error if more than one material is found
       } else {
-        std::stringstream err_msg;
-        err_msg << "More than one material found with name " << mat_string
-                << ". Please ensure materials have unique names if using this"
-                << " property to assign materials.";
-        fatal_error(err_msg);
+        fatal_error(fmt::format(
+          "More than one material found with name {}. Please ensure materials "
+          "have unique names if using this property to assign materials.",
+          mat_string));
       }
     }
   }
@@ -125,10 +123,8 @@ void legacy_assign_material(const std::string& mat_string, DAGCell* c)
       auto id = std::stoi(mat_string);
       c->material_.emplace_back(id);
     } catch (const std::invalid_argument&) {
-      std::stringstream err_msg;
-      err_msg << "No material " << mat_string
-              << " found for volume (cell) " << c->id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format(
+        "No material {} found for volume (cell) {}", mat_string, c->id_));
     }
   }
 
@@ -152,7 +148,6 @@ void load_dagmc_geometry()
   if (!model::DAG) {
     model::DAG = new moab::DagMC();
   }
-
 
   std::string filename = settings::path_input + DAGMC_FILENAME;
   // --- Materials ---
@@ -253,9 +248,7 @@ void load_dagmc_geometry()
       rval = model::DAG->prop_value(vol_handle, "mat", mat_value);
       MB_CHK_ERR_CONT(rval);
     } else {
-      std::stringstream err_msg;
-      err_msg << "Volume " << c->id_ << " has no material assignment.";
-      fatal_error(err_msg.str());
+      fatal_error(fmt::format("Volume {} has no material assignment.", c->id_));
     }
 
     std::string cmp_str = mat_value;
@@ -277,10 +270,8 @@ void load_dagmc_geometry()
           int mat_number = uwuw.material_library[uwuw_mat].metadata["mat_number"].asInt();
           c->material_.push_back(mat_number);
         } else {
-          std::stringstream err_msg;
-          err_msg << "Material with value " << mat_value << " not found ";
-          err_msg << "in the UWUW material library";
-          fatal_error(err_msg);
+          fatal_error(fmt::format("Material with value {} not found in the "
+            "UWUW material library", mat_value));
         }
       } else {
         legacy_assign_material(mat_value, c);
@@ -348,10 +339,8 @@ void load_dagmc_geometry()
       } else if (bc_value == "periodic") {
         fatal_error("Periodic boundary condition not supported in DAGMC.");
       } else {
-        std::stringstream err_msg;
-        err_msg << "Unknown boundary condition \"" << bc_value
-                << "\" specified on surface " << s->id_;
-        fatal_error(err_msg);
+        fatal_error(fmt::format("Unknown boundary condition \"{}\" specified "
+          "on surface {}", bc_value, s->id_));
       }
     } else {
       // if no condition is found, set to transmit

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -15,7 +15,7 @@
 #include "uwuw.hpp"
 #include "dagmcmetadata.hpp"
 #endif
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <string>
 #include <sstream>

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -96,9 +96,7 @@ CylindricalIndependent::CylindricalIndependent(pugi::xml_node node)
     if (origin.size() == 3) {
       origin_ = origin;
     } else {
-      std::stringstream err_msg;
-      err_msg << "Origin for cylindrical source distribution must be length 3";
-      fatal_error(err_msg);
+      fatal_error("Origin for cylindrical source distribution must be length 3");
     }
   } else {
     // If no coordinates were specified, default to (0, 0, 0)
@@ -162,9 +160,7 @@ SphericalIndependent::SphericalIndependent(pugi::xml_node node)
     if (origin.size() == 3) {
       origin_ = origin;
     } else {
-      std::stringstream err_msg;
-      err_msg << "Origin for spherical source distribution must be length 3";
-      fatal_error(err_msg);
+      fatal_error("Origin for spherical source distribution must be length 3");
     }
   } else {
     // If no coordinates were specified, default to (0, 0, 0)

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -1,7 +1,9 @@
 #include "openmc/geometry.h"
 
 #include <array>
-#include <sstream>
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "openmc/cell.h"
 #include "openmc/constants.h"
@@ -47,11 +49,9 @@ bool check_cell_overlap(Particle* p, bool error)
       if (c.contains(p->coord_[j].r, p->coord_[j].u, p->surface_)) {
         if (index_cell != p->coord_[j].cell) {
           if (error) {
-            std::stringstream err_msg;
-            err_msg << "Overlapping cells detected: " << c.id_ << ", "
-                    << model::cells[p->coord_[j].cell]->id_ << " on universe "
-                    << univ.id_;
-            fatal_error(err_msg);
+            fatal_error(fmt::format(
+              "Overlapping cells detected: {}, {} on universe {}",
+              c.id_, model::cells[p->coord_[j].cell]->id_, univ.id_));
           }
           return true;
         }
@@ -120,8 +120,7 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
 
   // Announce the cell that the particle is entering.
   if (found && (settings::verbosity >= 10 || p->trace_)) {
-    std::stringstream msg;
-    msg << "    Entering cell " << model::cells[i_cell]->id_;
+    auto msg = fmt::format("    Entering cell {}", model::cells[i_cell]->id_);
     write_message(msg, 1);
   }
 
@@ -229,11 +228,8 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
         if (lat.outer_ != NO_OUTER_UNIVERSE) {
           coord.universe = lat.outer_;
         } else {
-          std::stringstream err_msg;
-          err_msg << "Particle " << p->id_ << " is outside lattice "
-                  << lat.id_ << " but the lattice has no defined outer "
-                  "universe.";
-          warning(err_msg);
+          warning(fmt::format("Particle {} is outside lattice {} but the "
+            "lattice has no defined outer universe.", p->id_, lat.id_));
           return false;
         }
       }
@@ -298,11 +294,9 @@ cross_lattice(Particle* p, const BoundaryInfo& boundary)
   auto& lat {*model::lattices[coord.lattice]};
 
   if (settings::verbosity >= 10 || p->trace_) {
-    std::stringstream msg;
-    msg << "    Crossing lattice " << lat.id_ << ". Current position ("
-        << coord.lattice_x << "," << coord.lattice_y << ","
-        << coord.lattice_z << "). r=" << p->r();
-    write_message(msg, 1);
+    write_message(fmt::format(
+      "    Crossing lattice {}. Current position ({},{},{}). r={}",
+      lat.id_, coord.lattice_x, coord.lattice_y, coord.lattice_z, p->r()), 1);
   }
 
   // Set the lattice indices.
@@ -326,10 +320,8 @@ cross_lattice(Particle* p, const BoundaryInfo& boundary)
     p->n_coord_ = 1;
     bool found = find_cell(p, 0);
     if (!found && p->alive_) {
-      std::stringstream err_msg;
-      err_msg << "Could not locate particle " << p->id_
-              << " after crossing a lattice boundary";
-      p->mark_as_lost(err_msg);
+      p->mark_as_lost(fmt::format("Could not locate particle {} after "
+        "crossing a lattice boundary", p->id_));
     }
 
   } else {
@@ -343,10 +335,8 @@ cross_lattice(Particle* p, const BoundaryInfo& boundary)
       p->n_coord_ = 1;
       bool found = find_cell(p, 0);
       if (!found && p->alive_) {
-        std::stringstream err_msg;
-        err_msg << "Could not locate particle " << p->id_
-                << " after crossing a lattice boundary";
-        p->mark_as_lost(err_msg);
+        p->mark_as_lost(fmt::format("Could not locate particle {} after "
+          "crossing a lattice boundary", p->id_));
       }
     }
   }
@@ -400,10 +390,8 @@ BoundaryInfo distance_to_boundary(Particle* p)
       level_lat_trans = lattice_distance.second;
 
       if (d_lat < 0) {
-        std::stringstream err_msg;
-        err_msg << "Particle " << p->id_
-                << " had a negative distance to a lattice boundary";
-        p->mark_as_lost(err_msg);
+        p->mark_as_lost(fmt::format(
+          "Particle {} had a negative distance to a lattice boundary", p->id_));
       }
     }
 
@@ -462,10 +450,7 @@ openmc_find_cell(const double* xyz, int32_t* index, int32_t* instance)
   p.u() = {0.0, 0.0, 1.0};
 
   if (!find_cell(&p, false)) {
-    std::stringstream msg;
-    msg << "Could not find cell at position (" << p.r().x << ", " << p.r().y
-      << ", " << p.r().z << ").";
-    set_errmsg(msg);
+    set_errmsg(fmt::format("Could not find cell at position {}.", p.r()));
     return OPENMC_E_GEOMETRY;
   }
 

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -2,7 +2,7 @@
 
 #include <array>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include <fmt/ostream.h>
 
 #include "openmc/cell.h"

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -4,7 +4,8 @@
 #include <sstream>
 #include <unordered_set>
 
-#include "pugixml.hpp"
+#include <fmt/format.h>
+#include <pugixml.hpp>
 
 #include "openmc/cell.h"
 #include "openmc/constants.h"
@@ -94,10 +95,8 @@ adjust_indices()
         c->type_ = Fill::LATTICE;
         c->fill_ = search_lat->second;
       } else {
-        std::stringstream err_msg;
-        err_msg << "Specified fill " << id << " on cell " << c->id_
-                << " is neither a universe nor a lattice.";
-        fatal_error(err_msg);
+        fatal_error(fmt::format("Specified fill {} on cell {} is neither a "
+          "universe nor a lattice.", id, c->id_));
       }
     } else {
       c->type_ = Fill::MATERIAL;
@@ -105,10 +104,9 @@ adjust_indices()
         if (mat_id != MATERIAL_VOID) {
           auto search = model::material_map.find(mat_id);
           if (search == model::material_map.end()) {
-            std::stringstream err_msg;
-            err_msg << "Could not find material " << mat_id
-                    << " specified on cell " << c->id_;
-            fatal_error(err_msg);
+            fatal_error(fmt::format(
+              "Could not find material {} specified on cell {}",
+              mat_id, c->id_));
           }
           // Change from ID to index
           mat_id = search->second;
@@ -123,10 +121,8 @@ adjust_indices()
     if (search != model::universe_map.end()) {
       c->universe_ = search->second;
     } else {
-      std::stringstream err_msg;
-      err_msg << "Could not find universe " << c->universe_
-              << " specified on cell " << c->id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Could not find universe {} specified on cell {}",
+        c->universe_, c->id_));
     }
   }
 
@@ -345,23 +341,21 @@ prepare_distribcell()
 
     if (c.material_.size() > 1) {
       if (c.material_.size() != c.n_instances_) {
-        std::stringstream err_msg;
-        err_msg <<  "Cell " << c.id_ <<  " was specified with "
-              << c.material_.size() << " materials but has " << c.n_instances_
-              << " distributed instances. The number of materials must equal "
-              "one or the number of instances.";
-        fatal_error(err_msg);
+        fatal_error(fmt::format(
+          "Cell {} was specified with {} materials but has {} distributed "
+          "instances. The number of materials must equal one or the number "
+          "of instances.", c.id_, c.material_.size(), c.n_instances_
+        ));
       }
     }
 
     if (c.sqrtkT_.size() > 1) {
       if (c.sqrtkT_.size() != c.n_instances_) {
-        std::stringstream err_msg;
-        err_msg <<  "Cell " << c.id_ <<  " was specified with "
-          << c.sqrtkT_.size() << " temperatures but has " << c.n_instances_
-          << " distributed instances. The number of temperatures must equal "
-          "one or the number of instances.";
-        fatal_error(err_msg);
+        fatal_error(fmt::format(
+          "Cell {} was specified with {} temperatures but has {} distributed "
+          "instances. The number of temperatures must equal one or the number "
+          "of instances.", c.id_, c.sqrtkT_.size(), c.n_instances_
+        ));
       }
     }
   }

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -4,7 +4,7 @@
 #include <sstream>
 #include <unordered_set>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include <pugixml.hpp>
 
 #include "openmc/cell.h"

--- a/src/hdf5_interface.cpp
+++ b/src/hdf5_interface.cpp
@@ -2,12 +2,12 @@
 
 #include <array>
 #include <cstring>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xarray.hpp"
+#include <fmt/format.h>
 
 #include "hdf5.h"
 #include "hdf5_hl.h"
@@ -105,9 +105,7 @@ create_group(hid_t parent_id, char const *name)
 {
   hid_t out = H5Gcreate(parent_id, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   if (out < 0) {
-    std::stringstream err_msg;
-    err_msg << "Failed to create HDF5 group \"" << name << "\"";
-    fatal_error(err_msg);
+    fatal_error(fmt::format("Failed to create HDF5 group \"{}\"", name));
   }
   return out;
 }
@@ -161,17 +159,13 @@ ensure_exists(hid_t obj_id, const char* name, bool attribute)
 {
   if (attribute) {
     if (!attribute_exists(obj_id, name)) {
-      std::stringstream err_msg;
-      err_msg << "Attribute \"" << name << "\" does not exist in object "
-              << object_name(obj_id);
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Attribute \"{}\" does not exist in object {}",
+        name, object_name(obj_id)));
     }
   } else {
     if (!object_exists(obj_id, name)) {
-      std::stringstream err_msg;
-      err_msg << "Object \"" << name << "\" does not exist in object "
-              << object_name(obj_id);
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Object \"{}\" does not exist in object {}",
+        name, object_name(obj_id)));
     }
   }
 }
@@ -194,9 +188,7 @@ file_open(const char* filename, char mode, bool parallel)
       flags = (mode == 'x' ? H5F_ACC_EXCL : H5F_ACC_TRUNC);
       break;
     default:
-      std::stringstream err_msg;
-      err_msg <<  "Invalid file mode: " << mode;
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Invalid file mode: ", mode));
   }
 
   hid_t plist = H5P_DEFAULT;
@@ -216,9 +208,8 @@ file_open(const char* filename, char mode, bool parallel)
     file_id = H5Fopen(filename, flags, plist);
   }
   if (file_id < 0) {
-    std::stringstream msg;
-    msg << "Failed to open HDF5 file with mode '" << mode << "': " << filename;
-    fatal_error(msg);
+    fatal_error(fmt::format(
+      "Failed to open HDF5 file with mode '{}': {}", mode, filename));
   }
 
 #ifdef PHDF5
@@ -394,9 +385,7 @@ object_exists(hid_t object_id, const char* name)
 {
   htri_t out = H5LTpath_valid(object_id, name, true);
   if (out < 0) {
-    std::stringstream err_msg;
-    err_msg << "Failed to check if object \"" << name << "\" exists.";
-    fatal_error(err_msg);
+    fatal_error(fmt::format("Failed to check if object \"{}\" exists.", name));
   }
   return (out > 0);
 }

--- a/src/hdf5_interface.cpp
+++ b/src/hdf5_interface.cpp
@@ -7,7 +7,7 @@
 
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xarray.hpp"
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "hdf5.h"
 #include "hdf5_hl.h"

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -9,7 +9,7 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/capi.h"
 #include "openmc/constants.h"
@@ -134,7 +134,7 @@ parse_command_line(int argc, char* argv[])
       } else if (arg == "-n" || arg == "--particles") {
         i += 1;
         settings::n_particles = std::stoll(argv[i]);
-      
+
       } else if (arg == "-e" || arg == "--event") {
         settings::event_based = true;
 

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -3,13 +3,13 @@
 #include <cstddef>
 #include <cstdlib> // for getenv
 #include <cstring>
-#include <sstream>
 #include <string>
 #include <vector>
 
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+#include <fmt/format.h>
 
 #include "openmc/capi.h"
 #include "openmc/constants.h"
@@ -155,9 +155,8 @@ parse_command_line(int argc, char* argv[])
           settings::path_particle_restart = argv[i];
           settings::particle_restart_run = true;
         } else {
-          std::stringstream msg;
-          msg << "Unrecognized file after restart flag: " << filetype << ".";
-          strcpy(openmc_err_msg, msg.str().c_str());
+          auto msg = fmt::format("Unrecognized file after restart flag: {}.", filetype);
+          strcpy(openmc_err_msg, msg.c_str());
           return OPENMC_E_INVALID_ARGUMENT;
         }
 
@@ -224,7 +223,7 @@ parse_command_line(int argc, char* argv[])
         settings::write_all_tracks = true;
 
       } else {
-        std::cerr << "Unknown option: " << argv[i] << '\n';
+        fmt::print(stderr, "Unknown option: {}\n", argv[i]);
         print_usage();
         return OPENMC_E_UNASSIGNED;
       }

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -1,8 +1,10 @@
 #include "openmc/lattice.h"
 
 #include <cmath>
-#include <sstream>
+#include <string>
 #include <vector>
+
+#include <fmt/format.h>
 
 #include "openmc/cell.h"
 #include "openmc/error.h"
@@ -71,10 +73,8 @@ Lattice::adjust_indices()
     if (search != model::universe_map.end()) {
       *it = search->second;
     } else {
-      std::stringstream err_msg;
-      err_msg << "Invalid universe number " << uid << " specified on "
-           "lattice " << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format(
+        "Invalid universe number {} specified on lattice {}", uid, id_));
     }
   }
 
@@ -84,10 +84,8 @@ Lattice::adjust_indices()
     if (search != model::universe_map.end()) {
       outer_ = search->second;
     } else {
-      std::stringstream err_msg;
-      err_msg << "Invalid universe number " << outer_ << " specified on "
-           "lattice " << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format(
+        "Invalid universe number {} specified on lattice {}", outer_, id_));
     }
   }
 }
@@ -184,12 +182,9 @@ RectLattice::RectLattice(pugi::xml_node lat_node)
   std::string univ_str {get_node_value(lat_node, "universes")};
   std::vector<std::string> univ_words {split(univ_str)};
   if (univ_words.size() != nx*ny*nz) {
-    std::stringstream err_msg;
-    err_msg << "Expected " << nx*ny*nz
-            << " universes for a rectangular lattice of size "
-            << nx << "x" << ny << "x" << nz << " but " << univ_words.size()
-            << " were specified.";
-    fatal_error(err_msg);
+    fatal_error(fmt::format(
+      "Expected {} universes for a rectangular lattice of size {}x{]x{} but {} "
+      "were specified.", nx*ny*nz,  nx, ny, nz, univ_words.size()));
   }
 
   // Parse the universes.
@@ -487,12 +482,10 @@ HexLattice::HexLattice(pugi::xml_node lat_node)
   std::string univ_str {get_node_value(lat_node, "universes")};
   std::vector<std::string> univ_words {split(univ_str)};
   if (univ_words.size() != n_univ) {
-    std::stringstream err_msg;
-    err_msg << "Expected " << n_univ
-            << " universes for a hexagonal lattice with " << n_rings_
-            << " rings and " << n_axial_ << " axial levels" << " but "
-            << univ_words.size() << " were specified.";
-    fatal_error(err_msg);
+    fatal_error(fmt::format(
+      "Expected {} universes for a hexagonal lattice with {} rings and {} "
+      "axial levels but {} were specified.", n_univ, n_rings_, n_axial_,
+      univ_words.size()));
   }
 
   // Parse the universes.
@@ -1069,9 +1062,8 @@ void read_lattices(pugi::xml_node node)
     if (in_map == model::lattice_map.end()) {
       model::lattice_map[id] = i_lat;
     } else {
-      std::stringstream err_msg;
-      err_msg << "Two or more lattices use the same unique ID: " << id;
-      fatal_error(err_msg);
+      fatal_error(fmt::format(
+        "Two or more lattices use the same unique ID: {}", id));
     }
   }
 }

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/cell.h"
 #include "openmc/error.h"

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -47,8 +47,9 @@ std::vector<std::unique_ptr<Material>> materials;
 //==============================================================================
 
 Material::Material(pugi::xml_node node)
-  : index_{model::materials.size()}
 {
+  index_ = model::materials.size(); // Avoids warning about narrowing
+
   if (check_for_node(node, "id")) {
     this->set_id(std::stoi(get_node_value(node, "id")));
   } else {

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -9,7 +9,7 @@
 #include <omp.h>
 #endif
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include "xtensor/xmath.hpp"
 #include "xtensor/xsort.hpp"
 #include "xtensor/xadapt.hpp"

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -9,6 +9,7 @@
 #include <omp.h>
 #endif
 
+#include <fmt/format.h>
 #include "xtensor/xmath.hpp"
 #include "xtensor/xsort.hpp"
 #include "xtensor/xadapt.hpp"
@@ -121,10 +122,9 @@ Mgxs::metadata_from_hdf5(hid_t xs_id, const std::vector<double>& temperature,
             temps_to_read.push_back(std::round(temp_actual));
           }
         } else {
-          std::stringstream msg;
-          msg << "MGXS library does not contain cross sections for "
-            << in_name << " at or near " << std::round(T) << " K.";
-          fatal_error(msg);
+          fatal_error(fmt::format(
+            "MGXS library does not contain cross sections for {} at or near {} K.",
+            in_name, std::round(T)));
         }
       }
       break;
@@ -350,10 +350,9 @@ Mgxs::Mgxs(const std::string& in_name, const std::vector<double>& mat_kTs,
           auto temp_actual = micros[m]->kTs[micro_t[m]];
 
           if (std::abs(temp_actual - temp_desired) >= K_BOLTZMANN * settings::temperature_tolerance) {
-            std::stringstream msg;
-            msg << "MGXS Library does not contain cross section for " << name
-              << " at or near " << std::round(temp_desired / K_BOLTZMANN) << "K.";
-            fatal_error(msg);
+            fatal_error(fmt::format(
+              "MGXS Library does not contain cross section for {} at or near {} K.",
+              name, std::round(temp_desired / K_BOLTZMANN)));
           }
         }
         break;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -11,7 +11,7 @@
 #include <unordered_map>
 #include <utility> // for pair
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include <fmt/ostream.h>
 #ifdef _OPENMP
 #include <omp.h>

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <utility> // for pair
 
+#include <fmt/format.h>
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -44,53 +45,53 @@ namespace openmc {
 
 void title()
 {
-  std::cout <<
-    "                                %%%%%%%%%%%%%%%\n" <<
-    "                           %%%%%%%%%%%%%%%%%%%%%%%%\n" <<
-    "                        %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n" <<
-    "                      %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n" <<
-    "                    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n" <<
-    "                   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n" <<
-    "                                    %%%%%%%%%%%%%%%%%%%%%%%%\n" <<
-    "                                     %%%%%%%%%%%%%%%%%%%%%%%%\n" <<
-    "                 ###############      %%%%%%%%%%%%%%%%%%%%%%%%\n" <<
-    "                ##################     %%%%%%%%%%%%%%%%%%%%%%%\n" <<
-    "                ###################     %%%%%%%%%%%%%%%%%%%%%%%\n" <<
-    "                ####################     %%%%%%%%%%%%%%%%%%%%%%\n" <<
-    "                #####################     %%%%%%%%%%%%%%%%%%%%%\n" <<
-    "                ######################     %%%%%%%%%%%%%%%%%%%%\n" <<
-    "                #######################     %%%%%%%%%%%%%%%%%%\n" <<
-    "                 #######################     %%%%%%%%%%%%%%%%%\n" <<
-    "                 ######################     %%%%%%%%%%%%%%%%%\n" <<
-    "                  ####################     %%%%%%%%%%%%%%%%%\n" <<
-    "                    #################     %%%%%%%%%%%%%%%%%\n" <<
-    "                     ###############     %%%%%%%%%%%%%%%%\n" <<
-    "                       ############     %%%%%%%%%%%%%%%\n" <<
-    "                          ########     %%%%%%%%%%%%%%\n" <<
-    "                                      %%%%%%%%%%%\n\n";
+  fmt::print(
+    "                                %%%%%%%%%%%%%%%\n"
+    "                           %%%%%%%%%%%%%%%%%%%%%%%%\n"
+    "                        %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n"
+    "                      %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n"
+    "                    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n"
+    "                   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n"
+    "                                    %%%%%%%%%%%%%%%%%%%%%%%%\n"
+    "                                     %%%%%%%%%%%%%%%%%%%%%%%%\n"
+    "                 ###############      %%%%%%%%%%%%%%%%%%%%%%%%\n"
+    "                ##################     %%%%%%%%%%%%%%%%%%%%%%%\n"
+    "                ###################     %%%%%%%%%%%%%%%%%%%%%%%\n"
+    "                ####################     %%%%%%%%%%%%%%%%%%%%%%\n"
+    "                #####################     %%%%%%%%%%%%%%%%%%%%%\n"
+    "                ######################     %%%%%%%%%%%%%%%%%%%%\n"
+    "                #######################     %%%%%%%%%%%%%%%%%%\n"
+    "                 #######################     %%%%%%%%%%%%%%%%%\n"
+    "                 ######################     %%%%%%%%%%%%%%%%%\n"
+    "                  ####################     %%%%%%%%%%%%%%%%%\n"
+    "                    #################     %%%%%%%%%%%%%%%%%\n"
+    "                     ###############     %%%%%%%%%%%%%%%%\n"
+    "                       ############     %%%%%%%%%%%%%%%\n"
+    "                          ########     %%%%%%%%%%%%%%\n"
+    "                                      %%%%%%%%%%%\n\n");
 
   // Write version information
-  std::cout <<
-    "                   | The OpenMC Monte Carlo Code\n" <<
-    "         Copyright | 2011-2020 MIT and OpenMC contributors\n" <<
-    "           License | http://openmc.readthedocs.io/en/latest/license.html\n" <<
-    "           Version | " << VERSION_MAJOR << '.' << VERSION_MINOR << '.'
-    << VERSION_RELEASE << (VERSION_DEV ? "-dev" : "") << '\n';
+  fmt::print(
+    "                   | The OpenMC Monte Carlo Code\n"
+    "         Copyright | 2011-2020 MIT and OpenMC contributors\n"
+    "           License | http://openmc.readthedocs.io/en/latest/license.html\n"
+    "           Version | {}.{}.{}{}\n", VERSION_MAJOR, VERSION_MINOR,
+    VERSION_RELEASE, VERSION_DEV ? "-dev" : "");
 #ifdef GIT_SHA1
-  std::cout << "          Git SHA1 | " << GIT_SHA1 << '\n';
+  fmt::print("          Git SHA1 | {}\n", GIT_SHA1);
 #endif
 
   // Write the date and time
-  std::cout << "         Date/Time | " << time_stamp() << '\n';
+  fmt::print("         Date/Time | {}\n", time_stamp());
 
 #ifdef OPENMC_MPI
   // Write number of processors
-  std::cout << "     MPI Processes | " << mpi::n_procs << '\n';
+  fmt::print("     MPI Processes | {}\n", mpi::n_procs);
 #endif
 
 #ifdef _OPENMP
   // Write number of OpenMP threads
-  std::cout << "    OpenMP Threads | " << omp_get_max_threads() << '\n';
+  fmt::print("    OpenMP Threads | {}\n", omp_get_max_threads());
 #endif
   std::cout << std::endl;
 }
@@ -146,64 +147,61 @@ extern "C" void print_particle(Particle* p)
   // Display particle type and ID.
   switch (p->type_) {
     case Particle::Type::neutron:
-      std::cout << "Neutron ";
+      fmt::print("Neutron ");
       break;
     case Particle::Type::photon:
-      std::cout << "Photon ";
+      fmt::print("Photon ");
       break;
     case Particle::Type::electron:
-      std::cout << "Electron ";
+      fmt::print("Electron ");
       break;
     case Particle::Type::positron:
-      std::cout << "Positron ";
+      fmt::print("Positron ");
       break;
     default:
-      std::cout << "Unknown Particle ";
+      fmt::print("Unknown Particle ");
   }
-  std::cout << p->id_ << "\n";
+  fmt::print("{}\n", p->id_);
 
   // Display particle geometry hierarchy.
   for (auto i = 0; i < p->n_coord_; i++) {
-    std::cout << "  Level " << i << "\n";
+    fmt::print("  Level {}\n", i);
 
     if (p->coord_[i].cell != C_NONE) {
       const Cell& c {*model::cells[p->coord_[i].cell]};
-      std::cout << "    Cell             = " << c.id_ << "\n";
+      fmt::print("    Cell             = {}\n", c.id_);
     }
 
     if (p->coord_[i].universe != C_NONE) {
       const Universe& u {*model::universes[p->coord_[i].universe]};
-      std::cout << "    Universe         = " << u.id_ << "\n";
+      fmt::print("    Universe         = {}\n", u.id_);
     }
 
     if (p->coord_[i].lattice != C_NONE) {
       const Lattice& lat {*model::lattices[p->coord_[i].lattice]};
-      std::cout << "    Lattice          = " << lat.id_ << "\n";
-      std::cout << "    Lattice position = (" << p->coord_[i].lattice_x
-                << "," << p->coord_[i].lattice_y << ","
-                << p->coord_[i].lattice_z << ")\n";
+      fmt::print("    Lattice          = {}\n", lat.id_);
+      fmt::print("    Lattice position = ({},{},{})\n", p->coord_[i].lattice_x,
+        p->coord_[i].lattice_y, p->coord_[i].lattice_z);
     }
 
-    std::cout << "    r = (" << p->coord_[i].r.x << ", "
-              << p->coord_[i].r.y << ", " << p->coord_[i].r.z << ")\n";
-    std::cout << "    u = (" << p->coord_[i].u.x << ", "
-              << p->coord_[i].u.y << ", " << p->coord_[i].u.z << ")\n";
+    fmt::print("    r = ");
+    std::cout << p->coord_[i].r << '\n';
+    fmt::print("    u = ");
+    std::cout << p->coord_[i].u << '\n';
   }
 
   // Display miscellaneous info.
   if (p->surface_ != 0) {
     const Surface& surf {*model::surfaces[std::abs(p->surface_)-1]};
-    std::cout << "  Surface = " << std::copysign(surf.id_, p->surface_) << "\n";
+    fmt::print("  Surface = {}\n", std::copysign(surf.id_, p->surface_));
   }
-  std::cout << "  Weight = " << p->wgt_ << "\n";
+  fmt::print("  Weight = {}\n", p->wgt_);
   if (settings::run_CE) {
-    std::cout << "  Energy = " << p->E_ << "\n";
+    fmt::print("  Energy = {}\n", p->E_);
   } else {
-    std::cout << "  Energy Group = " << p->g_ << "\n";
+    fmt::print("  Energy Group = {}\n", p->g_);
   }
-  std::cout << "  Delayed Group = " << p->delayed_group_ << "\n";
-
-  std::cout << "\n";
+  fmt::print("  Delayed Group = {}\n\n", p->delayed_group_);
 }
 
 //==============================================================================
@@ -215,65 +213,53 @@ void print_plot()
 
   for (auto pl : model::plots) {
     // Plot id
-    std::cout << "Plot ID: " << pl.id_ << "\n";
+    fmt::print("Plot ID: {}\n", pl.id_);
     // Plot filename
-    std::cout << "Plot file: " << pl.path_plot_ << "\n";
+    fmt::print("Plot file: {}\n", pl.path_plot_);
     // Plot level
-    std::cout << "Universe depth: " << pl.level_ << "\n";
+    fmt::print("Universe depth: {}\n", pl.level_);
 
     // Plot type
     if (PlotType::slice == pl.type_) {
-      std::cout << "Plot Type: Slice" << "\n";
+      fmt::print("Plot Type: Slice\n");
     } else if (PlotType::voxel == pl.type_) {
-      std::cout << "Plot Type: Voxel" << "\n";
+      fmt::print("Plot Type: Voxel\n");
     }
 
     // Plot parameters
-    std::cout << "Origin: " << pl.origin_[0] << " "
-              << pl.origin_[1] << " "
-              << pl.origin_[2] << "\n";
+    fmt::print("Origin: {} {} {}\n", pl.origin_[0], pl.origin_[1], pl.origin_[2]);
 
     if (PlotType::slice == pl.type_) {
-      std::cout << std::setprecision(4)
-                << "Width: "
-                << pl.width_[0] << " "
-                << pl.width_[1] << "\n";
+      fmt::print("Width: {:4} {:4}\n", pl.width_[0], pl.width_[1]);
     } else if (PlotType::voxel == pl.type_) {
-      std::cout << std::setprecision(4)
-                << "Width: "
-                << pl.width_[0] << " "
-                << pl.width_[1] << " "
-                << pl.width_[2] << "\n";
+      fmt::print("Width: {:4} {:4} {:4}\n", pl.width_[0], pl.width_[1],
+        pl.width_[2]);
     }
 
     if (PlotColorBy::cells == pl.color_by_) {
-      std::cout << "Coloring: Cells" << "\n";
+      fmt::print("Coloring: Cells\n");
     } else if (PlotColorBy::mats == pl.color_by_) {
-      std::cout << "Coloring: Materials" << "\n";
+      fmt::print("Coloring: Materials\n");
     }
 
     if (PlotType::slice == pl.type_) {
       switch(pl.basis_) {
       case PlotBasis::xy:
-        std::cout <<  "Basis: XY" << "\n";
+        fmt::print("Basis: XY\n");
         break;
       case PlotBasis::xz:
-        std::cout <<  "Basis: XZ" << "\n";
+        fmt::print("Basis: XZ\n");
         break;
       case PlotBasis::yz:
-        std::cout <<  "Basis: YZ" << "\n";
+        fmt::print("Basis: YZ\n");
         break;
       }
-      std::cout << "Pixels: " << pl.pixels_[0] << " "
-                << pl.pixels_[1] << " " << "\n";
+      fmt::print("Pixels: {} {}\n", pl.pixels_[0], pl.pixels_[1]);
     } else if (PlotType::voxel == pl.type_) {
-      std::cout << "Voxels: " << pl.pixels_[0] << " "
-                << pl.pixels_[1] << " "
-                << pl.pixels_[2] << "\n";
+      fmt::print("Voxels: {} {} {}\n", pl.pixels_[0], pl.pixels_[1], pl.pixels_[2]);
     }
 
-    std::cout << "\n";
-
+    fmt::print("\n");
   }
 }
 
@@ -291,23 +277,22 @@ print_overlap_check()
 
   if (mpi::master) {
     header("cell overlap check summary", 1);
-    std::cout << " Cell ID      No. Overlap Checks\n";
+    fmt::print(" Cell ID      No. Overlap Checks\n");
 
     std::vector<int32_t> sparse_cell_ids;
     for (int i = 0; i < model::cells.size(); i++) {
-      std::cout << " " << std::setw(8) << model::cells[i]->id_ << std::setw(17)
-                << model::overlap_check_count[i] << "\n";
+      fmt::print(" {:8}{:17}\n", model::cells[i]->id_, model::overlap_check_count[i]);
       if (model::overlap_check_count[i] < 10) {
         sparse_cell_ids.push_back(model::cells[i]->id_);
       }
     }
 
-    std::cout << "\n There were " << sparse_cell_ids.size()
-              << " cells with less than 10 overlap checks\n";
+    fmt::print("\n There were {} cells with less than 10 overlap checks\n",
+      sparse_cell_ids.size());
     for (auto id : sparse_cell_ids) {
-      std::cout << " " << id;
+      fmt::print(" {}", id);
     }
-    std::cout << "\n";
+    fmt::print("\n");
   }
 }
 
@@ -316,7 +301,7 @@ print_overlap_check()
 void print_usage()
 {
   if (mpi::master) {
-    std::cout <<
+    fmt::print(
       "Usage: openmc [options] [directory]\n\n"
       "Options:\n"
       "  -c, --volume           Run in stochastic volume calculation mode\n"
@@ -329,7 +314,7 @@ void print_usage()
       "  -t, --track            Write tracks for all particles\n"
       "  -e, --event            Run using event-based parallelism\n"
       "  -v, --version          Show version information\n"
-      "  -h, --help             Show this message\n";
+      "  -h, --help             Show this message\n");
   }
 }
 
@@ -338,14 +323,14 @@ void print_usage()
 void print_version()
 {
   if (mpi::master) {
-    std::cout << "OpenMC version " << VERSION_MAJOR << '.' << VERSION_MINOR
-      << '.' << VERSION_RELEASE << '\n';
+    fmt::print("OpenMC version {}.{}.{}\n", VERSION_MAJOR, VERSION_MINOR,
+      VERSION_RELEASE);
 #ifdef GIT_SHA1
-    std::cout << "Git SHA1: " << GIT_SHA1 << '\n';
+    fmt::print("Git SHA1: {}\n", GIT_SHA1);
 #endif
-    std::cout << "Copyright (c) 2011-2019 Massachusetts Institute of "
+    fmt::print("Copyright (c) 2011-2019 Massachusetts Institute of "
       "Technology and OpenMC contributors\nMIT/X license at "
-      "<http://openmc.readthedocs.io/en/latest/license.html>\n";
+      "<http://openmc.readthedocs.io/en/latest/license.html>\n");
   }
 }
 
@@ -354,13 +339,13 @@ void print_version()
 void print_columns()
 {
   if (settings::entropy_on) {
-    std::cout <<
+    fmt::print(
       "  Bat./Gen.      k       Entropy         Average k \n"
-      "  =========   ========   ========   ====================\n";
+      "  =========   ========   ========   ====================\n");
   } else {
-    std::cout <<
+    fmt::print(
       "  Bat./Gen.      k            Average k\n"
-      "  =========   ========   ====================\n";
+      "  =========   ========   ====================\n");
   }
 }
 
@@ -368,85 +353,63 @@ void print_columns()
 
 void print_generation()
 {
-  // Save state of cout
-  auto f {std::cout.flags()};
-
   // Determine overall generation and number of active generations
   int i = overall_generation() - 1;
   int n = simulation::current_batch > settings::n_inactive ?
     settings::gen_per_batch*simulation::n_realizations + simulation::current_gen : 0;
 
-  // Set format for values
-  std::cout << std::fixed << std::setprecision(5);
-
   // write out information batch and option independent output
-  std::cout << "  "  << std::setw(9) <<  std::to_string(simulation::current_batch)
-    + "/" + std::to_string(simulation::current_gen) << "   " << std::setw(8)
-    << simulation::k_generation[i];
+  auto batch_and_gen = std::to_string(simulation::current_batch) + "/" +
+    std::to_string(simulation::current_gen);
+  fmt::print("  {:>9}   {:8.5f}", batch_and_gen, simulation::k_generation[i]);
 
   // write out entropy info
   if (settings::entropy_on) {
-    std::cout << "   " << std::setw(8) << simulation::entropy[i];
+    fmt::print("   {:8.5f}", simulation::entropy[i]);
   }
 
   if (n > 1) {
-    std::cout << "   " << std::setw(8) << simulation::keff << " +/-"
-      << std::setw(8) << simulation::keff_std;
+    fmt::print("   {:8.5f} +/-{:8.5f}", simulation::keff, simulation::keff_std);
   }
-  std::cout << '\n';
-
-  // Restore state of cout
-  std::cout.flags(f);
+  std::cout << std::endl;
 }
 
 //==============================================================================
 
 void print_batch_keff()
 {
-  // Save state of cout
-  auto f {std::cout.flags()};
-
   // Determine overall generation and number of active generations
   int i = simulation::current_batch*settings::gen_per_batch - 1;
   int n = simulation::n_realizations*settings::gen_per_batch;
 
-  // Set format for values
-  std::cout << std::fixed << std::setprecision(5);
-
   // write out information batch and option independent output
-  std::cout << "  "  << std::setw(9) <<  std::to_string(simulation::current_batch)
-    + "/" + std::to_string(settings::gen_per_batch) << "   " << std::setw(8)
-    << simulation::k_generation[i];
+  auto batch_and_gen = std::to_string(simulation::current_batch) + "/" +
+    std::to_string(settings::gen_per_batch);
+  fmt::print("  {:>9}   {:8.5f}", batch_and_gen, simulation::k_generation[i]);
 
   // write out entropy info
   if (settings::entropy_on) {
-    std::cout << "   " << std::setw(8) << simulation::entropy[i];
+    fmt::print("   {:8.5f}", simulation::entropy[i]);
   }
 
   if (n > 1) {
-    std::cout << "   " << std::setw(8) << simulation::keff << " +/-"
-      << std::setw(8) << simulation::keff_std;
+    fmt::print("   {:8.5f} +/-{:8.5f}", simulation::keff, simulation::keff_std);
   }
   std::cout << std::endl;
-
-  // Restore state of cout
-  std::cout.flags(f);
 }
 
 //==============================================================================
 
 void show_time(const char* label, double secs, int indent_level=0)
 {
-  std::cout << std::string(2*indent_level, ' ');
   int width = 33 - indent_level*2;
-  std::cout << " " << std::setw(width) << std::left << label << " = "
-    << std::setw(10) << std::right << secs << " seconds\n";
+  fmt::print("{0:{1}} {2:<{3}} = {4:>10.4e} seconds\n",
+    "", 2*indent_level, label, width, secs);
 }
 
 void show_rate(const char* label, double particles_per_sec)
 {
-  std::cout << " " << std::setw(33) << std::left << label << " = " <<
-    particles_per_sec << " particles/second\n";
+  fmt::print(" {:<33} = {:.6} particles/second\n", label, particles_per_sec);
 }
 
 void print_runtime()
@@ -457,11 +420,7 @@ void print_runtime()
   header("Timing Statistics", 6);
   if (settings::verbosity < 6) return;
 
-  // Save state of cout
-  auto f {std::cout.flags()};
-
   // display time elapsed for various sections
-  std::cout << std::scientific << std::setprecision(4);
   show_time("Total time for initialization", time_initialize.elapsed());
   show_time("Reading cross sections", time_read_xs.elapsed(), 1);
   show_time("Total time in simulation", time_inactive.elapsed() +
@@ -490,9 +449,6 @@ void print_runtime()
   show_time("Total time for finalization", time_finalize.elapsed());
   show_time("Total time elapsed", time_total.elapsed());
 
-  // Restore state of cout
-  std::cout.flags(f);
-
   // Calculate particle rate in active/inactive batches
   int n_active = simulation::current_batch - settings::n_inactive;
   double speed_inactive = 0.0;
@@ -519,15 +475,11 @@ void print_runtime()
   }
 
   // display calculation rate
-  std::cout << std::setprecision(6) << std::showpoint;
   if (!(settings::restart_run && (simulation::restart_batch >= settings::n_inactive))
       && settings::n_inactive > 0) {
     show_rate("Calculation Rate (inactive)", speed_inactive);
   }
   show_rate("Calculation Rate (active)", speed_active);
-
-  // Restore state of cout
-  std::cout.flags(f);
 }
 
 //==============================================================================
@@ -545,9 +497,6 @@ mean_stdev(const double* x, int n)
 
 void print_results()
 {
-  // Save state of cout
-  auto f {std::cout.flags()};
-
   // display header block for results
   header("Results", 4);
   if (settings::verbosity < 4) return;
@@ -564,52 +513,46 @@ void print_results()
     t_n3 = 1.0;
   }
 
-  // Set formatting for floats
-  std::cout << std::fixed << std::setprecision(5);
-
   // write global tallies
   const auto& gt = simulation::global_tallies;
   double mean, stdev;
   if (n > 1) {
     if (settings::run_mode == RunMode::EIGENVALUE) {
       std::tie(mean, stdev) = mean_stdev(&gt(GlobalTally::K_COLLISION, 0), n);
-      std::cout << " k-effective (Collision)     = "
-        << mean << " +/- " << t_n1 * stdev << '\n';
+      fmt::print(" k-effective (Collision)     = {:.5f} +/- {:.5f}\n",
+        mean, t_n1 * stdev);
       std::tie(mean, stdev) = mean_stdev(&gt(GlobalTally::K_TRACKLENGTH, 0), n);
-      std::cout << " k-effective (Track-length)  = "
-        << mean << " +/- " << t_n1 * stdev << '\n';
+      fmt::print(" k-effective (Track-length)  = {:.5f} +/- {:.5f}\n",
+        mean, t_n1 * stdev);
       std::tie(mean, stdev) = mean_stdev(&gt(GlobalTally::K_ABSORPTION, 0), n);
-      std::cout << " k-effective (Absorption)    = "
-        << mean << " +/- " << t_n1 * stdev << '\n';
+      fmt::print(" k-effective (Absorption)    = {:.5f} +/- {:.5f}\n",
+        mean, t_n1 * stdev);
       if (n > 3) {
         double k_combined[2];
         openmc_get_keff(k_combined);
-        std::cout << " Combined k-effective        = "
-          << k_combined[0] << " +/- " << t_n3 * k_combined[1] << '\n';
+        fmt::print(" Combined k-effective        = {:.5f} +/- {:.5f}\n",
+          k_combined[0], k_combined[1]);
       }
     }
     std::tie(mean, stdev) = mean_stdev(&gt(GlobalTally::LEAKAGE, 0), n);
-    std::cout << " Leakage Fraction            = "
-      << mean << " +/- " << t_n1 * stdev << '\n';
+    fmt::print(" Leakage Fraction            = {:.5f} +/- {:.5f}\n",
+      mean, t_n1 * stdev);
   } else {
     if (mpi::master) warning("Could not compute uncertainties -- only one "
       "active batch simulated!");
 
     if (settings::run_mode == RunMode::EIGENVALUE) {
-      std::cout << " k-effective (Collision)    = "
-        << gt(GlobalTally::K_COLLISION, TallyResult::SUM) / n << '\n';
-      std::cout << " k-effective (Track-length) = "
-        << gt(GlobalTally::K_TRACKLENGTH, TallyResult::SUM) / n << '\n';
-      std::cout << " k-effective (Absorption)   = "
-        << gt(GlobalTally::K_ABSORPTION, TallyResult::SUM) / n << '\n';
+      fmt::print(" k-effective (Collision)    = {:.5f}\n",
+        gt(GlobalTally::K_COLLISION, TallyResult::SUM) / n);
+      fmt::print(" k-effective (Track-length) = {:.5f}\n",
+        gt(GlobalTally::K_TRACKLENGTH, TallyResult::SUM) / n);
+      fmt::print(" k-effective (Absorption)   = {:.5f}\n",
+        gt(GlobalTally::K_ABSORPTION, TallyResult::SUM) / n);
     }
-    std::cout << " Leakage Fraction           = "
-      << gt(GlobalTally::LEAKAGE, TallyResult::SUM) / n << '\n';
+    fmt::print(" Leakage Fraction           = {:.5f}\n",
+      gt(GlobalTally::LEAKAGE, TallyResult::SUM) / n);
   }
-  std::cout << '\n';
-
-  // Restore state of cout
-  std::cout.flags(f);
+  fmt::print("\n");
 }
 
 //==============================================================================

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -3,7 +3,7 @@
 #include <algorithm> // copy, min
 #include <cmath>     // log, abs, copysign
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/bank.h"
 #include "openmc/capi.h"
@@ -236,7 +236,7 @@ Particle::event_advance()
     score_track_derivative(this, distance);
   }
 }
-  
+
 void
 Particle::event_cross_surface()
 {

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -2,7 +2,8 @@
 
 #include <algorithm> // copy, min
 #include <cmath>     // log, abs, copysign
-#include <sstream>
+
+#include <fmt/format.h>
 
 #include "openmc/bank.h"
 #include "openmc/capi.h"
@@ -643,14 +644,13 @@ Particle::write_restart() const
   if (settings::run_mode == RunMode::PARTICLE) return;
 
   // Set up file name
-  std::stringstream filename;
-  filename << settings::path_output << "particle_" << simulation::current_batch
-    << '_' << id_ << ".h5";
+  auto filename = fmt::format("{}particle_{}_{}.h5", settings::path_output,
+    simulation::current_batch, id_);
 
   #pragma omp critical (WriteParticleRestart)
   {
     // Create file
-    hid_t file_id = file_open(filename.str(), 'w');
+    hid_t file_id = file_open(filename, 'w');
 
     // Write filetype and version info
     write_attribute(file_id, "filetype", "particle restart");

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -21,7 +21,7 @@
 #include "openmc/thermal.h"
 #include "openmc/tallies/tally.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <algorithm> // for max, min, max_element
 #include <cmath> // for sqrt, exp, log, abs, copysign

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -21,9 +21,10 @@
 #include "openmc/thermal.h"
 #include "openmc/tallies/tally.h"
 
+#include <fmt/format.h>
+
 #include <algorithm> // for max, min, max_element
 #include <cmath> // for sqrt, exp, log, abs, copysign
-#include <sstream>
 
 namespace openmc {
 
@@ -61,17 +62,19 @@ void collision(Particle* p)
 
   // Display information about collision
   if (settings::verbosity >= 10 || p->trace_) {
-    std::stringstream msg;
+    std::string msg;
     if (p->event_ == TallyEvent::KILL) {
-      msg << "    Killed. Energy = " << p->E_ << " eV.";
+      msg = fmt::format("    Killed. Energy = {} eV.", p->E_);
     } else if (p->type_ == Particle::Type::neutron) {
-      msg << "    " << reaction_name(p->event_mt_) << " with " <<
-        data::nuclides[p->event_nuclide_]->name_ << ". Energy = " << p->E_ << " eV.";
+      msg = fmt::format("    {} with {}. Energy = {} eV.",
+        reaction_name(p->event_mt_), data::nuclides[p->event_nuclide_]->name_,
+        p->E_);
     } else if (p->type_ == Particle::Type::photon) {
-      msg << "    " << reaction_name(p->event_mt_) << " with " <<
-        to_element(data::nuclides[p->event_nuclide_]->name_) << ". Energy = " << p->E_ << " eV.";
+      msg = fmt::format("    {} with {}. Energy = {} eV.",
+        reaction_name(p->event_mt_),
+        to_element(data::nuclides[p->event_nuclide_]->name_), p->E_);
     } else {
-      msg << "    Disappeared. Energy = " << p->E_ << " eV.";
+      msg = fmt::format("    Disappeared. Energy = {} eV.", p->E_);
     }
     write_message(msg, 1);
   }
@@ -189,7 +192,7 @@ create_fission_sites(Particle* p, int i_nuclide, const Reaction* rx)
 
     // Sample delayed group and angle/energy for fission reaction
     sample_fission_neutron(i_nuclide, rx, p->E_, &site, p->current_seed());
-    
+
     // Store fission site in bank
     if (use_fission_bank) {
       int64_t idx = simulation::fission_bank.thread_safe_append(site);
@@ -210,7 +213,7 @@ create_fission_sites(Particle* p, int i_nuclide, const Reaction* rx)
     if (p->delayed_group_ > 0) {
       nu_d[p->delayed_group_-1]++;
     }
-    
+
     // Write fission particles to nuBank
     if (use_fission_bank) {
       p->nu_bank_.emplace_back();
@@ -220,7 +223,7 @@ create_fission_sites(Particle* p, int i_nuclide, const Reaction* rx)
       nu_bank_entry->delayed_group    = site.delayed_group;
     }
   }
-  
+
   // If shared fission bank was full, and no fissions could be added,
   // set the particle fission flag to false.
   if (nu == skipped) {

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -1,8 +1,8 @@
 #include "openmc/physics_mg.h"
 
 #include <stdexcept>
-#include <sstream>
 
+#include <fmt/format.h>
 #include "xtensor/xarray.hpp"
 
 #include "openmc/bank.h"
@@ -31,10 +31,8 @@ collision_mg(Particle* p)
   sample_reaction(p);
 
   // Display information about collision
-  if ((settings::verbosity >= 10) || (p->trace_)) {
-    std::stringstream msg;
-    msg << "    Energy Group = " << p->g_;
-    write_message(msg, 1);
+  if ((settings::verbosity >= 10) || p->trace_) {
+    write_message(fmt::format("    Energy Group = {}", p->g_), 1);
   }
 }
 
@@ -113,13 +111,13 @@ create_fission_sites(Particle* p)
   // Initialize the counter of delayed neutrons encountered for each delayed
   // group.
   double nu_d[MAX_DELAYED_GROUPS] = {0.};
-  
+
   // Clear out particle's nu fission bank
   p->nu_bank_.clear();
 
   p->fission_ = true;
   int skipped = 0;
-  
+
   // Determine whether to place fission sites into the shared fission bank
   // or the secondary particle bank.
   bool use_fission_bank = (settings::run_mode == RunMode::EIGENVALUE);
@@ -176,7 +174,7 @@ create_fission_sites(Particle* p)
     if (p->delayed_group_ > 0) {
       nu_d[dg]++;
     }
-    
+
     // Write fission particles to nuBank
     if (use_fission_bank) {
       p->nu_bank_.emplace_back();
@@ -186,7 +184,7 @@ create_fission_sites(Particle* p)
       nu_bank_entry->delayed_group    = site.delayed_group;
     }
   }
-  
+
   // If shared fission bank was full, and no fissions could be added,
   // set the particle fission flag to false.
   if (nu == skipped) {

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -2,7 +2,7 @@
 
 #include <stdexcept>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include "xtensor/xarray.hpp"
 
 #include "openmc/bank.h"
@@ -153,7 +153,7 @@ create_fission_sites(Particle* p)
     // We add 1 to the delayed_group bc in MG, -1 is prompt, but in the rest
     // of the code, 0 is prompt.
     site.delayed_group = dg + 1;
-    
+
     // Store fission site in bank
     if (use_fission_bank) {
       int64_t idx = simulation::fission_bank.thread_safe_append(site);

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -4,6 +4,8 @@
 #include <fstream>
 #include <sstream>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 #include "xtensor/xview.hpp"
 
 #include "openmc/constants.h"
@@ -92,10 +94,8 @@ extern "C"
 int openmc_plot_geometry()
 {
   for (auto pl : model::plots) {
-    std::stringstream ss;
-    ss << "Processing plot " << pl.id_ << ": "
-       << pl.path_plot_ << "...";
-    write_message(ss.str(), 5);
+    write_message(fmt::format("Processing plot {}: {}...",
+      pl.id_, pl.path_plot_), 5);
 
     if (PlotType::slice == pl.type_) {
       // create 2D image
@@ -188,9 +188,7 @@ Plot::set_id(pugi::xml_node plot_node)
 
   // Check to make sure 'id' hasn't been used
   if (model::plot_map.find(id_) != model::plot_map.end()) {
-    std::stringstream err_msg;
-    err_msg << "Two or more plots use the same unique ID: " << id_;
-    fatal_error(err_msg.str());
+    fatal_error(fmt::format("Two or more plots use the same unique ID: {}", id_));
   }
 }
 
@@ -210,11 +208,9 @@ Plot::set_type(pugi::xml_node plot_node)
     else if (type_str == "voxel") {
       type_ = PlotType::voxel;
     } else {
-    // if we're here, something is wrong
-    std::stringstream err_msg;
-    err_msg << "Unsupported plot type '" << type_str
-            << "' in plot " << id_;
-    fatal_error(err_msg.str());
+      // if we're here, something is wrong
+      fatal_error(fmt::format("Unsupported plot type '{}' in plot {}",
+        type_str, id_));
     }
   }
 }
@@ -223,24 +219,24 @@ void
 Plot::set_output_path(pugi::xml_node plot_node)
 {
   // Set output file path
-  std::stringstream filename;
+  std::string filename;
 
   if (check_for_node(plot_node, "filename")) {
-    filename << get_node_value(plot_node, "filename");
+    filename = get_node_value(plot_node, "filename");
   } else {
-    filename << "plot_" << id_;
+    filename = fmt::format("plot_{}", id_);
   }
   // add appropriate file extension to name
   switch(type_) {
   case PlotType::slice:
-    filename << ".ppm";
+    filename.append(".ppm");
     break;
   case PlotType::voxel:
-    filename << ".h5";
+    filename.append(".h5");
     break;
   }
 
-  path_plot_ = filename.str();
+  path_plot_ = filename;
 
   // Copy plot pixel size
   std::vector<int> pxls = get_node_array<int>(plot_node, "pixels");
@@ -249,10 +245,7 @@ Plot::set_output_path(pugi::xml_node plot_node)
       pixels_[0] = pxls[0];
       pixels_[1] = pxls[1];
     } else {
-      std::stringstream err_msg;
-      err_msg << "<pixels> must be length 2 in slice plot "
-              << id_;
-      fatal_error(err_msg.str());
+      fatal_error(fmt::format("<pixels> must be length 2 in slice plot {}", id_));
     }
   } else if (PlotType::voxel == type_) {
     if (pxls.size() == 3) {
@@ -260,10 +253,7 @@ Plot::set_output_path(pugi::xml_node plot_node)
       pixels_[1] = pxls[1];
       pixels_[2] = pxls[2];
     } else {
-      std::stringstream err_msg;
-      err_msg << "<pixels> must be length 3 in voxel plot "
-              << id_;
-      fatal_error(err_msg.str());
+      fatal_error(fmt::format("<pixels> must be length 3 in voxel plot {}", id_));
     }
   }
 }
@@ -276,19 +266,13 @@ Plot::set_bg_color(pugi::xml_node plot_node)
     std::vector<int> bg_rgb = get_node_array<int>(plot_node, "background");
     if (PlotType::voxel == type_) {
       if (mpi::master) {
-        std::stringstream err_msg;
-        err_msg << "Background color ignored in voxel plot "
-                << id_;
-        warning(err_msg.str());
+        warning(fmt::format("Background color ignored in voxel plot {}", id_));
       }
     }
     if (bg_rgb.size() == 3) {
       not_found_ = bg_rgb;
     } else {
-      std::stringstream err_msg;
-      err_msg << "Bad background RGB in plot "
-              << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Bad background RGB in plot {}", id_));
     }
   }
 }
@@ -309,10 +293,8 @@ Plot::set_basis(pugi::xml_node plot_node)
     } else if ("yz" == pl_basis) {
       basis_ = PlotBasis::yz;
     } else {
-      std::stringstream err_msg;
-      err_msg << "Unsupported plot basis '" << pl_basis
-              << "' in plot " << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Unsupported plot basis '{}' in plot {}",
+        pl_basis, id_));
     }
   }
 }
@@ -325,10 +307,7 @@ Plot::set_origin(pugi::xml_node plot_node)
   if (pl_origin.size() == 3) {
     origin_ = pl_origin;
   } else {
-    std::stringstream err_msg;
-    err_msg << "Origin must be length 3 in plot "
-            << id_;
-    fatal_error(err_msg);
+    fatal_error(fmt::format("Origin must be length 3 in plot {}", id_));
   }
 }
 
@@ -342,20 +321,14 @@ Plot::set_width(pugi::xml_node plot_node)
       width_.x = pl_width[0];
       width_.y = pl_width[1];
     } else {
-      std::stringstream err_msg;
-      err_msg << "<width> must be length 2 in slice plot "
-              << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format("<width> must be length 2 in slice plot {}", id_));
     }
   } else if (PlotType::voxel == type_) {
     if (pl_width.size() == 3) {
       pl_width = get_node_array<double>(plot_node, "width");
       width_ = pl_width;
     } else {
-      std::stringstream err_msg;
-      err_msg << "<width> must be length 3 in voxel plot "
-              << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format("<width> must be length 3 in voxel plot {}", id_));
     }
   }
 }
@@ -367,9 +340,7 @@ Plot::set_universe(pugi::xml_node plot_node)
   if (check_for_node(plot_node, "level")) {
     level_ = std::stoi(get_node_value(plot_node, "level"));
     if (level_ < 0) {
-      std::stringstream err_msg;
-      err_msg << "Bad universe level in plot " << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Bad universe level in plot {}", id_));
     }
   } else {
     level_ = PLOT_LEVEL_LOWEST;
@@ -391,10 +362,8 @@ Plot::set_default_colors(pugi::xml_node plot_node)
     color_by_ = PlotColorBy::mats;
     colors_.resize(model::materials.size());
   } else {
-    std::stringstream err_msg;
-    err_msg << "Unsupported plot color type '" << pl_color_by
-            << "' in plot " << id_;
-    fatal_error(err_msg);
+    fatal_error(fmt::format("Unsupported plot color type '{}' in plot {}",
+      pl_color_by, id_));
   }
 
   for (auto& c : colors_) {
@@ -411,10 +380,7 @@ Plot::set_user_colors(pugi::xml_node plot_node)
 {
   if (!plot_node.select_nodes("color").empty() && PlotType::voxel == type_) {
     if (mpi::master) {
-      std::stringstream err_msg;
-      err_msg << "Color specifications ignored in voxel plot "
-              << id_;
-      warning(err_msg);
+      warning(fmt::format("Color specifications ignored in voxel plot {}", id_));
     }
   }
 
@@ -422,19 +388,15 @@ Plot::set_user_colors(pugi::xml_node plot_node)
     // Make sure 3 values are specified for RGB
     std::vector<int> user_rgb = get_node_array<int>(cn, "rgb");
     if (user_rgb.size() != 3) {
-      std::stringstream err_msg;
-      err_msg << "Bad RGB in plot " << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Bad RGB in plot {}", id_));
     }
     // Ensure that there is an id for this color specification
     int col_id;
     if (check_for_node(cn, "id")) {
       col_id = std::stoi(get_node_value(cn, "id"));
     } else {
-      std::stringstream err_msg;
-      err_msg << "Must specify id for color specification in plot "
-              << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format(
+        "Must specify id for color specification in plot {}", id_));
     }
     // Add RGB
     if (PlotColorBy::cells == color_by_) {
@@ -442,20 +404,16 @@ Plot::set_user_colors(pugi::xml_node plot_node)
         col_id = model::cell_map[col_id];
         colors_[col_id] = user_rgb;
       } else {
-        std::stringstream err_msg;
-        err_msg << "Could not find cell " << col_id
-                << " specified in plot " << id_;
-        fatal_error(err_msg);
+        fatal_error(fmt::format("Could not find cell {} specified in plot {}",
+          col_id, id_));
       }
     } else if (PlotColorBy::mats == color_by_) {
       if (model::material_map.find(col_id) != model::material_map.end()) {
         col_id = model::material_map[col_id];
         colors_[col_id] = user_rgb;
       } else {
-        std::stringstream err_msg;
-        err_msg << "Could not find material " << col_id
-                << " specified in plot " << id_;
-        fatal_error(err_msg);
+        fatal_error(fmt::format(
+          "Could not find material {} specified in plot {}", col_id, id_));
       }
     }
   } // color node loop
@@ -469,9 +427,7 @@ Plot::set_meshlines(pugi::xml_node plot_node)
 
   if (!mesh_line_nodes.empty()) {
     if (PlotType::voxel == type_) {
-      std::stringstream msg;
-      msg << "Meshlines ignored in voxel plot " << id_;
-      warning(msg);
+      warning(fmt::format("Meshlines ignored in voxel plot {}", id_));
     }
 
     if (mesh_line_nodes.size() == 1) {
@@ -483,9 +439,8 @@ Plot::set_meshlines(pugi::xml_node plot_node)
       if (check_for_node(meshlines_node, "meshtype")) {
         meshtype = get_node_value(meshlines_node, "meshtype");
       } else {
-        std::stringstream err_msg;
-        err_msg << "Must specify a meshtype for meshlines specification in plot " << id_;
-        fatal_error(err_msg);
+        fatal_error(fmt::format(
+          "Must specify a meshtype for meshlines specification in plot {}", id_));
       }
 
       // Ensure that there is a linewidth for this meshlines specification
@@ -494,9 +449,8 @@ Plot::set_meshlines(pugi::xml_node plot_node)
         meshline_width = get_node_value(meshlines_node, "linewidth");
         meshlines_width_ = std::stoi(meshline_width);
       } else {
-        std::stringstream err_msg;
-        err_msg << "Must specify a linewidth for meshlines specification in plot " << id_;
-        fatal_error(err_msg);
+        fatal_error(fmt::format(
+          "Must specify a linewidth for meshlines specification in plot {}", id_));
       }
 
       // Check for color
@@ -504,9 +458,7 @@ Plot::set_meshlines(pugi::xml_node plot_node)
         // Check and make sure 3 values are specified for RGB
         std::vector<int> ml_rgb = get_node_array<int>(meshlines_node, "color");
         if (ml_rgb.size() != 3) {
-          std::stringstream err_msg;
-          err_msg << "Bad RGB for meshlines color in plot " << id_;
-          fatal_error(err_msg);
+          fatal_error(fmt::format("Bad RGB for meshlines color in plot {}", id_));
         }
         meshlines_color_ = ml_rgb;
       }
@@ -514,9 +466,7 @@ Plot::set_meshlines(pugi::xml_node plot_node)
       // Set mesh based on type
       if ("ufs" == meshtype) {
         if (!simulation::ufs_mesh) {
-          std::stringstream err_msg;
-          err_msg << "No UFS mesh for meshlines on plot " << id_;
-          fatal_error(err_msg);
+          fatal_error(fmt::format("No UFS mesh for meshlines on plot {}", id_));
         } else {
           for (int i = 0; i < model::meshes.size(); ++i) {
             if (const auto* m
@@ -531,9 +481,7 @@ Plot::set_meshlines(pugi::xml_node plot_node)
         }
       } else if ("entropy" == meshtype) {
         if (!simulation::entropy_mesh) {
-          std::stringstream err_msg;
-          err_msg << "No entropy mesh for meshlines on plot " << id_;
-          fatal_error(err_msg);
+          fatal_error(fmt::format("No entropy mesh for meshlines on plot {}", id_));
         } else {
           for (int i = 0; i < model::meshes.size(); ++i) {
             if (const auto* m
@@ -553,29 +501,22 @@ Plot::set_meshlines(pugi::xml_node plot_node)
           tally_mesh_id = std::stoi(get_node_value(meshlines_node, "id"));
         } else {
           std::stringstream err_msg;
-          err_msg << "Must specify a mesh id for meshlines tally "
-                  << "mesh specification in plot " << id_;
-          fatal_error(err_msg);
+          fatal_error(fmt::format("Must specify a mesh id for meshlines tally "
+            "mesh specification in plot {}", id_));
         }
         // find the tally index
         int idx;
         int err = openmc_get_mesh_index(tally_mesh_id, &idx);
         if (err != 0) {
-          std::stringstream err_msg;
-          err_msg << "Could not find mesh " << tally_mesh_id
-                  << " specified in meshlines for plot " << id_;
-          fatal_error(err_msg);
+          fatal_error(fmt::format("Could not find mesh {} specified in "
+            "meshlines for plot {}", tally_mesh_id, id_));
         }
         index_meshlines_mesh_ = idx;
       } else {
-        std::stringstream err_msg;
-        err_msg << "Invalid type for meshlines on plot " << id_ ;
-        fatal_error(err_msg);
+        fatal_error(fmt::format("Invalid type for meshlines on plot {}", id_ ));
       }
     } else {
-      std::stringstream err_msg;
-      err_msg << "Mutliple meshlines specified in plot " << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Mutliple meshlines specified in plot {}", id_));
     }
   }
 }
@@ -589,9 +530,7 @@ Plot::set_mask(pugi::xml_node plot_node)
   if (!mask_nodes.empty()) {
     if (PlotType::voxel == type_) {
       if (mpi::master) {
-        std::stringstream wrn_msg;
-        wrn_msg << "Mask ignored in voxel plot " << id_;
-        warning(wrn_msg);
+        warning(fmt::format("Mask ignored in voxel plot {}", id_));
       }
     }
 
@@ -602,9 +541,7 @@ Plot::set_mask(pugi::xml_node plot_node)
       // Determine how many components there are and allocate
       std::vector<int> iarray = get_node_array<int>(mask_node, "components");
       if (iarray.size() == 0) {
-        std::stringstream err_msg;
-        err_msg << "Missing <components> in mask of plot " << id_;
-        fatal_error(err_msg);
+        fatal_error(fmt::format("Missing <components> in mask of plot {}", id_));
       }
 
       // First we need to change the user-specified identifiers to indices
@@ -615,20 +552,16 @@ Plot::set_mask(pugi::xml_node plot_node)
             col_id  = model::cell_map[col_id];
           }
           else {
-            std::stringstream err_msg;
-            err_msg << "Could not find cell " << col_id
-                    << " specified in the mask in plot " << id_;
-            fatal_error(err_msg);
+            fatal_error(fmt::format("Could not find cell {} specified in the "
+              "mask in plot {}", col_id, id_));
           }
         } else if (PlotColorBy::mats == color_by_) {
           if (model::material_map.find(col_id) != model::material_map.end()) {
             col_id = model::material_map[col_id];
           }
           else {
-            std::stringstream err_msg;
-            err_msg << "Could not find material " << col_id
-                    << " specified in the mask in plot " << id_;
-            fatal_error(err_msg);
+            fatal_error(fmt::format("Could not find material {} specified in "
+              "the mask in plot {}", col_id, id_));
           }
         }
       }
@@ -646,9 +579,7 @@ Plot::set_mask(pugi::xml_node plot_node)
       }
 
     } else {
-      std::stringstream err_msg;
-      err_msg << "Mutliple masks specified in plot " << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Mutliple masks specified in plot {}", id_));
     }
   }
 }
@@ -660,18 +591,14 @@ void Plot::set_overlap_color(pugi::xml_node plot_node) {
     // check for custom overlap color
     if (check_for_node(plot_node, "overlap_color")) {
       if (!color_overlaps_) {
-        std::stringstream wrn_msg;
-        wrn_msg << "Overlap color specified in plot " << id_
-                << " but overlaps won't be shown.";
-        warning(wrn_msg);
+        warning(fmt::format(
+          "Overlap color specified in plot {} but overlaps won't be shown.", id_));
       }
       std::vector<int> olap_clr = get_node_array<int>(plot_node, "overlap_color");
       if (olap_clr.size() == 3) {
         overlap_color_ = olap_clr;
       } else {
-        std::stringstream err_msg;
-        err_msg << "Bad overlap RGB in plot " << id_;
-        fatal_error(err_msg);
+        fatal_error(fmt::format("Bad overlap RGB in plot {}", id_));
       }
     }
   }
@@ -716,9 +643,9 @@ void output_ppm(Plot pl, const ImageData& data)
   of.open(fname);
 
   // Write header
-  of << "P6" << "\n";
+  of << "P6\n";
   of << pl.pixels_[0] << " " << pl.pixels_[1] << "\n";
-  of << "255" << "\n";
+  of << "255\n";
   of.close();
 
   of.open(fname, std::ios::binary | std::ios::app);
@@ -729,11 +656,7 @@ void output_ppm(Plot pl, const ImageData& data)
       of << rgb.red << rgb.green << rgb.blue;
     }
   }
-
-  // Close file
-  // THIS IS HERE TO MATCH FORTRAN VERSION, NOT TECHNICALLY NECESSARY
   of << "\n";
-  of.close();
 }
 
 //==============================================================================

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -4,7 +4,7 @@
 #include <fstream>
 #include <sstream>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include <fmt/ostream.h>
 #include "xtensor/xview.hpp"
 

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <utility> // for move
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/constants.h"
 #include "openmc/hdf5_interface.h"

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -3,6 +3,8 @@
 #include <string>
 #include <utility> // for move
 
+#include <fmt/format.h>
+
 #include "openmc/constants.h"
 #include "openmc/hdf5_interface.h"
 #include "openmc/endf.h"
@@ -35,8 +37,7 @@ Reaction::Reaction(hid_t group, const std::vector<int>& temperatures)
   // Read cross section and threshold_idx data
   for (auto t : temperatures) {
     // Get group corresponding to temperature
-    std::string temp_str {std::to_string(t) + "K"};
-    hid_t temp_group = open_group(group, temp_str.c_str());
+    hid_t temp_group = open_group(group, fmt::format("{}K", t).c_str());
     hid_t dset = open_dataset(temp_group, "xs");
 
     // Get threshold index
@@ -178,7 +179,7 @@ std::string reaction_name(int mt)
   } else if (mt == N_NPA) {
     return "(n,npa)";
   } else if (N_N1 <= mt && mt <= N_N40) {
-    return "(n,n" + std::to_string(mt-50) + ")";
+    return fmt::format("(n,n{})", mt - 50);
   } else if (mt == N_NC) {
     return "(n,nc)";
   } else if (mt == N_DISAPPEAR) {
@@ -244,33 +245,31 @@ std::string reaction_name(int mt)
   } else if (mt == PHOTOELECTRIC) {
     return "photoelectric";
   } else if (534 <= mt && mt <= 572) {
-    std::stringstream name;
-    name << "photoelectric, " << SUBSHELLS[mt - 534] << " subshell";
-    return name.str();
+    return fmt::format("photoelectric, {} subshell", SUBSHELLS[mt - 534]);
   } else if (600 <= mt && mt <= 648) {
-    return "(n,p" + std::to_string(mt-600) + ")";
+    return fmt::format("(n,p{})", mt - 600);
   } else if (mt == 649) {
     return "(n,pc)";
   } else if (650 <= mt && mt <= 698) {
-    return "(n,d" + std::to_string(mt-650) + ")";
+    return fmt::format("(n,d{})", mt - 650);
   } else if (mt == 699) {
     return "(n,dc)";
   } else if (700 <= mt && mt <= 748) {
-    return "(n,t" + std::to_string(mt-700) + ")";
+    return fmt::format("(n,t{})", mt - 700);
   } else if (mt == 749) {
     return "(n,tc)";
   } else if (750 <= mt && mt <= 798) {
-    return "(n,3He" + std::to_string(mt-750) + ")";
+    return fmt::format("(n,3He{})", mt - 750);
   } else if (mt == 799) {
     return "(n,3Hec)";
   } else if (800 <= mt && mt <= 848) {
-    return "(n,a" + std::to_string(mt-800) + ")";
+    return fmt::format("(n,a{})", mt - 800);
   } else if (mt == 849) {
     return "(n,ac)";
   } else if (mt == HEATING_LOCAL) {
     return "heating-local";
   } else {
-    return "MT=" + std::to_string(mt);
+    return fmt::format("MT={}", mt);
   }
 }
 

--- a/src/secondary_uncorrelated.cpp
+++ b/src/secondary_uncorrelated.cpp
@@ -2,7 +2,7 @@
 
 #include <string>  // for string
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/error.h"
 #include "openmc/hdf5_interface.h"

--- a/src/secondary_uncorrelated.cpp
+++ b/src/secondary_uncorrelated.cpp
@@ -1,7 +1,8 @@
 #include "openmc/secondary_uncorrelated.h"
 
-#include <sstream> // for stringstream
 #include <string>  // for string
+
+#include <fmt/format.h>
 
 #include "openmc/error.h"
 #include "openmc/hdf5_interface.h"
@@ -42,9 +43,7 @@ UncorrelatedAngleEnergy::UncorrelatedAngleEnergy(hid_t group)
     } else if (type == "watt") {
       energy_ = UPtrEDist{new WattEnergy{energy_group}};
     } else {
-      std::stringstream msg;
-      msg << "Energy distribution type '" << type << "' not implemented.";
-      warning(msg);
+      warning(fmt::format("Energy distribution type '{}' not implemented.", type));
     }
     close_group(energy_group);
   }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -4,7 +4,7 @@
 #include <limits> // for numeric_limits
 #include <string>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #ifdef _OPENMP
 #include <omp.h>
 #endif

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -2,9 +2,9 @@
 
 #include <cmath> // for ceil, pow
 #include <limits> // for numeric_limits
-#include <sstream>
 #include <string>
 
+#include <fmt/format.h>
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -130,7 +130,7 @@ void get_run_parameters(pugi::xml_node node_base)
   if (n_particles == -1) {
     n_particles = std::stoll(get_node_value(node_base, "particles"));
   }
-  
+
   // Get maximum number of in flight particles for event-based mode
   if (check_for_node(node_base, "max_particles_in_flight")) {
     max_particles_in_flight = std::stoll(get_node_value(node_base,
@@ -195,13 +195,13 @@ void read_settings_xml()
   std::string filename = path_input + "settings.xml";
   if (!file_exists(filename)) {
     if (run_mode != RunMode::PLOTTING) {
-      std::stringstream msg;
-      msg << "Settings XML file '" << filename << "' does not exist! In order "
+      fatal_error(fmt::format(
+        "Settings XML file '{}' does not exist! In order "
         "to run OpenMC, you first need a set of input files; at a minimum, this "
         "includes settings.xml, geometry.xml, and materials.xml. Please consult "
-        "the user's guide at http://openmc.readthedocs.io for further "
-        "information.";
-      fatal_error(msg);
+        "the user's guide at https://docs.openmc.org for further "
+        "information.", filename
+      ));
     } else {
       // The settings.xml file is optional if we just want to make a plot.
       return;
@@ -494,9 +494,8 @@ void read_settings_xml()
   if (check_for_node(root, "entropy_mesh")) {
     int temp = std::stoi(get_node_value(root, "entropy_mesh"));
     if (model::mesh_map.find(temp) == model::mesh_map.end()) {
-      std::stringstream msg;
-      msg << "Mesh " << temp << " specified for Shannon entropy does not exist.";
-      fatal_error(msg);
+      fatal_error(fmt::format(
+        "Mesh {} specified for Shannon entropy does not exist.", temp));
     }
     index_entropy_mesh = model::mesh_map.at(temp);
 
@@ -544,10 +543,8 @@ void read_settings_xml()
   if (check_for_node(root, "ufs_mesh")) {
     auto temp = std::stoi(get_node_value(root, "ufs_mesh"));
     if (model::mesh_map.find(temp) == model::mesh_map.end()) {
-      std::stringstream msg;
-      msg << "Mesh " << temp << " specified for uniform fission site method "
-        "does not exist.";
-      fatal_error(msg);
+      fatal_error(fmt::format("Mesh {} specified for uniform fission site "
+        "method does not exist.", temp));
     }
     i_ufs_mesh = model::mesh_map.at(temp);
 
@@ -792,7 +789,7 @@ void read_settings_xml()
   if (check_for_node(root, "delayed_photon_scaling")) {
     delayed_photon_scaling = get_node_value_bool(root, "delayed_photon_scaling");
   }
-  
+
   // Check whether to use event-based parallelism
   if (check_for_node(root, "event_based")) {
     event_based = get_node_value_bool(root, "event_based");

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -2,7 +2,7 @@
 
 #include <algorithm> // for move
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include "xtensor/xadapt.hpp"
 
 #include "openmc/bank.h"

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -1,8 +1,8 @@
 #include "openmc/source.h"
 
 #include <algorithm> // for move
-#include <sstream> // for stringstream
 
+#include <fmt/format.h>
 #include "xtensor/xadapt.hpp"
 
 #include "openmc/bank.h"
@@ -68,9 +68,8 @@ SourceDistribution::SourceDistribution(pugi::xml_node node)
 
     // Check if source file exists
     if (!file_exists(settings::path_source)) {
-      std::stringstream msg;
-      msg << "Source file '" << settings::path_source <<  "' does not exist.";
-      fatal_error(msg);
+      fatal_error(fmt::format("Source file '{}' does not exist.",
+        settings::path_source));
     }
 
   } else {
@@ -97,9 +96,8 @@ SourceDistribution::SourceDistribution(pugi::xml_node node)
       } else if (type == "point") {
         space_ = UPtrSpace{new SpatialPoint(node_space)};
       } else {
-        std::stringstream msg;
-        msg << "Invalid spatial distribution for external source: " << type;
-        fatal_error(msg);
+        fatal_error(fmt::format(
+          "Invalid spatial distribution for external source: {}", type));
       }
 
     } else {
@@ -123,9 +121,8 @@ SourceDistribution::SourceDistribution(pugi::xml_node node)
       } else if (type == "mu-phi") {
         angle_ = UPtrAngle{new PolarAzimuthal(node_angle)};
       } else {
-        std::stringstream msg;
-        msg << "Invalid angular distribution for external source: " << type;
-        fatal_error(msg);
+        fatal_error(fmt::format(
+          "Invalid angular distribution for external source: {}", type));
       }
 
     } else {
@@ -244,9 +241,8 @@ void initialize_source()
     // Read the source from a binary file instead of sampling from some
     // assumed source distribution
 
-    std::stringstream msg;
-    msg << "Reading source file from " << settings::path_source << "...";
-    write_message(msg, 6);
+    write_message(fmt::format("Reading source file from {}...",
+      settings::path_source), 6);
 
     // Open the binary file
     hid_t file_id = file_open(settings::path_source, 'r', true);

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include "xtensor/xbuilder.hpp" // for empty_like
 #include "xtensor/xview.hpp"
 

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -2,10 +2,10 @@
 
 #include <algorithm>
 #include <cstdint> // for int64_t
-#include <iomanip> // for setfill, setw
 #include <string>
 #include <vector>
 
+#include <fmt/format.h>
 #include "xtensor/xbuilder.hpp" // for empty_like
 #include "xtensor/xview.hpp"
 
@@ -41,10 +41,8 @@ openmc_statepoint_write(const char* filename, bool* write_source)
     int w = std::to_string(settings::n_max_batches).size();
 
     // Set filename for state point
-    std::stringstream ss;
-    ss << settings::path_output << "statepoint." << std::setfill('0')
-      << std::setw(w) << simulation::current_batch << ".h5";
-    filename_ = ss.str();
+    filename_ = fmt::format("{0}statepoint.{1:0{2}}.h5",
+      settings::path_output, simulation::current_batch, w);
   }
 
   // Determine whether or not to write the source bank
@@ -523,10 +521,8 @@ write_source_point(const char* filename)
     // Determine width for zero padding
     int w = std::to_string(settings::n_max_batches).size();
 
-    std::stringstream s;
-    s << settings::path_output << "source." << std::setfill('0')
-      << std::setw(w) << simulation::current_batch << ".h5";
-    filename_ = s.str();
+    filename_ = fmt::format("{0}source.{1:0{2}}.h5",
+      settings::path_output, simulation::current_batch, w);
   }
 
   hid_t file_id;

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <utility>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/error.h"
 #include "openmc/dagmc.h"

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -2,8 +2,9 @@
 
 #include <array>
 #include <cmath>
-#include <sstream>
 #include <utility>
+
+#include <fmt/format.h>
 
 #include "openmc/error.h"
 #include "openmc/dagmc.h"
@@ -35,10 +36,8 @@ void read_coeffs(pugi::xml_node surf_node, int surf_id, double &c1)
   std::string coeffs = get_node_value(surf_node, "coeffs");
   int n_words = word_count(coeffs);
   if (n_words != 1) {
-    std::stringstream err_msg;
-    err_msg << "Surface " << surf_id << " expects 1 coeff but was given "
-            << n_words;
-    fatal_error(err_msg);
+    fatal_error(fmt::format("Surface {} expects 1 coeff but was given {}",
+      surf_id, n_words));
   }
 
   // Parse the coefficients.
@@ -55,10 +54,8 @@ void read_coeffs(pugi::xml_node surf_node, int surf_id, double &c1, double &c2,
   std::string coeffs = get_node_value(surf_node, "coeffs");
   int n_words = word_count(coeffs);
   if (n_words != 3) {
-    std::stringstream err_msg;
-    err_msg << "Surface " << surf_id << " expects 3 coeffs but was given "
-            << n_words;
-    fatal_error(err_msg);
+    fatal_error(fmt::format("Surface {} expects 3 coeffs but was given {}",
+      surf_id, n_words));
   }
 
   // Parse the coefficients.
@@ -75,10 +72,8 @@ void read_coeffs(pugi::xml_node surf_node, int surf_id, double &c1, double &c2,
   std::string coeffs = get_node_value(surf_node, "coeffs");
   int n_words = word_count(coeffs);
   if (n_words != 4) {
-    std::stringstream err_msg;
-    err_msg << "Surface " << surf_id << " expects 4 coeffs but was given "
-            << n_words;
-    fatal_error(err_msg);
+    fatal_error(fmt::format("Surface {} expects 4 coeffs but was given ",
+      surf_id, n_words));
   }
 
   // Parse the coefficients.
@@ -96,10 +91,8 @@ void read_coeffs(pugi::xml_node surf_node, int surf_id, double &c1, double &c2,
   std::string coeffs = get_node_value(surf_node, "coeffs");
   int n_words = word_count(coeffs);
   if (n_words != 10) {
-    std::stringstream err_msg;
-    err_msg << "Surface " << surf_id << " expects 10 coeffs but was given "
-            << n_words;
-    fatal_error(err_msg);
+    fatal_error(fmt::format("Surface {} expects 10 coeffs but was given {}",
+      surf_id, n_words));
   }
 
   // Parse the coefficients.
@@ -145,10 +138,8 @@ Surface::Surface(pugi::xml_node surf_node)
     } else if (surf_bc == "periodic") {
       bc_ = BoundaryType::PERIODIC;
     } else {
-      std::stringstream err_msg;
-      err_msg << "Unknown boundary condition \"" << surf_bc
-              << "\" specified on surface " << id_;
-      fatal_error(err_msg);
+      fatal_error(fmt::format("Unknown boundary condition \"{}\" specified "
+        "on surface {}", surf_bc, id_));
     }
 
   } else {
@@ -1170,9 +1161,7 @@ void read_surfaces(pugi::xml_node node)
         model::surfaces.push_back(std::make_unique<SurfaceQuadric>(surf_node));
 
       } else {
-        std::stringstream err_msg;
-        err_msg << "Invalid surface type, \"" << surf_type << "\"";
-        fatal_error(err_msg);
+        fatal_error(fmt::format("Invalid surface type, \"{}\"", surf_type));
       }
     }
   }
@@ -1184,9 +1173,8 @@ void read_surfaces(pugi::xml_node node)
     if (in_map == model::surface_map.end()) {
       model::surface_map[id] = i_surf;
     } else {
-      std::stringstream err_msg;
-      err_msg << "Two or more surfaces use the same unique ID: " << id;
-      fatal_error(err_msg);
+      fatal_error(fmt::format(
+        "Two or more surfaces use the same unique ID: {}", id));
     }
   }
 
@@ -1202,11 +1190,9 @@ void read_surfaces(pugi::xml_node node)
 
       // Make sure this surface inherits from PeriodicSurface.
       if (!surf) {
-        std::stringstream err_msg;
-        err_msg << "Periodic boundary condition not supported for surface "
-                << surf_base->id_
-                << ". Periodic BCs are only supported for planar surfaces.";
-        fatal_error(err_msg);
+        fatal_error(fmt::format(
+          "Periodic boundary condition not supported for surface {}. Periodic "
+          "BCs are only supported for planar surfaces.", surf_base->id_));
       }
 
       // See if this surface makes part of the global bounding box.
@@ -1278,10 +1264,8 @@ void read_surfaces(pugi::xml_node node)
         // This is a SurfacePlane.  We won't try to find it's partner if the
         // user didn't specify one.
         if (surf->i_periodic_ == C_NONE) {
-          std::stringstream err_msg;
-          err_msg << "No matching periodic surface specified for periodic "
-                     "boundary condition on surface " << surf->id_;
-          fatal_error(err_msg);
+          fatal_error(fmt::format("No matching periodic surface specified for "
+            "periodic boundary condition on surface {}", surf->id_));
         } else {
           // Convert the surface id to an index.
           surf->i_periodic_ = model::surface_map[surf->i_periodic_];
@@ -1290,10 +1274,8 @@ void read_surfaces(pugi::xml_node node)
 
       // Make sure the opposite surface is also periodic.
       if (model::surfaces[surf->i_periodic_]->bc_ != Surface::BoundaryType::PERIODIC) {
-        std::stringstream err_msg;
-        err_msg << "Could not find matching surface for periodic boundary "
-                   "condition on surface " << surf->id_;
-        fatal_error(err_msg);
+        fatal_error(fmt::format("Could not find matching surface for periodic "
+          "boundary condition on surface {}", surf->id_));
       }
     }
   }

--- a/src/tallies/derivative.cpp
+++ b/src/tallies/derivative.cpp
@@ -7,7 +7,7 @@
 #include "openmc/tallies/tally.h"
 #include "openmc/xml_interface.h"
 
-#include <sstream>
+#include <fmt/format.h>
 
 template class std::vector<openmc::TallyDerivative>;
 
@@ -55,20 +55,16 @@ TallyDerivative::TallyDerivative(pugi::xml_node node)
       }
     }
     if (!found) {
-      std::stringstream out;
-      out << "Could not find the nuclide \"" << nuclide_name
-          << "\" specified in derivative " << id << " in any material.";
-      fatal_error(out);
+      fatal_error(fmt::format("Could not find the nuclide \"{}\" specified in "
+        "derivative {} in any material.", nuclide_name, id));
     }
 
   } else if (variable_str == "temperature") {
     variable = DerivativeVariable::TEMPERATURE;
 
   } else {
-    std::stringstream out;
-    out << "Unrecognized variable \"" << variable_str
-        << "\" on derivative " << id;
-    fatal_error(out);
+    fatal_error(fmt::format("Unrecognized variable \"{}\" on derivative {}",
+      variable_str, id));
   }
 
   diff_material = std::stoi(get_node_value(node, "material"));
@@ -568,7 +564,7 @@ score_track_derivative(Particle* p, double distance)
   // A void material cannot be perturbed so it will not affect flux derivatives.
   if (p->material_ == MATERIAL_VOID) return;
   const Material& material {*model::materials[p->material_]};
-  
+
   for (auto idx = 0; idx < model::tally_derivs.size(); idx++) {
     const auto& deriv = model::tally_derivs[idx];
     auto& flux_deriv = p->flux_derivs_[idx];
@@ -641,11 +637,9 @@ void score_collision_derivative(Particle* p)
         if (material.nuclide_[i] == deriv.diff_nuclide) break;
       // Make sure we found the nuclide.
       if (material.nuclide_[i] != deriv.diff_nuclide) {
-        std::stringstream err_msg;
-        err_msg << "Could not find nuclide "
-          << data::nuclides[deriv.diff_nuclide]->name_ << " in material "
-          << material.id_ << " for tally derivative " << deriv.id;
-        fatal_error(err_msg);
+        fatal_error(fmt::format(
+          "Could not find nuclide {} in material {} for tally derivative {}",
+          data::nuclides[deriv.diff_nuclide]->name_, material.id_, deriv.id));
       }
       // phi is proportional to Sigma_s
       // (1 / phi) * (d_phi / d_N) = (d_Sigma_s / d_N) / Sigma_s

--- a/src/tallies/derivative.cpp
+++ b/src/tallies/derivative.cpp
@@ -7,7 +7,7 @@
 #include "openmc/tallies/tally.h"
 #include "openmc/xml_interface.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 template class std::vector<openmc::TallyDerivative>;
 

--- a/src/tallies/filter.cpp
+++ b/src/tallies/filter.cpp
@@ -57,8 +57,10 @@ extern "C" size_t tally_filters_size()
 // Filter implementation
 //==============================================================================
 
-Filter::Filter() : index_{model::tally_filters.size()}
-{ }
+Filter::Filter()
+{
+  index_ = model::tally_filters.size(); // Avoids warning about narrowing
+}
 
 Filter::~Filter()
 {

--- a/src/tallies/filter_azimuthal.cpp
+++ b/src/tallies/filter_azimuthal.cpp
@@ -2,7 +2,7 @@
 
 #include <cmath>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/constants.h"
 #include "openmc/error.h"

--- a/src/tallies/filter_azimuthal.cpp
+++ b/src/tallies/filter_azimuthal.cpp
@@ -1,7 +1,8 @@
 #include "openmc/tallies/filter_azimuthal.h"
 
 #include <cmath>
-#include <sstream>
+
+#include <fmt/format.h>
 
 #include "openmc/constants.h"
 #include "openmc/error.h"
@@ -77,9 +78,7 @@ AzimuthalFilter::to_statepoint(hid_t filter_group) const
 std::string
 AzimuthalFilter::text_label(int bin) const
 {
-  std::stringstream out;
-  out << "Azimuthal Angle [" << bins_[bin] << ", " << bins_[bin+1] << ")";
-  return out.str();
+  return fmt::format("Azimuthal Angle [{}, {})", bins_[bin], bins_[bin+1]);
 }
 
 } // namespace openmc

--- a/src/tallies/filter_cell.cpp
+++ b/src/tallies/filter_cell.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_cell.h"
 
-#include <sstream>
+#include <fmt/format.h>
 
 #include "openmc/capi.h"
 #include "openmc/cell.h"
@@ -17,10 +17,8 @@ CellFilter::from_xml(pugi::xml_node node)
   for (auto& c : cells) {
     auto search = model::cell_map.find(c);
     if (search == model::cell_map.end()) {
-      std::stringstream err_msg;
-      err_msg << "Could not find cell " << c
-              << " specified on tally filter.";
-      throw std::runtime_error{err_msg.str()};
+      throw std::runtime_error{fmt::format(
+        "Could not find cell {} specified on tally filter.", c)};
     }
     c = search->second;
   }
@@ -72,7 +70,7 @@ CellFilter::to_statepoint(hid_t filter_group) const
 std::string
 CellFilter::text_label(int bin) const
 {
-  return "Cell " + std::to_string(model::cells[cells_[bin]]->id_);
+  return fmt::format("Cell {}", model::cells[cells_[bin]]->id_);
 }
 
 //==============================================================================

--- a/src/tallies/filter_cell.cpp
+++ b/src/tallies/filter_cell.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_cell.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/capi.h"
 #include "openmc/cell.h"

--- a/src/tallies/filter_cell_instance.cpp
+++ b/src/tallies/filter_cell_instance.cpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/capi.h"
 #include "openmc/cell.h"

--- a/src/tallies/filter_cell_instance.cpp
+++ b/src/tallies/filter_cell_instance.cpp
@@ -1,7 +1,8 @@
 #include "openmc/tallies/filter_cell_instance.h"
 
-#include <sstream>
 #include <string>
+
+#include <fmt/format.h>
 
 #include "openmc/capi.h"
 #include "openmc/cell.h"
@@ -29,10 +30,8 @@ CellInstanceFilter::from_xml(pugi::xml_node node)
     gsl::index instance = cells[2*i + 1];
     auto search = model::cell_map.find(cell_id);
     if (search == model::cell_map.end()) {
-      std::stringstream err_msg;
-      err_msg << "Could not find cell " << cell_id
-              << " specified on tally filter.";
-      throw std::runtime_error{err_msg.str()};
+      throw std::runtime_error{fmt::format(
+        "Could not find cell {} specified on tally filter.", cell_id)};
     }
     gsl::index index = search->second;
     instances.push_back({index, instance});
@@ -55,9 +54,9 @@ CellInstanceFilter::set_cell_instances(gsl::span<CellInstance> instances)
     Expects(x.index_cell < model::cells.size());
     const auto& c {model::cells[x.index_cell]};
     if (c->type_ != Fill::MATERIAL) {
-      throw std::invalid_argument{"Cell " + std::to_string(c->id_) + " is not "
-        "filled with a material. Only material cells can be used in a cell "
-        "instance filter."};
+      throw std::invalid_argument{fmt::format(
+        "Cell {} is not filled with a material. Only material cells can be "
+        "used in a cell instance filter.", c->id_)};
     }
     cell_instances_.push_back(x);
     map_[x] = cell_instances_.size() - 1;

--- a/src/tallies/filter_distribcell.cpp
+++ b/src/tallies/filter_distribcell.cpp
@@ -1,5 +1,7 @@
 #include "openmc/tallies/filter_distribcell.h"
 
+#include <fmt/format.h>
+
 #include "openmc/cell.h"
 #include "openmc/error.h"
 #include "openmc/geometry_aux.h" // For distribcell_path
@@ -19,10 +21,8 @@ DistribcellFilter::from_xml(pugi::xml_node node)
   // Find index in global cells vector corresponding to cell ID
   auto search = model::cell_map.find(cells[0]);
   if (search == model::cell_map.end()) {
-    std::stringstream err_msg;
-    err_msg << "Could not find cell " << cell_
-            << " specified on tally filter.";
-    throw std::runtime_error{err_msg.str()};
+    throw std::runtime_error{fmt::format(
+      "Could not find cell {} specified on tally filter.", cell_)};
   }
 
   this->set_cell(search->second);

--- a/src/tallies/filter_distribcell.cpp
+++ b/src/tallies/filter_distribcell.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_distribcell.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/cell.h"
 #include "openmc/error.h"

--- a/src/tallies/filter_energy.cpp
+++ b/src/tallies/filter_energy.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_energy.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/capi.h"
 #include "openmc/constants.h"  // For F90_NONE

--- a/src/tallies/filter_energy.cpp
+++ b/src/tallies/filter_energy.cpp
@@ -1,5 +1,7 @@
 #include "openmc/tallies/filter_energy.h"
 
+#include <fmt/format.h>
+
 #include "openmc/capi.h"
 #include "openmc/constants.h"  // For F90_NONE
 #include "openmc/mgxs_interface.h"
@@ -90,9 +92,7 @@ EnergyFilter::to_statepoint(hid_t filter_group) const
 std::string
 EnergyFilter::text_label(int bin) const
 {
-  std::stringstream out;
-  out << "Incoming Energy [" << bins_[bin] << ", " << bins_[bin+1] << ")";
-  return out.str();
+  return fmt::format("Incoming Energy [{}, {})", bins_[bin], bins_[bin+1]);
 }
 
 //==============================================================================
@@ -119,9 +119,7 @@ EnergyoutFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
 std::string
 EnergyoutFilter::text_label(int bin) const
 {
-  std::stringstream out;
-  out << "Outgoing Energy [" << bins_[bin] << ", " << bins_[bin+1] << ")";
-  return out.str();
+  return fmt::format("Outgoing Energy [{}, {})", bins_[bin], bins_[bin+1]);
 }
 
 //==============================================================================

--- a/src/tallies/filter_energyfunc.cpp
+++ b/src/tallies/filter_energyfunc.cpp
@@ -1,8 +1,6 @@
 #include "openmc/tallies/filter_energyfunc.h"
 
-#include <iomanip>  // for setprecision
-#include <ios>  // for scientific
-#include <sstream>
+#include <fmt/format.h>
 
 #include "openmc/error.h"
 #include "openmc/search.h"
@@ -82,12 +80,9 @@ EnergyFunctionFilter::to_statepoint(hid_t filter_group) const
 std::string
 EnergyFunctionFilter::text_label(int bin) const
 {
-  std::stringstream out;
-  out << std::scientific << std::setprecision(1)
-      << "Energy Function f"
-      << "([ " << energy_.front() << ", ..., " << energy_.back() << "]) = "
-      << "[" << y_.front() << ", ..., " << y_.back() << "]";
-  return out.str();
+  return fmt::format(
+    "Energy Function f([{:.1e}, ..., {:.1e}]) = [{:.1e}, ..., {:.1e}]",
+    energy_.front(), energy_.back(), y_.front(), y_.back());
 }
 
 //==============================================================================

--- a/src/tallies/filter_energyfunc.cpp
+++ b/src/tallies/filter_energyfunc.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_energyfunc.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/error.h"
 #include "openmc/search.h"

--- a/src/tallies/filter_material.cpp
+++ b/src/tallies/filter_material.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_material.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/capi.h"
 #include "openmc/material.h"

--- a/src/tallies/filter_material.cpp
+++ b/src/tallies/filter_material.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_material.h"
 
-#include <sstream>
+#include <fmt/format.h>
 
 #include "openmc/capi.h"
 #include "openmc/material.h"
@@ -16,10 +16,8 @@ MaterialFilter::from_xml(pugi::xml_node node)
   for (auto& m : mats) {
     auto search = model::material_map.find(m);
     if (search == model::material_map.end()) {
-      std::stringstream err_msg;
-      err_msg << "Could not find material " << m
-              << " specified on tally filter.";
-      throw std::runtime_error{err_msg.str()};
+      throw std::runtime_error{fmt::format(
+        "Could not find material {} specified on tally filter.", m)};
     }
     m = search->second;
   }
@@ -69,7 +67,7 @@ MaterialFilter::to_statepoint(hid_t filter_group) const
 std::string
 MaterialFilter::text_label(int bin) const
 {
-  return "Material " + std::to_string(model::materials[materials_[bin]]->id_);
+  return fmt::format("Material {}", model::materials[materials_[bin]]->id_);
 }
 
 //==============================================================================

--- a/src/tallies/filter_mesh.cpp
+++ b/src/tallies/filter_mesh.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_mesh.h"
 
-#include <sstream>
+#include <fmt/format.h>
 
 #include "openmc/capi.h"
 #include "openmc/constants.h"
@@ -24,9 +24,8 @@ MeshFilter::from_xml(pugi::xml_node node)
   if (search != model::mesh_map.end()) {
     set_mesh(search->second);
   } else{
-    std::stringstream err_msg;
-    err_msg << "Could not find mesh " << id << " specified on tally filter.";
-    fatal_error(err_msg);
+    fatal_error(fmt::format(
+      "Could not find mesh {} specified on tally filter.", id));
   }
 }
 
@@ -61,13 +60,13 @@ MeshFilter::text_label(int bin) const
   std::vector<int> ijk(n_dim);
   mesh.get_indices_from_bin(bin, ijk.data());
 
-  std::stringstream out;
-  out << "Mesh Index (" << ijk[0];
-  if (n_dim > 1) out << ", " << ijk[1];
-  if (n_dim > 2) out << ", " << ijk[2];
-  out << ")";
-
-  return out.str();
+  if (n_dim > 2) {
+    return fmt::format("Mesh Index ({}, {}, {})", ijk[0], ijk[1], ijk[2]);
+  } else if (n_dim > 1) {
+    return fmt::format("Mesh Index ({}, {})", ijk[0], ijk[1]);
+  } else {
+    return fmt::format("Mesh Index ({})", ijk[0]) ;
+  }
 }
 
 void

--- a/src/tallies/filter_mesh.cpp
+++ b/src/tallies/filter_mesh.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_mesh.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/capi.h"
 #include "openmc/constants.h"

--- a/src/tallies/filter_mu.cpp
+++ b/src/tallies/filter_mu.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_mu.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/error.h"
 #include "openmc/search.h"

--- a/src/tallies/filter_mu.cpp
+++ b/src/tallies/filter_mu.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_mu.h"
 
-#include <sstream>
+#include <fmt/format.h>
 
 #include "openmc/error.h"
 #include "openmc/search.h"
@@ -69,9 +69,7 @@ MuFilter::to_statepoint(hid_t filter_group) const
 std::string
 MuFilter::text_label(int bin) const
 {
-  std::stringstream out;
-  out << "Change-in-Angle [" << bins_[bin] << ", " << bins_[bin+1] << ")";
-  return out.str();
+  return fmt::format("Change-in-Angle [{}, {})", bins_[bin], bins_[bin+1]);
 }
 
 } // namespace openmc

--- a/src/tallies/filter_polar.cpp
+++ b/src/tallies/filter_polar.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_polar.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/constants.h"
 #include "openmc/error.h"

--- a/src/tallies/filter_polar.cpp
+++ b/src/tallies/filter_polar.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_polar.h"
 
-#include <sstream>
+#include <fmt/format.h>
 
 #include "openmc/constants.h"
 #include "openmc/error.h"
@@ -77,9 +77,7 @@ PolarFilter::to_statepoint(hid_t filter_group) const
 std::string
 PolarFilter::text_label(int bin) const
 {
-  std::stringstream out;
-  out << "Polar Angle [" << bins_[bin] << ", " << bins_[bin+1] << ")";
-  return out.str();
+  return fmt::format("Polar Angle [{}, {})", bins_[bin], bins_[bin+1]);
 }
 
 } // namespace openmc

--- a/src/tallies/filter_sph_harm.cpp
+++ b/src/tallies/filter_sph_harm.cpp
@@ -2,6 +2,9 @@
 
 #include <utility>  // For pair
 
+#include <fmt/format.h>
+#include <gsl/gsl>
+
 #include "openmc/capi.h"
 #include "openmc/error.h"
 #include "openmc/math_functions.h"
@@ -36,10 +39,8 @@ SphericalHarmonicsFilter::set_cosine(gsl::cstring_span cosine)
   } else if (cosine == "particle") {
     cosine_ = SphericalHarmonicsCosine::particle;
   } else {
-    std::stringstream err_msg;
-    err_msg << "Unrecognized cosine type, \"" << cosine
-            << "\" in spherical harmonics filter";
-    throw std::invalid_argument{err_msg.str()};
+    throw std::invalid_argument{fmt::format("Unrecognized cosine type, \"{}\" "
+      "in spherical harmonics filter", gsl::to_string(cosine))};
   }
 }
 
@@ -88,15 +89,14 @@ SphericalHarmonicsFilter::to_statepoint(hid_t filter_group) const
 std::string
 SphericalHarmonicsFilter::text_label(int bin) const
 {
-  std::stringstream out;
+  Expects(bin >= 0 && bin < n_bins_);
   for (int n = 0; n < order_ + 1; n++) {
     if (bin < (n + 1) * (n + 1)) {
       int m = (bin - n*n) - n;
-      out << "Spherical harmonic expansion, Y" << n << "," << m;
-      break;
+      return fmt::format("Spherical harmonic expansion, Y{},{}", n, m);
     }
   }
-  return out.str();
+  UNREACHABLE();
 }
 
 //==============================================================================

--- a/src/tallies/filter_sph_harm.cpp
+++ b/src/tallies/filter_sph_harm.cpp
@@ -2,7 +2,7 @@
 
 #include <utility>  // For pair
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include <gsl/gsl>
 
 #include "openmc/capi.h"

--- a/src/tallies/filter_sptl_legendre.cpp
+++ b/src/tallies/filter_sptl_legendre.cpp
@@ -2,7 +2,7 @@
 
 #include <utility>  // For pair
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/capi.h"
 #include "openmc/error.h"

--- a/src/tallies/filter_sptl_legendre.cpp
+++ b/src/tallies/filter_sptl_legendre.cpp
@@ -2,6 +2,8 @@
 
 #include <utility>  // For pair
 
+#include <fmt/format.h>
+
 #include "openmc/capi.h"
 #include "openmc/error.h"
 #include "openmc/math_functions.h"
@@ -107,17 +109,13 @@ SpatialLegendreFilter::to_statepoint(hid_t filter_group) const
 std::string
 SpatialLegendreFilter::text_label(int bin) const
 {
-  std::stringstream out;
-  out << "Legendre expansion, ";
   if (axis_ == LegendreAxis::x) {
-    out << "x";
+    return fmt::format("Legendre expansion, x axis, P{}", bin);
   } else if (axis_ == LegendreAxis::y) {
-    out << "y";
+    return fmt::format("Legendre expansion, y axis, P{}", bin);
   } else {
-    out << "z";
+    return fmt::format("Legendre expansion, z axis, P{}", bin);
   }
-  out << " axis, P" << std::to_string(bin);
-  return out.str();
 }
 
 //==============================================================================

--- a/src/tallies/filter_surface.cpp
+++ b/src/tallies/filter_surface.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_surface.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/error.h"
 #include "openmc/surface.h"

--- a/src/tallies/filter_surface.cpp
+++ b/src/tallies/filter_surface.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_surface.h"
 
-#include <sstream>
+#include <fmt/format.h>
 
 #include "openmc/error.h"
 #include "openmc/surface.h"
@@ -17,10 +17,8 @@ SurfaceFilter::from_xml(pugi::xml_node node)
   for (auto& s : surfaces) {
     auto search = model::surface_map.find(s);
     if (search == model::surface_map.end()) {
-      std::stringstream err_msg;
-      err_msg << "Could not find surface " << s
-              << " specified on tally filter.";
-      throw std::runtime_error{err_msg.str()};
+      throw std::runtime_error{fmt::format(
+        "Could not find surface {} specified on tally filter.", s)};
     }
 
     s = search->second;
@@ -75,7 +73,7 @@ SurfaceFilter::to_statepoint(hid_t filter_group) const
 std::string
 SurfaceFilter::text_label(int bin) const
 {
-  return "Surface " + std::to_string(model::surfaces[surfaces_[bin]]->id_);
+  return fmt::format("Surface {}", model::surfaces[surfaces_[bin]]->id_);
 }
 
 } // namespace openmc

--- a/src/tallies/filter_universe.cpp
+++ b/src/tallies/filter_universe.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_universe.h"
 
-#include <sstream>
+#include <fmt/format.h>
 
 #include "openmc/cell.h"
 #include "openmc/error.h"
@@ -16,10 +16,8 @@ UniverseFilter::from_xml(pugi::xml_node node)
   for (auto& u : universes) {
     auto search = model::universe_map.find(u);
     if (search == model::universe_map.end()) {
-      std::stringstream err_msg;
-      err_msg << "Could not find universe " << u
-              << " specified on tally filter.";
-      throw std::runtime_error{err_msg.str()};
+      throw std::runtime_error{fmt::format(
+        "Could not find universe {} specified on tally filter.", u)};
     }
     u = search->second;
   }
@@ -71,7 +69,7 @@ UniverseFilter::to_statepoint(hid_t filter_group) const
 std::string
 UniverseFilter::text_label(int bin) const
 {
-  return "Universe " + std::to_string(model::universes[universes_[bin]]->id_);
+  return fmt::format("Universe {}", model::universes[universes_[bin]]->id_);
 }
 
 } // namespace openmc

--- a/src/tallies/filter_universe.cpp
+++ b/src/tallies/filter_universe.cpp
@@ -1,6 +1,6 @@
 #include "openmc/tallies/filter_universe.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/cell.h"
 #include "openmc/error.h"

--- a/src/tallies/filter_zernike.cpp
+++ b/src/tallies/filter_zernike.cpp
@@ -4,6 +4,9 @@
 #include <sstream>
 #include <utility>  // For pair
 
+#include <fmt/format.h>
+#include <gsl/gsl>
+
 #include "openmc/capi.h"
 #include "openmc/error.h"
 #include "openmc/math_functions.h"
@@ -58,17 +61,16 @@ ZernikeFilter::to_statepoint(hid_t filter_group) const
 std::string
 ZernikeFilter::text_label(int bin) const
 {
-  std::stringstream out;
+  Expects(bin >= 0 && bin < n_bins_);
   for (int n = 0; n < order_+1; n++) {
     int last = (n + 1) * (n + 2) / 2;
     if (bin < last) {
       int first = last - (n + 1);
       int m = -n + (bin - first) * 2;
-      out << "Zernike expansion, Z" << n << "," << m;
-      break;
+      return fmt::format("Zernike expansion, Z{},{}", n, m);
     }
   }
-  return out.str();
+  UNREACHABLE();
 }
 
 void

--- a/src/tallies/filter_zernike.cpp
+++ b/src/tallies/filter_zernike.cpp
@@ -4,7 +4,7 @@
 #include <sstream>
 #include <utility>  // For pair
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include <gsl/gsl>
 
 #include "openmc/capi.h"

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -28,7 +28,7 @@
 #include "openmc/tallies/filter_surface.h"
 #include "openmc/xml_interface.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include "xtensor/xadapt.hpp"
 #include "xtensor/xbuilder.hpp" // for empty_like
 #include "xtensor/xview.hpp"

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -244,15 +244,16 @@ score_str_to_int(std::string score_str)
 //==============================================================================
 
 Tally::Tally(int32_t id)
-  : index_{model::tallies.size()}
 {
+  index_ = model::tallies.size(); // Avoids warning about narrowing
   this->set_id(id);
   this->set_filters({});
 }
 
 Tally::Tally(pugi::xml_node node)
-  : index_{model::tallies.size()}
 {
+  index_ = model::tallies.size(); // Avoids warning about narrowing
+
   // Copy and set tally id
   if (!check_for_node(node, "id")) {
     throw std::runtime_error{"Must specify id for tally in tally XML file."};

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -28,6 +28,7 @@
 #include "openmc/tallies/filter_surface.h"
 #include "openmc/xml_interface.h"
 
+#include <fmt/format.h>
 #include "xtensor/xadapt.hpp"
 #include "xtensor/xbuilder.hpp" // for empty_like
 #include "xtensor/xview.hpp"
@@ -35,7 +36,6 @@
 #include <algorithm> // for max
 #include <array>
 #include <cstddef> // for size_t
-#include <sstream>
 #include <string>
 
 namespace openmc {
@@ -287,8 +287,8 @@ Tally::Tally(pugi::xml_node node)
     // Determine if filter ID is valid
     auto it = model::filter_map.find(filter_id);
     if (it == model::filter_map.end()) {
-      throw std::runtime_error{"Could not find filter " + std::to_string(filter_id)
-        + " specified on tally " + std::to_string(id_)};
+      throw std::runtime_error{fmt::format(
+        "Could not find filter {} specified on tally {}", filter_id, id_)};
     }
 
     // Store the index of the filter
@@ -334,8 +334,7 @@ Tally::Tally(pugi::xml_node node)
   this->set_scores(node);
 
   if (!check_for_node(node, "scores")) {
-    fatal_error("No scores specified on tally " + std::to_string(id_)
-      + ".");
+    fatal_error(fmt::format("No scores specified on tally {}.", id_));
   }
 
   // Check if tally is compatible with particle type
@@ -371,9 +370,9 @@ Tally::Tally(pugi::xml_node node)
       auto pf = dynamic_cast<ParticleFilter*>(f);
       for (auto p : pf->particles()) {
         if (p != Particle::Type::neutron) {
-          warning("Particle filter other than NEUTRON used with photon "
-            "transport turned off. All tallies for particle type " +
-            std::to_string(static_cast<int>(p)) + " will have no scores");
+          warning(fmt::format("Particle filter other than NEUTRON used with "
+            "photon transport turned off. All tallies for particle type {}"
+            " will have no scores", static_cast<int>(p)));
         }
       }
     }
@@ -386,8 +385,8 @@ Tally::Tally(pugi::xml_node node)
     // Find the derivative with the given id, and store it's index.
     auto it = model::tally_deriv_map.find(deriv_id);
     if (it == model::tally_deriv_map.end()) {
-      fatal_error("Could not find derivative " + std::to_string(deriv_id)
-        + " specified on tally " + std::to_string(id_));
+      fatal_error(fmt::format(
+        "Could not find derivative {} specified on tally {}", deriv_id, id_));
     }
 
     deriv_ = it->second;
@@ -403,11 +402,10 @@ Tally::Tally(pugi::xml_node node)
       || deriv.variable == DerivativeVariable::TEMPERATURE) {
       for (int i_nuc : nuclides_) {
         if (has_energyout && i_nuc == -1) {
-          fatal_error("Error on tally " + std::to_string(id_)
-            + ": Cannot use a 'nuclide_density' or 'temperature' "
-            "derivative on a tally with an outgoing energy filter and "
-            "'total' nuclide rate. Instead, tally each nuclide in the "
-            "material individually.");
+          fatal_error(fmt::format("Error on tally {}: Cannot use a "
+            "'nuclide_density' or 'temperature' derivative on a tally with an "
+            "outgoing energy filter and 'total' nuclide rate. Instead, tally "
+            "each nuclide in the material individually.", id_));
           // Note that diff tallies with these characteristics would work
           // correctly if no tally events occur in the perturbed material
           // (e.g. pertrubing moderator but only tallying fuel), but this
@@ -432,11 +430,11 @@ Tally::Tally(pugi::xml_node node)
       estimator_ = TallyEstimator::ANALOG;
     } else if (est == "tracklength" || est == "track-length"
       || est == "pathlength" || est == "path-length") {
-      // If the estimator was set to an analog/collision estimator, this means
-      // the tally needs post-collision information
+      // If the estimator was set to an analog estimator, this means the
+      // tally needs post-collision information
       if (estimator_ == TallyEstimator::ANALOG || estimator_ == TallyEstimator::COLLISION) {
-        throw std::runtime_error{"Cannot use track-length estimator for tally "
-          + std::to_string(id_)};
+        throw std::runtime_error{fmt::format("Cannot use track-length "
+          "estimator for tally {}", id_)};
       }
 
       // Set estimator to track-length estimator
@@ -446,16 +444,16 @@ Tally::Tally(pugi::xml_node node)
       // If the estimator was set to an analog estimator, this means the
       // tally needs post-collision information
       if (estimator_ == TallyEstimator::ANALOG) {
-        throw std::runtime_error{"Cannot use collision estimator for tally " +
-          std::to_string(id_)};
+        throw std::runtime_error{fmt::format("Cannot use collision estimator "
+          "for tally ", id_)};
       }
 
       // Set estimator to collision estimator
       estimator_ = TallyEstimator::COLLISION;
 
     } else {
-      throw std::runtime_error{"Invalid estimator '" + est + "' on tally " +
-        std::to_string(id_)};
+      throw std::runtime_error{fmt::format(
+        "Invalid estimator '{}' on tally {}", est, id_)};
     }
   }
 }
@@ -485,7 +483,7 @@ Tally::set_id(int32_t id)
 
   // Make sure no other tally has the same ID
   if (model::tally_map.find(id) != model::tally_map.end()) {
-    throw std::runtime_error{"Two tallies have the same ID: " + std::to_string(id)};
+    throw std::runtime_error{fmt::format("Two tallies have the same ID: {}", id)};
   }
 
   // If no ID specified, auto-assign next ID in sequence
@@ -542,7 +540,7 @@ void
 Tally::set_scores(pugi::xml_node node)
 {
   if (!check_for_node(node, "scores"))
-    fatal_error("No scores specified on tally " + std::to_string(id_));
+    fatal_error(fmt::format("No scores specified on tally {}", id_));
 
   auto scores = get_node_array<std::string>(node, "scores");
   set_scores(scores);
@@ -659,8 +657,9 @@ Tally::set_scores(const std::vector<std::string>& scores)
   for (auto it1 = scores_.begin(); it1 != scores_.end(); ++it1) {
     for (auto it2 = it1 + 1; it2 != scores_.end(); ++it2) {
       if (*it1 == *it2)
-        fatal_error("Duplicate score of type \"" + reaction_name(*it1)
-          + "\" found in tally " + std::to_string(id_));
+        fatal_error(fmt::format(
+          "Duplicate score of type \"{}\" found in tally {}",
+          reaction_name(*it1), id_));
     }
   }
 
@@ -720,9 +719,8 @@ Tally::set_nuclides(const std::vector<std::string>& nuclides)
     } else {
       auto search = data::nuclide_map.find(nuc);
       if (search == data::nuclide_map.end())
-        fatal_error("Could not find the nuclide " + nuc
-          + " specified in tally " + std::to_string(id_)
-          + " in any material");
+        fatal_error(fmt::format("Could not find the nuclide {} specified in "
+          "tally {} in any material", nuc, id_));
       nuclides_.push_back(search->second);
     }
   }
@@ -743,15 +741,12 @@ Tally::init_triggers(pugi::xml_node node)
       } else if (type_str == "rel_err") {
         metric = TriggerMetric::relative_error;
       } else {
-        std::stringstream msg;
-        msg << "Unknown trigger type \"" << type_str << "\" in tally "  << id_;
-        fatal_error(msg);
+        fatal_error(fmt::format("Unknown trigger type \"{}\" in tally {}",
+          type_str, id_));
       }
     } else {
-      std::stringstream msg;
-      msg << "Must specify trigger type for tally " << id_
-          << " in tally XML file";
-      fatal_error(msg);
+      fatal_error(fmt::format(
+        "Must specify trigger type for tally {} in tally XML file", id_));
     }
 
     // Read the trigger threshold.
@@ -759,10 +754,8 @@ Tally::init_triggers(pugi::xml_node node)
     if (check_for_node(trigger_node, "threshold")) {
       threshold = std::stod(get_node_value(trigger_node, "threshold"));
     } else {
-      std::stringstream msg;
-      msg << "Must specify trigger threshold for tally " << id_
-          << " in tally XML file";
-      fatal_error(msg);
+      fatal_error(fmt::format(
+        "Must specify trigger threshold for tally {} in tally XML file", id_));
     }
 
     // Read the trigger scores.
@@ -786,10 +779,8 @@ Tally::init_triggers(pugi::xml_node node)
           if (reaction_name(this->scores_[i_score]) == score_str) break;
         }
         if (i_score == this->scores_.size()) {
-          std::stringstream msg;
-          msg << "Could not find the score \"" << score_str << "\" in tally "
-              << id_ << " but it was listed in a trigger on that tally";
-          fatal_error(msg);
+          fatal_error(fmt::format("Could not find the score \"{}\" in tally "
+            "{} but it was listed in a trigger on that tally", score_str, id_));
         }
         triggers_.push_back({metric, threshold, i_score});
       }
@@ -1078,7 +1069,7 @@ openmc_get_tally_index(int32_t id, int32_t* index)
 {
   auto it = model::tally_map.find(id);
   if (it == model::tally_map.end()) {
-    set_errmsg("No tally exists with ID=" + std::to_string(id) + ".");
+    set_errmsg(fmt::format("No tally exists with ID={}.", id));
     return OPENMC_E_INVALID_ID;
   }
 
@@ -1182,9 +1173,7 @@ openmc_tally_set_type(int32_t index, const char* type)
   } else if (strcmp(type, "surface") == 0) {
     model::tallies[index]->type_ = TallyType::SURFACE;
   } else {
-    std::stringstream errmsg;
-    errmsg << "Unknown tally type: " << type;
-    set_errmsg(errmsg);
+    set_errmsg(fmt::format("Unknown tally type: {}", type));
     return OPENMC_E_INVALID_ARGUMENT;
   }
 

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -3,7 +3,7 @@
 #include <cmath>
 #include <utility> // for std::pair
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/capi.h"
 #include "openmc/constants.h"

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -1,8 +1,9 @@
 #include "openmc/tallies/trigger.h"
 
 #include <cmath>
-#include <sstream>
 #include <utility> // for std::pair
+
+#include <fmt/format.h>
 
 #include "openmc/capi.h"
 #include "openmc/constants.h"
@@ -170,13 +171,14 @@ check_triggers()
 
   // At least one trigger is unsatisfied.  Let the user know which one.
   simulation::satisfy_triggers = false;
-  std::stringstream msg;
-  msg << "Triggers unsatisfied, max unc./thresh. is ";
+  std::string msg;
   if (keff_ratio >= tally_ratio) {
-    msg << keff_ratio << " for eigenvalue";
+    msg = fmt::format("Triggers unsatisfied, max unc./thresh. is {} for "
+      "eigenvalue", keff_ratio);
   } else {
-    msg << tally_ratio << " for " << reaction_name(score) << " in tally "
-        << tally_id;
+    msg = fmt::format(
+      "Triggers unsatisfied, max unc./thresh. is {} for {} in tally {}",
+      tally_ratio, reaction_name(score), tally_id);
   }
   write_message(msg, 7);
 
@@ -189,10 +191,10 @@ check_triggers()
     auto n_pred_batches = static_cast<int>(n_active * max_ratio * max_ratio)
       + settings::n_inactive + 1;
 
-    std::stringstream msg;
-    msg << "The estimated number of batches is " << n_pred_batches;
+    std::string msg = fmt::format("The estimated number of batches is {}",
+      n_pred_batches);
     if (n_pred_batches > settings::n_max_batches) {
-      msg << " --- greater than max batches";
+      msg.append(" --- greater than max batches");
       warning(msg);
     } else {
       write_message(msg, 7);

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -3,7 +3,7 @@
 #include <algorithm> // for sort, move, min, max, find
 #include <cmath>     // for round, sqrt, abs
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include "xtensor/xarray.hpp"
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xmath.hpp"

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -2,8 +2,8 @@
 
 #include <algorithm> // for sort, move, min, max, find
 #include <cmath>     // for round, sqrt, abs
-#include <sstream>   // for stringstream
 
+#include <fmt/format.h>
 #include "xtensor/xarray.hpp"
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xmath.hpp"
@@ -88,10 +88,8 @@ ThermalScattering::ThermalScattering(hid_t group, const std::vector<double>& tem
           temps_to_read.push_back(std::round(temp_actual));
         }
       } else {
-        std::stringstream msg;
-        msg << "Nuclear data library does not contain cross sections for "
-          << name_ << " at or near " << std::round(T) << " K.";
-        fatal_error(msg);
+        fatal_error(fmt::format("Nuclear data library does not contain cross "
+          "sections for {} at or near {} K.", name_, std::round(T)));
       }
     }
     break;
@@ -115,10 +113,8 @@ ThermalScattering::ThermalScattering(hid_t group, const std::vector<double>& tem
         }
       }
       if (!found) {
-        std::stringstream msg;
-        msg << "Nuclear data library does not contain cross sections for "
-          << name_ << " at temperatures that bound " << std::round(T) << " K.";
-        fatal_error(msg);
+        fatal_error(fmt::format("Nuclear data library does not contain cross "
+          "sections for {} at temperatures that bound {} K.", name_, std::round(T)));
       }
     }
   }
@@ -132,7 +128,7 @@ ThermalScattering::ThermalScattering(hid_t group, const std::vector<double>& tem
 
   for (auto T : temps_to_read) {
     // Get temperature as a string
-    std::string temp_str = std::to_string(T) + "K";
+    std::string temp_str = fmt::format("{}K", T);
 
     // Read exact temperature value
     double kT;

--- a/src/track_output.cpp
+++ b/src/track_output.cpp
@@ -6,10 +6,10 @@
 #include "openmc/settings.h"
 #include "openmc/simulation.h"
 
+#include <fmt/format.h>
 #include "xtensor/xtensor.hpp"
 
 #include <cstddef> // for size_t
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -35,9 +35,9 @@ void write_particle_track(Particle& p)
 
 void finalize_particle_track(Particle& p)
 {
-  std::stringstream filename;
-  filename << settings::path_output << "track_" << simulation::current_batch
-    << '_' << simulation::current_gen << '_' << p.id_ << ".h5";
+  std::string filename = fmt::format("{}track_{}_{}_{}.h5",
+    settings::path_output, simulation::current_batch, simulation::current_gen,
+    p.id_);
 
   // Determine number of coordinates for each particle
   std::vector<int> n_coords;
@@ -47,7 +47,7 @@ void finalize_particle_track(Particle& p)
 
   #pragma omp critical (FinalizeParticleTrack)
   {
-    hid_t file_id = file_open(filename.str().c_str(), 'w');
+    hid_t file_id = file_open(filename, 'w');
     write_attribute(file_id, "filetype", "track");
     write_attribute(file_id, "version", VERSION_TRACK);
     write_attribute(file_id, "n_particles", p.tracks_.size());
@@ -61,7 +61,7 @@ void finalize_particle_track(Particle& p)
         data(j, 1) = t[j].y;
         data(j, 2) = t[j].z;
       }
-      std::string name = "coordinates_" + std::to_string(i);
+      std::string name = fmt::format("coordinates_{}", i);
       write_dataset(file_id, name.c_str(), data);
     }
     file_close(file_id);

--- a/src/track_output.cpp
+++ b/src/track_output.cpp
@@ -6,7 +6,7 @@
 #include "openmc/settings.h"
 #include "openmc/simulation.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #include "xtensor/xtensor.hpp"
 
 #include <cstddef> // for size_t

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -15,6 +15,7 @@
 #include "openmc/timer.h"
 #include "openmc/xml_interface.h"
 
+#include <fmt/format.h>
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -23,7 +24,6 @@
 
 #include <algorithm> // for copy
 #include <cmath> // for pow, sqrt
-#include <sstream>
 #include <unordered_set>
 
 namespace openmc {
@@ -66,9 +66,8 @@ VolumeCalculation::VolumeCalculation(pugi::xml_node node)
 
     threshold_ = std::stod(get_node_value(threshold_node, "threshold"));
     if (threshold_ <= 0.0) {
-      std::stringstream msg;
-      msg << "Invalid error threshold " << threshold_ << " provided for a volume calculation.";
-      fatal_error(msg);
+      fatal_error(fmt::format("Invalid error threshold {} provided for a "
+        "volume calculation.", threshold_));
     }
 
     std::string tmp = get_node_value(threshold_node, "type");
@@ -79,9 +78,8 @@ VolumeCalculation::VolumeCalculation(pugi::xml_node node)
     } else if ( tmp == "rel_err") {
       trigger_type_ = TriggerMetric::relative_error;
     } else {
-      std::stringstream msg;
-      msg << "Invalid volume calculation trigger type '" << tmp << "' provided.";
-      fatal_error(msg);
+      fatal_error(fmt::format(
+        "Invalid volume calculation trigger type '{}' provided.", tmp));
     }
 
   }
@@ -394,8 +392,7 @@ void VolumeCalculation::to_hdf5(const std::string& filename,
 
   for (int i = 0; i < domain_ids_.size(); ++i)
   {
-    hid_t group_id = create_group(file_id, "domain_"
-      + std::to_string(domain_ids_[i]));
+    hid_t group_id = create_group(file_id, fmt::format("domain_{}", domain_ids_[i]));
 
     // Write volume for domain
     const auto& result {results[i]};
@@ -468,7 +465,7 @@ int openmc_calculate_volumes() {
 
   for (int i = 0; i < model::volume_calcs.size(); ++i) {
     if (mpi::master) {
-      write_message("Running volume calculation " + std::to_string(i+1) + "...", 4);
+      write_message(fmt::format("Running volume calculation {}...", i + 1), 4);
     }
 
     // Run volume calculation
@@ -487,15 +484,13 @@ int openmc_calculate_volumes() {
 
       // Display domain volumes
       for (int j = 0; j < vol_calc.domain_ids_.size(); j++) {
-        std::stringstream msg;
-        msg << domain_type << vol_calc.domain_ids_[j] << ": " <<
-          results[j].volume[0] << " +/- " << results[j].volume[1] << " cm^3";
-        write_message(msg, 4);
+        write_message(fmt::format("{}{}: {} +/- {} cm^3", domain_type,
+          vol_calc.domain_ids_[j], results[j].volume[0], results[j].volume[1]), 4);
       }
 
       // Write volumes to HDF5 file
-      std::string filename = settings::path_output + "volume_"
-        + std::to_string(i+1) + ".h5";
+      std::string filename = fmt::format("{}volume_{}.h5",
+        settings::path_output, i + 1);
       vol_calc.to_hdf5(filename, results);
     }
 
@@ -504,8 +499,7 @@ int openmc_calculate_volumes() {
   // Show elapsed time
   time_volume.stop();
   if (mpi::master) {
-    write_message("Elapsed time: " + std::to_string(time_volume.elapsed())
-      + " s", 6);
+    write_message(fmt::format("Elapsed time: {} s", time_volume.elapsed()), 6);
   }
 
   return 0;

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -15,7 +15,7 @@
 #include "openmc/timer.h"
 #include "openmc/xml_interface.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 #ifdef _OPENMP
 #include <omp.h>
 #endif

--- a/src/wmp.cpp
+++ b/src/wmp.cpp
@@ -6,8 +6,9 @@
 #include "openmc/math_functions.h"
 #include "openmc/nuclide.h"
 
+#include <fmt/format.h>
+
 #include <cmath>
-#include <sstream>
 
 namespace openmc {
 
@@ -201,15 +202,14 @@ void check_wmp_version(hid_t file)
     std::array<int, 2> version;
     read_attribute(file, "version", version);
     if (version[0] != WMP_VERSION[0]) {
-      std::stringstream msg;
-      msg << "WMP data format uses version " << version[0] << "." <<
-        version[1] << " whereas your installation of OpenMC expects version "
-        << WMP_VERSION[0] << ".x data.";
-      fatal_error(msg);
+      fatal_error(fmt::format(
+        "WMP data format uses version {}.{} whereas your installation of "
+        "OpenMC expects version {}.x data.",
+        version[0], version[1], WMP_VERSION[0]));
     }
   } else {
-    fatal_error("WMP data does not indicate a version. Your installation of "
-      "OpenMC expects version " + std::to_string(WMP_VERSION[0]) + ".x data.");
+    fatal_error(fmt::format("WMP data does not indicate a version. Your "
+      "installation of OpenMC expects version {}x data.", WMP_VERSION[0]));
   }
 }
 

--- a/src/wmp.cpp
+++ b/src/wmp.cpp
@@ -6,7 +6,7 @@
 #include "openmc/math_functions.h"
 #include "openmc/nuclide.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include <cmath>
 

--- a/src/xml_interface.cpp
+++ b/src/xml_interface.cpp
@@ -1,6 +1,6 @@
 #include "openmc/xml_interface.h"
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "openmc/error.h"
 #include "openmc/string_utils.h"

--- a/src/xml_interface.cpp
+++ b/src/xml_interface.cpp
@@ -1,10 +1,9 @@
 #include "openmc/xml_interface.h"
 
-#include <algorithm>  // for transform
-#include <sstream>
+#include <fmt/format.h>
 
 #include "openmc/error.h"
-
+#include "openmc/string_utils.h"
 
 namespace openmc {
 
@@ -19,17 +18,13 @@ get_node_value(pugi::xml_node node, const char* name, bool lowercase,
   } else if (node.child(name)) {
     value_char = node.child_value(name);
   } else {
-    std::stringstream err_msg;
-    err_msg << "Node \"" << name << "\" is not a member of the \""
-            << node.name() << "\" XML node";
-    fatal_error(err_msg);
+    fatal_error(fmt::format(
+      "Node \"{}\" is not a member of the \"{}\" XML node", name, node.name()));
   }
   std::string value {value_char};
 
   // Convert to lower-case if needed
-  if (lowercase) {
-    std::transform(value.begin(), value.end(), value.begin(), ::tolower);
-  }
+  if (lowercase) to_lower(value);
 
   // Strip leading/trailing whitespace if needed
   if (strip) {
@@ -48,10 +43,8 @@ get_node_value_bool(pugi::xml_node node, const char* name)
   } else if (node.child(name)) {
     return node.child(name).text().as_bool();
   } else {
-    std::stringstream err_msg;
-    err_msg << "Node \"" << name << "\" is not a member of the \""
-            << node.name() << "\" XML node";
-    fatal_error(err_msg);
+    fatal_error(fmt::format(
+      "Node \"{}\" is not a member of the \"{}\" XML node", name, node.name()));
   }
   return false;
 }


### PR DESCRIPTION
C++20 will have a new feature, [std::format](https://en.cppreference.com/w/cpp/utility/format/format), that provide Python-inspired string formatting and is based on a third-party library called [fmtlib](https://fmt.dev/latest/index.html). Since compiler support will take some time, this PR uses the fmtlib library as a submodule to replace most of our use of iostreams with this wonderful Python-style formatting. I think this is definitely a nice convenience for developers working on OpenMC because they only need to understand one kind of formatting.

One thing I am sensitive to is build times. Fortunately, including fmtlib has a very small effect on build times, as demonstrated by the following measurements on my laptop:
- `develop` branch
  - `make -j1` = 103s
  - `make -j2` = 59s
  - `make -j` = 26s
- this branch
  - `make -j1` = 110s
  - `make -j2` = 64s
  - `make -j` = 28s

Personally, I'm willing to sacrifice a few seconds of build time for the convenience that this provides.

One other minor change -- I've updated the GSL submodule in this PR.