### PR TITLE
Address review from PullRequest Inc. (part 5)

### DIFF
--- a/include/openmc/eigenvalue.h
+++ b/include/openmc/eigenvalue.h
@@ -69,7 +69,7 @@ void shannon_entropy();
 void ufs_count_sites();
 
 //! Get UFS weight corresponding to particle's location
-extern "C" double ufs_get_weight(const Particle* p);
+double ufs_get_weight(const Particle& p);
 
 //! Write data related to k-eigenvalue to statepoint
 //! \param[in] group HDF5 group

--- a/include/openmc/geometry.h
+++ b/include/openmc/geometry.h
@@ -36,7 +36,7 @@ inline bool coincident(double d1, double d2) {
 //! Check for overlapping cells at a particle's position.
 //==============================================================================
 
-bool check_cell_overlap(Particle* p, bool error=true);
+bool check_cell_overlap(Particle& p, bool error=true);
 
 //==============================================================================
 //! Locate a particle in the geometry tree and set its geometry data fields.
@@ -50,19 +50,19 @@ bool check_cell_overlap(Particle* p, bool error=true);
 //!   valid geometry coordinate stack.
 //==============================================================================
 
-bool find_cell(Particle* p, bool use_neighbor_lists);
+bool find_cell(Particle& p, bool use_neighbor_lists);
 
 //==============================================================================
 //! Move a particle into a new lattice tile.
 //==============================================================================
 
-void cross_lattice(Particle* p, const BoundaryInfo& boundary);
+void cross_lattice(Particle& p, const BoundaryInfo& boundary);
 
 //==============================================================================
 //! Find the next boundary a particle will intersect.
 //==============================================================================
 
-BoundaryInfo distance_to_boundary(Particle* p);
+BoundaryInfo distance_to_boundary(Particle& p);
 
 } // namespace openmc
 

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -53,7 +53,7 @@ public:
   //! \param[in] p Particle to check
   //! \param[out] bins Bins that were crossed
   //! \param[out] lengths Fraction of tracklength in each bin
-  virtual void bins_crossed(const Particle* p, std::vector<int>& bins,
+  virtual void bins_crossed(const Particle& p, std::vector<int>& bins,
                             std::vector<double>& lengths) const = 0;
 
   //! Determine which surface bins were crossed by a particle
@@ -61,7 +61,7 @@ public:
   //! \param[in] p Particle to check
   //! \param[out] bins Surface bins that were crossed
   virtual void
-  surface_bins_crossed(const Particle* p, std::vector<int>& bins) const = 0;
+  surface_bins_crossed(const Particle& p, std::vector<int>& bins) const = 0;
 
   //! Get bin at a given position in space
   //
@@ -145,10 +145,10 @@ public:
 
   // Overriden methods
 
-  void bins_crossed(const Particle* p, std::vector<int>& bins,
+  void bins_crossed(const Particle& p, std::vector<int>& bins,
                     std::vector<double>& lengths) const override;
 
-  void surface_bins_crossed(const Particle* p, std::vector<int>& bins)
+  void surface_bins_crossed(const Particle& p, std::vector<int>& bins)
   const override;
 
   int get_bin(Position r) const override;
@@ -207,10 +207,10 @@ public:
 
   // Overriden methods
 
-  void bins_crossed(const Particle* p, std::vector<int>& bins,
+  void bins_crossed(const Particle& p, std::vector<int>& bins,
                     std::vector<double>& lengths) const override;
 
-  void surface_bins_crossed(const Particle* p, std::vector<int>& bins)
+  void surface_bins_crossed(const Particle& p, std::vector<int>& bins)
   const override;
 
   int get_bin(Position r) const override;
@@ -256,7 +256,7 @@ public:
   UnstructuredMesh(pugi::xml_node);
   ~UnstructuredMesh() = default;
 
-  void bins_crossed(const Particle* p,
+  void bins_crossed(const Particle& p,
                     std::vector<int>& bins,
                     std::vector<double>& lengths) const override;
 
@@ -267,7 +267,7 @@ public:
   //
   //! \param[in] p Particle to check
   //! \param[out] bins Surface bins that were crossed
-  void surface_bins_crossed(const Particle* p, std::vector<int>& bins) const;
+  void surface_bins_crossed(const Particle& p, std::vector<int>& bins) const;
 
   //! Write mesh data to an HDF5 group.
   //

--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -113,7 +113,7 @@ private:
 //! Checks for the right version of nuclear data within HDF5 files
 void check_data_version(hid_t file_id);
 
-bool multipole_in_range(const Nuclide* nuc, double E);
+bool multipole_in_range(const Nuclide& nuc, double E);
 
 //==============================================================================
 // Global variables

--- a/include/openmc/output.h
+++ b/include/openmc/output.h
@@ -26,7 +26,7 @@ void header(const char* msg, int level);
 std::string time_stamp();
 
 //! Display the attributes of a particle.
-extern "C" void print_particle(Particle* p);
+void print_particle(Particle& p);
 
 //! Display plot information.
 void print_plot();

--- a/include/openmc/output.h
+++ b/include/openmc/output.h
@@ -46,10 +46,6 @@ void print_columns();
 //! Display information about a generation of neutrons
 void print_generation();
 
-//! \brief Display last batch's tallied value of the neutron multiplication
-//! factor as well as the average value if we're in active batches
-void print_batch_keff();
-
 //! Display time elapsed for various stages of a run
 void print_runtime();
 

--- a/include/openmc/particle.h
+++ b/include/openmc/particle.h
@@ -157,7 +157,7 @@ public:
   };
 
   //! Saved ("banked") state of a particle
-  //! NOTE: This structure's MPI type is built in initialize_mpi() of 
+  //! NOTE: This structure's MPI type is built in initialize_mpi() of
   //! initialize.cpp. Any changes made to the struct here must also be
   //! made when building the Bank MPI type in initialize_mpi().
   //! NOTE: This structure is also used on the python side, and is defined
@@ -173,7 +173,7 @@ public:
     int64_t parent_id;
     int64_t progeny_id;
   };
-  
+
   //! Saved ("banked") state of a particle, for nu-fission tallying
   struct NuBank {
     double E;  //!< particle energy
@@ -311,7 +311,7 @@ public:
   int cell_born_ {-1};      //!< index for cell particle was born in
   int material_ {-1};       //!< index for current material
   int material_last_ {-1};  //!< index for last material
-  
+
   // Boundary information
   BoundaryInfo boundary_;
 
@@ -328,7 +328,7 @@ public:
   // Current PRNG state
   uint64_t seeds_[N_STREAMS]; // current seeds
   int      stream_;           // current RNG stream
-  
+
   // Secondary particle bank
   std::vector<Particle::Bank> secondary_bank_;
 
@@ -362,6 +362,14 @@ public:
 
   int64_t n_progeny_ {0}; // Number of progeny produced by this particle
 };
+
+//============================================================================
+//! Functions
+//============================================================================
+
+std::string particle_type_to_str(Particle::Type type);
+
+Particle::Type str_to_particle_type(std::string str);
 
 } // namespace openmc
 

--- a/include/openmc/physics.h
+++ b/include/openmc/physics.h
@@ -16,55 +16,55 @@ namespace openmc {
 //==============================================================================
 
 //! Sample a nuclide and reaction and then calls the appropriate routine
-void collision(Particle* p);
+void collision(Particle& p);
 
 //! Samples an incident neutron reaction
-void sample_neutron_reaction(Particle* p);
+void sample_neutron_reaction(Particle& p);
 
 //! Samples an element based on the macroscopic cross sections for each nuclide
 //! within a material and then samples a reaction for that element and calls the
 //! appropriate routine to process the physics.
-void sample_photon_reaction(Particle* p);
+void sample_photon_reaction(Particle& p);
 
 //! Terminates the particle and either deposits all energy locally
 //! (electron_treatment = ElectronTreatment::LED) or creates secondary bremsstrahlung
 //! photons from electron deflections with charged particles (electron_treatment
 //! = ElectronTreatment::TTB).
-void sample_electron_reaction(Particle* p);
+void sample_electron_reaction(Particle& p);
 
 //! Terminates the particle and either deposits all energy locally
 //! (electron_treatment = ElectronTreatment::LED) or creates secondary bremsstrahlung
 //! photons from electron deflections with charged particles (electron_treatment
 //! = ElectronTreatment::TTB). Two annihilation photons of energy MASS_ELECTRON_EV (0.511
 //! MeV) are created and travel in opposite directions.
-void sample_positron_reaction(Particle* p);
+void sample_positron_reaction(Particle& p);
 
 //! Sample a nuclide based on their total cross sections and densities within
 //! the current material
 //!
 //! \param[in] p Particle
 //! \return Index in the data::nuclides vector
-int sample_nuclide(Particle* p);
+int sample_nuclide(Particle& p);
 
 //! Determine the average total, prompt, and delayed neutrons produced from
 //! fission and creates appropriate bank sites.
-void create_fission_sites(Particle* p, int i_nuclide, const Reaction* rx);
+void create_fission_sites(Particle& p, int i_nuclide, const Reaction* rx);
 
-int sample_element(Particle* p);
+int sample_element(Particle& p);
 
-Reaction* sample_fission(int i_nuclide, Particle* p);
+Reaction* sample_fission(int i_nuclide, Particle& p);
 
-void sample_photon_product(int i_nuclide, Particle* p, int* i_rx, int* i_product);
+void sample_photon_product(int i_nuclide, Particle& p, int* i_rx, int* i_product);
 
-void absorption(Particle* p, int i_nuclide);
+void absorption(Particle& p, int i_nuclide);
 
-void scatter(Particle* p, int i_nuclide);
+void scatter(Particle& p, int i_nuclide);
 
 //! Treats the elastic scattering of a neutron with a target.
 void elastic_scatter(int i_nuclide, const Reaction& rx, double kT,
-  Particle* p);
+  Particle& p);
 
-void sab_scatter(int i_nuclide, int i_sab, Particle* p);
+void sab_scatter(int i_nuclide, int i_sab, Particle& p);
 
 //! samples the target velocity. The constant cross section free gas model is
 //! the default method. Methods for correctly accounting for the energy
@@ -85,9 +85,9 @@ void sample_fission_neutron(int i_nuclide, const Reaction* rx, double E_in,
 
 //! handles all reactions with a single secondary neutron (other than fission),
 //! i.e. level scattering, (n,np), (n,na), etc.
-void inelastic_scatter(const Nuclide* nuc, const Reaction* rx, Particle* p);
+void inelastic_scatter(const Nuclide* nuc, const Reaction* rx, Particle& p);
 
-void sample_secondary_photons(Particle* p, int i_nuclide);
+void sample_secondary_photons(Particle& p, int i_nuclide);
 
 } // namespace openmc
 

--- a/include/openmc/physics.h
+++ b/include/openmc/physics.h
@@ -52,7 +52,7 @@ void create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx);
 
 int sample_element(Particle& p);
 
-Reaction* sample_fission(int i_nuclide, Particle& p);
+Reaction& sample_fission(int i_nuclide, Particle& p);
 
 void sample_photon_product(int i_nuclide, Particle& p, int* i_rx, int* i_product);
 

--- a/include/openmc/physics.h
+++ b/include/openmc/physics.h
@@ -48,7 +48,7 @@ int sample_nuclide(Particle& p);
 
 //! Determine the average total, prompt, and delayed neutrons produced from
 //! fission and creates appropriate bank sites.
-void create_fission_sites(Particle& p, int i_nuclide, const Reaction* rx);
+void create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx);
 
 int sample_element(Particle& p);
 
@@ -70,7 +70,7 @@ void sab_scatter(int i_nuclide, int i_sab, Particle& p);
 //! the default method. Methods for correctly accounting for the energy
 //! dependence of cross sections in treating resonance elastic scattering such
 //! as the DBRC and a new, accelerated scheme are also implemented here.
-Direction sample_target_velocity(const Nuclide* nuc, double E, Direction u,
+Direction sample_target_velocity(const Nuclide& nuc, double E, Direction u,
   Direction v_neut, double xs_eff, double kT, uint64_t* seed);
 
 //! samples a target velocity based on the free gas scattering formulation, used
@@ -80,12 +80,12 @@ Direction sample_target_velocity(const Nuclide* nuc, double E, Direction u,
 Direction sample_cxs_target_velocity(double awr, double E, Direction u, double kT,
   uint64_t* seed);
 
-void sample_fission_neutron(int i_nuclide, const Reaction* rx, double E_in,
+void sample_fission_neutron(int i_nuclide, const Reaction& rx, double E_in,
   Particle::Bank* site, uint64_t* seed);
 
 //! handles all reactions with a single secondary neutron (other than fission),
 //! i.e. level scattering, (n,np), (n,na), etc.
-void inelastic_scatter(const Nuclide* nuc, const Reaction* rx, Particle& p);
+void inelastic_scatter(const Nuclide& nuc, const Reaction& rx, Particle& p);
 
 void sample_secondary_photons(Particle& p, int i_nuclide);
 

--- a/include/openmc/physics_common.h
+++ b/include/openmc/physics_common.h
@@ -9,8 +9,7 @@
 namespace openmc {
 
 //! \brief Performs the russian roulette operation for a particle
-extern "C" void
-russian_roulette(Particle* p);
+void russian_roulette(Particle& p);
 
 } // namespace openmc
 #endif // OPENMC_PHYSICS_COMMON_H

--- a/include/openmc/physics_mg.h
+++ b/include/openmc/physics_mg.h
@@ -15,7 +15,7 @@ namespace openmc {
 //! \brief samples particle behavior after a collision event.
 //! \param p Particle to operate on
 void
-collision_mg(Particle* p);
+collision_mg(Particle& p);
 
 //! \brief samples a reaction type.
 //!
@@ -23,23 +23,23 @@ collision_mg(Particle* p);
 //! fission and disappearance are treated implicitly.
 //! \param p Particle to operate on
 void
-sample_reaction(Particle* p);
+sample_reaction(Particle& p);
 
 //! \brief Samples the scattering event
 //! \param p Particle to operate on
 void
-scatter(Particle* p);
+scatter(Particle& p);
 
 //! \brief Determines the average total, prompt and delayed neutrons produced
 //! from fission and creates the appropriate bank sites.
 //! \param p Particle to operate on
 void
-create_fission_sites(Particle* p);
+create_fission_sites(Particle& p);
 
 //! \brief Handles an absorption event
 //! \param p Particle to operate on
 void
-absorption(Particle* p);
+absorption(Particle& p);
 
 } // namespace openmc
 #endif // OPENMC_PHYSICS_MG_H

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -182,13 +182,13 @@ T PlotBase::get_map() const {
         p.r()[in_i] = xyz[in_i] + in_pixel * x;
         p.n_coord_ = 1;
         // local variables
-        bool found_cell = find_cell(&p, 0);
+        bool found_cell = find_cell(p, 0);
         j = p.n_coord_ - 1;
         if (level >=0) {j = level + 1;}
         if (found_cell) {
           data.set_value(y, x, p, j);
         }
-        if (color_overlaps_ && check_cell_overlap(&p, false)) {
+        if (color_overlaps_ && check_cell_overlap(p, false)) {
           data.set_overlap(y, x);
         }
       } // inner for

--- a/include/openmc/simulation.h
+++ b/include/openmc/simulation.h
@@ -64,10 +64,10 @@ void initialize_batch();
 void initialize_generation();
 
 //! Full initialization of a particle history
-void initialize_history(Particle* p, int64_t index_source);
+void initialize_history(Particle& p, int64_t index_source);
 
 //! Helper function for initialize_history() that is called independently elsewhere
-void initialize_history_partial(Particle* p);
+void initialize_history_partial(Particle& p);
 
 //! Finalize a batch
 //!

--- a/include/openmc/tallies/derivative.h
+++ b/include/openmc/tallies/derivative.h
@@ -53,13 +53,13 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
 //! further tallies are scored.
 //
 //! \param p The particle being tracked
-void score_collision_derivative(Particle* p);
+void score_collision_derivative(Particle& p);
 
 //! Adjust diff tally flux derivatives for a particle tracking event.
 //
 //! \param p The particle being tracked
 //! \param distance The distance in [cm] traveled by the particle
-void score_track_derivative(Particle* p, double distance);
+void score_track_derivative(Particle& p, double distance);
 
 } // namespace openmc
 

--- a/include/openmc/tallies/derivative.h
+++ b/include/openmc/tallies/derivative.h
@@ -42,7 +42,7 @@ void read_tally_derivatives(pugi::xml_node node);
 //! Scale the given score by its logarithmic derivative
 
 void
-apply_derivative_to_score(const Particle* p, int i_tally, int i_nuclide,
+apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
   double atom_density, int score_bin, double& score);
 
 //! Adjust diff tally flux derivatives for a particle scattering event.

--- a/include/openmc/tallies/filter.h
+++ b/include/openmc/tallies/filter.h
@@ -55,10 +55,12 @@ public:
 
   //! Matches a tally event to a set of filter bins and weights.
   //!
+  //! \param[in] p Particle being tracked
+  //! \param[in] estimator Tally estimator being used
   //! \param[out] match will contain the matching bins and corresponding
   //!   weights; note that there may be zero matching bins
   virtual void
-  get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match) const = 0;
+  get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match) const = 0;
 
   //! Writes data describing this filter to an HDF5 statepoint group.
   virtual void

--- a/include/openmc/tallies/filter_azimuthal.h
+++ b/include/openmc/tallies/filter_azimuthal.h
@@ -29,7 +29,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_cell.h
+++ b/include/openmc/tallies/filter_cell.h
@@ -30,7 +30,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_cell_instance.h
+++ b/include/openmc/tallies/filter_cell_instance.h
@@ -33,7 +33,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_cellborn.h
+++ b/include/openmc/tallies/filter_cellborn.h
@@ -19,7 +19,7 @@ public:
 
   std::string type() const override {return "cellborn";}
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   std::string text_label(int bin) const override;

--- a/include/openmc/tallies/filter_cellfrom.h
+++ b/include/openmc/tallies/filter_cellfrom.h
@@ -19,7 +19,7 @@ public:
 
   std::string type() const override {return "cellfrom";}
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   std::string text_label(int bin) const override;

--- a/include/openmc/tallies/filter_delayedgroup.h
+++ b/include/openmc/tallies/filter_delayedgroup.h
@@ -31,7 +31,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_distribcell.h
+++ b/include/openmc/tallies/filter_distribcell.h
@@ -26,7 +26,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_energy.h
+++ b/include/openmc/tallies/filter_energy.h
@@ -28,7 +28,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;
@@ -68,7 +68,7 @@ public:
 
   std::string type() const override {return "energyout";}
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   std::string text_label(int bin) const override;

--- a/include/openmc/tallies/filter_energyfunc.h
+++ b/include/openmc/tallies/filter_energyfunc.h
@@ -33,7 +33,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_legendre.h
+++ b/include/openmc/tallies/filter_legendre.h
@@ -26,7 +26,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_material.h
+++ b/include/openmc/tallies/filter_material.h
@@ -30,7 +30,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_mesh.h
+++ b/include/openmc/tallies/filter_mesh.h
@@ -28,7 +28,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_meshsurface.h
+++ b/include/openmc/tallies/filter_meshsurface.h
@@ -13,7 +13,7 @@ public:
 
   std::string type() const override {return "meshsurface";}
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   std::string text_label(int bin) const override;

--- a/include/openmc/tallies/filter_mu.h
+++ b/include/openmc/tallies/filter_mu.h
@@ -29,7 +29,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_particle.h
+++ b/include/openmc/tallies/filter_particle.h
@@ -27,7 +27,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_polar.h
+++ b/include/openmc/tallies/filter_polar.h
@@ -29,7 +29,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_sph_harm.h
+++ b/include/openmc/tallies/filter_sph_harm.h
@@ -32,7 +32,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_sptl_legendre.h
+++ b/include/openmc/tallies/filter_sptl_legendre.h
@@ -30,7 +30,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_surface.h
+++ b/include/openmc/tallies/filter_surface.h
@@ -30,7 +30,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_universe.h
+++ b/include/openmc/tallies/filter_universe.h
@@ -30,7 +30,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;

--- a/include/openmc/tallies/filter_zernike.h
+++ b/include/openmc/tallies/filter_zernike.h
@@ -26,7 +26,7 @@ public:
 
   void from_xml(pugi::xml_node node) override;
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   void to_statepoint(hid_t filter_group) const override;
@@ -76,7 +76,7 @@ public:
 
   std::string type() const override {return "zernikeradial";}
 
-  void get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+  void get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
   const override;
 
   std::string text_label(int bin) const override;

--- a/include/openmc/tallies/tally_scoring.h
+++ b/include/openmc/tallies/tally_scoring.h
@@ -23,7 +23,7 @@ class FilterBinIter
 public:
 
   //! Construct an iterator over bins that match a given particle's state.
-  FilterBinIter(const Tally& tally, Particle* p);
+  FilterBinIter(const Tally& tally, Particle& p);
 
   //! Construct an iterator over all filter bin combinations.
   //
@@ -41,7 +41,7 @@ public:
 
   int index_ {1};
   double weight_ {1.};
-  
+
   std::vector<FilterMatch>& filter_matches_;
 
 private:
@@ -63,21 +63,21 @@ private:
 //! since collisions do not occur in voids.
 //
 //! \param p The particle being tracked
-void score_collision_tally(Particle* p);
+void score_collision_tally(Particle& p);
 
 //! Score tallies based on a simple count of events (for continuous energy).
 //
 //! Analog tallies are triggered at every collision, not every event.
 //
 //! \param p The particle being tracked
-void score_analog_tally_ce(Particle* p);
+void score_analog_tally_ce(Particle& p);
 
 //! Score tallies based on a simple count of events (for multigroup).
 //
 //! Analog tallies are triggered at every collision, not every event.
 //
 //! \param p The particle being tracked
-void score_analog_tally_mg(Particle* p);
+void score_analog_tally_mg(Particle& p);
 
 //! Score tallies using a tracklength estimate of the flux.
 //
@@ -87,13 +87,13 @@ void score_analog_tally_mg(Particle* p);
 //
 //! \param p The particle being tracked
 //! \param distance The distance in [cm] traveled by the particle
-void score_tracklength_tally(Particle* p, double distance);
+void score_tracklength_tally(Particle& p, double distance);
 
 //! Score surface or mesh-surface tallies for particle currents.
 //
 //! \param p The particle being tracked
 //! \param tallies A vector of tallies to score to
-void score_surface_tally(Particle* p, const std::vector<int>& tallies);
+void score_surface_tally(Particle& p, const std::vector<int>& tallies);
 
 } // namespace openmc
 

--- a/src/bank.cpp
+++ b/src/bank.cpp
@@ -72,7 +72,7 @@ void sort_fission_bank()
 
   // TODO: C++17 introduces the exclusive_scan() function which could be
   // used to replace everything above this point in this function.
-  
+
   // We need a scratch vector to make permutation of the fission bank into
   // sorted order easy. Under normal usage conditions, the fission bank is
   // over provisioned, so we can use that as scratch space.
