### PR TITLE
Fix for depletion with photon transport turned on

### DIFF
--- a/docs/source/capi/index.rst
+++ b/docs/source/capi/index.rst
@@ -313,11 +313,15 @@ Functions
    :return: Return status (negative if an error occurs)
    :rtype: int
 
-.. c:function:: int openmc_load_nuclide(char name[])
+.. c:function:: int openmc_load_nuclide(const char* name, const double* temps, int n)
 
    Load data for a nuclide from the HDF5 data library.
 
-   :param char[] name: Name of the nuclide.
+   :param name: Name of the nuclide.
+   :type name: const char*
+   :param temps: Temperatures in [K] to load data at
+   :type temps: const double*
+   :param int n: Number of temperatures
    :return: Return status (negative if an error occurs)
    :rtype: int
 
@@ -373,7 +377,7 @@ Functions
    :return: Return status (negative if an error occurs)
    :rtype: int
 
-.. c:function:: int openmc_material_set_densities(int32_t index, int n, const char** name, const double density*)
+.. c:function:: int openmc_material_set_densities(int32_t index, int n, const char** name, const double* density)
 
    :param int32_t index: Index in the materials array
    :param int n: Length of name/density

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -121,6 +121,9 @@ Coupling and Multi-physics
 Geometry and Visualization
 --------------------------
 
+- Patrick C. Shriwise, Xiaokang Zhang, and Andrew Davis, "DAG-OpenMC: CAD-Based
+  Geometry in OpenMC", *Trans. Am. Nucl. Soc.*, **122**, 395-398 (2020).
+
 - Sterling Harper, Paul Romano, Benoit Forget, and Kord Smith, "Efficient
   dynamic threadsafe neighbor lists for Monte Carlo ray tracing," *Proc. M&C*,
   918-926, Portland, Oregon, Aug. 25-29 (2019).
@@ -145,6 +148,10 @@ Geometry and Visualization
 -------------
 Miscellaneous
 -------------
+
+- Jiankai Yu, Qiudong Wang, Ding She, and Benoit Forget, "Modelling of the
+  HTR-PM Pebble-bed Reactor using OpenMC", *Trans. Am. Nucl. Soc.*, **122**,
+  643-646 (2020).
 
 - Sharif Abu Darda, Abdelfattah Y. Soliman, Mohammed S. Aljohani, and Ned Xoubi,
   "`Technical feasibility study of BAEC TRIGA reactor (BTRR) as a neutron source

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -146,10 +146,25 @@ Geometry and Visualization
 Miscellaneous
 -------------
 
-- Ned Xoubi, Sharif Abu Darda,  Abdelfattah Y. Soliman, and Tareq Abulfaraj,
+- Sharif Abu Darda, Abdelfattah Y. Soliman, Mohammed S. Aljohani, and Ned Xoubi,
+  "`Technical feasibility study of BAEC TRIGA reactor (BTRR) as a neutron source
+  for BNCT using OpenMC Monte Carlo code
+  <https://doi.org/10.1016/j.pnucene.2020.103418>`_", *Prog. Nucl. Energy*,
+  **126**, 103418 (2020).
+
+- Stefano Segantin, Raffaella Testoni, and Massimo Zucchetti, "`ARC reactor --
+  Neutron irradiation analysis <https://doi.org/10.1016/j.fusengdes.2020.111792>`_",
+  *Fus. Eng. Design*, **159**, 111792 (2020).
+
+- Muhammad Ilham, Helen Raflis, and Zaki Suud, "`Full Core Optimization of Small
+  Modular Gas-Cooled Fast Reactors Using OpenMC Program Code
+  <https://doi.org/10.1088/1742-6596/1493/1/012007>`_", *J. Phys.: Conf. Series*,
+  **1493**, 012007 (2020).
+
+- Ned Xoubi, Sharif Abu Darda, Abdelfattah Y. Soliman, and Tareq Abulfaraj,
   "`An investigative study of enrichment reduction impact on the neutron flux in
   the in-core flux-trap facility of MTR research reactors
