### PR TITLE
Correct typo in retrieving stored pointer from CartesianIndependent distribution

### DIFF
--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -35,8 +35,8 @@ public:
 
   // Observer pointers
   Distribution* x() const { return x_.get(); }
-  Distribution* y() const { return x_.get(); }
-  Distribution* z() const { return x_.get(); }
+  Distribution* y() const { return y_.get(); }
+  Distribution* z() const { return z_.get(); }
 private:
   UPtrDist x_; //!< Distribution of x coordinates
   UPtrDist y_; //!< Distribution of y coordinates


### PR DESCRIPTION
Correct typo in returning the stored pointers for the y and z directions in `CartesianIndependent` distribution. If this is indeed not a typo, please forgive my ignorance!

Closes #1680 
