### PR TITLE
Fix secondary photon creation

### DIFF
--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -1137,7 +1137,7 @@ void inelastic_scatter(const Nuclide& nuc, const Reaction& rx, Particle& p)
 void sample_secondary_photons(Particle& p, int i_nuclide)
 {
   // Sample the number of photons produced
-  double y_t = p.wgt_ * p.neutron_xs_[i_nuclide].photon_prod /
+  double y_t = /*p.wgt_ */ p.neutron_xs_[i_nuclide].photon_prod /
     p.neutron_xs_[i_nuclide].total;
   int y = static_cast<int>(y_t);
   if (prn(p.current_seed()) <= y_t - y) ++y;

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -1137,7 +1137,7 @@ void inelastic_scatter(const Nuclide& nuc, const Reaction& rx, Particle& p)
 void sample_secondary_photons(Particle& p, int i_nuclide)
 {
   // Sample the number of photons produced
-  double y_t = /*p.wgt_ */ p.neutron_xs_[i_nuclide].photon_prod /
+  double y_t =  p.neutron_xs_[i_nuclide].photon_prod /
     p.neutron_xs_[i_nuclide].total;
   int y = static_cast<int>(y_t);
   if (prn(p.current_seed()) <= y_t - y) ++y;


### PR DESCRIPTION
This PR fixes #1472 .
I found that OpenMC counts the neutron weight twice when created secondary photons, once in the secondary photon weight and once in the number of photons produced.
The easiest way to fix this is just not counting the neutron weight Wn through the number of secondary photons when photons are generated.