### PR TITLE
Introduce the alpha-k iteration

### DIFF
--- a/include/openmc/particle.h
+++ b/include/openmc/particle.h
@@ -76,6 +76,10 @@ struct NuclideMicroXS {
   double thermal_elastic;  //!< Bound thermal elastic scattering
   double photon_prod;      //!< microscopic photon production xs
 
+  // Cross sections for alpha (time eigenvalue) mode
+  double nu_fission_alpha;  //!< nu_fission with time correction
+  double nu_fission_prompt; //!< prompt neutron production from fission
+
   // Cross sections for depletion reactions (note that these are not stored in
   // macroscopic cache)
   double reaction[DEPLETION_RX.size()];
@@ -123,6 +127,10 @@ struct MacroXS {
   double fission;       //!< macroscopic fission xs
   double nu_fission;    //!< macroscopic production xs
   double photon_prod;   //!< macroscopic photon production xs
+
+  // Cross sections for alpha (time eigenvalue) mode
+  double nu_fission_alpha;  //!< nu_fission with time correction
+  double nu_fission_prompt;
 
   // Photon cross sections
   double coherent;        //!< macroscopic coherent xs
@@ -347,6 +355,10 @@ public:
   double keff_tally_collision_ {0.0};
   double keff_tally_tracklength_ {0.0};
   double keff_tally_leakage_ {0.0};
+  // For alpha (time eigenvalue) mode
+  double alpha_tally_Cn_ {0.0};
+  double alpha_tally_Cp_ {0.0};
+  std::vector<std::vector<double>> alpha_tally_Cd_;
 
   bool trace_ {false};     //!< flag to show debug information
 

--- a/include/openmc/reaction_product.h
+++ b/include/openmc/reaction_product.h
@@ -27,9 +27,11 @@ class ReactionProduct {
 public:
   //! Emission mode for product
   enum class EmissionMode {
-    prompt,  // Prompt emission of secondary particle
-    delayed, // Yield represents total emission (prompt + delayed)
-    total    // Delayed emission of secondary particle
+    prompt,        // Prompt emission of secondary particle
+    delayed,       // Delayed emission of secondary particle
+    delayed_alpha, //   with time correction
+    total,         // Yield represents total emission (prompt + delayed)
+    total_alpha    //   with time correction
   };
 
   using Secondary = std::unique_ptr<AngleEnergy>;

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -85,6 +85,7 @@ extern double res_scat_energy_min;   //!< Min energy in [eV] for res. upscatteri
 extern double res_scat_energy_max;   //!< Max energy in [eV] for res. upscattering
 extern std::vector<std::string> res_scat_nuclides;  //!< Nuclides using res. upscattering treatment
 extern RunMode run_mode;                 //!< Run mode (eigenvalue, fixed src, etc.)
+extern "C" bool alpha_mode;              //!< alpha (time eigenvalue) mode?
 extern std::unordered_set<int> sourcepoint_batch; //!< Batches when source should be written
 extern std::unordered_set<int> statepoint_batch; //!< Batches when state should be written
 extern TemperatureMethod temperature_method;           //!< method for choosing temperatures
@@ -99,6 +100,10 @@ extern int trigger_batch_interval;   //!< Batch interval for triggers
 extern "C" int verbosity;                //!< How verbose to make output
 extern double weight_cutoff;         //!< Weight cutoff for Russian roulette
 extern double weight_survive;        //!< Survival weight after Russian roulette
+
+// Miscellany
+extern std::vector<double> mg_speeds; //!< Speeds for MG mode
+                                      //!< TODO: should be integrated with MG TDMC if available
 } // namespace settings
 
 //==============================================================================

--- a/include/openmc/simulation.h
+++ b/include/openmc/simulation.h
@@ -43,7 +43,20 @@ extern const RegularMesh* entropy_mesh;
 extern const RegularMesh* ufs_mesh;
 
 extern std::vector<double> k_generation;
+extern std::vector<double> alpha_generation;
 extern std::vector<int64_t> work_index;
+
+// For alpha (time eigenvalue) mode
+extern "C" double alpha_eff;       //!< average alpha over batches
+extern "C" double alpha_eff_std;   //!< standard deviation of average alpha
+extern "C" double alpha_min;       //!< minimum possible value of alpha
+                                   //!< (negative of the smallest precursor group decay constant
+// Helper constants
+extern "C" int alpha_I;            //!< # of fissionable nuclides
+extern std::vector<int>alpha_J;    //!< # of precursor groups in fissionable nuclide i
+extern std::vector<int> alpha_idx; //!< global_tally_alpha_Cd (see in tally.h) indices for nuclides in data::nuclides
+extern std::vector<std::vector<double>> alpha_lambda; //!< decay constant for each i & j
+// Note that we allow different J for each fissionable nuclide i
 
 } // namespace simulation
 

--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -166,6 +166,11 @@ extern double global_tally_absorption;
 extern double global_tally_collision;
 extern double global_tally_tracklength;
 extern double global_tally_leakage;
+// Global quavariables for alpha (time) eigenvalue update
+extern double global_tally_alpha_Cn;                           // inverse-speed (neutron density)
+extern double global_tally_alpha_Cp;                           // prompt fission production
+extern std::vector<std::vector<double>> global_tally_alpha_Cd; // delayed fission production for 
+                                                               // each fissionable nuclide i & delayed group j
 
 //==============================================================================
 // Non-member functions

--- a/openmc/particle_restart.py
+++ b/openmc/particle_restart.py
@@ -26,6 +26,8 @@ class Particle:
         Number of particles per generation
     run_mode : int
         Type of simulation (criticality or fixed source)
+    alpha_mode : bool
+        Running alpha (time eigenvalue) mode?
     id : long
         Identifier of the particle
     type : int
@@ -55,6 +57,7 @@ class Particle:
             self.type = f['type'][()]
             self.n_particles = f['n_particles'][()]
             self.run_mode = f['run_mode'][()].decode()
+            self.alpha_mode = f['alpha_mode'][()].decode()
             self.uvw = f['uvw'][()]
             self.weight = f['weight'][()]
             self.xyz = f['xyz'][()]

--- a/openmc/statepoint.py
+++ b/openmc/statepoint.py
@@ -71,6 +71,10 @@ class StatePoint:
         Cross-product of absorption and tracklength estimates of k-effective
     k_generation : numpy.ndarray
         Estimate of k-effective for each batch/generation
+    alpha_final : numpy.ndarray
+        Final alpha value
+    alpha_generation : numpy.ndarray
+        Estimate of alpha for each batch/generation
     meshes : dict
         Dictionary whose keys are mesh IDs and whose values are MeshBase objects
     n_batches : int
@@ -87,6 +91,8 @@ class StatePoint:
         Indicate whether photon transport is active
     run_mode : str
         Simulation run mode, e.g. 'eigenvalue'
+    alpha_mode : bool
+        Running alpha mode?
     runtime : dict
         Dictionary whose keys are strings describing various runtime metrics
         and whose values are time values in seconds.
@@ -261,6 +267,13 @@ class StatePoint:
             return None
 
     @property
+    def alpha_generation(self):
+        if self.run_mode == 'eigenvalue':
+            return self._f['alpha_generation'][()]
+        else:
+            return None
+
+    @property
     def k_combined(self):
         if self.run_mode == 'eigenvalue':
             return ufloat(*self._f['k_combined'][()])
@@ -285,6 +298,13 @@ class StatePoint:
     def k_abs_tra(self):
         if self.run_mode == 'eigenvalue':
             return self._f['k_abs_tra'][()]
+        else:
+            return None
+
+    @property
+    def alpha_final(self):
+        if self.run_mode == 'eigenvalue':
+            return self._f['alpha_final'][()]
         else:
             return None
 
@@ -332,6 +352,10 @@ class StatePoint:
     @property
     def run_mode(self):
         return self._f['run_mode'][()].decode()
+
+    @property
+    def alpha_mode(self):
+        return self._f.attrs['alpha_mode'] > 0
 
     @property
     def runtime(self):

--- a/src/eigenvalue.cpp
+++ b/src/eigenvalue.cpp
@@ -37,6 +37,7 @@ namespace simulation {
 
 double keff_generation;
 std::array<double, 2> k_sum;
+std::array<double, 2> alpha_sum;
 std::vector<double> entropy;
 xt::xtensor<double, 1> source_frac;
 
@@ -66,6 +67,42 @@ void calculate_generation_keff()
   // TODO: This should be normalized by total_weight, not by n_particles
   keff_reduced /= settings::n_particles;
   simulation::k_generation.push_back(keff_reduced);
+
+  // Get and normalize global tallies for alpha (time) eigenvalue update
+  if (settings::alpha_mode) {
+#ifdef OPENMC_MPI
+    // Combine values across all processors (TODO: group it as one reduce)
+    double Cn_reduced, Cp_reduced, Cd_reduced;
+
+    // Cn
+    MPI_Allreduce(&global_tally_alpha_Cn, &Cn_reduced, 1, MPI_DOUBLE,
+      MPI_SUM, mpi::intracomm);
+    global_tally_alpha_Cn = Cn_reduced;
+
+    // Cp
+    MPI_Allreduce(&global_tally_alpha_Cp, &Cp_reduced, 1, MPI_DOUBLE,
+      MPI_SUM, mpi::intracomm);
+    global_tally_alpha_Cp = Cp_reduced;
+
+    // Cd
+    for (int i = 0; i < simulation::alpha_I; i++) { 
+      for (int j = 0; j < simulation::alpha_J[i]; j++) {
+        MPI_Allreduce(&global_tally_alpha_Cd[i][j], &Cd_reduced, 1, MPI_DOUBLE,
+          MPI_SUM, mpi::intracomm);
+        global_tally_alpha_Cd[i][j] = Cd_reduced;
+      }
+    }
+#endif
+  }
+  
+  // TODO: This should be normalized by total_weight, not by n_particles
+  global_tally_alpha_Cn /= settings::n_particles;
+  global_tally_alpha_Cp /= settings::n_particles;
+  for (int i = 0; i < simulation::alpha_I; i++) { 
+    for (int j = 0; j < simulation::alpha_J[i]; j++) {
+      global_tally_alpha_Cd[i][j] /= settings::n_particles;
+    }
+  }
 }
 
 void synchronize_bank()
@@ -348,6 +385,96 @@ void calculate_average_keff()
         std::pow(simulation::keff, 2)) / (n - 1));
     }
   }
