### PR TITLE
Ensure actinides without FPY data have a suitable replacement

### DIFF
--- a/docs/source/io_formats/depletion_chain.rst
+++ b/docs/source/io_formats/depletion_chain.rst
@@ -82,7 +82,7 @@ element has the following attributes:
 ------------------------------------
 
 The ``<neutron_fission_yields>`` element provides yields of fission products for
-fissionable nuclides. It has the follow sub-elements:
+fissionable nuclides. Normally, it has the follow sub-elements:
 
   :energies:
     Energies in [eV] at which yields for products are tabulated
@@ -100,3 +100,11 @@ fissionable nuclides. It has the follow sub-elements:
 
       :data:
         Independent yields for each fission product
+
+In the event that a nuclide doesn't have any known fission product yields, it is
+possible to have that nuclide borrow yields from another nuclide by indicating
+the other nuclide in a single `parent` attribute. For example:
+
+.. code-block:: xml
+
+    <neutron_fission_yields parent="U235"/>

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -264,6 +264,16 @@ class Chain:
         -------
         Chain
 
+        Notes
+        -----
+        When an actinide is missing fission product yield (FPY) data, yields will
+        copied from a parent isotope, found according to:
+
+        1. If the nuclide is in a ground state and a metastable state exists with
+           fission yields, copy the yields from the metastable
+        2. Find an isotone (same number of neutrons) and copy those yields
+        3. Copy the yields of U235 if the previous two checks fail
+
         """
         chain = cls()
 

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -47,6 +47,7 @@ _REACTIONS = [
 
 __all__ = ["Chain"]
 
+
 def replace_missing(product, decay_data):
     """Replace missing product with suitable decay daughter.
 
@@ -107,6 +108,54 @@ def replace_missing(product, decay_data):
         product = '{}{}'.format(openmc.data.ATOMIC_SYMBOL[Z], A)
 
     return product
+
+
+def replace_missing_fpy(actinide, fpy_data, decay_data):
+    """Replace missing fission product yields
+
+    Parameters
+    ----------
+    actinide : str
+        Name of actinide missing FPY data
+    fpy_data : dict
+        Dictionary of FPY data
+    decay_data : dict
+        Dictionary of decay data
+
+    Returns
+    -------
+    str
+        Actinide that can be used as replacement for FPY purposes
+
+    """
+
+    # Check if metastable state has data (e.g., Am242m)
+    Z, A, m = zam(actinide)
+    if m == 0:
+        metastable = gnd_name(Z, A, 1)
+        if metastable in fpy_data:
+            return metastable
+
+    # Try increasing Z, holding N constant
+    isotone = actinide
+    while isotone in decay_data:
+        Z += 1
+        A += 1
+        isotone = gnd_name(Z, A, 0)
+        if isotone in fpy_data:
+            return isotone
+
+    # Try decreasing Z, holding N constant
+    isotone = actinide
+    while isotone in decay_data:
+        Z -= 1
+        A -= 1
+        isotone = gnd_name(Z, A, 0)
+        if isotone in fpy_data:
+            return isotone
+
+    # If all else fails, use U235 yields
+    return 'U235'
 
 
 _SECONDARY_PARTICLES = {
@@ -290,6 +339,7 @@ class Chain:
                     # Append decay mode
                     nuclide.decay_modes.append(DecayTuple(type_, target, br))
 
+            fissionable = False
             if parent in reactions:
                 reactions_available = set(reactions[parent].keys())
                 for name, mts, changes in _REACTIONS:
@@ -317,18 +367,21 @@ class Chain:
                             name, daughter, q_value, 1.0))
 
                 if any(mt in reactions_available for mt in openmc.data.FISSION_MTS):
-                    if parent in fpy_data:
-                        q_value = reactions[parent][18]
-                        nuclide.reactions.append(
-                            ReactionTuple('fission', 0, q_value, 1.0))
+                    q_value = reactions[parent][18]
+                    nuclide.reactions.append(
+                        ReactionTuple('fission', None, q_value, 1.0))
+                    fissionable = True
 
-                        if 'fission' not in chain.reactions:
-                            chain.reactions.append('fission')
-                    else:
-                        missing_fpy.append(parent)
+                    if 'fission' not in chain.reactions:
+                        chain.reactions.append('fission')
 