-  <https://doi.org/10.1016/j.net.2019.08.008>`_", Nucl. Eng. Technol., **52**,
+  <https://doi.org/10.1016/j.net.2019.08.008>`_", *Nucl. Eng. Technol.*, **52**,
   469-476 (2020).
 
 - J. Rolando Granada, J. Ignacio Marquez Damian, and Christian Helman, "`Studies
@@ -161,6 +176,10 @@ Miscellaneous
   Shutdown System in a Small Lead-Cooled Reactor
   <https://doi.org/10.13140/RG.2.2.26088.01281>`_," M.S. Thesis, KTH Royal
   Institute of Technology (2019).
+
+- Ilham Variansyah, Benjamin R. Betzler, and William R. Martin,
+  ":math:`\alpha`\ -weighted transition rate matrix method", *Proc. M&C*,
+  1368-1377, Portland, Oregon, Aug. 25-29 (2019).
 
 - Shikhar Kumar, Benoit Forget, and Kord Smith, "Analysis of fission source
   convergence for a 3-D SMR core using functional expansion tallies," *Proc.
@@ -248,6 +267,16 @@ Miscellaneous
 -----------------------------------
 Multigroup Cross Section Generation
 -----------------------------------
+
+- Ilham Variansyah, Benjamin R. Betzler, and William R. Martin, "`Multigroup
+  Constant Calculation with Static :math:`\alpha`\ -Eigenvalue Monte Carlo for
+  Time-Dependent Neutron Transport Simulation
+  <https://doi.org/10.1080/00295639.2020.1743578>`_", *Nucl. Sci. Eng.*, 2020.
+
+- Chenghui Wan, Tianliang Hu, and Liangzhi Cao, "`Multi-physics numerical
+  analysis of the fuel-addition transients in the liquid-fuel molten salt reactor
+  <https://doi.org/10.1016/j.anucene.2020.107514>`_", *Ann. Nucl. Energy*,
+  **144**, 107514 (2020).
 
 - William Boyd, Adam Nelson, Paul K. Romano, Samuel Shaner, Benoit Forget, and
   Kord Smith, "`Multigroup Cross-Section Generation with the OpenMC Monte Carlo

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -185,8 +185,8 @@ Miscellaneous
   Institute of Technology (2019).
 
 - Ilham Variansyah, Benjamin R. Betzler, and William R. Martin,
-  ":math:`\alpha`\ -weighted transition rate matrix method", *Proc. M&C*,
-  1368-1377, Portland, Oregon, Aug. 25-29 (2019).
+  "α-weighted transition rate matrix method", *Proc. M&C*, 1368-1377, Portland,
+  Oregon, Aug. 25-29 (2019).
 
 - Shikhar Kumar, Benoit Forget, and Kord Smith, "Analysis of fission source
   convergence for a 3-D SMR core using functional expansion tallies," *Proc.
@@ -276,7 +276,7 @@ Multigroup Cross Section Generation
 -----------------------------------
 
 - Ilham Variansyah, Benjamin R. Betzler, and William R. Martin, "`Multigroup
-  Constant Calculation with Static :math:`\alpha`\ -Eigenvalue Monte Carlo for
+  Constant Calculation with Static α-Eigenvalue Monte Carlo for
   Time-Dependent Neutron Transport Simulation
   <https://doi.org/10.1080/00295639.2020.1743578>`_", *Nucl. Sci. Eng.*, 2020.
 

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -55,7 +55,7 @@ extern "C" {
   bool openmc_is_statepoint_batch();
   int openmc_legendre_filter_get_order(int32_t index, int* order);
   int openmc_legendre_filter_set_order(int32_t index, int order);
-  int openmc_load_nuclide(const char* name);
+  int openmc_load_nuclide(const char* name, const double* temps, int n);
   int openmc_material_add_nuclide(int32_t index, const char name[], double density);
   int openmc_material_get_densities(int32_t index, const int** nuclides, const double** densities, int* n);
   int openmc_material_get_id(int32_t index, int32_t* id);

--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -34,8 +34,9 @@ public:
     std::vector<double> energy;
   };
 
