### PR TITLE
Fix plotting of individual universe levels.

### DIFF
--- a/include/openmc/geometry.h
+++ b/include/openmc/geometry.h
@@ -18,7 +18,7 @@ namespace openmc {
 namespace model {
 
 extern int root_universe;  //!< Index of root universe
-extern int n_coord_levels; //!< Number of CSG coordinate levels
+extern "C" int n_coord_levels; //!< Number of CSG coordinate levels
 
 extern std::vector<int64_t> overlap_check_count;
 

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -184,7 +184,7 @@ T PlotBase::get_map() const {
         // local variables
         bool found_cell = find_cell(p, 0);
         j = p.n_coord_ - 1;
-        if (level >= 0) {j = level;}
+        if (level >= 0) {j = level + 1;}
         if (found_cell) {
           data.set_value(y, x, p, j);
         }

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -184,7 +184,7 @@ T PlotBase::get_map() const {
         // local variables
         bool found_cell = find_cell(p, 0);
         j = p.n_coord_ - 1;
-        if (level >=0) {j = level + 1;}
+        if (level >= 0) {j = level;}
         if (found_cell) {
           data.set_value(y, x, p, j);
         }

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -184,7 +184,7 @@ T PlotBase::get_map() const {
         // local variables
         bool found_cell = find_cell(p, 0);
         j = p.n_coord_ - 1;
-        if (level >= 0) {j = level + 1;}
+        if (level >= 0) { j = level; }
         if (found_cell) {
           data.set_value(y, x, p, j);
         }

--- a/openmc/lib/__init__.py
+++ b/openmc/lib/__init__.py
@@ -12,7 +12,7 @@ functions or objects in :mod:`openmc.lib`, for example:
 
 """
 
-from ctypes import CDLL, c_bool
+from ctypes import CDLL, c_bool, c_int
 import os
 import sys
 
@@ -41,6 +41,9 @@ else:
 
 def _dagmc_enabled():
     return c_bool.in_dll(_dll, "dagmc_enabled").value
+
+def _coord_levels():
+    return c_int.in_dll(_dll, "n_coord_levels").value
 
 from .error import *
 from .core import *

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -42,7 +42,7 @@ IdData::IdData(size_t h_res, size_t v_res)
 void
 IdData::set_value(size_t y, size_t x, const Particle& p, int level) {
   // set cell data
-  if (p.n_coord_ < level) {
+  if (p.n_coord_ <= level) {
     data_(y, x, 0) = NOT_FOUND;
   } else {
     data_(y, x, 0) = model::cells.at(p.coord_.at(level).cell)->id_;

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -45,16 +45,16 @@ IdData::set_value(size_t y, size_t x, const Particle& p, int level) {
   if (p.n_coord_ < level) {
     data_(y, x, 0) = NOT_FOUND;
   } else {
-    data_(y, x, 0) = model::cells[p.coord_[level].cell]->id_;
+    data_(y, x, 0) = model::cells.at(p.coord_.at(level).cell)->id_;
   }
 
   // set material data
-  Cell* c = model::cells[p.coord_[p.n_coord_ - 1].cell].get();
+  Cell* c = model::cells.at(p.coord_.at(p.n_coord_ - 1).cell).get();
   if (p.material_ == MATERIAL_VOID) {
     data_(y, x, 1) = MATERIAL_VOID;
     return;
   } else if (c->type_ == Fill::MATERIAL) {
-    Material* m = model::materials[p.material_].get();
+    Material* m = model::materials.at(p.material_).get();
     data_(y, x, 1) = m->id_;
   }
 }
@@ -69,10 +69,10 @@ PropertyData::PropertyData(size_t h_res, size_t v_res)
 
 void
 PropertyData::set_value(size_t y, size_t x, const Particle& p, int level) {
-  Cell* c = model::cells[p.coord_[p.n_coord_ - 1].cell].get();
+  Cell* c = model::cells.at(p.coord_.at(p.n_coord_ - 1).cell).get();
   data_(y,x,0) = (p.sqrtkT_ * p.sqrtkT_) / K_BOLTZMANN;
   if (c->type_ != Fill::UNIVERSE && p.material_ != MATERIAL_VOID) {
-    Material* m = model::materials[p.material_].get();
+    Material* m = model::materials.at(p.material_).get();
     data_(y,x,1) = m->density_gpcc_;
   }
 }

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -87,8 +87,8 @@ void PropertyData::set_overlap(size_t y, size_t x) {
 
 namespace model {
 
-std::vector<Plot> plots;
 std::unordered_map<int, int> plot_map;
+std::vector<Plot> plots;
 uint64_t plotter_seed = 1;
 
 } // namespace model
@@ -101,8 +101,7 @@ extern "C"
 int openmc_plot_geometry()
 {
   for (auto pl : model::plots) {
-    write_message(fmt::format("Processing plot {}: {}...",
-      pl.id_, pl.path_plot_), 5);
+    write_message(5, "Processing plot {}: {}...", pl.id_, pl.path_plot_);
 
     if (PlotType::slice == pl.type_) {
       // create 2D image

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -42,7 +42,7 @@ IdData::IdData(size_t h_res, size_t v_res)
 void
 IdData::set_value(size_t y, size_t x, const Particle& p, int level) {
   // set cell data
-  if (p.n_coord_ <= level) {
+  if (p.n_coord_ < level) {
     data_(y, x, 0) = NOT_FOUND;
   } else {
     data_(y, x, 0) = model::cells[p.coord_[level].cell]->id_;

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -121,7 +121,7 @@ void read_plots_xml()
   // Check if plots.xml exists
   std::string filename = settings::path_input + "plots.xml";
   if (!file_exists(filename)) {
-    fatal_error("Plots XML file '" + filename + "' does not exist!");
+    fatal_error(fmt::format("Plots XML file '{}' does not exist!", filename));
   }
 
   write_message("Reading plot XML file...", 5);


### PR DESCRIPTION
Attempting to plot a specific universe level is risky right now after the changes in #1201. If the universe level is higher than the number of coordinates for the particle at a given pixel location in the image, it's possible that an invalid access in the particle coordinates can occur, resulting in a segfault. The relevant chunk of code is here:

https://github.com/openmc-dev/openmc/blob/828e0aa7dfc2e9774d8ff7532e5269723e3b6e55/src/plot.cpp#L63-L71

This PR corrects that by setting any pixel color to `NOT_FOUND` when the coordinate level of the particle is lower than the requested universe level. For density and temperature plots, the particle's coordinate level is always used.

This also exposes the `model::n_coord_level` variable in the CAPI and the `openmc.lib` module to allow our [plotting application](https://github.com/openmc-dev/plotter) to correctly populate the number of available universe levels.