### PR TITLE
Make sure IPFCramSolver doesn't modify nuclide vector

### DIFF
--- a/openmc/deplete/cram.py
+++ b/openmc/deplete/cram.py
@@ -76,7 +76,7 @@ class IPFCramSolver(DepSystemSolver):
 
         """
         A = sp.csr_matrix(A * dt, dtype=np.float64)
-        y = np.asarray(n0, dtype=np.float64)
+        y = n0.copy()
         ident = sp.eye(A.shape[0])
         for alpha, theta in zip(self.alpha, self.theta):
             y += 2*np.real(alpha*sla.spsolve(A - theta*ident, y))


### PR DESCRIPTION
This fixes a potential bug that @gwenchee helped to uncover. If you get rid of the use of multiprocessing in our depletion solver (pool.py), the solution gets all messed up currently. After some digging, I was able to figure out that the reason is that `IPFCramSolver.__call__` actually modifies the nuclide vector `n0` that gets passed into it. When we're using multiprocessing, the CRAM solve takes place on a new process, so the nuclide vector on the original process remains unchanged. But without multiprocessing, this serendipitous copying doesn't take place. This PR simply ensures that the nuclide vector passed in doesn't actually get changed. So again, to emphasize here, this is not really a "bug", but maybe a bug waiting to happen... a larva perhaps? :bug: 