### PR TITLE
One more MGXS fix

### DIFF
--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -1094,6 +1094,11 @@ class Library:
             xsdata.set_beta_mgxs(mymgxs, xs_type=xs_type, nuclide=[nuclide],
                                  subdomain=subdomain)
 
+        if 'decay-rate' in self.mgxs_types:
+            mymgxs = self.get_mgxs(domain, 'decay-rate')
+            xsdata.set_decay_rate_mgxs(mymgxs, xs_types=xs_type, nuclide=[nuclide],
+                                subdomain=subdomain)
+
         # If multiplicity matrix is available, prefer that
         if 'multiplicity matrix' in self.mgxs_types:
             mymgxs = self.get_mgxs(domain, 'multiplicity matrix')

--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -2044,7 +2044,7 @@ class XSdata:
                     xs_grp.create_dataset("beta", data=self._beta[i])
 
                 if self._decay_rate[i] is not None:
-                    xs_grp.create_dataset("decay rate",
+                    xs_grp.create_dataset("decay-rate",
                                           data=self._decay_rate[i])
 
             if self._scatter_matrix[i] is None:
@@ -2210,7 +2210,7 @@ class XSdata:
             xs_types = ['total', 'absorption', 'fission', 'kappa-fission',
                         'chi', 'chi-prompt', 'chi-delayed', 'nu-fission',
                         'prompt-nu-fission', 'delayed-nu-fission', 'beta',
-                        'decay rate', 'inverse-velocity']
+                        'decay-rate', 'inverse-velocity']
 
             temperature_group = group[temp]
 

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -16,7 +16,7 @@ PLOT_TYPES = ['total', 'scatter', 'elastic', 'inelastic', 'fission',
 PLOT_TYPES_MGXS = ['total', 'absorption', 'scatter', 'fission',
                    'kappa-fission', 'nu-fission', 'prompt-nu-fission',
                    'deleyed-nu-fission', 'chi', 'chi-prompt', 'chi-delayed',
-                   'inverse-velocity', 'beta', 'decay rate', 'unity']
+                   'inverse-velocity', 'beta', 'decay-rate', 'unity']
 # Create a dictionary which can be used to convert PLOT_TYPES_MGXS to the
 # openmc.XSdata attribute name needed to access the data
 _PLOT_MGXS_ATTR = {line: line.replace(' ', '_').replace('-', '_')

--- a/src/xsdata.cpp
+++ b/src/xsdata.cpp
@@ -93,7 +93,7 @@ XsData::from_hdf5(hid_t xsdata_grp, bool fissionable, AngleDistributionType scat
     fission_from_hdf5(xsdata_grp, n_ang, is_isotropic);
   }
   // Get the non-fission-specific data
-  read_nd_vector(xsdata_grp, "decay rate", decay_rate);
+  read_nd_vector(xsdata_grp, "decay-rate", decay_rate);
   read_nd_vector(xsdata_grp, "absorption", absorption, true);
   read_nd_vector(xsdata_grp, "inverse-velocity", inverse_velocity);
 


### PR DESCRIPTION
I added decay-rate to get_xsdata since it was missing and cleaned up its name to avoid a major error. 

I would also like to update the mg-mode-part-ii example notebook, but I'm having trouble. Since I'm working on a remote machine, it's difficult for me to edit notebooks without a browser. I'd like to:

Replace lines from
(comment) Create a MGXS File which can then be written to disk
To 
Materials_file.export_to_xml()
With:
mgxs_file, new_materials_file, new_geometry_file = mgxs_lib.create_mg_mode()
mgxs_file.export_to_hdf5()
new_materials_file.export_to_xml()
new_geometry_file.export_to_xml()

*also use r instead of R in ZCylinder definition

