### PR TITLE
Account for light nuclide production in depletion

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -534,12 +534,11 @@ class Chain:
 
                         # Determine light nuclide production, e.g., (n,d) should
                         # produce H2
-                        light_nucs = _SECONDARY_PARTICLES.get(r_type)
-                        if light_nucs is not None:
-                            for light_nuc in light_nucs:
-                                k = self.nuclide_dict.get(light_nuc)
-                                if k is not None:
-                                    matrix[k, i] += path_rate * br
+                        light_nucs = _SECONDARY_PARTICLES.get(r_type, [])
+                        for light_nuc in light_nucs:
+                            k = self.nuclide_dict.get(light_nuc)
+                            if k is not None:
+                                matrix[k, i] += path_rate * br
 
                     else:
                         for product, y in fission_yields[nuc.name].items():

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -968,13 +968,23 @@ class Chain:
 
                 # Follow all transmutation paths for this nuclide
                 for rxn in nuclide.reactions + nuclide.decay_modes:
-                    if rxn.type == "fission" or rxn.target is None:
+                    if rxn.type == "fission":
                         continue
-                    # Skip if we've already come across this isotope
-                    elif (rxn.target in next_iso
-                          or rxn.target in found or rxn.target in isotopes):
-                        continue
-                    next_iso.add(rxn.target)
+
+                    # Figure out if this reaction produces light nuclides
+                    secondaries = _SECONDARY_PARTICLES.get(rxn.type, [])
+
+                    # Only include secondaries if they are present in original chain
+                    secondaries = [x for x in secondaries if x in self]
+
+                    for product in chain([rxn.target], secondaries):
+                        if product is None:
+                            continue
+                        # Skip if we've already come across this isotope
+                        elif (product in next_iso or product in found
+                              or product in isotopes):
+                            continue
+                        next_iso.add(product)
 
                 if nuclide.yield_data is not None:
                     for product in nuclide.yield_data.products:

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -531,6 +531,16 @@ class Chain:
                         if target is not None and path_rate != 0.0:
                             k = self.nuclide_dict[target]
                             matrix[k, i] += path_rate * br
+
+                        # Determine light nuclide production, e.g., (n,d) should
+                        # produce H2
+                        light_nucs = _SECONDARY_PARTICLES.get(r_type)
+                        if light_nucs is not None:
+                            for light_nuc in light_nucs:
+                                k = self.nuclide_dict.get(light_nuc)
+                                if k is not None:
+                                    matrix[k, i] += path_rate * br
+
                     else:
                         for product, y in fission_yields[nuc.name].items():
                             yield_val = y * path_rate


### PR DESCRIPTION
This PR updates the `Chain.form_matrix` method to account for the production of light nuclides in reactions like (n,p), (n,d), etc. during depletion. Right now, these reactions don't result in production terms in the burnup matrix for the light nuclide. I've also modified `Chain.reduce` to ensure that light nuclides are not removed from a chain if they are present in the chain and there are reactions like (n,p) listed.

As proof that this works, here's a comparison of H1 production in fuel for a PWR pincell using OpenMC and Serpent:
![compare_H1](https://user-images.githubusercontent.com/743095/80747511-2e7a4700-8ae9-11ea-906d-36ff17ac1f16.png)
Without this fix, the OpenMC line is just flat at zero.