### PR TITLE
Don't write reaction targets that are None to XML

### DIFF
--- a/openmc/deplete/nuclide.py
+++ b/openmc/deplete/nuclide.py
@@ -243,7 +243,7 @@ class Nuclide:
             rx_elem = ET.SubElement(elem, 'reaction')
             rx_elem.set('type', rx)
             rx_elem.set('Q', str(Q))
-            if rx != 'fission' or daughter is not None:
+            if daughter is not None:
                 rx_elem.set('target', daughter)
             if br != 1.0:
                 rx_elem.set('branching_ratio', str(br))


### PR DESCRIPTION
This is related to a bug pointed out in the user's group, where
writing a ReactionTuple with a None target errors.
https://groups.google.com/forum/#!topic/openmc-users/jB_-zEKhF-k
The condition appeared when the reaction was a non-fission
(n, gamma), but the daughter isotope did not exist in the Chain,
represented by None.
```python
>>> import openmc.deplete
>>> c = openmc.deplete.Chain.from_xml("chain_casl_pwr.xml")
>>> c.export_to_xml("new.xml")
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/drew/openmc/openmc/deplete/chain.py", line 433, in export_to_xml
    root_elem.append(nuclide.to_xml_element())
  File "/home/drew/openmc/openmc/deplete/nuclide.py", line 247, in to_xml_element
    rx_elem.set('target', daughter)
  File "src/lxml/etree.pyx", line 816, in lxml.etree._Element.set
  File "src/lxml/apihelpers.pxi", line 593, in lxml.etree._setAttributeValue
  File "src/lxml/apihelpers.pxi", line 1538, in lxml.etree._utf8
TypeError: Argument must be bytes or unicode, got 'NoneType'
```

This issue is resolved by skipping the target only if daughter
is None, regardless of reaction. The Nuclide.from_xml can handle
a missing target just as it handles a target of "Nothing"
[case-insensitive]