### PR TITLE
Add missing filters in openmc/lib/filter.py

### DIFF
--- a/openmc/lib/filter.py
+++ b/openmc/lib/filter.py
@@ -202,6 +202,10 @@ class CellfromFilter(Filter):
     filter_type = 'cellfrom'
 
 
+class CellInstanceFilter(Filter):
+    filter_type = 'cellinstance'
+
+
 class DelayedGroupFilter(Filter):
     filter_type = 'delayedgroup'
 
@@ -340,6 +344,10 @@ class MuFilter(Filter):
     filter_type = 'mu'
 
 
+class ParticleFilter(Filter):
+    filter_type = 'particle'
+
+
 class PolarFilter(Filter):
     filter_type = 'polar'
 
@@ -418,6 +426,7 @@ _FILTER_TYPE_MAP = {
     'cell': CellFilter,
     'cellborn': CellbornFilter,
     'cellfrom': CellfromFilter,
+    'cellinstance': CellInstanceFilter,
     'delayedgroup': DelayedGroupFilter,
     'distribcell': DistribcellFilter,
     'energy': EnergyFilter,
@@ -428,6 +437,7 @@ _FILTER_TYPE_MAP = {
     'mesh': MeshFilter,
     'meshsurface': MeshSurfaceFilter,
     'mu': MuFilter,
+    'particle': ParticleFilter,
     'polar': PolarFilter,
     'sphericalharmonics': SphericalHarmonicsFilter,
     'spatiallegendre': SpatialLegendreFilter,

--- a/openmc/lib/filter.py
+++ b/openmc/lib/filter.py
@@ -14,13 +14,14 @@ from .material import Material
 from .mesh import RegularMesh
 
 
-__all__ = ['Filter', 'AzimuthalFilter', 'CellFilter',
-           'CellbornFilter', 'CellfromFilter', 'DistribcellFilter',
-           'DelayedGroupFilter', 'EnergyFilter', 'EnergyoutFilter',
-           'EnergyFunctionFilter', 'LegendreFilter', 'MaterialFilter', 'MeshFilter',
-           'MeshSurfaceFilter', 'MuFilter', 'PolarFilter', 'SphericalHarmonicsFilter',
-           'SpatialLegendreFilter', 'SurfaceFilter',
-           'UniverseFilter', 'ZernikeFilter', 'ZernikeRadialFilter', 'filters']
+__all__ = [
+    'Filter', 'AzimuthalFilter', 'CellFilter', 'CellbornFilter', 'CellfromFilter',
+    'CellInstanceFilter', 'DistribcellFilter', 'DelayedGroupFilter', 'EnergyFilter',
+    'EnergyoutFilter', 'EnergyFunctionFilter', 'LegendreFilter', 'MaterialFilter',
+    'MeshFilter', 'MeshSurfaceFilter', 'MuFilter', 'ParticleFilter', 'PolarFilter',
+    'SphericalHarmonicsFilter', 'SpatialLegendreFilter', 'SurfaceFilter',
+    'UniverseFilter', 'ZernikeFilter', 'ZernikeRadialFilter', 'filters'
+]
 
 # Tally functions
 _dll.openmc_cell_filter_get_bins.argtypes = [


### PR DESCRIPTION
The `openmc.lib` Python bindings to the C/C++ API rely on some stub classes for tally filters to work properly. It turns out there were two filters (ParticleFilter and CellInstanceFilter) that were missing there, and this actually caused an issue for a user trying to run a depletion calculation when their model had a ParticleFilter in it. This PR should resolve this issue.