### PR TITLE
Make sure output_dir gets set for ThermalScattering.from_njoy

### DIFF
--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -766,8 +766,8 @@ class ThermalScattering(EqualityMixin):
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             # Run NJOY to create an ACE library
-            kwargs.setdefault('ace', os.path.join(tmpdir, 'ace'))
-            kwargs.setdefault('xsdir', os.path.join(tmpdir, 'xsdir'))
+            kwargs.setdefault('output_dir', tmpdir)
+            kwargs.setdefault('ace', os.path.join(kwargs['output_dir'], 'ace'))
             kwargs['evaluation'] = evaluation
             kwargs['evaluation_thermal'] = evaluation_thermal
             make_ace_thermal(filename, filename_thermal, temperatures, **kwargs)


### PR DESCRIPTION
This is a small bugfix for something I overlooked in #1522. After that PR, calls to `IncidentNeutron.from_njoy` use the `output_dir` argument of `make_ace`, but the same is not true for `ThermalScattering.from_njoy` and `make_ace_thermal`. This PR fixes that so that if two calls to `ThermalScattering.from_njoy` are run in parallel, they don't overwrite each other's files.

@amandalund requesting your review since you looked at #1522 and should be familiar with this.