### PR TITLE
Fix calculation of decay energy for depletion chains

### DIFF
--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -298,7 +298,7 @@ class Decay(EqualityMixin):
         applications.
     decay_constant : uncertainties.UFloat
         Decay constant in inverse seconds.
-    decay_energy : float
+    decay_energy : uncertainties.UFloat
         Average energy in [eV] per decay for a decay heat
     half_life : uncertainties.UFloat
         Half-life of the decay in seconds.
@@ -472,7 +472,7 @@ class Decay(EqualityMixin):
         if energy:
             return energy['light'] + energy['electromagnetic'] + energy['heavy']
         else:
-            return 0.0
+            return ufloat(0, 0)
 
     @classmethod
     def from_endf(cls, ev_or_filename):

--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -298,6 +298,8 @@ class Decay(EqualityMixin):
         applications.
     decay_constant : uncertainties.UFloat
         Decay constant in inverse seconds.
+    decay_energy : float
+        Average energy in [eV] per decay for a decay heat
     half_life : uncertainties.UFloat
         Half-life of the decay in seconds.
     modes : list
@@ -347,7 +349,7 @@ class Decay(EqualityMixin):
             items, values = get_list_record(file_obj)
             self.half_life = ufloat(items[0], items[1])
             NC = items[4]//2
-            pairs = [x for x in zip(values[::2], values[1::2])]
+            pairs = list(zip(values[::2], values[1::2]))
             ex = self.average_energies
             ex['light'] = ufloat(*pairs[0])
             ex['electromagnetic'] = ufloat(*pairs[1])
@@ -359,7 +361,7 @@ class Decay(EqualityMixin):
                 ex['conversion'] = ufloat(*pairs[6])
                 ex['gamma'] = ufloat(*pairs[7])
                 ex['xray'] = ufloat(*pairs[8])
-                ex['Bremsstrahlung'] = ufloat(*pairs[9])
+                ex['bremsstrahlung'] = ufloat(*pairs[9])
                 ex['annihilation'] = ufloat(*pairs[10])
                 ex['alpha'] = ufloat(*pairs[11])
                 ex['recoil'] = ufloat(*pairs[12])
@@ -463,6 +465,14 @@ class Decay(EqualityMixin):
         else:
             mu, sigma = self.half_life
             return ufloat(log(2.)/mu, log(2.)/mu**2*sigma)
+
+    @property
+    def decay_energy(self):
+        energy = self.average_energies
+        if energy:
+            return energy['light'] + energy['electromagnetic'] + energy['heavy']
+        else:
+            return 0.0
 
     @classmethod
     def from_endf(cls, ev_or_filename):

--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -299,7 +299,7 @@ class Decay(EqualityMixin):
     decay_constant : uncertainties.UFloat
         Decay constant in inverse seconds.
     decay_energy : uncertainties.UFloat
-        Average energy in [eV] per decay for a decay heat
+        Average energy in [eV] per decay for decay heat applications
     half_life : uncertainties.UFloat
         Half-life of the decay in seconds.
     modes : list

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -395,8 +395,7 @@ class Chain:
 
             if not data.nuclide['stable'] and data.half_life.nominal_value != 0.0:
                 nuclide.half_life = data.half_life.nominal_value
-                nuclide.decay_energy = sum(E.nominal_value for E in
-                                           data.average_energies.values())
+                nuclide.decay_energy = data.decay_energy.nominal_value
                 sum_br = 0.0
                 for i, mode in enumerate(data.modes):
                     type_ = ','.join(mode.modes)

--- a/tests/unit_tests/test_data_decay.py
+++ b/tests/unit_tests/test_data_decay.py
@@ -34,7 +34,7 @@ def u235_yields():
 def test_nb90_halflife(nb90):
     ufloat_close(nb90.half_life, ufloat(52560.0, 180.0))
     ufloat_close(nb90.decay_constant, log(2.)/nb90.half_life)
-
+    ufloat_close(nb90.decay_energy, ufloat(2265527.5, 25159.400474401213))
 
 def test_nb90_nuclide(nb90):
     assert nb90.nuclide['atomic_number'] == 41


### PR DESCRIPTION
As reported in #1672, there was a potential bug in how the total decay energy is calculated for a depletion chain in cases where the underlying decay sublibrary file breaks out the average energy release into many categories (instead of the standard summarized three categories: light, heavy, and electromagnetic). This PR fixes this by adding a new `decay_energy` attribute on the `Decay` class that explicitly returns the sum of the light, heavy, and electromagnetic average energies for decay, and then using this new property during depletion chain generation.

Closes #1672