### PR TITLE
Small fixes to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
 FROM ubuntu:latest
 
 # Setup environment variables for Docker image
-ENV FC=/usr/bin/mpif90 CC=/usr/bin/mpicc CXX=/usr/bin/mpicxx \
+ENV CC=/usr/bin/mpicc CXX=/usr/bin/mpicxx \
     PATH=/opt/openmc/bin:/opt/NJOY2016/build:$PATH \
     LD_LIBRARY_PATH=/opt/openmc/lib:$LD_LIBRARY_PATH \
     OPENMC_CROSS_SECTIONS=/root/nndc_hdf5/cross_sections.xml \
-    OPENMC_ENDF_DATA=/root/endf-b-vii.1
+    OPENMC_ENDF_DATA=/root/endf-b-vii.1 \
+    DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies from Debian package manager
 RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y python3-pip && \
-    apt-get install -y wget git emacs && \
+    apt-get install -y wget git && \
     apt-get install -y gfortran g++ cmake && \
     apt-get install -y mpich libmpich-dev && \
     apt-get install -y libhdf5-serial-dev libhdf5-mpich-dev && \
@@ -28,8 +29,8 @@ RUN git clone https://github.com/njoy/NJOY2016 /opt/NJOY2016 && \
     cmake -Dstatic=on .. && make 2>/dev/null && make install
 
 # Clone and install OpenMC
-RUN git clone https://github.com/openmc-dev/openmc.git /opt/openmc && \
-    cd /opt/openmc && mkdir -p build && cd build && \
+RUN git clone --recurse-submodules https://github.com/openmc-dev/openmc.git \
+    /opt/openmc && cd /opt/openmc && mkdir -p build && cd build && \
     cmake -Doptimize=on -DHDF5_PREFER_PARALLEL=on .. && \
     make && make install && \
     cd .. && pip install -e .[test]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,10 @@ ENV CC=/usr/bin/mpicc CXX=/usr/bin/mpicxx \
 # Install dependencies from Debian package manager
 RUN apt-get update -y && \
     apt-get upgrade -y && \
-    apt-get install -y python3-pip && \
-    apt-get install -y wget git && \
-    apt-get install -y gfortran g++ cmake && \
-    apt-get install -y mpich libmpich-dev && \
-    apt-get install -y libhdf5-serial-dev libhdf5-mpich-dev && \
-    apt-get install -y imagemagick && \
+    apt-get install -y \
+        python3-pip python-is-python3 wget git gfortran g++ cmake \
+        mpich libmpich-dev libhdf5-serial-dev libhdf5-mpich-dev \
+        imagemagick && \
     apt-get autoremove
 
 # Update system-provided pip
@@ -36,4 +34,4 @@ RUN git clone --recurse-submodules https://github.com/openmc-dev/openmc.git \
     cd .. && pip install -e .[test]
 
 # Download cross sections (NNDC and WMP) and ENDF data needed by test suite
-RUN ./opt/openmc/tools/ci/download-xs.sh
+RUN /opt/openmc/tools/ci/download-xs.sh


### PR DESCRIPTION
This PR has a few small changes to our Dockerfile to ensure it still works:
- Remove `FC` environment variable, which is not needed
- Make Debian frontend non-interactive to avoid prompt asking for timezone
- Explicitly put `--recurse-submodules` on the `git clone` command