### PR TITLE
Fixed erroneous normal distro sampling

### DIFF
--- a/src/math_functions.cpp
+++ b/src/math_functions.cpp
@@ -692,25 +692,17 @@ double maxwell_spectrum(double T, uint64_t* seed) {
 
 
 double normal_variate(double mean, double standard_deviation, uint64_t* seed) {
-  // perhaps there should be a limit to the number of resamples
-  while ( true ) {
-    double v1 = 2 * prn(seed) - 1.;
-    double v2 = 2 * prn(seed) - 1.;
-
-    double r = std::pow(v1, 2) + std::pow(v2, 2);
-    double r2 = std::pow(r, 2);
-    if (r2 < 1) {
-      double z = std::sqrt(-2.0 * std::log(r2)/r2);
-      z *= (prn(seed) <= 0.5) ? v1 : v2;
-      return mean + standard_deviation*z;
-    }
-  }
+  // now correct method to sample a normal distubted number
+  double v1 = 2 * prn(seed) - 1.;
+  double v2 = 2 * prn(seed) - 1.;
+  double r = std::pow(v1, 2) + std::pow(v2, 2);
+  if ( r == 0 || r > 1 ) return normal_variate(mean,standard_deviation,seed);
+  double z = std::sqrt(-2.0 * std::log(r)/r);
+  return mean + standard_deviation*z*v1;
 }
 
 double muir_spectrum(double e0, double m_rat, double kt, uint64_t* seed) {
-  // note sigma here is a factor of 2 shy of equation
-  // 8 in https://permalink.lanl.gov/object/tr?what=info:lanl-repo/lareport/LA-05411-MS
-  double sigma = std::sqrt(2.*e0*kt/m_rat);
+  double sigma = std::sqrt(4.*e0*kt/m_rat);
   return normal_variate(e0, sigma, seed);
 }
 

--- a/tests/unit_tests/test_math.py
+++ b/tests/unit_tests/test_math.py
@@ -213,13 +213,24 @@ def test_normal_dist():
 
     assert ref_val == pytest.approx(test_val)
 
-    prn_seed = 1
-    a = 14.08
+    # make sigma = 1.0
     b = 1.0
-    ref_val = 16.436645416691427
-    test_val = openmc.lib.math.normal_variate(a, b, prn_seed)
 
-    assert ref_val == pytest.approx(test_val)
+    # import shapiro test 
+    from scipy.stats import shapiro
+    samples = []
+    num_samples = 10000
+    # sample some numbers
+    for i in range(num_samples):
+        # sample the normal distribution from openmc
+        samples.append(openmc.lib.math.normal_variate(a, b, prn_seed)
+        prn_seed += 1
+
+    stat,p = shaprio(samples)
+    assert stat > 0.97
+
+    # cleanup
+    del samples
 
 
 def test_broaden_wmp_polynomials():

--- a/tests/unit_tests/test_math.py
+++ b/tests/unit_tests/test_math.py
@@ -224,7 +224,7 @@ def test_normal_dist():
     for i in range(num_samples):
         # sample the normal distribution from openmc
         samples.append(openmc.lib.math.normal_variate(a, b, prn_seed)
-        prn_seed += 1
+        prn_seed = prn_seed + 1
 
     stat,p = shaprio(samples)
     assert stat > 0.97

--- a/tests/unit_tests/test_math.py
+++ b/tests/unit_tests/test_math.py
@@ -224,7 +224,7 @@ def test_normal_dist():
     for i in range(num_samples):
         # sample the normal distribution from openmc
         samples.append(openmc.lib.math.normal_variate(a, b, prn_seed))
-        prn_seed += 1
+        prn_seed = prn_seed + 1
 
     stat,p = shaprio(samples)
     assert stat > 0.97

--- a/tests/unit_tests/test_math.py
+++ b/tests/unit_tests/test_math.py
@@ -223,8 +223,8 @@ def test_normal_dist():
     # sample some numbers
     for i in range(num_samples):
         # sample the normal distribution from openmc
-        samples.append(openmc.lib.math.normal_variate(a, b, prn_seed)
-        prn_seed = prn_seed + 1
+        samples.append(openmc.lib.math.normal_variate(a, b, prn_seed))
+        prn_seed += 1
 
     stat,p = shaprio(samples)
     assert stat > 0.97

--- a/tests/unit_tests/test_math.py
+++ b/tests/unit_tests/test_math.py
@@ -226,7 +226,7 @@ def test_normal_dist():
         samples.append(openmc.lib.math.normal_variate(a, b, prn_seed))
         prn_seed = prn_seed + 1
 
-    stat,p = shaprio(samples)
+    stat,p = shapiro(samples)
     assert stat > 0.97
 
     # cleanup


### PR DESCRIPTION
Previous normal distribution was just flat out wrong. In my opinion we should shift to - https://en.cppreference.com/w/cpp/numeric/random/normal_distribution for this, but its easy to change - this current method obviously uses prn() which is convenient and fits nicely alongside the other sampling techniques. 

![Screenshot from 2020-09-22 14-29-00](https://user-images.githubusercontent.com/2439754/94405747-e8ddab00-0168-11eb-96e7-13f2ce59539f.png)

Attached is an example of the guassian sampling from this implmentation and another independent gaussian sample, and a gaussian distribution with the same mean and std dev.

I would like an actual unit test on this, but currently none of the sample functions are callable from the python API - should this be done in the longer term too?