### PR TITLE
Adding reaction name dict

### DIFF
--- a/openmc/data/reaction.py
+++ b/openmc/data/reaction.py
@@ -64,7 +64,8 @@ REACTION_NAME.update({i: '(n,3He{})'.format(i - 750) for i in range(750, 799)})
 REACTION_NAME.update({i: '(n,a{})'.format(i - 800) for i in range(800, 849)})
 REACTION_NAME.update({i: '(n,2n{})'.format(i - 875) for i in range(875, 891)})
 
-REACTION_NUMBER = dict(zip(REACTION_NAME.values(), REACTION_NAME.keys()))
+REACTION_MT = {name: mt for mt, name in REACTION_NAME.items()}
+REACTION_MT['fission'] = 18
 
 FISSION_MTS = (18, 19, 20, 21, 38)
 

--- a/openmc/data/reaction.py
+++ b/openmc/data/reaction.py
@@ -64,6 +64,8 @@ REACTION_NAME.update({i: '(n,3He{})'.format(i - 750) for i in range(750, 799)})
 REACTION_NAME.update({i: '(n,a{})'.format(i - 800) for i in range(800, 849)})
 REACTION_NAME.update({i: '(n,2n{})'.format(i - 875) for i in range(875, 891)})
 
+REACTION_NUMBER = dict(zip(REACTION_NAME.values(), REACTION_NAME.keys()))
+
 FISSION_MTS = (18, 19, 20, 21, 38)
 
 

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -11,7 +11,7 @@ from numpy import dot, zeros, newaxis, asarray
 
 from . import comm
 from openmc.checkvalue import check_type, check_greater_than
-from openmc.data import JOULE_PER_EV, REACTION_NAME
+from openmc.data import JOULE_PER_EV, REACTION_NUMBER
 from openmc.lib import (
     Tally, MaterialFilter, EnergyFilter, EnergyFunctionFilter)
 import openmc.lib
