### PR TITLE
Ensure that unstable nuclides with no listed decay modes still decay

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -490,16 +490,14 @@ class Chain:
             fission_yields = self.get_default_fission_yields()
 
         for i, nuc in enumerate(self.nuclides):
-
-            if nuc.n_decay_modes != 0:
-                # Decay paths
-                # Loss
+            # Loss from radioactive decay
+            if nuc.half_life is not None:
                 decay_constant = math.log(2) / nuc.half_life
-
                 if decay_constant != 0.0:
                     matrix[i, i] -= decay_constant
 
-                # Gain
+            # Gain from radioactive decay
+            if nuc.n_decay_modes != 0:
                 for _, target, branching_ratio in nuc.decay_modes:
                     # Allow for total annihilation for debug purposes
                     if target is not None:


### PR DESCRIPTION
In doing some depletion comparisons with Serpent, I found a small bug in how the depletion matrix is formed. If an unstable nuclide is present in the depletion chain and doesn't have any decay modes listed, right now it won't decay at all. This situation doesn't really happen with the full depletion chain, but for a simplified chain (e.g., the CASL chain) this does happen when the daughter of the true decay mode doesn't exist in the chain. In the CASL chain, the following nuclides are unstable but don't have any decay modes:
- Kr85, Y90, Zr93, Tc99, Sb125, Cs135, Cs136, Th234, U233

Note that some of these nuclides have really long half-lives, so not accounting for their decay is not a big deal. However, for the ones with shorter half-lives (Kr85, for example), not accounting for decay will result in overproduction. As an example, here is comparison between OpenMC and Serpent showing the Kr85 density built up over time in a high burnup PWR pincell case:
![Kr85](https://user-images.githubusercontent.com/743095/83523730-37738500-a4a8-11ea-9174-a4798296b9b5.png)

The fix for this is really simple: in `Chain.form_matrix` rather than checking `n_decay_modes` when adding the loss term from radioactive decay (which might be 0 even though the nuclide is radioactive), check `half_life` instead.