### PR TITLE
Make mixed material inherit "depletable" attribute of involved materials

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1079,6 +1079,13 @@ class Material(IDManagerMixin):
         new_density = np.sum([dens for dens in mass_per_cc.values()])
         new_mat.set_density('g/cm3', new_density)
 
+        # If any of the involved materials is depletable, the new material is 
+        # depletable
+        for mat in materials:
+            if mat.depletable:
+                new_mat.depletable = True
+                break
+
         return new_mat
 
     @classmethod

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1081,10 +1081,7 @@ class Material(IDManagerMixin):
 
         # If any of the involved materials is depletable, the new material is 
         # depletable
-        for mat in materials:
-            if mat.depletable:
-                new_mat.depletable = True
-                break
+        new_mat.depletable = any(mat.depletable for mat in materials)
 
         return new_mat
 


### PR DESCRIPTION
This PR modifies mix_materials() function. If any of the involved materials is depletable, the new material created by mix_materials() is also depletable. 