+  
+  //============================================================================
+  // Update alpha eigenvalue
+  //============================================================================
+ 
+  if (settings::alpha_mode) {
+    // The constants (for easy referring)
+    const double Cn = global_tally_alpha_Cn;
+    const double Cp = global_tally_alpha_Cp;
+    const std::vector<std::vector<double>> Cd = global_tally_alpha_Cd;
+    const std::vector<std::vector<double>> lambda = simulation::alpha_lambda;
+    const double alpha_min = simulation::alpha_min;
+
+    // Newton raphson to update alpha [Goal: find x yielding f(x) = 0]
+    const double epsilon = 1E-8;                  // error tolerance (TODO: let user decide?)
+    const double alpha   = simulation::alpha_eff; // previous alpha
+    double error1        = 1.0;                   // iterate relative change
+    double error2        = 1.0;                   // residual
+    double x             = alpha;                 // updated alpha (solution)
+    while (error1 > epsilon || error2 > epsilon) {
+      // Evaluate f(x)
+      double f = (alpha - x)*Cn + Cp - 1.0;
+      // Accumulate delayed terms
+      for (int i = 0; i < simulation::alpha_I; i++) {
+        // i is local
+        for (int j = 0; j < simulation::alpha_J[i]; j++) {
+          f += lambda[i][j]/(x+lambda[i][j]) * Cd[i][j];
+        }
+      }
+
+      // Evaluate f'(x) function
+      double df = -Cn;
+      // Accumulate delayed terms
+      for (int i = 0; i < simulation::alpha_I; i++) { 
+        // i is local
+        for (int j = 0; j < simulation::alpha_J[i]; j++) {
+          double denom = (x+lambda[i][j]); denom *= denom;
+          df -= lambda[i][j]/denom * Cd[i][j];
+        }
+      }
+
+      // Next solution
+      double x_new = x - f/df;
+      
+      // Exceed minimum?
+      if (x_new < alpha_min) { x_new = 0.5*(x + alpha_min); }
+
+      // Calculate errors
+      error1 = std::abs((x_new - x)/x_new);
+      error2 = (alpha - x_new)*Cn + Cp - 1.0;
+      for (int i = 0; i < simulation::alpha_I; i++) { 
+        // i is local
+        for (int j = 0; j < simulation::alpha_J[i]; j++) {
+          error2 += lambda[i][j]/(x_new+lambda[i][j]) * Cd[i][j];
+        }
+      }
+    
+      // Reset x
+      x = x_new;
+    }
+    // Update alpha
+    simulation::alpha_eff = x;
+    simulation::alpha_generation.push_back(simulation::alpha_eff);
+
+    if (n > 0) {
+      // The following follows the procedure used for k eigenvalue
+      // Sample mean of alpha_eff
+      simulation::alpha_sum[0] += simulation::alpha_generation[i];
+      simulation::alpha_sum[1] += std::pow(simulation::alpha_generation[i], 2);
+
+      // Determine mean
+      simulation::alpha_eff = simulation::alpha_sum[0] / n;
+
+      if (n > 1) {
+        double t_value;
+        if (settings::confidence_intervals) {
+          // Calculate t-value for confidence intervals
+          double alpha = 1.0 - CONFIDENCE_LEVEL;
+          t_value = t_percentile(1.0 - alpha/2.0, n - 1);
+        } else {
+          t_value = 1.0;
+        }
+
+        // Standard deviation of the sample mean of alpha
+        simulation::alpha_eff_std = t_value 
+          * std::sqrt((simulation::alpha_sum[1]/n 
+                       - std::pow(simulation::alpha_eff, 2)) / (n - 1));
+      }
+    }
+  }
 }
 
 int openmc_get_keff(double* k_combined)
