### PR TITLE
Implementation of WMP library generation from ENDF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,8 @@ matrix:
     - python: "3.8"
       env: OMP=y MPI=n PHDF5=n
     - python: "3.8"
-      env: OMP=n MPI=y PHDF5=n
-    - python: "3.8"
       env: OMP=n MPI=y PHDF5=n VECTFIT=y
-    - python: "3.7"
+    - python: "3.8"
       env: OMP=n MPI=y PHDF5=y
     - python: "3.8"
       env: OMP=y MPI=y PHDF5=y DAGMC=y

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ matrix:
     - python: "3.8"
       env: OMP=n MPI=y PHDF5=n
     - python: "3.8"
+      env: OMP=n MPI=y PHDF5=n VECTFIT=y
+    - python: "3.7"
       env: OMP=n MPI=y PHDF5=y
     - python: "3.8"
       env: OMP=y MPI=y PHDF5=y DAGMC=y

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -175,7 +175,7 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
 
     """
 
-    # import vectfit package: https://github.com/mit-crpg/vectfit
+    # import vectfit package: https://github.com/liangjg/vectfit
     import vectfit as vf
 
     ne = energy.size
@@ -568,7 +568,7 @@ def _windowing(mp_data, rtol=1e-3, atol=1e-5, n_win=None, n_cf=None,
 
     """
 
