### PR TITLE
Fixed bug which prevents creating photon data with no atomic relax

### DIFF
--- a/openmc/data/photon.py
+++ b/openmc/data/photon.py
@@ -784,8 +784,9 @@ class IncidentPhoton(EqualityMixin):
                 sub_group = shell_group.create_group(key)
 
                 # Write atomic relaxation
-                if key in self.atomic_relaxation.subshells:
-                    self.atomic_relaxation.to_hdf5(sub_group, key)
+                if self.atomic_relaxation is not None:
+                    if key in self.atomic_relaxation.subshells:
+                        self.atomic_relaxation.to_hdf5(sub_group, key)
             else:
                 continue
 

--- a/tests/unit_tests/test_data_photon.py
+++ b/tests/unit_tests/test_data_photon.py
@@ -144,3 +144,11 @@ def test_export_to_hdf5(tmpdir, element):
            element2.bremsstrahlung['electron_energy']).all()
     # Export to hdf5 again
     element2.export_to_hdf5(filename, 'w')
+
+def test_photodat_only(tmpdir):
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    filename = str(tmpdir.join('tmp.h5'))
+    p_file = 'photoat-{:03}_{}_000.endf'.format(1, 'H')
+    p_path = os.path.join(endf_data, 'photoat', p_file)
+    data=openmc.data.IncidentPhoton.from_endf(p_path)
+    data.export_to_hdf5(filename, 'w')

--- a/tests/unit_tests/test_data_photon.py
+++ b/tests/unit_tests/test_data_photon.py
@@ -148,6 +148,6 @@ def test_export_to_hdf5(tmpdir, element):
 
 def test_photodat_only(run_in_tmpdir):
     endf_dir = Path(os.environ['OPENMC_ENDF_DATA'])
-    photoatomic_file = endf_dir / 'photoat/photoat-001_H_000.endf'
-    data=openmc.data.IncidentPhoton.from_endf(photoatomic_file)
+    photoatomic_file = endf_dir / 'photoat' / 'photoat-001_H_000.endf'
+    data = openmc.data.IncidentPhoton.from_endf(photoatomic_file)
     data.export_to_hdf5('tmp.h5', 'w')

--- a/tests/unit_tests/test_data_photon.py
+++ b/tests/unit_tests/test_data_photon.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Mapping, Callable
 import os
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -145,10 +146,8 @@ def test_export_to_hdf5(tmpdir, element):
     # Export to hdf5 again
     element2.export_to_hdf5(filename, 'w')
 
-def test_photodat_only(tmpdir):
-    endf_data = os.environ['OPENMC_ENDF_DATA']
-    filename = str(tmpdir.join('tmp.h5'))
-    p_file = 'photoat-{:03}_{}_000.endf'.format(1, 'H')
-    p_path = os.path.join(endf_data, 'photoat', p_file)
-    data=openmc.data.IncidentPhoton.from_endf(p_path)
-    data.export_to_hdf5(filename, 'w')
+def test_photodat_only(run_in_tmpdir):
+    endf_dir = Path(os.environ['OPENMC_ENDF_DATA'])
+    photoatomic_file = endf_dir / 'photoat/photoat-001_H_000.endf'
+    data=openmc.data.IncidentPhoton.from_endf(photoatomic_file)
+    data.export_to_hdf5('tmp.h5', 'w')


### PR DESCRIPTION
Added check to make sure atomic relax data exists before trying to access it. This is a fix for #1488.