### PR TITLE
Assign prev_results to correct member in TrasnportOperator's constructor

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -122,7 +122,7 @@ class TransportOperator(ABC):
             self.prev_res = None
         else:
             check_type("previous results", prev_results, ResultsList)
-            self.prev_results = prev_results
+            self.prev_res = prev_results
 
     @property
     def dilute_initial(self):


### PR DESCRIPTION

a little more fix to keep user-supplied prev_results on operator #1610