### PR TITLE
These fixes allow the Cmake find_package infrastructure to work correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,6 @@ endif()
 add_library(faddeeva STATIC vendor/faddeeva/Faddeeva.cc)
 target_include_directories(faddeeva
   PUBLIC
-    $<INSTALL_INTERFACE:include/faddeeva>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/faddeeva>
 )
 target_compile_options(faddeeva PRIVATE ${cxxflags})
@@ -389,7 +388,7 @@ add_custom_command(TARGET libopenmc POST_BUILD
 #===============================================================================
 
 set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/OpenMC)
-install(TARGETS openmc libopenmc faddeeva
+install(TARGETS openmc libopenmc faddeeva pugixml gsl-lite
   EXPORT openmc-targets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ endif()
 add_library(faddeeva STATIC vendor/faddeeva/Faddeeva.cc)
 target_include_directories(faddeeva
   PUBLIC
+    $<INSTALL_INTERFACE:include/faddeeva>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/faddeeva>
 )
 target_compile_options(faddeeva PRIVATE ${cxxflags})
@@ -388,7 +389,7 @@ add_custom_command(TARGET libopenmc POST_BUILD
 #===============================================================================
 
 set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/OpenMC)
-install(TARGETS openmc libopenmc faddeeva pugixml gsl-lite
+install(TARGETS openmc libopenmc faddeeva
   EXPORT openmc-targets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/cmake/OpenMCConfig.cmake
+++ b/cmake/OpenMCConfig.cmake
@@ -1,5 +1,8 @@
 get_filename_component(OpenMC_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 
+find_package(fmt REQUIRED HINTS ${OpenMC_CMAKE_DIR}/../fmt)
+find_package(gsl-lite REQUIRED HINTS ${OpenMC_CMAKE_DIR}/../gsl-lite)
+find_package(pugixml REQUIRED HINTS ${OpenMC_CMAKE_DIR}/../pugixml)
 find_package(xtl REQUIRED HINTS ${OpenMC_CMAKE_DIR}/../xtl)
 find_package(xtensor REQUIRED HINTS ${OpenMC_CMAKE_DIR}/../xtensor)
 


### PR DESCRIPTION
The PR that included a proper set of CMAKE infrastructure for finding OpenMC libraries and headers, was not quite complete. In order to fully usable there need to be a few changes. This changes the include status of faddeeva, which never actually gets installed to the place it says it does, so I've removed that, and the additional set of dependencies are also included for the OpenMCTargets.cmake file. 