### PR TITLE
More surface constructors (great for externally linked mini-apps!)

### DIFF
--- a/include/openmc/surface.h
+++ b/include/openmc/surface.h
@@ -196,7 +196,7 @@ public:
   explicit PeriodicSurface(pugi::xml_node surf_node);
 
   // Default constructor has no periodic surface associated
-  PeriodicSurface();
+  PeriodicSurface() : i_periodic_(C_NONE) {}
 
   //! Translate a particle onto this surface from a periodic partner surface.
   //! \param other A pointer to the partner surface in this periodic BC.

--- a/include/openmc/surface.h
+++ b/include/openmc/surface.h
@@ -195,6 +195,9 @@ public:
 
   explicit PeriodicSurface(pugi::xml_node surf_node);
 
+  // Default constructor has no periodic surface associated
+  PeriodicSurface();
+
   //! Translate a particle onto this surface from a periodic partner surface.
   //! \param other A pointer to the partner surface in this periodic BC.
   //! \param r A point on the partner surface that will be translated onto
@@ -218,6 +221,7 @@ class SurfaceXPlane : public PeriodicSurface
 {
 public:
   explicit SurfaceXPlane(pugi::xml_node surf_node);
+  explicit SurfaceXPlane(double x) : x0_(x) {}
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
@@ -239,6 +243,7 @@ class SurfaceYPlane : public PeriodicSurface
 {
 public:
   explicit SurfaceYPlane(pugi::xml_node surf_node);
+  explicit SurfaceYPlane(double y) : y0_(y) {}
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
@@ -260,6 +265,7 @@ class SurfaceZPlane : public PeriodicSurface
 {
 public:
   explicit SurfaceZPlane(pugi::xml_node surf_node);
+  explicit SurfaceZPlane(double z) : z0_(z) {}
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
@@ -281,6 +287,8 @@ class SurfacePlane : public PeriodicSurface
 {
 public:
   explicit SurfacePlane(pugi::xml_node surf_node);
+  explicit SurfacePlane(double a, double b, double c, double d) :
+    A_(a), B_(b), C_(c), D_(d) {}
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
@@ -302,6 +310,8 @@ class SurfaceXCylinder : public CSGSurface
 {
 public:
   explicit SurfaceXCylinder(pugi::xml_node surf_node);
+  explicit SurfaceXCylinder(double y, double z, double r) :
+    y0_(y), z0_(z), radius_(r) {}
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
@@ -322,6 +332,8 @@ class SurfaceYCylinder : public CSGSurface
 {
 public:
   explicit SurfaceYCylinder(pugi::xml_node surf_node);
+  explicit SurfaceYCylinder(double x, double z, double r) :
+    x0_(x), z0_(z), radius_(r) {}
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
@@ -342,6 +354,8 @@ class SurfaceZCylinder : public CSGSurface
 {
 public:
   explicit SurfaceZCylinder(pugi::xml_node surf_node);
+  explicit SurfaceZCylinder(double x, double y, double r) :
+    x0_(x), y0_(y), radius_(r) {}
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
@@ -362,6 +376,8 @@ class SurfaceSphere : public CSGSurface
 {
 public:
   explicit SurfaceSphere(pugi::xml_node surf_node);
+  explicit SurfaceSphere(double x, double y, double z, double r) :
+    x0_(x), y0_(y), z0_(z), radius_(r) {}
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
@@ -382,6 +398,8 @@ class SurfaceXCone : public CSGSurface
 {
 public:
   explicit SurfaceXCone(pugi::xml_node surf_node);
+  explicit SurfaceXCone(double x, double y, double z, double rad_sq) :
+    x0_(x), y0_(y), z0_(z), radius_sq_(rad_sq) {}
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
@@ -401,6 +419,8 @@ class SurfaceYCone : public CSGSurface
 {
 public:
   explicit SurfaceYCone(pugi::xml_node surf_node);
+  explicit SurfaceYCone(double x, double y, double z, double rad_sq) :
+    x0_(x), y0_(y), z0_(z), radius_sq_(rad_sq) {}
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
@@ -420,6 +440,8 @@ class SurfaceZCone : public CSGSurface
 {
 public:
   explicit SurfaceZCone(pugi::xml_node surf_node);
+  explicit SurfaceZCone(double x, double y, double z, double rad_sq) :
+    x0_(x), y0_(y), z0_(z), radius_sq_(rad_sq) {}
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;
@@ -438,6 +460,9 @@ class SurfaceQuadric : public CSGSurface
 {
 public:
   explicit SurfaceQuadric(pugi::xml_node surf_node);
+  explicit SurfaceQuadric(double a, double b, double c, double d,
+      double e, double f, double g, double h, double j, double k) :
+    A_(a), B_(b), C_(c), D_(d), E_(e), F_(f), G_(g), H_(h), J_(j), K_(k) {}
   double evaluate(Position r) const;
   double distance(Position r, Direction u, bool coincident) const;
   Direction normal(Position r) const;


### PR DESCRIPTION
Hi all,

I recently was looking to play around with a modified particles-in-a-box eigenvalue algorithm, and was looking to save some work on writing the plane intersection and reflection routines. The constructors I've added here allow surfaces to be created in externally linked apps, e.g.:

```c++
// Create the box surfaces to simplify reflection stuff
openmc::SurfaceXPlane s_x1(box_lower_left.x);
openmc::SurfaceXPlane s_x2(box_upper_right.x);
openmc::SurfaceYPlane s_y1(box_lower_left.y);
openmc::SurfaceYPlane s_y2(box_upper_right.y);
openmc::SurfaceZPlane s_z1(box_lower_left.z);
openmc::SurfaceZPlane s_z2(box_upper_right.z);

std::vector<openmc::Surface*> surfaces {
  &s_x1,
  &s_x2,
  &s_y1,
  &s_y2,
  &s_z1,
  &s_z2};

...

  for (auto& part: particles) {

    // Skip dead particles
    if (part.wgt == 0) continue;

    // Get distances to boundaries
    int i_surf = 0;
    part.distance_to_bdry = openmc::INFTY;
    for (openmc::Surface* surf: surfaces) {
      double dist = surf->distance(part.r, part.u, part.surf_id==i_surf);
      if (dist < part.distance_to_bdry) {
        part.distance_to_bdry = dist;
        part.bdry_surf = i_surf;
      }
      i_surf++;
    }

```

Of course, I would completely understand it if the maintainers would prefer to not add code which isn't explicitly used in the main codebase. This is part of an overarching dream to generalize OpenMC's classes to work well as a Monte Carlo library that aids in research rather than simply being a monolithic program.