### PR TITLE
Use Chain.reduce to follow paths and reduce the size

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -906,7 +906,7 @@ class Chain(object):
 
     def _follow(self, isotopes, level):
         """Return all isotopes present up to depth level"""
-        found = set(isotopes)
+        found = isotopes.copy()
         remaining = set(self.nuclide_dict)
         if not found.issubset(remaining):
             raise IndexError(
@@ -916,7 +916,7 @@ class Chain(object):
         if level == 0:
             return found
 
-        remaining.difference_update(found)
+        remaining -= found
 
         depth = 0
         next_iso = set()
@@ -952,8 +952,8 @@ class Chain(object):
 
             # Prepare for next dig
             depth += 1
-            isotopes.update(next_iso)
-            remaining.difference_update(next_iso)
+            isotopes |= next_iso
+            remaining -= next_iso
             next_iso.clear()
 
         # Process isotope that would have started next depth

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -500,7 +500,7 @@ class Chain(object):
                 # Gain
                 for _, target, branching_ratio in nuc.decay_modes:
                     # Allow for total annihilation for debug purposes
-                    if target != 'Nothing':
+                    if target is not None:
                         branch_val = branching_ratio * decay_constant
 
                         if branch_val != 0.0:
@@ -525,17 +525,16 @@ class Chain(object):
                             matrix[i, i] -= path_rate
 
                     # Gain term; allow for total annihilation for debug purposes
-                    if target != 'Nothing':
-                        if r_type != 'fission':
-                            if path_rate != 0.0:
-                                k = self.nuclide_dict[target]
-                                matrix[k, i] += path_rate * br
-                        else:
-                            for product, y in fission_yields[nuc.name].items():
-                                yield_val = y * path_rate
-                                if yield_val != 0.0:
-                                    k = self.nuclide_dict[product]
-                                    matrix[k, i] += yield_val
+                    if r_type != 'fission':
+                        if target is not None and path_rate != 0.0:
+                            k = self.nuclide_dict[target]
+                            matrix[k, i] += path_rate * br
+                    else:
+                        for product, y in fission_yields[nuc.name].items():
+                            yield_val = y * path_rate
+                            if yield_val != 0.0:
+                                k = self.nuclide_dict[product]
+                                matrix[k, i] += yield_val
 
                 # Clear set of reactions
                 reactions.clear()

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -822,7 +822,30 @@ class Chain(object):
         return valid
 
     def reduce(self, initial_isotopes, level=None):
-        """Reduce the size of the chain by follwing transmutation paths
+        """Reduce the size of the chain by following transmutation paths
+
+        As an example, consider a simple chain with the following
+        isotopes and transmutation paths::
+
+            U235 (n,gamma) U236
+                 (n,fission) (Xe135, I135, Cs135)
+            I135 (beta decay) Xe135 (beta decay) Cs135
+            Xe135 (n,gamma) Xe136
+
+        Calling ``chain.reduce(["I135"])`` will produce a depletion
+        chain that contains only isotopes that would originate from
+        I135: I135, Xe135, Cs135, and Xe136. U235 and U236 will not
+        be included, but multiple isotopes can be used to start
+        the search.
+
+        The ``level`` value controls the depth of the search.
+        ``chain.reduce(["U235"], level=1)`` would return a chain
+        with all isotopes except Xe136, since it is two transmutations
+        removed from U235 in this case.
+
+        While targets will not be included in the new chain, the
+        total destruction rate and decay rate of included isotopes
+        will be preserved.
 
         Parameters
         ----------
@@ -839,6 +862,8 @@ class Chain(object):
         Returns
         -------
         Chain
+            Depletion chain containing isotopes that would appear
+            after following up to ``level`` reactions and decay paths
 
         """
         check_type("initial_isotopes", initial_isotopes, Iterable, str)

--- a/openmc/deplete/nuclide.py
+++ b/openmc/deplete/nuclide.py
@@ -406,9 +406,7 @@ class FissionYieldDistribution(Mapping):
         for g_index, energy in enumerate(energies):
             prod_map = fission_yields[energy]
             for prod_ix, product in enumerate(ordered_prod):
-                yield_val = prod_map.get(product)
-                yield_matrix[g_index, prod_ix] = (
-                    0.0 if yield_val is None else yield_val)
+                yield_matrix[g_index, prod_ix] = prod_map.get(product, 0.0)
         self.energies = tuple(energies)
         self.products = tuple(ordered_prod)
         self.yield_matrix = yield_matrix
@@ -444,7 +442,7 @@ class FissionYieldDistribution(Mapping):
         FissionYieldDistribution
         """
         all_yields = {}
-        for elem_index, yield_elem in enumerate(element.iter("fission_yields")):
+        for yield_elem in element.iter("fission_yields"):
             energy = float(yield_elem.get("energy"))
             products = yield_elem.find("products").text.split()
             yields = map(float, yield_elem.find("data").text.split())

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -10,13 +10,10 @@ densities is all done in-memory instead of through the filesystem.
 import sys
 import copy
 from collections import OrderedDict
-from itertools import chain
 import os
-import time
 import xml.etree.ElementTree as ET
 from warnings import warn
 
-import h5py
 import numpy as np
 from uncertainties import ufloat
 

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -113,12 +113,13 @@ class Operator(TransportOperator):
         ``fission_yield_mode``. Will be passed directly on to the
         helper. Passing a value of None will use the defaults for
         the associated helper.
-    reduce_chain : bool or int, optional
-        If ``True`` or an integer, create a reduced depletion chain by
-        following transmuation paths for isotopes in burnable materials.
-        A value of ``True`` implies to follow all paths to completion,
-        while a non-negative integer indicates the depth. See
-        :meth:`openmc.deplete.Chain.reduce`
+    reduce_chain : bool, optional
+        If True, use :meth:`openmc.deplete.Chain.reduce` to reduce the
+        depletion chain up to ``reduce_chain_level``. Default is False.
+    reduce_chain_level : int, optional
+        Depth of the search when reducing the depletion chain. Only used
+        if ``reduce_chain`` evaluates to true. The default value of
+        ``None`` implies no limit on the depth.
 
     Attributes
     ----------
@@ -165,7 +166,7 @@ class Operator(TransportOperator):
                  diff_burnable_mats=False, energy_mode="fission-q",
                  fission_q=None, dilute_initial=1.0e3,
                  fission_yield_mode="constant", fission_yield_opts=None,
-                 reduce_chain=False):
+                 reduce_chain=False, reduce_chain_level=None):
         if fission_yield_mode not in self._fission_helpers:
             raise KeyError(
                 "fission_yield_mode must be one of {}, not {}".format(
@@ -187,15 +188,14 @@ class Operator(TransportOperator):
         self.diff_burnable_mats = diff_burnable_mats
 
         # Reduce the chain before we create more materials
-        if reduce_chain is not False:
+        if reduce_chain:
             all_isotopes = set()
             for material in geometry.get_all_materials().values():
                 if not material.depletable:
                     continue
                 for name, _dens_percent, _dens_type in material.nuclides:
                     all_isotopes.add(name)
-            level = None if reduce_chain is True else reduce_chain
-            self.chain = self.chain.reduce(all_isotopes, level)
+            self.chain = self.chain.reduce(all_isotopes, reduce_chain_level)
 
         # Differentiate burnable materials with multiple instances
         if self.diff_burnable_mats:

--- a/tests/unit_tests/test_deplete_chain.py
+++ b/tests/unit_tests/test_deplete_chain.py
@@ -479,18 +479,18 @@ def test_reduce(gnd_simple_chain):
     assert u5_round0.n_decay_modes == ref_U5.n_decay_modes
     for newmode, refmode in zip(u5_round0.decay_modes, ref_U5.decay_modes):
         assert newmode.target is None
-        assert newmode.type == refmode.type, newmode
-        assert newmode.branching_ratio == refmode.branching_ratio, newmode
+        assert newmode.type == refmode.type
+        assert newmode.branching_ratio == refmode.branching_ratio
 
     assert u5_round0.n_reaction_paths == ref_U5.n_reaction_paths
     for newrxn, refrxn in zip(u5_round0.reactions, ref_U5.reactions):
-        assert newrxn.target is None, newrxn
-        assert newrxn.type == refrxn.type, newrxn
-        assert newrxn.Q == refrxn.Q, newrxn
-        assert newrxn.branching_ratio == refrxn.branching_ratio, newrxn
+        assert newrxn.target is None
+        assert newrxn.type == refrxn.type
+        assert newrxn.Q == refrxn.Q
+        assert newrxn.branching_ratio == refrxn.branching_ratio
 
     assert u5_round0.yield_data is not None
-    assert u5_round0.yield_data.products == ("I135", )
+    assert u5_round0.yield_data.products == ("I135",)
     assert u5_round0.yield_data.yield_matrix == (
             ref_U5_yields.yield_matrix[:, ref_U5_yields.products.index("I135")]
     )
@@ -499,15 +499,15 @@ def test_reduce(gnd_simple_chain):
     assert bareI5.n_decay_modes == ref_iodine.n_decay_modes
     for newmode, refmode in zip(bareI5.decay_modes, ref_iodine.decay_modes):
         assert newmode.target is None
-        assert newmode.type == refmode.type, newmode
-        assert newmode.branching_ratio == refmode.branching_ratio, newmode
+        assert newmode.type == refmode.type
+        assert newmode.branching_ratio == refmode.branching_ratio
 
     assert bareI5.n_reaction_paths == ref_iodine.n_reaction_paths
     for newrxn, refrxn in zip(bareI5.reactions, ref_iodine.reactions):
-        assert newrxn.target is None, newrxn
-        assert newrxn.type == refrxn.type, newrxn
-        assert newrxn.Q == refrxn.Q, newrxn
-        assert newrxn.branching_ratio == refrxn.branching_ratio, newrxn
+        assert newrxn.target is None
+        assert newrxn.type == refrxn.type
+        assert newrxn.Q == refrxn.Q
+        assert newrxn.branching_ratio == refrxn.branching_ratio
 
     follow_u5 = gnd_simple_chain.reduce(["U235"], 1)
     u5_round1 = follow_u5["U235"]

--- a/tests/unit_tests/test_deplete_nuclide.py
+++ b/tests/unit_tests/test_deplete_nuclide.py
@@ -176,6 +176,21 @@ def test_fission_yield_distribution():
     with pytest.raises(TypeError):
         orig_yields *= similar
 
+    # Test restriction of fission products
+    strict_restrict = yield_dist.restrict_products(["Xe135", "Sm149"])
+    with_extras = yield_dist.restrict_products(
+        ["Xe135", "Sm149", "H1", "U235"])
+
+    assert strict_restrict.products == ("Sm149", "Xe135", )
+    assert strict_restrict.energies == yield_dist.energies
+    assert with_extras.products == ("Sm149", "Xe135", )
+    assert with_extras.energies == yield_dist.energies
+    for ene, new_yields in strict_restrict.items():
+        for product in strict_restrict.products:
+            assert new_yields[product] == yield_dist[ene][product]
+            assert with_extras[ene][product] == yield_dist[ene][product]
+
+    assert yield_dist.restrict_products(["U235"]) is None
 
 def test_validate():
 

--- a/tests/unit_tests/test_deplete_nuclide.py
+++ b/tests/unit_tests/test_deplete_nuclide.py
@@ -181,9 +181,9 @@ def test_fission_yield_distribution():
     with_extras = yield_dist.restrict_products(
         ["Xe135", "Sm149", "H1", "U235"])
 
-    assert strict_restrict.products == ("Sm149", "Xe135", )
+    assert strict_restrict.products == ("Sm149", "Xe135")
     assert strict_restrict.energies == yield_dist.energies
-    assert with_extras.products == ("Sm149", "Xe135", )
+    assert with_extras.products == ("Sm149", "Xe135")
     assert with_extras.energies == yield_dist.energies
     for ene, new_yields in strict_restrict.items():
         for product in strict_restrict.products:


### PR DESCRIPTION
This PR introduces a new method `Chain.reduce` for reducing the size of the depletion chain. Given some initial isotopes, the transmutation paths are followed up to a user-specified depth, collecting target isotopes along the way. By default, the chain is followed until all the isotopes that could appear in a given problem, no matter how far away, are found.

A new chain is built using these isotopes by making new nuclides with modified reaction and decay paths. If a target for a given reaction or decay is not in the new subset of isotopes, the target is set to ``None``. When building the depletion matrix, the total destruction rate is still conserved, even if the target is ``None``.

The ``FissionYieldDistribution`` has a new method to aid in this reduction: ``FY.restrict_products``. Given a sorted set of potential products, it will return a new fission yield distribution containing only fission products in the intersection of ``potential_products`` and ``self.products``. A value of ``None`` is returned if there is no overlap. This approach allows fissionable isotopes to still be destroyed by fission, but not produce any products, nor have to handle the fission yield data.

Lastly, the `Operator` now accepts an argument ``reduce_chain`` that can be a boolean or non-negative integer depth. A value other than ``False`` instructs the `Operator` to collect isotopes that are present in all depletable materials, and pass these to `self.chain.reduce` given the user depth. This new chain is applied back to the `Operator` to be used in the simulation.

These new chains can also be exported and loaded back so the reduction doesn't have to occur every time. This allows users to create fuel-specific chains, should they desire.

## Motivation

The main benefit is the ENDF chain contains around 4000 isotopes. Surely not every single isotope has the possibility of being produced from, say UO2 fuel. To test this, I used the ENDF/B-VII.1 PWR chain from the data repository, and reduced using U235, U238, U234, U236, and O16. Without placing a limit on reduction, the number of nuclides in the chain was reduced by more than 50 (!)%.  

|Full Size | Reduced Size |
|-|-|
|3820 | 1615|

Just for kicks, I did a study on the size of the chain against depths up to and including 20 levels. The CASL chain is pretty optimized for UO2 **in terms of number of nuclides tracked** as it contains 223 isotopes, and this reduction produces a chain with 200 isotopes.

![Size of ENDF/B-VII.1 and CASL chains after reducing to various depths](https://user-images.githubusercontent.com/19477741/77227451-ec0f3300-6b56-11ea-9b93-0b562e93dc3d.png)

## Benefits
1. Fewer isotopic reaction rates have to be tallied
2. Depletion matrix is now smaller (about 1/5th the size for this example) which should improve the time spent solving the depletion equations
3. The size of the result file will be smaller. The isotopes that don't appear in these reduced chains should always have zero valued densities, because they won't be produced.