-  // Constructors
-  Nuclide(hid_t group, const std::vector<double>& temperature, int i_nuclide);
+  // Constructors/destructors
+  Nuclide(hid_t group, const std::vector<double>& temperature);
+  ~Nuclide();
 
   //! Initialize logarithmic grid for energy searches
   void init_grid();

--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <gsl/gsl>
 #include <hdf5.h>
 
 #include "openmc/constants.h"
@@ -63,7 +64,7 @@ public:
   int A_; //!< Mass number
   int metastable_; //!< Metastable state
   double awr_; //!< Atomic weight ratio
-  int i_nuclide_; //!< Index in the nuclides array
+  gsl::index index_; //!< Index in the nuclides array
 
   // Temperature dependent cross section data
   std::vector<double> kTs_; //!< temperatures in eV (k*T)

--- a/include/openmc/photon.h
+++ b/include/openmc/photon.h
@@ -4,6 +4,7 @@
 #include "openmc/endf.h"
 #include "openmc/particle.h"
 
+#include <gsl/gsl>
 #include <hdf5.h>
 #include "xtensor/xtensor.hpp"
 
@@ -58,7 +59,7 @@ public:
   // Data members
   std::string name_; //!< Name of element, e.g. "Zr"
   int Z_; //!< Atomic number
-  int i_element_; //!< Index in global elements vector
+  gsl::index index_; //!< Index in global elements vector
 
   // Microscopic cross sections
   xt::xtensor<double, 1> energy_;

--- a/include/openmc/photon.h
+++ b/include/openmc/photon.h
@@ -8,6 +8,7 @@
 #include <hdf5.h>
 #include "xtensor/xtensor.hpp"
 
+#include <memory> // for unique_ptr
 #include <string>
 #include <unordered_map>
 #include <utility> // for pair
@@ -119,7 +120,7 @@ namespace data {
 extern xt::xtensor<double, 1> compton_profile_pz; //! Compton profile momentum grid
 
 //! Photon interaction data for each element
-extern std::vector<PhotonInteraction> elements;
+extern std::vector<std::unique_ptr<PhotonInteraction>> elements;
 extern std::unordered_map<std::string, int> element_map;
 
 } // namespace data

