### PR TITLE
adding elements to a material from formula

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -599,8 +599,6 @@ class Material(IDManagerMixin):
             Formula to add, e.g., 'C2O', 'C6H12O6', or (NH4)2SO4.
             Note this is case sensitive, elements must start with an uppercase
             character. Any numbers will be converted to integers (rounded down).
-        percent : float
-            Atom or weight percent
         percent_type : {'ao', 'wo'}, optional
             'ao' for atom percent and 'wo' for weight percent. Defaults to atom
             percent.

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -607,9 +607,9 @@ class Material(IDManagerMixin):
             If enrichment_target is not supplied then it is enrichment for U235
             in weight percent. For example, input 4.95 for 4.95 weight percent
             enriched U. Default is None (natural composition).
-        enrichment_target: str, optional
+        enrichment_target : str, optional
             Single nuclide name to enrich from a natural composition (e.g., 'O16')
-        enrichment_type: {'ao', 'wo'}, optional
+        enrichment_type : {'ao', 'wo'}, optional
             'ao' for enrichment as atom percent and 'wo' for weight percent.
             Default is: 'ao' for two-isotope enrichment; 'wo' for U enrichment
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -598,7 +598,7 @@ class Material(IDManagerMixin):
         formula : str
             Formula to add, e.g., 'C2O', 'C6H12O6', or (NH4)2SO4.
             Note this is case sensitive, elements must start with an uppercase
-            character. Any numbers will be converted to integers (rounded down).
+            character. Multiplier numbers must be integers.
         percent_type : {'ao', 'wo'}, optional
             'ao' for atom percent and 'wo' for weight percent. Defaults to atom
             percent.
@@ -621,6 +621,11 @@ class Material(IDManagerMixin):
 
         """
         cv.check_type('formula', formula, str)
+
+        if '.' in formula:
+            msg = 'Non-integer multiplier values are not accepted. The ' \
+                  'input formula {} contains a "." character.'.format(formula)
+            raise ValueError(msg)
 
         # Tokenizes the formula and check validity of tokens
         tokens = re.findall(r"([A-Z][a-z]*)(\d*)|(\()|(\))(\d*)", formula)

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -603,11 +603,10 @@ class Material(IDManagerMixin):
             'ao' for atom percent and 'wo' for weight percent. Defaults to atom
             percent.
         enrichment : float, optional
-            Enrichment of an enrichment_taget nuclide in percent (ao or wo).
-            If enrichment_taget is not supplied then it is enrichment for U235
+            Enrichment of an enrichment_target nuclide in percent (ao or wo).
+            If enrichment_target is not supplied then it is enrichment for U235
             in weight percent. For example, input 4.95 for 4.95 weight percent
-            enriched U.
-            Default is None (natural composition).
+            enriched U. Default is None (natural composition).
         enrichment_target: str, optional
             Single nuclide name to enrich from a natural composition (e.g., 'O16')
         enrichment_type: {'ao', 'wo'}, optional
@@ -628,7 +627,7 @@ class Material(IDManagerMixin):
         for row in tokens:
             for token in row:
                 if token.isalpha():
-                    if token not in list(openmc.data.ATOMIC_NUMBER.keys())[1:]:
+                    if token == "n" or token not in openmc.data.ATOMIC_NUMBER:
                         msg = 'Formula entry {} not an element symbol.' \
                               .format(token)
                         raise ValueError(msg)
@@ -663,8 +662,8 @@ class Material(IDManagerMixin):
                 mat_stack.append(Counter())
             if closing_bracket:
                 stack_top = mat_stack.pop()
-                for i in stack_top:
-                    mat_stack[-1][i] += int(multi2 or 1) * stack_top[i]
+                for symbol, value in stack_top.items():
+                    mat_stack[-1][symbol] += int(multi2 or 1) * value
 
         # Normalizing percentages
         percents = mat_stack[0].values()
@@ -678,8 +677,6 @@ class Material(IDManagerMixin):
                                  enrichment_target, enrichment_type)
             else:
                 self.add_element(element, percent, percent_type)
-
-
     def add_s_alpha_beta(self, name, fraction=1.0):
         r"""Add an :math:`S(\alpha,\beta)` table to the material
 

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -58,7 +58,8 @@ def test_elements_by_name():
     assert a._nuclides == b._nuclides
     assert b._nuclides == c._nuclides
 
