### PR TITLE
Add decay energy  to reduce openmc.deplete function

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -898,7 +898,7 @@ class Chain:
             previous = self[iso]
             new_nuclide = Nuclide(previous.name)
             new_nuclide.half_life = previous.half_life
-            new_nuclide.decay_energy = new_nuclide.decay_energy
+            new_nuclide.decay_energy = previous.decay_energy
 
             new_decay = []
             for mode in previous.decay_modes:

--- a/tests/unit_tests/test_deplete_chain.py
+++ b/tests/unit_tests/test_deplete_chain.py
@@ -487,6 +487,8 @@ def test_reduce(gnd_simple_chain, endf_chain):
 
     u5_round0 = no_depth["U235"]
     assert u5_round0.n_decay_modes == ref_U5.n_decay_modes
+    assert u5_round0.half_life == ref_U5.half_life
+    assert u5_round0.decay_energy == ref_U5.decay_energy
     for newmode, refmode in zip(u5_round0.decay_modes, ref_U5.decay_modes):
         assert newmode.target is None
         assert newmode.type == refmode.type
@@ -507,6 +509,8 @@ def test_reduce(gnd_simple_chain, endf_chain):
 
     bareI5 = no_depth["I135"]
     assert bareI5.n_decay_modes == ref_iodine.n_decay_modes
+    assert bareI5.half_life == ref_iodine.half_life
+    assert bareI5.decay_energy == ref_iodine.decay_energy
     for newmode, refmode in zip(bareI5.decay_modes, ref_iodine.decay_modes):
         assert newmode.target is None
         assert newmode.type == refmode.type


### PR DESCRIPTION
I'm currently working with decay heat curves, and to investigate influence of nuclide chain length to result I had used the `reduce` function, but all heat values turned out to "0.0". The reason was the decay energy were missed out casued by code line             `new_nuclide.decay_energy = new_nuclide.decay_energy`. I have replaced `new_nuclide` by `previous` one and add some strings to unit test of the function `reduce` to catch such mistakes in the future