### PR TITLE
Fix related to the declaration order of maps and vectors

### DIFF
--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -49,11 +49,11 @@ class Universe;
 class UniversePartitioner;
 
 namespace model {
-  extern std::vector<std::unique_ptr<Cell>> cells;
   extern std::unordered_map<int32_t, int32_t> cell_map;
+  extern std::vector<std::unique_ptr<Cell>> cells;
 
-  extern std::vector<std::unique_ptr<Universe>> universes;
   extern std::unordered_map<int32_t, int32_t> universe_map;
+  extern std::vector<std::unique_ptr<Universe>> universes;
 } // namespace model
 
 //==============================================================================

--- a/include/openmc/cross_sections.h
+++ b/include/openmc/cross_sections.h
@@ -43,11 +43,11 @@ using LibraryKey = std::pair<Library::Type, std::string>;
 
 namespace data {
 
-//!< Data libraries
-extern std::vector<Library> libraries;
-
 //! Maps (type, name) to index in libraries
 extern std::map<LibraryKey, std::size_t> library_map;
+
+//!< Data libraries
+extern std::vector<Library> libraries;
 
 } // namespace data
 

--- a/include/openmc/lattice.h
+++ b/include/openmc/lattice.h
@@ -35,8 +35,8 @@ enum class LatticeType {
 class Lattice;
 
 namespace model {
-  extern std::vector<std::unique_ptr<Lattice>> lattices;
   extern std::unordered_map<int32_t, int32_t> lattice_map;
+  extern std::vector<std::unique_ptr<Lattice>> lattices;
 } // namespace model
 
 //==============================================================================

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -32,8 +32,8 @@ class Mesh;
 
 namespace model {
 
-extern std::vector<std::unique_ptr<Mesh>> meshes;
 extern std::unordered_map<int32_t, int32_t> mesh_map;
+extern std::vector<std::unique_ptr<Mesh>> meshes;
 
 } // namespace model
 

--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -138,8 +138,8 @@ extern double temperature_min;
 //! Maximum temperature in [K] that nuclide data is available at
 extern double temperature_max;
 
-extern std::vector<std::unique_ptr<Nuclide>> nuclides;
 extern std::unordered_map<std::string, int> nuclide_map;
+extern std::vector<std::unique_ptr<Nuclide>> nuclides;
 
 } // namespace data
 

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -27,8 +27,8 @@ class Plot;
 
 namespace model {
 
-extern std::vector<Plot> plots; //!< Plot instance container
 extern std::unordered_map<int, int> plot_map; //!< map of plot ids to index
+extern std::vector<Plot> plots; //!< Plot instance container
 
 extern uint64_t plotter_prn_seeds[N_STREAMS]; // Random number seeds used for plotter
 extern int plotter_stream; // Stream index used by the plotter

--- a/include/openmc/surface.h
+++ b/include/openmc/surface.h
@@ -24,8 +24,8 @@ namespace openmc {
 class Surface;
 
 namespace model {
-  extern std::vector<std::unique_ptr<Surface>> surfaces;
   extern std::unordered_map<int, int> surface_map;
+  extern std::vector<std::unique_ptr<Surface>> surfaces;
 } // namespace model
 
 //==============================================================================

--- a/include/openmc/tallies/derivative.h
+++ b/include/openmc/tallies/derivative.h
@@ -70,8 +70,8 @@ void score_track_derivative(Particle& p, double distance);
 namespace openmc {
 
 namespace model {
-extern std::vector<TallyDerivative> tally_derivs;
 extern std::unordered_map<int, int> tally_deriv_map;
+extern std::vector<TallyDerivative> tally_derivs;
 } // namespace model
 
 } // namespace openmc

--- a/include/openmc/thermal.h
+++ b/include/openmc/thermal.h
@@ -23,8 +23,8 @@ namespace openmc {
 class ThermalScattering;
 
 namespace data {
-extern std::vector<std::unique_ptr<ThermalScattering>> thermal_scatt;
 extern std::unordered_map<std::string, int> thermal_scatt_map;
+extern std::vector<std::unique_ptr<ThermalScattering>> thermal_scatt;
 }
 
 //==============================================================================

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -32,11 +32,11 @@ namespace openmc {
 //==============================================================================
 
 namespace model {
-  std::vector<std::unique_ptr<Cell>> cells;
   std::unordered_map<int32_t, int32_t> cell_map;
+  std::vector<std::unique_ptr<Cell>> cells;
 
-  std::vector<std::unique_ptr<Universe>> universes;
   std::unordered_map<int32_t, int32_t> universe_map;
+  std::vector<std::unique_ptr<Universe>> universes;
 } // namespace model
 
 //==============================================================================

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -34,8 +34,8 @@ namespace openmc {
 
 namespace data {
 
-std::vector<Library> libraries;
 std::map<LibraryKey, std::size_t> library_map;
+std::vector<Library> libraries;
 
 }
 

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -22,8 +22,8 @@ namespace openmc {
 //==============================================================================
 
 namespace model {
-  std::vector<std::unique_ptr<Lattice>> lattices;
   std::unordered_map<int32_t, int32_t> lattice_map;
+  std::vector<std::unique_ptr<Lattice>> lattices;
 }
 
 //==============================================================================

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -35,8 +35,8 @@ namespace openmc {
 
 namespace model {
 
-std::vector<std::unique_ptr<Mesh>> meshes;
 std::unordered_map<int32_t, int32_t> mesh_map;
+std::vector<std::unique_ptr<Mesh>> meshes;
 
 } // namespace model
 

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -32,8 +32,8 @@ std::array<double, 2> energy_min {0.0, 0.0};
 std::array<double, 2> energy_max {INFTY, INFTY};
 double temperature_min {0.0};
 double temperature_max {INFTY};
-std::vector<std::unique_ptr<Nuclide>> nuclides;
 std::unordered_map<std::string, int> nuclide_map;
+std::vector<std::unique_ptr<Nuclide>> nuclides;
 } // namespace data
 
 //==============================================================================

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -80,8 +80,8 @@ void PropertyData::set_overlap(size_t y, size_t x) {
 
 namespace model {
 
-std::vector<Plot> plots;
 std::unordered_map<int, int> plot_map;
+std::vector<Plot> plots;
 uint64_t plotter_seed = 1;
 
 } // namespace model

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -23,8 +23,8 @@ namespace openmc {
 //==============================================================================
 
 namespace model {
-  std::vector<std::unique_ptr<Surface>> surfaces;
   std::unordered_map<int, int> surface_map;
+  std::vector<std::unique_ptr<Surface>> surfaces;
 } // namespace model
 
 //==============================================================================

--- a/src/tallies/derivative.cpp
+++ b/src/tallies/derivative.cpp
@@ -18,8 +18,8 @@ namespace openmc {
 //==============================================================================
 
 namespace model {
-  std::vector<TallyDerivative> tally_derivs;
   std::unordered_map<int, int> tally_deriv_map;
+  std::vector<TallyDerivative> tally_derivs;
 }
 
 //==============================================================================

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -27,8 +27,8 @@ namespace openmc {
 //==============================================================================
 
 namespace data {
-std::vector<std::unique_ptr<ThermalScattering>> thermal_scatt;
 std::unordered_map<std::string, int> thermal_scatt_map;
+std::vector<std::unique_ptr<ThermalScattering>> thermal_scatt;
 }
 
 //==============================================================================


### PR DESCRIPTION
If the destructor of an object (that's part of a vector) tries to remove an entry from its corresponding map, the map may not exist anymore if it was declared after the vector of objects, resulting in a segfault. By declaring the map first, we avoid this. Currently this is an issue for Nuclide, so most importantly the PR fixes that case, but it also reorders other ones that may potentially become an issue in the future.

If you want to see this segfault in action, just go to a directory with an OpenMC model and run `python -c 'import openmc.lib; openmc.lib.init()'`.