-def test_adding_elements_by_formula():
+
+def test_add_elements_by_formula():
     """Test adding elements from a formula"""
     # testing the correct nuclides and elements are added to a material
     m = openmc.Material()
@@ -354,4 +355,3 @@ def test_mix_materials():
     assert m3.density == pytest.approx(dens3)
     assert m4.density == pytest.approx(dens4)
     assert m5.density == pytest.approx(dens5)
-

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -58,6 +58,61 @@ def test_elements_by_name():
     assert a._nuclides == b._nuclides
     assert b._nuclides == c._nuclides
 
+def test_adding_elements_by_formula():
+    """Test adding elements from a formula"""
+    # testing the correct nuclides are added to the Material
+    m = openmc.Material()
+    m.add_elements_from_formula('Li4SiO4')
+    ref_dens = {'Li6': 0.033728, 'Li7': 0.410715,
+                'Si28': 0.102477, 'Si29': 0.0052035, 'Si30': 0.0034301,
+                'O16': 0.443386, 'O17': 0.000168}
+    nuc_dens = m.get_nuclide_atom_densities()
+    for nuclide in ref_dens:
+        assert nuc_dens[nuclide][1] == pytest.approx(ref_dens[nuclide], 1e-2)
+
+    # testing the correct nuclides are added to the Material when enriched
+    m = openmc.Material()
+    m.add_elements_from_formula('Li4SiO4',
+                                enrichment=60.,
+                                enrichment_target='Li6')
+    ref_dens = {'Li6': 0.2666, 'Li7': 0.1777,
+                'Si28': 0.102477, 'Si29': 0.0052035, 'Si30': 0.0034301,
+                'O16': 0.443386, 'O17': 0.000168}
+    nuc_dens = m.get_nuclide_atom_densities()
+    for nuclide in ref_dens:
+        assert nuc_dens[nuclide][1] == pytest.approx(ref_dens[nuclide], 1e-2)
+
+    # testing the use of brackets
+    m = openmc.Material()
+    m.add_elements_from_formula('Mg2(NO3)2')
+    ref_dens = {'Mg24': 0.157902, 'Mg25': 0.02004, 'Mg26': 0.022058,
+                'N14': 0.199267, 'N15': 0.000732,
+                'O16': 0.599772, 'O17': 0.000227}
+    nuc_dens = m.get_nuclide_atom_densities()
+    for nuclide in ref_dens:
+        assert nuc_dens[nuclide][1] == pytest.approx(ref_dens[nuclide], 1e-2)
+
+    # testing lowercase elements results in a value error
+    m = openmc.Material()
+    with pytest.raises(ValueError):
+        m.add_elements_from_formula('li4SiO4')
+
+    # testing lowercase elements results in a value error
+    m = openmc.Material()
+    with pytest.raises(ValueError):
+        m.add_elements_from_formula('Li4Sio4')
+
+    # testing incorrect character in formula results in a value error
+    m = openmc.Material()
+    with pytest.raises(ValueError):
+        m.add_elements_from_formula('Li4$SiO4')
+
+    # testing unequal opening and closing brackets
+    m = openmc.Material()
+    with pytest.raises(ValueError):
+        m.add_elements_from_formula('Fe(H2O)4(OH)2)')
+
+
 def test_density():
     m = openmc.Material()
     for unit in ['g/cm3', 'g/cc', 'kg/m3', 'atom/b-cm', 'atom/cm3']:

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -92,6 +92,11 @@ def test_adding_elements_by_formula():
     for nuclide in ref_dens:
         assert nuc_dens[nuclide][1] == pytest.approx(ref_dens[nuclide], 1e-2)
 