@@ -595,6 +722,8 @@ void write_eigenvalue_hdf5(hid_t group)
   write_dataset(group, "n_inactive", settings::n_inactive);
   write_dataset(group, "generations_per_batch", settings::gen_per_batch);
   write_dataset(group, "k_generation", simulation::k_generation);
+  if (settings::alpha_mode)
+    write_dataset(group, "alpha_generation", simulation::alpha_generation);
   if (settings::entropy_on) {
     write_dataset(group, "entropy", simulation::entropy);
   }
@@ -604,6 +733,14 @@ void write_eigenvalue_hdf5(hid_t group)
   std::array<double, 2> k_combined;
   openmc_get_keff(k_combined.data());
   write_dataset(group, "k_combined", k_combined);
+
+  // alpha (time) eigenvalue for easy access
+  std::array<double, 2> alpha_final;
+  const int n = simulation::k_generation.size() - settings::n_inactive;
+  alpha_final[0] = simulation::alpha_sum[0]/n;
+  alpha_final[1] = simulation::alpha_eff_std;
+  write_dataset(group, "alpha_final", alpha_final);
+  write_attribute(group, "alpha_final", alpha_final);
 }
 
 void read_eigenvalue_hdf5(hid_t group)
@@ -611,7 +748,10 @@ void read_eigenvalue_hdf5(hid_t group)
   read_dataset(group, "generations_per_batch", settings::gen_per_batch);
   int n = simulation::restart_batch*settings::gen_per_batch;
   simulation::k_generation.resize(n);
