### PR TITLE
Update Quick Install Guide

### DIFF
--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -22,17 +22,19 @@ you have `conda` installed on your system, OpenMC can be installed via the
 
     conda config --add channels conda-forge
 
-To list the versions of OpenMC that are available to install, in your terminal window or an Anaconda Prompt, run:
+To list the versions of OpenMC that are available on `conda-forge` channel to install, in your terminal window or an Anaconda Prompt, run:
 
 .. code-block:: sh 
 
     conda search openmc
     
-Specific version of OpenMC can then be installed with:
+OpenMC can then be installed with:
 
 .. code-block:: sh
 
     conda install openmc=0.X.0 python=3.X
+    
+.. note:: Replace ``python=3.X`` with ``python=2.7`` if using legacy Python2. ``openmc=0.X.0`` is the package and version you want to install.
 
 --------------------------------
 Installing on Ubuntu through PPA

--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -23,6 +23,7 @@ you have `conda` installed on your system, OpenMC can be installed via the
     conda config --add channels conda-forge
 
 To list the versions of OpenMC that are available to install, in your terminal window or an Anaconda Prompt, run:
+
 .. code-block:: sh 
 
     conda search openmc

--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -32,9 +32,14 @@ OpenMC can then be installed with:
 
 .. code-block:: sh
 
-    conda install openmc=0.X.0 python=3.X
+    conda install -n openmc-env openmc
     
-.. note:: Replace ``python=3.X`` with ``python=2.7`` if using legacy Python2. ``openmc=0.X.0`` is the package and version you want to install.
+This will install OpenMC in a conda environment called `openmc-env`. To activate
+the environment, run:
+
+.. code-block:: sh
+
+    conda activate openmc-env
 
 --------------------------------
 Installing on Ubuntu through PPA

--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -22,7 +22,8 @@ you have `conda` installed on your system, OpenMC can be installed via the
 
     conda config --add channels conda-forge
 
-To list the versions of OpenMC that are available on `conda-forge` channel to install, in your terminal window or an Anaconda Prompt, run:
+To list the versions of OpenMC that are available on the `conda-forge` channel,
+in your terminal window or an Anaconda Prompt run:
 
 .. code-block:: sh 
 

--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -22,11 +22,16 @@ you have `conda` installed on your system, OpenMC can be installed via the
 
     conda config --add channels conda-forge
 
-OpenMC can then be installed with:
+To list the versions of OpenMC that are available to install, in your terminal window or an Anaconda Prompt, run:
+.. code-block:: sh 
+
+    conda search openmc
+    
+Specific version of OpenMC can then be installed with:
 
 .. code-block:: sh
 
-    conda install openmc
+    conda install openmc=0.X.0 python=3.X
 
 --------------------------------
 Installing on Ubuntu through PPA

--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -33,7 +33,7 @@ OpenMC can then be installed with:
 
 .. code-block:: sh
 
-    conda install -n openmc-env openmc
+    conda create -n openmc-env openmc
     
 This will install OpenMC in a conda environment called `openmc-env`. To activate
 the environment, run:


### PR DESCRIPTION
This PR has updated a quick installation guide to install the proper version of OpenMC with the specific python version and official  Pregenerated  HDF5 data libraries and a list of OpenMC versions that is available on conda-forge channel if someone needed an older version of OpenMC.