### PR TITLE
Python bindings for setting n_batches through C API

### DIFF
--- a/docs/source/capi/index.rst
+++ b/docs/source/capi/index.rst
@@ -266,12 +266,12 @@ Functions
    :return: Return status (negative if an error occurs)
    :rtype: int
 
-.. c:function:: int openmc_get_n_batches(int* n_batches, int* n_max_batches)
+.. c:function:: int openmc_get_n_batches(int* n_batches, bool get_max_batches)
 
    Get number of batches to simulate
 
    :param int* n_batches: Number of batches to simulate
-   :param int* n_max_batches: Maximum number of batches to simulate (only relevant when triggers are used)
+   :param int* get_max_batches: Whether to return `n_batches` or `n_max_batches` (only relevant when triggers are used)
    :return: Return status (negative if an error occurred)
    :rtype: int
 
@@ -461,12 +461,12 @@ Functions
    :return: Return status (negative if an error occurs)
    :rtype: int
 
-.. c:function:: int openmc_set_n_batches(int32_t n_batches, int32_t n_max_batches, int32_t add_statepoint_batch)
+.. c:function:: int openmc_set_n_batches(int32_t n_batches, bool set_max_batches, bool add_statepoint_batch)
 
    Set number of batches and number of max batches
 
    :param int32_t n_batches: Number of batches to simulate
-   :param int32_t n_max_batches: Maximum number of batches to simulate (only relevant when triggers are used)
+   :param bool set_max_batches: Whether to set `settings::n_max_batches` or `settings::n_batches` (only relevant when triggers are used)
    :param bool add_statepoint_batch: Whether to add `n_batches` to `settings::statepoint_batch`
    :return: Return status (negative if an error occurred)
    :rtype: int

--- a/docs/source/capi/index.rst
+++ b/docs/source/capi/index.rst
@@ -271,7 +271,7 @@ Functions
    Get number of batches to simulate
 
    :param int* n_batches: Number of batches to simulate
-   :param int* get_max_batches: Whether to return `n_batches` or `n_max_batches` (only relevant when triggers are used)
+   :param bool get_max_batches: Whether to return `n_batches` or `n_max_batches` (only relevant when triggers are used)
    :return: Return status (negative if an error occurred)
    :rtype: int
 

--- a/docs/source/capi/index.rst
+++ b/docs/source/capi/index.rst
@@ -452,6 +452,16 @@ Functions
    :return: Return status (negative if an error occurs)
    :rtype: int
 
+.. c:function:: int openmc_set_n_batches(int32_t n_batches, int32_t n_max_batches, int32_t add_statepoint_batch)
+
+   Set number of batches and number of max batches
+
+   :param int32_t n_batches: Number of batches to simulate
+   :param int32_t n_batches: Maximum number of batches to simulate (only relevant when triggers are used)
+   :param bool add_statepoint_batch: Whether to add `n_batches` to `settings::statepoint_batch`
+   :return: Return status (negative if an error occurred)
+   :rtype: int
+
 .. c:function:: int openmc_simulation_finalize()
 
    Finalize a simulation.

--- a/docs/source/capi/index.rst
+++ b/docs/source/capi/index.rst
@@ -266,6 +266,15 @@ Functions
    :return: Return status (negative if an error occurs)
    :rtype: int
 
+.. c:function:: int openmc_get_n_batches(int* n_batches, int* n_max_batches)
+
+   Get number of batches to simulate
+
+   :param int* n_batches: Number of batches to simulate
+   :param int* n_max_batches: Maximum number of batches to simulate (only relevant when triggers are used)
+   :return: Return status (negative if an error occurred)
+   :rtype: int
+
 .. c:function:: int openmc_get_nuclide_index(const char name[], int* index)
 
    Get the index in the nuclides array for a nuclide with a given name
@@ -457,7 +466,7 @@ Functions
    Set number of batches and number of max batches
 
    :param int32_t n_batches: Number of batches to simulate
