### PR TITLE
Reorder data members

### DIFF
--- a/include/openmc/mgxs.h
+++ b/include/openmc/mgxs.h
@@ -40,8 +40,8 @@ class Mgxs {
 
     xt::xtensor<double, 1> kTs;   // temperature in eV (k * T)
     AngleDistributionType scatter_format; // flag for if this is legendre, histogram, or tabular
-    int num_delayed_groups; // number of delayed neutron groups
     int num_groups;     // number of energy groups
+    int num_delayed_groups; // number of delayed neutron groups
     std::vector<XsData> xs; // Cross section data
     // MGXS Incoming Flux Angular grid information
     bool is_isotropic; // used to skip search for angle indices if isotropic

--- a/include/openmc/tallies/tally_scoring.h
+++ b/include/openmc/tallies/tally_scoring.h
@@ -39,15 +39,18 @@ public:
 
   FilterBinIter& operator++();
 
-  int index_ {1};
-  double weight_ {1.};
-  
-  std::vector<FilterMatch>& filter_matches_;
-
 private:
   void compute_index_weight();
 
+  // Data members
   const Tally& tally_;
+
+public:
+
+  int index_ {1};
+  double weight_ {1.};
+
+  std::vector<FilterMatch>& filter_matches_;
 };
 
 //==============================================================================

--- a/include/openmc/tallies/tally_scoring.h
+++ b/include/openmc/tallies/tally_scoring.h
@@ -39,18 +39,15 @@ public:
 
   FilterBinIter& operator++();
 
+  int index_ {1};
+  double weight_ {1.};
+  
+  std::vector<FilterMatch>& filter_matches_;
+
 private:
   void compute_index_weight();
 
-  // Data members
   const Tally& tally_;
-
-public:
-
-  int index_ {1};
-  double weight_ {1.};
-
-  std::vector<FilterMatch>& filter_matches_;
 };
 
 //==============================================================================

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -27,7 +27,7 @@ namespace openmc {
 //==============================================================================
 
 FilterBinIter::FilterBinIter(const Tally& tally, Particle* p)
-  : tally_{tally}, filter_matches_{p->filter_matches_}
+  : filter_matches_{p->filter_matches_}, tally_{tally}
 {
   // Find all valid bins in each relevant filter if they have not already been
   // found for this event.
@@ -57,7 +57,7 @@ FilterBinIter::FilterBinIter(const Tally& tally, Particle* p)
 
 FilterBinIter::FilterBinIter(const Tally& tally, bool end,
     std::vector<FilterMatch>* particle_filter_matches)
-  : tally_{tally}, filter_matches_{*particle_filter_matches}
+  : filter_matches_{*particle_filter_matches}, tally_{tally}
 {
   // Handle the special case for an iterator that points to the end.
   if (end) {


### PR DESCRIPTION
An external project applies the `-Werror=reorder` flag when building with OpenMC and caught a couple of instances where data members of classes appear in a different order than they are initialized in the class constructors. This contains a couple fixes to remedy that.