+  simulation::alpha_generation.resize(n);
   read_dataset(group, "k_generation", simulation::k_generation);
+  if (settings::alpha_mode)
+    read_dataset(group, "alpha_generation", simulation::alpha_generation);
   if (settings::entropy_on) {
     read_dataset(group, "entropy", simulation::entropy);
   }

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -96,6 +96,7 @@ int openmc_finalize()
   settings::restart_run = false;
   settings::run_CE = true;
   settings::run_mode = RunMode::UNSET;
+  settings::alpha_mode = false;
   settings::dagmc = false;
   settings::source_latest = false;
   settings::source_separate = false;
@@ -118,6 +119,8 @@ int openmc_finalize()
   settings::write_initial_source = false;
 
   simulation::keff = 1.0;
+  simulation::alpha_eff = 0.0;
+  simulation::alpha_min = -INFTY;
   simulation::n_lost_particles = 0;
   simulation::satisfy_triggers = false;
   simulation::total_gen = 0;
@@ -181,6 +184,8 @@ int openmc_hard_reset()
 
   // Reset total generations and keff guess
   simulation::keff = 1.0;
+  simulation::alpha_eff = 0.0;
+  simulation::alpha_min = -INFTY;
   simulation::total_gen = 0;
 
   // Reset the random number generator state

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -742,6 +742,10 @@ void Material::calculate_xs(Particle& p) const
   p.macro_xs_.absorption = 0.0;
   p.macro_xs_.fission = 0.0;
   p.macro_xs_.nu_fission = 0.0;
+  if (settings::alpha_mode) {
+    p.macro_xs_.nu_fission_alpha = 0.0;
+    p.macro_xs_.nu_fission_prompt = 0.0;
+  }
 
   if (p.type_ == Particle::Type::neutron) {
     this->calculate_neutron_xs(p);
@@ -817,6 +821,10 @@ void Material::calculate_neutron_xs(Particle& p) const
     p.macro_xs_.absorption += atom_density * micro.absorption;
     p.macro_xs_.fission += atom_density * micro.fission;
     p.macro_xs_.nu_fission += atom_density * micro.nu_fission;
+    if (settings::alpha_mode){
+      p.macro_xs_.nu_fission_alpha += atom_density * micro.nu_fission_alpha;
+      p.macro_xs_.nu_fission_prompt += atom_density * micro.nu_fission_prompt;
+    }
   }
 }
 

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -476,12 +476,42 @@ double Nuclide::nu(double E, EmissionMode mode, int group) const
     } else {
       return 0.0;
     }
