### PR TITLE
Parallel depletion fix (and other assorted fixes)

### DIFF
--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -339,7 +339,7 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
 
     ev = evaluation if evaluation is not None else endf.Evaluation(filename)
     mat = ev.material
-    zsymam = ev.target['zsymam']
+    zsymam = ev.target.get('zsymam', 'Unknown')
 
     # Determine name of library
     library = '{}-{}.{}'.format(*ev.info['library'])
@@ -499,7 +499,7 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
     ev_thermal = (evaluation_thermal if evaluation_thermal is not None
                   else endf.Evaluation(filename_thermal))
     mat_thermal = ev_thermal.material
-    zsymam_thermal = ev_thermal.target['zsymam']
+    zsymam_thermal = ev_thermal.target.get('zsymam', 'Unknown')
 
     # Determine name, isotopes based on MAT number
     data = _get_thermal_data(ev_thermal, mat_thermal)

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -444,7 +444,7 @@ class FissionYieldCutoffHelper(TalliedFissionYieldHelper):
 
     def unpack(self):
         """Obtain fast and thermal fission fractions from tally"""
-        if not self._tally_nucs:
+        if not self._tally_nucs or self._local_indexes.size == 0:
             self.results = None
             return
         fission_rates = self._fission_rate_tally.results[..., 1].reshape(
@@ -605,7 +605,7 @@ class AveragedFissionYieldHelper(TalliedFissionYieldHelper):
 
     def unpack(self):
         """Unpack tallies and populate :attr:`results` with average energies"""
-        if not self._tally_nucs:
+        if not self._tally_nucs or self._local_indexes.size == 0:
             self.results = None
             return
         fission_results = (

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ kwargs = {
     'download_url': 'https://github.com/openmc-dev/openmc/releases',
     'project_urls': {
         'Issue Tracker': 'https://github.com/openmc-dev/openmc/issues',
-        'Documentation': 'https://openmc.readthedocs.io',
+        'Documentation': 'https://docs.openmc.org',
         'Source Code': 'https://github.com/openmc-dev/openmc',
     },
     'classifiers': [
@@ -59,6 +59,7 @@ kwargs = {
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 
     # Dependencies
@@ -68,6 +69,7 @@ kwargs = {
         'pandas', 'lxml', 'uncertainties'
     ],
     'extras_require': {
+        'depletion-mpi': ['mpi4py'],
         'test': ['pytest', 'pytest-cov', 'colorama'],
         'vtk': ['vtk'],
     },


### PR DESCRIPTION
This PR contains a number of bug fixes:

- Trying to run a depletion simulation in parallel using one of the non-default fission yield modes doesn't work currently. This is now fixed
- Building with GCC 10 doesn't work because of an issue with gsl-lite. This has been fixes upstream, so I've updated the submodule.
- Fix for #1564 (as well as the issue discussed [here](https://groups.google.com/d/msg/openmc-users/uN6tEVYXFDQ/1trxHMMeAAAJ))

@drewejohnson Would you mind reviewing since the most important fix is related to depletion?