+    # testing non integer multiplier results in a value error
+    m = openmc.Material()
+    with pytest.raises(ValueError):
+        m.add_elements_from_formula('Li4.2SiO4')
+
     # testing lowercase elements results in a value error
     m = openmc.Material()
     with pytest.raises(ValueError):

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -1,9 +1,12 @@
+from collections import defaultdict
+
+import pytest
+
 import openmc
+import openmc.examples
 import openmc.model
 import openmc.stats
-import openmc.examples
-import pytest
-from collections import defaultdict
+
 
 def test_attributes(uo2):
     assert uo2.name == 'UO2'

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -3,7 +3,7 @@ import openmc.model
 import openmc.stats
 import openmc.examples
 import pytest
-
+from collections import defaultdict
 
 def test_attributes(uo2):
     assert uo2.name == 'UO2'
@@ -60,9 +60,23 @@ def test_elements_by_name():
 
 def test_adding_elements_by_formula():
     """Test adding elements from a formula"""
-    # testing the correct nuclides are added to the Material
+    # testing the correct nuclides and elements are added to a material
     m = openmc.Material()
     m.add_elements_from_formula('Li4SiO4')
+    # checking the ratio of elements is 4:1:4 for Li:Si:O
+    elem = defaultdict(float)
+    for nuclide, adens in m.get_nuclide_atom_densities().values():
+        if nuclide.startswith("Li"):
+            elem["Li"] += adens
+        if nuclide.startswith("Si"):
+            elem["Si"] += adens
+        if nuclide.startswith("O"):
+            elem["O"] += adens
+    total_number_of_atoms = 9
+    assert elem["Li"] == pytest.approx(4./total_number_of_atoms)
+    assert elem["Si"] == pytest.approx(1./total_number_of_atoms)
+    assert elem["O"] == pytest.approx(4/total_number_of_atoms)
+    # testing the correct nuclides are added to the Material
     ref_dens = {'Li6': 0.033728, 'Li7': 0.410715,
                 'Si28': 0.102477, 'Si29': 0.0052035, 'Si30': 0.0034301,
                 'O16': 0.443386, 'O17': 0.000168}
@@ -85,6 +99,22 @@ def test_adding_elements_by_formula():
     # testing the use of brackets
     m = openmc.Material()
     m.add_elements_from_formula('Mg2(NO3)2')
+
+    # checking the ratio of elements is 2:2:6 for Mg:N:O
+    elem = defaultdict(float)
+    for nuclide, adens in m.get_nuclide_atom_densities().values():
+        if nuclide.startswith("Mg"):
+            elem["Mg"] += adens
+        if nuclide.startswith("N"):
+            elem["N"] += adens
+        if nuclide.startswith("O"):
+            elem["O"] += adens
+    total_number_of_atoms = 10
+    assert elem["Mg"] == pytest.approx(2./total_number_of_atoms)
+    assert elem["N"] == pytest.approx(2./total_number_of_atoms)
+    assert elem["O"] == pytest.approx(6/total_number_of_atoms)
+
+    # testing the correct nuclides are added when brackets are used
     ref_dens = {'Mg24': 0.157902, 'Mg25': 0.02004, 'Mg26': 0.022058,
                 'N14': 0.199267, 'N15': 0.000732,
                 'O16': 0.599772, 'O17': 0.000227}


### PR DESCRIPTION
This PR adds the ability to quickly make a material from a formula. This is useful when making a few fusion relevant materials like lithium ceramics (e.g. Li4SiO4), molten salts (e.g. Li2BeF4), neutron multipliers (e.g. Be12Ti), superconductors (e.g. Nb3Ti). The formula can also accept brackets like Al2(SO4)3 

The most simple use case is below
```
m = openmc.Material()
m.add_elements_from_formula('Li4SiO4')
```

Arguments like enrichment are also allowed
```
m = openmc.Material()
m.add_elements_from_formula('Li4SiO4', enrichment=60, enrichment_target='Li6')
```

There is some checking of the formula in the method to ensure that the material is created correctly. However some of the checking is also carried out by add_element which is called. 

Unit tests have also been added to check the various value errors and check the results are as expected for a few representative cases.