+  case EmissionMode::delayed_alpha:
+    if (n_precursor_ > 0) {
+      auto rx = fission_rx_[0];
+      if (group >= 1 && group < rx->products_.size()) {
+        // If delayed group specified, determine yield immediately
+        double lambda = rx->products_[group].decay_rate_;
+        return (*rx->products_[group].yield_)(E)
+               * lambda / (simulation::alpha_eff + lambda);
+      } else {
+        double nu {0.0};
+
+        for (int i = 1; i < rx->products_.size(); ++i) {
+          // Skip any non-neutron products
+          const auto& product = rx->products_[i];
+          if (product.particle_ != Particle::Type::neutron) continue;
+
+          // Evaluate yield
+          if (product.emission_mode_ == EmissionMode::delayed) {
+            double lambda = product.decay_rate_;
+            nu += (*product.yield_)(E) 
+                  * lambda / (simulation::alpha_eff + lambda);
+          }
+        }
+        return nu;
+      }
+    } else {
+      return 0.0;
+    }
   case EmissionMode::total:
     if (total_nu_) {
       return (*total_nu_)(E);
     } else {
       return (*fission_rx_[0]->products_[0].yield_)(E);
     }
+  case EmissionMode::total_alpha:
+    return nu(E, EmissionMode::prompt) + nu(E, EmissionMode::delayed_alpha);
   }
   UNREACHABLE();
 }
