### PR TITLE
Fixed typo in data/photon.py

### DIFF
--- a/openmc/data/photon.py
+++ b/openmc/data/photon.py
@@ -880,7 +880,7 @@ class IncidentPhoton(EqualityMixin):
                     # Cubic spline interpolation in log energy and linear DCS
                     cs = CubicSpline(logx, y[:, j])
 
-                    # Get scaled DCS values (millibarns) on new energy grid
+                    # Get scaled DCS values (barns) on new energy grid
                     dcs[:, j] = cs(log_energy)
 
                 _BREMSSTRAHLUNG[i]['dcs'] = dcs


### PR DESCRIPTION
photon.py states the data for bremsstrahlung cross sections is in millibarns and converts to barns in a previous line. The cross sections are then interpolated and the values are stated to be in millibarns again. Should be in barns.