### PR TITLE
Make sure GSL compatibility header gets installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,8 @@ target_link_libraries(xtensor INTERFACE xtl)
 # GSL header-only library
 #===============================================================================
 
+set(GSL_LITE_OPT_INSTALL_COMPAT_HEADER ON CACHE BOOL
+  "Install MS-GSL compatibility header <gsl/gsl>")
 add_subdirectory(vendor/gsl-lite)
 
 # Make sure contract violations throw exceptions


### PR DESCRIPTION
Problem described in #1496. The CMakeLists.txt file for GSL actually includes an option for this that is off by default. My fix is to just turn it on :tada: 