### PR TITLE
Fix for typo in compiler macros in the OpenMP interface class

### DIFF
--- a/include/openmc/openmp_interface.h
+++ b/include/openmc/openmp_interface.h
@@ -18,14 +18,14 @@ class OpenMPMutex
 public:
   OpenMPMutex()
   {
-    #ifdef _OPEMP
+    #ifdef _OPENMP
       omp_init_lock(&mutex_);
     #endif
   }
 
   ~OpenMPMutex()
   {
-    #ifdef _OPEMP
+    #ifdef _OPENMP
       omp_destroy_lock(&mutex_);
     #endif
   }
@@ -41,7 +41,7 @@ public:
   //! This function blocks execution until the lock succeeds.
   void lock()
   {
-    #ifdef _OPEMP
+    #ifdef _OPENMP
       omp_set_lock(&mutex_);
     #endif
   }
@@ -52,7 +52,7 @@ public:
   //! the lock is unavailable.
   bool try_lock() noexcept
   {
-    #ifdef _OPEMP
+    #ifdef _OPENMP
       return omp_test_lock(&mutex_);
     #else
       return true;
@@ -62,13 +62,13 @@ public:
   //! Unlock the mutex.
   void unlock() noexcept
   {
-    #ifdef _OPEMP
+    #ifdef _OPENMP
       omp_unset_lock(&mutex_);
     #endif
   }
 
 private:
-  #ifdef _OPEMP
+  #ifdef _OPENMP
     omp_lock_t mutex_;
   #endif
 };


### PR DESCRIPTION
The neighbor list class introduced in #1140 requires use of a few OpenMP functions (notably, a mutex and associated locking/unlocking functions). To access these OpenMP functions, a wrapper class was implemented in openmp_interface.h. To allow for compilation without requiring OpenMP, compiler macro definitions are used to protect the calls to OpenMP functions while allowing the OpenMP interface class to still be compiled and called as normal. This is all good, but the problem is that the macro was spelled incorrectly throughout the openmp_interface.h file as `_OPEMP` instead of `_OPENMP`, meaning that all the functions in the interface have no effect, even if using openmp, e.g.:

```C++
  //! Lock the mutex.
  //
  //! This function blocks execution until the lock succeeds.
  void lock()
  {
    #ifdef _OPEMP
      omp_set_lock(&mutex_);
    #endif
  }
```

This results in undefined behavior with the neighbor lists when running with multiple threads, and makes usage of the openmp interface class for other purposes problematic.

This PR simply changes the macro definition to `_OPENMP` which fixes the issue. It's a super easy fix but took me forever to track down, as typo's like this are just about impossible to spot! I'm not sure how the interface list was able to work without the mutex -- I'm guessing it may be related to #1445 where the instructions required for the particular use case in the neighbor list class happen to be atomic on Intel CPUs. I only found this issue as I was using the openmp interface class for some other operations in readying the code for GPU usage and was getting undefined behavior.

With this fix, it might be worth another look at the pros/cons of the neighbor list implementation, as it appears performance results with the existing implementation would not have been including the costs to set/unset the mutex. It's very well possible these costs may be small or completely trivial, but I think it could be worth testing out. Or, if there is a fix already in the pipeline for #1445, perhaps new performance results will be generated when documenting that anyway.