### PR TITLE
Test OpenMC on Python 3.6 through 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,21 +31,21 @@ env:
     - NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=0
 matrix:
   include:
-    - python: "3.5"
-      env: OMP=n MPI=n PHDF5=n
     - python: "3.6"
       env: OMP=n MPI=n PHDF5=n
     - python: "3.7"
       env: OMP=n MPI=n PHDF5=n
-    - python: "3.7"
+    - python: "3.8"
+      env: OMP=n MPI=n PHDF5=n
+    - python: "3.8"
       env: OMP=y MPI=n PHDF5=n
-    - python: "3.7"
+    - python: "3.8"
       env: OMP=n MPI=y PHDF5=n
-    - python: "3.7"
+    - python: "3.8"
       env: OMP=n MPI=y PHDF5=y
-    - python: "3.7"
+    - python: "3.8"
       env: OMP=y MPI=y PHDF5=y DAGMC=y
-    - python: "3.7"
+    - python: "3.8"
       env: OMP=y MPI=n PHDF5=n EVENT=y
 notifications:
   webhooks: https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN


### PR DESCRIPTION
Python 3.5 officially reached end-of-life in September, so I thought it would be prudent to remove 3.5 from our testing matrix and add 3.8 in.