### PR TITLE
DAGMC Updates/Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ addons:
       - libmpich-dev
       - libhdf5-serial-dev
       - libhdf5-mpich-dev
-      - libblas-dev
-      - liblapack-dev
+      - libeigen3-dev
     config:
       retries: true
 services:

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -176,11 +176,10 @@ void load_dagmc_geometry()
   MB_CHK_ERR_CONT(rval);
 
   // parse model metadata
-  dagmcMetaData DMD(model::DAG);
-  if (using_uwuw) {
-    DMD.load_property_data();
-  }
-  std::vector<std::string> keywords {"temp", "mat", "density", "boundary"};
+  dagmcMetaData DMD(model::DAG, false, false);
+  DMD.load_property_data();
+
+  std::vector<std::string> keywords {"temp", "boundary"};
   std::map<std::string, std::string> dum;
   std::string delimiters = ":/";
   rval = model::DAG->parse_properties(keywords, dum, delimiters.c_str());
@@ -218,54 +217,25 @@ void load_dagmc_geometry()
 
     // MATERIALS
 
-    if (model::DAG->is_implicit_complement(vol_handle)) {
-      if (model::DAG->has_prop(vol_handle, "mat")) {
-        // if the implicit complement has been assigned a material, use it
-        if (using_uwuw) {
-          std::string comp_mat = DMD.volume_material_property_data_eh[vol_handle];
-          // Note: material numbers are set by UWUW
-          int mat_number = uwuw.material_library[comp_mat].metadata["mat_number"].asInt();
-          c->material_.push_back(mat_number);
-        } else {
-          std::string mat_value;
-          rval= model::DAG->prop_value(vol_handle, "mat", mat_value);
-          MB_CHK_ERR_CONT(rval);
-          // remove _comp
-          std::string _comp = "_comp";
-          size_t _comp_pos = mat_value.find(_comp);
-          if (_comp_pos != std::string::npos) { mat_value.erase(_comp_pos, _comp.length()); }
-          // assign IC material by id
-          legacy_assign_material(mat_value, c);
-        }
-      } else {
-        // if no material is found, the implicit complement is void
-        c->material_.push_back(MATERIAL_VOID);
-      }
-      continue;
-    }
-
     // determine volume material assignment
-    std::string mat_value;
-    if (model::DAG->has_prop(vol_handle, "mat")) {
-      rval = model::DAG->prop_value(vol_handle, "mat", mat_value);
-      MB_CHK_ERR_CONT(rval);
-    } else {
+    std::string mat_str = DMD.get_volume_property("material", vol_handle);
+
+    if (mat_str.empty()) {
       fatal_error(fmt::format("Volume {} has no material assignment.", c->id_));
     }
 
-    std::string cmp_str = mat_value;
-    to_lower(cmp_str);
+    to_lower(mat_str);
 
-    if (cmp_str == "graveyard") {
+    if (mat_str == "graveyard") {
       graveyard = vol_handle;
     }
 
     // material void checks
-    if (cmp_str == "void" || cmp_str == "vacuum" || cmp_str == "graveyard") {
+    if (mat_str == "void" || mat_str == "vacuum" || mat_str == "graveyard") {
       c->material_.push_back(MATERIAL_VOID);
     } else {
       if (using_uwuw) {
-        // lookup material in uwuw if the were present
+        // lookup material in uwuw if present
         std::string uwuw_mat = DMD.volume_material_property_data_eh[vol_handle];
         if (uwuw.material_library.count(uwuw_mat) != 0) {
           // Note: material numbers are set by UWUW
@@ -273,10 +243,10 @@ void load_dagmc_geometry()
           c->material_.push_back(mat_number);
         } else {
           fatal_error(fmt::format("Material with value {} not found in the "
-            "UWUW material library", mat_value));
+            "UWUW material library", mat_str));
         }
       } else {
-        legacy_assign_material(mat_value, c);
+        legacy_assign_material(mat_str, c);
       }
     }
 
@@ -356,7 +326,7 @@ void load_dagmc_geometry()
 
     // if this surface belongs to the graveyard
     if (graveyard && parent_vols.find(graveyard) != parent_vols.end()) {
-      // set BC to vacuum
+      // set graveyard surface BC's to vacuum
       s->bc_ = Surface::BoundaryType::VACUUM;
     }
 

--- a/tools/ci/travis-install-dagmc.sh
+++ b/tools/ci/travis-install-dagmc.sh
@@ -19,7 +19,7 @@ cd $HOME
 mkdir MOAB && cd MOAB
 git clone -b $MOAB_BRANCH $MOAB_REPO
 mkdir build && cd build
-cmake ../moab -DENABLE_HDF5=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR
+cmake ../moab -DENABLE_HDF5=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR -DENABLE_BLASLAPACK=OFF
 make -j && make -j install
 cmake ../moab -DBUILD_SHARED_LIBS=OFF
 make -j install


### PR DESCRIPTION
This PR contains a fix for implicit complement material assignment in DAGMC and allows all material assignments to rely on a class dedicated to DAGMC metadata management by relaxing the restriction that a density be supplied along with a material assignment in the DAGMC `.h5m` file. The relevant changes to DAGMC to allow that can be found [here](https://github.com/svalinn/DAGMC/pull/688).

Similar updates to how boundary conditions are found have been made as well (corresponding changes in DAGMC to support the variety of boundary conditions in OpenMC can be found [here](https://github.com/svalinn/DAGMC/pull/690)). 

These changes make the code for DAGMC setup cleaner, avoiding a lot of duplicate queries for property information and removal of error code checks for calls directly into the DAGMC interface.

***
The final update here is a change from the use of blas/lapack to eigen3 when building DAGMC. Eigen3 is a C++ template library, making a theoretical build of DAGMC on Windows viable. It is rapidly becoming the default build for DAGMC and it's best that we go ahead and reflect that change in our CI as well.