-    # import vectfit package: https://github.com/mit-crpg/vectfit
+    # import vectfit package: https://github.com/liangjg/vectfit
     import vectfit as vf
 
     # unpack multipole data

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -448,23 +448,19 @@ def _vectfit_nuclide(endf_file, njoy_error=5e-4, vf_error=1e-3, vf_pieces=None,
     E_min, E_max = energy[0], energy[-1]
     n_points = energy.size
     total_xs = nuc_ce[1].xs['0K'](energy)
-    if 2 in nuc_ce:
+    try:
         elastic_xs = nuc_ce[2].xs['0K'](energy)
-    else:
+    except:
         elastic_xs = np.zeros_like(total_xs)
-    if 27 in nuc_ce:
+    try:
         absorption_xs = nuc_ce[27].xs['0K'](energy)
-    else:
-        if 101 in nuc_ce:
-            absorption_xs = nuc_ce[101].xs['0K'](energy)
-            if 18 in nuc_ce:
-                absorption_xs += nuc_ce[18].xs['0K'](energy)
-        else:
-            absorption_xs = np.zeros_like(total_xs)
+    except:
+        absorption_xs = np.zeros_like(total_xs)
     fissionable = False
-    if 18 in nuc_ce:
+    try:
         fission_xs = nuc_ce[18].xs['0K'](energy)
         fissionable = True
+    except:pass
 
     # make vectors
     if fissionable:

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -203,7 +203,7 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
     test_s = np.sqrt(test_energy)
     weight = 1.0/f
 
-    # very small cross sections can lead to huge weights, which will harm the 
+    # very small cross sections can lead to huge weights, which will harm the
     # fitting accuracy
     MIN_CROSS_SECTION = 1e-7
     for i in range(nmt):
@@ -631,7 +631,7 @@ def _windowing(mp_data, rtol=1e-3, atol=1e-5, n_win=None, n_cf=None,
         inbegin = sqrt(E_min) + spacing * iw
         inend = inbegin + spacing
         incenter = (inbegin + inend) / 2.0
-        # extend window energy range for Doppler broadening 
+        # extend window energy range for Doppler broadening
         if iw == 0 or sqrt(alpha)*inbegin < 4.0:
             e_start = inbegin**2
         else:
@@ -1024,7 +1024,7 @@ class WindowedMultipole(EqualityMixin):
             Dictionary of keyword arguments, e.g. {'rtol':0.001, 'log':True},
             passed to :func:`openmc.data.multipole._vectfit_nuclide`
         wmp_options : dict
-            Dictionary of keyword arguments, e.g. {'search': True, 'log': True},
+            Dictionary of keyword arguments, e.g. {'search':True, 'log': True},
             passed to :func:`openmc.data.WindowedMultipole.from_multipole`
 
         Returns

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -8,8 +8,6 @@ import h5py
 import pickle
 import numpy as np
 from scipy.signal import find_peaks
-import matplotlib
-matplotlib.use("agg")
 import matplotlib.pyplot as plt
 
 import openmc.checkvalue as cv
@@ -646,7 +644,8 @@ def _windowing(mp_data, n_cf, rtol=1e-3, atol=1e-5, n_win=None, spacing=None,
         energy_sqrt = np.linspace(np.sqrt(e_start), np.sqrt(e_end), n_points)
         energy = energy_sqrt**2
 
-        # reference xs from multipole form
+        # reference xs from multipole form, note the residue terms in the
+        # multipole and vector fitting representations differ by a 1j
         xs_ref = vf.evaluate(energy_sqrt, poles, residues*1j) / energy
 
         # curve fit matrix

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -469,7 +469,7 @@ def _vectfit_nuclide(endf_file, njoy_error=5e-4, vf_error=1e-3, vf_pieces=None,
         mts = [2, 27]
 
     if log:
-        print("  MTs: {})".format(mts))
+        print("  MTs: {}".format(mts))
         print("  Energy range: {:.3e} to {:.3e} eV ({} points)".format(
               E_min, E_max, n_points))
 
@@ -480,8 +480,8 @@ def _vectfit_nuclide(endf_file, njoy_error=5e-4, vf_error=1e-3, vf_pieces=None,
         # divide into pieces for complex nuclides
         peaks, _ = find_peaks(total_xs)
         n_peaks = peaks.size
-        if n_peaks > 300 or n_points > 50000 or n_peaks * n_points > 100*30000:
-            vf_pieces = max(5, n_peaks // 80,  n_points // 5000)
+        if n_peaks > 200 or n_points > 30000 or n_peaks * n_points > 100*10000:
+            vf_pieces = max(5, n_peaks // 50,  n_points // 2000)
         else:
             vf_pieces = 1
     piece_width = (sqrt(E_max) - sqrt(E_min)) / vf_pieces

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -243,8 +243,8 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
         if log:
             print("Order={}({}/{})".format(order, i, len(orders)))
         # initial guessed poles
-        poles = np.linspace(s[0], s[-1], order//2)
-        poles += poles*0.01j
+        poles_r = np.linspace(s[0], s[-1], order//2)
+        poles = poles_r + poles_r*0.01j
         poles = np.sort(np.append(poles, np.conj(poles)))
 
         found_better = False

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -20,8 +20,6 @@ from .data import K_BOLTZMANN
 from .neutron import IncidentNeutron
 from .resonance import ResonanceRange
 
-import vectfit as vf
-
 
 # Constants that determine which value to access
 _MP_EA = 0       # Pole
@@ -353,7 +351,7 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
     if log:
         print("Found {} real poles and {} conjugate complex pairs.".format(
                len(real_idx), len(conj_idx)))
-    mp_poles = best_poles[real_idx+conj_idx]
+    mp_poles = best_poles[real_idx + conj_idx]
     mp_residues = np.concatenate((best_residues[:, real_idx],
                                   best_residues[:, conj_idx]*2), axis=1)/1j
     if log:

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -1143,7 +1143,8 @@ class WindowedMultipole(EqualityMixin):
         # the 1-based vs. 0-based indexing.  Similarly startw needs to be
         # decreased by 1.  endw does not need to be decreased because
         # range(startw, endw) does not include endw.
-        i_window = int(np.floor((sqrtE - sqrt(self.E_min)) / self.spacing))
+        i_window = min(self.n_windows - 1,
+                       int(np.floor((sqrtE - sqrt(self.E_min)) / self.spacing)))
         startw = self.windows[i_window, 0] - 1
         endw = self.windows[i_window, 1]
 

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -36,7 +36,7 @@ _FIT_F = 2       # Fission
 TEMPERATURE_LIMIT = 3000
 
 # Logging control
-DETAILED_LOGGING = 1
+DETAILED_LOGGING = 2
 
 def _faddeeva(z):
     r"""Evaluate the complex Faddeeva function.
@@ -240,7 +240,7 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
         found_better = False
         # fitting iteration
         for i_vf in range(n_vf_iter):
-            if log > DETAILED_LOGGING:
+            if log >= DETAILED_LOGGING:
                 print("VF iteration {}/{}".format(i_vf+1, n_vf_iter))
 
             # call vf
@@ -262,7 +262,7 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
             new_poles = np.array(new_poles)
             # re-calculate residues if poles changed
             if n_real_poles > 0:
-                if log > DETAILED_LOGGING:
+                if log >= DETAILED_LOGGING:
                     print("  # real poles: {}".format(n_real_poles))
                 new_poles, residues, cf, f_fit, rms = \
                       vf.vectfit(f, s, new_poles, weight, skip_pole=True)
@@ -285,14 +285,14 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
             if np.any(test_xs < -atol):
                 quality = -np.inf
 
-            if log > DETAILED_LOGGING:
+            if log >= DETAILED_LOGGING:
                 print("  # poles: {}".format(new_poles.size))
                 print("  Max relative error: {:.3f}%".format(maxre*100))
                 print("  Satisfaction: {:.1f}%, {:.1f}%".format(ratio*100, ratio2*100))
                 print("  Quality: {:.2f}".format(quality))
 
             if quality > best_quality:
-                if log > DETAILED_LOGGING:
+                if log >= DETAILED_LOGGING:
                     print("  Best by far!")
                 found_better = True
                 best_quality, best_ratio = quality, ratio
@@ -304,7 +304,7 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
                     found_ideal = True
                     break
             else:
-                if log > DETAILED_LOGGING:
+                if log >= DETAILED_LOGGING:
                     print("  Discarded!")
 
         if found_ideal:
@@ -317,7 +317,7 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
             if order > max(2*n_peaks, 50) and best_ratio > 0.7:
                 n_discarded += 1
                 if n_discarded >= 10 or (n_discarded >= 5 and best_ratio > 0.9):
-                    if log > DETAILED_LOGGING:
+                    if log >= DETAILED_LOGGING:
                         print("Couldn't get better results. Stop!")
                     break
 
@@ -618,7 +618,7 @@ def _windowing(mp_data, rtol=1e-3, atol=1e-5, n_win=None, n_cf=None,
     # consecutive poles and curve fit coefficients to reproduce cross section
     win_data = []
     for iw in range(n_win):
-        if log > DETAILED_LOGGING:
+        if log >= DETAILED_LOGGING:
             print("Processing window {}/{}...".format(iw+1, n_win))
 
         # inner window boundaries
@@ -652,7 +652,7 @@ def _windowing(mp_data, rtol=1e-3, atol=1e-5, n_win=None, n_cf=None,
         center_pole_ind = np.argmin((np.fabs(poles.real - incenter)))
         lp, rp = center_pole_ind, center_pole_ind
         while True:
-            if log > DETAILED_LOGGING:
+            if log >= DETAILED_LOGGING:
                 print("Trying poles {} to {}".format(lp, rp))
 
             # calculate the cross sections contributed by the windowed poles
@@ -675,7 +675,7 @@ def _windowing(mp_data, rtol=1e-3, atol=1e-5, n_win=None, n_cf=None,
                    (re.max() <= 2*rtol and (re>rtol).sum() <= 0.01*relerr.size) or \
                    (iw == 0 and np.all(relerr.mean(axis=1) <= rtol)):
                     # meet tolerances
-                    if log > DETAILED_LOGGING:
+                    if log >= DETAILED_LOGGING:
                         print("Accuracy satisfied.")
                     break
 
@@ -1076,7 +1076,7 @@ class WindowedMultipole(EqualityMixin):
         n_win_max = 2000 if n_poles < 2000 else 8000
         best_wmp, best_metric = None, None
         for n_w in np.unique(np.linspace(n_win_min, n_win_max, 20, dtype=int)):
-            for n_cf in range(11, 2, -1):
+            for n_cf in range(10, 1, -1):
                 if log:
                     print("Testing N_win={} N_cf={}".format(n_w, n_cf))
 
@@ -1088,8 +1088,8 @@ class WindowedMultipole(EqualityMixin):
                     wmp = _windowing(mp_data, log=log, **kwargs)
                 except Exception as e:
                     if log:
-                        print('Failed to do windowing: ' + str(e))
-                    continue
+                        print('Failed: ' + str(e))
+                    break
 
                 # select wmp library with metric:
                 # - performance: average # used poles per window and CF order

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -726,10 +726,8 @@ class WindowedMultipole(EqualityMixin):
 
     Attributes
     ----------
-    fit_order : int
-        Order of the windowed curvefit.
-    fissionable : bool
-        Whether or not the target nuclide has fission data.
+    name : str
+        Name of the nuclide using the GND naming convention
     spacing : float
         The width of each window in sqrt(E)-space.  For example, the frst window
         will end at (sqrt(E_min) + spacing)**2 and the second window at
@@ -783,6 +781,18 @@ class WindowedMultipole(EqualityMixin):
     @property
     def fissionable(self):
         return self.data.shape[1] == 4
+
+    @property
+    def n_poles(self):
+        return self.data.shape[0]
+
+    @property
+    def n_windows(self):
+        return self.windows.shape[0]
+
+    @property
+    def poles_per_window(self):
+        return (self.windows[:, 1] - self.windows[:, 0] + 1).mean()
 
     @property
     def spacing(self):

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -455,10 +455,7 @@ def vectfit_nuclide(endf_file, njoy_error=5e-4, vf_pieces=None,
     E_min, E_max = energy[0], energy[-1]
     n_points = energy.size
     total_xs = nuc_ce[1].xs['0K'](energy)
-    try:
-        elastic_xs = nuc_ce[2].xs['0K'](energy)
-    except KeyError:
-        elastic_xs = np.zeros_like(total_xs)
+    elastic_xs = nuc_ce[2].xs['0K'](energy)
 
     try:
         absorption_xs = nuc_ce[27].xs['0K'](energy)
@@ -1067,7 +1064,8 @@ class WindowedMultipole(EqualityMixin):
         mp_data : dictionary or str
             Dictionary or Path to the multipole data stored in a pickle file
         search : bool, optional
-            Whether to search for optimal window size and curvefit order
+            Whether to search for optimal window size and curvefit order.
+            Defaults to True if no windowing parameters are specified.
         log : bool or int, optional
             Whether to print running logs (use int for verbosity control)
         **kwargs

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -175,6 +175,9 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
 
     """
 
+    # import vectfit package: https://github.com/mit-crpg/vectfit
+    import vectfit as vf
+
     ne = energy.size
     nmt = len(mts)
     if ce_xs.shape != (nmt, ne):
@@ -568,6 +571,9 @@ def _windowing(mp_data, rtol=1e-3, atol=1e-5, n_win=None, n_cf=None,
         format.
 
     """
+
+    # import vectfit package: https://github.com/mit-crpg/vectfit
+    import vectfit as vf
 
     # unpack multipole data
     name = mp_data["name"]

--- a/src/wmp.cpp
+++ b/src/wmp.cpp
@@ -10,6 +10,7 @@
 #include <fmt/core.h>
 
 #include <cmath>
+#include <algorithm> // for min
 
 namespace openmc {
 
@@ -71,7 +72,7 @@ WindowedMultipole::evaluate(double E, double sqrtkT)
 
   // Locate window containing energy
   int i_window = std::min(windows_.shape()[0] - 1,
-                          (sqrtE - std::sqrt(E_min_)) / spacing_);
+        static_cast<unsigned long>((sqrtE - std::sqrt(E_min_)) / spacing_));
   int startw = windows_(i_window, 0) - 1;
   int endw = windows_(i_window, 1) - 1;
 

--- a/src/wmp.cpp
+++ b/src/wmp.cpp
@@ -70,7 +70,8 @@ WindowedMultipole::evaluate(double E, double sqrtkT)
   double invE = 1.0 / E;
 
   // Locate window containing energy
-  int i_window = (sqrtE - std::sqrt(E_min_)) / spacing_;
+  int i_window = std::min(windows_.shape()[0] - 1,
+                          (sqrtE - std::sqrt(E_min_)) / spacing_);
   int startw = windows_(i_window, 0) - 1;
   int endw = windows_(i_window, 1) - 1;
 

--- a/tests/unit_tests/test_data_multipole.py
+++ b/tests/unit_tests/test_data_multipole.py
@@ -5,6 +5,14 @@ import numpy as np
 import pytest
 import openmc.data
 
+no_vectfit = False
+try:
+    import vectfit as vf
+except:
+    no_vectfit = True
+
+vf_only = pytest.mark.skipif(no_vectfit, reason="vectfit package not installed")
+
 
 @pytest.fixture(scope='module')
 def u235():
@@ -46,3 +54,10 @@ def test_export_to_hdf5(tmpdir, u235):
     filename = str(tmpdir.join('092235.h5'))
     u235.export_to_hdf5(filename)
     assert os.path.exists(filename)
+
+@vf_only
+def test_from_endf():
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    endf_file = os.path.join(endf_data, 'neutrons', 'n-001_H_001.endf')
+    return openmc.data.WindowedMultipole.from_endf(
+            endf_file, wmp_options={"search": True})

--- a/tests/unit_tests/test_data_multipole.py
+++ b/tests/unit_tests/test_data_multipole.py
@@ -60,4 +60,10 @@ def test_from_endf():
     endf_data = os.environ['OPENMC_ENDF_DATA']
     endf_file = os.path.join(endf_data, 'neutrons', 'n-001_H_001.endf')
     return openmc.data.WindowedMultipole.from_endf(
+            endf_file, wmp_options={"n_win": 400, "n_cf": 3})
+@vf_only
+def test_from_endf_search():
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    endf_file = os.path.join(endf_data, 'neutrons', 'n-095_Am_244.endf')
+    return openmc.data.WindowedMultipole.from_endf(
             endf_file, wmp_options={"search": True})

--- a/tests/unit_tests/test_data_multipole.py
+++ b/tests/unit_tests/test_data_multipole.py
@@ -49,7 +49,7 @@ def test_export_to_hdf5(tmpdir, u235):
 
 
 def test_from_endf():
-    pytest.importerskip('vectfit')
+    pytest.importorskip('vectfit')
     endf_data = os.environ['OPENMC_ENDF_DATA']
     endf_file = os.path.join(endf_data, 'neutrons', 'n-001_H_001.endf')
     return openmc.data.WindowedMultipole.from_endf(
@@ -57,8 +57,8 @@ def test_from_endf():
 
 
 def test_from_endf_search():
-    pytest.importerskip('vectfit')
+    pytest.importorskip('vectfit')
     endf_data = os.environ['OPENMC_ENDF_DATA']
     endf_file = os.path.join(endf_data, 'neutrons', 'n-095_Am_244.endf')
     return openmc.data.WindowedMultipole.from_endf(
-            endf_file, wmp_options={"search": True})
+            endf_file, wmp_options={"search": True, 'rtol':1e-2})

--- a/tests/unit_tests/test_data_multipole.py
+++ b/tests/unit_tests/test_data_multipole.py
@@ -55,12 +55,15 @@ def test_export_to_hdf5(tmpdir, u235):
     u235.export_to_hdf5(filename)
     assert os.path.exists(filename)
 
+
 @vf_only
 def test_from_endf():
     endf_data = os.environ['OPENMC_ENDF_DATA']
     endf_file = os.path.join(endf_data, 'neutrons', 'n-001_H_001.endf')
     return openmc.data.WindowedMultipole.from_endf(
             endf_file, wmp_options={"n_win": 400, "n_cf": 3})
+
+
 @vf_only
 def test_from_endf_search():
     endf_data = os.environ['OPENMC_ENDF_DATA']

--- a/tests/unit_tests/test_data_multipole.py
+++ b/tests/unit_tests/test_data_multipole.py
@@ -53,7 +53,7 @@ def test_from_endf():
     endf_data = os.environ['OPENMC_ENDF_DATA']
     endf_file = os.path.join(endf_data, 'neutrons', 'n-001_H_001.endf')
     return openmc.data.WindowedMultipole.from_endf(
-            endf_file, wmp_options={"n_win": 400, "n_cf": 3})
+            endf_file, log=True, wmp_options={"n_win": 400, "n_cf": 3})
 
 
 def test_from_endf_search():
@@ -61,4 +61,4 @@ def test_from_endf_search():
     endf_data = os.environ['OPENMC_ENDF_DATA']
     endf_file = os.path.join(endf_data, 'neutrons', 'n-095_Am_244.endf')
     return openmc.data.WindowedMultipole.from_endf(
-            endf_file, wmp_options={"search": True, 'rtol':1e-2})
+            endf_file, log=True, wmp_options={"search": True, 'rtol':1e-2})

--- a/tests/unit_tests/test_data_multipole.py
+++ b/tests/unit_tests/test_data_multipole.py
@@ -5,14 +5,6 @@ import numpy as np
 import pytest
 import openmc.data
 
-no_vectfit = False
-try:
-    import vectfit as vf
-except:
-    no_vectfit = True
-
-vf_only = pytest.mark.skipif(no_vectfit, reason="vectfit package not installed")
-
 
 @pytest.fixture(scope='module')
 def u235():
@@ -56,16 +48,16 @@ def test_export_to_hdf5(tmpdir, u235):
     assert os.path.exists(filename)
 
 
-@vf_only
 def test_from_endf():
+    pytest.importerskip('vectfit')
     endf_data = os.environ['OPENMC_ENDF_DATA']
     endf_file = os.path.join(endf_data, 'neutrons', 'n-001_H_001.endf')
     return openmc.data.WindowedMultipole.from_endf(
             endf_file, wmp_options={"n_win": 400, "n_cf": 3})
 
 
-@vf_only
 def test_from_endf_search():
+    pytest.importerskip('vectfit')
     endf_data = os.environ['OPENMC_ENDF_DATA']
     endf_file = os.path.join(endf_data, 'neutrons', 'n-095_Am_244.endf')
     return openmc.data.WindowedMultipole.from_endf(

--- a/tools/ci/travis-install-vectfit.sh
+++ b/tools/ci/travis-install-vectfit.sh
@@ -19,8 +19,8 @@ XTENSOR_BLAS_REPO='https://github.com/xtensor-stack/xtensor-blas'
 
 cd $HOME
 git clone -b $PYBIND_BRANCH $PYBIND_REPO
-pip install ./pybind11
 cd pybind11 && mkdir build && cd build && cmake .. && sudo make install
+pip install $HOME/pybind11
 
 cd $HOME
 git clone -b $XTL_BRANCH $XTL_REPO

--- a/tools/ci/travis-install-vectfit.sh
+++ b/tools/ci/travis-install-vectfit.sh
@@ -16,6 +16,7 @@ XTENSOR_PYTHON_REPO='https://github.com/xtensor-stack/xtensor-python'
 XTENSOR_BLAS_BRANCH='0.17.1'
 XTENSOR_BLAS_REPO='https://github.com/xtensor-stack/xtensor-blas'
 
+sudo apt-get install -y libblas-dev liblapack-dev
 
 cd $HOME
 git clone -b $PYBIND_BRANCH $PYBIND_REPO

--- a/tools/ci/travis-install-vectfit.sh
+++ b/tools/ci/travis-install-vectfit.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -ex
 
-#pip3 install pybind11
 PYBIND_BRANCH='master'
 PYBIND_REPO='https://github.com/pybind/pybind11'
 
@@ -17,8 +16,10 @@ XTENSOR_PYTHON_REPO='https://github.com/xtensor-stack/xtensor-python'
 XTENSOR_BLAS_BRANCH='0.17.1'
 XTENSOR_BLAS_REPO='https://github.com/xtensor-stack/xtensor-blas'
 
+
 cd $HOME
 git clone -b $PYBIND_BRANCH $PYBIND_REPO
+pip install ./pybind11
 cd pybind11 && mkdir build && cd build && cmake .. && sudo make install
 
 cd $HOME
@@ -40,4 +41,4 @@ cd xtensor-blas && mkdir build && cd build && cmake .. && sudo make install
 # Install vectfit
 cd $HOME
 git clone https://github.com/liangjg/vectfit.git
-pip3 install ./vectfit
+pip install ./vectfit

--- a/tools/ci/travis-install-vectfit.sh
+++ b/tools/ci/travis-install-vectfit.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -ex
+
+#pip3 install pybind11
+PYBIND_BRANCH='master'
+PYBIND_REPO='https://github.com/pybind/pybind11'
+
+XTL_BRANCH='0.6.9'
+XTL_REPO='https://github.com/xtensor-stack/xtl'
+
+XTENSOR_BRANCH='0.21.2'
+XTENSOR_REPO='https://github.com/xtensor-stack/xtensor'
+
+XTENSOR_PYTHON_BRANCH='0.24.1'
+XTENSOR_PYTHON_REPO='https://github.com/xtensor-stack/xtensor-python'
+
+XTENSOR_BLAS_BRANCH='0.17.1'
+XTENSOR_BLAS_REPO='https://github.com/xtensor-stack/xtensor-blas'
+
+cd $HOME
+git clone -b $PYBIND_BRANCH $PYBIND_REPO
+cd pybind11 && mkdir build && cd build && cmake .. && sudo make install
+
+cd $HOME
+git clone -b $XTL_BRANCH $XTL_REPO
+cd xtl && mkdir build && cd build && cmake .. && sudo make install
+
+cd $HOME
+git clone -b $XTENSOR_BRANCH $XTENSOR_REPO
+cd xtensor && mkdir build && cd build && cmake .. && sudo make install
+
+cd $HOME
+git clone -b $XTENSOR_PYTHON_BRANCH $XTENSOR_PYTHON_REPO
+cd xtensor-python && mkdir build && cd build && cmake .. && sudo make install
+
+cd $HOME
+git clone -b $XTENSOR_BLAS_BRANCH $XTENSOR_BLAS_REPO
+cd xtensor-blas && mkdir build && cd build && cmake .. && sudo make install
+
+# Install vectfit
+cd $HOME
+git clone https://github.com/liangjg/vectfit.git
+pip3 install ./vectfit

--- a/tools/ci/travis-install.sh
+++ b/tools/ci/travis-install.sh
@@ -9,6 +9,11 @@ if [[ $DAGMC = 'y' ]]; then
     ./tools/ci/travis-install-dagmc.sh
 fi
 
+# Install vectfit for WMP generation if needed
+if [[ $VECTFIT = 'y' ]]; then
+    ./tools/ci/travis-install-vectfit.sh
+fi
+
 # Upgrade pip, pytest, numpy before doing anything else
 pip install --upgrade pip
 pip install --upgrade pytest


### PR DESCRIPTION
This PR tries to implement WMP library generation workflow in OpenMC, using Vector Fitting approach.

You can now generate a WMP library from ENDF file with the new `openmc.data.WindowedMultipole.from_endf` method.
``` python
endf_file = '/opt/nucdata/endf-b-vii.1/neutrons/n-001_H_001.endf'

# generate a library with specified windowing size and curve fitting order
nuc = openmc.data.WindowedMultipole.from_endf(endf_file, wmp_options={"n_win": 400, "n_cf":3})

# Or, let OpenMC search from a range of window size and CF order
# and select the optimal WMP library (using built-in performance metric)
nuc_opt = openmc.data.WindowedMultipole.from_endf(endf_file, wmp_options={"search": True})
```

Through this approach, any nuclide with 0K point-wise data can be converted to WMP format, no resonance parameters are required. 
To achieve this, several steps are integrated:
- run NJOY on the ENDF file to get 0K ACE and extract relevant point-wise data (up to RRR boundary or the lowest threshold)
- perform Vector Fitting on point-wise data to get multipole parameters. This relies on an independent package `vectfit` (https://github.com/mit-crpg/vectfit).
- do windowing on the vector-fitted poles to get the WMP representation. As shown above, an automatic optimization procedure is implemented to get the best performance library by searching among different windowing parameters.

It should be noted that for complex resonant nuclides like U238, straightforward vector fitting is not doable because of both the time cost and memory constraints with the huge matrix operations. An energy domain decomposition approach is adopted in the workflow, i.e. carrying out the Vector Fitting and windowing on partitioned energy pieces. This makes the approach practical. I just managed to process a whole WMP library from ENDFB/VIII.0 with all 556 nuclides. The processing time for different nuclides varies widely, from seconds to tens of hours, depending on the complexity of the point-wise data.

For this PR, in addition to the new functions in `openmc.data.WindowedMultipole`, I was thinking if it is necessary to add some test cases on these functions. A little trouble here is I may have to install [`vectfit` package](https://github.com/mit-crpg/vectfit) on Travis, which relies on `conda`. Note currently 'import vectfit' is done when the relevant functions are called so 'import openmc' doesn't rely on `vectfit` package by default.