### PR TITLE
Allow depletion without multiprocessing

### DIFF
--- a/docs/source/pythonapi/deplete.rst
+++ b/docs/source/pythonapi/deplete.rst
@@ -145,6 +145,17 @@ with :func:`cram.CRAM48` being the default.
    cram.CRAM48
    pool.deplete
 
+.. data:: pool.USE_MULTIPROCESSING
+
+   Boolean switch to enable or disable the use of :mod:`multiprocessing`
+   when solving the Bateman equations. The default is to use
+   :mod:`multiprocessing`, but can cause the simulation for hang in
+   some computing environments, namely due to MPI and networking
+   restrictions. Disabling this option will not utilize all processing
+   units and take a little more time.
+
+   :type: bool
+
 The following classes are used to help the :class:`openmc.deplete.Operator`
 compute quantities like effective fission yields, reaction rates, and
 total system energy.

--- a/docs/source/pythonapi/deplete.rst
+++ b/docs/source/pythonapi/deplete.rst
@@ -149,10 +149,10 @@ with :func:`cram.CRAM48` being the default.
 
    Boolean switch to enable or disable the use of :mod:`multiprocessing`
    when solving the Bateman equations. The default is to use
-   :mod:`multiprocessing`, but can cause the simulation for hang in
+   :mod:`multiprocessing`, but can cause the simulation to hang in
    some computing environments, namely due to MPI and networking
-   restrictions. Disabling this option will not utilize all processing
-   units and take a little more time.
+   restrictions. Disabling this option will result in only a single
+   CPU core being used for depletion.
 
    :type: bool
 

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -887,14 +887,6 @@ class Integrator(ABC):
             Results.save(self.operator, [conc], res_list, [t, t],
                          p, self._i_res + len(self), proc_time)
             self.operator.write_bos_data(len(self) + self._i_res)
-        self._finalize()
-
-    @staticmethod
-    def _finalize():
-        # Revert the se of multiprocessing, regardless of
-        # how the integration was performed
-        global _USE_MULTIPROCESSING
-        _USE_MULTIPROCESSING = True
 
 
 class SIIntegrator(Integrator):
@@ -1028,9 +1020,6 @@ class SIIntegrator(Integrator):
             Results.save(self.operator, [conc], [res_list[-1]], [t, t],
                          p, self._i_res + len(self), proc_time)
             self.operator.write_bos_data(self._i_res + len(self))
-
-        # Tidy up: reset use of multiprocessing
-        super()._finalize()
 
 
 class DepSystemSolver(ABC):

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -887,6 +887,14 @@ class Integrator(ABC):
             Results.save(self.operator, [conc], res_list, [t, t],
                          p, self._i_res + len(self), proc_time)
             self.operator.write_bos_data(len(self) + self._i_res)
+        self._finalize()
+
+    @staticmethod
+    def _finalize():
+        # Revert the se of multiprocessing, regardless of
+        # how the integration was performed
+        global _USE_MULTIPROCESSING
+        _USE_MULTIPROCESSING = True
 
 
 class SIIntegrator(Integrator):
@@ -1020,6 +1028,9 @@ class SIIntegrator(Integrator):
             Results.save(self.operator, [conc], [res_list[-1]], [t, t],
                          p, self._i_res + len(self), proc_time)
             self.operator.write_bos_data(self._i_res + len(self))
+
+        # Tidy up: reset use of multiprocessing
+        super()._finalize()
 
 
 class DepSystemSolver(ABC):


### PR DESCRIPTION
[A user reported issues on a HPC with multiprocessing and depletion.](https://groups.google.com/forum/#!topic/openmc-users/xHKYV-EBgrY) Some environments, through networking and/or MPI restrictions, do not allow `fork()` to create necessary subprocesses during the depletion solution. This leads to the depletion hanging at
https://github.com/openmc-dev/openmc/blob/a905e5c9e22a7682c273233572904e21bc0ec739/openmc/deplete/pool.py#L53-L56

This PR allows integrators to deplete without multiprocessing, but with [`itertools.starmap`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.starmap), essentially the serial version of [`multiprocessing.Pool.starmap`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.starmap). ~All integrators support the argument
`Integrator(..., with_multiprocessing=False)` to enable or disable the use of multiprocessing.~ The default is to use multiprocessing.

~In order to facilitate this, two intermediate classes are used. One that mimics the `multiprocessing.Pool` API with respect to `starmap` and use as a context manager. The other interfaces between the `Integrator` and the `deplete` function (now a method) and uses `multiprocessing.Pool` or this new `PoolShim` class, if `multiprocessing` is to be used or not.~

The depletion regression test is also parametrized to deplete with and without multiprocessing. Using `itertools.starmap` is slower on my machine
```
$ time pytest tests/regression_tests/deplete/test.py::test_full[True]

real    0m6.550s
user    0m10.088s
sys     0m0.573s

$ time pytest tests/regression_tests/deplete/test.py::test_full[False]
real    0m8.134s
user    0m9.101s
sys     0m0.375s
```
shows the time in the regression test with and without multiprocessing, respectively. We see it is a little slower, but this will depend on computing environment and number of depletable materials. 

As for the impact on Travis for the new regression test, the individual builds do take around or slightly longer to build and test, but not dramatically. The largest increase is for `OMP=y,MPI=y,PHDF5=y,DAGMC=y` which increased just under two minutes to 46 min 37 s. Not sure if this is due to this specific test. We are still under the 50 minute Travis time limit, but I understand not wanting to get too close. 

[Develop Travis build](https://travis-ci.com/github/drewejohnson/openmc/builds/172098877)

[Feature Travis build before a minor change to `PoolShim.starmap` signature](https://travis-ci.com/github/drewejohnson/openmc/builds/172112487)

## Update
After a spirited discussion, the use of multiprocessing is handled by a boolean switch `openmc.deplete.pool.USE_MULTIPROCESSING`. It is up to the user to disable this switch as they need it, rather than pass arguments through the `Integrator`s