### PR TITLE
Reduce memory usage of Materials.export_to_xml

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1177,7 +1177,9 @@ class Materials(cv.CheckedList):
         if p.is_dir():
             p /= 'materials.xml'
 
-        # Open the file in write mode.
+        # Write materials to the file one-at-a-time.  This significantly reduces
+        # memory demand over allocating a complete ElementTree and writing it in
+        # one go.
         with open(str(p), 'w', encoding='utf-8',
                   errors='xmlcharrefreplace') as fh:
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1178,26 +1178,30 @@ class Materials(cv.CheckedList):
             p /= 'materials.xml'
 
         # Open the file in write mode.
-        with open(str(p), 'wb') as fh:
+        with open(str(p), 'w', encoding='utf-8',
+                  errors='xmlcharrefreplace') as fh:
+
             # Write the header and the opening tag for the root element.
-            fh.write(b"<?xml version='1.0' encoding='utf-8'?>\n")
-            fh.write(b'<materials>\n')
+            fh.write("<?xml version='1.0' encoding='utf-8'?>\n")
+            fh.write('<materials>\n')
 
             # Write the <cross_sections> element.
             if self._cross_sections is not None:
                 element = ET.Element('cross_sections')
                 element.text = str(self._cross_sections)
                 clean_indentation(element, level=1)
-                fh.write(b'  ' + ET.tostring(element).strip() + b'\n')
+                out = ET.tostring(element, encoding='utf-8').strip()
+                fh.write('  ' + str(out, encoding='utf-8') + '\n')
 
             # Write the <material> elements.
             for material in sorted(self, key=lambda x: x.id):
                 element = material.to_xml_element(self.cross_sections)
                 clean_indentation(element, level=1)
-                fh.write(b'  ' + ET.tostring(element).strip() + b'\n')
+                out = ET.tostring(element, encoding='utf-8').strip()
+                fh.write('  ' + str(out, encoding='utf-8') + '\n')
 
             # Write the closing tag for the root element.
-            fh.write(b'</materials>\n')
+            fh.write('</materials>\n')
 
     @classmethod
     def from_xml(cls, path='materials.xml'):

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1190,15 +1190,17 @@ class Materials(cv.CheckedList):
                 element = ET.Element('cross_sections')
                 element.text = str(self._cross_sections)
                 clean_indentation(element, level=1)
-                out = ET.tostring(element, encoding='utf-8').strip()
-                fh.write('  ' + str(out, encoding='utf-8') + '\n')
+                element.tail = element.tail.strip(' ')
+                fh.write('  ')
+                ET.ElementTree(element).write(fh, encoding='unicode')
 
             # Write the <material> elements.
             for material in sorted(self, key=lambda x: x.id):
                 element = material.to_xml_element(self.cross_sections)
                 clean_indentation(element, level=1)
-                out = ET.tostring(element, encoding='utf-8').strip()
-                fh.write('  ' + str(out, encoding='utf-8') + '\n')
+                element.tail = element.tail.strip(' ')
+                fh.write('  ')
+                ET.ElementTree(element).write(fh, encoding='unicode')
 
             # Write the closing tag for the root element.
             fh.write('</materials>\n')


### PR DESCRIPTION
Our current implementation of `Materials.export_to_xml` uses a ton of memory.  It's even larger than the output .xml file by an order of magnitude so it's pretty easy to eat up GB levels of memory here (and crash your laptop :upside_down_face:).

This PR fixes those memory issues by writing each `<material>` element to the file as it is produced.  The runtime of the file writing looks to be within 10% of the previous implementation.