### PR TITLE
Fix bug occurring when surface ID > 999999

### DIFF
--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -377,7 +377,7 @@ CSGCell::CSGCell(pugi::xml_node cell_node)
         throw std::runtime_error{"Invalid surface ID " + std::to_string(abs(r))
           + " specified in region for cell " + std::to_string(id_) + "."};
       }
-      r = copysign(it->second + 1, r);
+      r = (r > 0) ? it->second + 1 : -(it->second + 1);
     }
   }
 
@@ -536,8 +536,8 @@ CSGCell::to_hdf5(hid_t cell_group) const
         region_spec << " |";
       } else {
         // Note the off-by-one indexing
-        region_spec << " "
-             << copysign(model::surfaces[abs(token)-1]->id_, token);
+        auto surf_id = model::surfaces[abs(token)-1]->id_;
+        region_spec << " " << ((token > 0) ? surf_id : -surf_id);
       }
     }
     write_string(group, "region", region_spec.str(), false);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -192,7 +192,7 @@ extern "C" void print_particle(Particle* p)
   // Display miscellaneous info.
   if (p->surface_ != 0) {
     const Surface& surf {*model::surfaces[std::abs(p->surface_)-1]};
-    fmt::print("  Surface = {}\n", std::copysign(surf.id_, p->surface_));
+    fmt::print("  Surface = {}\n", (p->surface_ > 0) ? surf.id_ : -surf.id_);
   }
   fmt::print("  Weight = {}\n", p->wgt_);
   if (settings::run_CE) {

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -1,7 +1,7 @@
 #include "openmc/particle.h"
 
 #include <algorithm> // copy, min
-#include <cmath>     // log, abs, copysign
+#include <cmath>     // log, abs
 
 #include <fmt/core.h>
 
@@ -539,7 +539,7 @@ Particle::cross_surface()
     // TODO: off-by-one
     surface_ = rotational ?
       surf_p->i_periodic_ + 1 :
-      std::copysign(surf_p->i_periodic_ + 1, surface_);
+      ((surface_ > 0) ? surf_p->i_periodic_ + 1 : -(surf_p->i_periodic_ + 1));
 
     // Figure out what cell particle is in now
     n_coord_ = 1;


### PR DESCRIPTION
There are a few places in our C++ where we are using `std::copysign` in a context where we need an integer return value, but copysign does't actually have an integer overload. In fact, I think we were just getting lucky that it happened to mostly work. There are evidently cases where it causes problems though. A user ran into one such case when they were trying to read a statepoint file after a run and [getting an exception](https://groups.google.com/forum/#!topic/openmc-users/ThbNIp5Ihkw) from when the summary file was being read. After talking to the user, I realized that this was occurring because the region specification being written to the summary.h5 file looked something like: `1e+6 -2e+6 ...` rather than having integer values. The following script is a MWE that demonstrates this bug:
```Python
import openmc

m = openmc.Material()
m.add_nuclide('U235', 1.0)
m.set_density('g/cm3', 5.0)
openmc.Materials([m]).export_to_xml()

surf = openmc.Sphere(r=10.0, boundary_type='vacuum', surface_id=1000000)
cell = openmc.Cell(fill=m, region=-surf)
openmc.Geometry([cell]).export_to_xml()

settings = openmc.Settings()
settings.batches = 20
settings.inactive = 10
settings.particles = 1000
settings.export_to_xml()

openmc.run()
su = openmc.Summary('summary.h5')
```

This PR fixes this bug by avoiding `copysign` in instances where we really need an integer return value.