### PR TITLE
Fix for missing zsymam in ENDF files

### DIFF
--- a/openmc/data/endf.py
+++ b/openmc/data/endf.py
@@ -448,10 +448,7 @@ class Evaluation:
         self._read_header()
 
     def __repr__(self):
-        if 'zsymam' in self.target:
-            name = self.target['zsymam'].replace(' ', '')
-        else:
-            name = 'Unknown'
+        name = self.target['zsymam'].replace(' ', '')
         return '<{} for {} {}>'.format(self.info['sublibrary'], name,
                                        self.info['library'])
 
@@ -514,6 +511,8 @@ class Evaluation:
             self.info['date_entry'] = text[1][55:63]
             self.info['identifier'] = text[2:5]
             self.info['description'] = text[5:]
+        else:
+            self.target['zsymam'] = 'Unknown'
 
         # File numbers, reaction designations, and number of records
         for i in range(NXC):

--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -339,7 +339,7 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
 
     ev = evaluation if evaluation is not None else endf.Evaluation(filename)
     mat = ev.material
-    zsymam = ev.target.get('zsymam', 'Unknown')
+    zsymam = ev.target['zsymam']
 
     # Determine name of library
     library = '{}-{}.{}'.format(*ev.info['library'])
@@ -499,7 +499,7 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
     ev_thermal = (evaluation_thermal if evaluation_thermal is not None
                   else endf.Evaluation(filename_thermal))
     mat_thermal = ev_thermal.material
-    zsymam_thermal = ev_thermal.target.get('zsymam', 'Unknown')
+    zsymam_thermal = ev_thermal.target['zsymam']
 
     # Determine name, isotopes based on MAT number
     data = _get_thermal_data(ev_thermal, mat_thermal)


### PR DESCRIPTION
Another fix here related to #1564 (addressed in #1565, but evidently it wasn't complete enough). Normally ENDF files include a field (zsymam) that lists the nuclide/material name, e.g. `92-U -235`. However, it's not required and in rare cases (some TENDL-2019 files) it may be missing. This PR ensures that data processing doesn't crash when this happens.