### PR TITLE
Ensure NJOY output goes to specified output directory

### DIFF
--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -422,7 +422,7 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
         with ace.open('w') as ace_file, xsdir.open('w') as xsdir_file:
             for temperature in temperatures:
                 # Get contents of ACE file
-                text = open(output_dir / fname.format("ace", temperature), 'r').read()
+                text = (output_dir / fname.format("ace", temperature)).read_text()
 
                 # If the target is metastable, make sure that ZAID in the ACE
                 # file reflects this by adding 400
@@ -435,8 +435,8 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
                 ace_file.write(text)
 
                 # Concatenate into destination xsdir file
-                text = open(output_dir / fname.format("xsdir", temperature), 'r').read()
-                xsdir_file.write(text)
+                xsdir_in = output_dir / fname.format("xsdir", temperature)
+                xsdir_file.write(xsdir_in.read_text())
 
 
 def make_ace_thermal(filename, filename_thermal, temperatures=None,
@@ -585,13 +585,13 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
     commands += 'stop\n'
     run(commands, tapein, tapeout, **kwargs)
 
-    ace_out = (output_dir / ace)
-    xsdir = (ace.parent / "xsdir") if xsdir is None else xsdir
-    with open(ace_out, 'w') as ace_file, open(xsdir, 'w') as xsdir_file:
+    ace_out = output_dir / ace
+    xsdir = (ace.parent / "xsdir") if xsdir is None else Path(xsdir)
+    with ace_out.open('w') as ace_file, xsdir.open('w') as xsdir_file:
         # Concatenate ACE and xsdir files together
         for temperature in temperatures:
-            text = open(output_dir / fname.format(ace, temperature), 'r').read()
-            ace_file.write(text)
+            ace_in = output_dir / fname.format(ace, temperature)
+            ace_file.write(ace_in.read_text())
 
-            text = open(output_dir / fname.format(xsdir, temperature), 'r').read()
-            xsdir_file.write(text)
+            xsdir_in = output_dir / fname.format(xsdir, temperature)
+            xsdir_file.write(xsdir_in.read_text())

--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -402,7 +402,6 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
     # acer
     if acer:
         nacer_in = nlast
-        fname = '{}_{:.1f}'
         for i, temperature in enumerate(temperatures):
             # Extend input with an ACER run for each temperature
             nace = nacer_in + 1 + 2*i
@@ -411,8 +410,8 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
             commands += _TEMPLATE_ACER.format(**locals())
 
             # Indicate tapes to save for each ACER run
-            tapeout[nace] = output_dir / fname.format("ace", temperature)
-            tapeout[ndir] = output_dir / fname.format("xsdir", temperature)
+            tapeout[nace] = output_dir / "ace_{:.1f}".format(temperature)
+            tapeout[ndir] = output_dir / "xsdir_{:.1f}".format(temperature)
     commands += 'stop\n'
     run(commands, tapein, tapeout, **kwargs)
 
@@ -422,7 +421,7 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
         with ace.open('w') as ace_file, xsdir.open('w') as xsdir_file:
             for temperature in temperatures:
                 # Get contents of ACE file
-                text = (output_dir / fname.format("ace", temperature)).read_text()
+                text = (output_dir / "ace_{:.1f}".format(temperature)).read_text()
 
                 # If the target is metastable, make sure that ZAID in the ACE
                 # file reflects this by adding 400
@@ -435,8 +434,13 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
                 ace_file.write(text)
 
                 # Concatenate into destination xsdir file
-                xsdir_in = output_dir / fname.format("xsdir", temperature)
+                xsdir_in = output_dir / "xsdir_{:.1f}".format(temperature)
                 xsdir_file.write(xsdir_in.read_text())
+
+        # Remove ACE/xsdir files for each temperature
+        for temperature in temperatures:
+            (output_dir / "ace_{:.1f}".format(temperature)).unlink()
+            (output_dir / "xsdir_{:.1f}".format(temperature)).unlink()
 
 
 def make_ace_thermal(filename, filename_thermal, temperatures=None,
@@ -571,7 +575,6 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
 
     # acer
     nthermal_acer_in = nlast
-    fname = '{}_{:.1f}'
     for i, temperature in enumerate(temperatures):
         # Extend input with an ACER run for each temperature
         nace = nthermal_acer_in + 1 + 2*i
@@ -580,18 +583,23 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
         commands += _THERMAL_TEMPLATE_ACER.format(**locals())
 
         # Indicate tapes to save for each ACER run
-        tapeout[nace] = output_dir / fname.format(ace, temperature)
-        tapeout[ndir] = output_dir / fname.format(xsdir, temperature)
+        tapeout[nace] = output_dir / "ace_{:.1f}".format(temperature)
+        tapeout[ndir] = output_dir / "xsdir_{:.1f}".format(temperature)
     commands += 'stop\n'
     run(commands, tapein, tapeout, **kwargs)
 
-    ace_out = output_dir / ace
+    ace = output_dir / ace
     xsdir = (ace.parent / "xsdir") if xsdir is None else Path(xsdir)
-    with ace_out.open('w') as ace_file, xsdir.open('w') as xsdir_file:
+    with ace.open('w') as ace_file, xsdir.open('w') as xsdir_file:
         # Concatenate ACE and xsdir files together
         for temperature in temperatures:
-            ace_in = output_dir / fname.format(ace, temperature)
+            ace_in = output_dir / "ace_{:.1f}".format(temperature)
             ace_file.write(ace_in.read_text())
 
-            xsdir_in = output_dir / fname.format(xsdir, temperature)
+            xsdir_in = output_dir / "xsdir_{:.1f}".format(temperature)
             xsdir_file.write(xsdir_in.read_text())
+
+    # Remove ACE/xsdir files for each temperature
+    for temperature in temperatures:
+        (output_dir / "ace_{:.1f}".format(temperature)).unlink()
+        (output_dir / "xsdir_{:.1f}".format(temperature)).unlink()


### PR DESCRIPTION
This PR solves an issue that I've been observing for some time. One of our scripts for data generation ([generate_endf71.py](https://github.com/openmc-dev/data/blob/master/generate_endf71.py)) runs many instances of NJOY in parallel when generating HDF5 files. However, when I've run this script on a large node with many cores, I've observed that sometimes one of the tasks will fail randomly. After looking at it a little closer, I realized that it's because of how ACE files are being written out. When multiple temperatures are specified, the ACE files were not being written to the specified output directory, and so if there were many parallel jobs running in the same directory, they would sometimes clobber each other, resulting in a missing file.