### PR TITLE
Documentation upgrades: numpy intersphinx and Sphinx CSS API

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -155,7 +155,7 @@ html_title = "OpenMC Documentation"
 html_static_path = ['_static']
 
 def setup(app):
-    app.add_stylesheet('theme_overrides.css')
+    app.add_css_file('theme_overrides.css')
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -254,7 +254,7 @@ napoleon_use_ivar = True
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'matplotlib': ('https://matplotlib.org/', None)


### PR DESCRIPTION
When building the documentation recently, I noticed a few warnings
```
/home/drew/openmc/docs/source/conf.py:158: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet('theme_overrides.css')
...
intersphinx inventory has moved: https://docs.scipy.org/doc/numpy/objects.inv -> https://numpy.org/doc/stable/objects.inv
```

These don't break the build, but could be problematic down the road. This PR
1. Uses the `numpy.org` intersphinx inventory file, and
2. Uses the renamed `app.add_css_file` which replaces `app.add_stylesheet` in `docs/source/conf.py`