### PR TITLE
Fix for deprecated HDF5 interface in version 1.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,10 @@ if(HDF5_IS_PARALLEL)
   message(STATUS "Using parallel HDF5")
 endif()
 
+if(${HDF5_VERSION} VERSION_LESS "1.12.0") 
+  list(APPEND cxxflags -DHDF5_LEGACY)
+endif()
+
 #===============================================================================
 # Set compile/link flags based on which compiler is being used
 #===============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,11 @@ if(HDF5_IS_PARALLEL)
   message(STATUS "Using parallel HDF5")
 endif()
 
-if(${HDF5_VERSION} VERSION_LESS "1.12.0") 
-  list(APPEND cxxflags -DHDF5_LEGACY)
+# Version 1.12 of HDF5 deprecates the H5Oget_info_by_idx() interface.
+# Thus, we give these flags to allow usage of the old interface in newer
+# versions of HDF5.
+if(${HDF5_VERSION} VERSION_GREATER_EQUAL "1.12.0") 
+  list(APPEND cxxflags -DH5Oget_info_by_idx_vers=1 -DH5O_info_t_vers=1)
 endif()
 
 #===============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ endif()
 # Version 1.12 of HDF5 deprecates the H5Oget_info_by_idx() interface.
 # Thus, we give these flags to allow usage of the old interface in newer
 # versions of HDF5.
-if(${HDF5_VERSION} VERSION_GREATER_EQUAL "1.12.0") 
+if(NOT (${HDF5_VERSION} VERSION_LESS 1.12.0))
   list(APPEND cxxflags -DH5Oget_info_by_idx_vers=1 -DH5O_info_t_vers=1)
 endif()
 

--- a/src/hdf5_interface.cpp
+++ b/src/hdf5_interface.cpp
@@ -251,13 +251,8 @@ int get_num_datasets(hid_t group_id)
   int ndatasets = 0;
   for (hsize_t i = 0; i < info.nlinks; ++i) {
     // Determine type of object (and skip non-group)
-    #ifdef HDF5_LEGACY
     H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
                        H5P_DEFAULT);
-    #else
-    H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
-                       H5O_INFO_BASIC, H5P_DEFAULT);
-    #endif
     if (oinfo.type == H5O_TYPE_DATASET) ndatasets += 1;
   }
 
@@ -276,13 +271,8 @@ int get_num_groups(hid_t group_id)
   int ngroups = 0;
   for (hsize_t i = 0; i < info.nlinks; ++i) {
     // Determine type of object (and skip non-group)
-    #ifdef HDF5_LEGACY
     H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
                        H5P_DEFAULT);
-    #else
-    H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
-                       H5O_INFO_BASIC, H5P_DEFAULT);
-    #endif
     if (oinfo.type == H5O_TYPE_GROUP) ngroups += 1;
   }
 
@@ -303,13 +293,8 @@ get_datasets(hid_t group_id, char* name[])
   size_t size;
   for (hsize_t i = 0; i < info.nlinks; ++i) {
     // Determine type of object (and skip non-group)
-    #ifdef HDF5_LEGACY
     H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
                        H5P_DEFAULT);
-    #else
-    H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
-                       H5O_INFO_BASIC, H5P_DEFAULT);
-    #endif
     if (oinfo.type != H5O_TYPE_DATASET) continue;
 
     // Get size of name
@@ -337,13 +322,8 @@ get_groups(hid_t group_id, char* name[])
   size_t size;
   for (hsize_t i = 0; i < info.nlinks; ++i) {
     // Determine type of object (and skip non-group)
-    #ifdef HDF5_LEGACY
     H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
                        H5P_DEFAULT);
-    #else
-    H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
-                       H5O_INFO_BASIC, H5P_DEFAULT);
-    #endif
     if (oinfo.type != H5O_TYPE_GROUP) continue;
 
     // Get size of name
@@ -370,13 +350,8 @@ member_names(hid_t group_id, H5O_type_t type)
   std::vector<std::string> names;
   for (hsize_t i = 0; i < info.nlinks; ++i) {
     // Determine type of object (and skip non-group)
-    #ifdef HDF5_LEGACY
     H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
                        H5P_DEFAULT);
-    #else
-    H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
-                       H5O_INFO_BASIC, H5P_DEFAULT);
-    #endif
     if (oinfo.type != type) continue;
 
     // Get size of name