--- a/include/openmc/photon.h
+++ b/include/openmc/photon.h
@@ -38,8 +38,9 @@ public:
 
 class PhotonInteraction {
 public:
-  // Constructors
-  PhotonInteraction(hid_t group, int i_element);
+  // Constructors/destructor
+  PhotonInteraction(hid_t group);
+  ~PhotonInteraction();
 
   // Methods
   void calculate_xs(Particle& p) const;

--- a/include/openmc/simulation.h
+++ b/include/openmc/simulation.h
@@ -57,6 +57,9 @@ void allocate_banks();
 //! Determine number of particles to transport per process
 void calculate_work();
 
+//! Determine energy limits for incident neutron/photon data
+void determine_energy_limits();
+
 //! Initialize a batch
 void initialize_batch();
 

--- a/include/openmc/simulation.h
+++ b/include/openmc/simulation.h
@@ -57,8 +57,8 @@ void allocate_banks();
 //! Determine number of particles to transport per process
 void calculate_work();
 
-//! Determine energy limits for incident neutron/photon data
-void determine_energy_limits();
+//! Initialize nuclear data before a simulation
+void initialize_data();
 
 //! Initialize a batch
 void initialize_batch();

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -965,6 +965,8 @@ class Chain:
             new_nuclide = Nuclide(previous.name)
             new_nuclide.half_life = previous.half_life
             new_nuclide.decay_energy = previous.decay_energy
+            if hasattr(previous, '_fpy'):
+                new_nuclide._fpy = previous._fpy
 
             new_decay = []
             for mode in previous.decay_modes:

--- a/openmc/lib/nuclide.py
+++ b/openmc/lib/nuclide.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from ctypes import c_int, c_char_p, POINTER, c_size_t
+from ctypes import c_int, c_double, c_char_p, POINTER, c_size_t
 from weakref import WeakValueDictionary
 
 from ..exceptions import DataError, AllocationError
@@ -14,7 +14,7 @@ __all__ = ['Nuclide', 'nuclides', 'load_nuclide']
 _dll.openmc_get_nuclide_index.argtypes = [c_char_p, POINTER(c_int)]
 _dll.openmc_get_nuclide_index.restype = c_int
 _dll.openmc_get_nuclide_index.errcheck = _error_handler
-_dll.openmc_load_nuclide.argtypes = [c_char_p]
+_dll.openmc_load_nuclide.argtypes = [c_char_p, POINTER(c_double), c_int]
 _dll.openmc_load_nuclide.restype = c_int
 _dll.openmc_load_nuclide.errcheck = _error_handler
 _dll.openmc_nuclide_name.argtypes = [c_int, POINTER(c_char_p)]
@@ -32,7 +32,7 @@ def load_nuclide(name):
         Name of the nuclide, e.g. 'U235'
 
     """
-    _dll.openmc_load_nuclide(name.encode())
+    _dll.openmc_load_nuclide(name.encode(), None, 0)
 
 
 class Nuclide(_FortranObject):

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -221,7 +221,7 @@ read_ce_cross_sections(const std::vector<std::vector<double>>& nuc_temps,
       hid_t group = open_group(file_id, name.c_str());
       int i_nuclide = data::nuclides.size();
       data::nuclides.push_back(std::make_unique<Nuclide>(
-        group, nuc_temps[i_nuc], i_nuclide));
+        group, nuc_temps[i_nuc]));
 
       close_group(group);
       file_close(file_id);
@@ -255,7 +255,7 @@ read_ce_cross_sections(const std::vector<std::vector<double>>& nuc_temps,
 
           // Read element data from HDF5
           hid_t group = open_group(file_id, element.c_str());
-          data::elements.emplace_back(group, data::elements.size());
+          data::elements.emplace_back(group);
 
           // Determine if minimum/maximum energy for this element is greater/less than
           // the previous

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -316,15 +316,6 @@ read_ce_cross_sections(const std::vector<std::vector<double>>& nuc_temps,
     mat->finalize();
   } // materials
 
-
-  // Set up logarithmic grid for nuclides
-  for (auto& nuc : data::nuclides) {
-    nuc->init_grid();
-  }
-  int neutron = static_cast<int>(Particle::Type::neutron);
-  simulation::log_spacing = std::log(data::energy_max[neutron] /
-    data::energy_min[neutron]) / settings::n_log_bins;
-
   if (settings::photon_transport && settings::electron_treatment == ElectronTreatment::TTB) {
     // Determine if minimum/maximum energy for bremsstrahlung is greater/less
     // than the current minimum/maximum

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -943,7 +943,7 @@ void Material::set_densities(const std::vector<std::string>& name,
   for (gsl::index i = 0; i < n; ++i) {
     const auto& nuc {name[i]};
     if (data::nuclide_map.find(nuc) == data::nuclide_map.end()) {
-      int err = openmc_load_nuclide(nuc.c_str());
+      int err = openmc_load_nuclide(nuc.c_str(), nullptr, 0);
       if (err < 0) throw std::runtime_error{openmc_err_msg};
     }
 
@@ -1053,7 +1053,7 @@ void Material::add_nuclide(const std::string& name, double density)
   }
 
   // If nuclide wasn't found, extend nuclide/density arrays
-  int err = openmc_load_nuclide(name.c_str());
+  int err = openmc_load_nuclide(name.c_str(), nullptr, 0);
   if (err < 0) throw std::runtime_error{openmc_err_msg};
 
   // Append new nuclide/density

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -475,7 +475,7 @@ void Material::collision_stopping_power(double* s_col, bool positron)
   std::vector<double> e_b_sq;
 
   for (int i = 0; i < element_.size(); ++i) {
-    const auto& elm = data::elements[element_[i]];
+    const auto& elm = *data::elements[element_[i]];
     double awr = data::nuclides[nuclide_[i]]->awr_;
 
     // Get atomic density of nuclide given atom/weight percent
@@ -589,7 +589,7 @@ void Material::init_bremsstrahlung()
     // Bragg's additivity rule.
     for (int i = 0; i < n; ++i) {
       // Get pointer to current element
-      const auto& elm = data::elements[element_[i]];
+      const auto& elm = *data::elements[element_[i]];
       double awr = data::nuclides[nuclide_[i]]->awr_;
 
       // Get atomic density and mass density of nuclide given atom/weight percent
@@ -838,7 +838,7 @@ void Material::calculate_photon_xs(Particle& p) const
     // Calculate microscopic cross section for this nuclide
     const auto& micro {p.photon_xs_[i_element]};
     if (p.E_ != micro.last_E) {
-      data::elements[i_element].calculate_xs(p);
+      data::elements[i_element]->calculate_xs(p);
     }
 
     // ========================================================================

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -982,7 +982,7 @@ extern "C" int openmc_load_nuclide(const char* name, const double* temps, int n)
 
         // Read element data from HDF5
         hid_t group = open_group(file_id, element.c_str());
-        data::elements.emplace_back(group);
+        data::elements.push_back(std::make_unique<PhotonInteraction>(group));
 
         close_group(group);
         file_close(file_id);

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -953,11 +953,8 @@ extern "C" int openmc_load_nuclide(const char* name)
     close_group(group);
     file_close(file_id);
 
-    // Initialize nuclide grid
-    const auto& nuc = data::nuclides.back();
-    nuc->init_grid();
-
     // Read multipole file into the appropriate entry on the nuclides array
+    const auto& nuc = data::nuclides.back();
     if (settings::temperature_multipole) read_multipole_data(nuc->i_nuclide_);
 
     // Read elemental data, if necessary

--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -74,6 +74,9 @@ void run_particle_restart()
   // Set verbosity high
   settings::verbosity = 10;
 
+  // Initialize nuclear data (energy limits, log grid, etc.)
+  initialize_data();
+
   // Initialize the particle to be tracked
   Particle p;
 

--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -39,11 +39,11 @@ std::unordered_map<std::string, int> element_map;
 PhotonInteraction::PhotonInteraction(hid_t group)
 {
   // Set index of element in global vector
-  i_element_ = data::elements.size();
+  index_ = data::elements.size();
 
   // Get name of nuclide from group, removing leading '/'
   name_ = object_name(group).substr(1);
-  data::element_map[name_] = i_element_;
+  data::element_map[name_] = index_;
 
   // Get atomic number
   read_attribute(group, "Z", Z_);
@@ -472,7 +472,7 @@ void PhotonInteraction::calculate_xs(Particle& p) const
   // calculate interpolation factor
   double f = (log_E - energy_(i_grid)) / (energy_(i_grid+1) - energy_(i_grid));
 
-  auto& xs {p.photon_xs_[i_element_]};
+  auto& xs {p.photon_xs_[index_]};
   xs.index_grid = i_grid;
   xs.interp_factor = f;
 

--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -36,11 +36,14 @@ std::unordered_map<std::string, int> element_map;
 // PhotonInteraction implementation
 //==============================================================================
 
-PhotonInteraction::PhotonInteraction(hid_t group, int i_element)
-  : i_element_{i_element}
+PhotonInteraction::PhotonInteraction(hid_t group)
 {
+  // Set index of element in global vector
+  i_element_ = data::elements.size();
+
   // Get name of nuclide from group, removing leading '/'
   name_ = object_name(group).substr(1);
+  data::element_map[name_] = i_element_;
 
   // Get atomic number
   read_attribute(group, "Z", Z_);
@@ -292,6 +295,11 @@ PhotonInteraction::PhotonInteraction(hid_t group, int i_element)
   pair_production_total_ = xt::where(pair_production_total_ > 0.0,
     xt::log(pair_production_total_), -500.0);
   heating_ = xt::where(heating_ > 0.0, xt::log(heating_), -500.0);
+}
+
+PhotonInteraction::~PhotonInteraction()
+{
+  data::element_map.erase(name_);
 }
 
 void PhotonInteraction::compton_scatter(double alpha, bool doppler,

--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -27,7 +27,7 @@ namespace data {
 
 xt::xtensor<double, 1> compton_profile_pz;
 
-std::vector<PhotonInteraction> elements;
+std::vector<std::unique_ptr<PhotonInteraction>> elements;
 std::unordered_map<std::string, int> element_map;
 
 } // namespace data

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -258,7 +258,7 @@ void sample_photon_reaction(Particle& p)
   // Sample element within material
   int i_element = sample_element(p);
   const auto& micro {p.photon_xs_[i_element]};
-  const auto& element {data::elements[i_element]};
+  const auto& element {*data::elements[i_element]};
 
   // Calculate photon energy over electron rest mass equivalent
   double alpha = p.E_/MASS_ELECTRON_EV;

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -68,6 +68,14 @@ int openmc_simulation_init()
   // Skip if simulation has already been initialized
   if (simulation::initialized) return 0;
 
+  // Set up logarithmic grid for nuclides
+  for (auto& nuc : data::nuclides) {
+    nuc->init_grid();
+  }
+  int neutron = static_cast<int>(Particle::Type::neutron);
+  simulation::log_spacing = std::log(data::energy_max[neutron] /
+    data::energy_min[neutron]) / settings::n_log_bins;
+
   // Determine how much work each process should do
   calculate_work();
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -578,13 +578,13 @@ void initialize_data()
 
   if (settings::photon_transport) {
     for (const auto& elem : data::elements) {
-      if (elem.energy_.size() >= 1) {
+      if (elem->energy_.size() >= 1) {
         int photon = static_cast<int>(Particle::Type::photon);
-        int n = elem.energy_.size();
+        int n = elem->energy_.size();
         data::energy_min[photon] = std::max(data::energy_min[photon],
-          std::exp(elem.energy_(1)));
+          std::exp(elem->energy_(1)));
         data::energy_max[photon] = std::min(data::energy_max[photon],
-          std::exp(elem.energy_(n - 1)));
+          std::exp(elem->energy_(n - 1)));
       }
     }
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #include <algorithm>
+#include <cmath>
 #include <string>
 
 
@@ -67,6 +68,11 @@ int openmc_simulation_init()
 
   // Skip if simulation has already been initialized
   if (simulation::initialized) return 0;
+
+  // Determine limits for incident neutron/photon data
+  if (settings::run_CE) {
+    determine_energy_limits();
+  }
 
   // Set up logarithmic grid for nuclides
   for (auto& nuc : data::nuclides) {
@@ -560,6 +566,68 @@ void calculate_work()
     // Set index into source bank for rank i
     i_bank += work_i;
     simulation::work_index[i + 1] = i_bank;
+  }
+}
+
+void determine_energy_limits()
+{
+  // Determine minimum/maximum energy for incident neutron/photon data
+  data::energy_max = {INFTY, INFTY};
+  data::energy_min = {0.0, 0.0};
+  for (const auto& nuc : data::nuclides) {
+    if (nuc->grid_.size() >= 1) {
+      int neutron = static_cast<int>(Particle::Type::neutron);
+      data::energy_min[neutron] = std::max(data::energy_min[neutron],
+        nuc->grid_[0].energy.front());
+      data::energy_max[neutron] = std::min(data::energy_max[neutron],
+        nuc->grid_[0].energy.back());
+    }
+  }
+
+  if (settings::photon_transport) {
+    for (const auto& elem : data::elements) {
+      if (elem.energy_.size() >= 1) {
+        int photon = static_cast<int>(Particle::Type::photon);
+        int n = elem.energy_.size();
+        data::energy_min[photon] = std::max(data::energy_min[photon],
+          std::exp(elem.energy_(1)));
+        data::energy_max[photon] = std::min(data::energy_max[photon],
+          std::exp(elem.energy_(n - 1)));
+      }
+    }
+
+    if (settings::electron_treatment == ElectronTreatment::TTB) {
+      // Determine if minimum/maximum energy for bremsstrahlung is greater/less
+      // than the current minimum/maximum
+      if (data::ttb_e_grid.size() >= 1) {
+        int photon = static_cast<int>(Particle::Type::photon);
+        int n_e = data::ttb_e_grid.size();
+        data::energy_min[photon] = std::max(data::energy_min[photon],
+          std::exp(data::ttb_e_grid(1)));
+        data::energy_max[photon] = std::min(data::energy_max[photon],
+          std::exp(data::ttb_e_grid(n_e - 1)));
+      }
+    }
+  }
+
+  // Show which nuclide results in lowest energy for neutron transport
+  for (const auto& nuc : data::nuclides) {
+    // If a nuclide is present in a material that's not used in the model, its
+    // grid has not been allocated
+    if (nuc->grid_.size() > 0) {
+      double max_E = nuc->grid_[0].energy.back();
+      int neutron = static_cast<int>(Particle::Type::neutron);
+      if (max_E == data::energy_max[neutron]) {
+        write_message("Maximum neutron transport energy: " +
+          std::to_string(data::energy_max[neutron]) + " eV for " +
+          nuc->name_, 7);
+        if (mpi::master && data::energy_max[neutron] < 20.0e6) {
+          warning("Maximum neutron energy is below 20 MeV. This may bias "
+            "the results.");
+        }
+        break;
+      }
+    }
   }
 }
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -69,18 +69,10 @@ int openmc_simulation_init()
   // Skip if simulation has already been initialized
   if (simulation::initialized) return 0;
 
-  // Determine limits for incident neutron/photon data
+  // Initialize nuclear data (energy limits, log grid)
   if (settings::run_CE) {
-    determine_energy_limits();
+    initialize_data();
   }
-
-  // Set up logarithmic grid for nuclides
-  for (auto& nuc : data::nuclides) {
-    nuc->init_grid();
-  }
-  int neutron = static_cast<int>(Particle::Type::neutron);
-  simulation::log_spacing = std::log(data::energy_max[neutron] /
-    data::energy_min[neutron]) / settings::n_log_bins;
 
   // Determine how much work each process should do
   calculate_work();
@@ -569,7 +561,7 @@ void calculate_work()
   }
 }
 
-void determine_energy_limits()
+void initialize_data()
 {
   // Determine minimum/maximum energy for incident neutron/photon data
   data::energy_max = {INFTY, INFTY};
@@ -629,6 +621,14 @@ void determine_energy_limits()
       }
     }
   }
+
+  // Set up logarithmic grid for nuclides
+  for (auto& nuc : data::nuclides) {
+    nuc->init_grid();
+  }
+  int neutron = static_cast<int>(Particle::Type::neutron);
+  simulation::log_spacing = std::log(data::energy_max[neutron] /
+    data::energy_min[neutron]) / settings::n_log_bins;
 }
 
 #ifdef OPENMC_MPI


### PR DESCRIPTION
This PR fixes #1585. Depletion relies on the `openmc_load_nuclide` C API call, and currently this function only loads incident neutron data. I've changed it so that it will now load photoatomic data as well. I've also refactored things a bit to improve the structure:

- `cross_sections.cpp` now uses `openmc_load_nuclide` as well to reduce redundant code
- Adding entries in `nuclide_map` and `element_map` is handled inside of the `Nuclide` and `PhotonInteraction` constructors
- Determining the min/max energies for neutron/photon transport and setting up the log grid for energy searches is determined during `simulation_init` rather than when cross sections are loaded
- `data::element` was set up as a vector of `PhotonInteraction` objects rather than pointers. This means that a `push_back` could result in all the photon data being copied. I've changed it to a vector of `unique_ptr` so that only pointers need to be copy upon a vector resize.