### PR TITLE
Update to how volume calculation results are verified in `load_results`.

### DIFF
--- a/openmc/volume.py
+++ b/openmc/volume.py
@@ -319,7 +319,7 @@ class VolumeCalculation:
         results = type(self).from_hdf5(filename)
 
         # Make sure properties match
-        assert self.ids == results.ids
+        assert set(self.ids) == set(results.ids)
         assert np.all(self.lower_left == results.lower_left)
         assert np.all(self.upper_right == results.upper_right)
 


### PR DESCRIPTION
A [user recently reported](https://openmc.discourse.group/t/error-when-load-volume-calculation-results-of-multiple-materials/769) that if domain IDs aren't in the same order for a `VolumeCalculation` object and the set of results being loaded, a failure is reported. 

This is a quick fix for that problem by doing the ID comparison using sets in `VolumeCalculation.load_results`.