### PR TITLE
update name of example problem directories in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ dist/
 openmc.egg-info/
 
 # Inputs generated from Python API
-examples/python/**/*.xml
+examples/**/*.xml
 
 # emacs and vim backups
 *~


### PR DESCRIPTION
Closes #1675 

When problems were moved out of a directory called `python`, their generated XML is not ignored by git any more. This will make it as it once was.