### PR TITLE
Fix secondary photon creation

### DIFF
--- a/include/openmc/particle.h
+++ b/include/openmc/particle.h
@@ -216,6 +216,16 @@ public:
   //! \param E Energy of the secondary particle in [eV]
   //! \param type Particle type
   void create_secondary(Direction u, double E, Type type);
+  
+  //! create a secondary particle with weight                add by Yuan
+  //
+  //! stores the current phase space attributes of the particle in the
+  //! secondary bank and increments the number of sites in the secondary bank.
+  //! \param u Direction of the secondary particle
+  //! \param E Energy of the secondary particle in [eV]
+  //! \param type Particle type
+  //! \param wgt Particle weight
+  void create_secondary(Direction u, double E, Type type, double weight);
 
   //! initialize from a source site
   //

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -54,6 +54,61 @@ extern bool urr_ptables_on;           //!< use unresolved resonance prob. tables
 extern bool write_all_tracks;         //!< write track files for every particle?
 extern bool write_initial_source;     //!< write out initial source file?
 
+// ---
+// weight window   add by Yuan
+// ---
+extern bool weightwindow;             // use weight window or not, add by Yuan
+extern int ww_type;                   // type of weight window input file
+// weight window mesh
+extern double lower_left_point[3];    //!< Lower-left coordinates of weight window mesh
+extern double upper_right_point[3];   //!< Upper-right coordinates of weight window mesh
+extern std::vector<double> coarse_x;  // Locations of the coarse meshes in the x direction
+extern std::vector<double> coarse_y;  // Locations of the coarse meshes in the y direction
+extern std::vector<double> coarse_z;  // Locations of the coarse meshes in the z direction
+extern std::vector<int> shape_x;      //!< Number of fine mesh in each coarse mesh in x dimension
+extern std::vector<int> shape_y;      //!< Number of fine mesh in each coarse mesh in y dimension
+extern std::vector<int> shape_z;      //!< Number of fine mesh in each coarse mesh in z dimension
+extern int shape[3];                  // total number of mesh elements in each dimension
+extern std::vector<double> width_x;   //!< Width of fine mesh in each coarse mesh in x dimension
+extern std::vector<double> width_y;   //!< Width of fine mesh in each coarse mesh in y dimension
+extern std::vector<double> width_z;   //!< Width of fine mesh in each coarse mesh in z dimension
+extern std::vector<double> mesh_x;    //!< Coordinates of each fine mesh elements in x dimension
+extern std::vector<double> mesh_y;    //!< Coordinates of each fine mesh elements in y dimension
+extern std::vector<double> mesh_z;    //!< Coordinates of each fine mesh elements in z dimension
+extern std::vector<double> n_energy_group; // energy group for neutron
+extern std::vector<double> p_energy_group; // energy group for photon
+extern std::vector<double> n_ww_lower;     // lower weight window for mesh for neutron
+extern std::vector<double> p_ww_lower;     // lower weight window for mesh for photon
+extern bool n_ww;                          // flag for neutron use weight window
+extern bool p_ww;                          // flag for photon use weight window
+// weight window mesh
+
+// WWP
+// neutron
+extern double n_upper_ratio;            // upper weight window = upper_ratio * lower weight window
+extern double n_survival_ratio;         // survival weight = survival_ratio * lower weight window
+extern int n_max_split;                 // max number of split particles
+extern double n_multiplier;             // multiplier for weight window lower bounds
+// neutron
+
+// photon
+extern double p_upper_ratio;            // upper weight window = upper_ratio * lower weight window
+extern double p_survival_ratio;         // survival weight = survival_ratio * lower weight window
+extern int p_max_split;                 // max number of split particles
+extern double p_multiplier;             // multiplier for weight window lower bounds
+// photon
+
+// source weight biasing in energy
+extern bool user_defined_biasing;      // use user difined weight or not
+extern std::vector<double> biasing_energy;   // energy group for weight biasing
+extern std::vector<double> origin_possibility; // possibility for each group
+extern std::vector<double> cumulative_possibility; // cumulative possibility for each group
+extern std::vector<double> biasing;   // biasing for each energy group
+extern std::vector<double> cumulative_biasing;   // cumulative possibility for biasing for each energy group
+// ---
+// weight window  add by Yuan
+// ---
+  
 // Paths to various files
 extern std::string path_cross_sections;   //!< path to cross_sections.xml
 extern std::string path_input;            //!< directory where main .xml files resides

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -97,6 +97,21 @@ Particle::create_secondary(Direction u, double E, Type type)
 
   n_bank_second_ += 1;
 }
+  
+void              // add by Yuan
+Particle::create_secondary(Direction u, double E, Type type, double weight)    
+{
+  secondary_bank_.emplace_back();
+
+  auto& bank {secondary_bank_.back()};
+  bank.particle = type;
+  bank.wgt = weight;
+  bank.r = this->r();
+  bank.u = u;
+  bank.E = settings::run_CE ? E : g_;
+
+  n_bank_second_ += 1;
+}       // add by Yuan
 
 void
 Particle::from_source(const Bank* src)

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -1137,7 +1137,7 @@ void inelastic_scatter(const Nuclide& nuc, const Reaction& rx, Particle& p)
 void sample_secondary_photons(Particle& p, int i_nuclide)
 {
   // Sample the number of photons produced
-  double y_t = p.wgt_ * p.neutron_xs_[i_nuclide].photon_prod /
+  double y_t = /*p.wgt_ */ p.neutron_xs_[i_nuclide].photon_prod /
     p.neutron_xs_[i_nuclide].total;
   int y = static_cast<int>(y_t);
   if (prn(p.current_seed()) <= y_t - y) ++y;


### PR DESCRIPTION
This PR fixes #1472 . 
I found that OpenMC counts the neutron weight twice when created secondary photons, once in the secondary photon weight and once in the number of photons produced.
The easiest way to fix this is just not counting the neutron weight Wn through the number of secondary photons when photons are generated.