--- a/src/hdf5_interface.cpp
+++ b/src/hdf5_interface.cpp
@@ -251,8 +251,13 @@ int get_num_datasets(hid_t group_id)
   int ndatasets = 0;
   for (hsize_t i = 0; i < info.nlinks; ++i) {
     // Determine type of object (and skip non-group)
+    #ifdef HDF5_LEGACY
     H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
                        H5P_DEFAULT);
+    #else
+    H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
+                       H5O_INFO_BASIC, H5P_DEFAULT);
+    #endif
     if (oinfo.type == H5O_TYPE_DATASET) ndatasets += 1;
   }
 
@@ -271,8 +276,13 @@ int get_num_groups(hid_t group_id)
   int ngroups = 0;
   for (hsize_t i = 0; i < info.nlinks; ++i) {
     // Determine type of object (and skip non-group)
+    #ifdef HDF5_LEGACY
     H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
                        H5P_DEFAULT);
+    #else
+    H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
+                       H5O_INFO_BASIC, H5P_DEFAULT);
+    #endif
     if (oinfo.type == H5O_TYPE_GROUP) ngroups += 1;
   }
 
@@ -293,8 +303,13 @@ get_datasets(hid_t group_id, char* name[])
   size_t size;
   for (hsize_t i = 0; i < info.nlinks; ++i) {
     // Determine type of object (and skip non-group)
+    #ifdef HDF5_LEGACY
     H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
                        H5P_DEFAULT);
+    #else
+    H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
+                       H5O_INFO_BASIC, H5P_DEFAULT);
+    #endif
     if (oinfo.type != H5O_TYPE_DATASET) continue;
 
     // Get size of name
@@ -322,8 +337,13 @@ get_groups(hid_t group_id, char* name[])
   size_t size;
   for (hsize_t i = 0; i < info.nlinks; ++i) {
     // Determine type of object (and skip non-group)
+    #ifdef HDF5_LEGACY
     H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
                        H5P_DEFAULT);
+    #else
+    H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
+                       H5O_INFO_BASIC, H5P_DEFAULT);
+    #endif
     if (oinfo.type != H5O_TYPE_GROUP) continue;
 
     // Get size of name
@@ -350,8 +370,13 @@ member_names(hid_t group_id, H5O_type_t type)
   std::vector<std::string> names;
   for (hsize_t i = 0; i < info.nlinks; ++i) {
     // Determine type of object (and skip non-group)
+    #ifdef HDF5_LEGACY
     H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
                        H5P_DEFAULT);
+    #else
+    H5Oget_info_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, i, &oinfo,
+                       H5O_INFO_BASIC, H5P_DEFAULT);
+    #endif
     if (oinfo.type != type) continue;
 
     // Get size of name


### PR DESCRIPTION
In the recently released version 1.12 of HDF5, the interface for H5Oget_info_by_idx() was changed to add an additional argument, as discussed [here](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO_BY_IDX).

This PR adds in support for the new interface required by HDF5 1.12, while maintaining support for the legacy interface as well. This is accomplished by adding some logic into CMakeLists.txt to test the version of HDF5 that is found, and if needed to define the HDF5 compatibility macros:

- H5Lget_info_by_idx_vers=1
- H5L_info_t_vers=1

as discussed [here](https://portal.hdfgroup.org/display/HDF5/API+Compatibility+Macros). These macros tell HDF5 to use the deprecated interface. This change should allow support both newer and older versions of HDF5.

An alternative option to accomplish this goal would be to have Cmake test the HDF5 version, but pass a definition to OpenMC and call the appropriate interface in OpenMC based on that variable. This would also work fine, but has a few downsides:

1. Complicates the source code that calls H5Oget_info_by_idx(), as both interfaces have to be used, protected by #defines, which is a little messy.

2. More importantly, it may create a maintenance challenge if a future developer uses H5Oget_info_by_idx() somewhere else in the code without realizing the need to test the definition and provide both interfaces. As travis uses the older version of HDF5 currently by default, use of the old interface would probably pass CI testing, but would silently break compatibility with 1.12 or newer. 

Thus, I think use of the compatibility macros in this PR should allow for cleaner code and better maintainability.

There may also be other options for accomplishing these goals, so I'm happy to try those out if someone has a better idea, but this solution seems simple enough.