### PR TITLE
Small fix for depletion chain generation

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -147,9 +147,9 @@ def replace_missing(product, decay_data):
     Z, A, state = openmc.data.zam(product)
     symbol = openmc.data.ATOMIC_SYMBOL[Z]
 
-    # Replace neutron with proton
-    if Z == 0 and A == 1:
-        return 'H1'
+    # Replace neutron with nothing
+    if Z == 0:
+        return None
 
     # First check if ground state is available
     if state:


### PR DESCRIPTION
Our depletion chain generation relies on a function called `replace_missing` that is used to replace missing decay and reaction products based on a set of heuristics. There is a special case in there right now for neutrons, which are replaced with H1. I believe we originally made this choice because a free neutron will eventually decay to a proton. However, with a half life of 10 min, it is _very_ unlikely that decay would happen locally where the neutron was produced. On further reflection, it makes more sense to just have no product if the product is a neutron.

I actually ran into trouble with the existing line in the following situation. I was producing a depletion chain for ENDF/B-VII.1 with all transmutation reactions. When it got to the reaction <sup>10</sup>B(n,t2a), it ended up failing in `replace_missing` because the reaction product was found to have Z=0 and A=0. This makes sense once you write out the reaction:

<sup>10</sup>B + n → t + 2a + ___

or 

(Z=5,A=10) + (Z=0,A=1) → (Z=1,A=3) + (Z=2,A=4) + (Z=2,A=4) + ___

It turns out there is no missing product on the right side. It would have made more sense for the evaluators to include <sup>10</sup>B(n,ta)<sup>4</sup>He, but this would require MT=155, which didn't exist in the ENDF-6 format until quite recently. Anyway, our special case handled Z=0 and A=1, but not Z=0 and A=0. Rather than add a new special case, just checking for Z=0 and returning `None` should cover these odd corner cases.