### PR TITLE
Fixed electron energy grid in thick target bremsstrahlung approximation

### DIFF
--- a/openmc/data/photon.py
+++ b/openmc/data/photon.py
@@ -847,7 +847,7 @@ class IncidentPhoton(EqualityMixin):
                 brem = fh.read().split()
 
             # Incident electron kinetic energy grid in eV
-            _BREMSSTRAHLUNG['electron_energy'] = np.logspace(3, 9, 200)
+            _BREMSSTRAHLUNG['electron_energy'] = np.logspace(3, 10, 200)
             log_energy = np.log(_BREMSSTRAHLUNG['electron_energy'])
 
             # Get number of tabulated electron and photon energy values


### PR DESCRIPTION
Suggested:

The BREMX.DAT file has a coarse energy grid for electron energies from 1keV to 10GeV. In the current photon data parsing script, the grid is interpolated for 200 points between 1keV and 1GeV. I am suggesting using the entire range of the available data.