-   :param int32_t n_batches: Maximum number of batches to simulate (only relevant when triggers are used)
+   :param int32_t n_max_batches: Maximum number of batches to simulate (only relevant when triggers are used)
    :param bool add_statepoint_batch: Whether to add `n_batches` to `settings::statepoint_batch`
    :return: Return status (negative if an error occurred)
    :rtype: int

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -44,6 +44,7 @@ extern "C" {
   int openmc_get_keff(double k_combined[]);
   int openmc_get_material_index(int32_t id, int32_t* index);
   int openmc_get_mesh_index(int32_t id, int32_t* index);
+  int openmc_get_n_batches(int* n_batches, bool get_max_batches);
   int openmc_get_nuclide_index(const char name[], int* index);
   int64_t openmc_get_seed();
   int openmc_get_tally_index(int32_t id, int32_t* index);
@@ -89,7 +90,7 @@ extern "C" {
   int openmc_reset_timers();
   int openmc_run();
   void openmc_set_seed(int64_t new_seed);
-  int openmc_set_n_batches(int32_t n_batches, int32_t n_max_batches,
+  int openmc_set_n_batches(int32_t n_batches, bool set_max_batches,
                            bool add_statepoint_batch);
   int openmc_simulation_finalize();
   int openmc_simulation_init();

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -89,6 +89,8 @@ extern "C" {
   int openmc_reset_timers();
   int openmc_run();
   void openmc_set_seed(int64_t new_seed);
+  int openmc_set_n_batches(int32_t n_batches, int32_t n_max_batches,
+                           bool add_statepoint_batch);
   int openmc_simulation_finalize();
   int openmc_simulation_init();
   int openmc_source_bank(void** ptr, int64_t* n);

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -64,7 +64,6 @@ extern std::string path_source_library;   //!< path to the source shared object
 extern std::string path_sourcepoint;      //!< path to a source file
 extern "C" std::string path_statepoint;   //!< path to a statepoint file
 
-extern "C" int32_t n_batches;                //!< number of (inactive+active) batches
 extern "C" int32_t n_inactive;               //!< number of inactive batches
 extern "C" int32_t max_lost_particles;     //!< maximum number of lost particles
 extern double rel_max_lost_particles;   //!< maximum number of lost particles, relative to the total number of particles
@@ -79,6 +78,7 @@ extern std::array<double, 4> energy_cutoff;  //!< Energy cutoff in [eV] for each
 extern int legendre_to_tabular_points; //!< number of points to convert Legendres
 extern int max_order;                //!< Maximum Legendre order for multigroup data
 extern int n_log_bins;               //!< number of bins for logarithmic energy grid
+extern int n_batches;                //!< number of (inactive+active) batches
 extern int n_max_batches;            //!< Maximum number of batches
 extern ResScatMethod res_scat_method; //!< resonance upscattering method
 extern double res_scat_energy_min;   //!< Min energy in [eV] for res. upscattering

--- a/openmc/cmfd.py
+++ b/openmc/cmfd.py
@@ -830,7 +830,7 @@ class CMFDRun:
 
         """
         if filename is None:
-            batch_str_len = len(str(openmc.lib.settings.batches))
+            batch_str_len = len(str(openmc.lib.settings.get_batches()))
             batch_str = str(openmc.lib.current_batch()).zfill(batch_str_len)
             filename = 'statepoint.{}.h5'.format(batch_str)
 
@@ -1164,8 +1164,8 @@ class CMFDRun:
                 self._k_cmfd.append(self._keff)
 
                 # Check to perform adjoint on last batch
-                if (openmc.lib.current_batch() == openmc.lib.settings.batches
-                        and self._run_adjoint):
+                batches = openmc.lib.settings.get_batches()
+                if openmc.lib.current_batch() == batches and self._run_adjoint:
                     self._cmfd_solver_execute(adjoint=True)
 
                 # Calculate fission source

--- a/openmc/lib/settings.py
+++ b/openmc/lib/settings.py
@@ -66,14 +66,14 @@ class _Settings:
         _dll.openmc_set_seed(seed)
 
     def set_batches(self, n_batches, set_max_batches=True, add_sp_batch=True):
-        """Set n_batches
+        """Set number of batches or maximum number of batches
 
         Parameters
         ----------
         n_batches : int
             Number of batches to simulate
-        set_max_batches : int
-            Whether to set maximum number of batches. If true, the value of
+        set_max_batches : bool
+            Whether to set maximum number of batches. If True, the value of
             `n_max_batches` is overridden, otherwise the value of `n_batches`
             is overridden. Only has an effect when triggers are used
         add_sp_batch : bool

--- a/openmc/lib/settings.py
+++ b/openmc/lib/settings.py
@@ -83,7 +83,7 @@ class _Settings:
         _dll.openmc_set_n_batches(n_batches, set_max_batches, add_sp_batch)
 
     def get_batches(self, get_max_batches=True):
-        """Set n_batches and n_max_batches
+        """Get number of batches or maximum number of batches
 
         Parameters
         ----------

--- a/openmc/lib/settings.py
+++ b/openmc/lib/settings.py
@@ -2,6 +2,7 @@ from ctypes import c_int, c_int32, c_int64, c_double, c_char_p, c_bool
 
 from . import _dll
 from .core import _DLLGlobal
+from .error import _error_handler
 
 _RUN_MODES = {1: 'fixed source',
               2: 'eigenvalue',
@@ -11,11 +12,13 @@ _RUN_MODES = {1: 'fixed source',
 
 _dll.openmc_set_seed.argtypes = [c_int64]
 _dll.openmc_get_seed.restype = c_int64
+_dll.openmc_set_n_batches.argtypes = [c_int32, c_int32, c_bool]
+_dll.openmc_set_n_batches.restype = c_int
+_dll.openmc_set_n_batches.errcheck = _error_handler
 
 
 class _Settings:
     # Attributes that are accessed through a descriptor
-    batches = _DLLGlobal(c_int32, 'n_batches')
     cmfd_run = _DLLGlobal(c_bool, 'cmfd_run')
     entropy_on = _DLLGlobal(c_bool, 'entropy_on')
     generations_per_batch = _DLLGlobal(c_int32, 'gen_per_batch')
@@ -58,6 +61,24 @@ class _Settings:
     @seed.setter
     def seed(self, seed):
         _dll.openmc_set_seed(seed)
+
+    def set_n_batches(self, n_batches, n_max_batches=None, add_sp_batch=True):
+        """Set n_batches and n_max_batches
+
+        Parameters
+        ----------
+        n_batches : int
+            Number of batches to simulate
+        n_max_batches : int
+            Maximum number of batches. Only has an effect when triggers are used
+        add_sp_batch : bool
+            Whether to add `n_batches` as a statepoint batch
+
+        """
+        if not n_max_batches:
+            _dll.openmc_set_n_batches(n_batches, n_batches, add_sp_batch)
+        else:
+            _dll.openmc_set_n_batches(n_batches, n_max_batches, add_sp_batch)
 
 
 settings = _Settings()

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -162,6 +162,8 @@ int openmc_reset()
   simulation::k_abs_tra = 0.0;
   simulation::k_sum = {0.0, 0.0};
 
+  settings::cmfd_run = false;
+
   return 0;
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -849,13 +849,13 @@ openmc_set_n_batches(int32_t n_batches, bool set_max_batches,
     // Set n_batches and n_max_batches to same value
     settings::n_batches = n_batches;
     settings::n_max_batches = n_batches;
-  }
-  else {
+  } else {
     // Set n_batches and n_max_batches based on value of set_max_batches
-    if (set_max_batches)
+    if (set_max_batches) {
       settings::n_max_batches = n_batches;
-    else
+    } else {
       settings::n_batches = n_batches;
+    }
   }
 
   // Update size of k_generation and entropy
@@ -874,10 +874,7 @@ openmc_set_n_batches(int32_t n_batches, bool set_max_batches,
 extern "C" int
 openmc_get_n_batches(int* n_batches, bool get_max_batches)
 {
-  if (get_max_batches)
-    *n_batches = settings::n_max_batches;
-  else
-    *n_batches = settings::n_batches;
+  *n_batches = get_max_batches ? settings::n_max_batches : settings::n_batches;
 
   return 0;
 }

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -162,8 +162,8 @@ def test_nuclide_mapping(lib_init):
 
 def test_settings(lib_init):
     settings = openmc.lib.settings
-    assert settings.batches == 10
-    settings.batches = 10
+    assert settings.get_batches() == 10
+    settings.set_batches(10)
     assert settings.inactive == 5
     assert settings.generations_per_batch == 1
     assert settings.particles == 100

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -346,6 +346,8 @@ def test_set_n_batches(lib_run):
 
     # n_active should have been overwritten from 5 to 15
     assert openmc.lib.num_realizations() == 15
+
+    # Ensure statepoint created at new value of n_batches
     assert os.path.exists('statepoint.20.h5')
 
 

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -316,11 +316,9 @@ def test_by_batch(lib_run):
         openmc.lib.simulation_finalize()
 
 
-def test_set_n_batches(lib_run, mpi_intracomm):
+def test_set_n_batches(lib_run):
     # Run simulation_init so that current_batch reset to 0
     openmc.lib.hard_reset()
-    openmc.lib.finalize()
-    openmc.lib.init(intracomm=mpi_intracomm)
     openmc.lib.simulation_init()
 
     settings = openmc.lib.settings
@@ -348,6 +346,7 @@ def test_set_n_batches(lib_run, mpi_intracomm):
 
     # n_active should have been overwritten from 5 to 15
     assert openmc.lib.num_realizations() == 15
+    assert os.path.exists('statepoint.20.h5')
 
 
 def test_reset(lib_run):
@@ -566,8 +565,8 @@ def test_trigger_set_n_batches(lib_run, mpi_intracomm):
 
     settings = openmc.lib.settings
     # Change n_batches to 12 and n_max_batches to 20
-    settings.set_batches(12, set_max_batches=False)
-    settings.set_batches(20, set_max_batches=True)
+    settings.set_batches(12, set_max_batches=False, add_sp_batch=False)
+    settings.set_batches(20, set_max_batches=True, add_sp_batch=True)
 
     assert settings.get_batches(get_max_batches=False) == 12
     assert settings.get_batches(get_max_batches=True) == 20
@@ -578,3 +577,7 @@ def test_trigger_set_n_batches(lib_run, mpi_intracomm):
 
     # n_active should have been overwritten from 5 to 15
     assert openmc.lib.num_realizations() == 15
+
+    # Ensure statepoint was created only at batch 20 when calling set_batches
+    assert not os.path.exists('statepoint.12.h5')
+    assert os.path.exists('statepoint.20.h5')


### PR DESCRIPTION
This PR creates the C++ functions and Python bindings needed to set number of batches in memory. Currently, the variable `openmc.lib.settings.batches` modifies the variable `settings::n_batches` directly but this does not actually alter the number of batches in the simulation since this is controlled by the variable `settings::n_max_batches`. For simulations without triggers, these values should be the same. For simulations that use triggers, `settings::n_batches` controls when to start checking for the trigger condition and `settings::n_max_batches` sets the maximum number of batches to simulate. 

I've gone ahead and removed the variable `batches` from `openmc.lib.settings` and replaced it with the setter/getter functions `set_batches` and `get_batches` with the following logic:

- If triggers are not being used, the argument `n_batches` modifies both `settings::n_batches` and `settings::n_max_batches` to the same value.
- If triggers are being used, the second argument `set_max_batches` controls whether the input argument should modify `settings::n_batches` or `settings::n_max_batches`
- In both cases, the variable `add_sp_batch` determines whether the argument `n_batches` should be inserted into `simulation::statepoint_batch` so that a statepoint is created at a batch. A statepoint is still created at the old value of `settings::n_batches` but I can add another input parameter to remove the old value from statepoint::batch if that is preferred
- `get_batches`  returns `settings::n_batches` if `get_max_batches` is false and `settings::n_max_batches` if it is true. Once again, these values should be the same if triggers are not being used.

For the unit tests, the `lib_simulation_init` pytest fixture is required so that `simulation::current_batch` is reset to 0 so all testing for `n_batches` are moved to a separate unit test. It also turns out that `settings::cmfd_run` remains True for all tests in `test_lib.py` which prevents any statepoints from being created in `finalize_batch` so I set this to False whenever `openmc.lib.hard_reset` is called. Without this any assertions that look for the file `statepoint.**.h5` will fail

Finally, in order to test the behavior of the getter/setter functions for `batches` when a trigger is used, I manually overwrite the settings.xml file to create a trigger in `test_trigger_set_n_batches`. I wasn't sure if there was a more elegant way of creating a separate model with a trigger.