### PR TITLE
Add some accessors and update XTL (small)

### DIFF
--- a/include/openmc/distribution_multi.h
+++ b/include/openmc/distribution_multi.h
@@ -43,6 +43,11 @@ public:
   //! \param seed Pseudorandom number seed pointer
   //! \return Direction sampled
   Direction sample(uint64_t* seed) const;
+
+  // Observing pointers
+  auto mu() const { return mu_.get(); }
+  auto phi() const { return phi_.get(); }
+
 private:
   UPtrDist mu_;  //!< Distribution of polar angle
   UPtrDist phi_; //!< Distribution of azimuthal angle

--- a/include/openmc/distribution_multi.h
+++ b/include/openmc/distribution_multi.h
@@ -45,8 +45,8 @@ public:
   Direction sample(uint64_t* seed) const;
 
   // Observing pointers
-  auto mu() const { return mu_.get(); }
-  auto phi() const { return phi_.get(); }
+  Distribution* mu() const { return mu_.get(); }
+  Distribution* phi() const { return phi_.get(); }
 
 private:
   UPtrDist mu_;  //!< Distribution of polar angle

--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -34,9 +34,9 @@ public:
   Position sample(uint64_t* seed) const;
 
   // Observer pointers
-  auto x() const { return x_.get(); }
-  auto y() const { return x_.get(); }
-  auto z() const { return x_.get(); }
+  Distribution* x() const { return x_.get(); }
+  Distribution* y() const { return x_.get(); }
+  Distribution* z() const { return x_.get(); }
 private:
   UPtrDist x_; //!< Distribution of x coordinates
   UPtrDist y_; //!< Distribution of y coordinates

--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -32,6 +32,11 @@ public:
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled position
   Position sample(uint64_t* seed) const;
+
+  // Observer pointers
+  auto x() const { return x_.get(); }
+  auto y() const { return x_.get(); }
+  auto z() const { return x_.get(); }
 private:
   UPtrDist x_; //!< Distribution of x coordinates
   UPtrDist y_; //!< Distribution of y coordinates
@@ -50,6 +55,11 @@ public:
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled position
   Position sample(uint64_t* seed) const;
+  
+  auto r() const { return r_.get(); }
+  auto phi() const { return phi_.get(); }
+  auto z() const { return z_.get(); }
+  auto origin() const { return origin_; }
 private:
   UPtrDist r_; //!< Distribution of r coordinates
   UPtrDist phi_; //!< Distribution of phi coordinates
@@ -70,6 +80,11 @@ public:
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled position
   Position sample(uint64_t* seed) const;
+
+  auto r() const { return r_.get(); }
+  auto theta() const { return theta_.get(); }
+  auto phi() const { return phi_.get(); }
+  auto origin () const { return origin_; }
 private:
   UPtrDist r_; //!< Distribution of r coordinates
   UPtrDist theta_; //!< Distribution of theta coordinates
@@ -92,6 +107,8 @@ public:
 
   // Properties
   bool only_fissionable() const { return only_fissionable_; }
+  Position lower_left() const { return lower_left_; }
+  Position upper_right() const { return upper_right_; }
 private:
   Position lower_left_; //!< Lower-left coordinates of box
   Position upper_right_; //!< Upper-right coordinates of box
@@ -112,6 +129,8 @@ public:
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled position
   Position sample(uint64_t* seed) const;
+
+  auto r() const { return r_; }
 private:
   Position r_; //!< Single position at which sites are generated
 };

--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -56,10 +56,10 @@ public:
   //! \return Sampled position
   Position sample(uint64_t* seed) const;
   
-  auto r() const { return r_.get(); }
-  auto phi() const { return phi_.get(); }
-  auto z() const { return z_.get(); }
-  auto origin() const { return origin_; }
+  Distribution* r() const { return r_.get(); }
+  Distribution* phi() const { return phi_.get(); }
+  Distribution* z() const { return z_.get(); }
+  Position origin() const { return origin_; }
 private:
   UPtrDist r_; //!< Distribution of r coordinates
   UPtrDist phi_; //!< Distribution of phi coordinates

--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -81,10 +81,10 @@ public:
   //! \return Sampled position
   Position sample(uint64_t* seed) const;
 
-  auto r() const { return r_.get(); }
-  auto theta() const { return theta_.get(); }
-  auto phi() const { return phi_.get(); }
-  auto origin () const { return origin_; }
+  Distribution* r() const { return r_.get(); }
+  Distribution* theta() const { return theta_.get(); }
+  Distribution* phi() const { return phi_.get(); }
+  Position origin () const { return origin_; }
 private:
   UPtrDist r_; //!< Distribution of r coordinates
   UPtrDist theta_; //!< Distribution of theta coordinates

--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -130,7 +130,7 @@ public:
   //! \return Sampled position
   Position sample(uint64_t* seed) const;
 
-  auto r() const { return r_; }
+  Position r() const { return r_; }
 private:
   Position r_; //!< Single position at which sites are generated
 };

--- a/include/openmc/source.h
+++ b/include/openmc/source.h
@@ -43,7 +43,14 @@ public:
   Particle::Bank sample(uint64_t* seed) const;
 
   // Properties
+  Particle::Type particle_type() const { return particle_; }
   double strength() const { return strength_; }
+
+  // Make observing pointers available
+  auto space() const { return space_.get(); }
+  auto angle() const { return angle_.get(); }
+  auto energy() const { return energy_.get(); }
+
 private:
   Particle::Type particle_ {Particle::Type::neutron}; //!< Type of particle emitted
   double strength_ {1.0}; //!< Source strength

--- a/include/openmc/source.h
+++ b/include/openmc/source.h
@@ -47,9 +47,9 @@ public:
   double strength() const { return strength_; }
 
   // Make observing pointers available
-  auto space() const { return space_.get(); }
-  auto angle() const { return angle_.get(); }
-  auto energy() const { return energy_.get(); }
+  SpatialDistribution* space() const { return space_.get(); }
+  UnitSphereDistribution* angle() const { return angle_.get(); }
+  Distribution* energy() const { return energy_.get(); }
 
 private:
   Particle::Type particle_ {Particle::Type::neutron}; //!< Type of particle emitted


### PR DESCRIPTION
Hey all,

So, last time I updated XTL, I thought a change I was trying to make there had gone through that lets it work with the latest CUDA compiler, but it seems it had in fact not yet gone through. Now, it has. That change is xtensor-stack/xtl#188 and mpark/variant#73. So, firstly, this PR takes XTL up to its 0.6.13 release.

Second, I added some methods for obtaining observing pointers to some unique_pointers in order to adapt data from CPU to GPU. I know that raw pointers are generally desirable to avoid, but the core guidelines say that they're OK in the context of being observing pointers, which they are here. So, yeah. Please let me add this :smile: 

https://stackoverflow.com/questions/38901846/pointing-to-the-content-of-stdunique-ptr