### PR TITLE
Fix bug when S(a,b) tables appear in depletable material

### DIFF
--- a/openmc/data/reaction.py
+++ b/openmc/data/reaction.py
@@ -422,7 +422,12 @@ def _get_fission_products_endf(ev):
             file_obj = StringIO(ev.section[5, 455])
             items = get_head_record(file_obj)
             nk = items[4]
-            if nk != len(decay_constants):
+            if nk > 1 and len(decay_constants) == 1:
+                # If only one precursor group is listed in MF=1, MT=455, use the
+                # energy spectra from MF=5 to split them into different groups
+                for _ in range(nk - 1):
+                    products.append(deepcopy(products[1]))
+            elif nk != len(decay_constants):
                 raise ValueError(
                     'Number of delayed neutron fission spectra ({}) does not '
                     'match number of delayed neutron precursors ({}).'.format(

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -654,6 +654,8 @@ class Material(IDManagerMixin):
             if enrichment_target is not None and element == re.sub(r'\d+$', '', enrichment_target):
                 self.add_element(element, percent, percent_type, enrichment,
                                  enrichment_target, enrichment_type)
+            elif enrichment is not None and enrichment_target is None and element == 'U':
+                self.add_element(element, percent, percent_type, enrichment)
             else:
                 self.add_element(element, percent, percent_type)
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -5,6 +5,7 @@
 #include <iterator>
 #include <string>
 #include <sstream>
+#include <unordered_set>
 
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xoperation.hpp"
@@ -412,7 +413,14 @@ void Material::init_thermal()
 {
   std::vector<ThermalTable> tables;
 
+  std::unordered_set<int> already_checked;
   for (const auto& table : thermal_tables_) {
+    // Make sure each S(a,b) table only gets checked once
+    if (already_checked.find(table.index_table) != already_checked.end()) {
+      continue;
+    }
+    already_checked.insert(table.index_table);
+
     // In order to know which nuclide the S(a,b) table applies to, we need
     // to search through the list of nuclides for one which has a matching
     // name


### PR DESCRIPTION
A user noted that when they used the `c_H_in_ZrH` and `c_Zr_in_ZrH` S(a,b) tables in a material that was depletable, they ran into an error on the second iteration where the code complains that a nuclide is present in two tables. This is due to a bug in how thermal scattering tables are assigned (there was an implicit assumption this was only done once, but in depletion, the assignment happens each time a material is updated).

Unrelated to the above: I also put in a small fix here to ensure `IncidentNeutron.from_endf` works with all TENDL-2019 files. Some of the fissionable nuclides (e.g., Ra234) list only one precursor group in MF=1,MT=455, but then list 6 separate energy spectra in MF=5,MT=455. The intention is to use the probability of selecting the energy spectra as a way of turning 1 group into 6 (this is how NJOY treats it when producing ACE files).