### PR TITLE
added get_elements function and tests

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -722,6 +722,18 @@ class Material(IDManagerMixin):
     def make_isotropic_in_lab(self):
         self.isotropic = [x[0] for x in self._nuclides]
 
+    def get_elements(self):
+        """Returns all elements in the material
+
+        Returns
+        -------
+        elements : list of str
+            List of element names
+
+        """
+
+        return list({re.split(r'(\d+)', i)[0] for i in self.get_nuclides()})
+
     def get_nuclides(self):
         """Returns all nuclides in the material
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -732,7 +732,7 @@ class Material(IDManagerMixin):
 
         """
 
-        return list({re.split(r'(\d+)', i)[0] for i in self.get_nuclides()})
+        return sorted({re.split(r'(\d+)', i)[0] for i in self.get_nuclides()})
 
     def get_nuclides(self):
         """Returns all nuclides in the material

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -223,6 +223,39 @@ def test_isotropic():
     assert m2.isotropic == ['H1']
 
 
+def test_get_elements():
+    # test that zero elements exist on creation
+    m = openmc.Material()
+    assert len(m.get_elements()) == 0
+
+    # test addition of a single element
+    m.add_element('Li', 0.2)
+    assert len(m.get_elements()) == 1
+    assert 'Li' in m.get_elements()
+
+    # test that adding the same element
+    m.add_element('Li', 0.3)
+    assert len(m.get_elements()) == 1
+    assert 'Li' in m.get_elements()
+
+    # test adding another element
+    m.add_element('Si', 0.3)
+    assert len(m.get_elements()) == 2
+    assert 'Si' in m.get_elements()
+
+    # test adding a third element
+    m.add_element('O', 0.4)
+    assert len(m.get_elements()) == 3
+
+    # test removal of nuclides
+    m.remove_nuclide('O16')
+    m.remove_nuclide('O17')
+    assert 'O' not in m.get_elements()
+    assert 'Si' in m.get_elements()
+    assert 'Li' in m.get_elements()
+    assert len(m.get_elements()) == 2
+
+
 def test_get_nuclide_densities(uo2):
     nucs = uo2.get_nuclide_densities()
     for nuc, density, density_type in nucs.values():

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -230,30 +230,26 @@ def test_get_elements():
 
     # test addition of a single element
     m.add_element('Li', 0.2)
-    assert len(m.get_elements()) == 1
     assert 'Li' in m.get_elements()
 
     # test that adding the same element
     m.add_element('Li', 0.3)
-    assert len(m.get_elements()) == 1
+    assert m.get_elements() == ["Li"]
     assert 'Li' in m.get_elements()
 
     # test adding another element
     m.add_element('Si', 0.3)
-    assert len(m.get_elements()) == 2
-    assert 'Si' in m.get_elements()
+    assert m.get_elements() == ["Li", "Si"]
 
     # test adding a third element
     m.add_element('O', 0.4)
     assert len(m.get_elements()) == 3
-
+    assert m.get_elements() == ["Li", "O", "Si"]
     # test removal of nuclides
     m.remove_nuclide('O16')
     m.remove_nuclide('O17')
     assert 'O' not in m.get_elements()
-    assert 'Si' in m.get_elements()
-    assert 'Li' in m.get_elements()
-    assert len(m.get_elements()) == 2
+    assert m.get_elements() == ["Si", "Li"]
 
 
 def test_get_nuclide_densities(uo2):

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -230,7 +230,7 @@ def test_get_elements():
 
     # test addition of a single element
     m.add_element('Li', 0.2)
-    assert 'Li' in m.get_elements()
+    assert m.get_elements() == ["Li"]
 
     # test that adding the same element
     m.add_element('Li', 0.3)
@@ -246,7 +246,7 @@ def test_get_elements():
     # test removal of nuclides
     m.remove_nuclide('O16')
     m.remove_nuclide('O17')
-    assert m.get_elements() == ["Si", "Li"]
+    assert m.get_elements() == ["Li", "Si"]
 
 
 def test_get_nuclide_densities(uo2):

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -235,7 +235,6 @@ def test_get_elements():
     # test that adding the same element
     m.add_element('Li', 0.3)
     assert m.get_elements() == ["Li"]
-    assert 'Li' in m.get_elements()
 
     # test adding another element
     m.add_element('Si', 0.3)
@@ -243,12 +242,10 @@ def test_get_elements():
 
     # test adding a third element
     m.add_element('O', 0.4)
-    assert len(m.get_elements()) == 3
     assert m.get_elements() == ["Li", "O", "Si"]
     # test removal of nuclides
     m.remove_nuclide('O16')
     m.remove_nuclide('O17')
-    assert 'O' not in m.get_elements()
     assert m.get_elements() == ["Si", "Li"]
 
 


### PR DESCRIPTION
Similar to the get_nuclides() function, this PR adds a get_elements() function to return all elements in a material.

Function uses a regular expression to split the strings returned by the get_nuclides() function and return the element symbol only. Element symbols of the material are put into a set to ensure each symbol is only return once, even if an element appears multiple times in a material.

Unit tests have also been added to demonstrate functionality.

Example use case:

```
test_material = openmc.Material()
test_material.add_element('Li', 4)
test_material.add_element('Si', 1)
test_material.add_element('O', 4)

test_material.get_elements()
```

Return:

`['Si', 'O', 'Li']`

If you are open to this idea, functions similar to the get_nuclide_densities() and get_nuclide_atom_densities() functions could also be added for elements. I.e. functions to return all elements in the material and their densities/atom densities could be added.

What do you think?
@Shimwell 
@drewejohnson 