### PR TITLE
add accessor of xsdata to mgxs

### DIFF
--- a/include/openmc/mgxs.h
+++ b/include/openmc/mgxs.h
@@ -187,8 +187,7 @@ class Mgxs {
     set_angle_index(Direction u);
 
     //! \brief Provide const access to list of XsData held by this
-    std::vector<XsData> const&
-    get_xsdata() const { return xs; }
+    const std::vector<XsData>& get_xsdata() const { return xs; }
 };
 
 } // namespace openmc

--- a/include/openmc/mgxs.h
+++ b/include/openmc/mgxs.h
@@ -185,6 +185,10 @@ class Mgxs {
     //! @param u Incoming particle direction.
     void
     set_angle_index(Direction u);
+
+    //! \brief Provide const access to list of XsData held by this
+    std::vector<XsData> const&
+    get_xsdata() const { return xs; }
 };
 
 } // namespace openmc


### PR DESCRIPTION
Hey folks.

Just needed this const accessor to a private variable to make some custom Mgxs objects. No crazy changes here.