### PR TITLE
Speed up distribcell initialization

### DIFF
--- a/include/openmc/geometry_aux.h
+++ b/include/openmc/geometry_aux.h
@@ -86,11 +86,15 @@ void count_cell_instances(int32_t univ_indx);
 //! Recursively search through universes and count universe instances.
 //! \param search_univ The index of the universe to begin searching from.
 //! \param target_univ_id The ID of the universe to be counted.
+//! \param univ_count_memo Memoized counts that make this function faster for
+//!   large systems.  The first call to this function for each target_univ_id
+//!   should start with an empty memo.
 //! \return The number of instances of target_univ_id in the geometry tree under
 //!   search_univ.
 //==============================================================================
 
-int count_universe_instances(int32_t search_univ, int32_t target_univ_id);
+int count_universe_instances(int32_t search_univ, int32_t target_univ_id,
+  std::unordered_map<int32_t, int32_t>& univ_count_memo);
 
 //==============================================================================
 //! Build a character array representing the path to a distribcell instance.

--- a/include/openmc/lattice.h
+++ b/include/openmc/lattice.h
@@ -77,7 +77,8 @@ public:
   {offsets_.resize(n_maps * universes_.size(), C_NONE);}
 
   //! Populate the distribcell offset tables.
-  int32_t fill_offset_table(int32_t offset, int32_t target_univ_id, int map);
+  int32_t fill_offset_table(int32_t offset, int32_t target_univ_id, int map,
+    std::unordered_map<int32_t, int32_t>& univ_count_memo);
 
   //! \brief Check lattice indices.
   //! \param i_xyz[3] The indices for a lattice tile.

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -93,11 +93,12 @@ Lattice::adjust_indices()
 //==============================================================================
 
 int32_t
-Lattice::fill_offset_table(int32_t offset, int32_t target_univ_id, int map)
+Lattice::fill_offset_table(int32_t offset, int32_t target_univ_id, int map,
+  std::unordered_map<int32_t, int32_t>& univ_count_memo)
 {
   for (LatticeIter it = begin(); it != end(); ++it) {
     offsets_[map * universes_.size() + it.indx_] = offset;
-    offset += count_universe_instances(*it, target_univ_id);
+    offset += count_universe_instances(*it, target_univ_id, univ_count_memo);
   }
   return offset;
 }


### PR DESCRIPTION
On big models quite a lot of time can be spent in the `Preparing distributed cell instances...` step. This PR speeds that process up by memozing cell counts. If I remember correctly, this feature existed in the original F90 distribcell implementation, but I removed it to make refactoring and the C++ rewrite easier. So I guess I got what I deserve by running into runtime issues with it now! For good measure, I also stuck a `#pragma omp for` on the relevant loop.

These changes combined bring the init time on one of my models from 7 minutes down to 25 seconds.