-            if parent in fpy_data:
-                fpy = fpy_data[parent]
+            if fissionable:
+                if parent in fpy_data:
+                    fpy = fpy_data[parent]
+                else:
+                    nuclide._fpy = replace_missing_fpy(parent, fpy_data, decay_data)
+                    missing_fpy.append((parent, nuclide._fpy))
+                    continue
 
                 if fpy.energies is not None:
                     yield_energies = fpy.energies
@@ -354,6 +407,11 @@ class Chain:
 
                 nuclide.yield_data = FissionYieldDistribution(yield_data)
 
+        # Replace missing FPY data
+        for nuclide in chain.nuclides:
+            if hasattr(nuclide, '_fpy'):
+                nuclide.yield_data = chain[nuclide._fpy].yield_data
+
         # Display warnings
         if missing_daughter:
             print('The following decay modes have daughters with no decay data:')
@@ -369,8 +427,8 @@ class Chain:
 
         if missing_fpy:
             print('The following fissionable nuclides have no fission product yields:')
-            for parent in missing_fpy:
-                print('  ' + parent)
+            for parent, replacement in missing_fpy:
+                print('  {}, replaced with {}'.format(parent, replacement))
             print('')
 
         if missing_fp:
@@ -406,7 +464,7 @@ class Chain:
         for i, nuclide_elem in enumerate(root.findall('nuclide')):
             this_q = fission_q.get(nuclide_elem.get("name"))
 
-            nuc = Nuclide.from_xml(nuclide_elem, this_q)
+            nuc = Nuclide.from_xml(nuclide_elem, root, this_q)
             chain.nuclide_dict[nuc.name] = i
 
             # Check for reaction paths

--- a/openmc/deplete/nuclide.py
+++ b/openmc/deplete/nuclide.py
@@ -155,15 +155,16 @@ class Nuclide:
         return self.yield_data.energies
 
     @classmethod
