### PR TITLE
Fix call to superclass constructor in MeshPlotter

### DIFF
--- a/scripts/openmc-plot-mesh-tally
+++ b/scripts/openmc-plot-mesh-tally
@@ -26,7 +26,7 @@ _COMBOBOX_SELECTED = '<<ComboboxSelected>>'
 
 class MeshPlotter(tk.Frame):
     def __init__(self, parent, filename):
-        super().__init__(self, parent)
+        super().__init__(parent)
 
         self.labels = {
             'Cell': 'Cell:',


### PR DESCRIPTION
This fixes an incorrect usage of `super()` when `MeshPlotter`'s constructor calls its superclass constructor.

The incorrect usage was:
```
class MeshPlotter(tk.Frame):
    def __init__(self, parent, filename):
        super().__init__(self, parent)
```

But since `super()` returns an instance (not a class itself), `super().__init__` is a bound method and should not be passed the instance `self`.  