@@ -168,10 +168,9 @@ class FluxCollapseHelper(ReactionRateHelper):
         """
         self._materials = materials
 
-        # Convert reactions to MT values (needed when collapsing)
-        mt_values = {v: k for k, v in REACTION_NAME.items()}
-        mt_values['fission'] = 18
-        self._mts = [mt_values[x] for x in scores]
+        # adds an entry for fisson to the dictionary of reactions
+        REACTION_NUMBER['fission'] = 18
+        self._mts = [REACTION_NUMBER[x] for x in scores]
         self._scores = scores
 
         # Create flux tally with material and energy filters

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -11,7 +11,7 @@ from numpy import dot, zeros, newaxis, asarray
 
 from . import comm
 from openmc.checkvalue import check_type, check_greater_than
-from openmc.data import JOULE_PER_EV, REACTION_NUMBER
+from openmc.data import JOULE_PER_EV, REACTION_MT
 from openmc.lib import (
     Tally, MaterialFilter, EnergyFilter, EnergyFunctionFilter)
 import openmc.lib
@@ -169,8 +169,7 @@ class FluxCollapseHelper(ReactionRateHelper):
         self._materials = materials
 
         # adds an entry for fisson to the dictionary of reactions
-        REACTION_NUMBER['fission'] = 18
-        self._mts = [REACTION_NUMBER[x] for x in scores]
+        self._mts = [REACTION_MT[x] for x in scores]
         self._scores = scores
 
         # Create flux tally with material and energy filters

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -405,13 +405,15 @@ def _calculate_cexs_nuclide(this, types, temperature=294., sab_name=None,
                     ops.append((np.add,) * (len(tmp_mts) - 2) + (np.multiply,))
                 else:
                     ops.append((np.add,) * (len(tmp_mts) - 1))
-            if line in openmc.data.REACTION_NUMBER:
-                openmc.data.REACTION_NUMBER[line]
-                tmp_mts = nuc.get_reaction_components(line)
+            elif line in openmc.data.REACTION_NUMBER.keys():
+                mt_number = openmc.data.REACTION_NUMBER[line]
+                cv.check_type('MT in types', mt_number, Integral)
+                cv.check_greater_than('MT in types', mt_number, 0)
+                tmp_mts = nuc.get_reaction_components(mt_number)
                 mts.append(tmp_mts)
                 ops.append((np.add,) * (len(tmp_mts) - 1))
                 yields.append(False)
-            else:
+            elif isinstance(line, int):
                 # Not a built-in type, we have to parse it ourselves
                 cv.check_type('MT in types', line, Integral)
                 cv.check_greater_than('MT in types', line, 0)
@@ -419,6 +421,8 @@ def _calculate_cexs_nuclide(this, types, temperature=294., sab_name=None,
                 mts.append(tmp_mts)
                 ops.append((np.add,) * (len(tmp_mts) - 1))
                 yields.append(False)
+            else:
+                raise TypeError("Invalid type", line)
 
         for i, mt_set in enumerate(mts):
             # Get the reaction xs data from the nuclide

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -309,7 +309,7 @@ def _calculate_cexs_nuclide(this, types, temperature=294., sab_name=None,
         Nuclide object to source data from
     types : Iterable of str or Integral
         The type of cross sections to calculate; values can either be those
-        in openmc.PLOT_TYPES or keys from openmc.data.REACTION_NUMBER which
+        in openmc.PLOT_TYPES or keys from openmc.data.REACTION_MT which
         correspond to a reaction description e.g '(n,2n)' or integers which
         correspond to reaction channel (MT) numbers.
     temperature : float, optional
@@ -405,8 +405,8 @@ def _calculate_cexs_nuclide(this, types, temperature=294., sab_name=None,
                     ops.append((np.add,) * (len(tmp_mts) - 2) + (np.multiply,))
                 else:
                     ops.append((np.add,) * (len(tmp_mts) - 1))
-            elif line in openmc.data.REACTION_NUMBER.keys():
-                mt_number = openmc.data.REACTION_NUMBER[line]
+            elif line in openmc.data.REACTION_MT:
+                mt_number = openmc.data.REACTION_MT[line]
                 cv.check_type('MT in types', mt_number, Integral)
                 cv.check_greater_than('MT in types', mt_number, 0)
                 tmp_mts = nuc.get_reaction_components(mt_number)

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -404,6 +404,12 @@ def _calculate_cexs_nuclide(this, types, temperature=294., sab_name=None,
                     ops.append((np.add,) * (len(tmp_mts) - 2) + (np.multiply,))
                 else:
                     ops.append((np.add,) * (len(tmp_mts) - 1))
+            if line in openmc.data.REACTION_NUMBER:
+                openmc.data.REACTION_NUMBER[line]
+                tmp_mts = nuc.get_reaction_components(line)
+                mts.append(tmp_mts)
+                ops.append((np.add,) * (len(tmp_mts) - 1))
+                yields.append(False)
             else:
                 # Not a built-in type, we have to parse it ourselves
                 cv.check_type('MT in types', line, Integral)

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -309,8 +309,9 @@ def _calculate_cexs_nuclide(this, types, temperature=294., sab_name=None,
         Nuclide object to source data from
     types : Iterable of str or Integral
         The type of cross sections to calculate; values can either be those
-        in openmc.PLOT_TYPES or integers which correspond to reaction
-        channel (MT) numbers.
+        in openmc.PLOT_TYPES or keys from openmc.data.REACTION_NUMBER which
+        correspond to a reaction description e.g '(n,2n)' or integers which
+        correspond to reaction channel (MT) numbers.
     temperature : float, optional
         Temperature in Kelvin to plot. If not specified, a default
         temperature of 294K will be plotted. Note that the nearest


### PR DESCRIPTION
I have put this in as a draft while I test it a bit more.

From time to time I find myself knowing the reaction description e.g (n,3n) but I don't know the MT number.

I noticed there is a helpful REACTION_NAME dictionary hidden away and I was wondering if another little dictionary with the reverse can be added.

This can be handy from time to time but admittedly doesn't save much effort

This PR adds REACTION_NUMBER and makes use of it in two places in the code.

In helpers.py the dictionary is used to save it being remade
In plotter.py the dictionary is used to allow users to plot materials, elements and nuclide using reaction descriptions like '(n,Xt') which are a bit easier to remember than the MT number

I've plotted a few test cases to check it works

```
test_nuclide = openmc.Nuclide('Li6')
type_of_reaction = ['(n,Xt)']
openmc.plot_xs(test_nuclide, type_of_reaction)

energy, xs_data = openmc.calculate_cexs(
    test_nuclide,
    'nuclide',
    type_of_reaction)

test_element = openmc.Element('Li')
type_of_reaction = ['(n,Xt)']
openmc.plot_xs(test_element, type_of_reaction)

test_element = openmc.Element('Li')
type_of_reaction = ['(n,Xt)']  
energy, xs_data = openmc.calculate_cexs(
    test_element,
    'element',
    type_of_reaction)

test_material = openmc.Material()
test_material.add_element('Li', 1)
type_of_reaction = ['(n,Xt)']
openmc.plot_xs(test_material, type_of_reaction)

test_material = openmc.Material()
test_material.add_element('Li', 1)
type_of_reaction = ['(n,Xt)']  
energy, xs_data = openmc.calculate_cexs(
    test_material,
    'material',
    type_of_reaction)
```