### PR TITLE
fix typo in energy unit in dose coefficients

### DIFF
--- a/openmc/data/effective_dose/dose.py
+++ b/openmc/data/effective_dose/dose.py
@@ -24,7 +24,7 @@ def _load_dose_icrp116():
     for particle, filename in _FILES:
         path = Path(__file__).parent / filename
         data = np.loadtxt(path, skiprows=3)
-        data[:, 0] *= 1e-6   # Change energies to eV
+        data[:, 0] *= 1e6   # Change energies to eV
         _DOSE_ICRP116[particle] = data
 
 

--- a/tests/unit_tests/test_data_dose.py
+++ b/tests/unit_tests/test_data_dose.py
@@ -5,21 +5,21 @@ from pytest import approx, raises
 def test_dose_coefficients():
     # Spot checks on values from ICRP tables
     energy, dose = dose_coefficients('photon', 'AP')
-    assert energy[0] == approx(0.01e-6)
+    assert energy[0] == approx(0.01e6)
     assert dose[0] == approx(0.0685)
-    assert energy[-1] == approx(10e-3)
+    assert energy[-1] == approx(10e9)
     assert dose[-1] == approx(90.4)  # updated in corrigendum
 
     energy, dose = dose_coefficients('neutron', 'LLAT')
-    assert energy[0] == approx(1e-15)
+    assert energy[0] == approx(1e-3)
     assert dose[0] == approx(1.04)
-    assert energy[-1] == approx(10e-3)
+    assert energy[-1] == approx(10e9)
     assert dose[-1] == approx(1.23e3)
 
     energy, dose = dose_coefficients('electron', 'ISO')
-    assert energy[0] == approx(0.01e-6)
+    assert energy[0] == approx(0.01e6)
     assert dose[0] == approx(0.0188)
-    assert energy[-1] == approx(10e-3)
+    assert energy[-1] == approx(10e9)
     assert dose[-1] == approx(699.0)
 
     # Invalid particle/geometry should raise an exception


### PR DESCRIPTION
The energies should be multiplied by `1E6` when converted from `MeV` to `eV`.