### PR TITLE
Reset timer in depletion for transport performance

### DIFF
--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -86,6 +86,7 @@ extern "C" {
   int openmc_id_map(const void* slice, int32_t* data_out);
   int openmc_property_map(const void* slice, double* data_out);
   int openmc_reset();
+  int openmc_reset_timers();
   int openmc_run();
   void openmc_set_seed(int64_t new_seed);
   int openmc_simulation_finalize();

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -87,6 +87,7 @@ extern "C" {
   int openmc_property_map(const void* slice, double* data_out);
   int openmc_reset();
   int openmc_reset_timers();
+  int openmc_restart_timers();
   int openmc_run();
   void openmc_set_seed(int64_t new_seed);
   int openmc_simulation_finalize();

--- a/include/openmc/timer.h
+++ b/include/openmc/timer.h
@@ -69,6 +69,8 @@ private:
 
 void reset_timers();
 
+void restart_timers();
+
 } // namespace openmc
 
 #endif // OPENMC_TIMER_H

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -274,6 +274,7 @@ class Operator(TransportOperator):
         # Run OpenMC
         openmc.lib.reset()
         openmc.lib.run()
+        openmc.lib.reset_timers()
 
         # Extract results
         op_result = self._unpack_tallies_and_normalize(power)

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -63,6 +63,8 @@ _dll.openmc_run.restype = c_int
 _dll.openmc_run.errcheck = _error_handler
 _dll.openmc_reset.restype = c_int
 _dll.openmc_reset.errcheck = _error_handler
+_dll.openmc_reset_timers.restype = c_int
+_dll.openmc_reset_timers.errcheck = _error_handler
 _run_linsolver_argtypes = [_array_1d_dble, _array_1d_dble, _array_1d_dble,
                            c_double]
 _dll.openmc_run_linsolver.argtypes = _run_linsolver_argtypes
@@ -305,6 +307,7 @@ def plot_geometry():
 def reset():
     """Reset tallies and timers."""
     _dll.openmc_reset()
+    _dll.openmc_reset_timers()
 
 
 def run():

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -65,6 +65,8 @@ _dll.openmc_reset.restype = c_int
 _dll.openmc_reset.errcheck = _error_handler
 _dll.openmc_reset_timers.restype = c_int
 _dll.openmc_reset_timers.errcheck = _error_handler
+_dll.openmc_restart_timers.restype = c_int
+_dll.openmc_restart_timers.errcheck = _error_handler
 _run_linsolver_argtypes = [_array_1d_dble, _array_1d_dble, _array_1d_dble,
                            c_double]
 _dll.openmc_run_linsolver.argtypes = _run_linsolver_argtypes
@@ -308,6 +310,7 @@ def reset():
     """Reset tallies and timers."""
     _dll.openmc_reset()
     _dll.openmc_reset_timers()
+    _dll.openmc_restart_timers()
 
 
 def run():

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -307,8 +307,12 @@ def plot_geometry():
 
 
 def reset():
-    """Reset tallies and timers."""
+    """Reset tallies but keep timers."""
     _dll.openmc_reset()
+
+
+def reset_timers():
+    """Reset timers and restart for next batch."""
     _dll.openmc_reset_timers()
     _dll.openmc_restart_timers()
 

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -307,7 +307,7 @@ def plot_geometry():
 
 
 def reset():
-    """Reset tallies but keep timers."""
+    """Reset tally results"""
     _dll.openmc_reset()
 
 

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -165,6 +165,12 @@ int openmc_reset()
   return 0;
 }
 
+int openmc_reset_timers()
+{
+  reset_timers();
+  return 0;
+}
+
 int openmc_hard_reset()
 {
   // Reset all tallies and timers

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -171,6 +171,12 @@ int openmc_reset_timers()
   return 0;
 }
 
+int openmc_restart_timers()
+{
+  restart_timers();
+  return 0;
+}
+
 int openmc_hard_reset()
 {
   // Reset all tallies and timers

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -87,4 +87,26 @@ void reset_timers()
   simulation::time_event_death.reset();
 }
 
+void restart_timers()
+{
+  simulation::time_active.restart();
+  simulation::time_bank.restart();
+  simulation::time_bank_sample.restart();
+  simulation::time_bank_sendrecv.restart();
+  simulation::time_finalize.restart();
+  simulation::time_inactive.restart();
+  simulation::time_initialize.restart();
+  simulation::time_read_xs.restart();
+  simulation::time_sample_source.restart();
+  simulation::time_tallies.restart();
+  simulation::time_total.restart();
+  simulation::time_transport.restart();
+  simulation::time_event_init.restart();
+  simulation::time_event_calculate_xs.restart();
+  simulation::time_event_advance_particle.restart();
+  simulation::time_event_surface_crossing.restart();
+  simulation::time_event_collision.restart();
+  simulation::time_event_death.restart();
+}
+
 } // namespace openmc

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -89,24 +89,7 @@ void reset_timers()
 
 void restart_timers()
 {
-  simulation::time_active.start();
-  simulation::time_bank.start();
-  simulation::time_bank_sample.start();
-  simulation::time_bank_sendrecv.start();
-  simulation::time_finalize.start();
-  simulation::time_inactive.start();
-  simulation::time_initialize.start();
-  simulation::time_read_xs.start();
-  simulation::time_sample_source.start();
-  simulation::time_tallies.start();
   simulation::time_total.start();
-  simulation::time_transport.start();
-  simulation::time_event_init.start();
-  simulation::time_event_calculate_xs.start();
-  simulation::time_event_advance_particle.start();
-  simulation::time_event_surface_crossing.start();
-  simulation::time_event_collision.start();
-  simulation::time_event_death.start();
 }
 
 } // namespace openmc

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -89,24 +89,24 @@ void reset_timers()
 
 void restart_timers()
 {
-  simulation::time_active.restart();
-  simulation::time_bank.restart();
-  simulation::time_bank_sample.restart();
-  simulation::time_bank_sendrecv.restart();
-  simulation::time_finalize.restart();
-  simulation::time_inactive.restart();
-  simulation::time_initialize.restart();
-  simulation::time_read_xs.restart();
-  simulation::time_sample_source.restart();
-  simulation::time_tallies.restart();
-  simulation::time_total.restart();
-  simulation::time_transport.restart();
-  simulation::time_event_init.restart();
-  simulation::time_event_calculate_xs.restart();
-  simulation::time_event_advance_particle.restart();
-  simulation::time_event_surface_crossing.restart();
-  simulation::time_event_collision.restart();
-  simulation::time_event_death.restart();
+  simulation::time_active.start();
+  simulation::time_bank.start();
+  simulation::time_bank_sample.start();
+  simulation::time_bank_sendrecv.start();
+  simulation::time_finalize.start();
+  simulation::time_inactive.start();
+  simulation::time_initialize.start();
+  simulation::time_read_xs.start();
+  simulation::time_sample_source.start();
+  simulation::time_tallies.start();
+  simulation::time_total.start();
+  simulation::time_transport.start();
+  simulation::time_event_init.start();
+  simulation::time_event_calculate_xs.start();
+  simulation::time_event_advance_particle.start();
+  simulation::time_event_surface_crossing.start();
+  simulation::time_event_collision.start();
+  simulation::time_event_death.start();
 }
 
 } // namespace openmc


### PR DESCRIPTION
This PR is to indeed reset the timer to display the transport speed when running depletion. This bug was found by a user who tried to tally the "calculation rate". This bug will lead to the dramatical decrease of the nominal "value" of calculation rate in the depletion.  I fix it by adding a reset_timers function in C API and apply it in `depletion.operator`.    