### PR TITLE
Fixing existing typos and errors in MGXS routines

### DIFF
--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -412,7 +412,7 @@ class Library:
             if self.correction == 'P0' and legendre_order > 0:
                 msg = 'The P0 correction will be ignored since the ' \
                       'scattering order {} is greater than '\
-                      'zero'.format(self.legendre_order)
+                      'zero'.format(legendre_order)
                 warn(msg, RuntimeWarning)
                 self.correction = None
         elif self.scatter_format == 'histogram':

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -1402,12 +1402,12 @@ class Library:
                 if self.domain_type == 'material':
                     # Fill all appropriate Cells with new Material
                     for cell in all_cells:
-                        if cell.fill.id == domain.id:
+                        if isinstance(cell.fill, openmc.Material) and cell.fill.id == domain.id:
                             cell.fill = material
 
                 elif self.domain_type == 'cell':
                     for cell in all_cells:
-                        if cell.id == domain.id:
+                        if isinstance(cell.fill, openmc.Material) and cell.id == domain.id:
                             cell.fill = material
 
         return mgxs_file, materials, geometry

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -1407,7 +1407,11 @@ class Library:
 
                 elif self.domain_type == 'cell':
                     for cell in all_cells:
-                        if isinstance(cell.fill, openmc.Material) and cell.id == domain.id:
+                        if not isinstance(cell.fill, openmc.Material):
+                            warn('If the library domain includes a lattice or universe cell '
+                            'in conjunction with a consituent cell of that lattice/universe, '
+                            'the multi-group simulation will fail') 
+                        if cell.id == domain.id:
                             cell.fill = material
 
         return mgxs_file, materials, geometry

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -1090,7 +1090,7 @@ class Library:
                                                subdomain=subdomain)
 
         if 'beta' in self.mgxs_types:
-            mymgxs = self.get_mgxs(domain, 'nu-fission')
+            mymgxs = self.get_mgxs(domain, 'beta')
             xsdata.set_beta_mgxs(mymgxs, xs_type=xs_type, nuclide=[nuclide],
                                  subdomain=subdomain)
 

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -4160,7 +4160,7 @@ class ScatterMatrixXS(MatrixMGXS):
             if self.correction == 'P0' and legendre_order > 0:
                 msg = 'The P0 correction will be ignored since the ' \
                       'scattering order {} is greater than '\
-                      'zero'.format(self.legendre_order)
+                      'zero'.format(legendre_order)
                 warnings.warn(msg, RuntimeWarning)
                 self.correction = None
         elif self.scatter_format == SCATTER_HISTOGRAM:

--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -350,6 +350,18 @@ class XSdata:
         return self._chi_delayed
 
     @property
+    def beta(self):
+        return self._beta
+
+    @property
+    def decay_rate(self):
+        return self._decay_rate
+
+    @property
+    def inverse_velocity(self):
+        return self._inverse_velocity
+
+    @property
     def num_orders(self):
         if self._order is None:
             raise ValueError('Order has not been set.')


### PR DESCRIPTION
Over the course of my summer internship, I used a lot of new-to-me mgxs routines and identified several errors in the existing code. 
1) create_mg_mode didn't account for cells filled with a lattice instead of a material
2) get_xsdata referenced 'beta' but then pointed to 'nu-fission' - obviously a typo. Once fixed, worked just like the others. This routine is tested whenever create_mg_library is called, but not with delayed mgxs_types. 
3) XSdata class had beta, decay_rate, inverse_velocity listed in attributes, but missing from property definitions. I'm sure this class is tested somewhere, but obviously not covering those three attributes. 
4) Warning message for setting Legendre order greater than 0 was erroneous. 