### PR TITLE
Support atom densities from ResultList.get_atoms

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -190,7 +190,7 @@ class TransportOperator(ABC):
 
         Returns
         -------
-        volume : list of float
+        volume : dict of str to float
             Volumes corresponding to materials in burn_list
         nuc_list : list of str
             A list of all nuclide names. Used for sorting the simulation.

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -36,7 +36,7 @@ class Results(object):
         Number of nuclides.
     rates : list of ReactionRates
         The reaction rates for each substep.
-    volume : OrderedDict of int to float
+    volume : OrderedDict of str to float
         Dictionary mapping mat id to volume.
     mat_to_ind : OrderedDict of str to int
         A dictionary mapping mat ID as string to index.

--- a/openmc/deplete/results_list.py
+++ b/openmc/deplete/results_list.py
@@ -57,7 +57,7 @@ class ResultsList(list):
             Material name to evaluate
         nuc : str
             Nuclide name to evaluate
-        nuc_units : {"atoms", "atoms/b/cm", "atoms/cm^3"}, optional
+        nuc_units : {"atoms", "atom/b-cm", "atom/cm3"}, optional
             Units for the returned concentration. Default is ``"atoms"``
         time_units : {"s", "d"}, optional
             Units for the returned time array. Default is ``"s"`` to
@@ -73,7 +73,7 @@ class ResultsList(list):
         """
         check_value("time_units", time_units, {"s", "d"})
         check_value("nuc_units", nuc_units,
-                    {"atoms", "atoms/b/cm", "atoms/cm^3"})
+                    {"atoms", "atom/b-cm", "atom/cm3"})
 
         time = np.empty_like(self, dtype=float)
         concentration = np.empty_like(self, dtype=float)
@@ -90,7 +90,7 @@ class ResultsList(list):
         if nuc_units != "atoms":
             # Divide by volume to get density
             concentration /= self[0].volume[mat]
-            if nuc_units == "atoms/b/cm":
+            if nuc_units == "atom/b-cm":
                 # 1 barn = 1e-24 cm^2
                 concentration *= 1e-24
 

--- a/openmc/deplete/results_list.py
+++ b/openmc/deplete/results_list.py
@@ -2,7 +2,7 @@ import h5py
 import numpy as np
 
 from .results import Results, _VERSION_RESULTS
-from openmc.checkvalue import check_filetype_version
+from openmc.checkvalue import check_filetype_version, check_value
 
 
 __all__ = ["ResultsList"]
@@ -40,7 +40,7 @@ class ResultsList(list):
                 new.append(Results.from_hdf5(fh, i))
         return new
 
-    def get_atoms(self, mat, nuc):
+    def get_atoms(self, mat, nuc, nuc_units="atoms", time_units="s"):
         """Get number of nuclides over time from a single material
 
         .. note::
@@ -57,15 +57,24 @@ class ResultsList(list):
             Material name to evaluate
         nuc : str
             Nuclide name to evaluate
+        nuc_units : {"atoms", "atoms/b/cm", "atoms/cm^3"}, optional
+            Units for the returned concentration. Default is ``"atoms"``
+        time_units : {"s", "d"}, optional
+            Units for the returned time array. Default is ``"s"`` to
+            return the value in seconds
 
         Returns
         -------
         time : numpy.ndarray
-            Array of times in [s]
+            Array of times in units of ``time_units``
         concentration : numpy.ndarray
-            Total number of atoms for specified nuclide
+            Concentration of specified nuclide in units of ``nuc_units``
 
         """
+        check_value("time_units", time_units, {"s", "d"})
+        check_value("nuc_units", nuc_units,
+                    {"atoms", "atoms/b/cm", "atoms/cm^3"})
+
         time = np.empty_like(self, dtype=float)
         concentration = np.empty_like(self, dtype=float)
 
@@ -73,6 +82,17 @@ class ResultsList(list):
         for i, result in enumerate(self):
             time[i] = result.time[0]
             concentration[i] = result[0, mat, nuc]
+
+        # Unit conversions
+        if time_units == "d":
+            time /= (60 * 60 * 24)
+
+        if nuc_units != "atoms":
+            # Divide by volume to get density
+            concentration /= self[0].volume[mat]
+            if nuc_units == "atoms/b/cm":
+                # 1 barn = 1e-24 cm^2
+                concentration *= 1e-24
 
         return time, concentration
 

--- a/openmc/deplete/results_list.py
+++ b/openmc/deplete/results_list.py
@@ -59,9 +59,9 @@ class ResultsList(list):
             Nuclide name to evaluate
         nuc_units : {"atoms", "atom/b-cm", "atom/cm3"}, optional
             Units for the returned concentration. Default is ``"atoms"``
-        time_units : {"s", "d"}, optional
+        time_units : {"s", "min", "h", "d"}, optional
             Units for the returned time array. Default is ``"s"`` to
-            return the value in seconds
+            return the value in seconds.
 
         Returns
         -------
@@ -71,7 +71,7 @@ class ResultsList(list):
             Concentration of specified nuclide in units of ``nuc_units``
 
         """
