### PR TITLE
Surface refactoring improvements

### DIFF
--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -404,7 +404,7 @@ to install the Python package in :ref:`"editable" mode <devguide_editable>`.
 Prerequisites
 -------------
 
-The Python API works with Python 3.4+. In addition to Python itself, the API
+The Python API works with Python 3.5+. In addition to Python itself, the API
 relies on a number of third-party packages. All prerequisites can be installed
 using Conda_ (recommended), pip_, or through the package manager in most Linux
 distributions. To run simulations in parallel using MPI, it is recommended to

--- a/openmc/model/funcs.py
+++ b/openmc/model/funcs.py
@@ -373,52 +373,7 @@ def get_hexagonal_prism(*args, **kwargs):
     return hexagonal_prism(*args, **kwargs)
 
 
-def cylinder_from_points(p1, p2, r, **kwargs):
-    """Return cylinder defined by two points passing through its center.
-
-    Parameters
-    ----------
-    p1, p2 : 3-tuples
-        Coordinates of two points that pass through the center of the cylinder
-    r : float
-        Radius of the cylinder
-    kwargs : dict
-        Keyword arguments passed to the :class:`openmc.Quadric` constructor
-
-    Returns
-    -------
-    openmc.Quadric
-        Quadric surface representing the cylinder.
-
-    """
-    # Get x, y, z coordinates of two points
-    x1, y1, z1 = p1
-    x2, y2, z2 = p2
-
-    # Define intermediate terms
-    dx = x2 - x1
-    dy = y2 - y1
-    dz = z2 - z1
-    cx = y1*z2 - y2*z1
-    cy = x2*z1 - x1*z2
-    cz = x1*y2 - x2*y1
-
-    # Given p=(x,y,z), p1=(x1, y1, z1), p2=(x2, y2, z2), the equation for the
-    # cylinder can be derived as r = |(p - p1) ⨯ (p - p2)| / |p2 - p1|.
-    # Expanding out all terms and grouping according to what Quadric expects
-    # gives the following coefficients.
-    kwargs['a'] = dy*dy + dz*dz
-    kwargs['b'] = dx*dx + dz*dz
-    kwargs['c'] = dx*dx + dy*dy
-    kwargs['d'] = -2*dx*dy
-    kwargs['e'] = -2*dy*dz
-    kwargs['f'] = -2*dx*dz
-    kwargs['g'] = 2*(cy*dz - cz*dy)
-    kwargs['h'] = 2*(cz*dx - cx*dz)
-    kwargs['j'] = 2*(cx*dy - cy*dx)
-    kwargs['k'] = cx*cx + cy*cy + cz*cz - (dx*dx + dy*dy + dz*dz)*r*r
-
-    return Quadric(**kwargs)
+cylinder_from_points = Cylinder.from_points
 
 
 def subdivide(surfaces):

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -24,8 +24,6 @@ _WARNING_KWARGS = """\
 will not accept positional parameters for superclass arguments.\
 """
 
-_SURFACE_CLASSES = {}
-
 
 class Surface(IDManagerMixin, metaclass=ABCMeta):
     """An implicit surface with an associated boundary condition.

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -24,6 +24,8 @@ _WARNING_KWARGS = """\
 will not accept positional parameters for superclass arguments.\
 """
 
+_SURFACE_CLASSES = {}
+
 
 class Surface(IDManagerMixin, metaclass=ABCMeta):
     """An implicit surface with an associated boundary condition.
@@ -76,6 +78,10 @@ class Surface(IDManagerMixin, metaclass=ABCMeta):
         # Key      - coefficient name
         # Value    - coefficient value
         self._coefficients = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        _SURFACE_CLASSES[cls._type] = cls
 
     def __neg__(self):
         return Halfspace(self, '-')
@@ -361,6 +367,36 @@ class PlaneMixin(metaclass=ABCMeta):
         self._periodic_surface = periodic_surface
         periodic_surface._periodic_surface = self
 