@@ -728,6 +758,13 @@ void Nuclide::calculate_xs(int i_sab, int i_log_union, double sab_frac, Particle
 
   micro.last_E = p.E_;
   micro.last_sqrtkT = p.sqrtkT_;
+
+  // Calculate nu_fission_alpha
+  // TODO: Is it good for multipole and interpolate as well?
+  if (settings::alpha_mode){
+    micro.nu_fission_alpha  = micro.fission * nu(p.E_, EmissionMode::total_alpha);
+    micro.nu_fission_prompt = micro.fission * nu(p.E_, EmissionMode::prompt);
+  }
 }
 
 void Nuclide::calculate_sab_xs(int i_sab, double sab_frac, Particle& p)

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -103,6 +103,7 @@ std::string
 header(const char* msg) {
   // Determine how many times to repeat the '=' character.
   int n_prefix = (63 - strlen(msg)) / 2;
+  if (settings::alpha_mode) n_prefix = (88 - strlen(msg)) / 2;
   int n_suffix = n_prefix;
   if ((strlen(msg) % 2) == 0) ++n_suffix;
 
@@ -338,14 +339,26 @@ void print_version()
 
 void print_columns()
 {
-  if (settings::entropy_on) {
-    fmt::print(
-      "  Bat./Gen.      k       Entropy         Average k \n"
-      "  =========   ========   ========   ====================\n");
+  if (!settings::alpha_mode) {
+    if (settings::entropy_on) {
+      std::cout <<
+        "  Bat./Gen.      k       Entropy         Average k \n"
+        "  =========   ========   ========   ====================\n";
+    } else {
+      std::cout <<
+        "  Bat./Gen.      k            Average k\n"
+        "  =========   ========   ====================\n";
+    }
   } else {
-    fmt::print(
-      "  Bat./Gen.      k            Average k\n"
-      "  =========   ========   ====================\n");
+    if (settings::entropy_on) {
+      std::cout <<
+        "  Bat./Gen.      k          alpha      Entropy         Average k               Average alpha       \n"
+        "  =========   ========   ===========   ========   ====================   ==========================\n";
+    } else {
+      std::cout <<
+        "  Bat./Gen.      k          alpha           Average k               Average alpha       \n"
+        "  =========   ========   ===========   ====================   ==========================\n";
+    }
   }
 }
 
@@ -363,6 +376,11 @@ void print_generation()
     std::to_string(simulation::current_gen);
   fmt::print("  {:>9}   {:8.5f}", batch_and_gen, simulation::k_generation[idx]);
 
+  // write out batch/generation and generation alpha (time) eigenvalue
+  if (settings::alpha_mode) {
+    fmt::print("   {:11.5e}", simulation::alpha_generation[idx]);
+  }
+
   // write out entropy info
   if (settings::entropy_on) {
     fmt::print("   {:8.5f}", simulation::entropy[idx]);
@@ -370,6 +388,7 @@ void print_generation()
 
   if (n > 1) {
     fmt::print("   {:8.5f} +/-{:8.5f}", simulation::keff, simulation::keff_std);
+    fmt::print("   {:11.5e} +/-{:11.5e}", simulation::alpha_eff, simulation::alpha_eff_std);
   }
   std::cout << std::endl;
 }

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -95,8 +95,14 @@ create_fission_sites(Particle& p)
   double weight = settings::ufs_on ? ufs_get_weight(p) : 1.0;
 
   // Determine the expected number of neutrons produced
-  double nu_t = p.wgt_ / simulation::keff * weight *
-       p.macro_xs_.nu_fission / p.macro_xs_.total;
+  double nu_t;
+  if (settings::alpha_mode) {
+    nu_t = p.wgt_ / simulation::keff * weight *
+      p.macro_xs_.nu_fission_alpha / p.macro_xs_.total;
+  } else {
+    nu_t = p.wgt_ / simulation::keff * weight *
+      p.macro_xs_.nu_fission / p.macro_xs_.total;
+  }
 
   // Sample the number of neutrons produced
   int nu = static_cast<int>(nu_t);
@@ -216,12 +222,22 @@ absorption(Particle& p)
     p.wgt_last_ = p.wgt_;
 
     // Score implicit absorpion estimate of keff
-    p.keff_tally_absorption_ += p.wgt_absorb_ * p.macro_xs_.nu_fission /
-        p.macro_xs_.absorption;
+    if (settings::alpha_mode) {
+      p.keff_tally_absorption_ += p.wgt_absorb_ * p.macro_xs_.nu_fission_alpha /
+          p.macro_xs_.absorption;
+    } else {
+      p.keff_tally_absorption_ += p.wgt_absorb_ * p.macro_xs_.nu_fission /
+          p.macro_xs_.absorption;
+    }
   } else {
     if (p.macro_xs_.absorption > prn(p.current_seed()) * p.macro_xs_.total) {
-      p.keff_tally_absorption_ += p.wgt_ * p.macro_xs_.nu_fission /
-           p.macro_xs_.absorption;
+      if (settings::alpha_mode) {
+        p.keff_tally_absorption_ += p.wgt_ * p.macro_xs_.nu_fission_alpha /
+             p.macro_xs_.absorption;
+      } else {
+        p.keff_tally_absorption_ += p.wgt_ * p.macro_xs_.nu_fission /
+             p.macro_xs_.absorption;
+      }
       p.alive_ = false;
       p.event_ = TallyEvent::ABSORB;
     }

--- a/src/reaction_product.cpp
+++ b/src/reaction_product.cpp
@@ -31,8 +31,12 @@ ReactionProduct::ReactionProduct(hid_t group)
     emission_mode_ = EmissionMode::prompt;
   } else if (temp == "delayed") {
     emission_mode_ = EmissionMode::delayed;
+  } else if (temp == "delayed_alpha") {
+    emission_mode_ = EmissionMode::delayed_alpha;
   } else if (temp == "total") {
     emission_mode_ = EmissionMode::total;
+  } else if (temp == "total_alpha") {
+    emission_mode_ = EmissionMode::total_alpha;
   }
 
   // Read decay rate for delayed emission

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -9,6 +9,7 @@
 #include "openmc/geometry_aux.h"
 #include "openmc/material.h"
 #include "openmc/message_passing.h"
+#include "openmc/mgxs_interface.h"
 #include "openmc/nuclide.h"
 #include "openmc/output.h"
 #include "openmc/particle.h"
@@ -35,6 +36,7 @@
 
 #include <algorithm>
 #include <string>
+#include <vector>
 
 
 //==============================================================================
@@ -68,6 +70,81 @@ int openmc_simulation_init()
   // Skip if simulation has already been initialized
   if (simulation::initialized) return 0;
 
+  //============================================================================
+  // Preparation for alpha (time eigenvalue) mode
+  //   Determine alpha_min, _I, _J, _idx, _lambda, and allocate global_tally_alpha_Cd
+  //============================================================================
+
+  if (settings::alpha_mode) {
+    if (settings::run_CE) {
+      simulation::alpha_min = -INFTY;
+      simulation::alpha_I = 0;
+      simulation::alpha_idx.resize(data::nuclides.size(),-1); // -1 for non-fissionable
+      for (int i = 0; i < data::nuclides.size(); i++){
+        if (data::nuclides[i]->fissionable_) {
+          // Set index
+          simulation::alpha_idx[i] = simulation::alpha_I;
+
+          // Increment I
+          simulation::alpha_I++;
+
+          // Allocate decay constant
+          simulation::alpha_lambda.resize(simulation::alpha_I);
+
+          // Set alpha_lambda for each precursor group j of nuclide i, and update alpha_min if necessary
+          auto rx = data::nuclides[i]->fission_rx_[0];
+          for (int j = 1; j < rx->products_.size(); ++j) {
+            const auto& product = rx->products_[j];
+            if (product.particle_ != Particle::Type::neutron) continue;
+            if (product.emission_mode_ == Nuclide::EmissionMode::delayed) {
+              // Set decay constant of precursor group j of nuclide i
+              simulation::alpha_lambda.back().push_back(product.decay_rate_);
+              if (simulation::alpha_min < -product.decay_rate_)
+                simulation::alpha_min = -product.decay_rate_;
+            }
+          }
+
+          // Total J in i
+          simulation::alpha_J.push_back(simulation::alpha_lambda.back().size());
+        }
+      }
+    } else {
+      simulation::alpha_min = -INFTY;
+      simulation::alpha_I = 0;
+      simulation::alpha_idx.resize(data::mg.macro_xs_.size(),-1);
+      for (int i = 0; i < data::mg.macro_xs_.size(); i++){
+        if (data::mg.macro_xs_[i].fissionable) {
+          // Set index
+          simulation::alpha_idx[i] = simulation::alpha_I;
+
+          // Increment I
+          simulation::alpha_I++;
+
+          // Allocate decay constant
+          simulation::alpha_lambda.resize(simulation::alpha_I);
+
+          // Set alpha_lambda for each precursor group j of nuclide i, and update alpha_min if necessary
+          int J = data::mg.num_delayed_groups_;
+          for (int j = 0; j < J; ++j) {
+            // Set decay constant of precursor group j of nuclide i
+            double lam = data::mg.macro_xs_[i].get_xs(MgxsType::DECAY_RATE,0,nullptr,nullptr,&j);
+            simulation::alpha_lambda.back().push_back(lam);
+            if (simulation::alpha_min < -lam)
+              simulation::alpha_min = -lam;
+          }
+
+          // Total J in i
+          simulation::alpha_J.push_back(simulation::alpha_lambda.back().size());
+        }
+      }
+    }
+    // Allocate global_tally_alpha_Cd
+    global_tally_alpha_Cd.resize(simulation::alpha_I);
+    for (int i = 0; i < simulation::alpha_I; i++)
+      global_tally_alpha_Cd[i].resize(simulation::alpha_J[i], 0.0);
+  }
+  // Alpha mode preparation done
+
   // Determine how much work each process should do
   calculate_work();
 
@@ -98,6 +175,7 @@ int openmc_simulation_init()
   // will potentially populate k_generation and entropy)
   simulation::current_batch = 0;
   simulation::k_generation.clear();
+  simulation::alpha_generation.clear();
   simulation::entropy.clear();
   simulation::need_depletion_rx = false;
   openmc_reset();
@@ -276,8 +354,17 @@ const RegularMesh* entropy_mesh {nullptr};
 const RegularMesh* ufs_mesh {nullptr};
 
 std::vector<double> k_generation;
+std::vector<double> alpha_generation;
 std::vector<int64_t> work_index;
 
+// For alpha (time eigenvalue) mode
+double alpha_eff {0.0};    
+double alpha_eff_std;
+double alpha_min {-INFTY};    
+int alpha_I;
+std::vector<int>alpha_J;
+std::vector<int> alpha_idx;
+std::vector<std::vector<double>> alpha_lambda;
 
 } // namespace simulation
 
