### PR TITLE
Several fixes/improvements for large tally cases

### DIFF
--- a/docs/source/io_formats/statepoint.rst
+++ b/docs/source/io_formats/statepoint.rst
@@ -161,3 +161,5 @@ All values are given in seconds and are measured on the master process.
              source sites between processes for load balancing.
            - **accumulating tallies** (*double*) -- Time spent communicating
              tally results and evaluating their statistics.
+          - **writing statepoints** (*double*) -- Time spent writing statepoint
+            files

--- a/include/openmc/timer.h
+++ b/include/openmc/timer.h
@@ -22,6 +22,7 @@ extern Timer time_inactive;
 extern Timer time_initialize;
 extern Timer time_read_xs;
 extern Timer time_sample_source;
+extern Timer time_statepoint;
 extern Timer time_tallies;
 extern Timer time_total;
 extern Timer time_transport;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -420,6 +420,7 @@ void print_runtime()
     show_time("SEND/RECV source sites", time_bank_sendrecv.elapsed(), 2);
   }
   show_time("Time accumulating tallies", time_tallies.elapsed(), 1);
+  show_time("Time writing statepoints", time_statepoint.elapsed(), 1);
   show_time("Total time for finalization", time_finalize.elapsed());
   show_time("Total time elapsed", time_total.elapsed());
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -666,7 +666,7 @@ void read_settings_xml()
   // Check if the user has specified to not reduce tallies at the end of every
   // batch
   if (check_for_node(root, "no_reduce")) {
-    reduce_tallies = get_node_value_bool(root, "no_reduce");
+    reduce_tallies = !get_node_value_bool(root, "no_reduce");
   }
 
   // Check if the user has specified to use confidence intervals for

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -33,6 +33,8 @@ namespace openmc {
 extern "C" int
 openmc_statepoint_write(const char* filename, bool* write_source)
 {
+  simulation::time_statepoint.start();
+
   // Set the filename
   std::string filename_;
   if (filename) {
@@ -296,6 +298,7 @@ openmc_statepoint_write(const char* filename, bool* write_source)
     }
     write_dataset(runtime_group, "accumulating tallies", time_tallies.elapsed());
     write_dataset(runtime_group, "total", time_total.elapsed());
+    write_dataset(runtime_group, "writing statepoints", time_statepoint.elapsed());
     close_group(runtime_group);
 
     file_close(file_id);
@@ -313,6 +316,8 @@ openmc_statepoint_write(const char* filename, bool* write_source)
     write_source_bank(file_id);
     if (mpi::master || parallel) file_close(file_id);
   }
+
+  simulation::time_statepoint.stop();
 
   return 0;
 }

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -642,6 +642,7 @@ void Tally::accumulate()
     double norm = total_source / (settings::n_particles * settings::gen_per_batch);
 
     // Accumulate each result
+    #pragma omp parallel for
     for (int i = 0; i < results_.shape()[0]; ++i) {
       for (int j = 0; j < results_.shape()[1]; ++j) {
         double val = results_(i, j, TallyResult::VALUE) * norm;

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -775,7 +775,7 @@ accumulate_tallies()
 {
 #ifdef OPENMC_MPI
   // Combine tally results onto master process
-  if (settings::reduce_tallies) reduce_tally_results();
+  if (settings::reduce_tallies && mpi::n_procs > 1) reduce_tally_results();
 #endif
 
   // Increase number of realizations (only used for global tallies)

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -17,6 +17,7 @@ Timer time_inactive;
 Timer time_initialize;
 Timer time_read_xs;
 Timer time_sample_source;
+Timer time_statepoint;
 Timer time_tallies;
 Timer time_total;
 Timer time_transport;
@@ -76,6 +77,7 @@ void reset_timers()
   simulation::time_initialize.reset();
   simulation::time_read_xs.reset();
   simulation::time_sample_source.reset();
+  simulation::time_statepoint.reset();
   simulation::time_tallies.reset();
   simulation::time_total.reset();
   simulation::time_transport.reset();


### PR DESCRIPTION
This PR makes a few small changes that were inspired by simulations I was doing with very large tallies:

- I've added a timer for measuring the time writing statepoint files. If you have extremely large tallies, this time can become significant and we don't really capture that well in the existing timers.
- Added thread parallelization for accumulating tally results. When you have a ton of filter combinations in a tally, this can help speed up the end-of-batch accumulation.
- Avoid reducing tallies when only one MPI process is being used.
- A few bug fixes for the `no_reduce` mode where tallies are not reduced across processes.