+    def _get_base_coeffs(self):
+        return (self.a, self.b, self.c, self.d)
+
+    def _get_normal(self):
+        a, b, c = self._get_base_coeffs()[0:3]
+        return np.array((a, b, c)) / np.sqrt(a*a + b*b + c*c)
+
+    def bounding_box(self, side):
+        # Compute the bounding box based on the normal vector to the plane
+        nhat = self._get_normal()
+        lb = np.array([-np.inf, -np.inf, -np.inf])
+        ub = np.array([np.inf, np.inf, np.inf])
+        # If the plane is axis aligned, find the proper bounding box
+        if np.any(np.isclose(np.abs(nhat), 1., rtol=0., atol=self._atol)):
+            sign = np.dot(np.array([1., 1., 1.]), nhat)
+            a, b, c, d = self._get_base_coeffs()
+            vals = tuple(d/i if round(i) != 0 else np.nan for i in (a, b, c))
+            if side == '-':
+                if sign > 0:
+                    ub = np.array([v if ~np.isnan(v) else np.inf for v in vals])
+                else:
+                    lb = np.array([v if ~np.isnan(v) else -np.inf for v in vals])
+            elif side == '+':
+                if sign > 0:
+                    lb = np.array([v if ~np.isnan(v) else -np.inf for v in vals])
+                else:
+                    ub = np.array([v if ~np.isnan(v) else np.inf for v in vals])
+
+        return (lb, ub)
+
     def evaluate(self, point):
         """Evaluate the surface equation at a given point.
 
@@ -509,6 +545,12 @@ class Plane(PlaneMixin, Surface):
                      FutureWarning)
                 setattr(self, k.lower(), val)
 
+    @classmethod
+    def __subclasshook__(cls, c):
+        if cls is Plane and c in (XPlane, YPlane, ZPlane):
+            return True
+        return NotImplemented
+
     @property
     def a(self):
         return self.coefficients['a']
@@ -544,9 +586,6 @@ class Plane(PlaneMixin, Surface):
     def d(self, d):
         check_type('D coefficient', d, Real)
         self._coefficients['d'] = d
-
-    def _get_base_coeffs(self):
-        return (self.a, self.b, self.c, self.d)
 
     @classmethod
     def from_points(cls, p1, p2, p3, **kwargs):
@@ -638,27 +677,29 @@ class XPlane(PlaneMixin, Surface):
     def x0(self):
         return self.coefficients['x0']
 
+    @property
+    def a(self):
+        return 1.
+
+    @property
+    def b(self):
+        return 0.
+
+    @property
+    def c(self):
+        return 0.
+
+    @property
+    def d(self):
+        return self.x0
+
     @x0.setter
     def x0(self, x0):
         check_type('x0 coefficient', x0, Real)
         self._coefficients['x0'] = x0
 
-    def _get_base_coeffs(self):
-        return (1., 0., 0., self.x0)
-
-    def bounding_box(self, side):
-        if side == '-':
-            return (np.array([-np.inf, -np.inf, -np.inf]),
-                    np.array([self.x0, np.inf, np.inf]))
-        elif side == '+':
-            return (np.array([self.x0, -np.inf, -np.inf]),
-                    np.array([np.inf, np.inf, np.inf]))
-
     def evaluate(self, point):
         return point[0] - self.x0
-
-
-Plane.register(XPlane)
 
 
 class YPlane(PlaneMixin, Surface):
@@ -718,27 +759,29 @@ class YPlane(PlaneMixin, Surface):
     def y0(self):
         return self.coefficients['y0']
 
+    @property
+    def a(self):
+        return 0.
+
+    @property
+    def b(self):
+        return 1.
+
+    @property
+    def c(self):
+        return 0.
+
+    @property
+    def d(self):
+        return self.y0
+
     @y0.setter
     def y0(self, y0):
         check_type('y0 coefficient', y0, Real)
         self._coefficients['y0'] = y0
 
-    def _get_base_coeffs(self):
-        return (0., 1., 0., self.y0)
-
-    def bounding_box(self, side):
-        if side == '-':
-            return (np.array([-np.inf, -np.inf, -np.inf]),
-                    np.array([np.inf, self.y0, np.inf]))
-        elif side == '+':
-            return (np.array([-np.inf, self.y0, -np.inf]),
-                    np.array([np.inf, np.inf, np.inf]))
-
     def evaluate(self, point):
         return point[1] - self.y0
-
-
-Plane.register(YPlane)
 
 
 class ZPlane(PlaneMixin, Surface):
@@ -798,27 +841,29 @@ class ZPlane(PlaneMixin, Surface):
     def z0(self):
         return self.coefficients['z0']
 
+    @property
+    def a(self):
+        return 0.
+
+    @property
+    def b(self):
+        return 0.
+
+    @property
+    def c(self):
+        return 1.
+
+    @property
+    def d(self):
+        return self.z0
+
     @z0.setter
     def z0(self, z0):
         check_type('z0 coefficient', z0, Real)
         self._coefficients['z0'] = z0
 
-    def _get_base_coeffs(self):
-        return (0., 0., 1., self.z0)
-
-    def bounding_box(self, side):
-        if side == '-':
-            return (np.array([-np.inf, -np.inf, -np.inf]),
-                    np.array([np.inf, np.inf, self.z0]))
-        elif side == '+':
-            return (np.array([-np.inf, -np.inf, self.z0]),
-                    np.array([np.inf, np.inf, np.inf]))
-
     def evaluate(self, point):
         return point[2] - self.z0
-
-
-Plane.register(ZPlane)
 
 
 class QuadricMixin(metaclass=ABCMeta):
@@ -884,7 +929,7 @@ class QuadricMixin(metaclass=ABCMeta):
         """
         x = np.asarray(point)
         A, b, c = self.get_Abc()
