### PR TITLE
make MG scattering gmin, gmax be int, not double

### DIFF
--- a/include/openmc/scattdata.h
+++ b/include/openmc/scattdata.h
@@ -43,8 +43,8 @@ class ScattData {
     double_2dvec energy;            // Normalized p0 matrix for sampling Eout
     double_2dvec mult;              // nu-scatter multiplication (nu-scatt/scatt)
     double_3dvec dist;              // Angular distribution
-    xt::xtensor<double, 1> gmin;    // minimum outgoing group
-    xt::xtensor<double, 1> gmax;    // maximum outgoing group
+    xt::xtensor<int, 1> gmin;    // minimum outgoing group
+    xt::xtensor<int, 1> gmax;    // maximum outgoing group
     xt::xtensor<double, 1> scattxs; // Isotropic Sigma_{s,g_{in}}
 
     //! \brief Calculates the value of normalized f(mu).


### PR DESCRIPTION
Hey,

So, here is a small thing in MG mode that bugged me. The scattering matrix is usually sparse, and dense between two indices on a given column. These bounding indices are stored, and are called gmin and gmax. Clearly, these should be integers and never doubles. In fact, because storing them as doubles requires casting back and forth between int and double, there is a slight performance hit to doing this. I have changed them to int, and measured a slight performance increase with the default optimizations. Just thought it may be good to submit any code giving a small performance gain.

```
double gmin, gmax:
 Calculation Rate (inactive)       = 39264.6 particles/second
 Calculation Rate (active)         = 7950.48 particles/second

int gmin, gmax
 Calculation Rate (inactive)       = 39746.2 particles/second
 Calculation Rate (active)         = 7981.01 particles/second
```