### PR TITLE
Ensure correct initialization of members for RegularMesh

### DIFF
--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -930,13 +930,13 @@ class Settings:
         if self.entropy_mesh is not None:
             # use default heuristic for entropy mesh if not set by user
             if self.entropy_mesh.dimension is None:
-                    if self.particles is None:
-                        raise RuntimeError("Number of particles must be set in order to " \
-                          "use entropy mesh dimension heuristic")
-                    else:
-                        n = ceil((self.particles / 20.0)**(1.0 / 3.0))
-                        d = len(self.entropy_mesh.lower_left)
-                        self.entropy_mesh.dimension = (n,)*d
+                if self.particles is None:
+                    raise RuntimeError("Number of particles must be set in order to " \
+                      "use entropy mesh dimension heuristic")
+                else:
+                    n = ceil((self.particles / 20.0)**(1.0 / 3.0))
+                    d = len(self.entropy_mesh.lower_left)
+                    self.entropy_mesh.dimension = (n,)*d
 
             # See if a <mesh> element already exists -- if not, add it
             path = "./mesh[@id='{}']".format(self.entropy_mesh.id)

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -930,9 +930,13 @@ class Settings:
         if self.entropy_mesh is not None:
             # use default heuristic for entropy mesh if not set by user
             if self.entropy_mesh.dimension is None:
-                n = ceil((self.particles / 20.0)**(1.0 / 3.0))
-                d = len(self.entropy_mesh.lower_left)
-                self.entropy_mesh.dimension = (n,)*d
+                    if self.particles is None:
+                        raise RuntimeError("Number of particles must be set in order to " \
+                          "use entropy mesh dimension heuristic")
+                    else:
+                        n = ceil((self.particles / 20.0)**(1.0 / 3.0))
+                        d = len(self.entropy_mesh.lower_left)
+                        self.entropy_mesh.dimension = (n,)*d
 
             # See if a <mesh> element already exists -- if not, add it
             path = "./mesh[@id='{}']".format(self.entropy_mesh.id)

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -582,7 +582,7 @@ void read_settings_xml()
 
     // Assign ID and set mapping
     model::meshes.back()->id_ = 10001;
-    model::mesh_map[10001] = index_entropy_mesh;
+    model::mesh_map[10001] = i_ufs_mesh;
   }
 
   if (i_ufs_mesh >= 0) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -532,39 +532,24 @@ void read_settings_xml()
   }
 
   // Uniform fission source weighting mesh
-  int32_t i_ufs_mesh = -1;
   if (check_for_node(root, "ufs_mesh")) {
     auto temp = std::stoi(get_node_value(root, "ufs_mesh"));
     if (model::mesh_map.find(temp) == model::mesh_map.end()) {
       fatal_error(fmt::format("Mesh {} specified for uniform fission site "
         "method does not exist.", temp));
     }
-    i_ufs_mesh = model::mesh_map.at(temp);
 
-  } else if (check_for_node(root, "uniform_fs")) {
-    warning("Specifying a UFS mesh via the <uniform_fs> element "
-      "is deprecated. Please create a mesh using <mesh> and then reference "
-      "it by specifying its ID in a <ufs_mesh> element.");
-
-    // Read entropy mesh from <entropy>
-    auto node_ufs = root.child("uniform_fs");
-    model::meshes.push_back(std::make_unique<RegularMesh>(node_ufs));
-
-    // Set entropy mesh index
-    i_ufs_mesh = model::meshes.size() - 1;
-
-    // Assign ID and set mapping
-    model::meshes.back()->id_ = 10001;
-    model::mesh_map[10001] = i_ufs_mesh;
-  }
-
-  if (i_ufs_mesh >= 0) {
-    auto* m = dynamic_cast<RegularMesh*>(model::meshes[i_ufs_mesh].get());
+    auto* m = dynamic_cast<RegularMesh*>(model::meshes[model::mesh_map.at(temp)].get());
     if (!m) fatal_error("Only regular meshes can be used as a UFS mesh");
     simulation::ufs_mesh = m;
 
     // Turn on uniform fission source weighting
     ufs_on = true;
+
+  } else if (check_for_node(root, "uniform_fs")) {
+    fatal_error("Specifying a UFS mesh via the <uniform_fs> element "
+      "is deprecated. Please create a mesh using <mesh> and then reference "
+      "it by specifying its ID in a <ufs_mesh> element.");
   }
 
   // Check if the user has specified to write state points

--- a/tests/regression_tests/uniform_fs/settings.xml
+++ b/tests/regression_tests/uniform_fs/settings.xml
@@ -10,10 +10,12 @@
     <space type="box" parameters="-10 -10 -10 10 10 10" />
   </source>
 
-  <uniform_fs>
+  <mesh id="1">
     <dimension>10 10 10</dimension>
     <lower_left>-10. -10. -10.</lower_left>
     <upper_right>10. 10. 10.</upper_right>
-  </uniform_fs>
+  </mesh>
+
+  <ufs_mesh>1</ufs_mesh>
 
 </settings>


### PR DESCRIPTION
I'm familiarizing myself with the `Mesh` representations, and came across what I think is an unprotected logic chain that could lead to unintended behavior for users. Basically, the `RegularMesh` is provided with a `lower_left_` coordinate, and either:

A) computes `upper_right_` from a provided `shape_` and `width_`
B) computes `width_` from a provided `shape_` and `upper_right_`

(a third option is to compute the `shape_` from `width_` and `upper_right_`, but you probably wouldn't have a perfect integer number of cells and it doesn't seem like this is even supported).

Therefore, `shape_` _must_ be provided, but currently no error is thrown if it's not provided, in which case `shape_` and `n_dimension_` are not set. You would also miss the check that the dimension is 1-D, 2-D, or 3-D.

This PR protects against the fringe case where the user doesn't set `"dimension"`.