@@ -106,6 +106,11 @@ void sort_fission_bank()
 
 extern "C" int openmc_source_bank(void** ptr, int64_t* n)
 {
+  if (!ptr || !n) {
+    set_errmsg("Received null pointer.");
+    return OPENMC_E_INVALID_ARGUMENT;
+  }
+
   if (simulation::source_bank.size() == 0) {
     set_errmsg("Source bank has not been allocated.");
     return OPENMC_E_ALLOCATE;
@@ -118,6 +123,11 @@ extern "C" int openmc_source_bank(void** ptr, int64_t* n)
 
 extern "C" int openmc_fission_bank(void** ptr, int64_t* n)
 {
+  if (!ptr || !n) {
+    set_errmsg("Received null pointer.");
+    return OPENMC_E_INVALID_ARGUMENT;
+  }
+
   if (simulation::fission_bank.size() == 0) {
     set_errmsg("Fission bank has not been allocated.");
     return OPENMC_E_ALLOCATE;

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -767,6 +767,7 @@ DAGCell::DAGCell() : Cell{} {};
 std::pair<double, int32_t>
 DAGCell::distance(Position r, Direction u, int32_t on_surface, Particle* p) const
 {
+  Expects(p);
   // if we've changed direction or we're not on a surface,
   // reset the history and update last direction
   if (u != p->last_dir_ || on_surface == 0) {

--- a/src/cmfd_solver.cpp
+++ b/src/cmfd_solver.cpp
@@ -74,8 +74,9 @@ void set_indexmap(const int* coremap)
   for (int z = 0; z < cmfd::nz; z++) {
     for (int y = 0; y < cmfd::ny; y++) {
       for (int x = 0; x < cmfd::nx; x++) {
-        if (coremap[(z*cmfd::ny*cmfd::nx) + (y*cmfd::nx) + x] != CMFD_NOACCEL) {
-          int counter = coremap[(z*cmfd::ny*cmfd::nx) + (y*cmfd::nx) + x];
+        int idx = (z*cmfd::ny*cmfd::nx) + (y*cmfd::nx) + x;
+        if (coremap[idx] != CMFD_NOACCEL) {
+          int counter = coremap[idx];
           cmfd::indexmap(counter, 0) = x;
           cmfd::indexmap(counter, 1) = y;
           cmfd::indexmap(counter, 2) = z;
@@ -173,7 +174,7 @@ int cmfd_linsolver_2g(const double* A_data, const double* b, double* x,
     for (int irb = 0; irb < 2; irb++) {
 
       // Loop around matrix rows
-      #pragma omp parallel for reduction (+:err) if(cmfd::use_all_threads) 
+      #pragma omp parallel for reduction (+:err) if(cmfd::use_all_threads)
       for (int irow = 0; irow < cmfd::dim; irow+=2) {
         int g, i, j, k;
         matrix_to_indices(irow, g, i, j, k);
@@ -311,6 +312,9 @@ void openmc_initialize_linsolver(const int* indptr, int len_indptr,
                                  double spectral, const int* cmfd_indices,
                                  const int* map, bool use_all_threads)
 {
+  // Make sure vectors are empty
+  free_memory_cmfd();
+
   // Store elements of indptr
   for (int i = 0; i < len_indptr; i++)
     cmfd::indptr.push_back(indptr[i]);

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -142,7 +142,7 @@ void read_cross_sections_xml()
               "materials.xml or in the OPENMC_MG_CROSS_SECTIONS environment "
               "variable. OpenMC needs such a file to identify where to "
               "find MG cross section libraries. Please consult the user's "
-              "guide at http://openmc.readthedocs.io for information on "
+              "guide at https://docs.openmc.org for information on "
               "how to set up MG cross section libraries.");
       }
       settings::path_cross_sections = envvar;

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -282,6 +282,7 @@ read_ce_cross_sections(const std::vector<std::vector<double>>& nuc_temps,
     }
   }
 
+  // Perform final tasks -- reading S(a,b) tables, normalizing densities
   for (auto& mat : model::materials) {
     for (const auto& table : mat->thermal_tables_) {
       // Get name of S(a,b) table
@@ -408,6 +409,8 @@ void read_ce_cross_sections_xml()
   } else {
     // If no directory is listed in cross_sections.xml, by default select the
     // directory in which the cross_sections.xml file resides
+
+    // TODO: Use std::filesystem functionality when C++17 is adopted
     auto pos = filename.rfind("/");
     if (pos == std::string::npos) {
       // no '/' found, probably a Windows directory

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -55,8 +55,9 @@ void Discrete::normalize()
 {
   // Renormalize density function so that it sums to unity
   double norm = std::accumulate(p_.begin(), p_.end(), 0.0);
-  for (auto& p_i : p_)
+  for (auto& p_i : p_) {
     p_i /= norm;
+  }
 }
 
 //==============================================================================
@@ -66,9 +67,10 @@ void Discrete::normalize()
 Uniform::Uniform(pugi::xml_node node)
 {
   auto params = get_node_array<double>(node, "parameters");
-  if (params.size() != 2)
+  if (params.size() != 2) {
     openmc::fatal_error("Uniform distribution must have two "
                         "parameters specified.");
+  }
 
   a_ = params.at(0);
   b_ = params.at(1);
@@ -119,9 +121,10 @@ double Watt::sample(uint64_t* seed) const
 Normal::Normal(pugi::xml_node node)
 {
   auto params = get_node_array<double>(node,"parameters");
-  if (params.size() != 2)
+  if (params.size() != 2) {
     openmc::fatal_error("Normal energy distribution must have two "
                         "parameters specified.");
+  }
 
   mean_value_ = params.at(0);
   std_dev_ = params.at(1);
@@ -138,9 +141,10 @@ double Normal::sample(uint64_t* seed) const
 Muir::Muir(pugi::xml_node node)
 {
   auto params = get_node_array<double>(node,"parameters");
-  if (params.size() != 3)
+  if (params.size() != 3) {
     openmc::fatal_error("Muir energy distribution must have three "
                         "parameters specified.");
+  }
 
   e0_ = params.at(0);
   m_rat_ = params.at(1);

--- a/src/eigenvalue.cpp
+++ b/src/eigenvalue.cpp
@@ -573,12 +573,12 @@ void ufs_count_sites()
   }
 }
 
-double ufs_get_weight(const Particle* p)
+double ufs_get_weight(const Particle& p)
 {
   // Determine indices on ufs mesh for current location
-  int mesh_bin = simulation::ufs_mesh->get_bin(p->r());
+  int mesh_bin = simulation::ufs_mesh->get_bin(p.r());
   if (mesh_bin < 0) {
-    p->write_restart();
+    p.write_restart();
     fatal_error("Source site outside UFS mesh!");
   }
 

--- a/src/eigenvalue.cpp
+++ b/src/eigenvalue.cpp
@@ -134,7 +134,8 @@ void synchronize_bank()
   // ==========================================================================
   // SAMPLE N_PARTICLES FROM FISSION BANK AND PLACE IN TEMP_SITES
 
-  // Allocate temporary source bank
+  // Allocate temporary source bank -- we don't really know how many fission
+  // sites were created, so overallocate by a factor of 3
   int64_t index_temp = 0;
   std::vector<Particle::Bank> temp_sites(3*simulation::work_per_rank);
 
@@ -396,7 +397,8 @@ int openmc_get_keff(double* k_combined)
   // two estimators (vice three) should be used instead.
 
   // First we will identify if there are any matching estimators
-  int i, j, k;
+  int i, j;
+  bool use_three = false;
   if ((std::abs(kv[0] - kv[1]) / kv[0] < FP_REL_PRECISION) &&
       (std::abs(cov(0, 0) - cov(1, 1)) / cov(0, 0) < FP_REL_PRECISION)) {
     // 0 and 1 match, so only use 0 and 2 in our comparisons
@@ -416,12 +418,11 @@ int openmc_get_keff(double* k_combined)
     j = 1;
 
   } else {
-    // No two estimators match, so set i to -1 and this will be the indicator
-    // to use all three estimators.
-    i = -1;
+    // No two estimators match, so set boolean to use all three estimators.
+    use_three = true;
   }
 
-  if (i == -1) {
+  if (use_three) {
     // Use three estimators as derived in the paper by Urbatsch
 
     // Initialize variables
@@ -430,6 +431,7 @@ int openmc_get_keff(double* k_combined)
 
     for (int l = 0; l < 3; ++l) {
       // Permutations of estimates
+      int k;
       switch (l) {
       case 0:
         // i = collision, j = absorption, k = tracklength
@@ -514,11 +516,11 @@ void shannon_entropy()
     if (mpi::master) warning("Fission source site(s) outside of entropy box.");
   }
 
-  // sum values to obtain shannon entropy
   if (mpi::master) {
     // Normalize to total weight of bank sites
     p /= xt::sum(p);
 
+    // Sum values to obtain Shannon entropy
     double H = 0.0;
     for (auto p_i : p) {
       if (p_i > 0.0) {

--- a/src/endf.cpp
+++ b/src/endf.cpp
@@ -43,7 +43,7 @@ Interpolation int2interp(int i)
 
 bool is_fission(int mt)
 {
-  return mt == 18 || mt == 19 || mt == 20 || mt == 21 || mt == 38;
+  return mt == N_FISSION || mt == N_F || mt == N_NF || mt == N_2NF || mt == N_3NF;
 }
 
 bool is_disappearance(int mt)

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -62,7 +62,7 @@ void process_init_events(int64_t n_particles, int64_t source_offset)
   simulation::time_event_init.start();
   #pragma omp parallel for schedule(runtime)
   for (int64_t i = 0; i < n_particles; i++) {
-    initialize_history(&simulation::particles[i], source_offset + i + 1);
+    initialize_history(simulation::particles[i], source_offset + i + 1);
     dispatch_xs_event(i);
   }
   simulation::time_event_init.stop();
@@ -76,17 +76,17 @@ void process_calculate_xs_events(SharedArray<EventQueueItem>& queue)
   // by particle type, material type, and then energy, in order to
   // improve cache locality and reduce thread divergence on GPU. Prior
   // to C++17, std::sort is a serial only operation, which in this case
-  // makes it too slow to be practical for most test problems. 
+  // makes it too slow to be practical for most test problems.
   //
   // std::sort(std::execution::par_unseq, queue.data(), queue.data() + queue.size());
-  
+
   int64_t offset = simulation::advance_particle_queue.size();;
 
   #pragma omp parallel for schedule(runtime)
   for (int64_t i = 0; i < queue.size(); i++) {
-    Particle* p = &simulation::particles[queue[i].idx]; 
+    Particle* p = &simulation::particles[queue[i].idx];
     p->event_calculate_xs();
-    
+
     // After executing a calculate_xs event, particles will
     // always require an advance event. Therefore, we don't need to use
     // the protected enqueuing function.
@@ -136,7 +136,7 @@ void process_surface_crossing_events()
   }
 
   simulation::surface_crossing_queue.resize(0);
-  
+
   simulation::time_event_surface_crossing.stop();
 }
 

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -35,23 +35,23 @@ std::vector<int64_t> overlap_check_count;
 // Non-member functions
 //==============================================================================
 
-bool check_cell_overlap(Particle* p, bool error)
+bool check_cell_overlap(Particle& p, bool error)
 {
-  int n_coord = p->n_coord_;
+  int n_coord = p.n_coord_;
 
   // Loop through each coordinate level
   for (int j = 0; j < n_coord; j++) {
-    Universe& univ = *model::universes[p->coord_[j].universe];
+    Universe& univ = *model::universes[p.coord_[j].universe];
 
     // Loop through each cell on this level
     for (auto index_cell : univ.cells_) {
       Cell& c = *model::cells[index_cell];
-      if (c.contains(p->coord_[j].r, p->coord_[j].u, p->surface_)) {
-        if (index_cell != p->coord_[j].cell) {
+      if (c.contains(p.coord_[j].r, p.coord_[j].u, p.surface_)) {
+        if (index_cell != p.coord_[j].cell) {
           if (error) {
             fatal_error(fmt::format(
               "Overlapping cells detected: {}, {} on universe {}",
-              c.id_, model::cells[p->coord_[j].cell]->id_, univ.id_));
+              c.id_, model::cells[p.coord_[j].cell]->id_, univ.id_));
           }
           return true;
         }
@@ -67,7 +67,7 @@ bool check_cell_overlap(Particle* p, bool error)
 //==============================================================================
 
 bool
-find_cell_inner(Particle* p, const NeighborList* neighbor_list)
+find_cell_inner(Particle& p, const NeighborList* neighbor_list)
 {
   // Find which cell of this universe the particle is in.  Use the neighbor list
   // to shorten the search if one was provided.
@@ -78,41 +78,41 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
       i_cell = *it;
 
       // Make sure the search cell is in the same universe.
-      int i_universe = p->coord_[p->n_coord_-1].universe;
+      int i_universe = p.coord_[p.n_coord_-1].universe;
       if (model::cells[i_cell]->universe_ != i_universe) continue;
 
       // Check if this cell contains the particle.
-      Position r {p->r_local()};
-      Direction u {p->u_local()};
-      auto surf = p->surface_;
+      Position r {p.r_local()};
+      Direction u {p.u_local()};
+      auto surf = p.surface_;
       if (model::cells[i_cell]->contains(r, u, surf)) {
-        p->coord_[p->n_coord_-1].cell = i_cell;
+        p.coord_[p.n_coord_-1].cell = i_cell;
         found = true;
         break;
       }
     }
 
   } else {
-    int i_universe = p->coord_[p->n_coord_-1].universe;
+    int i_universe = p.coord_[p.n_coord_-1].universe;
     const auto& univ {*model::universes[i_universe]};
     const auto& cells {
       !univ.partitioner_
       ? model::universes[i_universe]->cells_
-      : univ.partitioner_->get_cells(p->r_local(), p->u_local())
+      : univ.partitioner_->get_cells(p.r_local(), p.u_local())
     };
     for (auto it = cells.cbegin(); it != cells.cend(); it++) {
       i_cell = *it;
 
       // Make sure the search cell is in the same universe.
-      int i_universe = p->coord_[p->n_coord_-1].universe;
+      int i_universe = p.coord_[p.n_coord_-1].universe;
       if (model::cells[i_cell]->universe_ != i_universe) continue;
 
       // Check if this cell contains the particle.
-      Position r {p->r_local()};
-      Direction u {p->u_local()};
-      auto surf = p->surface_;
+      Position r {p.r_local()};
+      Direction u {p.u_local()};
+      auto surf = p.surface_;
       if (model::cells[i_cell]->contains(r, u, surf)) {
-        p->coord_[p->n_coord_-1].cell = i_cell;
+        p.coord_[p.n_coord_-1].cell = i_cell;
         found = true;
         break;
       }
@@ -120,7 +120,7 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
   }
 
   // Announce the cell that the particle is entering.
-  if (found && (settings::verbosity >= 10 || p->trace_)) {
+  if (found && (settings::verbosity >= 10 || p.trace_)) {
     auto msg = fmt::format("    Entering cell {}", model::cells[i_cell]->id_);
     write_message(msg, 1);
   }
@@ -134,35 +134,35 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
       // Find the distribcell instance number.
       int offset = 0;
       if (c.distribcell_index_ >= 0) {
-        for (int i = 0; i < p->n_coord_; i++) {
-          const auto& c_i {*model::cells[p->coord_[i].cell]};
+        for (int i = 0; i < p.n_coord_; i++) {
+          const auto& c_i {*model::cells[p.coord_[i].cell]};
           if (c_i.type_ == Fill::UNIVERSE) {
             offset += c_i.offset_[c.distribcell_index_];
           } else if (c_i.type_ == Fill::LATTICE) {
-            auto& lat {*model::lattices[p->coord_[i+1].lattice]};
-            int i_xyz[3] {p->coord_[i+1].lattice_x,
-                          p->coord_[i+1].lattice_y,
-                          p->coord_[i+1].lattice_z};
+            auto& lat {*model::lattices[p.coord_[i+1].lattice]};
+            int i_xyz[3] {p.coord_[i+1].lattice_x,
+                          p.coord_[i+1].lattice_y,
+                          p.coord_[i+1].lattice_z};
             if (lat.are_valid_indices(i_xyz)) {
               offset += lat.offset(c.distribcell_index_, i_xyz);
             }
           }
         }
       }
-      p->cell_instance_ = offset;
+      p.cell_instance_ = offset;
 
       // Set the material and temperature.
-      p->material_last_ = p->material_;
+      p.material_last_ = p.material_;
       if (c.material_.size() > 1) {
-        p->material_ = c.material_[p->cell_instance_];
+        p.material_ = c.material_[p.cell_instance_];
       } else {
-        p->material_ = c.material_[0];
+        p.material_ = c.material_[0];
       }
-      p->sqrtkT_last_ = p->sqrtkT_;
+      p.sqrtkT_last_ = p.sqrtkT_;
       if (c.sqrtkT_.size() > 1) {
-        p->sqrtkT_ = c.sqrtkT_[p->cell_instance_];
+        p.sqrtkT_ = c.sqrtkT_[p.cell_instance_];
       } else {
-        p->sqrtkT_ = c.sqrtkT_[0];
+        p.sqrtkT_ = c.sqrtkT_[0];
       }
 
       return true;
@@ -172,12 +172,12 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
       //! Found a lower universe, update this coord level then search the next.
 
       // Set the lower coordinate level universe.
-      auto& coord {p->coord_[p->n_coord_]};
+      auto& coord {p.coord_[p.n_coord_]};
       coord.universe = c.fill_;
 
       // Set the position and direction.
-      coord.r = p->r_local();
-      coord.u = p->u_local();
+      coord.r = p.r_local();
+      coord.u = p.u_local();
 
       // Apply translation.
       coord.r -= c.translation_;
@@ -188,7 +188,7 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
       }
 
       // Update the coordinate level and recurse.
-      ++p->n_coord_;
+      ++p.n_coord_;
       return find_cell_inner(p, nullptr);
 
     } else if (c.type_ == Fill::LATTICE) {
@@ -198,9 +198,9 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
       Lattice& lat {*model::lattices[c.fill_]};
 
       // Set the position and direction.
-      auto& coord {p->coord_[p->n_coord_]};
-      coord.r = p->r_local();
-      coord.u = p->u_local();
+      auto& coord {p.coord_[p.n_coord_]};
+      coord.r = p.r_local();
+      coord.u = p.u_local();
 
       // Apply translation.
       coord.r -= c.translation_;
@@ -230,13 +230,13 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
           coord.universe = lat.outer_;
         } else {
           warning(fmt::format("Particle {} is outside lattice {} but the "
-            "lattice has no defined outer universe.", p->id_, lat.id_));
+            "lattice has no defined outer universe.", p.id_, lat.id_));
           return false;
         }
       }
 
       // Update the coordinate level and recurse.
-      ++p->n_coord_;
+      ++p.n_coord_;
       return find_cell_inner(p, nullptr);
     }
   }
@@ -247,25 +247,25 @@ find_cell_inner(Particle* p, const NeighborList* neighbor_list)
 //==============================================================================
 
 bool
-find_cell(Particle* p, bool use_neighbor_lists)
+find_cell(Particle& p, bool use_neighbor_lists)
 {
   // Determine universe (if not yet set, use root universe).
-  int i_universe = p->coord_[p->n_coord_-1].universe;
+  int i_universe = p.coord_[p.n_coord_-1].universe;
   if (i_universe == C_NONE) {
-    p->coord_[0].universe = model::root_universe;
-    p->n_coord_ = 1;
+    p.coord_[0].universe = model::root_universe;
+    p.n_coord_ = 1;
     i_universe = model::root_universe;
   }
 
   // Reset all the deeper coordinate levels.
-  for (int i = p->n_coord_; i < p->coord_.size(); i++) {
-    p->coord_[i].reset();
+  for (int i = p.n_coord_; i < p.coord_.size(); i++) {
+    p.coord_[i].reset();
   }
 
   if (use_neighbor_lists) {
     // Get the cell this particle was in previously.
-    auto coord_lvl = p->n_coord_ - 1;
-    auto i_cell = p->coord_[coord_lvl].cell;
+    auto coord_lvl = p.n_coord_ - 1;
+    auto i_cell = p.coord_[coord_lvl].cell;
     Cell& c {*model::cells[i_cell]};
 
     // Search for the particle in that cell's neighbor list.  Return if we
@@ -277,7 +277,7 @@ find_cell(Particle* p, bool use_neighbor_lists)
     // cells in this universe, and update the neighbor list if we find a new
     // neighboring cell.
     found = find_cell_inner(p, nullptr);
-    if (found) c.neighbors_.push_back(p->coord_[coord_lvl].cell);
+    if (found) c.neighbors_.push_back(p.coord_[coord_lvl].cell);
     return found;
 
   } else {
@@ -289,15 +289,15 @@ find_cell(Particle* p, bool use_neighbor_lists)
 //==============================================================================
 
 void
-cross_lattice(Particle* p, const BoundaryInfo& boundary)
+cross_lattice(Particle& p, const BoundaryInfo& boundary)
 {
-  auto& coord {p->coord_[p->n_coord_ - 1]};
+  auto& coord {p.coord_[p.n_coord_ - 1]};
   auto& lat {*model::lattices[coord.lattice]};
 
-  if (settings::verbosity >= 10 || p->trace_) {
+  if (settings::verbosity >= 10 || p.trace_) {
     write_message(fmt::format(
       "    Crossing lattice {}. Current position ({},{},{}). r={}",
-      lat.id_, coord.lattice_x, coord.lattice_y, coord.lattice_z, p->r()), 1);
+      lat.id_, coord.lattice_x, coord.lattice_y, coord.lattice_z, p.r()), 1);
   }
 
   // Set the lattice indices.
@@ -307,37 +307,37 @@ cross_lattice(Particle* p, const BoundaryInfo& boundary)
   std::array<int, 3> i_xyz {coord.lattice_x, coord.lattice_y, coord.lattice_z};
 
   // Set the new coordinate position.
-  const auto& upper_coord {p->coord_[p->n_coord_ - 2]};
+  const auto& upper_coord {p.coord_[p.n_coord_ - 2]};
   const auto& cell {model::cells[upper_coord.cell]};
   Position r = upper_coord.r;
   r -= cell->translation_;
   if (!cell->rotation_.empty()) {
     r = r.rotate(cell->rotation_);
   }
-  p->r_local() = lat.get_local_position(r, i_xyz);
+  p.r_local() = lat.get_local_position(r, i_xyz);
 
   if (!lat.are_valid_indices(i_xyz)) {
     // The particle is outside the lattice.  Search for it from the base coords.
-    p->n_coord_ = 1;
+    p.n_coord_ = 1;
     bool found = find_cell(p, 0);
-    if (!found && p->alive_) {
-      p->mark_as_lost(fmt::format("Could not locate particle {} after "
-        "crossing a lattice boundary", p->id_));
+    if (!found && p.alive_) {
+      p.mark_as_lost(fmt::format("Could not locate particle {} after "
+        "crossing a lattice boundary", p.id_));
     }
 
   } else {
     // Find cell in next lattice element.
-    p->coord_[p->n_coord_-1].universe = lat[i_xyz];
+    p.coord_[p.n_coord_-1].universe = lat[i_xyz];
     bool found = find_cell(p, 0);
 
     if (!found) {
       // A particle crossing the corner of a lattice tile may not be found.  In
       // this case, search for it from the base coords.
-      p->n_coord_ = 1;
+      p.n_coord_ = 1;
       bool found = find_cell(p, 0);
-      if (!found && p->alive_) {
-        p->mark_as_lost(fmt::format("Could not locate particle {} after "
-          "crossing a lattice boundary", p->id_));
+      if (!found && p.alive_) {
+        p.mark_as_lost(fmt::format("Could not locate particle {} after "
+          "crossing a lattice boundary", p.id_));
       }
     }
   }
@@ -345,7 +345,7 @@ cross_lattice(Particle* p, const BoundaryInfo& boundary)
 
 //==============================================================================
 
-BoundaryInfo distance_to_boundary(Particle* p)
+BoundaryInfo distance_to_boundary(Particle& p)
 {
   BoundaryInfo info;
   double d_lat = INFINITY;
@@ -354,14 +354,14 @@ BoundaryInfo distance_to_boundary(Particle* p)
   std::array<int, 3> level_lat_trans {};
 
   // Loop over each coordinate level.
-  for (int i = 0; i < p->n_coord_; i++) {
-    const auto& coord {p->coord_[i]};
+  for (int i = 0; i < p.n_coord_; i++) {
+    const auto& coord {p.coord_[i]};
     Position r {coord.r};
     Direction u {coord.u};
     Cell& c {*model::cells[coord.cell]};
 
     // Find the oncoming surface in this cell and the distance to it.
-    auto surface_distance = c.distance(r, u, p->surface_, p);
+    auto surface_distance = c.distance(r, u, p.surface_, &p);
     d_surf = surface_distance.first;
     level_surf_cross = surface_distance.second;
 
@@ -377,8 +377,8 @@ BoundaryInfo distance_to_boundary(Particle* p)
           lattice_distance = lat.distance(r, u, i_xyz);
           break;
         case LatticeType::hex:
-          auto& cell_above {model::cells[p->coord_[i-1].cell]};
-          Position r_hex {p->coord_[i-1].r};
+          auto& cell_above {model::cells[p.coord_[i-1].cell]};
+          Position r_hex {p.coord_[i-1].r};
           r_hex -= cell_above->translation_;
           if (coord.rotated) {
             r_hex = r_hex.rotate(cell_above->rotation_);
@@ -391,8 +391,8 @@ BoundaryInfo distance_to_boundary(Particle* p)
       level_lat_trans = lattice_distance.second;
 
       if (d_lat < 0) {
-        p->mark_as_lost(fmt::format(
-          "Particle {} had a negative distance to a lattice boundary", p->id_));
+        p.mark_as_lost(fmt::format(
+          "Particle {} had a negative distance to a lattice boundary", p.id_));
       }
     }
 
@@ -450,7 +450,7 @@ openmc_find_cell(const double* xyz, int32_t* index, int32_t* instance)
   p.r() = Position{xyz};
   p.u() = {0.0, 0.0, 1.0};
 
-  if (!find_cell(&p, false)) {
+  if (!find_cell(p, false)) {
     set_errmsg(fmt::format("Could not find cell at position {}.", p.r()));
     return OPENMC_E_GEOMETRY;
   }

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -55,6 +55,7 @@ bool check_cell_overlap(Particle* p, bool error)
           }
           return true;
         }
+        #pragma omp atomic
         ++model::overlap_check_count[index_cell];
       }
     }

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -111,7 +111,9 @@ void initialize_mpi(MPI_Comm intracomm)
   MPI_Get_address(&b.particle, &disp[5]);
   MPI_Get_address(&b.parent_id, &disp[6]);
   MPI_Get_address(&b.progeny_id, &disp[7]);
-  for (int i = 7; i >= 0; --i) disp[i] -= disp[0];
+  for (int i = 7; i >= 0; --i) {
+    disp[i] -= disp[0];
+  }
 
   int blocks[] {3, 3, 1, 1, 1, 1, 1, 1};
   MPI_Datatype types[] {MPI_DOUBLE, MPI_DOUBLE, MPI_DOUBLE, MPI_DOUBLE, MPI_INT, MPI_INT, MPI_LONG, MPI_LONG};
@@ -208,8 +210,9 @@ parse_command_line(int argc, char* argv[])
         }
         omp_set_num_threads(n_threads);
 #else
-        if (mpi::master)
+        if (mpi::master) {
           warning("Ignoring number of threads specified on command line.");
+        }
 #endif
 
       } else if (arg == "-?" || arg == "-h" || arg == "--help") {

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -671,6 +671,7 @@ ReverseLatticeIter HexLattice::rbegin()
 bool
 HexLattice::are_valid_indices(const int i_xyz[3]) const
 {
+  // Check if (x, alpha, z) indices are valid, accounting for number of rings
   return ((i_xyz[0] >= 0) && (i_xyz[1] >= 0) && (i_xyz[2] >= 0)
           && (i_xyz[0] < 2*n_rings_-1) && (i_xyz[1] < 2*n_rings_-1)
           && (i_xyz[0] + i_xyz[1] > n_rings_-2)

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -508,16 +508,16 @@ bool RegularMesh::intersects_3d(Position& r0, Position r1, int* ijk) const
   return min_dist < INFTY;
 }
 
-void RegularMesh::bins_crossed(const Particle* p, std::vector<int>& bins,
+void RegularMesh::bins_crossed(const Particle& p, std::vector<int>& bins,
                                std::vector<double>& lengths) const
 {
   // ========================================================================
   // Determine where the track intersects the mesh and if it intersects at all.
 
   // Copy the starting and ending coordinates of the particle.
-  Position last_r {p->r_last_};
-  Position r {p->r()};
-  Direction u {p->u()};
+  Position last_r {p.r_last_};
+  Position r {p.r()};
+  Direction u {p.u()};
 
   // Compute the length of the entire track.
   double total_distance = (r - last_r).norm();
@@ -614,16 +614,16 @@ void RegularMesh::bins_crossed(const Particle* p, std::vector<int>& bins,
   }
 }
 
-void RegularMesh::surface_bins_crossed(const Particle* p,
+void RegularMesh::surface_bins_crossed(const Particle& p,
                                        std::vector<int>& bins) const
 {
   // ========================================================================
   // Determine if the track intersects the tally mesh.
 
   // Copy the starting and ending coordinates of the particle.
-  Position r0 {p->r_last_current_};
-  Position r1 {p->r()};
-  Direction u {p->u()};
+  Position r0 {p.r_last_current_};
+  Position r1 {p.r()};
+  Direction u {p.u()};
 
   // Determine indices for starting and ending location.
   int n = n_dimension_;
@@ -899,16 +899,16 @@ RectilinearMesh::RectilinearMesh(pugi::xml_node node)
   upper_right_ = {grid_[0].back(), grid_[1].back(), grid_[2].back()};
 }
 
-void RectilinearMesh::bins_crossed(const Particle* p, std::vector<int>& bins,
+void RectilinearMesh::bins_crossed(const Particle& p, std::vector<int>& bins,
                                    std::vector<double>& lengths) const
 {
   // ========================================================================
   // Determine where the track intersects the mesh and if it intersects at all.
 
   // Copy the starting and ending coordinates of the particle.
-  Position last_r {p->r_last_};
-  Position r {p->r()};
-  Direction u {p->u()};
+  Position last_r {p.r_last_};
+  Position r {p.r()};
+  Direction u {p.u()};
 
   // Compute the length of the entire track.
   double total_distance = (r - last_r).norm();
@@ -1004,16 +1004,16 @@ void RectilinearMesh::bins_crossed(const Particle* p, std::vector<int>& bins,
   }
 }
 
-void RectilinearMesh::surface_bins_crossed(const Particle* p,
+void RectilinearMesh::surface_bins_crossed(const Particle& p,
                                            std::vector<int>& bins) const
 {
   // ========================================================================
   // Determine if the track intersects the tally mesh.
 
   // Copy the starting and ending coordinates of the particle.
-  Position r0 {p->r_last_current_};
-  Position r1 {p->r()};
-  Direction u {p->u()};
+  Position r0 {p.r_last_current_};
+  Position r1 {p.r()};
+  Direction u {p.u()};
 
   // Determine indices for starting and ending location.
   int ijk0[3], ijk1[3];
@@ -1650,15 +1650,13 @@ UnstructuredMesh::intersect_track(const moab::CartVect& start,
 }
 
 void
-UnstructuredMesh::bins_crossed(const Particle* p,
+UnstructuredMesh::bins_crossed(const Particle& p,
                                std::vector<int>& bins,
                                std::vector<double>& lengths) const
 {
-
-  moab::ErrorCode rval;
-  Position last_r{p->r_last_};
-  Position r{p->r()};
-  Direction u{p->u()};
+  Position last_r{p.r_last_};
+  Position r{p.r()};
+  Direction u{p.u()};
   u /= u.norm();
   moab::CartVect r0(last_r.x, last_r.y, last_r.z);
   moab::CartVect r1(r.x, r.y, r.z);
@@ -1772,7 +1770,7 @@ double UnstructuredMesh::tet_volume(moab::EntityHandle tet) const {
  return 1.0 / 6.0 * (((p[1] - p[0]) * (p[2] - p[0])) % (p[3] - p[0]));
 }
 
-void UnstructuredMesh::surface_bins_crossed(const Particle* p, std::vector<int>& bins) const {
+void UnstructuredMesh::surface_bins_crossed(const Particle& p, std::vector<int>& bins) const {
   // TODO: Implement triangle crossings here
   throw std::runtime_error{"Unstructured mesh surface tallies are not implemented."};
 }

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -989,10 +989,9 @@ void nuclides_clear()
   data::nuclide_map.clear();
 }
 
-bool multipole_in_range(const Nuclide* nuc, double E)
+bool multipole_in_range(const Nuclide& nuc, double E)
 {
-  return nuc->multipole_ && E >= nuc->multipole_->E_min_&&
-    E <= nuc->multipole_->E_max_;
+  return E >= nuc.multipole_->E_min_ && E <= nuc.multipole_->E_max_;
 }
 
 } // namespace openmc

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -75,7 +75,7 @@ void title()
   fmt::print(
     "                   | The OpenMC Monte Carlo Code\n"
     "         Copyright | 2011-2020 MIT and OpenMC contributors\n"
-    "           License | http://openmc.readthedocs.io/en/latest/license.html\n"
+    "           License | https://docs.openmc.org/en/latest/license.html\n"
     "           Version | {}.{}.{}{}\n", VERSION_MAJOR, VERSION_MINOR,
     VERSION_RELEASE, VERSION_DEV ? "-dev" : "");
 #ifdef GIT_SHA1
@@ -328,9 +328,9 @@ void print_version()
 #ifdef GIT_SHA1
     fmt::print("Git SHA1: {}\n", GIT_SHA1);
 #endif
-    fmt::print("Copyright (c) 2011-2019 Massachusetts Institute of "
+    fmt::print("Copyright (c) 2011-2020 Massachusetts Institute of "
       "Technology and OpenMC contributors\nMIT/X license at "
-      "<http://openmc.readthedocs.io/en/latest/license.html>\n");
+      "<https://docs.openmc.org/en/latest/license.html>\n");
   }
 }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -143,10 +143,10 @@ std::string time_stamp()
 
 //==============================================================================
 
-extern "C" void print_particle(Particle* p)
+void print_particle(Particle& p)
 {
   // Display particle type and ID.
-  switch (p->type_) {
+  switch (p.type_) {
     case Particle::Type::neutron:
       fmt::print("Neutron ");
       break;
@@ -162,46 +162,46 @@ extern "C" void print_particle(Particle* p)
     default:
       fmt::print("Unknown Particle ");
   }
-  fmt::print("{}\n", p->id_);
+  fmt::print("{}\n", p.id_);
 
   // Display particle geometry hierarchy.
-  for (auto i = 0; i < p->n_coord_; i++) {
+  for (auto i = 0; i < p.n_coord_; i++) {
     fmt::print("  Level {}\n", i);
 
-    if (p->coord_[i].cell != C_NONE) {
-      const Cell& c {*model::cells[p->coord_[i].cell]};
+    if (p.coord_[i].cell != C_NONE) {
+      const Cell& c {*model::cells[p.coord_[i].cell]};
       fmt::print("    Cell             = {}\n", c.id_);
     }
 
-    if (p->coord_[i].universe != C_NONE) {
-      const Universe& u {*model::universes[p->coord_[i].universe]};
+    if (p.coord_[i].universe != C_NONE) {
+      const Universe& u {*model::universes[p.coord_[i].universe]};
       fmt::print("    Universe         = {}\n", u.id_);
     }
 
-    if (p->coord_[i].lattice != C_NONE) {
-      const Lattice& lat {*model::lattices[p->coord_[i].lattice]};
+    if (p.coord_[i].lattice != C_NONE) {
+      const Lattice& lat {*model::lattices[p.coord_[i].lattice]};
       fmt::print("    Lattice          = {}\n", lat.id_);
-      fmt::print("    Lattice position = ({},{},{})\n", p->coord_[i].lattice_x,
-        p->coord_[i].lattice_y, p->coord_[i].lattice_z);
+      fmt::print("    Lattice position = ({},{},{})\n", p.coord_[i].lattice_x,
+        p.coord_[i].lattice_y, p.coord_[i].lattice_z);
     }
 
-    fmt::print("    r = {}\n", p->coord_[i].r);
-    fmt::print("    u = {}\n", p->coord_[i].u);
+    fmt::print("    r = {}\n", p.coord_[i].r);
+    fmt::print("    u = {}\n", p.coord_[i].u);
   }
 
   // Display miscellaneous info.
-  if (p->surface_ != 0) {
+  if (p.surface_ != 0) {
     // Surfaces identifiers are >= 1, but indices are >= 0 so we need -1
-    const Surface& surf {*model::surfaces[std::abs(p->surface_)-1]};
-    fmt::print("  Surface = {}\n", (p->surface_ > 0) ? surf.id_ : -surf.id_);
+    const Surface& surf {*model::surfaces[std::abs(p.surface_)-1]};
+    fmt::print("  Surface = {}\n", (p.surface_ > 0) ? surf.id_ : -surf.id_);
   }
-  fmt::print("  Weight = {}\n", p->wgt_);
+  fmt::print("  Weight = {}\n", p.wgt_);
   if (settings::run_CE) {
-    fmt::print("  Energy = {}\n", p->E_);
+    fmt::print("  Energy = {}\n", p.E_);
   } else {
-    fmt::print("  Energy Group = {}\n", p->g_);
+    fmt::print("  Energy Group = {}\n", p.g_);
   }
-  fmt::print("  Delayed Group = {}\n\n", p->delayed_group_);
+  fmt::print("  Delayed Group = {}\n\n", p.delayed_group_);
 }
 
 //==============================================================================

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -191,6 +191,7 @@ extern "C" void print_particle(Particle* p)
 
   // Display miscellaneous info.
   if (p->surface_ != 0) {
+    // Surfaces identifiers are >= 1, but indices are >= 0 so we need -1
     const Surface& surf {*model::surfaces[std::abs(p->surface_)-1]};
     fmt::print("  Surface = {}\n", (p->surface_ > 0) ? surf.id_ : -surf.id_);
   }
@@ -280,7 +281,7 @@ print_overlap_check()
 
     std::vector<int32_t> sparse_cell_ids;
     for (int i = 0; i < model::cells.size(); i++) {
-      fmt::print(" {:8}{:17}\n", model::cells[i]->id_, model::overlap_check_count[i]);
+      fmt::print(" {:8} {:17}\n", model::cells[i]->id_, model::overlap_check_count[i]);
       if (model::overlap_check_count[i] < 10) {
         sparse_cell_ids.push_back(model::cells[i]->id_);
       }
@@ -352,43 +353,19 @@ void print_columns()
 
 void print_generation()
 {
-  // Determine overall generation and number of active generations
-  int i = overall_generation() - 1;
+  // Determine overall generation index and number of active generations
+  int idx = overall_generation() - 1;
   int n = simulation::current_batch > settings::n_inactive ?
     settings::gen_per_batch*simulation::n_realizations + simulation::current_gen : 0;
 
-  // write out information batch and option independent output
+  // write out batch/generation and generation k-effective
   auto batch_and_gen = std::to_string(simulation::current_batch) + "/" +
     std::to_string(simulation::current_gen);
-  fmt::print("  {:>9}   {:8.5f}", batch_and_gen, simulation::k_generation[i]);
+  fmt::print("  {:>9}   {:8.5f}", batch_and_gen, simulation::k_generation[idx]);
 
   // write out entropy info
   if (settings::entropy_on) {
-    fmt::print("   {:8.5f}", simulation::entropy[i]);
-  }
-
-  if (n > 1) {
-    fmt::print("   {:8.5f} +/-{:8.5f}", simulation::keff, simulation::keff_std);
-  }
-  std::cout << std::endl;
-}
-
-//==============================================================================
-
-void print_batch_keff()
-{
-  // Determine overall generation and number of active generations
-  int i = simulation::current_batch*settings::gen_per_batch - 1;
-  int n = simulation::n_realizations*settings::gen_per_batch;
-
-  // write out information batch and option independent output
-  auto batch_and_gen = std::to_string(simulation::current_batch) + "/" +
-    std::to_string(settings::gen_per_batch);
-  fmt::print("  {:>9}   {:8.5f}", batch_and_gen, simulation::k_generation[i]);
-
-  // write out entropy info
-  if (settings::entropy_on) {
-    fmt::print("   {:8.5f}", simulation::entropy[i]);
+    fmt::print("   {:8.5f}", simulation::entropy[idx]);
   }
 
   if (n > 1) {

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -156,7 +156,7 @@ Particle::event_calculate_xs()
   // initiate a search for the current cell. This generally happens at the
   // beginning of the history and again for any secondary particles
   if (coord_[n_coord_ - 1].cell == C_NONE) {
-    if (!find_cell(this, false)) {
+    if (!find_cell(*this, false)) {
       this->mark_as_lost("Could not find the cell containing particle "
         + std::to_string(id_));
       return;
@@ -169,7 +169,7 @@ Particle::event_calculate_xs()
   // Write particle track.
   if (write_track_) write_particle_track(*this);
 
-  if (settings::check_overlaps) check_cell_overlap(this);
+  if (settings::check_overlaps) check_cell_overlap(*this);
 
   // Calculate microscopic and macroscopic cross sections
   if (material_ != MATERIAL_VOID) {
@@ -201,7 +201,7 @@ void
 Particle::event_advance()
 {
   // Find the distance to the nearest boundary
-  boundary_ = distance_to_boundary(this);
+  boundary_ = distance_to_boundary(*this);
 
   // Sample a distance to collision
   if (type_ == Particle::Type::electron ||
@@ -234,7 +234,7 @@ Particle::event_advance()
 
   // Score flux derivative accumulators for differential tallies.
   if (!model::active_tallies.empty()) {
-    score_track_derivative(this, distance);
+    score_track_derivative(*this, distance);
   }
 }
 
@@ -255,7 +255,7 @@ Particle::event_cross_surface()
       boundary_.lattice_translation[1] != 0 ||
       boundary_.lattice_translation[2] != 0) {
     // Particle crosses lattice boundary
-    cross_lattice(this, boundary_);
+    cross_lattice(*this, boundary_);
     event_ = TallyEvent::LATTICE;
   } else {
     // Particle crosses surface
@@ -337,7 +337,7 @@ Particle::event_collide()
   }
 
   // Score flux derivative accumulators for differential tallies.
-  if (!model::active_tallies.empty()) score_collision_derivative(this);
+  if (!model::active_tallies.empty()) score_collision_derivative(*this);
 }
 
 void
@@ -490,7 +490,7 @@ Particle::cross_surface()
     // (unless we're using a dagmc model, which has exactly one universe)
     if (!settings::dagmc) {
       n_coord_ = 1;
-      if (!find_cell(this, true)) {
+      if (!find_cell(*this, true)) {
         this->mark_as_lost("Couldn't find particle after reflecting from surface "
                            + std::to_string(surf->id_) + ".");
         return;
@@ -545,7 +545,7 @@ Particle::cross_surface()
     // Figure out what cell particle is in now
     n_coord_ = 1;
 
-    if (!find_cell(this, true)) {
+    if (!find_cell(*this, true)) {
       this->mark_as_lost("Couldn't find particle after hitting periodic "
         "boundary on surface " + std::to_string(surf->id_) + ".");
       return;
@@ -583,7 +583,7 @@ Particle::cross_surface()
   }
 #endif
 
-  if (find_cell(this, true)) return;
+  if (find_cell(*this, true)) return;
 
   // ==========================================================================
   // COULDN'T FIND PARTICLE IN NEIGHBORING CELLS, SEARCH ALL CELLS
@@ -591,7 +591,7 @@ Particle::cross_surface()
   // Remove lower coordinate levels and assignment of surface
   surface_ = 0;
   n_coord_ = 1;
-  bool found = find_cell(this, false);
+  bool found = find_cell(*this, false);
 
   if (settings::run_mode != RunMode::PLOTTING && (!found)) {
     // If a cell is still not found, there are two possible causes: 1) there is
@@ -605,7 +605,7 @@ Particle::cross_surface()
     // Couldn't find next cell anywhere! This probably means there is an actual
     // undefined region in the geometry.
 
-    if (!find_cell(this, false)) {
+    if (!find_cell(*this, false)) {
       this->mark_as_lost("After particle " + std::to_string(id_) +
         " crossed surface " + std::to_string(surf->id_) +
         " it could not be located in any cell and it did not leak.");

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -707,4 +707,34 @@ Particle::write_restart() const
   } // #pragma omp critical
 }
 
+std::string particle_type_to_str(Particle::Type type)
+{
+  switch (type) {
+    case Particle::Type::neutron:
+      return "neutron";
+    case Particle::Type::photon:
+      return "photon";
+    case Particle::Type::electron:
+      return "electron";
+    case Particle::Type::positron:
+      return "positron";
+  }
+  UNREACHABLE();
+}
+
+Particle::Type str_to_particle_type(std::string str)
+{
+  if (str == "neutron") {
+    return Particle::Type::neutron;
+  } else if (str == "photon") {
+    return Particle::Type::photon;
+  } else if (str == "electron") {
+    return Particle::Type::electron;
+  } else if (str == "positron") {
+    return Particle::Type::positron;
+  } else {
+    throw std::invalid_argument{fmt::format("Invalid particle name: {}", str)};
+  }
+}
+
 } // namespace openmc

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -289,9 +289,9 @@ Particle::event_collide()
   surface_ = 0;
 
   if (settings::run_CE) {
-    collision(this);
+    collision(*this);
   } else {
-    collision_mg(this);
+    collision_mg(*this);
   }
 
   // Score collision estimator tallies -- this is done after a collision

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -223,7 +223,7 @@ Particle::event_advance()
 
   // Score track-length tallies
   if (!model::active_tracklength_tallies.empty()) {
-    score_tracklength_tally(this, distance);
+    score_tracklength_tally(*this, distance);
   }
 
   // Score track-length estimate of k-eff
@@ -264,7 +264,7 @@ Particle::event_cross_surface()
   }
   // Score cell to cell partial currents
   if (!model::active_surface_tallies.empty()) {
-    score_surface_tally(this, model::active_surface_tallies);
+    score_surface_tally(*this, model::active_surface_tallies);
   }
 }
 
@@ -283,7 +283,7 @@ Particle::event_collide()
   // pre-collision direction to figure out what mesh surfaces were crossed
 
   if (!model::active_meshsurf_tallies.empty())
-    score_surface_tally(this, model::active_meshsurf_tallies);
+    score_surface_tally(*this, model::active_meshsurf_tallies);
 
   // Clear surface component
   surface_ = 0;
@@ -297,12 +297,12 @@ Particle::event_collide()
   // Score collision estimator tallies -- this is done after a collision
   // has occurred rather than before because we need information on the
   // outgoing energy for any tallies with an outgoing energy filter
-  if (!model::active_collision_tallies.empty()) score_collision_tally(this);
+  if (!model::active_collision_tallies.empty()) score_collision_tally(*this);
   if (!model::active_analog_tallies.empty()) {
     if (settings::run_CE) {
-      score_analog_tally_ce(this);
+      score_analog_tally_ce(*this);
     } else {
-      score_analog_tally_mg(this);
+      score_analog_tally_mg(*this);
     }
   }
 
@@ -429,7 +429,7 @@ Particle::cross_surface()
       // physically moving the particle forward slightly
 
       this->r() += TINY_BIT * this->u();
-      score_surface_tally(this, model::active_meshsurf_tallies);
+      score_surface_tally(*this, model::active_meshsurf_tallies);
     }
 
     // Score to global leakage tally
@@ -462,14 +462,14 @@ Particle::cross_surface()
     // with a mesh boundary
 
     if (!model::active_surface_tallies.empty()) {
-      score_surface_tally(this, model::active_surface_tallies);
+      score_surface_tally(*this, model::active_surface_tallies);
     }
 
 
     if (!model::active_meshsurf_tallies.empty()) {
       Position r {this->r()};
       this->r() -= TINY_BIT * this->u();
-      score_surface_tally(this, model::active_meshsurf_tallies);
+      score_surface_tally(*this, model::active_meshsurf_tallies);
       this->r() = r;
     }
 
@@ -524,7 +524,7 @@ Particle::cross_surface()
     if (!model::active_meshsurf_tallies.empty()) {
       Position r {this->r()};
       this->r() -= TINY_BIT * this->u();
-      score_surface_tally(this, model::active_meshsurf_tallies);
+      score_surface_tally(*this, model::active_meshsurf_tallies);
       this->r() = r;
     }
 

--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -115,7 +115,7 @@ void run_particle_restart()
     p.flux_derivs_.resize(model::tally_derivs.size(), 0.0);
     std::fill(p.flux_derivs_.begin(), p.flux_derivs_.end(), 0.0);
   }
-  
+
   // Allocate space for tally filter matches
   p.filter_matches_.resize(model::tally_filters.size());
 
@@ -123,7 +123,7 @@ void run_particle_restart()
   transport_history_based_single_particle(p);
 
   // Write output if particle made it
-  print_particle(&p);
+  print_particle(p);
 }
 
 } // namespace openmc

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -153,7 +153,7 @@ create_fission_sites(Particle* p, int i_nuclide, const Reaction* rx)
 {
   // If uniform fission source weighting is turned on, we increase or decrease
   // the expected number of fission sites produced
-  double weight = settings::ufs_on ? ufs_get_weight(p) : 1.0;
+  double weight = settings::ufs_on ? ufs_get_weight(*p) : 1.0;
 
   // Determine the expected number of neutrons produced
   double nu_t = p->wgt_ / simulation::keff * weight * p->neutron_xs_[

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -32,13 +32,13 @@ namespace openmc {
 // Non-member functions
 //==============================================================================
 
-void collision(Particle* p)
+void collision(Particle& p)
 {
   // Add to collision counter for particle
-  ++(p->n_collision_);
+  ++(p.n_collision_);
 
   // Sample reaction for the material the particle is in
-  switch (static_cast<Particle::Type>(p->type_)) {
+  switch (static_cast<Particle::Type>(p.type_)) {
   case Particle::Type::neutron:
     sample_neutron_reaction(p);
     break;
@@ -54,39 +54,39 @@ void collision(Particle* p)
   }
 
   // Kill particle if energy falls below cutoff
-  int type = static_cast<int>(p->type_);
-  if (p->E_ < settings::energy_cutoff[type]) {
-    p->alive_ = false;
-    p->wgt_ = 0.0;
+  int type = static_cast<int>(p.type_);
+  if (p.E_ < settings::energy_cutoff[type]) {
+    p.alive_ = false;
+    p.wgt_ = 0.0;
   }
 
   // Display information about collision
-  if (settings::verbosity >= 10 || p->trace_) {
+  if (settings::verbosity >= 10 || p.trace_) {
     std::string msg;
-    if (p->event_ == TallyEvent::KILL) {
-      msg = fmt::format("    Killed. Energy = {} eV.", p->E_);
-    } else if (p->type_ == Particle::Type::neutron) {
+    if (p.event_ == TallyEvent::KILL) {
+      msg = fmt::format("    Killed. Energy = {} eV.", p.E_);
+    } else if (p.type_ == Particle::Type::neutron) {
       msg = fmt::format("    {} with {}. Energy = {} eV.",
-        reaction_name(p->event_mt_), data::nuclides[p->event_nuclide_]->name_,
-        p->E_);
-    } else if (p->type_ == Particle::Type::photon) {
+        reaction_name(p.event_mt_), data::nuclides[p.event_nuclide_]->name_,
+        p.E_);
+    } else if (p.type_ == Particle::Type::photon) {
       msg = fmt::format("    {} with {}. Energy = {} eV.",
-        reaction_name(p->event_mt_),
-        to_element(data::nuclides[p->event_nuclide_]->name_), p->E_);
+        reaction_name(p.event_mt_),
+        to_element(data::nuclides[p.event_nuclide_]->name_), p.E_);
     } else {
-      msg = fmt::format("    Disappeared. Energy = {} eV.", p->E_);
+      msg = fmt::format("    Disappeared. Energy = {} eV.", p.E_);
     }
     write_message(msg, 1);
   }
 }
 
-void sample_neutron_reaction(Particle* p)
+void sample_neutron_reaction(Particle& p)
 {
   // Sample a nuclide within the material
   int i_nuclide = sample_nuclide(p);
 
   // Save which nuclide particle had collision with
-  p->event_nuclide_ = i_nuclide;
+  p.event_nuclide_ = i_nuclide;
 
   // Create fission bank sites. Note that while a fission reaction is sampled,
   // it never actually "happens", i.e. the weight of the particle does not
@@ -105,7 +105,7 @@ void sample_neutron_reaction(Particle* p)
 
       // Make sure particle population doesn't grow out of control for
       // subcritical multiplication problems.
-      if (p->secondary_bank_.size() >= 10000) {
+      if (p.secondary_bank_.size() >= 10000) {
         fatal_error("The secondary particle bank appears to be growing without "
         "bound. You are likely running a subcritical multiplication problem "
         "with k-effective close to or greater than one.");
@@ -115,53 +115,53 @@ void sample_neutron_reaction(Particle* p)
 
   // Create secondary photons
   if (settings::photon_transport) {
-    p->stream_ = STREAM_PHOTON;
+    p.stream_ = STREAM_PHOTON;
     sample_secondary_photons(p, i_nuclide);
-	p->stream_ = STREAM_TRACKING;
+	p.stream_ = STREAM_TRACKING;
   }
 
   // If survival biasing is being used, the following subroutine adjusts the
   // weight of the particle. Otherwise, it checks to see if absorption occurs
 
-  if (p->neutron_xs_[i_nuclide].absorption > 0.0) {
+  if (p.neutron_xs_[i_nuclide].absorption > 0.0) {
     absorption(p, i_nuclide);
   } else {
-    p->wgt_absorb_ = 0.0;
+    p.wgt_absorb_ = 0.0;
   }
-  if (!p->alive_) return;
+  if (!p.alive_) return;
 
   // Sample a scattering reaction and determine the secondary energy of the
   // exiting neutron
   scatter(p, i_nuclide);
 
   // Advance URR seed stream 'N' times after energy changes
-  if (p->E_ != p->E_last_) {
-    p->stream_ = STREAM_URR_PTABLE;
-    advance_prn_seed(data::nuclides.size(), p->current_seed());
-    p->stream_ = STREAM_TRACKING;
+  if (p.E_ != p.E_last_) {
+    p.stream_ = STREAM_URR_PTABLE;
+    advance_prn_seed(data::nuclides.size(), p.current_seed());
+    p.stream_ = STREAM_TRACKING;
   }
 
   // Play russian roulette if survival biasing is turned on
   if (settings::survival_biasing) {
     russian_roulette(p);
-    if (!p->alive_) return;
+    if (!p.alive_) return;
   }
 }
 
 void
-create_fission_sites(Particle* p, int i_nuclide, const Reaction* rx)
+create_fission_sites(Particle& p, int i_nuclide, const Reaction* rx)
 {
   // If uniform fission source weighting is turned on, we increase or decrease
   // the expected number of fission sites produced
-  double weight = settings::ufs_on ? ufs_get_weight(*p) : 1.0;
+  double weight = settings::ufs_on ? ufs_get_weight(p) : 1.0;
 
   // Determine the expected number of neutrons produced
-  double nu_t = p->wgt_ / simulation::keff * weight * p->neutron_xs_[
-    i_nuclide].nu_fission / p->neutron_xs_[i_nuclide].total;
+  double nu_t = p.wgt_ / simulation::keff * weight * p.neutron_xs_[
+    i_nuclide].nu_fission / p.neutron_xs_[i_nuclide].total;
 
   // Sample the number of neutrons produced
   int nu = static_cast<int>(nu_t);
-  if (prn(p->current_seed()) <= (nu_t - nu)) ++nu;
+  if (prn(p.current_seed()) <= (nu_t - nu)) ++nu;
 
   // Begin banking the source neutrons
   // First, if our bank is full then don't continue
@@ -172,9 +172,9 @@ create_fission_sites(Particle* p, int i_nuclide, const Reaction* rx)
   double nu_d[MAX_DELAYED_GROUPS] = {0.};
 
   // Clear out particle's nu fission bank
-  p->nu_bank_.clear();
+  p.nu_bank_.clear();
 
-  p->fission_ = true;
+  p.fission_ = true;
   int skipped = 0;
 
   // Determine whether to place fission sites into the shared fission bank
@@ -184,14 +184,14 @@ create_fission_sites(Particle* p, int i_nuclide, const Reaction* rx)
   for (int i = 0; i < nu; ++i) {
     // Initialize fission site object with particle data
     Particle::Bank site;
-    site.r = p->r();
+    site.r = p.r();
     site.particle = Particle::Type::neutron;
     site.wgt = 1. / weight;
-    site.parent_id = p->id_;
-    site.progeny_id = p->n_progeny_++;
+    site.parent_id = p.id_;
+    site.progeny_id = p.n_progeny_++;
 
     // Sample delayed group and angle/energy for fission reaction
-    sample_fission_neutron(i_nuclide, rx, p->E_, &site, p->current_seed());
+    sample_fission_neutron(i_nuclide, rx, p.E_, &site, p.current_seed());
 
     // Store fission site in bank
     if (use_fission_bank) {
@@ -203,21 +203,21 @@ create_fission_sites(Particle* p, int i_nuclide, const Reaction* rx)
         break;
       }
     } else {
-      p->secondary_bank_.push_back(site);
+      p.secondary_bank_.push_back(site);
     }
 
     // Set the delayed group on the particle as well
-    p->delayed_group_ = site.delayed_group;
+    p.delayed_group_ = site.delayed_group;
 
     // Increment the number of neutrons born delayed
-    if (p->delayed_group_ > 0) {
-      nu_d[p->delayed_group_-1]++;
+    if (p.delayed_group_ > 0) {
+      nu_d[p.delayed_group_-1]++;
     }
 
     // Write fission particles to nuBank
     if (use_fission_bank) {
-      p->nu_bank_.emplace_back();
-      Particle::NuBank* nu_bank_entry = &p->nu_bank_.back();
+      p.nu_bank_.emplace_back();
+      Particle::NuBank* nu_bank_entry = &p.nu_bank_.back();
       nu_bank_entry->wgt              = site.wgt;
       nu_bank_entry->E                = site.E;
       nu_bank_entry->delayed_group    = site.delayed_group;
@@ -227,7 +227,7 @@ create_fission_sites(Particle* p, int i_nuclide, const Reaction* rx)
   // If shared fission bank was full, and no fissions could be added,
   // set the particle fission flag to false.
   if (nu == skipped) {
-    p->fission_ = false;
+    p.fission_ = false;
     return;
   }
 
@@ -236,45 +236,45 @@ create_fission_sites(Particle* p, int i_nuclide, const Reaction* rx)
   nu -= skipped;
 
   // Store the total weight banked for analog fission tallies
-  p->n_bank_ = nu;
-  p->wgt_bank_ = nu / weight;
+  p.n_bank_ = nu;
+  p.wgt_bank_ = nu / weight;
   for (size_t d = 0; d < MAX_DELAYED_GROUPS; d++) {
-    p->n_delayed_bank_[d] = nu_d[d];
+    p.n_delayed_bank_[d] = nu_d[d];
   }
 }
 
-void sample_photon_reaction(Particle* p)
+void sample_photon_reaction(Particle& p)
 {
   // Kill photon if below energy cutoff -- an extra check is made here because
   // photons with energy below the cutoff may have been produced by neutrons
   // reactions or atomic relaxation
   int photon = static_cast<int>(Particle::Type::photon);
-  if (p->E_ < settings::energy_cutoff[photon]) {
-    p->E_ = 0.0;
-    p->alive_ = false;
+  if (p.E_ < settings::energy_cutoff[photon]) {
+    p.E_ = 0.0;
+    p.alive_ = false;
     return;
   }
 
   // Sample element within material
   int i_element = sample_element(p);
-  const auto& micro {p->photon_xs_[i_element]};
+  const auto& micro {p.photon_xs_[i_element]};
   const auto& element {data::elements[i_element]};
 
   // Calculate photon energy over electron rest mass equivalent
-  double alpha = p->E_/MASS_ELECTRON_EV;
+  double alpha = p.E_/MASS_ELECTRON_EV;
 
   // For tallying purposes, this routine might be called directly. In that
   // case, we need to sample a reaction via the cutoff variable
   double prob = 0.0;
-  double cutoff = prn(p->current_seed()) * micro.total;
+  double cutoff = prn(p.current_seed()) * micro.total;
 
   // Coherent (Rayleigh) scattering
   prob += micro.coherent;
   if (prob > cutoff) {
-    double mu = element.rayleigh_scatter(alpha, p->current_seed());
-    p->u() = rotate_angle(p->u(), mu, nullptr, p->current_seed());
-    p->event_ = TallyEvent::SCATTER;
-    p->event_mt_ = COHERENT;
+    double mu = element.rayleigh_scatter(alpha, p.current_seed());
+    p.u() = rotate_angle(p.u(), mu, nullptr, p.current_seed());
+    p.event_ = TallyEvent::SCATTER;
+    p.event_mt_ = COHERENT;
     return;
   }
 
@@ -283,7 +283,7 @@ void sample_photon_reaction(Particle* p)
   if (prob > cutoff) {
     double alpha_out, mu;
     int i_shell;
-    element.compton_scatter(alpha, true, &alpha_out, &mu, &i_shell, p->current_seed());
+    element.compton_scatter(alpha, true, &alpha_out, &mu, &i_shell, p.current_seed());
 
     // Determine binding energy of shell. The binding energy is 0.0 if
     // doppler broadening is not used.
@@ -295,14 +295,14 @@ void sample_photon_reaction(Particle* p)
     }
 
     // Create Compton electron
-    double phi = 2.0*PI*prn(p->current_seed());
+    double phi = 2.0*PI*prn(p.current_seed());
     double E_electron = (alpha - alpha_out)*MASS_ELECTRON_EV - e_b;
     int electron = static_cast<int>(Particle::Type::electron);
     if (E_electron >= settings::energy_cutoff[electron]) {
       double mu_electron = (alpha - alpha_out*mu)
         / std::sqrt(alpha*alpha + alpha_out*alpha_out - 2.0*alpha*alpha_out*mu);
-      Direction u = rotate_angle(p->u(), mu_electron, &phi, p->current_seed());
-      p->create_secondary(u, E_electron, Particle::Type::electron);
+      Direction u = rotate_angle(p.u(), mu_electron, &phi, p.current_seed());
+      p.create_secondary(u, E_electron, Particle::Type::electron);
     }
 
     // TODO: Compton subshell data does not match atomic relaxation data
@@ -310,14 +310,14 @@ void sample_photon_reaction(Particle* p)
     // and fluorescent photons
     if (i_shell >= 0) {
       const auto& shell = element.shells_[i_shell];
-      element.atomic_relaxation(shell, *p);
+      element.atomic_relaxation(shell, p);
     }
 
     phi += PI;
-    p->E_ = alpha_out*MASS_ELECTRON_EV;
-    p->u() = rotate_angle(p->u(), mu, &phi, p->current_seed());
-    p->event_ = TallyEvent::SCATTER;
-    p->event_mt_ = INCOHERENT;
+    p.E_ = alpha_out*MASS_ELECTRON_EV;
+    p.u() = rotate_angle(p.u(), mu, &phi, p.current_seed());
+    p.event_ = TallyEvent::SCATTER;
+    p.event_mt_ = INCOHERENT;
     return;
   }
 
@@ -340,15 +340,15 @@ void sample_photon_reaction(Particle* p)
 
       prob += xs;
       if (prob > cutoff) {
-        double E_electron = p->E_ - shell.binding_energy;
+        double E_electron = p.E_ - shell.binding_energy;
 
         // Sample mu using non-relativistic Sauter distribution.
         // See Eqns 3.19 and 3.20 in "Implementing a photon physics
         // model in Serpent 2" by Toni Kaltiaisenaho
         double mu;
         while (true) {
-          double r = prn(p->current_seed());
-          if (4.0*(1.0 - r)*r >= prn(p->current_seed())) {
+          double r = prn(p.current_seed());
+          if (4.0*(1.0 - r)*r >= prn(p.current_seed())) {
             double rel_vel = std::sqrt(E_electron * (E_electron +
               2.0*MASS_ELECTRON_EV)) / (E_electron + MASS_ELECTRON_EV);
             mu = (2.0*r + rel_vel - 1.0) / (2.0*rel_vel*r - rel_vel + 1.0);
@@ -356,22 +356,22 @@ void sample_photon_reaction(Particle* p)
           }
         }
 
-        double phi = 2.0*PI*prn(p->current_seed());
+        double phi = 2.0*PI*prn(p.current_seed());
         Direction u;
         u.x = mu;
         u.y = std::sqrt(1.0 - mu*mu)*std::cos(phi);
         u.z = std::sqrt(1.0 - mu*mu)*std::sin(phi);
 
         // Create secondary electron
-        p->create_secondary(u, E_electron, Particle::Type::electron);
+        p.create_secondary(u, E_electron, Particle::Type::electron);
 
         // Allow electrons to fill orbital and produce auger electrons
         // and fluorescent photons
-        element.atomic_relaxation(shell, *p);
-        p->event_ = TallyEvent::ABSORB;
-        p->event_mt_ = 533 + shell.index_subshell;
-        p->alive_ = false;
-        p->E_ = 0.0;
+        element.atomic_relaxation(shell, p);
+        p.event_ = TallyEvent::ABSORB;
+        p.event_mt_ = 533 + shell.index_subshell;
+        p.alive_ = false;
+        p.E_ = 0.0;
         return;
       }
     }
@@ -384,70 +384,70 @@ void sample_photon_reaction(Particle* p)
     double E_electron, E_positron;
     double mu_electron, mu_positron;
     element.pair_production(alpha, &E_electron, &E_positron,
-      &mu_electron, &mu_positron, p->current_seed());
+      &mu_electron, &mu_positron, p.current_seed());
 
     // Create secondary electron
-    Direction u = rotate_angle(p->u(), mu_electron, nullptr, p->current_seed());
-    p->create_secondary(u, E_electron, Particle::Type::electron);
+    Direction u = rotate_angle(p.u(), mu_electron, nullptr, p.current_seed());
+    p.create_secondary(u, E_electron, Particle::Type::electron);
 
     // Create secondary positron
-    u = rotate_angle(p->u(), mu_positron, nullptr, p->current_seed());
-    p->create_secondary(u, E_positron, Particle::Type::positron);
+    u = rotate_angle(p.u(), mu_positron, nullptr, p.current_seed());
+    p.create_secondary(u, E_positron, Particle::Type::positron);
 
-    p->event_ = TallyEvent::ABSORB;
-    p->event_mt_ = PAIR_PROD;
-    p->alive_ = false;
-    p->E_ = 0.0;
+    p.event_ = TallyEvent::ABSORB;
+    p.event_mt_ = PAIR_PROD;
+    p.alive_ = false;
+    p.E_ = 0.0;
   }
 }
 
-void sample_electron_reaction(Particle* p)
+void sample_electron_reaction(Particle& p)
 {
   // TODO: create reaction types
 
   if (settings::electron_treatment == ElectronTreatment::TTB) {
     double E_lost;
-    thick_target_bremsstrahlung(*p, &E_lost);
+    thick_target_bremsstrahlung(p, &E_lost);
   }
 
-  p->E_ = 0.0;
-  p->alive_ = false;
-  p->event_ = TallyEvent::ABSORB;
+  p.E_ = 0.0;
+  p.alive_ = false;
+  p.event_ = TallyEvent::ABSORB;
 }
 
-void sample_positron_reaction(Particle* p)
+void sample_positron_reaction(Particle& p)
 {
   // TODO: create reaction types
 
   if (settings::electron_treatment == ElectronTreatment::TTB) {
     double E_lost;
-    thick_target_bremsstrahlung(*p, &E_lost);
+    thick_target_bremsstrahlung(p, &E_lost);
   }
 
   // Sample angle isotropically
-  double mu = 2.0*prn(p->current_seed()) - 1.0;
-  double phi = 2.0*PI*prn(p->current_seed());
+  double mu = 2.0*prn(p.current_seed()) - 1.0;
+  double phi = 2.0*PI*prn(p.current_seed());
   Direction u;
   u.x = mu;
   u.y = std::sqrt(1.0 - mu*mu)*std::cos(phi);
   u.z = std::sqrt(1.0 - mu*mu)*std::sin(phi);
 
   // Create annihilation photon pair traveling in opposite directions
-  p->create_secondary(u, MASS_ELECTRON_EV, Particle::Type::photon);
-  p->create_secondary(-u, MASS_ELECTRON_EV, Particle::Type::photon);
+  p.create_secondary(u, MASS_ELECTRON_EV, Particle::Type::photon);
+  p.create_secondary(-u, MASS_ELECTRON_EV, Particle::Type::photon);
 
-  p->E_ = 0.0;
-  p->alive_ = false;
-  p->event_ = TallyEvent::ABSORB;
+  p.E_ = 0.0;
+  p.alive_ = false;
+  p.event_ = TallyEvent::ABSORB;
 }
 
-int sample_nuclide(Particle* p)
+int sample_nuclide(Particle& p)
 {
   // Sample cumulative distribution function
-  double cutoff = prn(p->current_seed()) * p->macro_xs_.total;
+  double cutoff = prn(p.current_seed()) * p.macro_xs_.total;
 
   // Get pointers to nuclide/density arrays
-  const auto& mat {model::materials[p->material_]};
+  const auto& mat {model::materials[p.material_]};
   int n = mat->nuclide_.size();
 
   double prob = 0.0;
@@ -457,22 +457,22 @@ int sample_nuclide(Particle* p)
     double atom_density = mat->atom_density_[i];
 
     // Increment probability to compare to cutoff
-    prob += atom_density * p->neutron_xs_[i_nuclide].total;
+    prob += atom_density * p.neutron_xs_[i_nuclide].total;
     if (prob >= cutoff) return i_nuclide;
   }
 
   // If we reach here, no nuclide was sampled
-  p->write_restart();
+  p.write_restart();
   throw std::runtime_error{"Did not sample any nuclide during collision."};
 }
 
-int sample_element(Particle* p)
+int sample_element(Particle& p)
 {
   // Sample cumulative distribution function
-  double cutoff = prn(p->current_seed()) * p->macro_xs_.total;
+  double cutoff = prn(p.current_seed()) * p.macro_xs_.total;
 
   // Get pointers to elements, densities
-  const auto& mat {model::materials[p->material_]};
+  const auto& mat {model::materials[p.material_]};
 
   double prob = 0.0;
   for (int i = 0; i < mat->element_.size(); ++i) {
@@ -481,24 +481,24 @@ int sample_element(Particle* p)
     double atom_density = mat->atom_density_[i];
 
     // Determine microscopic cross section
-    double sigma = atom_density * p->photon_xs_[i_element].total;
+    double sigma = atom_density * p.photon_xs_[i_element].total;
 
     // Increment probability to compare to cutoff
     prob += sigma;
     if (prob > cutoff) {
       // Save which nuclide particle had collision with for tally purpose
-      p->event_nuclide_ = mat->nuclide_[i];
+      p.event_nuclide_ = mat->nuclide_[i];
 
       return i_element;
     }
   }
 
   // If we made it here, no element was sampled
-  p->write_restart();
+  p.write_restart();
   fatal_error("Did not sample any element during collision.");
 }
 
-Reaction* sample_fission(int i_nuclide, Particle* p)
+Reaction* sample_fission(int i_nuclide, Particle& p)
 {
   // Get pointer to nuclide
   const auto& nuc {data::nuclides[i_nuclide]};
@@ -506,23 +506,23 @@ Reaction* sample_fission(int i_nuclide, Particle* p)
   // If we're in the URR, by default use the first fission reaction. We also
   // default to the first reaction if we know that there are no partial fission
   // reactions
-  if (p->neutron_xs_[i_nuclide].use_ptable || !nuc->has_partial_fission_) {
+  if (p.neutron_xs_[i_nuclide].use_ptable || !nuc->has_partial_fission_) {
     return nuc->fission_rx_[0];
   }
 
   // Check to see if we are in a windowed multipole range.  WMP only supports
   // the first fission reaction.
   if (nuc->multipole_) {
-    if (p->E_ >= nuc->multipole_->E_min_ && p->E_ <= nuc->multipole_->E_max_) {
+    if (p.E_ >= nuc->multipole_->E_min_ && p.E_ <= nuc->multipole_->E_max_) {
       return nuc->fission_rx_[0];
     }
   }
 
   // Get grid index and interpolatoin factor and sample fission cdf
-  int i_temp = p->neutron_xs_[i_nuclide].index_temp;
-  int i_grid = p->neutron_xs_[i_nuclide].index_grid;
-  double f = p->neutron_xs_[i_nuclide].interp_factor;
-  double cutoff = prn(p->current_seed()) * p->neutron_xs_[i_nuclide].fission;
+  int i_temp = p.neutron_xs_[i_nuclide].index_temp;
+  int i_grid = p.neutron_xs_[i_nuclide].index_grid;
+  double f = p.neutron_xs_[i_nuclide].interp_factor;
+  double cutoff = prn(p.current_seed()) * p.neutron_xs_[i_nuclide].fission;
   double prob = 0.0;
 
   // Loop through each partial fission reaction type
@@ -543,13 +543,13 @@ Reaction* sample_fission(int i_nuclide, Particle* p)
   throw std::runtime_error{"No fission reaction was sampled for " + nuc->name_};
 }
 
-void sample_photon_product(int i_nuclide, Particle* p, int* i_rx, int* i_product)
+void sample_photon_product(int i_nuclide, Particle& p, int* i_rx, int* i_product)
 {
   // Get grid index and interpolation factor and sample photon production cdf
-  int i_temp = p->neutron_xs_[i_nuclide].index_temp;
-  int i_grid = p->neutron_xs_[i_nuclide].index_grid;
-  double f = p->neutron_xs_[i_nuclide].interp_factor;
-  double cutoff = prn(p->current_seed()) * p->neutron_xs_[i_nuclide].photon_prod;
+  int i_temp = p.neutron_xs_[i_nuclide].index_temp;
+  int i_grid = p.neutron_xs_[i_nuclide].index_grid;
+  double f = p.neutron_xs_[i_nuclide].interp_factor;
+  double cutoff = prn(p.current_seed()) * p.neutron_xs_[i_nuclide].photon_prod;
   double prob = 0.0;
 
   // Loop through each reaction type
@@ -568,7 +568,7 @@ void sample_photon_product(int i_nuclide, Particle* p, int* i_rx, int* i_product
     for (int j = 0; j < rx->products_.size(); ++j) {
       if (rx->products_[j].particle_ == Particle::Type::photon) {
         // add to cumulative probability
-        prob += (*rx->products_[j].yield_)(p->E_) * xs;
+        prob += (*rx->products_[j].yield_)(p.E_) * xs;
 
         *i_rx = i;
         *i_product = j;
@@ -578,59 +578,59 @@ void sample_photon_product(int i_nuclide, Particle* p, int* i_rx, int* i_product
   }
 }
 
-void absorption(Particle* p, int i_nuclide)
+void absorption(Particle& p, int i_nuclide)
 {
   if (settings::survival_biasing) {
     // Determine weight absorbed in survival biasing
-    p->wgt_absorb_ = p->wgt_ * p->neutron_xs_[i_nuclide].absorption /
-          p->neutron_xs_[i_nuclide].total;
+    p.wgt_absorb_ = p.wgt_ * p.neutron_xs_[i_nuclide].absorption /
+          p.neutron_xs_[i_nuclide].total;
 
     // Adjust weight of particle by probability of absorption
-    p->wgt_ -= p->wgt_absorb_;
-    p->wgt_last_ = p->wgt_;
+    p.wgt_ -= p.wgt_absorb_;
+    p.wgt_last_ = p.wgt_;
 
     // Score implicit absorption estimate of keff
     if (settings::run_mode == RunMode::EIGENVALUE) {
-      p->keff_tally_absorption_ += p->wgt_absorb_ * p->neutron_xs_[
-        i_nuclide].nu_fission / p->neutron_xs_[i_nuclide].absorption;
+      p.keff_tally_absorption_ += p.wgt_absorb_ * p.neutron_xs_[
+        i_nuclide].nu_fission / p.neutron_xs_[i_nuclide].absorption;
     }
   } else {
     // See if disappearance reaction happens
-    if (p->neutron_xs_[i_nuclide].absorption >
-        prn(p->current_seed()) * p->neutron_xs_[i_nuclide].total) {
+    if (p.neutron_xs_[i_nuclide].absorption >
+        prn(p.current_seed()) * p.neutron_xs_[i_nuclide].total) {
       // Score absorption estimate of keff
       if (settings::run_mode == RunMode::EIGENVALUE) {
-        p->keff_tally_absorption_ += p->wgt_ * p->neutron_xs_[
-          i_nuclide].nu_fission / p->neutron_xs_[i_nuclide].absorption;
+        p.keff_tally_absorption_ += p.wgt_ * p.neutron_xs_[
+          i_nuclide].nu_fission / p.neutron_xs_[i_nuclide].absorption;
       }
 
-      p->alive_ = false;
-      p->event_ = TallyEvent::ABSORB;
-      p->event_mt_ = N_DISAPPEAR;
+      p.alive_ = false;
+      p.event_ = TallyEvent::ABSORB;
+      p.event_mt_ = N_DISAPPEAR;
     }
   }
 }
 
-void scatter(Particle* p, int i_nuclide)
+void scatter(Particle& p, int i_nuclide)
 {
   // copy incoming direction
-  Direction u_old {p->u()};
+  Direction u_old {p.u()};
 
   // Get pointer to nuclide and grid index/interpolation factor
   const auto& nuc {data::nuclides[i_nuclide]};
-  const auto& micro {p->neutron_xs_[i_nuclide]};
+  const auto& micro {p.neutron_xs_[i_nuclide]};
   int i_temp =  micro.index_temp;
   int i_grid =  micro.index_grid;
   double f = micro.interp_factor;
 
   // For tallying purposes, this routine might be called directly. In that
   // case, we need to sample a reaction via the cutoff variable
-  double cutoff = prn(p->current_seed()) * (micro.total - micro.absorption);
+  double cutoff = prn(p.current_seed()) * (micro.total - micro.absorption);
   bool sampled = false;
 
   // Calculate elastic cross section if it wasn't precalculated
   if (micro.elastic == CACHE_INVALID) {
-    nuc->calculate_elastic_xs(*p);
+    nuc->calculate_elastic_xs(p);
   }
 
   double prob = micro.elastic - micro.thermal;
@@ -639,12 +639,12 @@ void scatter(Particle* p, int i_nuclide)
     // NON-S(A,B) ELASTIC SCATTERING
 
     // Determine temperature
-    double kT = nuc->multipole_ ? p->sqrtkT_*p->sqrtkT_ : nuc->kTs_[i_temp];
+    double kT = nuc->multipole_ ? p.sqrtkT_*p.sqrtkT_ : nuc->kTs_[i_temp];
 
     // Perform collision physics for elastic scattering
     elastic_scatter(i_nuclide, *nuc->reactions_[0], kT, p);
 
-    p->event_mt_ = ELASTIC;
+    p.event_mt_ = ELASTIC;
     sampled = true;
   }
 
@@ -655,7 +655,7 @@ void scatter(Particle* p, int i_nuclide)
 
     sab_scatter(i_nuclide, micro.index_sab, p);
 
-    p->event_mt_ = ELASTIC;
+    p.event_mt_ = ELASTIC;
     sampled = true;
   }
 
@@ -671,7 +671,7 @@ void scatter(Particle* p, int i_nuclide)
 
       // Check to make sure inelastic scattering reaction sampled
       if (i >= nuc->reactions_.size()) {
-        p->write_restart();
+        p.write_restart();
         fatal_error("Did not sample any reaction for nuclide " + nuc->name_);
       }
 
@@ -687,47 +687,47 @@ void scatter(Particle* p, int i_nuclide)
     // Perform collision physics for inelastic scattering
     const auto& rx {nuc->reactions_[i]};
     inelastic_scatter(nuc.get(), rx.get(), p);
-    p->event_mt_ = rx->mt_;
+    p.event_mt_ = rx->mt_;
   }
 
   // Set event component
-  p->event_ = TallyEvent::SCATTER;
+  p.event_ = TallyEvent::SCATTER;
 
   // Sample new outgoing angle for isotropic-in-lab scattering
-  const auto& mat {model::materials[p->material_]};
+  const auto& mat {model::materials[p.material_]};
   if (!mat->p0_.empty()) {
     int i_nuc_mat = mat->mat_nuclide_index_[i_nuclide];
     if (mat->p0_[i_nuc_mat]) {
       // Sample isotropic-in-lab outgoing direction
-      double mu = 2.0*prn(p->current_seed()) - 1.0;
-      double phi = 2.0*PI*prn(p->current_seed());
+      double mu = 2.0*prn(p.current_seed()) - 1.0;
+      double phi = 2.0*PI*prn(p.current_seed());
 
       // Change direction of particle
-      p->u().x = mu;
-      p->u().y = std::sqrt(1.0 - mu*mu)*std::cos(phi);
-      p->u().z = std::sqrt(1.0 - mu*mu)*std::sin(phi);
-      p->mu_ = u_old.dot(p->u());
+      p.u().x = mu;
+      p.u().y = std::sqrt(1.0 - mu*mu)*std::cos(phi);
+      p.u().z = std::sqrt(1.0 - mu*mu)*std::sin(phi);
+      p.mu_ = u_old.dot(p.u());
     }
   }
 }
 
 void elastic_scatter(int i_nuclide, const Reaction& rx, double kT,
-  Particle* p)
+  Particle& p)
 {
   // get pointer to nuclide
   const auto& nuc {data::nuclides[i_nuclide]};
 
-  double vel = std::sqrt(p->E_);
+  double vel = std::sqrt(p.E_);
   double awr = nuc->awr_;
 
   // Neutron velocity in LAB
-  Direction v_n = vel*p->u();
+  Direction v_n = vel*p.u();
 
   // Sample velocity of target nucleus
   Direction v_t {};
-  if (!p->neutron_xs_[i_nuclide].use_ptable) {
-    v_t = sample_target_velocity(nuc.get(), p->E_, p->u(), v_n,
-      p->neutron_xs_[i_nuclide].elastic, kT, p->current_seed());
+  if (!p.neutron_xs_[i_nuclide].use_ptable) {
+    v_t = sample_target_velocity(nuc.get(), p.E_, p.u(), v_n,
+      p.neutron_xs_[i_nuclide].elastic, kT, p.current_seed());
   }
 
   // Velocity of center-of-mass
@@ -745,9 +745,9 @@ void elastic_scatter(int i_nuclide, const Reaction& rx, double kT,
   auto& d = rx.products_[0].distribution_[0];
   auto d_ = dynamic_cast<UncorrelatedAngleEnergy*>(d.get());
   if (!d_->angle().empty()) {
-    mu_cm = d_->angle().sample(p->E_, p->current_seed());
+    mu_cm = d_->angle().sample(p.E_, p.current_seed());
   } else {
-    mu_cm = 2.0*prn(p->current_seed()) - 1.0;
+    mu_cm = 2.0*prn(p.current_seed()) - 1.0;
   }
 
   // Determine direction cosines in CM
@@ -756,40 +756,40 @@ void elastic_scatter(int i_nuclide, const Reaction& rx, double kT,
   // Rotate neutron velocity vector to new angle -- note that the speed of the
   // neutron in CM does not change in elastic scattering. However, the speed
   // will change when we convert back to LAB
-  v_n = vel * rotate_angle(u_cm, mu_cm, nullptr, p->current_seed());
+  v_n = vel * rotate_angle(u_cm, mu_cm, nullptr, p.current_seed());
 
   // Transform back to LAB frame
   v_n += v_cm;
 
-  p->E_ = v_n.dot(v_n);
-  vel = std::sqrt(p->E_);
+  p.E_ = v_n.dot(v_n);
+  vel = std::sqrt(p.E_);
 
   // compute cosine of scattering angle in LAB frame by taking dot product of
   // neutron's pre- and post-collision angle
-  p->mu_ = p->u().dot(v_n) / vel;
+  p.mu_ = p.u().dot(v_n) / vel;
 
   // Set energy and direction of particle in LAB frame
-  p->u() = v_n / vel;
+  p.u() = v_n / vel;
 
   // Because of floating-point roundoff, it may be possible for mu_lab to be
   // outside of the range [-1,1). In these cases, we just set mu_lab to exactly
   // -1 or 1
-  if (std::abs(p->mu_) > 1.0) p->mu_ = std::copysign(1.0, p->mu_);
+  if (std::abs(p.mu_) > 1.0) p.mu_ = std::copysign(1.0, p.mu_);
 }
 
-void sab_scatter(int i_nuclide, int i_sab, Particle* p)
+void sab_scatter(int i_nuclide, int i_sab, Particle& p)
 {
   // Determine temperature index
-  const auto& micro {p->neutron_xs_[i_nuclide]};
+  const auto& micro {p.neutron_xs_[i_nuclide]};
   int i_temp = micro.index_temp_sab;
 
   // Sample energy and angle
   double E_out;
-  data::thermal_scatt[i_sab]->data_[i_temp].sample(micro, p->E_, &E_out, &p->mu_, p->current_seed());
+  data::thermal_scatt[i_sab]->data_[i_temp].sample(micro, p.E_, &E_out, &p.mu_, p.current_seed());
 
   // Set energy to outgoing, change direction of particle
-  p->E_ = E_out;
-  p->u() = rotate_angle(p->u(), p->mu_, nullptr, p->current_seed());
+  p.E_ = E_out;
+  p.u() = rotate_angle(p.u(), p.mu_, nullptr, p.current_seed());
 }
 
 Direction sample_target_velocity(const Nuclide* nuc, double E, Direction u,
@@ -1085,15 +1085,15 @@ void sample_fission_neutron(int i_nuclide, const Reaction* rx, double E_in, Part
   }
 }
 
-void inelastic_scatter(const Nuclide* nuc, const Reaction* rx, Particle* p)
+void inelastic_scatter(const Nuclide* nuc, const Reaction* rx, Particle& p)
 {
   // copy energy of neutron
-  double E_in = p->E_;
+  double E_in = p.E_;
 
   // sample outgoing energy and scattering cosine
   double E;
   double mu;
-  rx->products_[0].sample(E_in, E, mu, p->current_seed());
+  rx->products_[0].sample(E_in, E, mu, p.current_seed());
 
   // if scattering system is in center-of-mass, transfer cosine of scattering
   // angle and outgoing energy from CM to LAB
@@ -1115,32 +1115,32 @@ void inelastic_scatter(const Nuclide* nuc, const Reaction* rx, Particle* p)
   if (std::abs(mu) > 1.0) mu = std::copysign(1.0, mu);
 
   // Set outgoing energy and scattering angle
-  p->E_ = E;
-  p->mu_ = mu;
+  p.E_ = E;
+  p.mu_ = mu;
 
   // change direction of particle
-  p->u() = rotate_angle(p->u(), mu, nullptr, p->current_seed());
+  p.u() = rotate_angle(p.u(), mu, nullptr, p.current_seed());
 
   // evaluate yield
   double yield = (*rx->products_[0].yield_)(E_in);
   if (std::floor(yield) == yield) {
     // If yield is integral, create exactly that many secondary particles
     for (int i = 0; i < static_cast<int>(std::round(yield)) - 1; ++i) {
-      p->create_secondary(p->u(), p->E_, Particle::Type::neutron);
+      p.create_secondary(p.u(), p.E_, Particle::Type::neutron);
     }
   } else {
     // Otherwise, change weight of particle based on yield
-    p->wgt_ *= yield;
+    p.wgt_ *= yield;
   }
 }
 
-void sample_secondary_photons(Particle* p, int i_nuclide)
+void sample_secondary_photons(Particle& p, int i_nuclide)
 {
   // Sample the number of photons produced
-  double y_t = p->wgt_ * p->neutron_xs_[i_nuclide].photon_prod /
-    p->neutron_xs_[i_nuclide].total;
+  double y_t = p.wgt_ * p.neutron_xs_[i_nuclide].photon_prod /
+    p.neutron_xs_[i_nuclide].total;
   int y = static_cast<int>(y_t);
-  if (prn(p->current_seed()) <= y_t - y) ++y;
+  if (prn(p.current_seed()) <= y_t - y) ++y;
 
   // Sample each secondary photon
   for (int i = 0; i < y; ++i) {
@@ -1153,13 +1153,13 @@ void sample_secondary_photons(Particle* p, int i_nuclide)
     auto& rx = data::nuclides[i_nuclide]->reactions_[i_rx];
     double E;
     double mu;
-    rx->products_[i_product].sample(p->E_, E, mu, p->current_seed());
+    rx->products_[i_product].sample(p.E_, E, mu, p.current_seed());
 
     // Sample the new direction
-    Direction u = rotate_angle(p->u(), mu, nullptr, p->current_seed());
+    Direction u = rotate_angle(p.u(), mu, nullptr, p.current_seed());
 
     // Create the secondary photon
-    p->create_secondary(u, E, Particle::Type::photon);
+    p.create_secondary(u, E, Particle::Type::photon);
   }
 }
 

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -38,7 +38,7 @@ void collision(Particle& p)
   ++(p.n_collision_);
 
   // Sample reaction for the material the particle is in
-  switch (static_cast<Particle::Type>(p.type_)) {
+  switch (p.type_) {
   case Particle::Type::neutron:
     sample_neutron_reaction(p);
     break;

--- a/src/physics_common.cpp
+++ b/src/physics_common.cpp
@@ -9,16 +9,16 @@ namespace openmc {
 // RUSSIAN_ROULETTE
 //==============================================================================
 
-void russian_roulette(Particle* p)
+void russian_roulette(Particle& p)
 {
-  if (p->wgt_ < settings::weight_cutoff) {
-    if (prn(p->current_seed()) < p->wgt_ / settings::weight_survive) {
-      p->wgt_ = settings::weight_survive;
-      p->wgt_last_ = p->wgt_;
+  if (p.wgt_ < settings::weight_cutoff) {
+    if (prn(p.current_seed()) < p.wgt_ / settings::weight_survive) {
+      p.wgt_ = settings::weight_survive;
+      p.wgt_last_ = p.wgt_;
     } else {
-      p->wgt_ = 0.;
-      p->wgt_last_ = 0.;
-      p->alive_ = false;
+      p.wgt_ = 0.;
+      p.wgt_last_ = 0.;
+      p.alive_ = false;
     }
   }
 }

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -92,7 +92,7 @@ create_fission_sites(Particle* p)
 {
   // If uniform fission source weighting is turned on, we increase or decrease
   // the expected number of fission sites produced
-  double weight = settings::ufs_on ? ufs_get_weight(p) : 1.0;
+  double weight = settings::ufs_on ? ufs_get_weight(*p) : 1.0;
 
   // Determine the expected number of neutrons produced
   double nu_t = p->wgt_ / simulation::keff * weight *

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -22,29 +22,29 @@
 namespace openmc {
 
 void
-collision_mg(Particle* p)
+collision_mg(Particle& p)
 {
   // Add to the collision counter for the particle
-  p->n_collision_++;
+  p.n_collision_++;
 
   // Sample the reaction type
   sample_reaction(p);
 
   // Display information about collision
-  if ((settings::verbosity >= 10) || p->trace_) {
-    write_message(fmt::format("    Energy Group = {}", p->g_), 1);
+  if ((settings::verbosity >= 10) || p.trace_) {
+    write_message(fmt::format("    Energy Group = {}", p.g_), 1);
   }
 }
 
 void
-sample_reaction(Particle* p)
+sample_reaction(Particle& p)
 {
   // Create fission bank sites. Note that while a fission reaction is sampled,
   // it never actually "happens", i.e. the weight of the particle does not
   // change when sampling fission sites. The following block handles all
   // absorption (including fission)
 
-  if (model::materials[p->material_]->fissionable_) {
+  if (model::materials[p.material_]->fissionable_) {
     if (settings::run_mode == RunMode::EIGENVALUE  ||
        (settings::run_mode == RunMode::FIXED_SOURCE &&
         settings::create_fission_neutrons)) {
@@ -54,12 +54,12 @@ sample_reaction(Particle* p)
 
   // If survival biasing is being used, the following subroutine adjusts the
   // weight of the particle. Otherwise, it checks to see if absorption occurs.
-  if (p->macro_xs_.absorption > 0.) {
+  if (p.macro_xs_.absorption > 0.) {
     absorption(p);
   } else {
-    p->wgt_absorb_ = 0.;
+    p.wgt_absorb_ = 0.;
   }
-  if (!p->alive_) return;
+  if (!p.alive_) return;
 
   // Sample a scattering event to determine the energy of the exiting neutron
   scatter(p);
@@ -67,40 +67,40 @@ sample_reaction(Particle* p)
   // Play Russian roulette if survival biasing is turned on
   if (settings::survival_biasing) {
     russian_roulette(p);
-    if (!p->alive_) return;
+    if (!p.alive_) return;
   }
 }
 
 void
-scatter(Particle* p)
+scatter(Particle& p)
 {
-  data::mg.macro_xs_[p->material_].sample_scatter(p->g_last_, p->g_, p->mu_,
-                                                  p->wgt_, p->current_seed());
+  data::mg.macro_xs_[p.material_].sample_scatter(p.g_last_, p.g_, p.mu_,
+                                                  p.wgt_, p.current_seed());
 
   // Rotate the angle
-  p->u() = rotate_angle(p->u(), p->mu_, nullptr, p->current_seed());
+  p.u() = rotate_angle(p.u(), p.mu_, nullptr, p.current_seed());
 
   // Update energy value for downstream compatability (in tallying)
-  p->E_ = data::mg.energy_bin_avg_[p->g_];
+  p.E_ = data::mg.energy_bin_avg_[p.g_];
 
   // Set event component
-  p->event_ = TallyEvent::SCATTER;
+  p.event_ = TallyEvent::SCATTER;
 }
 
 void
-create_fission_sites(Particle* p)
+create_fission_sites(Particle& p)
 {
   // If uniform fission source weighting is turned on, we increase or decrease
   // the expected number of fission sites produced
-  double weight = settings::ufs_on ? ufs_get_weight(*p) : 1.0;
+  double weight = settings::ufs_on ? ufs_get_weight(p) : 1.0;
 
   // Determine the expected number of neutrons produced
-  double nu_t = p->wgt_ / simulation::keff * weight *
-       p->macro_xs_.nu_fission / p->macro_xs_.total;
+  double nu_t = p.wgt_ / simulation::keff * weight *
+       p.macro_xs_.nu_fission / p.macro_xs_.total;
 
   // Sample the number of neutrons produced
   int nu = static_cast<int>(nu_t);
-  if (prn(p->current_seed()) <= (nu_t - int(nu_t))) {
+  if (prn(p.current_seed()) <= (nu_t - int(nu_t))) {
     nu++;
   }
 
@@ -113,9 +113,9 @@ create_fission_sites(Particle* p)
   double nu_d[MAX_DELAYED_GROUPS] = {0.};
 
   // Clear out particle's nu fission bank
-  p->nu_bank_.clear();
+  p.nu_bank_.clear();
 
-  p->fission_ = true;
+  p.fission_ = true;
   int skipped = 0;
 
   // Determine whether to place fission sites into the shared fission bank
@@ -125,18 +125,18 @@ create_fission_sites(Particle* p)
   for (int i = 0; i < nu; ++i) {
     // Initialize fission site object with particle data
     Particle::Bank site;
-    site.r = p->r();
+    site.r = p.r();
     site.particle = Particle::Type::neutron;
     site.wgt = 1. / weight;
-    site.parent_id = p->id_;
-    site.progeny_id = p->n_progeny_++;
+    site.parent_id = p.id_;
+    site.progeny_id = p.n_progeny_++;
 
     // Sample the cosine of the angle, assuming fission neutrons are emitted
     // isotropically
-    double mu = 2.*prn(p->current_seed()) - 1.;
+    double mu = 2.*prn(p.current_seed()) - 1.;
 
     // Sample the azimuthal angle uniformly in [0, 2.pi)
-    double phi = 2. * PI * prn(p->current_seed() );
+    double phi = 2. * PI * prn(p.current_seed() );
     site.u.x = mu;
     site.u.y = std::sqrt(1. - mu * mu) * std::cos(phi);
     site.u.z = std::sqrt(1. - mu * mu) * std::sin(phi);
@@ -144,8 +144,8 @@ create_fission_sites(Particle* p)
     // Sample secondary energy distribution for the fission reaction
     int dg;
     int gout;
-    data::mg.macro_xs_[p->material_].sample_fission_energy(p->g_, dg, gout,
-      p->current_seed());
+    data::mg.macro_xs_[p.material_].sample_fission_energy(p.g_, dg, gout,
+      p.current_seed());
 
     // Store the energy and delayed groups on the fission bank
     site.E = gout;
@@ -164,21 +164,21 @@ create_fission_sites(Particle* p)
         break;
       }
     } else {
-      p->secondary_bank_.push_back(site);
+      p.secondary_bank_.push_back(site);
     }
 
     // Set the delayed group on the particle as well
-    p->delayed_group_ = dg + 1;
+    p.delayed_group_ = dg + 1;
 
     // Increment the number of neutrons born delayed
-    if (p->delayed_group_ > 0) {
+    if (p.delayed_group_ > 0) {
       nu_d[dg]++;
     }
 
     // Write fission particles to nuBank
     if (use_fission_bank) {
-      p->nu_bank_.emplace_back();
-      Particle::NuBank* nu_bank_entry = &p->nu_bank_.back();
+      p.nu_bank_.emplace_back();
+      Particle::NuBank* nu_bank_entry = &p.nu_bank_.back();
       nu_bank_entry->wgt              = site.wgt;
       nu_bank_entry->E                = site.E;
       nu_bank_entry->delayed_group    = site.delayed_group;
@@ -188,7 +188,7 @@ create_fission_sites(Particle* p)
   // If shared fission bank was full, and no fissions could be added,
   // set the particle fission flag to false.
   if (nu == skipped) {
-    p->fission_ = false;
+    p.fission_ = false;
     return;
   }
 
@@ -197,33 +197,33 @@ create_fission_sites(Particle* p)
   nu -= skipped;
 
   // Store the total weight banked for analog fission tallies
-  p->n_bank_ = nu;
-  p->wgt_bank_ = nu / weight;
+  p.n_bank_ = nu;
+  p.wgt_bank_ = nu / weight;
   for (size_t d = 0; d < MAX_DELAYED_GROUPS; d++) {
-    p->n_delayed_bank_[d] = nu_d[d];
+    p.n_delayed_bank_[d] = nu_d[d];
   }
 }
 
 void
-absorption(Particle* p)
+absorption(Particle& p)
 {
   if (settings::survival_biasing) {
     // Determine weight absorbed in survival biasing
-    p->wgt_absorb_ = p->wgt_ * p->macro_xs_.absorption / p->macro_xs_.total;
+    p.wgt_absorb_ = p.wgt_ * p.macro_xs_.absorption / p.macro_xs_.total;
 
     // Adjust weight of particle by the probability of absorption
-    p->wgt_ -= p->wgt_absorb_;
-    p->wgt_last_ = p->wgt_;
+    p.wgt_ -= p.wgt_absorb_;
+    p.wgt_last_ = p.wgt_;
 
     // Score implicit absorpion estimate of keff
-    p->keff_tally_absorption_ += p->wgt_absorb_ * p->macro_xs_.nu_fission /
-        p->macro_xs_.absorption;
+    p.keff_tally_absorption_ += p.wgt_absorb_ * p.macro_xs_.nu_fission /
+        p.macro_xs_.absorption;
   } else {
-    if (p->macro_xs_.absorption > prn(p->current_seed()) * p->macro_xs_.total) {
-      p->keff_tally_absorption_ += p->wgt_ * p->macro_xs_.nu_fission /
-           p->macro_xs_.absorption;
-      p->alive_ = false;
-      p->event_ = TallyEvent::ABSORB;
+    if (p.macro_xs_.absorption > prn(p.current_seed()) * p.macro_xs_.total) {
+      p.keff_tally_absorption_ += p.wgt_ * p.macro_xs_.nu_fission /
+           p.macro_xs_.absorption;
+      p.alive_ = false;
+      p.event_ = TallyEvent::ABSORB;
     }
 
   }

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -1,6 +1,7 @@
 #include "openmc/reaction.h"
 
 #include <string>
+#include <unordered_map>
 #include <utility> // for move
 
 #include <fmt/core.h>
@@ -86,190 +87,118 @@ Reaction::Reaction(hid_t group, const std::vector<int>& temperatures)
 // Non-member functions
 //==============================================================================
 
+const std::unordered_map<int, std::string> REACTION_NAME_MAP {
+  {SCORE_FLUX, "flux"},
+  {SCORE_TOTAL, "total"},
+  {SCORE_SCATTER, "scatter"},
+  {SCORE_NU_SCATTER, "nu-scatter"},
+  {SCORE_ABSORPTION, "absorption"},
+  {SCORE_FISSION, "fission"},
+  {SCORE_NU_FISSION, "nu-fission"},
+  {SCORE_DECAY_RATE, "decay-rate"},
+  {SCORE_DELAYED_NU_FISSION, "delayed-nu-fission"},
+  {SCORE_PROMPT_NU_FISSION, "prompt-nu-fission"},
+  {SCORE_KAPPA_FISSION, "kappa-fission"},
+  {SCORE_CURRENT, "current"},
+  {SCORE_EVENTS, "events"},
+  {SCORE_INVERSE_VELOCITY, "inverse-velocity"},
+  {SCORE_FISS_Q_PROMPT, "fission-q-prompt"},
+  {SCORE_FISS_Q_RECOV, "fission-q-recoverable"},
+  // Normal ENDF-based reactions
+  {TOTAL_XS, "(n,total)"},
+  {ELASTIC, "(n,elastic)"},
+  {N_LEVEL, "(n,level)"},
+  {N_2ND, "(n,2nd)"},
+  {N_2N, "(n,2n)"},
+  {N_3N, "(n,3n)"},
+  {N_FISSION, "(n,fission)"},
+  {N_F, "(n,f)"},
+  {N_NF, "(n,nf)"},
+  {N_2NF, "(n,2nf)"},
+  {N_NA, "(n,na)"},
+  {N_N3A, "(n,n3a)"},
+  {N_2NA, "(n,2na)"},
+  {N_3NA, "(n,3na)"},
+  {N_NP, "(n,np)"},
+  {N_N2A, "(n,n2a)"},
+  {N_2N2A, "(n,2n2a)"},
+  {N_ND, "(n,nd)"},
+  {N_NT, "(n,nt)"},
+  {N_N3HE, "(n,nHe-3)"},
+  {N_ND2A, "(n,nd2a)"},
+  {N_NT2A, "(n,nt2a)"},
+  {N_4N, "(n,4n)"},
+  {N_3NF, "(n,3nf)"},
+  {N_2NP, "(n,2np)"},
+  {N_3NP, "(n,3np)"},
+  {N_N2P, "(n,n2p)"},
+  {N_NPA, "(n,npa)"},
+  {N_NC, "(n,nc)"},
+  {N_DISAPPEAR, "(n,disappear)"},
+  {N_GAMMA, "(n,gamma)"},
+  {N_P, "(n,p)"},
+  {N_D, "(n,d)"},
+  {N_T, "(n,t)"},
+  {N_3HE, "(n,3He)"},
+  {N_A, "(n,a)"},
+  {N_2A, "(n,2a)"},
+  {N_3A, "(n,3a)"},
+  {N_2P, "(n,2p)"},
+  {N_PA, "(n,pa)"},
+  {N_T2A, "(n,t2a)"},
+  {N_D2A, "(n,d2a)"},
+  {N_PD, "(n,pd)"},
+  {N_PT, "(n,pt)"},
+  {N_DA, "(n,da)"},
+  {201, "(n,Xn)"},
+  {202, "(n,Xgamma)"},
+  {N_XP, "(n,Xp)"},
+  {N_XD, "(n,Xd)"},
+  {N_XT, "(n,Xt)"},
+  {N_X3HE, "(n,X3He)"},
+  {N_XA, "(n,Xa)"},
+  {HEATING, "heating"},
+  {DAMAGE_ENERGY, "damage-energy"},
+  {COHERENT, "coherent scatter"},
+  {INCOHERENT, "incoherent scatter"},
+  {PAIR_PROD_ELEC, "pair production, electron"},
+  {PAIR_PROD, "pair production"},
+  {PAIR_PROD_NUC, "pair production, nuclear"},
+  {PHOTOELECTRIC, "photoelectric"},
+  {N_PC, "(n,pc)"},
+  {N_DC, "(n,dc)"},
+  {N_TC, "(n,tc)"},
+  {N_3HEC, "(n,3Hec)"},
+  {N_AC, "(n,ac)"},
+  {N_2NC, "(n,2nc)"},
+  {HEATING_LOCAL, "heating-local"},
+};
+
 std::string reaction_name(int mt)
 {
-  if (mt == SCORE_FLUX) {
-    return "flux";
-  } else if (mt == SCORE_TOTAL) {
-    return "total";
-  } else if (mt == SCORE_SCATTER) {
-    return "scatter";
-  } else if (mt == SCORE_NU_SCATTER) {
-    return "nu-scatter";
-  } else if (mt == SCORE_ABSORPTION) {
-    return "absorption";
-  } else if (mt == SCORE_FISSION) {
-    return "fission";
-  } else if (mt == SCORE_NU_FISSION) {
-    return "nu-fission";
-  } else if (mt == SCORE_DECAY_RATE) {
-    return "decay-rate";
-  } else if (mt == SCORE_DELAYED_NU_FISSION) {
-    return "delayed-nu-fission";
-  } else if (mt == SCORE_PROMPT_NU_FISSION) {
-    return "prompt-nu-fission";
-  } else if (mt == SCORE_KAPPA_FISSION) {
-    return "kappa-fission";
-  } else if (mt == SCORE_CURRENT) {
-    return "current";
-  } else if (mt == SCORE_EVENTS) {
-    return "events";
-  } else if (mt == SCORE_INVERSE_VELOCITY) {
-    return "inverse-velocity";
-  } else if (mt == SCORE_FISS_Q_PROMPT) {
-    return "fission-q-prompt";
-  } else if (mt == SCORE_FISS_Q_RECOV) {
-    return "fission-q-recoverable";
-
-  // Normal ENDF-based reactions
-  } else if (mt == TOTAL_XS) {
-    return "(n,total)";
-  } else if (mt == ELASTIC) {
-    return "(n,elastic)";
-  } else if (mt == N_LEVEL) {
-    return "(n,level)";
-  } else if (mt == N_2ND) {
-    return "(n,2nd)";
-  } else if (mt == N_2N) {
-    return "(n,2n)";
-  } else if (mt == N_3N) {
-    return "(n,3n)";
-  } else if (mt == N_FISSION) {
-    return "(n,fission)";
-  } else if (mt == N_F) {
-    return "(n,f)";
-  } else if (mt == N_NF) {
-    return "(n,nf)";
-  } else if (mt == N_2NF) {
-    return "(n,2nf)";
-  } else if (mt == N_NA) {
-    return "(n,na)";
-  } else if (mt == N_N3A) {
-    return "(n,n3a)";
-  } else if (mt == N_2NA) {
-    return "(n,2na)";
-  } else if (mt == N_3NA) {
-    return "(n,3na)";
-  } else if (mt == N_NP) {
-    return "(n,np)";
-  } else if (mt == N_N2A) {
-    return "(n,n2a)";
-  } else if (mt == N_2N2A) {
-    return "(n,2n2a)";
-  } else if (mt == N_ND) {
-    return "(n,nd)";
-  } else if (mt == N_NT) {
-    return "(n,nt)";
-  } else if (mt == N_N3HE) {
-    return "(n,nHe-3)";
-  } else if (mt == N_ND2A) {
-    return "(n,nd2a)";
-  } else if (mt == N_NT2A) {
-    return "(n,nt2a)";
-  } else if (mt == N_4N) {
-    return "(n,4n)";
-  } else if (mt == N_3NF) {
-    return "(n,3nf)";
-  } else if (mt == N_2NP) {
-    return "(n,2np)";
-  } else if (mt == N_3NP) {
-    return "(n,3np)";
-  } else if (mt == N_N2P) {
-    return "(n,n2p)";
-  } else if (mt == N_NPA) {
-    return "(n,npa)";
-  } else if (N_N1 <= mt && mt <= N_N40) {
+  if (N_N1 <= mt && mt <= N_N40) {
     return fmt::format("(n,n{})", mt - 50);
-  } else if (mt == N_NC) {
-    return "(n,nc)";
-  } else if (mt == N_DISAPPEAR) {
-    return "(n,disappear)";
-  } else if (mt == N_GAMMA) {
-    return "(n,gamma)";
-  } else if (mt == N_P) {
-    return "(n,p)";
-  } else if (mt == N_D) {
-    return "(n,d)";
-  } else if (mt == N_T) {
-    return "(n,t)";
-  } else if (mt == N_3HE) {
-    return "(n,3He)";
-  } else if (mt == N_A) {
-    return "(n,a)";
-  } else if (mt == N_2A) {
-    return "(n,2a)";
-  } else if (mt == N_3A) {
-    return "(n,3a)";
-  } else if (mt == N_2P) {
-    return "(n,2p)";
-  } else if (mt == N_PA) {
-    return "(n,pa)";
-  } else if (mt == N_T2A) {
-    return "(n,t2a)";
-  } else if (mt == N_D2A) {
-    return "(n,d2a)";
-  } else if (mt == N_PD) {
-    return "(n,pd)";
-  } else if (mt == N_PT) {
-    return "(n,pt)";
-  } else if (mt == N_DA) {
-    return "(n,da)";
-  } else if (mt == 201) {
-    return "(n,Xn)";
-  } else if (mt == 202) {
-    return "(n,Xgamma)";
-  } else if (mt == N_XP) {
-    return "(n,Xp)";
-  } else if (mt == N_XD) {
-    return "(n,Xd)";
-  } else if (mt == N_XT) {
-    return "(n,Xt)";
-  } else if (mt == N_X3HE) {
-    return "(n,X3He)";
-  } else if (mt == N_XA) {
-    return "(n,Xa)";
-  } else if (mt == HEATING) {
-    return "heating";
-  } else if (mt == DAMAGE_ENERGY) {
-    return "damage-energy";
-  } else if (mt == COHERENT) {
-    return "coherent scatter";
-  } else if (mt == INCOHERENT) {
-    return "incoherent scatter";
-  } else if (mt == PAIR_PROD_ELEC) {
-    return "pair production, electron";
-  } else if (mt == PAIR_PROD) {
-    return "pair production";
-  } else if (mt == PAIR_PROD_NUC) {
-    return "pair production, nuclear";
-  } else if (mt == PHOTOELECTRIC) {
-    return "photoelectric";
   } else if (534 <= mt && mt <= 572) {
     return fmt::format("photoelectric, {} subshell", SUBSHELLS[mt - 534]);
-  } else if (600 <= mt && mt <= 648) {
-    return fmt::format("(n,p{})", mt - 600);
-  } else if (mt == 649) {
-    return "(n,pc)";
-  } else if (650 <= mt && mt <= 698) {
-    return fmt::format("(n,d{})", mt - 650);
-  } else if (mt == 699) {
-    return "(n,dc)";
-  } else if (700 <= mt && mt <= 748) {
-    return fmt::format("(n,t{})", mt - 700);
-  } else if (mt == 749) {
-    return "(n,tc)";
-  } else if (750 <= mt && mt <= 798) {
-    return fmt::format("(n,3He{})", mt - 750);
-  } else if (mt == 799) {
-    return "(n,3Hec)";
-  } else if (800 <= mt && mt <= 848) {
-    return fmt::format("(n,a{})", mt - 800);
-  } else if (mt == 849) {
-    return "(n,ac)";
-  } else if (mt == HEATING_LOCAL) {
-    return "heating-local";
+  } else if (N_P0 <= mt && mt < N_PC) {
+    return fmt::format("(n,p{})", mt - N_P0);
+  } else if (N_D0 <= mt && mt < N_DC) {
+    return fmt::format("(n,d{})", mt - N_D0);
+  } else if (N_T0 <= mt && mt < N_TC) {
+    return fmt::format("(n,t{})", mt - N_T0);
+  } else if (N_3HE0 <= mt && mt < N_3HEC) {
+    return fmt::format("(n,3He{})", mt - N_3HE0);
+  } else if (N_A0 <= mt && mt < N_AC) {
+    return fmt::format("(n,a{})", mt - N_A0);
+  } else if (N_2N0 <= mt && mt < N_2NC) {
+    return fmt::format("(n,2n{})", mt - N_2N0);
   } else {
-    return fmt::format("MT={}", mt);
+    auto it = REACTION_NAME_MAP.find(mt);
+    if (it != REACTION_NAME_MAP.end()) {
+      return it->second;
+    } else {
+      return fmt::format("MT={}", mt);
+    }
   }
 }
 

--- a/src/reaction_product.cpp
+++ b/src/reaction_product.cpp
@@ -5,6 +5,7 @@
 
 #include "openmc/endf.h"
 #include "openmc/hdf5_interface.h"
+#include "openmc/particle.h"
 #include "openmc/random_lcg.h"
 #include "openmc/secondary_correlated.h"
 #include "openmc/secondary_kalbach.h"
@@ -22,11 +23,7 @@ ReactionProduct::ReactionProduct(hid_t group)
   // Read particle type
   std::string temp;
   read_attribute(group, "particle", temp);
-  if (temp == "neutron") {
-    particle_ = Particle::Type::neutron;
-  } else if (temp == "photon") {
-    particle_ = Particle::Type::photon;
-  }
+  particle_ = str_to_particle_type(temp);
 
   // Read emission mode and decay rate
   read_attribute(group, "emission_mode", temp);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -149,12 +149,12 @@ void get_run_parameters(pugi::xml_node node_base)
   // Get max number of lost particles
   if (check_for_node(node_base, "max_lost_particles")) {
     max_lost_particles = std::stoi(get_node_value(node_base, "max_lost_particles"));
-  }  
+  }
 
   // Get relative number of lost particles
   if (check_for_node(node_base, "rel_max_lost_particles")) {
     rel_max_lost_particles = std::stod(get_node_value(node_base, "rel_max_lost_particles"));
-  }    
+  }
 
   // Get number of inactive batches
   if (run_mode == RunMode::EIGENVALUE) {
@@ -192,6 +192,9 @@ void get_run_parameters(pugi::xml_node node_base)
       if (check_for_node(node_keff_trigger, "threshold")) {
         keff_trigger.threshold = std::stod(get_node_value(
           node_keff_trigger, "threshold"));
+        if (keff_trigger.threshold <= 0) {
+          fatal_error("keff trigger threshold must be positive");
+        }
       } else {
         fatal_error("Specify keff trigger threshold in settings XML");
       }
@@ -367,7 +370,7 @@ void read_settings_xml()
       fatal_error("Number of max lost particles must be greater than zero.");
     } else if (rel_max_lost_particles <= 0.0 || rel_max_lost_particles >= 1.0) {
       fatal_error("Relative max lost particles must be between zero and one.");
-    }       
+    }
   }
 
   // Copy random number seed if specified

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -345,11 +345,6 @@ void finalize_batch()
     simulation::n_realizations = 0;
   }
 
-  if (settings::run_mode == RunMode::EIGENVALUE) {
-    // Write batch output
-    if (mpi::master && settings::verbosity >= 7) print_batch_keff();
-  }
-
   // Check_triggers
   if (mpi::master) check_triggers();
 #ifdef OPENMC_MPI
@@ -442,9 +437,7 @@ void finalize_generation()
 
     // Write generation output
     if (mpi::master && settings::verbosity >= 7) {
-      if (simulation::current_gen != settings::gen_per_batch) {
-        print_generation();
-      }
+      print_generation();
     }
 
   }

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include <fmt/core.h>
+#include <gsl/gsl>
 
 #include "openmc/error.h"
 #include "openmc/dagmc.h"
@@ -276,6 +277,7 @@ Direction DAGSurface::normal(Position r) const
 
 Direction DAGSurface::reflect(Position r, Direction u, Particle* p) const
 {
+  Expects(p);
   p->history_.reset_to_last_intersection();
   p->last_dir_ = Surface::reflect(r, u, p);
   return p->last_dir_;

--- a/src/tallies/derivative.cpp
+++ b/src/tallies/derivative.cpp
@@ -42,7 +42,6 @@ TallyDerivative::TallyDerivative(pugi::xml_node node)
 
   if (variable_str == "density") {
     variable = DerivativeVariable::DENSITY;
-
   } else if (variable_str == "nuclide_density") {
     variable = DerivativeVariable::NUCLIDE_DENSITY;
 
@@ -58,10 +57,8 @@ TallyDerivative::TallyDerivative(pugi::xml_node node)
       fatal_error(fmt::format("Could not find the nuclide \"{}\" specified in "
         "derivative {} in any material.", nuclide_name, id));
     }
-
   } else if (variable_str == "temperature") {
     variable = DerivativeVariable::TEMPERATURE;
-
   } else {
     fatal_error(fmt::format("Unrecognized variable \"{}\" on derivative {}",
       variable_str, id));
@@ -562,6 +559,7 @@ score_track_derivative(Particle& p, double distance)
 {
   // A void material cannot be perturbed so it will not affect flux derivatives.
   if (p.material_ == MATERIAL_VOID) return;
+
   const Material& material {*model::materials[p.material_]};
 
   for (auto idx = 0; idx < model::tally_derivs.size(); idx++) {

--- a/src/tallies/derivative.cpp
+++ b/src/tallies/derivative.cpp
@@ -315,7 +315,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           if (material.nuclide_[i] == p.event_nuclide_) break;
 
         const auto& nuc {*data::nuclides[p.event_nuclide_]};
-        if (!multipole_in_range(&nuc, p.E_last_)) {
+        if (!multipole_in_range(nuc, p.E_last_)) {
           score *= flux_deriv;
           break;
         }
@@ -395,7 +395,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
     case TallyEstimator::COLLISION:
       if (i_nuclide != -1) {
         const auto& nuc {data::nuclides[i_nuclide]};
-        if (!multipole_in_range(nuc.get(), p.E_last_)) {
+        if (!multipole_in_range(*nuc, p.E_last_)) {
           score *= flux_deriv;
           return;
         }
@@ -409,7 +409,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
             const auto& nuc {*data::nuclides[i_nuc]};
-            if (multipole_in_range(&nuc, p.E_last_)
+            if (multipole_in_range(nuc, p.E_last_)
                 && p.neutron_xs_[i_nuc].total) {
               double dsig_s, dsig_a, dsig_f;
               std::tie(dsig_s, dsig_a, dsig_f)
@@ -437,7 +437,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
             const auto& nuc {*data::nuclides[i_nuc]};
-            if (multipole_in_range(&nuc, p.E_last_)
+            if (multipole_in_range(nuc, p.E_last_)
                 && (p.neutron_xs_[i_nuc].total
                 - p.neutron_xs_[i_nuc].absorption)) {
               double dsig_s, dsig_a, dsig_f;
@@ -467,7 +467,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
             const auto& nuc {*data::nuclides[i_nuc]};
-            if (multipole_in_range(&nuc, p.E_last_)
+            if (multipole_in_range(nuc, p.E_last_)
                 && p.neutron_xs_[i_nuc].absorption) {
               double dsig_s, dsig_a, dsig_f;
               std::tie(dsig_s, dsig_a, dsig_f)
@@ -494,7 +494,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
             const auto& nuc {*data::nuclides[i_nuc]};
-            if (multipole_in_range(&nuc, p.E_last_)
+            if (multipole_in_range(nuc, p.E_last_)
                 && p.neutron_xs_[i_nuc].fission) {
               double dsig_s, dsig_a, dsig_f;
               std::tie(dsig_s, dsig_a, dsig_f)
@@ -521,7 +521,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
             const auto& nuc {*data::nuclides[i_nuc]};
-            if (multipole_in_range(&nuc, p.E_last_)
+            if (multipole_in_range(nuc, p.E_last_)
                 && p.neutron_xs_[i_nuc].fission) {
               double nu = p.neutron_xs_[i_nuc].nu_fission
                 / p.neutron_xs_[i_nuc].fission;
@@ -590,7 +590,7 @@ score_track_derivative(Particle& p, double distance)
     case DerivativeVariable::TEMPERATURE:
       for (auto i = 0; i < material.nuclide_.size(); ++i) {
         const auto& nuc {*data::nuclides[material.nuclide_[i]]};
-        if (multipole_in_range(&nuc, p.E_last_)) {
+        if (multipole_in_range(nuc, p.E_last_)) {
           // phi is proportional to e^(-Sigma_tot * dist)
           // (1 / phi) * (d_phi / d_T) = - (d_Sigma_tot / d_T) * dist
           // (1 / phi) * (d_phi / d_T) = - N (d_sigma_tot / d_T) * dist
@@ -651,7 +651,7 @@ void score_collision_derivative(Particle& p)
       // Loop over the material's nuclides until we find the event nuclide.
       for (auto i_nuc : material.nuclide_) {
         const auto& nuc {*data::nuclides[i_nuc]};
-        if (i_nuc == p.event_nuclide_ && multipole_in_range(&nuc, p.E_last_)) {
+        if (i_nuc == p.event_nuclide_ && multipole_in_range(nuc, p.E_last_)) {
           // phi is proportional to Sigma_s
           // (1 / phi) * (d_phi / d_T) = (d_Sigma_s / d_T) / Sigma_s
           // (1 / phi) * (d_phi / d_T) = (d_sigma_s / d_T) / sigma_s

--- a/src/tallies/derivative.cpp
+++ b/src/tallies/derivative.cpp
@@ -99,7 +99,7 @@ read_tally_derivatives(pugi::xml_node node)
 }
 
 void
-apply_derivative_to_score(const Particle* p, int i_tally, int i_nuclide,
+apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
   double atom_density, int score_bin, double& score)
 {
   const Tally& tally {*model::tallies[i_tally]};
@@ -112,17 +112,17 @@ apply_derivative_to_score(const Particle* p, int i_tally, int i_nuclide,
   // perturbated variable.
 
   const auto& deriv {model::tally_derivs[tally.deriv_]};
-  const auto flux_deriv = p->flux_derivs_[tally.deriv_];
+  const auto flux_deriv = p.flux_derivs_[tally.deriv_];
 
   // Handle special cases where we know that d_c/d_p must be zero.
   if (score_bin == SCORE_FLUX) {
     score *= flux_deriv;
     return;
-  } else if (p->material_ == MATERIAL_VOID) {
+  } else if (p.material_ == MATERIAL_VOID) {
     score *= flux_deriv;
     return;
   }
-  const Material& material {*model::materials[p->material_]};
+  const Material& material {*model::materials[p.material_]};
   if (material.id_ != deriv.diff_material) {
     score *= flux_deriv;
     return;
@@ -182,7 +182,7 @@ apply_derivative_to_score(const Particle* p, int i_tally, int i_nuclide,
     switch (tally.estimator_) {
 
     case TallyEstimator::ANALOG:
-      if (p->event_nuclide_ != deriv.diff_nuclide) {
+      if (p.event_nuclide_ != deriv.diff_nuclide) {
         score *= flux_deriv;
         return;
       }
@@ -213,12 +213,12 @@ apply_derivative_to_score(const Particle* p, int i_tally, int i_nuclide,
       switch (score_bin) {
 
       case SCORE_TOTAL:
-        if (i_nuclide == -1 && p->macro_xs_.total > 0.0) {
+        if (i_nuclide == -1 && p.macro_xs_.total > 0.0) {
           score *= flux_deriv
-            + p->neutron_xs_[deriv.diff_nuclide].total
-            / p->macro_xs_.total;
+            + p.neutron_xs_[deriv.diff_nuclide].total
+            / p.macro_xs_.total;
         } else if (i_nuclide == deriv.diff_nuclide
-                   && p->neutron_xs_[i_nuclide].total) {
+                   && p.neutron_xs_[i_nuclide].total) {
           score *= flux_deriv + 1. / atom_density;
         } else {
           score *= flux_deriv;
@@ -226,13 +226,13 @@ apply_derivative_to_score(const Particle* p, int i_tally, int i_nuclide,
         break;
 
       case SCORE_SCATTER:
-        if (i_nuclide == -1 && (p->macro_xs_.total
-                                - p->macro_xs_.absorption) > 0.0) {
+        if (i_nuclide == -1 && (p.macro_xs_.total
+                                - p.macro_xs_.absorption) > 0.0) {
           score *= flux_deriv
-            + (p->neutron_xs_[deriv.diff_nuclide].total
-            - p->neutron_xs_[deriv.diff_nuclide].absorption)
-            / (p->macro_xs_.total
-            - p->macro_xs_.absorption);
+            + (p.neutron_xs_[deriv.diff_nuclide].total
+            - p.neutron_xs_[deriv.diff_nuclide].absorption)
+            / (p.macro_xs_.total
+            - p.macro_xs_.absorption);
         } else if (i_nuclide == deriv.diff_nuclide) {
           score *= flux_deriv + 1. / atom_density;
         } else {
@@ -241,12 +241,12 @@ apply_derivative_to_score(const Particle* p, int i_tally, int i_nuclide,
         break;
 
       case SCORE_ABSORPTION:
-        if (i_nuclide == -1 && p->macro_xs_.absorption > 0.0) {
+        if (i_nuclide == -1 && p.macro_xs_.absorption > 0.0) {
           score *= flux_deriv
-            + p->neutron_xs_[deriv.diff_nuclide].absorption
-            / p->macro_xs_.absorption;
+            + p.neutron_xs_[deriv.diff_nuclide].absorption
+            / p.macro_xs_.absorption;
         } else if (i_nuclide == deriv.diff_nuclide
-                   && p->neutron_xs_[i_nuclide].absorption) {
+                   && p.neutron_xs_[i_nuclide].absorption) {
           score *= flux_deriv + 1. / atom_density;
         } else {
           score *= flux_deriv;
@@ -254,12 +254,12 @@ apply_derivative_to_score(const Particle* p, int i_tally, int i_nuclide,
         break;
 
       case SCORE_FISSION:
-        if (i_nuclide == -1 && p->macro_xs_.fission > 0.0) {
+        if (i_nuclide == -1 && p.macro_xs_.fission > 0.0) {
           score *= flux_deriv
-            + p->neutron_xs_[deriv.diff_nuclide].fission
-            / p->macro_xs_.fission;
+            + p.neutron_xs_[deriv.diff_nuclide].fission
+            / p.macro_xs_.fission;
         } else if (i_nuclide == deriv.diff_nuclide
-                   && p->neutron_xs_[i_nuclide].fission) {
+                   && p.neutron_xs_[i_nuclide].fission) {
           score *= flux_deriv + 1. / atom_density;
         } else {
           score *= flux_deriv;
@@ -267,12 +267,12 @@ apply_derivative_to_score(const Particle* p, int i_tally, int i_nuclide,
         break;
 
       case SCORE_NU_FISSION:
-        if (i_nuclide == -1 && p->macro_xs_.nu_fission > 0.0) {
+        if (i_nuclide == -1 && p.macro_xs_.nu_fission > 0.0) {
           score *= flux_deriv
-            + p->neutron_xs_[deriv.diff_nuclide].nu_fission
-            / p->macro_xs_.nu_fission;
+            + p.neutron_xs_[deriv.diff_nuclide].nu_fission
+            / p.macro_xs_.nu_fission;
         } else if (i_nuclide == deriv.diff_nuclide
-                   && p->neutron_xs_[i_nuclide].nu_fission) {
+                   && p.neutron_xs_[i_nuclide].nu_fission) {
           score *= flux_deriv + 1. / atom_density;
         } else {
           score *= flux_deriv;
@@ -312,10 +312,10 @@ apply_derivative_to_score(const Particle* p, int i_tally, int i_nuclide,
         // Find the index of the event nuclide.
         int i;
         for (i = 0; i < material.nuclide_.size(); ++i)
-          if (material.nuclide_[i] == p->event_nuclide_) break;
+          if (material.nuclide_[i] == p.event_nuclide_) break;
 
-        const auto& nuc {*data::nuclides[p->event_nuclide_]};
-        if (!multipole_in_range(&nuc, p->E_last_)) {
+        const auto& nuc {*data::nuclides[p.event_nuclide_]};
+        if (!multipole_in_range(&nuc, p.E_last_)) {
           score *= flux_deriv;
           break;
         }
@@ -323,64 +323,63 @@ apply_derivative_to_score(const Particle* p, int i_tally, int i_nuclide,
         switch (score_bin) {
 
         case SCORE_TOTAL:
-          if (p->neutron_xs_[p->event_nuclide_].total) {
+          if (p.neutron_xs_[p.event_nuclide_].total) {
             double dsig_s, dsig_a, dsig_f;
             std::tie(dsig_s, dsig_a, dsig_f)
-              = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+              = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
             score *= flux_deriv + (dsig_s + dsig_a) * material.atom_density_(i)
-              / p->macro_xs_.total;
+              / p.macro_xs_.total;
           } else {
             score *= flux_deriv;
           }
           break;
 
         case SCORE_SCATTER:
-          if (p->neutron_xs_[p->event_nuclide_].total
-              - p->neutron_xs_[p->event_nuclide_].absorption) {
+          if (p.neutron_xs_[p.event_nuclide_].total
+              - p.neutron_xs_[p.event_nuclide_].absorption) {
             double dsig_s, dsig_a, dsig_f;
             std::tie(dsig_s, dsig_a, dsig_f)
-              = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+              = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
             score *= flux_deriv + dsig_s * material.atom_density_(i)
-              / (p->macro_xs_.total
-              - p->macro_xs_.absorption);
+              / (p.macro_xs_.total - p.macro_xs_.absorption);
           } else {
             score *= flux_deriv;
           }
           break;
 
         case SCORE_ABSORPTION:
-          if (p->neutron_xs_[p->event_nuclide_].absorption) {
+          if (p.neutron_xs_[p.event_nuclide_].absorption) {
             double dsig_s, dsig_a, dsig_f;
             std::tie(dsig_s, dsig_a, dsig_f)
-              = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+              = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
             score *= flux_deriv + dsig_a * material.atom_density_(i)
-              / p->macro_xs_.absorption;
+              / p.macro_xs_.absorption;
           } else {
             score *= flux_deriv;
           }
           break;
 
         case SCORE_FISSION:
-          if (p->neutron_xs_[p->event_nuclide_].fission) {
+          if (p.neutron_xs_[p.event_nuclide_].fission) {
             double dsig_s, dsig_a, dsig_f;
             std::tie(dsig_s, dsig_a, dsig_f)
-              = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+              = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
             score *= flux_deriv + dsig_f * material.atom_density_(i)
-              / p->macro_xs_.fission;
+              / p.macro_xs_.fission;
           } else {
             score *= flux_deriv;
           }
           break;
 
         case SCORE_NU_FISSION:
-          if (p->neutron_xs_[p->event_nuclide_].fission) {
-            double nu = p->neutron_xs_[p->event_nuclide_].nu_fission
-              / p->neutron_xs_[p->event_nuclide_].fission;
+          if (p.neutron_xs_[p.event_nuclide_].fission) {
+            double nu = p.neutron_xs_[p.event_nuclide_].nu_fission
+              / p.neutron_xs_[p.event_nuclide_].fission;
             double dsig_s, dsig_a, dsig_f;
             std::tie(dsig_s, dsig_a, dsig_f)
-              = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+              = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
             score *= flux_deriv + nu * dsig_f * material.atom_density_(i)
-              / p->macro_xs_.nu_fission;
+              / p.macro_xs_.nu_fission;
           } else {
             score *= flux_deriv;
           }
@@ -396,7 +395,7 @@ apply_derivative_to_score(const Particle* p, int i_tally, int i_nuclide,
     case TallyEstimator::COLLISION:
       if (i_nuclide != -1) {
         const auto& nuc {data::nuclides[i_nuclide]};
-        if (!multipole_in_range(nuc.get(), p->E_last_)) {
+        if (!multipole_in_range(nuc.get(), p.E_last_)) {
           score *= flux_deriv;
           return;
         }
@@ -405,141 +404,141 @@ apply_derivative_to_score(const Particle* p, int i_tally, int i_nuclide,
       switch (score_bin) {
 
       case SCORE_TOTAL:
-        if (i_nuclide == -1 && p->macro_xs_.total > 0.0) {
+        if (i_nuclide == -1 && p.macro_xs_.total > 0.0) {
           double cum_dsig = 0;
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
             const auto& nuc {*data::nuclides[i_nuc]};
-            if (multipole_in_range(&nuc, p->E_last_)
-                && p->neutron_xs_[i_nuc].total) {
+            if (multipole_in_range(&nuc, p.E_last_)
+                && p.neutron_xs_[i_nuc].total) {
               double dsig_s, dsig_a, dsig_f;
               std::tie(dsig_s, dsig_a, dsig_f)
-                = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+                = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
               cum_dsig += (dsig_s + dsig_a) * material.atom_density_(i);
             }
           }
-          score *= flux_deriv + cum_dsig / p->macro_xs_.total;
-        } else if (p->neutron_xs_[i_nuclide].total) {
+          score *= flux_deriv + cum_dsig / p.macro_xs_.total;
+        } else if (p.neutron_xs_[i_nuclide].total) {
           const auto& nuc {*data::nuclides[i_nuclide]};
           double dsig_s, dsig_a, dsig_f;
           std::tie(dsig_s, dsig_a, dsig_f)
-            = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+            = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
           score *= flux_deriv
-            + (dsig_s + dsig_a) / p->neutron_xs_[i_nuclide].total;
+            + (dsig_s + dsig_a) / p.neutron_xs_[i_nuclide].total;
         } else {
           score *= flux_deriv;
         }
         break;
 
       case SCORE_SCATTER:
-        if (i_nuclide == -1 && (p->macro_xs_.total
-            - p->macro_xs_.absorption)) {
+        if (i_nuclide == -1 && (p.macro_xs_.total
+            - p.macro_xs_.absorption)) {
           double cum_dsig = 0;
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
             const auto& nuc {*data::nuclides[i_nuc]};
-            if (multipole_in_range(&nuc, p->E_last_)
-                && (p->neutron_xs_[i_nuc].total
-                - p->neutron_xs_[i_nuc].absorption)) {
+            if (multipole_in_range(&nuc, p.E_last_)
+                && (p.neutron_xs_[i_nuc].total
+                - p.neutron_xs_[i_nuc].absorption)) {
               double dsig_s, dsig_a, dsig_f;
               std::tie(dsig_s, dsig_a, dsig_f)
-                = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+                = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
               cum_dsig += dsig_s * material.atom_density_(i);
             }
           }
-          score *= flux_deriv + cum_dsig / (p->macro_xs_.total
-            - p->macro_xs_.absorption);
-        } else if (p->neutron_xs_[i_nuclide].total
-                   - p->neutron_xs_[i_nuclide].absorption) {
+          score *= flux_deriv + cum_dsig / (p.macro_xs_.total
+            - p.macro_xs_.absorption);
+        } else if (p.neutron_xs_[i_nuclide].total
+                   - p.neutron_xs_[i_nuclide].absorption) {
           const auto& nuc {*data::nuclides[i_nuclide]};
           double dsig_s, dsig_a, dsig_f;
           std::tie(dsig_s, dsig_a, dsig_f)
-            = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
-          score *= flux_deriv + dsig_s / (p->neutron_xs_[i_nuclide].total
-            - p->neutron_xs_[i_nuclide].absorption);
+            = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
+          score *= flux_deriv + dsig_s / (p.neutron_xs_[i_nuclide].total
+            - p.neutron_xs_[i_nuclide].absorption);
         } else {
           score *= flux_deriv;
         }
         break;
 
       case SCORE_ABSORPTION:
-        if (i_nuclide == -1 && p->macro_xs_.absorption > 0.0) {
+        if (i_nuclide == -1 && p.macro_xs_.absorption > 0.0) {
           double cum_dsig = 0;
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
             const auto& nuc {*data::nuclides[i_nuc]};
-            if (multipole_in_range(&nuc, p->E_last_)
-                && p->neutron_xs_[i_nuc].absorption) {
+            if (multipole_in_range(&nuc, p.E_last_)
+                && p.neutron_xs_[i_nuc].absorption) {
               double dsig_s, dsig_a, dsig_f;
               std::tie(dsig_s, dsig_a, dsig_f)
-                = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+                = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
               cum_dsig += dsig_a * material.atom_density_(i);
             }
           }
-          score *= flux_deriv + cum_dsig / p->macro_xs_.absorption;
-        } else if (p->neutron_xs_[i_nuclide].absorption) {
+          score *= flux_deriv + cum_dsig / p.macro_xs_.absorption;
+        } else if (p.neutron_xs_[i_nuclide].absorption) {
           const auto& nuc {*data::nuclides[i_nuclide]};
           double dsig_s, dsig_a, dsig_f;
           std::tie(dsig_s, dsig_a, dsig_f)
-            = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+            = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
           score *= flux_deriv
-            + dsig_a / p->neutron_xs_[i_nuclide].absorption;
+            + dsig_a / p.neutron_xs_[i_nuclide].absorption;
         } else {
           score *= flux_deriv;
         }
         break;
 
       case SCORE_FISSION:
-        if (i_nuclide == -1 && p->macro_xs_.fission > 0.0) {
+        if (i_nuclide == -1 && p.macro_xs_.fission > 0.0) {
           double cum_dsig = 0;
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
             const auto& nuc {*data::nuclides[i_nuc]};
-            if (multipole_in_range(&nuc, p->E_last_)
-                && p->neutron_xs_[i_nuc].fission) {
+            if (multipole_in_range(&nuc, p.E_last_)
+                && p.neutron_xs_[i_nuc].fission) {
               double dsig_s, dsig_a, dsig_f;
               std::tie(dsig_s, dsig_a, dsig_f)
-                = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+                = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
               cum_dsig += dsig_f * material.atom_density_(i);
             }
           }
-          score *= flux_deriv + cum_dsig / p->macro_xs_.fission;
-        } else if (p->neutron_xs_[i_nuclide].fission) {
+          score *= flux_deriv + cum_dsig / p.macro_xs_.fission;
+        } else if (p.neutron_xs_[i_nuclide].fission) {
           const auto& nuc {*data::nuclides[i_nuclide]};
           double dsig_s, dsig_a, dsig_f;
           std::tie(dsig_s, dsig_a, dsig_f)
-            = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+            = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
           score *= flux_deriv
-            + dsig_f / p->neutron_xs_[i_nuclide].fission;
+            + dsig_f / p.neutron_xs_[i_nuclide].fission;
         } else {
           score *= flux_deriv;
         }
         break;
 
       case SCORE_NU_FISSION:
-        if (i_nuclide == -1 && p->macro_xs_.nu_fission > 0.0) {
+        if (i_nuclide == -1 && p.macro_xs_.nu_fission > 0.0) {
           double cum_dsig = 0;
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
             const auto& nuc {*data::nuclides[i_nuc]};
-            if (multipole_in_range(&nuc, p->E_last_)
-                && p->neutron_xs_[i_nuc].fission) {
-              double nu = p->neutron_xs_[i_nuc].nu_fission
-                / p->neutron_xs_[i_nuc].fission;
+            if (multipole_in_range(&nuc, p.E_last_)
+                && p.neutron_xs_[i_nuc].fission) {
+              double nu = p.neutron_xs_[i_nuc].nu_fission
+                / p.neutron_xs_[i_nuc].fission;
               double dsig_s, dsig_a, dsig_f;
               std::tie(dsig_s, dsig_a, dsig_f)
-                = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+                = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
               cum_dsig += nu * dsig_f * material.atom_density_(i);
             }
           }
-          score *= flux_deriv + cum_dsig / p->macro_xs_.nu_fission;
-        } else if (p->neutron_xs_[i_nuclide].fission) {
+          score *= flux_deriv + cum_dsig / p.macro_xs_.nu_fission;
+        } else if (p.neutron_xs_[i_nuclide].fission) {
           const auto& nuc {*data::nuclides[i_nuclide]};
           double dsig_s, dsig_a, dsig_f;
           std::tie(dsig_s, dsig_a, dsig_f)
-            = nuc.multipole_->evaluate_deriv(p->E_last_, p->sqrtkT_);
+            = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
           score *= flux_deriv
-            + dsig_f / p->neutron_xs_[i_nuclide].fission;
+            + dsig_f / p.neutron_xs_[i_nuclide].fission;
         } else {
           score *= flux_deriv;
         }

--- a/src/tallies/filter_azimuthal.cpp
+++ b/src/tallies/filter_azimuthal.cpp
@@ -51,14 +51,14 @@ void AzimuthalFilter::set_bins(gsl::span<double> bins)
 }
 
 void
-AzimuthalFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+AzimuthalFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                               FilterMatch& match) const
 {
   double phi;
   if (estimator == TallyEstimator::TRACKLENGTH) {
-    phi = std::atan2(p->u().y, p->u().x);
+    phi = std::atan2(p.u().y, p.u().x);
   } else {
-    phi = std::atan2(p->u_last_.y, p->u_last_.x);
+    phi = std::atan2(p.u_last_.y, p.u_last_.x);
   }
 
   if (phi >= bins_.front() && phi <= bins_.back()) {

--- a/src/tallies/filter_azimuthal.cpp
+++ b/src/tallies/filter_azimuthal.cpp
@@ -54,12 +54,8 @@ void
 AzimuthalFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                               FilterMatch& match) const
 {
-  double phi;
-  if (estimator == TallyEstimator::TRACKLENGTH) {
-    phi = std::atan2(p.u().y, p.u().x);
-  } else {
-    phi = std::atan2(p.u_last_.y, p.u_last_.x);
-  }
+  Direction u = (estimator == TallyEstimator::TRACKLENGTH) ? p.u() : p.u_last_;
+  double phi = std::atan2(u.y, u.x);
 
   if (phi >= bins_.front() && phi <= bins_.back()) {
     auto bin = lower_bound_index(bins_.begin(), bins_.end(), phi);
@@ -78,7 +74,7 @@ AzimuthalFilter::to_statepoint(hid_t filter_group) const
 std::string
 AzimuthalFilter::text_label(int bin) const
 {
-  return fmt::format("Azimuthal Angle [{}, {})", bins_[bin], bins_[bin+1]);
+  return fmt::format("Azimuthal Angle [{}, {})", bins_.at(bin), bins_.at(bin+1));
 }
 
 } // namespace openmc

--- a/src/tallies/filter_cell.cpp
+++ b/src/tallies/filter_cell.cpp
@@ -46,11 +46,11 @@ CellFilter::set_cells(gsl::span<int32_t> cells)
 }
 
 void
-CellFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+CellFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                          FilterMatch& match) const
 {
-  for (int i = 0; i < p->n_coord_; i++) {
-    auto search = map_.find(p->coord_[i].cell);
+  for (int i = 0; i < p.n_coord_; i++) {
+    auto search = map_.find(p.coord_[i].cell);
     if (search != map_.end()) {
       match.bins_.push_back(search->second);
       match.weights_.push_back(1.0);

--- a/src/tallies/filter_cell_instance.cpp
+++ b/src/tallies/filter_cell_instance.cpp
@@ -66,11 +66,11 @@ CellInstanceFilter::set_cell_instances(gsl::span<CellInstance> instances)
 }
 
 void
-CellInstanceFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+CellInstanceFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                          FilterMatch& match) const
 {
-  gsl::index index_cell = p->coord_[p->n_coord_ - 1].cell;
-  gsl::index instance = p->cell_instance_;
+  gsl::index index_cell = p.coord_[p.n_coord_ - 1].cell;
+  gsl::index instance = p.cell_instance_;
   auto search = map_.find({index_cell, instance});
   if (search != map_.end()) {
     int index_bin = search->second;

--- a/src/tallies/filter_cellborn.cpp
+++ b/src/tallies/filter_cellborn.cpp
@@ -5,10 +5,10 @@
 namespace openmc {
 
 void
-CellbornFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+CellbornFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                              FilterMatch& match) const
 {
-  auto search = map_.find(p->cell_born_);
+  auto search = map_.find(p.cell_born_);
   if (search != map_.end()) {
     match.bins_.push_back(search->second);
     match.weights_.push_back(1.0);

--- a/src/tallies/filter_cellfrom.cpp
+++ b/src/tallies/filter_cellfrom.cpp
@@ -5,11 +5,11 @@
 namespace openmc {
 
 void
-CellFromFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+CellFromFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                              FilterMatch& match) const
 {
-  for (int i = 0; i < p->n_coord_last_; i++) {
-    auto search = map_.find(p->cell_last_[i]);
+  for (int i = 0; i < p.n_coord_last_; i++) {
+    auto search = map_.find(p.cell_last_[i]);
     if (search != map_.end()) {
       match.bins_.push_back(search->second);
       match.weights_.push_back(1.0);

--- a/src/tallies/filter_delayedgroup.cpp
+++ b/src/tallies/filter_delayedgroup.cpp
@@ -37,7 +37,7 @@ DelayedGroupFilter::set_groups(gsl::span<int> groups)
 }
 
 void
-DelayedGroupFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+DelayedGroupFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                                  FilterMatch& match) const
 {
   match.bins_.push_back(0);

--- a/src/tallies/filter_distribcell.cpp
+++ b/src/tallies/filter_distribcell.cpp
@@ -38,25 +38,25 @@ DistribcellFilter::set_cell(int32_t cell)
 }
 
 void
-DistribcellFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+DistribcellFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                                 FilterMatch& match) const
 {
   int offset = 0;
   auto distribcell_index = model::cells[cell_]->distribcell_index_;
-  for (int i = 0; i < p->n_coord_; i++) {
-    auto& c {*model::cells[p->coord_[i].cell]};
+  for (int i = 0; i < p.n_coord_; i++) {
+    auto& c {*model::cells[p.coord_[i].cell]};
     if (c.type_ == Fill::UNIVERSE) {
       offset += c.offset_[distribcell_index];
     } else if (c.type_ == Fill::LATTICE) {
-      auto& lat {*model::lattices[p->coord_[i+1].lattice]};
-      int i_xyz[3] {p->coord_[i+1].lattice_x,
-                    p->coord_[i+1].lattice_y,
-                    p->coord_[i+1].lattice_z};
+      auto& lat {*model::lattices[p.coord_[i+1].lattice]};
+      int i_xyz[3] {p.coord_[i+1].lattice_x,
+                    p.coord_[i+1].lattice_y,
+                    p.coord_[i+1].lattice_z};
       if (lat.are_valid_indices(i_xyz)) {
         offset += lat.offset(distribcell_index, i_xyz);
       }
     }
-    if (cell_ == p->coord_[i].cell) {
+    if (cell_ == p.coord_[i].cell) {
       match.bins_.push_back(offset);
       match.weights_.push_back(1.0);
       return;

--- a/src/tallies/filter_energy.cpp
+++ b/src/tallies/filter_energy.cpp
@@ -119,7 +119,7 @@ EnergyoutFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
 std::string
 EnergyoutFilter::text_label(int bin) const
 {
-  return fmt::format("Outgoing Energy [{}, {})", bins_[bin], bins_[bin+1]);
+  return fmt::format("Outgoing Energy [{}, {})", bins_.at(bin), bins_.at(bin+1));
 }
 
 //==============================================================================

--- a/src/tallies/filter_energy.cpp
+++ b/src/tallies/filter_energy.cpp
@@ -58,20 +58,20 @@ EnergyFilter::set_bins(gsl::span<const double> bins)
 }
 
 void
-EnergyFilter::get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+EnergyFilter::get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
 const
 {
-  if (p->g_ != F90_NONE && matches_transport_groups_) {
+  if (p.g_ != F90_NONE && matches_transport_groups_) {
     if (estimator == TallyEstimator::TRACKLENGTH) {
-      match.bins_.push_back(data::mg.num_energy_groups_ - p->g_ - 1);
+      match.bins_.push_back(data::mg.num_energy_groups_ - p.g_ - 1);
     } else {
-      match.bins_.push_back(data::mg.num_energy_groups_ - p->g_last_ - 1);
+      match.bins_.push_back(data::mg.num_energy_groups_ - p.g_last_ - 1);
     }
     match.weights_.push_back(1.0);
 
   } else {
     // Get the pre-collision energy of the particle.
-    auto E = p->E_last_;
+    auto E = p.E_last_;
 
     // Bin the energy.
     if (E >= bins_.front() && E <= bins_.back()) {
@@ -100,16 +100,16 @@ EnergyFilter::text_label(int bin) const
 //==============================================================================
 
 void
-EnergyoutFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+EnergyoutFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                               FilterMatch& match) const
 {
-  if (p->g_ != F90_NONE && matches_transport_groups_) {
-    match.bins_.push_back(data::mg.num_energy_groups_ - p->g_ - 1);
+  if (p.g_ != F90_NONE && matches_transport_groups_) {
+    match.bins_.push_back(data::mg.num_energy_groups_ - p.g_ - 1);
     match.weights_.push_back(1.0);
 
   } else {
-    if (p->E_ >= bins_.front() && p->E_ <= bins_.back()) {
-      auto bin = lower_bound_index(bins_.begin(), bins_.end(), p->E_);
+    if (p.E_ >= bins_.front() && p.E_ <= bins_.back()) {
+      auto bin = lower_bound_index(bins_.begin(), bins_.end(), p.E_);
       match.bins_.push_back(bin);
       match.weights_.push_back(1.0);
     }

--- a/src/tallies/filter_energyfunc.cpp
+++ b/src/tallies/filter_energyfunc.cpp
@@ -53,15 +53,15 @@ EnergyFunctionFilter::set_data(gsl::span<const double> energy,
 }
 
 void
-EnergyFunctionFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+EnergyFunctionFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                                    FilterMatch& match) const
 {
-  if (p->E_last_ >= energy_.front() && p->E_last_ <= energy_.back()) {
+  if (p.E_last_ >= energy_.front() && p.E_last_ <= energy_.back()) {
     // Search for the incoming energy bin.
-    auto i = lower_bound_index(energy_.begin(), energy_.end(), p->E_last_);
+    auto i = lower_bound_index(energy_.begin(), energy_.end(), p.E_last_);
 
     // Compute the interpolation factor between the nearest bins.
-    double f = (p->E_last_ - energy_[i]) / (energy_[i+1] - energy_[i]);
+    double f = (p.E_last_ - energy_[i]) / (energy_[i+1] - energy_[i]);
 
     // Interpolate on the lin-lin grid.
     match.bins_.push_back(0);

--- a/src/tallies/filter_legendre.cpp
+++ b/src/tallies/filter_legendre.cpp
@@ -24,11 +24,11 @@ LegendreFilter::set_order(int order)
 }
 
 void
-LegendreFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+LegendreFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                              FilterMatch& match) const
 {
   std::vector<double> wgt(n_bins_);
-  calc_pn_c(order_, p->mu_, wgt.data());
+  calc_pn_c(order_, p.mu_, wgt.data());
   for (int i = 0; i < n_bins_; i++) {
     match.bins_.push_back(i);
     match.weights_.push_back(wgt[i]);

--- a/src/tallies/filter_material.cpp
+++ b/src/tallies/filter_material.cpp
@@ -45,10 +45,10 @@ MaterialFilter::set_materials(gsl::span<const int32_t> materials)
 }
 
 void
-MaterialFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+MaterialFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                              FilterMatch& match) const
 {
-  auto search = map_.find(p->material_);
+  auto search = map_.find(p.material_);
   if (search != map_.end()) {
     match.bins_.push_back(search->second);
     match.weights_.push_back(1.0);

--- a/src/tallies/filter_mesh.cpp
+++ b/src/tallies/filter_mesh.cpp
@@ -41,7 +41,7 @@ const
       match.weights_.push_back(1.0);
     }
   } else {
-    model::meshes[mesh_]->bins_crossed(&p, match.bins_, match.weights_);
+    model::meshes[mesh_]->bins_crossed(p, match.bins_, match.weights_);
   }
 }
 

--- a/src/tallies/filter_mesh.cpp
+++ b/src/tallies/filter_mesh.cpp
@@ -1,6 +1,7 @@
 #include "openmc/tallies/filter_mesh.h"
 
 #include <fmt/core.h>
+#include <gsl/gsl>
 
 #include "openmc/capi.h"
 #include "openmc/constants.h"
@@ -54,7 +55,7 @@ MeshFilter::to_statepoint(hid_t filter_group) const
 std::string
 MeshFilter::text_label(int bin) const
 {
-  auto& mesh = *model::meshes[mesh_];
+  auto& mesh = *model::meshes.at(mesh_);
   return mesh.bin_label(bin);
 }
 
@@ -72,6 +73,11 @@ MeshFilter::set_mesh(int32_t mesh)
 extern "C" int
 openmc_mesh_filter_get_mesh(int32_t index, int32_t* index_mesh)
 {
+  if (!index_mesh) {
+    set_errmsg("Mesh index argument is a null pointer.");
+    return OPENMC_E_INVALID_ARGUMENT;
+  }
+
   // Make sure this is a valid index to an allocated filter.
   if (int err = verify_filter(index)) return err;
 

--- a/src/tallies/filter_mesh.cpp
+++ b/src/tallies/filter_mesh.cpp
@@ -31,17 +31,17 @@ MeshFilter::from_xml(pugi::xml_node node)
 }
 
 void
-MeshFilter::get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+MeshFilter::get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
 const
 {
   if (estimator != TallyEstimator::TRACKLENGTH) {
-    auto bin = model::meshes[mesh_]->get_bin(p->r());
+    auto bin = model::meshes[mesh_]->get_bin(p.r());
     if (bin >= 0) {
       match.bins_.push_back(bin);
       match.weights_.push_back(1.0);
     }
   } else {
-    model::meshes[mesh_]->bins_crossed(p, match.bins_, match.weights_);
+    model::meshes[mesh_]->bins_crossed(&p, match.bins_, match.weights_);
   }
 }
 

--- a/src/tallies/filter_meshsurface.cpp
+++ b/src/tallies/filter_meshsurface.cpp
@@ -8,10 +8,10 @@
 namespace openmc {
 
 void
-MeshSurfaceFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+MeshSurfaceFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                                 FilterMatch& match) const
 {
-  model::meshes[mesh_]->surface_bins_crossed(p, match.bins_);
+  model::meshes[mesh_]->surface_bins_crossed(&p, match.bins_);
   for (auto b : match.bins_) match.weights_.push_back(1.0);
 }
 

--- a/src/tallies/filter_meshsurface.cpp
+++ b/src/tallies/filter_meshsurface.cpp
@@ -11,7 +11,7 @@ void
 MeshSurfaceFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                                 FilterMatch& match) const
 {
-  model::meshes[mesh_]->surface_bins_crossed(&p, match.bins_);
+  model::meshes[mesh_]->surface_bins_crossed(p, match.bins_);
   for (auto b : match.bins_) match.weights_.push_back(1.0);
 }
 

--- a/src/tallies/filter_mu.cpp
+++ b/src/tallies/filter_mu.cpp
@@ -49,11 +49,11 @@ MuFilter::set_bins(gsl::span<double> bins)
 }
 
 void
-MuFilter::get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+MuFilter::get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
 const
 {
-  if (p->mu_ >= bins_.front() && p->mu_ <= bins_.back()) {
-    auto bin = lower_bound_index(bins_.begin(), bins_.end(), p->mu_);
+  if (p.mu_ >= bins_.front() && p.mu_ <= bins_.back()) {
+    auto bin = lower_bound_index(bins_.begin(), bins_.end(), p.mu_);
     match.bins_.push_back(bin);
     match.weights_.push_back(1.0);
   }

--- a/src/tallies/filter_particle.cpp
+++ b/src/tallies/filter_particle.cpp
@@ -1,5 +1,7 @@
 #include "openmc/tallies/filter_particle.h"
 
+#include <fmt/core.h>
+
 #include "openmc/xml_interface.h"
 
 namespace openmc {
@@ -12,15 +14,7 @@ ParticleFilter::from_xml(pugi::xml_node node)
   // Convert to vector of Particle::Type
   std::vector<Particle::Type> types;
   for (auto& p : particles) {
-    if (p == "neutron") {
-      types.push_back(Particle::Type::neutron);
-    } else if (p == "photon") {
-      types.push_back(Particle::Type::photon);
-    } else if (p == "electron") {
-      types.push_back(Particle::Type::electron);
-    } else if (p == "positron") {
-      types.push_back(Particle::Type::positron);
-    }
+    types.push_back(str_to_particle_type(p));
   }
   this->set_particles(types);
 }
@@ -57,20 +51,7 @@ ParticleFilter::to_statepoint(hid_t filter_group) const
   Filter::to_statepoint(filter_group);
   std::vector<std::string> particles;
   for (auto p : particles_) {
-    switch (p) {
-    case Particle::Type::neutron:
-      particles.push_back("neutron");
-      break;
-    case Particle::Type::photon:
-      particles.push_back("photon");
-      break;
-    case Particle::Type::electron:
-      particles.push_back("electron");
-      break;
-    case Particle::Type::positron:
-      particles.push_back("positron");
-      break;
-    }
+    particles.push_back(particle_type_to_str(p));
   }
   write_dataset(filter_group, "bins", particles);
 }
@@ -78,17 +59,8 @@ ParticleFilter::to_statepoint(hid_t filter_group) const
 std::string
 ParticleFilter::text_label(int bin) const
 {
-  switch (particles_[bin]) {
-  case Particle::Type::neutron:
-    return "Particle: neutron";
-  case Particle::Type::photon:
-    return "Particle: photon";
-  case Particle::Type::electron:
-    return "Particle: electron";
-  case Particle::Type::positron:
-    return "Particle: positron";
-  }
-  UNREACHABLE();
+  const auto& p = particles_.at(bin);
+  return fmt::format("Particle: {}", particle_type_to_str(p));
 }
 
 } // namespace openmc

--- a/src/tallies/filter_particle.cpp
+++ b/src/tallies/filter_particle.cpp
@@ -40,11 +40,11 @@ ParticleFilter::set_particles(gsl::span<Particle::Type> particles)
 }
 
 void
-ParticleFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+ParticleFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                              FilterMatch& match) const
 {
   for (auto i = 0; i < particles_.size(); i++) {
-    if (particles_[i] == p->type_) {
+    if (particles_[i] == p.type_) {
       match.bins_.push_back(i);
       match.weights_.push_back(1.0);
     }

--- a/src/tallies/filter_polar.cpp
+++ b/src/tallies/filter_polar.cpp
@@ -50,15 +50,12 @@ PolarFilter::set_bins(gsl::span<double> bins)
 }
 
 void
-PolarFilter::get_all_bins(const Particle* p, TallyEstimator estimator, FilterMatch& match)
+PolarFilter::get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
 const
 {
-  double theta;
-  if (estimator == TallyEstimator::TRACKLENGTH) {
-    theta = std::acos(p->u().z);
-  } else {
-    theta = std::acos(p->u_last_.z);
-  }
+  double theta = std::acos(
+    estimator == TallyEstimator::TRACKLENGTH ? p.u().z : p.u_last_.z
+  );
 
   if (theta >= bins_.front() && theta <= bins_.back()) {
     auto bin = lower_bound_index(bins_.begin(), bins_.end(), theta);

--- a/src/tallies/filter_polar.cpp
+++ b/src/tallies/filter_polar.cpp
@@ -53,9 +53,8 @@ void
 PolarFilter::get_all_bins(const Particle& p, TallyEstimator estimator, FilterMatch& match)
 const
 {
-  double theta = std::acos(
-    estimator == TallyEstimator::TRACKLENGTH ? p.u().z : p.u_last_.z
-  );
+  double z = (estimator == TallyEstimator::TRACKLENGTH) ? p.u().z : p.u_last_.z;
+  double theta = std::acos(z);
 
   if (theta >= bins_.front() && theta <= bins_.back()) {
     auto bin = lower_bound_index(bins_.begin(), bins_.end(), theta);

--- a/src/tallies/filter_sph_harm.cpp
+++ b/src/tallies/filter_sph_harm.cpp
@@ -45,20 +45,22 @@ SphericalHarmonicsFilter::set_cosine(gsl::cstring_span cosine)
 }
 
 void
-SphericalHarmonicsFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+SphericalHarmonicsFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                                        FilterMatch& match) const
 {
   // Determine cosine term for scatter expansion if necessary
   std::vector<double> wgt(order_ + 1);
   if (cosine_ == SphericalHarmonicsCosine::scatter) {
-    calc_pn_c(order_, p->mu_, wgt.data());
+    calc_pn_c(order_, p.mu_, wgt.data());
   } else {
-    for (int i = 0; i < order_ + 1; i++) wgt[i] = 1;
+    for (int i = 0; i < order_ + 1; i++) {
+      wgt[i] = 1;
+    }
   }
 
   // Find the Rn,m values
   std::vector<double> rn(n_bins_);
-  calc_rn(order_, p->u_last_, rn.data());
+  calc_rn(order_, p.u_last_, rn.data());
 
   int j = 0;
   for (int n = 0; n < order_ + 1; n++) {

--- a/src/tallies/filter_sptl_legendre.cpp
+++ b/src/tallies/filter_sptl_legendre.cpp
@@ -55,7 +55,7 @@ SpatialLegendreFilter::set_axis(LegendreAxis axis)
 void
 SpatialLegendreFilter::set_minmax(double min, double max)
 {
-  if (max < min) {
+  if (max <= min) {
     throw std::invalid_argument{"Maximum value must be greater than minimum value"};
   }
   min_ = min;

--- a/src/tallies/filter_sptl_legendre.cpp
+++ b/src/tallies/filter_sptl_legendre.cpp
@@ -63,17 +63,17 @@ SpatialLegendreFilter::set_minmax(double min, double max)
 }
 
 void
-SpatialLegendreFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+SpatialLegendreFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                                     FilterMatch& match) const
 {
   // Get the coordinate along the axis of interest.
   double x;
   if (axis_ == LegendreAxis::x) {
-    x = p->r().x;
+    x = p.r().x;
   } else if (axis_ == LegendreAxis::y) {
-    x = p->r().y;
+    x = p.r().y;
   } else {
-    x = p->r().z;
+    x = p.r().z;
   }
 
   if (x >= min_ && x <= max_) {

--- a/src/tallies/filter_surface.cpp
+++ b/src/tallies/filter_surface.cpp
@@ -47,13 +47,13 @@ SurfaceFilter::set_surfaces(gsl::span<int32_t> surfaces)
 }
 
 void
-SurfaceFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+SurfaceFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                             FilterMatch& match) const
 {
-  auto search = map_.find(std::abs(p->surface_)-1);
+  auto search = map_.find(std::abs(p.surface_)-1);
   if (search != map_.end()) {
     match.bins_.push_back(search->second);
-    if (p->surface_ < 0) {
+    if (p.surface_ < 0) {
       match.weights_.push_back(-1.0);
     } else {
       match.weights_.push_back(1.0);

--- a/src/tallies/filter_universe.cpp
+++ b/src/tallies/filter_universe.cpp
@@ -45,11 +45,11 @@ UniverseFilter::set_universes(gsl::span<int32_t> universes)
 }
 
 void
-UniverseFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+UniverseFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                              FilterMatch& match) const
 {
-  for (int i = 0; i < p->n_coord_; i++) {
-    auto search = map_.find(p->coord_[i].universe);
+  for (int i = 0; i < p.n_coord_; i++) {
+    auto search = map_.find(p.coord_[i].universe);
     if (search != map_.end()) {
       match.bins_.push_back(search->second);
       match.weights_.push_back(1.0);

--- a/src/tallies/filter_zernike.cpp
+++ b/src/tallies/filter_zernike.cpp
@@ -28,12 +28,12 @@ ZernikeFilter::from_xml(pugi::xml_node node)
 }
 
 void
-ZernikeFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+ZernikeFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                             FilterMatch& match) const
 {
   // Determine the normalized (r,theta) coordinates.
-  double x = p->r().x - x_;
-  double y = p->r().y - y_;
+  double x = p.r().x - x_;
+  double y = p.r().y - y_;
   double r = std::sqrt(x*x + y*y) / r_;
   double theta = std::atan2(y, x);
 
@@ -88,12 +88,12 @@ ZernikeFilter::set_order(int order)
 //==============================================================================
 
 void
-ZernikeRadialFilter::get_all_bins(const Particle* p, TallyEstimator estimator,
+ZernikeRadialFilter::get_all_bins(const Particle& p, TallyEstimator estimator,
                                   FilterMatch& match) const
 {
   // Determine the normalized radius coordinate.
-  double x = p->r().x - x_;
-  double y = p->r().y - y_;
+  double x = p.r().x - x_;
+  double y = p.r().y - y_;
   double r = std::sqrt(x*x + y*y) / r_;
 
   if (r <= 1.0) {

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -753,6 +753,9 @@ Tally::init_triggers(pugi::xml_node node)
     double threshold;
     if (check_for_node(trigger_node, "threshold")) {
       threshold = std::stod(get_node_value(trigger_node, "threshold"));
+      if (threshold <= 0) {
+        fatal_error("Tally trigger threshold must be positive");
+      }
     } else {
       fatal_error(fmt::format(
         "Must specify trigger threshold for tally {} in tally XML file", id_));

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -36,7 +36,7 @@ FilterBinIter::FilterBinIter(const Tally& tally, Particle* p)
     if (!match.bins_present_) {
       match.bins_.clear();
       match.weights_.clear();
-      model::tally_filters[i_filt]->get_all_bins(p, tally_.estimator_, match);
+      model::tally_filters[i_filt]->get_all_bins(*p, tally_.estimator_, match);
       match.bins_present_ = true;
     }
 

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -26,8 +26,8 @@ namespace openmc {
 // FilterBinIter implementation
 //==============================================================================
 
-FilterBinIter::FilterBinIter(const Tally& tally, Particle* p)
-  : filter_matches_{p->filter_matches_}, tally_{tally}
+FilterBinIter::FilterBinIter(const Tally& tally, Particle& p)
+  : filter_matches_{p.filter_matches_}, tally_{tally}
 {
   // Find all valid bins in each relevant filter if they have not already been
   // found for this event.
@@ -36,7 +36,7 @@ FilterBinIter::FilterBinIter(const Tally& tally, Particle* p)
     if (!match.bins_present_) {
       match.bins_.clear();
       match.weights_.clear();
-      model::tally_filters[i_filt]->get_all_bins(*p, tally_.estimator_, match);
+      model::tally_filters[i_filt]->get_all_bins(p, tally_.estimator_, match);
       match.bins_present_ = true;
     }
 
@@ -177,15 +177,15 @@ score_fission_delayed_dg(int i_tally, int d_bin, double score, int score_index,
 
 //! Helper function to retrieve fission q value from a nuclide
 
-double get_nuc_fission_q(const Nuclide& nuc, const Particle* p, int score_bin)
+double get_nuc_fission_q(const Nuclide& nuc, const Particle& p, int score_bin)
 {
   if (score_bin == SCORE_FISS_Q_PROMPT) {
     if (nuc.fission_q_prompt_) {
-      return (*nuc.fission_q_prompt_)(p->E_last_);
+      return (*nuc.fission_q_prompt_)(p.E_last_);
     }
   } else if (score_bin == SCORE_FISS_Q_RECOV) {
     if (nuc.fission_q_recov_) {
-      return (*nuc.fission_q_recov_)(p->E_last_);
+      return (*nuc.fission_q_recov_)(p.E_last_);
     }
   }
   return 0.0;
@@ -196,47 +196,47 @@ double get_nuc_fission_q(const Nuclide& nuc, const Particle* p, int score_bin)
 //! Pulled out to support both the fission_q scores and energy deposition
 //! score
 
-double score_fission_q(const Particle* p, int score_bin, const Tally& tally,
+double score_fission_q(const Particle& p, int score_bin, const Tally& tally,
   double flux, int i_nuclide, double atom_density)
 {
   if (tally.estimator_ == TallyEstimator::ANALOG) {
-    const Nuclide& nuc {*data::nuclides[p->event_nuclide_]};
+    const Nuclide& nuc {*data::nuclides[p.event_nuclide_]};
     if (settings::survival_biasing) {
       // No fission events occur if survival biasing is on -- need to
       // calculate fraction of absorptions that would have resulted in
       // fission scaled by the Q-value
-      if (p->neutron_xs_[p->event_nuclide_].absorption > 0) {
-        return p->wgt_absorb_ * get_nuc_fission_q(nuc, p, score_bin)
-               * p->neutron_xs_[p->event_nuclide_].fission * flux
-               / p->neutron_xs_[p->event_nuclide_].absorption;
+      if (p.neutron_xs_[p.event_nuclide_].absorption > 0) {
+        return p.wgt_absorb_ * get_nuc_fission_q(nuc, p, score_bin)
+               * p.neutron_xs_[p.event_nuclide_].fission * flux
+               / p.neutron_xs_[p.event_nuclide_].absorption;
       }
     } else {
       // Skip any non-absorption events
-      if (p->event_ == TallyEvent::SCATTER) return 0.0;
+      if (p.event_ == TallyEvent::SCATTER) return 0.0;
       // All fission events will contribute, so again we can use particle's
       // weight entering the collision as the estimate for the fission
       // reaction rate
-      if (p->neutron_xs_[p->event_nuclide_].absorption > 0) {
-        return p->wgt_last_ * get_nuc_fission_q(nuc, p, score_bin)
-               * p->neutron_xs_[p->event_nuclide_].fission * flux
-               / p->neutron_xs_[p->event_nuclide_].absorption;
+      if (p.neutron_xs_[p.event_nuclide_].absorption > 0) {
+        return p.wgt_last_ * get_nuc_fission_q(nuc, p, score_bin)
+               * p.neutron_xs_[p.event_nuclide_].fission * flux
+               / p.neutron_xs_[p.event_nuclide_].absorption;
       }
     }
   } else {
     if (i_nuclide >= 0) {
       const Nuclide& nuc {*data::nuclides[i_nuclide]};
       return get_nuc_fission_q(nuc, p, score_bin) * atom_density * flux
-             * p->neutron_xs_[i_nuclide].fission;
+             * p.neutron_xs_[i_nuclide].fission;
     } else {
-      if (p->material_ != MATERIAL_VOID) {
-        const Material& material {*model::materials[p->material_]};
+      if (p.material_ != MATERIAL_VOID) {
+        const Material& material {*model::materials[p.material_]};
         double score {0.0};
         for (auto i = 0; i < material.nuclide_.size(); ++i) {
           auto j_nuclide = material.nuclide_[i];
           auto atom_density = material.atom_density_(i);
           const Nuclide& nuc {*data::nuclides[j_nuclide]};
           score += get_nuc_fission_q(nuc, p, score_bin) * atom_density
-            * p->neutron_xs_[j_nuclide].fission;
+            * p.neutron_xs_[j_nuclide].fission;
         }
         return score * flux;
       }
@@ -247,28 +247,28 @@ double score_fission_q(const Particle* p, int score_bin, const Tally& tally,
 
 //! Helper function to obtain the kerma coefficient for a given nuclide
 
-double get_nuclide_neutron_heating(const Particle* p, const Nuclide& nuc,
+double get_nuclide_neutron_heating(const Particle& p, const Nuclide& nuc,
     int rxn_index, int i_nuclide)
 {
   size_t mt = nuc.reaction_index_[rxn_index];
   if (mt == C_NONE) return 0.0;
 
-  auto i_temp = p->neutron_xs_[i_nuclide].index_temp;
+  auto i_temp = p.neutron_xs_[i_nuclide].index_temp;
   if (i_temp < 0) return 0.0; // Can be true due to multipole
 
   const auto& rxn {*nuc.reactions_[mt]};
   const auto& xs {rxn.xs_[i_temp]};
-  auto i_grid = p->neutron_xs_[i_nuclide].index_grid;
+  auto i_grid = p.neutron_xs_[i_nuclide].index_grid;
   if (i_grid < xs.threshold) return 0.0;
 
-  auto f = p->neutron_xs_[i_nuclide].interp_factor;
+  auto f = p.neutron_xs_[i_nuclide].interp_factor;
   return (1.0 - f) * xs.value[i_grid-xs.threshold]
     + f * xs.value[i_grid-xs.threshold+1];
 }
 
 //! Helper function to obtain neutron heating [eV]
 
-double score_neutron_heating(const Particle* p, const Tally& tally, double flux,
+double score_neutron_heating(const Particle& p, const Tally& tally, double flux,
     int rxn_bin, int i_nuclide, double atom_density)
 {
   double score;
@@ -278,14 +278,14 @@ double score_neutron_heating(const Particle* p, const Tally& tally, double flux,
     const Nuclide& nuc {*data::nuclides[i_nuclide]};
     heating_xs = get_nuclide_neutron_heating(p, nuc, rxn_bin, i_nuclide);
     if (tally.estimator_ == TallyEstimator::ANALOG) {
-      heating_xs /= p->neutron_xs_[i_nuclide].total;
+      heating_xs /= p.neutron_xs_[i_nuclide].total;
     } else {
       heating_xs *= atom_density;
     }
   } else {
-    if (p->material_ != MATERIAL_VOID) {
+    if (p.material_ != MATERIAL_VOID) {
       heating_xs = 0.0;
-      const Material& material {*model::materials[p->material_]};
+      const Material& material {*model::materials[p.material_]};
       for (auto i = 0; i< material.nuclide_.size(); ++i) {
         int j_nuclide = material.nuclide_[i];
         double atom_density {material.atom_density_(i)};
@@ -293,7 +293,7 @@ double score_neutron_heating(const Particle* p, const Tally& tally, double flux,
         heating_xs += atom_density * get_nuclide_neutron_heating(p, nuc, rxn_bin, j_nuclide);
       }
       if (tally.estimator_ == TallyEstimator::ANALOG) {
-        heating_xs /= p->macro_xs_.total;
+        heating_xs /= p.macro_xs_.total;
       }
     }
   }
@@ -304,9 +304,9 @@ double score_neutron_heating(const Particle* p, const Tally& tally, double flux,
     // reaction-wise heating cross section
     if (settings::survival_biasing) {
       // Account for the fact that some weight has been absorbed
-      score *= p->wgt_last_ + p->wgt_absorb_;
+      score *= p.wgt_last_ + p.wgt_absorb_;
     } else {
-      score *= p->wgt_last_;
+      score *= p.wgt_last_;
     }
   }
   return score;
@@ -318,12 +318,12 @@ double score_neutron_heating(const Particle* p, const Tally& tally, double flux,
 //! neutrons produced with different energies.
 
 void
-score_fission_eout(Particle* p, int i_tally, int i_score, int score_bin)
+score_fission_eout(Particle& p, int i_tally, int i_score, int score_bin)
 {
   auto& tally {*model::tallies[i_tally]};
   auto i_eout_filt = tally.filters()[tally.energyout_filter_];
-  auto i_bin = p->filter_matches_[i_eout_filt].i_bin_;
-  auto bin_energyout = p->filter_matches_[i_eout_filt].bins_[i_bin];
+  auto i_bin = p.filter_matches_[i_eout_filt].i_bin_;
+  auto bin_energyout = p.filter_matches_[i_eout_filt].bins_[i_bin];
 
   const EnergyoutFilter& eo_filt
     {*dynamic_cast<EnergyoutFilter*>(model::tally_filters[i_eout_filt].get())};
@@ -334,8 +334,8 @@ score_fission_eout(Particle* p, int i_tally, int i_score, int score_bin)
   // rate. Otherwise, the sum of all nu-fission rates would be ~1.0.
 
   // loop over number of particles banked
-  for (auto i = 0; i < p->n_bank_; ++i) {
-    const auto& bank = p->nu_bank_[i];
+  for (auto i = 0; i < p.n_bank_; ++i) {
+    const auto& bank = p.nu_bank_[i];
 
     // get the delayed group
     auto g = bank.delayed_group;
@@ -347,7 +347,7 @@ score_fission_eout(Particle* p, int i_tally, int i_score, int score_bin)
     // i_nuclide and atom_density arguments do not matter since this is an
     // analog estimator.
     if (tally.deriv_ != C_NONE)
-      apply_derivative_to_score(*p, i_tally, 0, 0., SCORE_NU_FISSION, score);
+      apply_derivative_to_score(p, i_tally, 0, 0., SCORE_NU_FISSION, score);
 
     if (!settings::run_CE && eo_filt.matches_transport_groups()) {
 
@@ -359,7 +359,7 @@ score_fission_eout(Particle* p, int i_tally, int i_score, int score_bin)
       g_out = eo_filt.n_bins() - g_out - 1;
 
       // change outgoing energy bin
-      p->filter_matches_[i_eout_filt].bins_[i_bin] = g_out;
+      p.filter_matches_[i_eout_filt].bins_[i_bin] = g_out;
 
     } else {
 
@@ -376,7 +376,7 @@ score_fission_eout(Particle* p, int i_tally, int i_score, int score_bin)
       } else {
         auto i_match = lower_bound_index(eo_filt.bins().begin(),
           eo_filt.bins().end(), E_out);
-        p->filter_matches_[i_eout_filt].bins_[i_bin] = i_match;
+        p.filter_matches_[i_eout_filt].bins_[i_bin] = i_match;
       }
 
     }
@@ -390,7 +390,7 @@ score_fission_eout(Particle* p, int i_tally, int i_score, int score_bin)
       double filter_weight = 1.0;
       for (auto j = 0; j < tally.filters().size(); ++j) {
         auto i_filt = tally.filters(j);
-        auto& match {p->filter_matches_[i_filt]};
+        auto& match {p.filter_matches_[i_filt]};
         auto i_bin = match.i_bin_;
         filter_index += match.bins_[i_bin] * tally.strides(j);
         filter_weight *= match.weights_[i_bin];
@@ -419,13 +419,13 @@ score_fission_eout(Particle* p, int i_tally, int i_score, int score_bin)
             double filter_weight = 1.;
             for (auto j = 0; j < tally.filters().size(); ++j) {
               auto i_filt = tally.filters(j);
-              auto& match {p->filter_matches_[i_filt]};
+              auto& match {p.filter_matches_[i_filt]};
               auto i_bin = match.i_bin_;
               filter_weight *= match.weights_[i_bin];
             }
 
             score_fission_delayed_dg(i_tally, d_bin, score*filter_weight,
-              i_score, p->filter_matches_);
+              i_score, p.filter_matches_);
           }
         }
 
@@ -437,7 +437,7 @@ score_fission_eout(Particle* p, int i_tally, int i_score, int score_bin)
         double filter_weight = 1.;
         for (auto j = 0; j < tally.filters().size(); ++j) {
           auto i_filt = tally.filters(j);
-          auto& match {p->filter_matches_[i_filt]};
+          auto& match {p.filter_matches_[i_filt]};
           auto i_bin = match.i_bin_;
           filter_index += match.bins_[i_bin] * tally.strides(j);
           filter_weight *= match.weights_[i_bin];
@@ -451,7 +451,7 @@ score_fission_eout(Particle* p, int i_tally, int i_score, int score_bin)
   }
 
   // Reset outgoing energy bin and score index
-  p->filter_matches_[i_eout_filt].bins_[i_bin] = bin_energyout;
+  p.filter_matches_[i_eout_filt].bins_[i_bin] = bin_energyout;
 }
 
 //! Update tally results for continuous-energy tallies with any estimator.
@@ -461,13 +461,13 @@ score_fission_eout(Particle* p, int i_tally, int i_score, int score_bin)
 //! is not used for analog tallies.
 
 void
-score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
+score_general_ce(Particle& p, int i_tally, int start_index, int filter_index,
   double filter_weight, int i_nuclide, double atom_density, double flux)
 {
   Tally& tally {*model::tallies[i_tally]};
 
   // Get the pre-collision energy of the particle.
-  auto E = p->E_last_;
+  auto E = p.E_last_;
 
   for (auto i = 0; i < tally.scores_.size(); ++i) {
     auto score_bin = tally.scores_[i];
@@ -483,14 +483,14 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
         if (settings::survival_biasing) {
           // We need to account for the fact that some weight was already
           // absorbed
-          score = p->wgt_last_ + p->wgt_absorb_;
+          score = p.wgt_last_ + p.wgt_absorb_;
         } else {
-          score = p->wgt_last_;
+          score = p.wgt_last_;
         }
 
-        if (p->type_ == Particle::Type::neutron ||
-          p->type_ == Particle::Type::photon) {
-          score *= flux / p->macro_xs_.total;
+        if (p.type_ == Particle::Type::neutron ||
+          p.type_ == Particle::Type::photon) {
+          score *= flux / p.macro_xs_.total;
         } else {
           score = 0.;
         }
@@ -507,20 +507,20 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
         if (settings::survival_biasing) {
           // We need to account for the fact that some weight was already
           // absorbed
-          score = (p->wgt_last_ + p->wgt_absorb_) * flux;
+          score = (p.wgt_last_ + p.wgt_absorb_) * flux;
         } else {
-          score = p->wgt_last_ * flux;
+          score = p.wgt_last_ * flux;
         }
 
       } else {
         if (i_nuclide >= 0) {
-          if (p->type_ == Particle::Type::neutron) {
-            score = p->neutron_xs_[i_nuclide].total * atom_density * flux;
-          } else if (p->type_ == Particle::Type::photon) {
-            score = p->photon_xs_[i_nuclide].total * atom_density * flux;
+          if (p.type_ == Particle::Type::neutron) {
+            score = p.neutron_xs_[i_nuclide].total * atom_density * flux;
+          } else if (p.type_ == Particle::Type::photon) {
+            score = p.photon_xs_[i_nuclide].total * atom_density * flux;
           }
         } else {
-          score = p->macro_xs_.total * flux;
+          score = p.macro_xs_.total * flux;
         }
       }
       break;
@@ -534,11 +534,11 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
         if (settings::survival_biasing) {
           // We need to account for the fact that some weight was already
           // absorbed
-          score = p->wgt_last_ + p->wgt_absorb_;
+          score = p.wgt_last_ + p.wgt_absorb_;
         } else {
-          score = p->wgt_last_;
+          score = p.wgt_last_;
         }
-        score *= flux / p->macro_xs_.total;
+        score *= flux / p.macro_xs_.total;
       } else {
         score = flux;
       }
@@ -550,17 +550,17 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
     case SCORE_SCATTER:
       if (tally.estimator_ == TallyEstimator::ANALOG) {
         // Skip any event where the particle didn't scatter
-        if (p->event_ != TallyEvent::SCATTER) continue;
+        if (p.event_ != TallyEvent::SCATTER) continue;
         // Since only scattering events make it here, again we can use the
         // weight entering the collision as the estimator for the reaction rate
-        score = p->wgt_last_ * flux;
+        score = p.wgt_last_ * flux;
       } else {
         if (i_nuclide >= 0) {
-          score = (p->neutron_xs_[i_nuclide].total
-            - p->neutron_xs_[i_nuclide].absorption) * atom_density * flux;
+          score = (p.neutron_xs_[i_nuclide].total
+            - p.neutron_xs_[i_nuclide].absorption) * atom_density * flux;
         } else {
-          score = (p->macro_xs_.total
-            - p->macro_xs_.absorption) * flux;
+          score = (p.macro_xs_.total
+            - p.macro_xs_.absorption) * flux;
         }
       }
       break;
@@ -569,21 +569,21 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
     case SCORE_NU_SCATTER:
       // Only analog estimators are available.
       // Skip any event where the particle didn't scatter
-      if (p->event_ != TallyEvent::SCATTER) continue;
+      if (p.event_ != TallyEvent::SCATTER) continue;
       // For scattering production, we need to use the pre-collision weight
       // times the yield as the estimate for the number of neutrons exiting a
       // reaction with neutrons in the exit channel
-      if (p->event_mt_ == ELASTIC || p->event_mt_ == N_LEVEL ||
-        (p->event_mt_ >= N_N1 && p->event_mt_ <= N_NC)) {
+      if (p.event_mt_ == ELASTIC || p.event_mt_ == N_LEVEL ||
+        (p.event_mt_ >= N_N1 && p.event_mt_ <= N_NC)) {
         // Don't waste time on very common reactions we know have
         // multiplicities of one.
-        score = p->wgt_last_ * flux;
+        score = p.wgt_last_ * flux;
       } else {
         // Get yield and apply to score
         auto m =
-          data::nuclides[p->event_nuclide_]->reaction_index_[p->event_mt_];
-        const auto& rxn {*data::nuclides[p->event_nuclide_]->reactions_[m]};
-        score = p->wgt_last_ * flux * (*rxn.products_[0].yield_)(E);
+          data::nuclides[p.event_nuclide_]->reaction_index_[p.event_mt_];
+        const auto& rxn {*data::nuclides[p.event_nuclide_]->reactions_[m]};
+        score = p.wgt_last_ * flux * (*rxn.products_[0].yield_)(E);
       }
       break;
 
@@ -593,63 +593,63 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
         if (settings::survival_biasing) {
           // No absorption events actually occur if survival biasing is on --
           // just use weight absorbed in survival biasing
-          score = p->wgt_absorb_ * flux;
+          score = p.wgt_absorb_ * flux;
         } else {
           // Skip any event where the particle wasn't absorbed
-          if (p->event_ == TallyEvent::SCATTER) continue;
+          if (p.event_ == TallyEvent::SCATTER) continue;
           // All fission and absorption events will contribute here, so we
           // can just use the particle's weight entering the collision
-          score = p->wgt_last_ * flux;
+          score = p.wgt_last_ * flux;
         }
       } else {
         if (i_nuclide >= 0) {
-          score = p->neutron_xs_[i_nuclide].absorption * atom_density
+          score = p.neutron_xs_[i_nuclide].absorption * atom_density
             * flux;
         } else {
-          score = p->macro_xs_.absorption * flux;
+          score = p.macro_xs_.absorption * flux;
         }
       }
       break;
 
 
     case SCORE_FISSION:
-      if (p->macro_xs_.absorption == 0) continue;
+      if (p.macro_xs_.absorption == 0) continue;
       if (tally.estimator_ == TallyEstimator::ANALOG) {
         if (settings::survival_biasing) {
           // No fission events occur if survival biasing is on -- need to
           // calculate fraction of absorptions that would have resulted in
           // fission
-          if (p->neutron_xs_[p->event_nuclide_].absorption > 0) {
-            score = p->wgt_absorb_
-              * p->neutron_xs_[p->event_nuclide_].fission
-              / p->neutron_xs_[p->event_nuclide_].absorption * flux;
+          if (p.neutron_xs_[p.event_nuclide_].absorption > 0) {
+            score = p.wgt_absorb_
+              * p.neutron_xs_[p.event_nuclide_].fission
+              / p.neutron_xs_[p.event_nuclide_].absorption * flux;
           } else {
             score = 0.;
           }
         } else {
           // Skip any non-absorption events
-          if (p->event_ == TallyEvent::SCATTER) continue;
+          if (p.event_ == TallyEvent::SCATTER) continue;
           // All fission events will contribute, so again we can use particle's
           // weight entering the collision as the estimate for the fission
           // reaction rate
-          score = p->wgt_last_
-            * p->neutron_xs_[p->event_nuclide_].fission
-            / p->neutron_xs_[p->event_nuclide_].absorption * flux;
+          score = p.wgt_last_
+            * p.neutron_xs_[p.event_nuclide_].fission
+            / p.neutron_xs_[p.event_nuclide_].absorption * flux;
         }
       } else {
         if (i_nuclide >= 0) {
-          score = p->neutron_xs_[i_nuclide].fission * atom_density * flux;
+          score = p.neutron_xs_[i_nuclide].fission * atom_density * flux;
         } else {
-          score = p->macro_xs_.fission * flux;
+          score = p.macro_xs_.fission * flux;
         }
       }
       break;
 
 
     case SCORE_NU_FISSION:
-      if (p->macro_xs_.absorption == 0) continue;
+      if (p.macro_xs_.absorption == 0) continue;
       if (tally.estimator_ == TallyEstimator::ANALOG) {
-        if (settings::survival_biasing || p->fission_) {
+        if (settings::survival_biasing || p.fission_) {
           if (tally.energyout_filter_ != C_NONE) {
             // Fission has multiple outgoing neutrons so this helper function
             // is used to handle scoring the multiple filter bins.
@@ -661,38 +661,38 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
           // No fission events occur if survival biasing is on -- need to
           // calculate fraction of absorptions that would have resulted in
           // nu-fission
-          if (p->neutron_xs_[p->event_nuclide_].absorption > 0) {
-            score = p->wgt_absorb_
-              * p->neutron_xs_[p->event_nuclide_].nu_fission
-              / p->neutron_xs_[p->event_nuclide_].absorption * flux;
+          if (p.neutron_xs_[p.event_nuclide_].absorption > 0) {
+            score = p.wgt_absorb_
+              * p.neutron_xs_[p.event_nuclide_].nu_fission
+              / p.neutron_xs_[p.event_nuclide_].absorption * flux;
           } else {
             score = 0.;
           }
         } else {
           // Skip any non-fission events
-          if (!p->fission_) continue;
+          if (!p.fission_) continue;
           // If there is no outgoing energy filter, than we only need to score
           // to one bin. For the score to be 'analog', we need to score the
           // number of particles that were banked in the fission bank. Since
           // this was weighted by 1/keff, we multiply by keff to get the proper
           // score.
-          score = simulation::keff * p->wgt_bank_ * flux;
+          score = simulation::keff * p.wgt_bank_ * flux;
         }
       } else {
         if (i_nuclide >= 0) {
-          score = p->neutron_xs_[i_nuclide].nu_fission * atom_density
+          score = p.neutron_xs_[i_nuclide].nu_fission * atom_density
             * flux;
         } else {
-          score = p->macro_xs_.nu_fission * flux;
+          score = p.macro_xs_.nu_fission * flux;
         }
       }
       break;
 
 
     case SCORE_PROMPT_NU_FISSION:
-      if (p->macro_xs_.absorption == 0) continue;
+      if (p.macro_xs_.absorption == 0) continue;
       if (tally.estimator_ == TallyEstimator::ANALOG) {
-        if (settings::survival_biasing || p->fission_) {
+        if (settings::survival_biasing || p.fission_) {
           if (tally.energyout_filter_ != C_NONE) {
             // Fission has multiple outgoing neutrons so this helper function
             // is used to handle scoring the multiple filter bins.
@@ -704,43 +704,43 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
           // No fission events occur if survival biasing is on -- need to
           // calculate fraction of absorptions that would have resulted in
           // prompt-nu-fission
-          if (p->neutron_xs_[p->event_nuclide_].absorption > 0) {
-            score = p->wgt_absorb_
-              * p->neutron_xs_[p->event_nuclide_].fission
-              * data::nuclides[p->event_nuclide_]
+          if (p.neutron_xs_[p.event_nuclide_].absorption > 0) {
+            score = p.wgt_absorb_
+              * p.neutron_xs_[p.event_nuclide_].fission
+              * data::nuclides[p.event_nuclide_]
               ->nu(E, ReactionProduct::EmissionMode::prompt)
-              / p->neutron_xs_[p->event_nuclide_].absorption * flux;
+              / p.neutron_xs_[p.event_nuclide_].absorption * flux;
           } else {
             score = 0.;
           }
         } else {
           // Skip any non-fission events
-          if (!p->fission_) continue;
+          if (!p.fission_) continue;
           // If there is no outgoing energy filter, than we only need to score
           // to one bin. For the score to be 'analog', we need to score the
           // number of particles that were banked in the fission bank. Since
           // this was weighted by 1/keff, we multiply by keff to get the proper
           // score.
-          auto n_delayed = std::accumulate(p->n_delayed_bank_,
-            p->n_delayed_bank_+MAX_DELAYED_GROUPS, 0);
-          auto prompt_frac = 1. - n_delayed / static_cast<double>(p->n_bank_);
-          score = simulation::keff * p->wgt_bank_ * prompt_frac * flux;
+          auto n_delayed = std::accumulate(p.n_delayed_bank_,
+            p.n_delayed_bank_+MAX_DELAYED_GROUPS, 0);
+          auto prompt_frac = 1. - n_delayed / static_cast<double>(p.n_bank_);
+          score = simulation::keff * p.wgt_bank_ * prompt_frac * flux;
         }
       } else {
         if (i_nuclide >= 0) {
-          score = p->neutron_xs_[i_nuclide].fission
+          score = p.neutron_xs_[i_nuclide].fission
             * data::nuclides[i_nuclide]
             ->nu(E, ReactionProduct::EmissionMode::prompt)
             * atom_density * flux;
         } else {
           score = 0.;
           // Add up contributions from each nuclide in the material.
-          if (p->material_ != MATERIAL_VOID) {
-            const Material& material {*model::materials[p->material_]};
+          if (p.material_ != MATERIAL_VOID) {
+            const Material& material {*model::materials[p.material_]};
             for (auto i = 0; i < material.nuclide_.size(); ++i) {
               auto j_nuclide = material.nuclide_[i];
               auto atom_density = material.atom_density_(i);
-              score += p->neutron_xs_[j_nuclide].fission
+              score += p.neutron_xs_[j_nuclide].fission
                 * data::nuclides[j_nuclide]
                 ->nu(E, ReactionProduct::EmissionMode::prompt)
                 * atom_density * flux;
@@ -752,9 +752,9 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
 
 
     case SCORE_DELAYED_NU_FISSION:
-      if (p->macro_xs_.absorption == 0) continue;
+      if (p.macro_xs_.absorption == 0) continue;
       if (tally.estimator_ == TallyEstimator::ANALOG) {
-        if (settings::survival_biasing || p->fission_) {
+        if (settings::survival_biasing || p.fission_) {
           if (tally.energyout_filter_ != C_NONE) {
             // Fission has multiple outgoing neutrons so this helper function
             // is used to handle scoring the multiple filter bins.
@@ -766,8 +766,8 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
           // No fission events occur if survival biasing is on -- need to
           // calculate fraction of absorptions that would have resulted in
           // delayed-nu-fission
-          if (p->neutron_xs_[p->event_nuclide_].absorption > 0
-            && data::nuclides[p->event_nuclide_]->fissionable_) {
+          if (p.neutron_xs_[p.event_nuclide_].absorption > 0
+            && data::nuclides[p.event_nuclide_]->fissionable_) {
             if (tally.delayedgroup_filter_ != C_NONE) {
               auto i_dg_filt = tally.filters()[tally.delayedgroup_filter_];
               const DelayedGroupFilter& filt
@@ -776,29 +776,29 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
               // Tally each delayed group bin individually
               for (auto d_bin = 0; d_bin < filt.n_bins(); ++d_bin) {
                 auto d = filt.groups()[d_bin];
-                auto yield = data::nuclides[p->event_nuclide_]
+                auto yield = data::nuclides[p.event_nuclide_]
                   ->nu(E, ReactionProduct::EmissionMode::delayed, d);
-                score = p->wgt_absorb_ * yield
-                  * p->neutron_xs_[p->event_nuclide_].fission
-                  / p->neutron_xs_[p->event_nuclide_].absorption * flux;
+                score = p.wgt_absorb_ * yield
+                  * p.neutron_xs_[p.event_nuclide_].fission
+                  / p.neutron_xs_[p.event_nuclide_].absorption * flux;
                 score_fission_delayed_dg(i_tally, d_bin, score,
-                  score_index, p->filter_matches_);
+                  score_index, p.filter_matches_);
               }
               continue;
             } else {
               // If the delayed group filter is not present, compute the score
               // by multiplying the absorbed weight by the fraction of the
               // delayed-nu-fission xs to the absorption xs
-              score = p->wgt_absorb_
-                * p->neutron_xs_[p->event_nuclide_].fission
-                * data::nuclides[p->event_nuclide_]
+              score = p.wgt_absorb_
+                * p.neutron_xs_[p.event_nuclide_].fission
+                * data::nuclides[p.event_nuclide_]
                 ->nu(E, ReactionProduct::EmissionMode::delayed)
-                / p->neutron_xs_[p->event_nuclide_].absorption *flux;
+                / p.neutron_xs_[p.event_nuclide_].absorption *flux;
             }
           }
         } else {
           // Skip any non-fission events
-          if (!p->fission_) continue;
+          if (!p.fission_) continue;
           // If there is no outgoing energy filter, than we only need to score
           // to one bin. For the score to be 'analog', we need to score the
           // number of particles that were banked in the fission bank. Since
@@ -814,16 +814,16 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
             // Tally each delayed group bin individually
             for (auto d_bin = 0; d_bin < filt.n_bins(); ++d_bin) {
               auto d = filt.groups()[d_bin];
-              score = simulation::keff * p->wgt_bank_ / p->n_bank_
-                * p->n_delayed_bank_[d-1] * flux;
-              score_fission_delayed_dg(i_tally, d_bin, score, score_index, p->filter_matches_);
+              score = simulation::keff * p.wgt_bank_ / p.n_bank_
+                * p.n_delayed_bank_[d-1] * flux;
+              score_fission_delayed_dg(i_tally, d_bin, score, score_index, p.filter_matches_);
             }
             continue;
           } else {
             // Add the contribution from all delayed groups
-            auto n_delayed = std::accumulate(p->n_delayed_bank_,
-              p->n_delayed_bank_+MAX_DELAYED_GROUPS, 0);
-            score = simulation::keff * p->wgt_bank_ / p->n_bank_ * n_delayed
+            auto n_delayed = std::accumulate(p.n_delayed_bank_,
+              p.n_delayed_bank_+MAX_DELAYED_GROUPS, 0);
+            score = simulation::keff * p.wgt_bank_ / p.n_bank_ * n_delayed
               * flux;
           }
         }
@@ -839,15 +839,15 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
               auto d = filt.groups()[d_bin];
               auto yield = data::nuclides[i_nuclide]
                 ->nu(E, ReactionProduct::EmissionMode::delayed, d);
-              score = p->neutron_xs_[i_nuclide].fission * yield
+              score = p.neutron_xs_[i_nuclide].fission * yield
                 * atom_density * flux;
-              score_fission_delayed_dg(i_tally, d_bin, score, score_index, p->filter_matches_);
+              score_fission_delayed_dg(i_tally, d_bin, score, score_index, p.filter_matches_);
             }
             continue;
           } else {
             // If the delayed group filter is not present, compute the score
             // by multiplying the delayed-nu-fission macro xs by the flux
-            score = p->neutron_xs_[i_nuclide].fission
+            score = p.neutron_xs_[i_nuclide].fission
               * data::nuclides[i_nuclide]
               ->nu(E, ReactionProduct::EmissionMode::delayed)
               * atom_density * flux;
@@ -858,8 +858,8 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
             const DelayedGroupFilter& filt
               {*dynamic_cast<DelayedGroupFilter*>(
               model::tally_filters[i_dg_filt].get())};
-            if (p->material_ != MATERIAL_VOID) {
-              const Material& material {*model::materials[p->material_]};
+            if (p.material_ != MATERIAL_VOID) {
+              const Material& material {*model::materials[p.material_]};
               for (auto i = 0; i < material.nuclide_.size(); ++i) {
                 auto j_nuclide = material.nuclide_[i];
                 auto atom_density = material.atom_density_(i);
@@ -868,22 +868,22 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
                   auto d = filt.groups()[d_bin];
                   auto yield = data::nuclides[j_nuclide]
                     ->nu(E, ReactionProduct::EmissionMode::delayed, d);
-                  score = p->neutron_xs_[j_nuclide].fission * yield
+                  score = p.neutron_xs_[j_nuclide].fission * yield
                     * atom_density * flux;
                   score_fission_delayed_dg(i_tally, d_bin, score,
-                    score_index, p->filter_matches_);
+                    score_index, p.filter_matches_);
                 }
               }
             }
             continue;
           } else {
             score = 0.;
-            if (p->material_ != MATERIAL_VOID) {
-              const Material& material {*model::materials[p->material_]};
+            if (p.material_ != MATERIAL_VOID) {
+              const Material& material {*model::materials[p.material_]};
               for (auto i = 0; i < material.nuclide_.size(); ++i) {
                 auto j_nuclide = material.nuclide_[i];
                 auto atom_density = material.atom_density_(i);
-                score += p->neutron_xs_[j_nuclide].fission
+                score += p.neutron_xs_[j_nuclide].fission
                   * data::nuclides[j_nuclide]
                   ->nu(E, ReactionProduct::EmissionMode::delayed)
                   * atom_density * flux;
@@ -896,14 +896,14 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
 
 
     case SCORE_DECAY_RATE:
-      if (p->macro_xs_.absorption == 0) continue;
+      if (p.macro_xs_.absorption == 0) continue;
       if (tally.estimator_ == TallyEstimator::ANALOG) {
         if (settings::survival_biasing) {
           // No fission events occur if survival biasing is on -- need to
           // calculate fraction of absorptions that would have resulted in
           // delayed-nu-fission
-          const auto& nuc {*data::nuclides[p->event_nuclide_]};
-          if (p->neutron_xs_[p->event_nuclide_].absorption > 0
+          const auto& nuc {*data::nuclides[p.event_nuclide_]};
+          if (p.neutron_xs_[p.event_nuclide_].absorption > 0
             && nuc.fissionable_) {
             const auto& rxn {*nuc.fission_rx_[0]};
             if (tally.delayedgroup_filter_ != C_NONE) {
@@ -917,12 +917,12 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
                 auto yield
                   = nuc.nu(E, ReactionProduct::EmissionMode::delayed, d);
                 auto rate = rxn.products_[d].decay_rate_;
-                score = p->wgt_absorb_ * yield
-                  * p->neutron_xs_[p->event_nuclide_].fission
-                  / p->neutron_xs_[p->event_nuclide_].absorption
+                score = p.wgt_absorb_ * yield
+                  * p.neutron_xs_[p.event_nuclide_].fission
+                  / p.neutron_xs_[p.event_nuclide_].absorption
                   * rate * flux;
                 score_fission_delayed_dg(i_tally, d_bin, score,
-                  score_index, p->filter_matches_);
+                  score_index, p.filter_matches_);
               }
               continue;
             } else {
@@ -940,15 +940,15 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
                 auto yield
                   = nuc.nu(E, ReactionProduct::EmissionMode::delayed, d+1);
                 auto rate = rxn.products_[d+1].decay_rate_;
-                score += rate * p->wgt_absorb_
-                  * p->neutron_xs_[p->event_nuclide_].fission * yield
-                  / p->neutron_xs_[p->event_nuclide_].absorption * flux;
+                score += rate * p.wgt_absorb_
+                  * p.neutron_xs_[p.event_nuclide_].fission * yield
+                  / p.neutron_xs_[p.event_nuclide_].absorption * flux;
               }
             }
           }
         } else {
           // Skip any non-fission events
-          if (!p->fission_) continue;
+          if (!p.fission_) continue;
           // If there is no outgoing energy filter, than we only need to score
           // to one bin. For the score to be 'analog', we need to score the
           // number of particles that were banked in the fission bank. Since
@@ -957,11 +957,11 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
           // ones are delayed. If a delayed neutron is encountered, add its
           // contribution to the fission bank to the score.
           score = 0.;
-          for (auto i = 0; i < p->n_bank_; ++i) {
-            const auto& bank = p->nu_bank_[i];
+          for (auto i = 0; i < p.n_bank_; ++i) {
+            const auto& bank = p.nu_bank_[i];
             auto g = bank.delayed_group;
             if (g != 0) {
-              const auto& nuc {*data::nuclides[p->event_nuclide_]};
+              const auto& nuc {*data::nuclides[p.event_nuclide_]};
               const auto& rxn {*nuc.fission_rx_[0]};
               auto rate = rxn.products_[g].decay_rate_;
               score += simulation::keff * bank.wgt * rate * flux;
@@ -975,7 +975,7 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
                   auto d = filt.groups()[d_bin];
                   if (d == g)
                     score_fission_delayed_dg(i_tally, d_bin, score,
-                      score_index, p->filter_matches_);
+                      score_index, p.filter_matches_);
                 }
                 score = 0.;
               }
@@ -998,9 +998,9 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
               auto yield
                 = nuc.nu(E, ReactionProduct::EmissionMode::delayed, d);
               auto rate = rxn.products_[d].decay_rate_;
-              score = p->neutron_xs_[i_nuclide].fission * yield * flux
+              score = p.neutron_xs_[i_nuclide].fission * yield * flux
                 * atom_density * rate;
-              score_fission_delayed_dg(i_tally, d_bin, score, score_index, p->filter_matches_);
+              score_fission_delayed_dg(i_tally, d_bin, score, score_index, p.filter_matches_);
             }
             continue;
           } else {
@@ -1014,7 +1014,7 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
               auto yield
                 = nuc.nu(E, ReactionProduct::EmissionMode::delayed, d+1);
               auto rate = rxn.products_[d+1].decay_rate_;
-              score += p->neutron_xs_[i_nuclide].fission * flux
+              score += p.neutron_xs_[i_nuclide].fission * flux
                 * yield * atom_density * rate;
             }
           }
@@ -1024,8 +1024,8 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
             const DelayedGroupFilter& filt
               {*dynamic_cast<DelayedGroupFilter*>(
               model::tally_filters[i_dg_filt].get())};
-            if (p->material_ != MATERIAL_VOID) {
-              const Material& material {*model::materials[p->material_]};
+            if (p.material_ != MATERIAL_VOID) {
+              const Material& material {*model::materials[p.material_]};
               for (auto i = 0; i < material.nuclide_.size(); ++i) {
                 auto j_nuclide = material.nuclide_[i];
                 auto atom_density = material.atom_density_(i);
@@ -1038,10 +1038,10 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
                     auto yield
                       = nuc.nu(E, ReactionProduct::EmissionMode::delayed, d);
                     auto rate = rxn.products_[d].decay_rate_;
-                    score = p->neutron_xs_[j_nuclide].fission * yield
+                    score = p.neutron_xs_[j_nuclide].fission * yield
                       * flux * atom_density * rate;
                     score_fission_delayed_dg(i_tally, d_bin, score,
-                      score_index, p->filter_matches_);
+                      score_index, p.filter_matches_);
                   }
                 }
               }
@@ -1049,8 +1049,8 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
             continue;
           } else {
             score = 0.;
-            if (p->material_ != MATERIAL_VOID) {
-              const Material& material {*model::materials[p->material_]};
+            if (p.material_ != MATERIAL_VOID) {
+              const Material& material {*model::materials[p.material_]};
               for (auto i = 0; i < material.nuclide_.size(); ++i) {
                 auto j_nuclide = material.nuclide_[i];
                 auto atom_density = material.atom_density_(i);
@@ -1066,7 +1066,7 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
                     auto yield
                       = nuc.nu(E, ReactionProduct::EmissionMode::delayed, d+1);
                     auto rate = rxn.products_[d+1].decay_rate_;
-                    score += p->neutron_xs_[j_nuclide].fission
+                    score += p.neutron_xs_[j_nuclide].fission
                       * yield * atom_density * flux * rate;
                   }
                 }
@@ -1079,7 +1079,7 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
 
 
     case SCORE_KAPPA_FISSION:
-      if (p->macro_xs_.absorption == 0.) continue;
+      if (p.macro_xs_.absorption == 0.) continue;
       score = 0.;
       // Kappa-fission values are determined from the Q-value listed for the
       // fission cross section.
@@ -1088,27 +1088,27 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
           // No fission events occur if survival biasing is on -- need to
           // calculate fraction of absorptions that would have resulted in
           // fission scaled by the Q-value
-          const auto& nuc {*data::nuclides[p->event_nuclide_]};
-          if (p->neutron_xs_[p->event_nuclide_].absorption > 0
+          const auto& nuc {*data::nuclides[p.event_nuclide_]};
+          if (p.neutron_xs_[p.event_nuclide_].absorption > 0
             && nuc.fissionable_) {
             const auto& rxn {*nuc.fission_rx_[0]};
-            score = p->wgt_absorb_ * rxn.q_value_
-              * p->neutron_xs_[p->event_nuclide_].fission
-              / p->neutron_xs_[p->event_nuclide_].absorption * flux;
+            score = p.wgt_absorb_ * rxn.q_value_
+              * p.neutron_xs_[p.event_nuclide_].fission
+              / p.neutron_xs_[p.event_nuclide_].absorption * flux;
           }
         } else {
           // Skip any non-absorption events
-          if (p->event_ == TallyEvent::SCATTER) continue;
+          if (p.event_ == TallyEvent::SCATTER) continue;
           // All fission events will contribute, so again we can use particle's
           // weight entering the collision as the estimate for the fission
           // reaction rate
-          const auto& nuc {*data::nuclides[p->event_nuclide_]};
-          if (p->neutron_xs_[p->event_nuclide_].absorption > 0
+          const auto& nuc {*data::nuclides[p.event_nuclide_]};
+          if (p.neutron_xs_[p.event_nuclide_].absorption > 0
             && nuc.fissionable_) {
             const auto& rxn {*nuc.fission_rx_[0]};
-            score = p->wgt_last_ * rxn.q_value_
-              * p->neutron_xs_[p->event_nuclide_].fission
-              / p->neutron_xs_[p->event_nuclide_].absorption * flux;
+            score = p.wgt_last_ * rxn.q_value_
+              * p.neutron_xs_[p.event_nuclide_].fission
+              / p.neutron_xs_[p.event_nuclide_].absorption * flux;
           }
         }
       } else {
@@ -1116,19 +1116,19 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
           const auto& nuc {*data::nuclides[i_nuclide]};
           if (nuc.fissionable_) {
             const auto& rxn {*nuc.fission_rx_[0]};
-            score = rxn.q_value_ * p->neutron_xs_[i_nuclide].fission
+            score = rxn.q_value_ * p.neutron_xs_[i_nuclide].fission
               * atom_density * flux;
           }
         } else {
-          if (p->material_ != MATERIAL_VOID) {
-            const Material& material {*model::materials[p->material_]};
+          if (p.material_ != MATERIAL_VOID) {
+            const Material& material {*model::materials[p.material_]};
             for (auto i = 0; i < material.nuclide_.size(); ++i) {
               auto j_nuclide = material.nuclide_[i];
               auto atom_density = material.atom_density_(i);
               const auto& nuc {*data::nuclides[j_nuclide]};
               if (nuc.fissionable_) {
                 const auto& rxn {*nuc.fission_rx_[0]};
-                score += rxn.q_value_ * p->neutron_xs_[j_nuclide].fission
+                score += rxn.q_value_ * p.neutron_xs_[j_nuclide].fission
                   * atom_density * flux;
               }
             }
@@ -1148,23 +1148,23 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
     case ELASTIC:
       if (tally.estimator_ == TallyEstimator::ANALOG) {
         // Check if event MT matches
-        if (p->event_mt_ != ELASTIC) continue;
-        score = p->wgt_last_ * flux;
+        if (p.event_mt_ != ELASTIC) continue;
+        score = p.wgt_last_ * flux;
       } else {
         if (i_nuclide >= 0) {
-          if (p->neutron_xs_[i_nuclide].elastic == CACHE_INVALID)
-            data::nuclides[i_nuclide]->calculate_elastic_xs(*p);
-          score = p->neutron_xs_[i_nuclide].elastic * atom_density * flux;
+          if (p.neutron_xs_[i_nuclide].elastic == CACHE_INVALID)
+            data::nuclides[i_nuclide]->calculate_elastic_xs(p);
+          score = p.neutron_xs_[i_nuclide].elastic * atom_density * flux;
         } else {
           score = 0.;
-          if (p->material_ != MATERIAL_VOID) {
-            const Material& material {*model::materials[p->material_]};
+          if (p.material_ != MATERIAL_VOID) {
+            const Material& material {*model::materials[p.material_]};
             for (auto i = 0; i < material.nuclide_.size(); ++i) {
               auto j_nuclide = material.nuclide_[i];
               auto atom_density = material.atom_density_(i);
-              if (p->neutron_xs_[j_nuclide].elastic == CACHE_INVALID)
-                data::nuclides[j_nuclide]->calculate_elastic_xs(*p);
-              score += p->neutron_xs_[j_nuclide].elastic * atom_density
+              if (p.neutron_xs_[j_nuclide].elastic == CACHE_INVALID)
+                data::nuclides[j_nuclide]->calculate_elastic_xs(p);
+              score += p.neutron_xs_[j_nuclide].elastic * atom_density
                 * flux;
             }
           }
@@ -1174,7 +1174,7 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
 
     case SCORE_FISS_Q_PROMPT:
     case SCORE_FISS_Q_RECOV:
-      if (p->macro_xs_.absorption == 0.) continue;
+      if (p.macro_xs_.absorption == 0.) continue;
       score = score_fission_q(p, score_bin, tally, flux, i_nuclide, atom_density);
       break;
 
@@ -1187,8 +1187,8 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
     case N_A:
       if (tally.estimator_ == TallyEstimator::ANALOG) {
         // Check if the event MT matches
-        if (p->event_mt_ != score_bin) continue;
-        score = p->wgt_last_ * flux;
+        if (p.event_mt_ != score_bin) continue;
+        score = p.wgt_last_ * flux;
       } else {
         int m;
         switch (score_bin) {
@@ -1200,16 +1200,16 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
         case N_4N: m = 5; break;
         }
         if (i_nuclide >= 0) {
-          score = p->neutron_xs_[i_nuclide].reaction[m] * atom_density
+          score = p.neutron_xs_[i_nuclide].reaction[m] * atom_density
             * flux;
         } else {
           score = 0.;
-          if (p->material_ != MATERIAL_VOID) {
-            const Material& material {*model::materials[p->material_]};
+          if (p.material_ != MATERIAL_VOID) {
+            const Material& material {*model::materials[p.material_]};
             for (auto i = 0; i < material.nuclide_.size(); ++i) {
               auto j_nuclide = material.nuclide_[i];
               auto atom_density = material.atom_density_(i);
-              score += p->neutron_xs_[j_nuclide].reaction[m]
+              score += p.neutron_xs_[j_nuclide].reaction[m]
                 * atom_density * flux;
             }
           }
@@ -1219,22 +1219,22 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
 
 
     case HEATING:
-      if (p->type_ == Particle::Type::neutron) {
+      if (p.type_ == Particle::Type::neutron) {
         score = score_neutron_heating(p, tally, flux, HEATING,
             i_nuclide, atom_density);
       } else {
         // The energy deposited is the difference between the pre-collision and
         // post-collision energy...
-        score = E - p->E_;
+        score = E - p.E_;
 
         // ...less the energy of any secondary particles since they will be
         // transported individually later
-        const auto& bank = p->secondary_bank_;
-        for (auto it = bank.end() - p->n_bank_second_; it < bank.end(); ++it) {
+        const auto& bank = p.secondary_bank_;
+        for (auto it = bank.end() - p.n_bank_second_; it < bank.end(); ++it) {
           score -= it->E;
         }
 
-        score *= p->wgt_last_;
+        score *= p.wgt_last_;
       }
       break;
 
@@ -1242,14 +1242,14 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
 
       // The default block is really only meant for redundant neutron reactions
       // (e.g. 444, 901)
-      if (p->type_ != Particle::Type::neutron) continue;
+      if (p.type_ != Particle::Type::neutron) continue;
 
       if (tally.estimator_ == TallyEstimator::ANALOG) {
 
         // Any other score is assumed to be a MT number. Thus, we just need
         // to check if it matches the MT number of the event
-        if (p->event_mt_ != score_bin) continue;
-        score = p->wgt_last_*flux;
+        if (p.event_mt_ != score_bin) continue;
+        score = p.wgt_last_*flux;
       } else {
         // Any other cross section has to be calculated on-the-fly
         if (score_bin < 2) fatal_error("Invalid score type on tally "
@@ -1260,10 +1260,10 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
           auto m = nuc.reaction_index_[score_bin];
           if (m == C_NONE) continue;
           const auto& rxn {*nuc.reactions_[m]};
-          auto i_temp = p->neutron_xs_[i_nuclide].index_temp;
+          auto i_temp = p.neutron_xs_[i_nuclide].index_temp;
           if (i_temp >= 0) { // Can be false due to multipole
-            auto i_grid = p->neutron_xs_[i_nuclide].index_grid;
-            auto f = p->neutron_xs_[i_nuclide].interp_factor;
+            auto i_grid = p.neutron_xs_[i_nuclide].index_grid;
+            auto f = p.neutron_xs_[i_nuclide].interp_factor;
             const auto& xs {rxn.xs_[i_temp]};
             if (i_grid >= xs.threshold) {
               score = ((1.0 - f) * xs.value[i_grid-xs.threshold]
@@ -1271,8 +1271,8 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
             }
           }
         } else {
-          if (p->material_ != MATERIAL_VOID) {
-            const Material& material {*model::materials[p->material_]};
+          if (p.material_ != MATERIAL_VOID) {
+            const Material& material {*model::materials[p.material_]};
             for (auto i = 0; i < material.nuclide_.size(); ++i) {
               auto j_nuclide = material.nuclide_[i];
               auto atom_density = material.atom_density_(i);
@@ -1280,10 +1280,10 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
               auto m = nuc.reaction_index_[score_bin];
               if (m == C_NONE) continue;
               const auto& rxn {*nuc.reactions_[m]};
-              auto i_temp = p->neutron_xs_[j_nuclide].index_temp;
+              auto i_temp = p.neutron_xs_[j_nuclide].index_temp;
               if (i_temp >= 0) { // Can be false due to multipole
-                auto i_grid = p->neutron_xs_[j_nuclide].index_grid;
-                auto f = p->neutron_xs_[j_nuclide].interp_factor;
+                auto i_grid = p.neutron_xs_[j_nuclide].index_grid;
+                auto f = p.neutron_xs_[j_nuclide].interp_factor;
                 const auto& xs {rxn.xs_[i_temp]};
                 if (i_grid >= xs.threshold) {
                   score += ((1.0 - f) * xs.value[i_grid-xs.threshold]
@@ -1299,7 +1299,7 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
 
     // Add derivative information on score for differential tallies.
     if (tally.deriv_ != C_NONE)
-      apply_derivative_to_score(*p, i_tally, i_nuclide, atom_density, score_bin,
+      apply_derivative_to_score(p, i_tally, i_nuclide, atom_density, score_bin,
         score);
 
     // Update tally results
@@ -1314,7 +1314,7 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
 //! argument is really just used for filter weights.
 
 void
-score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
+score_general_mg(Particle& p, int i_tally, int start_index, int filter_index,
   double filter_weight, int i_nuclide, double atom_density, double flux)
 {
   auto& tally {*model::tallies[i_tally]};
@@ -1329,40 +1329,40 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
 
       // Then we either are alive and had a scatter (and so g changed),
       // or are dead and g did not change
-      if (p->alive_) {
-        p_u = p->u_last_;
-        p_g = p->g_last_;
+      if (p.alive_) {
+        p_u = p.u_last_;
+        p_g = p.g_last_;
       } else {
-        p_u = p->u_local();
-        p_g = p->g_;
+        p_u = p.u_local();
+        p_g = p.g_;
       }
-    } else if (p->event_ == TallyEvent::SCATTER) {
+    } else if (p.event_ == TallyEvent::SCATTER) {
 
       // Then the energy group has been changed by the scattering routine
       // meaning gin is now in p % last_g
-      p_u = p->u_last_;
-      p_g = p->g_last_;
+      p_u = p.u_last_;
+      p_g = p.g_last_;
     } else {
 
       // No scatter, no change in g.
-      p_u = p->u_local();
-      p_g = p->g_;
+      p_u = p.u_local();
+      p_g = p.g_;
     }
   } else {
 
     // No actual collision so g has not changed.
-    p_u = p->u_local();
-    p_g = p->g_;
+    p_u = p.u_local();
+    p_g = p.g_;
   }
 
   // For shorthand, assign pointers to the material and nuclide xs set
   auto& nuc_xs = data::mg.nuclides_[i_nuclide];
-  auto& macro_xs = data::mg.macro_xs_[p->material_];
+  auto& macro_xs = data::mg.macro_xs_[p.material_];
 
   // Find the temperature and angle indices of interest
   macro_xs.set_angle_index(p_u);
   if (i_nuclide >= 0) {
-    nuc_xs.set_temperature_index(p->sqrtkT_);
+    nuc_xs.set_temperature_index(p.sqrtkT_);
     nuc_xs.set_angle_index(p_u);
   }
 
@@ -1383,11 +1383,11 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
         if (settings::survival_biasing) {
           // We need to account for the fact that some weight was already
           // absorbed
-          score = p->wgt_last_ + p->wgt_absorb_;
+          score = p.wgt_last_ + p.wgt_absorb_;
         } else {
-          score = p->wgt_last_;
+          score = p.wgt_last_;
         }
-        score *= flux / p->macro_xs_.total;
+        score *= flux / p.macro_xs_.total;
       } else {
         score = flux;
       }
@@ -1401,9 +1401,9 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
         if (settings::survival_biasing) {
           // We need to account for the fact that some weight was already
           // absorbed
-          score = p->wgt_last_ + p->wgt_absorb_;
+          score = p.wgt_last_ + p.wgt_absorb_;
         } else {
-          score = p->wgt_last_;
+          score = p.wgt_last_;
         }
         //TODO: should flux be multiplied in above instead of below?
         if (i_nuclide >= 0) {
@@ -1414,7 +1414,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
         if (i_nuclide >= 0) {
           score = atom_density * flux * nuc_xs.get_xs(MgxsType::TOTAL, p_g);
         } else {
-          score = p->macro_xs_.total * flux;
+          score = p.macro_xs_.total * flux;
         }
       }
       break;
@@ -1429,9 +1429,9 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
         if (settings::survival_biasing) {
           // We need to account for the fact that some weight was already
           // absorbed
-          score = p->wgt_last_ + p->wgt_absorb_;
+          score = p.wgt_last_ + p.wgt_absorb_;
         } else {
-          score = p->wgt_last_;
+          score = p.wgt_last_;
         }
         if (i_nuclide >= 0) {
           score *= flux * nuc_xs.get_xs(MgxsType::INVERSE_VELOCITY, p_g)
@@ -1453,23 +1453,23 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
     case SCORE_SCATTER:
       if (tally.estimator_ == TallyEstimator::ANALOG) {
         // Skip any event where the particle didn't scatter
-        if (p->event_ != TallyEvent::SCATTER) continue;
+        if (p.event_ != TallyEvent::SCATTER) continue;
         // Since only scattering events make it here, again we can use the
         // weight entering the collision as the estimator for the reaction rate
-        score = p->wgt_last_ * flux;
+        score = p.wgt_last_ * flux;
         if (i_nuclide >= 0) {
           score *= atom_density * nuc_xs.get_xs(
-              MgxsType::SCATTER_FMU_MULT, p->g_last_, &p->g_, &p->mu_, nullptr)
+              MgxsType::SCATTER_FMU_MULT, p.g_last_, &p.g_, &p.mu_, nullptr)
             / macro_xs.get_xs(
-              MgxsType::SCATTER_FMU_MULT, p->g_last_, &p->g_, &p->mu_, nullptr);
+              MgxsType::SCATTER_FMU_MULT, p.g_last_, &p.g_, &p.mu_, nullptr);
         }
       } else {
         if (i_nuclide >= 0) {
           score = atom_density * flux * nuc_xs.get_xs(
-            MgxsType::SCATTER_MULT, p_g, nullptr, &p->mu_, nullptr);
+            MgxsType::SCATTER_MULT, p_g, nullptr, &p.mu_, nullptr);
         } else {
           score = flux * macro_xs.get_xs(
-            MgxsType::SCATTER_MULT, p_g, nullptr, &p->mu_, nullptr);
+            MgxsType::SCATTER_MULT, p_g, nullptr, &p.mu_, nullptr);
         }
       }
       break;
@@ -1478,20 +1478,20 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
     case SCORE_NU_SCATTER:
       if (tally.estimator_ == TallyEstimator::ANALOG) {
         // Skip any event where the particle didn't scatter
-        if (p->event_ != TallyEvent::SCATTER) continue;
+        if (p.event_ != TallyEvent::SCATTER) continue;
         // For scattering production, we need to use the pre-collision weight
         // times the multiplicity as the estimate for the number of neutrons
         // exiting a reaction with neutrons in the exit channel
-        score = p->wgt_ * flux;
+        score = p.wgt_ * flux;
         // Since we transport based on material data, the angle selected
         // was not selected from the f(mu) for the nuclide.  Therefore
         // adjust the score by the actual probability for that nuclide.
         if (i_nuclide >= 0) {
           score *= atom_density
-            * nuc_xs.get_xs(MgxsType::SCATTER_FMU, p->g_last_, &p->g_,
-                            &p->mu_, nullptr)
-            / macro_xs.get_xs(MgxsType::SCATTER_FMU, p->g_last_, &p->g_,
-                              &p->mu_, nullptr);
+            * nuc_xs.get_xs(MgxsType::SCATTER_FMU, p.g_last_, &p.g_,
+                            &p.mu_, nullptr)
+            / macro_xs.get_xs(MgxsType::SCATTER_FMU, p.g_last_, &p.g_,
+                              &p.mu_, nullptr);
         }
       } else {
         if (i_nuclide >= 0) {
@@ -1508,13 +1508,13 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
         if (settings::survival_biasing) {
           // No absorption events actually occur if survival biasing is on --
           // just use weight absorbed in survival biasing
-          score = p->wgt_absorb_ * flux;
+          score = p.wgt_absorb_ * flux;
         } else {
           // Skip any event where the particle wasn't absorbed
-          if (p->event_ == TallyEvent::SCATTER) continue;
+          if (p.event_ == TallyEvent::SCATTER) continue;
           // All fission and absorption events will contribute here, so we
           // can just use the particle's weight entering the collision
-          score = p->wgt_last_ * flux;
+          score = p.wgt_last_ * flux;
         }
         if (i_nuclide >= 0) {
           score *= atom_density * nuc_xs.get_xs(MgxsType::ABSORPTION, p_g)
@@ -1525,7 +1525,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
           score = atom_density * flux
             * nuc_xs.get_xs(MgxsType::ABSORPTION, p_g);
         } else {
-          score = p->macro_xs_.absorption * flux;
+          score = p.macro_xs_.absorption * flux;
         }
       }
       break;
@@ -1537,14 +1537,14 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
           // No fission events occur if survival biasing is on -- need to
           // calculate fraction of absorptions that would have resulted in
           // fission
-          score = p->wgt_absorb_ * flux;
+          score = p.wgt_absorb_ * flux;
         } else {
           // Skip any non-absorption events
-          if (p->event_ == TallyEvent::SCATTER) continue;
+          if (p.event_ == TallyEvent::SCATTER) continue;
           // All fission events will contribute, so again we can use particle's
           // weight entering the collision as the estimate for the fission
           // reaction rate
-          score = p->wgt_last_ * flux;
+          score = p.wgt_last_ * flux;
         }
         if (i_nuclide >= 0) {
           score *= atom_density * nuc_xs.get_xs(MgxsType::FISSION, p_g)
@@ -1565,7 +1565,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
 
     case SCORE_NU_FISSION:
       if (tally.estimator_ == TallyEstimator::ANALOG) {
-        if (settings::survival_biasing || p->fission_) {
+        if (settings::survival_biasing || p.fission_) {
           if (tally.energyout_filter_ != C_NONE) {
             // Fission has multiple outgoing neutrons so this helper function
             // is used to handle scoring the multiple filter bins.
@@ -1577,7 +1577,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
           // No fission events occur if survival biasing is on -- need to
           // calculate fraction of absorptions that would have resulted in
           // nu-fission
-          score = p->wgt_absorb_ * flux;
+          score = p.wgt_absorb_ * flux;
           if (i_nuclide >= 0) {
             score *= atom_density * nuc_xs.get_xs(MgxsType::NU_FISSION, p_g)
               / macro_xs.get_xs(MgxsType::ABSORPTION, p_g);
@@ -1587,13 +1587,13 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
           }
         } else {
           // Skip any non-fission events
-          if (!p->fission_) continue;
+          if (!p.fission_) continue;
           // If there is no outgoing energy filter, than we only need to score
           // to one bin. For the score to be 'analog', we need to score the
           // number of particles that were banked in the fission bank. Since
           // this was weighted by 1/keff, we multiply by keff to get the proper
           // score.
-          score = simulation::keff * p->wgt_bank_ * flux;
+          score = simulation::keff * p.wgt_bank_ * flux;
           if (i_nuclide >= 0) {
             score *= atom_density * nuc_xs.get_xs(MgxsType::FISSION, p_g)
               / macro_xs.get_xs(MgxsType::FISSION, p_g);
@@ -1612,7 +1612,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
 
     case SCORE_PROMPT_NU_FISSION:
       if (tally.estimator_ == TallyEstimator::ANALOG) {
-        if (settings::survival_biasing || p->fission_) {
+        if (settings::survival_biasing || p.fission_) {
           if (tally.energyout_filter_ != C_NONE) {
             // Fission has multiple outgoing neutrons so this helper function
             // is used to handle scoring the multiple filter bins.
@@ -1624,7 +1624,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
           // No fission events occur if survival biasing is on -- need to
           // calculate fraction of absorptions that would have resulted in
           // prompt-nu-fission
-          score = p->wgt_absorb_ * flux;
+          score = p.wgt_absorb_ * flux;
           if (i_nuclide >= 0) {
             score *= atom_density *
               nuc_xs.get_xs(MgxsType::PROMPT_NU_FISSION, p_g)
@@ -1635,16 +1635,16 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
           }
         } else {
           // Skip any non-fission events
-          if (!p->fission_) continue;
+          if (!p.fission_) continue;
           // If there is no outgoing energy filter, than we only need to score
           // to one bin. For the score to be 'analog', we need to score the
           // number of particles that were banked in the fission bank. Since
           // this was weighted by 1/keff, we multiply by keff to get the proper
           // score.
-          auto n_delayed = std::accumulate(p->n_delayed_bank_,
-            p->n_delayed_bank_+MAX_DELAYED_GROUPS, 0);
-          auto prompt_frac = 1. - n_delayed / static_cast<double>(p->n_bank_);
-          score = simulation::keff * p->wgt_bank_ * prompt_frac * flux;
+          auto n_delayed = std::accumulate(p.n_delayed_bank_,
+            p.n_delayed_bank_+MAX_DELAYED_GROUPS, 0);
+          auto prompt_frac = 1. - n_delayed / static_cast<double>(p.n_bank_);
+          score = simulation::keff * p.wgt_bank_ * prompt_frac * flux;
           if (i_nuclide >= 0) {
             score *= atom_density * nuc_xs.get_xs(MgxsType::FISSION, p_g)
               / macro_xs.get_xs(MgxsType::FISSION, p_g);
@@ -1663,7 +1663,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
 
     case SCORE_DELAYED_NU_FISSION:
       if (tally.estimator_ == TallyEstimator::ANALOG) {
-        if (settings::survival_biasing || p->fission_) {
+        if (settings::survival_biasing || p.fission_) {
           if (tally.energyout_filter_ != C_NONE) {
             // Fission has multiple outgoing neutrons so this helper function
             // is used to handle scoring the multiple filter bins.
@@ -1685,7 +1685,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
               // Tally each delayed group bin individually
               for (auto d_bin = 0; d_bin < filt.n_bins(); ++d_bin) {
                 auto d = filt.groups()[d_bin] - 1;
-                score = p->wgt_absorb_ * flux;
+                score = p.wgt_absorb_ * flux;
                 if (i_nuclide >= 0) {
                   score *= nuc_xs.get_xs(MgxsType::DELAYED_NU_FISSION, p_g,
                                          nullptr, nullptr, &d)
@@ -1695,14 +1695,14 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
                                            nullptr, nullptr, &d)
                     / abs_xs;
                 }
-                score_fission_delayed_dg(i_tally, d_bin, score, score_index, p->filter_matches_);
+                score_fission_delayed_dg(i_tally, d_bin, score, score_index, p.filter_matches_);
               }
               continue;
             } else {
               // If the delayed group filter is not present, compute the score
               // by multiplying the absorbed weight by the fraction of the
               // delayed-nu-fission xs to the absorption xs
-              score = p->wgt_absorb_ * flux;
+              score = p.wgt_absorb_ * flux;
               if (i_nuclide >= 0) {
                 score *= nuc_xs.get_xs(MgxsType::DELAYED_NU_FISSION, p_g)
                   / abs_xs;
@@ -1714,7 +1714,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
           }
         } else {
           // Skip any non-fission events
-          if (!p->fission_) continue;
+          if (!p.fission_) continue;
           // If there is no outgoing energy filter, than we only need to score
           // to one bin. For the score to be 'analog', we need to score the
           // number of particles that were banked in the fission bank. Since
@@ -1730,20 +1730,20 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
             // Tally each delayed group bin individually
             for (auto d_bin = 0; d_bin < filt.n_bins(); ++d_bin) {
               auto d = filt.groups()[d_bin];
-              score = simulation::keff * p->wgt_bank_ / p->n_bank_
-                * p->n_delayed_bank_[d-1] * flux;
+              score = simulation::keff * p.wgt_bank_ / p.n_bank_
+                * p.n_delayed_bank_[d-1] * flux;
               if (i_nuclide >= 0) {
                 score *= atom_density * nuc_xs.get_xs(MgxsType::FISSION, p_g)
                   / macro_xs.get_xs(MgxsType::FISSION, p_g);
               }
-              score_fission_delayed_dg(i_tally, d_bin, score, score_index, p->filter_matches_);
+              score_fission_delayed_dg(i_tally, d_bin, score, score_index, p.filter_matches_);
             }
             continue;
           } else {
             // Add the contribution from all delayed groups
-            auto n_delayed = std::accumulate(p->n_delayed_bank_,
-              p->n_delayed_bank_+MAX_DELAYED_GROUPS, 0);
-            score = simulation::keff * p->wgt_bank_ / p->n_bank_ * n_delayed
+            auto n_delayed = std::accumulate(p.n_delayed_bank_,
+              p.n_delayed_bank_+MAX_DELAYED_GROUPS, 0);
+            score = simulation::keff * p.wgt_bank_ / p.n_bank_ * n_delayed
               * flux;
             if (i_nuclide >= 0) {
               score *= atom_density * nuc_xs.get_xs(MgxsType::FISSION, p_g)
@@ -1767,7 +1767,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
               score = flux * macro_xs.get_xs(
                 MgxsType::DELAYED_NU_FISSION, p_g, nullptr, nullptr, &d);
             }
-            score_fission_delayed_dg(i_tally, d_bin, score, score_index, p->filter_matches_);
+            score_fission_delayed_dg(i_tally, d_bin, score, score_index, p.filter_matches_);
           }
           continue;
         } else {
@@ -1798,7 +1798,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
               // Tally each delayed group bin individually
               for (auto d_bin = 0; d_bin < filt.n_bins(); ++d_bin) {
                 auto d = filt.groups()[d_bin] - 1;
-                score = p->wgt_absorb_ * flux;
+                score = p.wgt_absorb_ * flux;
                 if (i_nuclide >= 0) {
                   score *= nuc_xs.get_xs(MgxsType::DECAY_RATE, p_g,
                                          nullptr, nullptr, &d)
@@ -1810,7 +1810,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
                     * macro_xs.get_xs(MgxsType::DELAYED_NU_FISSION, p_g,
                                       nullptr, nullptr, &d) / abs_xs;
                 }
-                score_fission_delayed_dg(i_tally, d_bin, score, score_index, p->filter_matches_);
+                score_fission_delayed_dg(i_tally, d_bin, score, score_index, p.filter_matches_);
               }
               continue;
             } else {
@@ -1821,13 +1821,13 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
               score = 0.;
               for (auto d = 0; d < data::mg.num_delayed_groups_; ++d) {
                 if (i_nuclide >= 0) {
-                  score += p->wgt_absorb_ * flux
+                  score += p.wgt_absorb_ * flux
                     * nuc_xs.get_xs(MgxsType::DECAY_RATE, p_g, nullptr,
                                     nullptr, &d)
                     * nuc_xs.get_xs(MgxsType::DELAYED_NU_FISSION, p_g,
                                     nullptr, nullptr, &d) / abs_xs;
                 } else {
-                  score += p->wgt_absorb_ * flux
+                  score += p.wgt_absorb_ * flux
                     * macro_xs.get_xs(MgxsType::DECAY_RATE, p_g, nullptr,
                                       nullptr, &d)
                     * macro_xs.get_xs(MgxsType::DELAYED_NU_FISSION, p_g,
@@ -1838,7 +1838,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
           }
         } else {
           // Skip any non-fission events
-          if (!p->fission_) continue;
+          if (!p.fission_) continue;
           // If there is no outgoing energy filter, than we only need to score
           // to one bin. For the score to be 'analog', we need to score the
           // number of particles that were banked in the fission bank. Since
@@ -1847,8 +1847,8 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
           // ones are delayed. If a delayed neutron is encountered, add its
           // contribution to the fission bank to the score.
           score = 0.;
-          for (auto i = 0; i < p->n_bank_; ++i) {
-            const auto& bank = p->nu_bank_[i];
+          for (auto i = 0; i < p.n_bank_; ++i) {
+            const auto& bank = p.nu_bank_[i];
             auto d = bank.delayed_group - 1;
             if (d != -1) {
               if (i_nuclide >= 0) {
@@ -1870,7 +1870,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
                   auto dg = filt.groups()[d_bin];
                   if (dg == d + 1)
                     score_fission_delayed_dg(i_tally, d_bin, score,
-                                             score_index, p->filter_matches_);
+                                             score_index, p.filter_matches_);
                 }
                 score = 0.;
               }
@@ -1900,7 +1900,7 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
                 * macro_xs.get_xs(MgxsType::DELAYED_NU_FISSION, p_g, nullptr,
                                   nullptr, &d);
             }
-            score_fission_delayed_dg(i_tally, d_bin, score, score_index, p->filter_matches_);
+            score_fission_delayed_dg(i_tally, d_bin, score, score_index, p.filter_matches_);
           }
           continue;
         } else {
@@ -1927,14 +1927,14 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
           // No fission events occur if survival biasing is on -- need to
           // calculate fraction of absorptions that would have resulted in
           // fission scaled by the Q-value
-          score = p->wgt_absorb_ * flux;
+          score = p.wgt_absorb_ * flux;
         } else {
           // Skip any non-absorption events
-          if (p->event_ == TallyEvent::SCATTER) continue;
+          if (p.event_ == TallyEvent::SCATTER) continue;
           // All fission events will contribute, so again we can use particle's
           // weight entering the collision as the estimate for the fission
           // reaction rate
-          score = p->wgt_last_ * flux;
+          score = p.wgt_last_ * flux;
         }
         if (i_nuclide >= 0) {
           score *= atom_density
@@ -1974,11 +1974,11 @@ score_general_mg(Particle* p, int i_tally, int start_index, int filter_index,
 //! Tally rates for when the user requests a tally on all nuclides.
 
 void
-score_all_nuclides(Particle* p, int i_tally, double flux,
+score_all_nuclides(Particle& p, int i_tally, double flux,
   int filter_index, double filter_weight)
 {
   const Tally& tally {*model::tallies[i_tally]};
-  const Material& material {*model::materials[p->material_]};
+  const Material& material {*model::materials[p.material_]};
 
   // Score all individual nuclide reaction rates.
   for (auto i = 0; i < material.nuclide_.size(); ++i) {
@@ -2009,13 +2009,13 @@ score_all_nuclides(Particle* p, int i_tally, double flux,
   }
 }
 
-void score_analog_tally_ce(Particle* p)
+void score_analog_tally_ce(Particle& p)
 {
   // Since electrons/positrons are not transported, we assign a flux of zero.
   // Note that the heating score does NOT use the flux and will be non-zero for
   // electrons/positrons.
   double flux =
-    (p->type_ == Particle::Type::neutron || p->type_ == Particle::Type::photon) ?
+    (p.type_ == Particle::Type::neutron || p.type_ == Particle::Type::photon) ?
     1.0 : 0.0;
 
   for (auto i_tally : model::active_analog_tallies) {
@@ -2025,7 +2025,7 @@ void score_analog_tally_ce(Particle* p)
     // no valid combinations, use a continue statement to ensure we skip the
     // assume_separate break below.
     auto filter_iter = FilterBinIter(tally, p);
-    auto end = FilterBinIter(tally, true, &p->filter_matches_);
+    auto end = FilterBinIter(tally, true, &p.filter_matches_);
     if (filter_iter == end) continue;
 
     // Loop over filter bins.
@@ -2041,7 +2041,7 @@ void score_analog_tally_ce(Particle* p)
           // Tally this event in the present nuclide bin if that bin represents
           // the event nuclide or the total material.  Note that the atomic
           // density argument for score_general is not used for analog tallies.
-          if (i_nuclide == p->event_nuclide_ || i_nuclide == -1)
+          if (i_nuclide == p.event_nuclide_ || i_nuclide == -1)
             score_general_ce(p, i_tally, i*tally.scores_.size(), filter_index,
               filter_weight, i_nuclide, -1.0, flux);
         }
@@ -2050,7 +2050,7 @@ void score_analog_tally_ce(Particle* p)
         // In the case that the user has requested to tally all nuclides, we
         // can take advantage of the fact that we know exactly how nuclide
         // bins correspond to nuclide indices.  First, tally the nuclide.
-        auto i = p->event_nuclide_;
+        auto i = p.event_nuclide_;
         score_general_ce(p, i_tally, i*tally.scores_.size(), filter_index,
           filter_weight, -1, -1.0, flux);
 
@@ -2069,11 +2069,11 @@ void score_analog_tally_ce(Particle* p)
   }
 
   // Reset all the filter matches for the next tally event.
-  for (auto& match : p->filter_matches_)
+  for (auto& match : p.filter_matches_)
     match.bins_present_ = false;
 }
 
-void score_analog_tally_mg(Particle* p)
+void score_analog_tally_mg(Particle& p)
 {
   for (auto i_tally : model::active_analog_tallies) {
     const Tally& tally {*model::tallies[i_tally]};
@@ -2082,7 +2082,7 @@ void score_analog_tally_mg(Particle* p)
     // no valid combinations, use a continue statement to ensure we skip the
     // assume_separate break below.
     auto filter_iter = FilterBinIter(tally, p);
-    auto end = FilterBinIter(tally, true, &p->filter_matches_);
+    auto end = FilterBinIter(tally, true, &p.filter_matches_);
     if (filter_iter == end) continue;
 
     // Loop over filter bins.
@@ -2096,9 +2096,9 @@ void score_analog_tally_mg(Particle* p)
 
         double atom_density = 0.;
         if (i_nuclide >= 0) {
-          auto j = model::materials[p->material_]->mat_nuclide_index_[i_nuclide];
+          auto j = model::materials[p.material_]->mat_nuclide_index_[i_nuclide];
           if (j == C_NONE) continue;
-          atom_density = model::materials[p->material_]->atom_density_(j);
+          atom_density = model::materials[p.material_]->atom_density_(j);
         }
 
         score_general_mg(p, i_tally, i*tally.scores_.size(), filter_index,
@@ -2114,15 +2114,15 @@ void score_analog_tally_mg(Particle* p)
   }
 
   // Reset all the filter matches for the next tally event.
-  for (auto& match : p->filter_matches_)
+  for (auto& match : p.filter_matches_)
     match.bins_present_ = false;
 }
 
 void
-score_tracklength_tally(Particle* p, double distance)
+score_tracklength_tally(Particle& p, double distance)
 {
   // Determine the tracklength estimate of the flux
-  double flux = p->wgt_ * distance;
+  double flux = p.wgt_ * distance;
 
   for (auto i_tally : model::active_tracklength_tallies) {
     const Tally& tally {*model::tallies[i_tally]};
@@ -2131,7 +2131,7 @@ score_tracklength_tally(Particle* p, double distance)
     // no valid combinations, use a continue statement to ensure we skip the
     // assume_separate break below.
     auto filter_iter = FilterBinIter(tally, p);
-    auto end = FilterBinIter(tally, true, &p->filter_matches_);
+    auto end = FilterBinIter(tally, true, &p.filter_matches_);
     if (filter_iter == end) continue;
 
     // Loop over filter bins.
@@ -2141,7 +2141,7 @@ score_tracklength_tally(Particle* p, double distance)
 
       // Loop over nuclide bins.
       if (tally.all_nuclides_) {
-        if (p->material_ != MATERIAL_VOID)
+        if (p.material_ != MATERIAL_VOID)
           score_all_nuclides(p, i_tally, flux*filter_weight, filter_index,
             filter_weight);
 
@@ -2151,10 +2151,10 @@ score_tracklength_tally(Particle* p, double distance)
 
           double atom_density = 0.;
           if (i_nuclide >= 0) {
-            if (p->material_ != MATERIAL_VOID) {
-              auto j = model::materials[p->material_]->mat_nuclide_index_[i_nuclide];
+            if (p.material_ != MATERIAL_VOID) {
+              auto j = model::materials[p.material_]->mat_nuclide_index_[i_nuclide];
               if (j == C_NONE) continue;
-              atom_density = model::materials[p->material_]->atom_density_(j);
+              atom_density = model::materials[p.material_]->atom_density_(j);
             }
           }
 
@@ -2179,19 +2179,19 @@ score_tracklength_tally(Particle* p, double distance)
   }
 
   // Reset all the filter matches for the next tally event.
-  for (auto& match : p->filter_matches_)
+  for (auto& match : p.filter_matches_)
     match.bins_present_ = false;
 }
 
-void score_collision_tally(Particle* p)
+void score_collision_tally(Particle& p)
 {
   // Determine the collision estimate of the flux
   double flux = 0.0;
-  if (p->type_ == Particle::Type::neutron || p->type_ == Particle::Type::photon) {
+  if (p.type_ == Particle::Type::neutron || p.type_ == Particle::Type::photon) {
     if (!settings::survival_biasing) {
-      flux = p->wgt_last_ / p->macro_xs_.total;
+      flux = p.wgt_last_ / p.macro_xs_.total;
     } else {
-      flux = (p->wgt_last_ + p->wgt_absorb_) / p->macro_xs_.total;
+      flux = (p.wgt_last_ + p.wgt_absorb_) / p.macro_xs_.total;
     }
   }
 
@@ -2202,7 +2202,7 @@ void score_collision_tally(Particle* p)
     // no valid combinations, use a continue statement to ensure we skip the
     // assume_separate break below.
     auto filter_iter = FilterBinIter(tally, p);
-    auto end = FilterBinIter(tally, true, &p->filter_matches_);
+    auto end = FilterBinIter(tally, true, &p.filter_matches_);
     if (filter_iter == end) continue;
 
     // Loop over filter bins.
@@ -2221,9 +2221,9 @@ void score_collision_tally(Particle* p)
 
           double atom_density = 0.;
           if (i_nuclide >= 0) {
-            auto j = model::materials[p->material_]->mat_nuclide_index_[i_nuclide];
+            auto j = model::materials[p.material_]->mat_nuclide_index_[i_nuclide];
             if (j == C_NONE) continue;
-            atom_density = model::materials[p->material_]->atom_density_(j);
+            atom_density = model::materials[p.material_]->atom_density_(j);
           }
 
           //TODO: consider replacing this "if" with pointers or templates
@@ -2246,15 +2246,15 @@ void score_collision_tally(Particle* p)
   }
 
   // Reset all the filter matches for the next tally event.
-  for (auto& match : p->filter_matches_)
+  for (auto& match : p.filter_matches_)
     match.bins_present_ = false;
 }
 
 void
-score_surface_tally(Particle* p, const std::vector<int>& tallies)
+score_surface_tally(Particle& p, const std::vector<int>& tallies)
 {
   // No collision, so no weight change when survival biasing
-  double flux = p->wgt_;
+  double flux = p.wgt_;
 
   for (auto i_tally : tallies) {
     auto& tally {*model::tallies[i_tally]};
@@ -2263,7 +2263,7 @@ score_surface_tally(Particle* p, const std::vector<int>& tallies)
     // no valid combinations, use a continue statement to ensure we skip the
     // assume_separate break below.
     auto filter_iter = FilterBinIter(tally, p);
-    auto end = FilterBinIter(tally, true, &p->filter_matches_);
+    auto end = FilterBinIter(tally, true, &p.filter_matches_);
     if (filter_iter == end) continue;
 
     // Loop over filter bins.
@@ -2290,7 +2290,7 @@ score_surface_tally(Particle* p, const std::vector<int>& tallies)
   }
 
   // Reset all the filter matches for the next tally event.
-  for (auto& match : p->filter_matches_)
+  for (auto& match : p.filter_matches_)
     match.bins_present_ = false;
 }
 

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -347,7 +347,7 @@ score_fission_eout(Particle* p, int i_tally, int i_score, int score_bin)
     // i_nuclide and atom_density arguments do not matter since this is an
     // analog estimator.
     if (tally.deriv_ != C_NONE)
-      apply_derivative_to_score(p, i_tally, 0, 0., SCORE_NU_FISSION, score);
+      apply_derivative_to_score(*p, i_tally, 0, 0., SCORE_NU_FISSION, score);
 
     if (!settings::run_CE && eo_filt.matches_transport_groups()) {
 
@@ -1299,7 +1299,7 @@ score_general_ce(Particle* p, int i_tally, int start_index, int filter_index,
 
     // Add derivative information on score for differential tallies.
     if (tally.deriv_ != C_NONE)
-      apply_derivative_to_score(p, i_tally, i_nuclide, atom_density, score_bin,
+      apply_derivative_to_score(*p, i_tally, i_nuclide, atom_density, score_bin,
         score);
 
     // Update tally results

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -61,6 +61,9 @@ check_tally_triggers(double& ratio, int& tally_id, int& score)
     if (t.n_realizations_ < 2) continue;
 
     for (const auto& trigger : t.triggers_) {
+      // Skip trigger if it is not active
+      if (trigger.metric == TriggerMetric::not_active) continue;
+
       const auto& results = t.results_;
       for (auto filter_index = 0; filter_index < results.shape()[0];
            ++filter_index) {
@@ -83,9 +86,6 @@ check_tally_triggers(double& ratio, int& tally_id, int& score)
               break;
             case TriggerMetric::relative_error:
               uncertainty = rel_err;
-              break;
-            case TriggerMetric::not_active:
-              uncertainty = 0.0;
               break;
           }
 

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -135,7 +135,7 @@ ThermalScattering::ThermalScattering(hid_t group, const std::vector<double>& tem
     read_dataset(kT_group, temp_str.data(), kT);
     kTs_.push_back(kT);
 
-    // Open group for temperature i
+    // Open group for this temperature
     hid_t T_group = open_group(group, temp_str.data());
     data_.emplace_back(T_group);
     close_group(T_group);

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -135,7 +135,7 @@ std::vector<VolumeCalculation::Result> VolumeCalculation::execute() const
         p.u() = {0.5, 0.5, 0.5};
 
         // If this location is not in the geometry at all, move on to next block
-        if (!find_cell(&p, false)) continue;
+        if (!find_cell(p, false)) continue;
 
         if (domain_type_ == TallyDomain::MATERIAL) {
           if (p.material_ != MATERIAL_VOID) {


### PR DESCRIPTION
This PR addresses most of the comments from #1459 (note that of the 5 parts of the review, this was the only one that covered the C++ source). The salient points are:
- There were a few comments about the use of pointers in function interfaces without any check for null pointers and a suggestion they be changed to references. I've gone ahead and done this for functions taking `Particle*` or `Nuclide*`, so I think the bulk of the line changes in this PR are just from that alone.
- The `print_generation` and `print_batch_keff` were almost exactly the same -- I realized that `print_batch_keff` can actually be removed altogether and `print_generation` used in its place
- Added functions that convert between `Particle::Type` and `std::string` for convenience
- I think all other changes are very minor things -- style fixes, adding comments, changing variable names, etc.

@smharper Would you be willing to review this since you are probably most familiar with the C++ side of the house?