@@ -411,7 +498,7 @@ void finalize_generation()
   }
   gt(GlobalTally::LEAKAGE, TallyResult::VALUE) += global_tally_leakage;
 
-  // reset tallies
+  // reset global tallies
   if (settings::run_mode == RunMode::EIGENVALUE) {
     global_tally_collision = 0.0;
     global_tally_absorption = 0.0;
@@ -434,12 +521,33 @@ void finalize_generation()
     // Collect results and statistics
     calculate_generation_keff();
     calculate_average_keff();
+    
+    // reset global tallies of alpha (time eigenvalue) mode
+    if (settings::alpha_mode) {
+      global_tally_alpha_Cn = 0.0;
+      global_tally_alpha_Cp = 0.0;
+      for (int i = 0; i < simulation::alpha_I; i++) { 
+        for (int j = 0; j < simulation::alpha_J[i]; j++) {
+          global_tally_alpha_Cd[i][j] = 0.0;
+        }
+      }
+    }
 
     // Write generation output
     if (mpi::master && settings::verbosity >= 7) {
       print_generation();
     }
 
+    // TODO: Shoud we use the new generation k estimate, not the current active-batch average, 
+    //       for the next transport iteration?
+    int idx = overall_generation() - 1;
+    int n = simulation::current_batch > settings::n_inactive ?
+      settings::gen_per_batch*simulation::n_realizations + simulation::current_gen : 0;
+    if (n > 1) {
+      simulation::keff = simulation::k_generation[idx];
+      if (settings::alpha_mode)
+        simulation::alpha_eff = simulation::alpha_generation[idx];
+    }
   }
 }
 