-        return np.matmul(x.T, np.matmul(A, x)) + np.matmul(b.T, x) + c
+        return x.T @ A @ x + b.T @ x + c
 
     def translate(self, vector, inplace=False):
         """Translate surface in given direction
@@ -907,17 +952,20 @@ class QuadricMixin(metaclass=ABCMeta):
 
         surf = self if inplace else self.clone()
 
-        if set(('x0', 'y0', 'z0')).intersection(set(surf._coeff_keys)):
+        if any((isinstance(self, cls) for cls in (Cylinder, Sphere, Cone))):
             for vi, xi in zip(vector, ('x0', 'y0', 'z0')):
-                val = getattr(surf, xi, None)
-                if val is not None:
+                val = getattr(surf, xi)
+                try:
                     setattr(surf, xi, val + vi)
-        else:
+                except AttributeError:
+                    # That attribute is read only i.e x0 for XCylinder
+                    pass
+
+        elif isinstance(self, Quadric):
             A, bvec, cnst = self.get_Abc()
 
-            g, h, j = bvec - 2*np.matmul(vector.T, A)
-            k = cnst + np.matmul(vector.T, np.matmul(A, vector)) \
-                - np.matmul(bvec.T, vector)
+            g, h, j = bvec - 2*vector.T @ A
+            k = cnst + vector.T @ A @ vector - bvec.T @ vector
 
             for key, val in zip(('g', 'h', 'j', 'k'), (g, h, j, k)):
                 setattr(surf, key, val)
@@ -993,15 +1041,16 @@ class Cylinder(QuadricMixin, Surface):
     _coeff_keys = ('x0', 'y0', 'z0', 'r', 'dx', 'dy', 'dz')
 
     def __init__(self, x0=0., y0=0., z0=0., r=1., dx=0., dy=0., dz=1., **kwargs):
-        raise NotImplementedError('There is no C++ implementation for general '
-                                  'Cylinders yet, please use '
-                                  'openmc.model.funcs.cylinder_from_points to '
-                                  'return a Quadric instance instead for now')
-
         super().__init__(**kwargs)
 
         for key, val in zip(self._coeff_keys, (x0, y0, z0, r, dx, dy, dz)):
             setattr(self, key, val)
+
+    @classmethod
+    def __subclasshook__(cls, c):
+        if cls is Cylinder and c in (XCylinder, YCylinder, ZCylinder):
+            return True
+        return NotImplemented
 
     @property
     def x0(self):
@@ -1118,10 +1167,6 @@ class Cylinder(QuadricMixin, Surface):
             radius r.
 
         """
-        raise NotImplementedError('There is no C++ implementation for general '
-                                  'Cylinders yet, please use '
-                                  'openmc.model.funcs.cylinder_from_points to '
-                                  'return a Quadric instance instead for now')
         # Convert to numpy arrays
         p1 = np.asarray(p1)
         p2 = np.asarray(p2)
@@ -1129,6 +1174,30 @@ class Cylinder(QuadricMixin, Surface):
         dx, dy, dz = p2 - p1
 
         return cls(x0=x0, y0=y0, z0=z0, r=r, dx=dx, dy=dy, dz=dz, **kwargs)
+
+    def to_xml_element(self):
+        """Return XML representation of the surface
+
+        Returns
+        -------
+        element : xml.etree.ElementTree.Element
+            XML element containing source data
+
+        """
+        # This method overrides Surface.to_xml_element to generate a Quadric
+        # since the C++ layer doesn't support Cylinders right now
+        element = ET.Element("surface")
+        element.set("id", str(self._id))
+
+        if len(self._name) > 0:
+            element.set("name", str(self._name))
+
+        element.set("type", 'quadric')
+        if self.boundary_type != 'transmission':
+            element.set("boundary", self.boundary_type)
+        element.set("coeffs", ' '.join([str(c) for c in self._get_base_coeffs()]))
+
+        return element
 
 
 class XCylinder(QuadricMixin, Surface):