-        check_value("time_units", time_units, {"s", "d"})
+        check_value("time_units", time_units, {"s", "d", "min", "h"})
         check_value("nuc_units", nuc_units,
                     {"atoms", "atom/b-cm", "atom/cm3"})
 
@@ -86,6 +86,10 @@ class ResultsList(list):
         # Unit conversions
         if time_units == "d":
             time /= (60 * 60 * 24)
+        elif time_units == "h":
+            time /= (60 * 60)
+        elif time_units == "min":
+            time /= 60
 
         if nuc_units != "atoms":
             # Divide by volume to get density

--- a/tests/unit_tests/test_deplete_resultslist.py
+++ b/tests/unit_tests/test_deplete_resultslist.py
@@ -19,11 +19,23 @@ def test_get_atoms(res):
     """Tests evaluating single nuclide concentration."""
     t, n = res.get_atoms("1", "Xe135")
 
-    t_ref = [0.0, 1296000.0, 2592000.0, 3888000.0]
-    n_ref = [6.67473282e+08, 3.76986925e+14, 3.68587383e+14, 3.91338675e+14]
+    t_ref = np.array([0.0, 1296000.0, 2592000.0, 3888000.0])
+    n_ref = np.array(
+        [6.67473282e+08, 3.76986925e+14, 3.68587383e+14, 3.91338675e+14])
 
     np.testing.assert_allclose(t, t_ref)
     np.testing.assert_allclose(n, n_ref)
+
+    # Check alternate units
+    volume = res[0].volume["1"]
+
+    t_days, n_cm3 = res.get_atoms("1", "Xe135", nuc_units="atoms/cm^3", time_units="d")
+
+    assert t_days == pytest.approx(t_ref / (60 * 60 * 24))
+    assert n_cm3 == pytest.approx(n_ref / volume)
+
+    _t, n_bcm = res.get_atoms("1", "Xe135", nuc_units="atoms/b/cm")
+    assert n_bcm == pytest.approx(n_cm3 * 1e-24)
 
 
 def test_get_reaction_rate(res):

--- a/tests/unit_tests/test_deplete_resultslist.py
+++ b/tests/unit_tests/test_deplete_resultslist.py
@@ -29,12 +29,12 @@ def test_get_atoms(res):
     # Check alternate units
     volume = res[0].volume["1"]
 
-    t_days, n_cm3 = res.get_atoms("1", "Xe135", nuc_units="atoms/cm^3", time_units="d")
+    t_days, n_cm3 = res.get_atoms("1", "Xe135", nuc_units="atom/cm3", time_units="d")
 
     assert t_days == pytest.approx(t_ref / (60 * 60 * 24))
     assert n_cm3 == pytest.approx(n_ref / volume)
 
-    _t, n_bcm = res.get_atoms("1", "Xe135", nuc_units="atoms/b/cm")
+    _t, n_bcm = res.get_atoms("1", "Xe135", nuc_units="atom/b-cm")
     assert n_bcm == pytest.approx(n_cm3 * 1e-24)
 
 

--- a/tests/unit_tests/test_deplete_resultslist.py
+++ b/tests/unit_tests/test_deplete_resultslist.py
@@ -34,8 +34,12 @@ def test_get_atoms(res):
     assert t_days == pytest.approx(t_ref / (60 * 60 * 24))
     assert n_cm3 == pytest.approx(n_ref / volume)
 
-    _t, n_bcm = res.get_atoms("1", "Xe135", nuc_units="atom/b-cm")
+    t_min, n_bcm = res.get_atoms("1", "Xe135", nuc_units="atom/b-cm", time_units="min")
     assert n_bcm == pytest.approx(n_cm3 * 1e-24)
+    assert t_min == pytest.approx(t_ref / 60)
+
+    t_hour, _n = res.get_atoms("1", "Xe135", time_units="h")
+    assert t_hour == pytest.approx(t_ref / (60 * 60))
 
 
 def test_get_reaction_rate(res):


### PR DESCRIPTION
There was a [post in the google group](https://groups.google.com/forum/#!topic/openmc-users/VbQoaWRHVAI) on obtaining atom densities from the result file. After some looking, we do store all the necessary information to do it internally.

Two new optional arguments to ResultsList.get_atoms are introduced that control the units on the return values. Time can be returned in second or in days if time_units is "s" or "d", respectively. Concentrations can be returned in "atoms/cm^3" or "atoms/b/cm" if nuc_units is one of those values. The default is to return time in seconds and number of atoms,
retaining back compatibility.

I also found some out of date docstrings that have been fixed.