### PR TITLE
DAGMC Surface Reflection update

### DIFF
--- a/include/openmc/position.h
+++ b/include/openmc/position.h
@@ -63,12 +63,10 @@ struct Position {
     return std::sqrt(x*x + y*y + z*z);
   }
 
-  inline Position reflect(Position n) {
-    const double projection = n.dot(*this);
-    const double magnitude = n.dot(n);
-    n *= (2.0 * projection / magnitude);
-    return *this - n;
-  }
+  //! Reflect a direction across a normal vector
+  //! \param[in] other Vector to reflect across
+  //! \result Reflected vector
+  Position reflect(Position n) const;
 
   //! Rotate the position based on a rotation matrix
   Position rotate(const std::vector<double>& rotation) const;
@@ -95,6 +93,13 @@ inline Position operator*(double a, Position b)   { return b *= a; }
 inline Position operator/(Position a, Position b) { return a /= b; }
 inline Position operator/(Position a, double b)   { return a /= b; }
 inline Position operator/(double a, Position b)   { return b /= a; }
+
+inline Position Position::reflect(Position n) const {
+  const double projection = n.dot(*this);
+  const double magnitude = n.dot(n);
+  n *= (2.0 * projection / magnitude);
+  return *this - n;
+}
 
 inline bool operator==(Position a, Position b)
 {return a.x == b.x && a.y == b.y && a.z == b.z;}

--- a/include/openmc/position.h
+++ b/include/openmc/position.h
@@ -67,7 +67,7 @@ struct Position {
     const double projection = n.dot(*this);
     const double magnitude = n.dot(n);
     n *= (2.0 * projection / magnitude);
-    return *this -= n;
+    return *this - n;
   }
 
   //! Rotate the position based on a rotation matrix

--- a/include/openmc/position.h
+++ b/include/openmc/position.h
@@ -66,7 +66,6 @@ struct Position {
   inline Position reflect(Position n) {
     const double projection = n.dot(*this);
     const double magnitude = n.dot(n);
-
     n *= (2.0 * projection / magnitude);
     return *this -= n;
   }

--- a/include/openmc/position.h
+++ b/include/openmc/position.h
@@ -63,6 +63,14 @@ struct Position {
     return std::sqrt(x*x + y*y + z*z);
   }
 
+  inline Position reflect(Position n) {
+    const double projection = n.dot(*this);
+    const double magnitude = n.dot(n);
+
+    n *= (2.0 * projection / magnitude);
+    return *this -= n;
+  }
+
   //! Rotate the position based on a rotation matrix
   Position rotate(const std::vector<double>& rotation) const;
 

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -779,7 +779,7 @@ CSGCell::contains_complex(Position r, Direction u, int32_t on_surface) const
 // DAGMC Cell implementation
 //==============================================================================
 #ifdef DAGMC
-DAGCell::DAGCell() : Cell{} {};
+DAGCell::DAGCell() : Cell{} { simple_ = true; };
 
 std::pair<double, int32_t>
 DAGCell::distance(Position r, Direction u, int32_t on_surface, Particle* p) const

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -196,7 +196,6 @@ void load_dagmc_geometry()
     // set cell ids using global IDs
     DAGCell* c = new DAGCell();
     c->dag_index_ = i+1;
-    c->simple_ = true;
     c->id_ = model::DAG->id_by_index(3, c->dag_index_);
     c->dagmc_ptr_ = model::DAG;
     c->universe_ = dagmc_univ_id; // set to zero for now

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -196,6 +196,7 @@ void load_dagmc_geometry()
     // set cell ids using global IDs
     DAGCell* c = new DAGCell();
     c->dag_index_ = i+1;
+    c->simple_ = true;
     c->id_ = model::DAG->id_by_index(3, c->dag_index_);
     c->dagmc_ptr_ = model::DAG;
     c->universe_ = dagmc_univ_id; // set to zero for now

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -172,11 +172,9 @@ Surface::reflect(Position r, Direction u, Particle* p) const
   // Determine projection of direction onto normal and squared magnitude of
   // normal.
   Direction n = normal(r);
-  const double projection = n.dot(u);
-  const double magnitude = n.dot(n);
 
   // Reflect direction according to normal.
-  return u -= (2.0 * projection / magnitude) * n;
+  return u.reflect(n);
 }
 
 Direction
@@ -279,7 +277,13 @@ Direction DAGSurface::reflect(Position r, Direction u, Particle* p) const
 {
   Expects(p);
   p->history_.reset_to_last_intersection();
-  p->last_dir_ = Surface::reflect(r, u, p);
+  moab::ErrorCode rval;
+  moab::EntityHandle surf = dagmc_ptr_->entity_by_index(2, dag_index_);
+  double pnt[3] = {r.x, r.y, r.z};
+  double dir[3];
+  rval = dagmc_ptr_->get_angle(surf, pnt, dir, &p->history_);
+  MB_CHK_ERR_CONT(rval);
+  p->last_dir_ = u.reflect(dir);
   return p->last_dir_;
 }
 


### PR DESCRIPTION
A few minor updates here related to surface reflections. The `RayHistory` object attached to the particle can be used to quickly determine a surface normal, but it wasn't being passed to the `DagMC::get_angle` call. The `DAGSurface::reflect` method has been updated to do so here.

It also ensures all `DAGCell` instances are marked as simple cells to avoid the additional calls to the surface normal here:

https://github.com/openmc-dev/openmc/blob/b4827e9ad295b89bda7364bcddefbaedb5864159/src/geometry.cpp#L411-L422