### PR TITLE
Fix #1634

### DIFF
--- a/examples/jupyter/post-processing.ipynb
+++ b/examples/jupyter/post-processing.ipynb
@@ -911,7 +911,7 @@
     "print(sum(probability*np.diff(energy_bins)))\n",
     "\n",
     "# Plot source energy PDF\n",
-    "plt.semilogx(energy_bins[:-1], probability*np.diff(energy_bins), linestyle='steps')\n",
+    "plt.semilogx(energy_bins[:-1], probability*np.diff(energy_bins), drawstyle='steps')\n",
     "plt.xlabel('Energy (eV)')\n",
     "plt.ylabel('Probability/eV')"
    ]


### PR DESCRIPTION
Post Processing tutorial: changed `linestyle='steps'` to `drawstyle='steps'` to get rid of error message (for source energy pdf plot).