### PR TITLE
Particle restart logs

### DIFF
--- a/docs/source/usersguide/troubleshoot.rst
+++ b/docs/source/usersguide/troubleshoot.rst
@@ -98,8 +98,8 @@ has a collision. For example, if you received this error at cycle 5, generation
     <trace>5 1 4032</trace>
 
 For large runs it is often advantageous to run only the offending particle by
-using particle restart mode with the ``-s``, ``-particle``, or ``--particle``
-command-line options in conjunction with the particle restart files that are
-created when particles are lost with this error.
+using particle restart mode with the ``-r`` command-line options in conjunction
+with the particle restart files that are created when particles are lost with
+this error.
 
 .. _mailing list: https://groups.google.com/forum/?fromgroups=#!forum/openmc-users

--- a/docs/source/usersguide/troubleshoot.rst
+++ b/docs/source/usersguide/troubleshoot.rst
@@ -98,7 +98,7 @@ has a collision. For example, if you received this error at cycle 5, generation
     <trace>5 1 4032</trace>
 
 For large runs it is often advantageous to run only the offending particle by
-using particle restart mode with the ``-r`` command-line options in conjunction
+using particle restart mode with the ``-r`` command-line option in conjunction
 with the particle restart files that are created when particles are lost with
 this error.
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -410,7 +410,7 @@ Particle::cross_surface()
   // TODO: off-by-one
   const auto& surf {model::surfaces[i_surface - 1].get()};
   if (settings::verbosity >= 10 || trace_) {
-    write_message("    Crossing surface {}", surf->id_);
+    write_message(1, "    Crossing surface {}", surf->id_);
   }
 
   if (surf->bc_ == Surface::BoundaryType::VACUUM && (settings::run_mode != RunMode::PLOTTING)) {
@@ -437,7 +437,7 @@ Particle::cross_surface()
 
     // Display message
     if (settings::verbosity >= 10 || trace_) {
-      write_message("    Leaked out of surface {}", surf->id_);
+      write_message(1, "    Leaked out of surface {}", surf->id_);
     }
     return;
 
@@ -502,7 +502,7 @@ Particle::cross_surface()
 
     // Diagnostic message
     if (settings::verbosity >= 10 || trace_) {
-      write_message("    Reflected from surface {}", surf->id_);
+      write_message(1, "    Reflected from surface {}", surf->id_);
     }
     return;
 
@@ -556,7 +556,7 @@ Particle::cross_surface()
 
     // Diagnostic message
     if (settings::verbosity >= 10 || trace_) {
-      write_message("    Hit periodic boundary on surface {}", surf->id_);
+      write_message(1, "    Hit periodic boundary on surface {}", surf->id_);
     }
     return;
   }


### PR DESCRIPTION
I came across an interesting bug while looking at particles vanishing from a PB-FHR geometry. 

The write_message routine is called in particle.cpp as : write_message("some string with {}", surface_id).

The intent of this is to have surface_id be recognized as a parameter of the string, and the templated write_message() routine can handle it throught a call to fmt::format
Unfortunately, the routine that ends up being called is write_message("some_string", log_level), so surface_id is not shown on screen.

I can't see an easy fix on the error.cpp side. Excluding "int" as a valid parameter in the template takes a bit of code and will be a bit confusing since it's the most common use case for this template. On the other hand, being able to write_message without specifying a level is also very convenient, so we do want `int level=0` as an optional second parameter. 
Having the templated write_message have a different name also slightly defeats the purpose.

I fixed the symptoms by adding the level to the problematic write_message logs. 
Note: An alternative "symptoms" fix is to make surface id be a int64_t, just like particle ids. 