@@ -491,6 +599,11 @@ void initialize_history(Particle& p, int64_t index_source)
       }
     }
   }
+
+  // Set alpha_tally_Cd_ size
+  p.alpha_tally_Cd_.resize(simulation::alpha_I);
+  for (int i = 0; i < simulation::alpha_I; i++)
+    p.alpha_tally_Cd_[i].resize(simulation::alpha_J[i], 0.0);
 
   // Display message if high verbosity or trace is on
   if (settings::verbosity >= 9 || p.trace_) {
@@ -592,6 +705,7 @@ void broadcast_results() {
 void free_memory_simulation()
 {
   simulation::k_generation.clear();
+  simulation::alpha_generation.clear();
   simulation::entropy.clear();
 }
 

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -91,7 +91,16 @@ openmc_statepoint_write(const char* filename, bool* write_source)
     default:
       break;
     }
+    // Write alpha mode
+    if (settings::run_mode == RunMode::EIGENVALUE){
+      if (settings::alpha_mode) {
+        write_dataset(file_id, "alpha_mode", 1);
+      } else {
+        write_dataset(file_id, "alpha_mode", 0);
+      }
+    }
     write_attribute(file_id, "photon_transport", settings::photon_transport);
+    write_attribute(file_id, "alpha_mode", settings::alpha_mode);
     write_dataset(file_id, "n_particles", settings::n_particles);
     write_dataset(file_id, "n_batches", settings::n_batches);
 
@@ -376,6 +385,7 @@ void load_state_point()
     settings::run_mode = RunMode::EIGENVALUE;
   }
   read_attribute(file_id, "photon_transport", settings::photon_transport);
+  read_attribute(file_id, "alpha_mode", settings::alpha_mode);
   read_dataset(file_id, "n_particles", settings::n_particles);
   int temp;
   read_dataset(file_id, "n_batches", temp);

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -64,6 +64,9 @@ double global_tally_absorption;
 double global_tally_collision;
 double global_tally_tracklength;
 double global_tally_leakage;
+double global_tally_alpha_Cn;                          
+double global_tally_alpha_Cp;                          
+std::vector<std::vector<double>> global_tally_alpha_Cd;
 
 int
 score_str_to_int(std::string score_str)


### PR DESCRIPTION
It modifies the k-eigenvalue power iteration (CE and MG) to converge to the fundamental alpha (time eigenvalue) mode.

Key modifications include
(1) particle weight correction during particle event_advance,
(2) time-corrected delayed fission neutron emission, and
(3) eigenvalues (k and alpha) update procedure.
Setting settings.alpha_mode to True activates the modifications listed above.

Tested on:
(1) Cullen's Godiva prompt-supercritical problems, and
(2) Subcritical and delayed-supercritical analytical two-group infinite media.
[Reference: https://www.tandfonline.com/doi/full/10.1080/00295639.2020.1743578]
[alpha_iteration_test.zip](https://github.com/openmc-dev/openmc/files/4826681/alpha_iteration_test.zip)

Notes:
(1) Has not been implemented for event_based mode
(2) Instead of the current active-batches-average, the new generation k estimate is used for the next transport iteration
(3) settings.mg_speeds (python list) needs to be supplied for MG mode

On-going work:
(1) alpha re-scaling for fission production tally scorings with analog-estimator
(2) spatial-mesh-filtered track-length scoring that considers the particle weight correction