### PR TITLE
Fix to openmc.lib.init arguments

### DIFF
--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -186,15 +186,15 @@ def init(args=None, intracomm=None):
     if args is not None:
         args = ['openmc'] + list(args)
         argc = len(args)
-
-        # Create the argv array. Note that it is actually expected to be of
-        # length argc + 1 with the final item being a null pointer.
-        argv = (POINTER(c_char) * (argc + 1))()
-        for i, arg in enumerate(args):
-            argv[i] = create_string_buffer(arg.encode())
     else:
-        argc = 0
-        argv = None
+        args = ['openmc']
+        argc = 1
+
+    # Create the argv array. Note that it is actually expected to be of
+    # length argc + 1 with the final item being a null pointer.
+    argv = (POINTER(c_char) * (argc + 1))()
+    for i, arg in enumerate(args):
+        argv[i] = create_string_buffer(arg.encode())
 
     if intracomm is not None:
         # If an mpi4py communicator was passed, convert it to void* to be passed

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -185,11 +185,10 @@ def init(args=None, intracomm=None):
     """
     if args is not None:
         args = ['openmc'] + list(args)
-        argc = len(args)
     else:
         args = ['openmc']
-        argc = 1
 
+    argc = len(args)
     # Create the argv array. Note that it is actually expected to be of
     # length argc + 1 with the final item being a null pointer.
     argv = (POINTER(c_char) * (argc + 1))()


### PR DESCRIPTION
This takes care of an inconsistency in the arguments passed to the CAPI `openmc_initialize` call from the Python API. When a set of arguments is passed to this call, `"openmc"` is prepended to the list to get the same set of arguments one would see if calling openmc from the command line. Currently, when no arguments are passed to this function, the argument list is set to `None` and the number of arguments to zero.

This PR updates those arguments so that `"openmc"` is always the first argument passed to `openmc_initialize` for consistency.