@@ -1202,6 +1271,22 @@ class XCylinder(QuadricMixin, Surface):
     def r(self):
         return self.coefficients['r']
 
+    @property
+    def x0(self):
+        return 0.
+
+    @property
+    def dx(self):
+        return 1.
+
+    @property
+    def dy(self):
+        return 0.
+
+    @property
+    def dz(self):
+        return 0.
+
     @y0.setter
     def y0(self, y0):
         check_type('y0 coefficient', y0, Real)
@@ -1238,9 +1323,6 @@ class XCylinder(QuadricMixin, Surface):
         y = point[1] - self.y0
         z = point[2] - self.z0
         return y*y + z*z - self.r**2
-
-
-Cylinder.register(XCylinder)
 
 
 class YCylinder(QuadricMixin, Surface):
@@ -1314,6 +1396,22 @@ class YCylinder(QuadricMixin, Surface):
     def r(self):
         return self.coefficients['r']
 
+    @property
+    def y0(self):
+        return 0.
+
+    @property
+    def dx(self):
+        return 0.
+
+    @property
+    def dy(self):
+        return 1.
+
+    @property
+    def dz(self):
+        return 0.
+
     @x0.setter
     def x0(self, x0):
         check_type('x0 coefficient', x0, Real)
@@ -1350,9 +1448,6 @@ class YCylinder(QuadricMixin, Surface):
         x = point[0] - self.x0
         z = point[2] - self.z0
         return x*x + z*z - self.r**2
-
-
-Cylinder.register(YCylinder)
 
 
 class ZCylinder(QuadricMixin, Surface):
@@ -1426,6 +1521,22 @@ class ZCylinder(QuadricMixin, Surface):
     def r(self):
         return self.coefficients['r']
 
+    @property
+    def z0(self):
+        return 0.
+
+    @property
+    def dx(self):
+        return 0.
+
+    @property
+    def dy(self):
+        return 0.
+
+    @property
+    def dz(self):
+        return 1.
+
     @x0.setter
     def x0(self, x0):
         check_type('x0 coefficient', x0, Real)
@@ -1462,9 +1573,6 @@ class ZCylinder(QuadricMixin, Surface):
         x = point[0] - self.x0
         y = point[1] - self.y0
         return x*x + y*y - self.r**2
-
-
-Cylinder.register(ZCylinder)
 
 
 class Sphere(QuadricMixin, Surface):
@@ -1656,9 +1764,6 @@ class Cone(QuadricMixin, Surface):
     _coeff_keys = ('x0', 'y0', 'z0', 'r2', 'dx', 'dy', 'dz')
 
     def __init__(self, x0=0., y0=0., z0=0., r2=1., dx=0., dy=0., dz=1., **kwargs):
