### PR TITLE
Fix for data crossover in VTK filess when using multiple tallies w/ unstructured mesh.

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -298,6 +298,9 @@ public:
   //! Add a score to the mesh instance
   void add_score(std::string score) const;
 
+  //! Remove a score from the mesh instance
+  void remove_score(std::string score) const;
+
   //! Set data for a score
   void set_score_data(const std::string& score,
                       std::vector<double> values,

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2015,6 +2015,30 @@ UnstructuredMesh::add_score(std::string score) const {
   auto score_tags = this->get_score_tags(score);
 }
 
+void UnstructuredMesh::remove_score(std::string score) const {
+  moab::ErrorCode rval;
+  moab::Tag tag;
+  auto value_name = score + "_mean";
+  rval = mbi_->tag_get_handle(value_name.c_str(), tag);
+  if (rval != moab::MB_SUCCESS) return;
+
+  rval = mbi_->tag_delete(tag);
+  if (rval != moab::MB_SUCCESS) {
+    auto msg = fmt::format("Failed to delete mesh tag for the score {}"
+                           " on unstructured mesh {}", score, id_);
+    fatal_error(msg);
+  }
+
+  auto std_dev_name = score + "_std_dev";
+  rval = mbi_->tag_get_handle(std_dev_name.c_str(), tag);
+  if (rval != moab::MB_SUCCESS) {
+    auto msg = fmt::format("Std. Dev. mesh tag does not exist for the score {}"
+                           " on unstructured mesh {}", score, id_);
+  }
+
+
+}
+
 void
 UnstructuredMesh::set_score_data(const std::string& score,
                                  std::vector<double> values,

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2036,7 +2036,12 @@ void UnstructuredMesh::remove_score(std::string score) const {
                            " on unstructured mesh {}", score, id_);
   }
 
-
+  rval = mbi_->tag_delete(tag);
+  if (rval != moab::MB_SUCCESS) {
+    auto msg = fmt::format("Failed to delete mesh tag for the score {}"
+                           " on unstructured mesh {}", score, id_);
+    fatal_error(msg);
+  }
 }
 
 void

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2016,10 +2016,9 @@ UnstructuredMesh::add_score(std::string score) const {
 }
 
 void UnstructuredMesh::remove_score(std::string score) const {
-  moab::ErrorCode rval;
-  moab::Tag tag;
   auto value_name = score + "_mean";
-  rval = mbi_->tag_get_handle(value_name.c_str(), tag);
+  moab::Tag tag;
+  moab::ErrorCode rval = mbi_->tag_get_handle(value_name.c_str(), tag);
   if (rval != moab::MB_SUCCESS) return;
 
   rval = mbi_->tag_delete(tag);

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -743,6 +743,7 @@ void write_unstructured_mesh_results() {
 
           std::string score_name = tally->score_name(i_score);
           auto score_str = fmt::format("{}_{}", score_name, nuclide_name);
+          tally_scores.push_back(score_str);
           umesh->set_score_data(score_str, mean_vec, std_dev_vec);
         }
       }

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -687,6 +687,8 @@ void read_source_bank(hid_t group_id)
 void write_unstructured_mesh_results() {
 
   for (auto& tally : model::tallies) {
+
+    std::vector<std::string> tally_scores;
     for (auto filter_idx : tally->filters()) {
       auto& filter = model::tally_filters[filter_idx];
       if (filter->type() != "mesh") continue;
@@ -754,6 +756,8 @@ void write_unstructured_mesh_results() {
                                          w);
       // Write the unstructured mesh and data to file
       umesh->write(filename);
+
+      for (const auto& score : tally_scores) { umesh->remove_score(score); }
     }
   }
 }


### PR DESCRIPTION
A user noted that unstructured mesh tally data from one tally was being written in the VTK file of another tally. 

This PR adds the `UnstructuredMesh::remove_score` method and applies it in `write_unstructured_mesh_results` to clear out data between tallies when writing VTK files.