-    def from_xml(cls, element, root, fission_q=None):
+    def from_xml(cls, element, root=None, fission_q=None):
         """Read nuclide from an XML element.
 
         Parameters
         ----------
         element : xml.etree.ElementTree.Element
             XML element to read nuclide data from
-        root : xml.etree.ElementTree.Element
-            Root XML element for chain file
+        root : None or xml.etree.ElementTree.Element
+            Root XML element for chain file (only used when fission product
+            yields are borrowed from another parent)
         fission_q : None or float
             User-supplied fission Q value [eV].
             Will be read from the element if not given

--- a/openmc/deplete/nuclide.py
+++ b/openmc/deplete/nuclide.py
@@ -218,9 +218,16 @@ class Nuclide:
             # Check for use of FPY from other nuclide
             parent = fpy_elem.get('parent')
             if parent is not None:
+                assert root is not None
                 fpy_elem = root.find(
                     './/nuclide[@name="{}"]/neutron_fission_yields'.format(parent)
                 )
+                if fpy_elem is None:
+                    raise ValueError(
+                        "Fission product yields for {0} borrow from {1}, but {1} is"
+                        " not present in the chain file or has no yields.".format(
+                            nuc.name, parent
+                        ))
                 nuc._fpy = parent
 
             nuc.yield_data = FissionYieldDistribution.from_xml_element(fpy_elem)

--- a/openmc/deplete/nuclide.py
+++ b/openmc/deplete/nuclide.py
@@ -162,7 +162,7 @@ class Nuclide:
         ----------
         element : xml.etree.ElementTree.Element
             XML element to read nuclide data from
-        root : None or xml.etree.ElementTree.Element
+        root : xml.etree.ElementTree.Element, optional
             Root XML element for chain file (only used when fission product
             yields are borrowed from another parent)
         fission_q : None or float

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -603,7 +603,7 @@ class Plot(IDManagerMixin):
         element.set("color_by", self._color_by)
         element.set("type", self._type)
 
-        if self._type is 'slice':
+        if self._type == 'slice':
             element.set("basis", self._basis)
 
         subelement = ET.SubElement(element, "origin")

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,8 @@ kwargs = {
     ],
     'extras_require': {
         'depletion-mpi': ['mpi4py'],
+        'docs': ['sphinx', 'sphinxcontrib-katex', 'sphinx-numfig', 'jupyter',
+                 'sphinxcontrib-svg2pdfconverter', 'sphinx-rtd-theme'],
         'test': ['pytest', 'pytest-cov', 'colorama'],
         'vtk': ['vtk'],
     },

--- a/tests/regression_tests/volume_calc/test.py
+++ b/tests/regression_tests/volume_calc/test.py
@@ -84,27 +84,27 @@ class VolumeTest(PyAPITestHarness):
             outstr += 'Iterations: {}\n'.format(volume_calc.iterations)
 
             if i == 3:
-                assert(volume_calc.trigger_type == 'std_dev')
-                assert(volume_calc.threshold == self.exp_std_dev)
+                assert volume_calc.trigger_type == 'std_dev'
+                assert volume_calc.threshold == self.exp_std_dev
             elif i == 4:
-                assert(volume_calc.trigger_type == 'rel_err')
-                assert(volume_calc.threshold == self.exp_rel_err)
+                assert volume_calc.trigger_type == 'rel_err'
+                assert volume_calc.threshold == self.exp_rel_err
             elif i == 5:
-                assert(volume_calc.trigger_type == 'variance')
-                assert(volume_calc.threshold == self.exp_variance)
+                assert volume_calc.trigger_type == 'variance'
+                assert volume_calc.threshold == self.exp_variance
             else:
-                assert(volume_calc.trigger_type == None)
-                assert(volume_calc.threshold == None)
-                assert(volume_calc.iterations == 1)
+                assert volume_calc.trigger_type is None
+                assert volume_calc.threshold is None
+                assert volume_calc.iterations == 1
 
             # if a trigger is applied, make sure the calculation satisfies the trigger
             for vol in volume_calc.volumes.values():
                 if volume_calc.trigger_type == 'std_dev':
-                    assert(vol.std_dev <= self.exp_std_dev)
+                    assert vol.std_dev <= self.exp_std_dev
                 if volume_calc.trigger_type == 'rel_err':
-                    assert(vol.std_dev/vol.nominal_value <= self.exp_rel_err)
+                    assert vol.std_dev/vol.nominal_value <= self.exp_rel_err
                 if volume_calc.trigger_type == 'variance':
-                    assert(vol.std_dev * vol.std_dev <= self.exp_variance)
+                    assert vol.std_dev * vol.std_dev <= self.exp_variance
 
             # Write cell volumes and total # of atoms for each nuclide
             for uid, volume in sorted(volume_calc.volumes.items()):

--- a/tests/unit_tests/test_deplete_nuclide.py
+++ b/tests/unit_tests/test_deplete_nuclide.py
@@ -2,7 +2,7 @@
 
 import xml.etree.ElementTree as ET
 
-import numpy
+import numpy as np
 import pytest
 from openmc.deplete import nuclide
 
@@ -81,6 +81,44 @@ def test_from_xml():
         u235.yield_energies = [0.0253, 5e5]
 
 
+def test_fpy_parent():
+    """Test reading nuclide data with FPY borrowed from another nuclide."""
+
+    data = """
+<depletion_chain>
+  <nuclide name="U235" reactions="1">
+    <reaction type="fission" Q="193405400.0"/>
+    <neutron_fission_yields>
+      <energies>0.0253</energies>
+      <fission_yields energy="0.0253">
+        <products>Te134 Zr100 Xe138</products>
+        <data>0.062155 0.0497641 0.0481413</data>
+      </fission_yields>
+    </neutron_fission_yields>
+  </nuclide>
+  <nuclide name="U238" reactions="1">
+    <reaction type="fission" Q="200.0e6"/>
+    <neutron_fission_yields parent="U235"/>
+  </nuclide>
+</depletion_chain>
+    """
+
+    root = ET.fromstring(data)
+    elems = root.findall('nuclide')
+    u235 = nuclide.Nuclide.from_xml(elems[0], root)
+    u238 = nuclide.Nuclide.from_xml(elems[1], root)
+
+    # Make sure U238 yield is same as U235
+    assert np.array_equal(u238.yield_data.energies, u235.yield_data.energies)
+    assert np.array_equal(u238.yield_data.yield_matrix, u235.yield_data.yield_matrix)
+
+    # Make sure XML element created has single attribute
+    elem = u238.to_xml_element()
+    fpy_elem = elem.find('neutron_fission_yields')
+    assert fpy_elem.get('parent') == 'U235'
+    assert len(fpy_elem) == 0
+
+
 def test_to_xml_element():
     """Test writing nuclide data to an XML element."""
 
@@ -134,11 +172,11 @@ def test_fission_yield_distribution():
         act_dist = yield_dict[exp_ene]
         for exp_prod, exp_yield in exp_dist.items():
             assert act_dist[exp_prod] == exp_yield
-    exp_yield = numpy.array([
+    exp_yield = np.array([
         [4.08e-12, 1.71e-12, 7.85e-4],
         [1.32e-12, 0.0, 1.12e-3],
         [5.83e-8, 2.69e-8, 4.54e-3]])
-    assert numpy.array_equal(yield_dist.yield_matrix, exp_yield)
+    assert np.array_equal(yield_dist.yield_matrix, exp_yield)
 
     # Test the operations / special methods for fission yield
     orig_yields = yield_dist[0.0253]
@@ -151,18 +189,18 @@ def test_fission_yield_distribution():
 
     # Scale and increment fission yields
     mod_yields = orig_yields * 2
-    assert numpy.array_equal(orig_yields.yields * 2, mod_yields.yields)
+    assert np.array_equal(orig_yields.yields * 2, mod_yields.yields)
     mod_yields += orig_yields
-    assert numpy.array_equal(orig_yields.yields * 3, mod_yields.yields)
+    assert np.array_equal(orig_yields.yields * 3, mod_yields.yields)
 
     mod_yields = 2.0 * orig_yields
-    assert numpy.array_equal(orig_yields.yields * 2, mod_yields.yields)
+    assert np.array_equal(orig_yields.yields * 2, mod_yields.yields)
 
-    mod_yields = numpy.float64(2.0) * orig_yields
-    assert numpy.array_equal(orig_yields.yields * 2, mod_yields.yields)
+    mod_yields = np.float64(2.0) * orig_yields
+    assert np.array_equal(orig_yields.yields * 2, mod_yields.yields)
 
     # Failure modes for adding, multiplying yields
-    similar = numpy.empty_like(orig_yields.yields)
+    similar = np.empty_like(orig_yields.yields)
     with pytest.raises(TypeError):
         orig_yields + similar
     with pytest.raises(TypeError):

--- a/tests/unit_tests/test_deplete_nuclide.py
+++ b/tests/unit_tests/test_deplete_nuclide.py
@@ -118,6 +118,24 @@ def test_fpy_parent():
     assert fpy_elem.get('parent') == 'U235'
     assert len(fpy_elem) == 0
 
+    data = """
+<depletion_chain>
+  <nuclide name="U235" reactions="1">
+    <reaction type="fission" Q="193405400.0"/>
+  </nuclide>
+  <nuclide name="U238" reactions="1">
+    <reaction type="fission" Q="200.0e6"/>
+    <neutron_fission_yields parent="U235"/>
+  </nuclide>
+</depletion_chain>
+    """
+
+    # U235 yields are missing, so we should get an exception
+    root = ET.fromstring(data)
+    elems = root.findall('nuclide')
+    with pytest.raises(ValueError, match="yields"):
+        u238 = nuclide.Nuclide.from_xml(elems[1], root)
+
 
 def test_to_xml_element():
     """Test writing nuclide data to an XML element."""


### PR DESCRIPTION
In a depletion calculation, fission product yield (FPY) data is needed for each nuclide that fissions. Unfortunately, not all nuclides that have a fission reaction have corresponding FPY data. For example, Pu243 and Am242g are fissionable but don't have FPY data. This PR makes it possible to indicate in a depletion chain file that a fissionable nuclide should use FPY data from another nuclide. In our `Chain.from_endf` method, I'd adopted the ad hoc approach that Serpent uses, which is basically:
- If metastable, use FPY data from the ground state
- Otherwise, use FPY data from a nuclide with the same neutron number
- Otherwise, just default to U235