### PR TITLE
Avoid transport solve for decay-only timesteps

### DIFF
--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -276,6 +276,16 @@ class Operator(TransportOperator):
             Eigenvalue and reaction rates resulting from transport operator
 
         """
+        # Reset results in OpenMC
+        openmc.lib.reset()
+
+        # If the source rate is zero, return zero reaction rates without running
+        # a transport solve
+        if power == 0.0:
+            rates = self.reaction_rates.copy()
+            rates.fill(0.0)
+            return OperatorResult(ufloat(0.0, 0.0), rates)
+
         # Prevent OpenMC from complaining about re-creating tallies
         openmc.reset_auto_ids()
 
@@ -290,7 +300,6 @@ class Operator(TransportOperator):
         self._yield_helper.update_tally_nuclides(nuclides)
 
         # Run OpenMC
-        openmc.lib.reset()
         openmc.lib.run()
         openmc.lib.reset_timers()
 


### PR DESCRIPTION
This PR ensures that when a timestep during depletion has a power of zero (or a source rate of zero once #1628 is merged), no transport calculation is run. Instead, a reaction rates array with all zeros is created an returned to the integrator. I've also added an argument in `Integrator.integrate()` for skipping the very last transport calculation (at the end of the last timestep, which is not strictly necessary). This is useful for activation calculations where you just want to irradiation a material for a certain length of time and obtain activated material composition (and don't care how the reaction rates change at the end of the irradiation period).

Closes #1620