-        raise NotImplementedError('There is no C++ implementation for general '
-                                  'Cones yet, this functionality should be '
-                                  'added soon.')
         R2 = kwargs.pop('R2', None)
         if R2 is not None:
             warn(_WARNING_UPPER.format(type(self).__name__, 'r2', 'R2'),
@@ -1668,6 +1773,12 @@ class Cone(QuadricMixin, Surface):
 
         for key, val in zip(self._coeff_keys, (x0, y0, z0, r2, dx, dy, dz)):
             setattr(self, key, val)
+
+    @classmethod
+    def __subclasshook__(cls, c):
+        if cls is Cone and c in (XCone, YCone, ZCone):
+            return True
+        return NotImplemented
 
     @property
     def x0(self):
@@ -1761,10 +1872,34 @@ class Cone(QuadricMixin, Surface):
         f = 2*dx*dz
         g = -2*(dx*dx*x0 + dx*dy*y0 + dx*dz*z0 - cos2)
         h = -2*(dy*dy*y0 + dx*dy*x0 + dy*dz*z0 - cos2)
-        j = -2*(dz*dz*y0 + dx*dz*x0 + dy*dz*y0 - cos2)
+        j = -2*(dz*dz*z0 + dx*dz*x0 + dy*dz*y0 - cos2)
         k = (dx*x0 + dy*y0 + dz*z0)**2 - cos2*(x0*x0 + y0*y0 + z0*z0)
 
         return (a, b, c, d, e, f, g, h, j, k)
+
+    def to_xml_element(self):
+        """Return XML representation of the surface
+
+        Returns
+        -------
+        element : xml.etree.ElementTree.Element
+            XML element containing source data
+
+        """
+        # This method overrides Surface.to_xml_element to generate a Quadric
+        # since the C++ layer doesn't support Cylinders right now
+        element = ET.Element("surface")
+        element.set("id", str(self._id))
+
+        if len(self._name) > 0:
+            element.set("name", str(self._name))
+
+        element.set("type", 'quadric')
+        if self.boundary_type != 'transmission':
+            element.set("boundary", self.boundary_type)
+        element.set("coeffs", ' '.join([str(c) for c in self._get_base_coeffs()]))
+
+        return element
 
 
 class XCone(QuadricMixin, Surface):
@@ -1845,6 +1980,18 @@ class XCone(QuadricMixin, Surface):
     def r2(self):
         return self.coefficients['r2']
 
+    @property
+    def dx(self):
+        return 1.
+
+    @property
+    def dy(self):
+        return 0.
+
+    @property
+    def dz(self):
+        return 0.
+
     @x0.setter
     def x0(self, x0):
         check_type('x0 coefficient', x0, Real)
@@ -1881,9 +2028,6 @@ class XCone(QuadricMixin, Surface):
         y = point[1] - self.y0
         z = point[2] - self.z0
         return y*y + z*z - self.r2*x*x
-
-
-Cone.register(XCone)
 
 
 class YCone(QuadricMixin, Surface):
@@ -1964,6 +2108,18 @@ class YCone(QuadricMixin, Surface):
     def r2(self):
         return self.coefficients['r2']
 
+    @property
+    def dx(self):
+        return 0.
+
+    @property
+    def dy(self):
+        return 1.
+
+    @property
+    def dz(self):
+        return 0.
+
     @x0.setter
     def x0(self, x0):
         check_type('x0 coefficient', x0, Real)
@@ -2000,9 +2156,6 @@ class YCone(QuadricMixin, Surface):
         y = point[1] - self.y0
         z = point[2] - self.z0
         return x*x + z*z - self.r2*y*y
-
-
-Cone.register(YCone)
 
 
 class ZCone(QuadricMixin, Surface):
@@ -2083,6 +2236,18 @@ class ZCone(QuadricMixin, Surface):
     def r2(self):
         return self.coefficients['r2']
 
+    @property
+    def dx(self):
+        return 0.
+
+    @property
+    def dy(self):
+        return 0.
+
+    @property
+    def dz(self):
+        return 1.
+
     @x0.setter
     def x0(self, x0):
         check_type('x0 coefficient', x0, Real)
@@ -2119,9 +2284,6 @@ class ZCone(QuadricMixin, Surface):
         y = point[1] - self.y0
         z = point[2] - self.z0
         return x*x + y*y - self.r2*z*z
-
-
-Cone.register(ZCone)
 
 
 class Quadric(QuadricMixin, Surface):
@@ -2451,6 +2613,3 @@ class Halfspace(Region):
 
         # Return translated surface
         return type(self)(memo[key], self.side)
-
-
-_SURFACE_CLASSES = {cls._type: cls for cls in Surface.__subclasses__()}

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -400,7 +400,8 @@ class PlaneMixin(metaclass=ABCMeta):
         if np.any(np.isclose(np.abs(nhat), 1., rtol=0., atol=self._atol)):
             sign = nhat.sum()
             a, b, c, d = self._get_base_coeffs()
-            vals = [d/val if round(val) != 0 else np.nan for val in (a, b, c)]
+            vals = [d/val if not np.isclose(val, 0., rtol=0., atol=self._atol) 
+                    else np.nan for val in (a, b, c)]
             if side == '-':
                 if sign > 0:
                     ur = np.array([v if not np.isnan(v) else np.inf for v in vals])

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -366,7 +366,7 @@ class PlaneMixin(metaclass=ABCMeta):
         return (self.a, self.b, self.c, self.d)
 
     def _get_normal(self):
-        a, b, c = self._get_base_coeffs()[0:3]
+        a, b, c = self._get_base_coeffs()[:3]
         return np.array((a, b, c)) / math.sqrt(a*a + b*b + c*c)
 
     def bounding_box(self, side):

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -79,10 +79,6 @@ class Surface(IDManagerMixin, metaclass=ABCMeta):
         # Value    - coefficient value
         self._coefficients = {}
 
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-        _SURFACE_CLASSES[cls._type] = cls
-
     def __neg__(self):
         return Halfspace(self, '-')
 
@@ -2613,3 +2609,5 @@ class Halfspace(Region):
 
         # Return translated surface
         return type(self)(memo[key], self.side)
+
+_SURFACE_CLASSES = {cls._type: cls for cls in Surface.__subclasses__()}

--- a/setup.py
+++ b/setup.py
@@ -56,14 +56,13 @@ kwargs = {
         'Topic :: Scientific/Engineering'
         'Programming Language :: C++',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
 
     # Dependencies
-    'python_requires': '>=3.4',
+    'python_requires': '>=3.5',
     'install_requires': [
         'numpy>=1.9', 'h5py', 'scipy', 'ipython', 'matplotlib',
         'pandas', 'lxml', 'uncertainties'

--- a/tests/unit_tests/test_surface.py
+++ b/tests/unit_tests/test_surface.py
@@ -370,23 +370,26 @@ def test_cylinder_from_points_axis():
     # (x - 3)^2 + (y - 4)^2 = 2^2
     # x^2 + y^2 - 6x - 8y + 21 = 0
     s = openmc.model.cylinder_from_points((3., 4., 0.), (3., 4., 1.), 2.)
-    assert (s.a, s.b, s.c) == pytest.approx((1., 1., 0.))
-    assert (s.d, s.e, s.f) == pytest.approx((0., 0., 0.))
-    assert (s.g, s.h, s.j) == pytest.approx((-6., -8., 0.))
-    assert s.k == pytest.approx(21.)
+    a, b, c, d, e, f, g, h, j, k = s._get_base_coeffs()
+    assert (a, b, c) == pytest.approx((1., 1., 0.))
+    assert (d, e, f) == pytest.approx((0., 0., 0.))
+    assert (g, h, j) == pytest.approx((-6., -8., 0.))
+    assert k == pytest.approx(21.)
 
     # (y + 7)^2 + (z - 1)^2 = 3^2
     # y^2 + z^2 + 14y - 2z + 41 = 0
     s = openmc.model.cylinder_from_points((0., -7, 1.), (1., -7., 1.), 3.)
-    assert (s.a, s.b, s.c) == pytest.approx((0., 1., 1.))
-    assert (s.d, s.e, s.f) == pytest.approx((0., 0., 0.))
-    assert (s.g, s.h, s.j) == pytest.approx((0., 14., -2.))
-    assert s.k == 41.
+    a, b, c, d, e, f, g, h, j, k = s._get_base_coeffs()
+    assert (a, b, c) == pytest.approx((0., 1., 1.))
+    assert (d, e, f) == pytest.approx((0., 0., 0.))
+    assert (g, h, j) == pytest.approx((0., 14., -2.))
+    assert k == 41.
 
     # (x - 2)^2 + (z - 5)^2 = 4^2
     # x^2 + z^2 - 4x - 10z + 13 = 0
     s = openmc.model.cylinder_from_points((2., 0., 5.), (2., 1., 5.), 4.)
-    assert (s.a, s.b, s.c) == pytest.approx((1., 0., 1.))
-    assert (s.d, s.e, s.f) == pytest.approx((0., 0., 0.))
-    assert (s.g, s.h, s.j) == pytest.approx((-4., 0., -10.))
-    assert s.k == pytest.approx(13.)
+    a, b, c, d, e, f, g, h, j, k = s._get_base_coeffs()
+    assert (a, b, c) == pytest.approx((1., 0., 1.))
+    assert (d, e, f) == pytest.approx((0., 0., 0.))
+    assert (g, h, j) == pytest.approx((-4., 0., -10.))
+    assert k == pytest.approx(13.)


### PR DESCRIPTION
This PR improves on the refactoring of `surface.py` done in PR #1483 by 
~~1.) autoregistering of `Surface` subclasses~~ removed since `__init_subclass__` is not available prior to Python 3.6
2.) abstracting `bounding_box` for `Planes` (and allow for bounding boxes of general `Planes` to be determined if possible)
3.) Implementing general `Cones` and `Cylinders` that export to `Quadric` in `geometry.xml` 
4.) Adding additional properties to subclasses of `Plane`, `Cone`, and `Cylinder` to provide identical interfaces to their virtual parent class 

The motivation of these improvements is to provide a more uniform interface for similar classes which allows cleaner implementation of rotations.