### PR TITLE
 Sample source sites with shared memory parallelism

### DIFF
--- a/src/source.cpp
+++ b/src/source.cpp
@@ -292,6 +292,7 @@ void initialize_source()
 
   } else {
     // Generation source sites from specified distribution in user input
+    #pragma omp parallel for
     for (int64_t i = 0; i < simulation::work_per_rank; ++i) {
       // initialize random number seed
       int64_t id = simulation::total_gen*settings::n_particles +


### PR DESCRIPTION
Hi OpenMC devs. I'm wrapping up my PhD work now (yay!), and it's time for me to merge over a few related odds and ends. I'm starting off with this really simple PR related to source site sampling. It turns out that we have previously not been sampling our non-fission source sites with OpenMP parallelism. Happily, this is a straightforward single-line fix.