### PR TITLE
Remove redundant error check that the Position is in the mesh

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -193,16 +193,6 @@ RegularMesh::RegularMesh(pugi::xml_node node)
 
 int RegularMesh::get_bin(Position r) const
 {
-  // Loop over the dimensions of the mesh
-  for (int i = 0; i < n_dimension_; ++i) {
-    // Check for cases where particle is outside of mesh
-    if (r[i] < lower_left_[i]) {
-      return -1;
-    } else if (r[i] > upper_right_[i]) {
-      return -1;
-    }
-  }
-
   // Determine indices
   std::vector<int> ijk(n_dimension_);
   bool in_mesh;


### PR DESCRIPTION
The `get_bin` method performs a check that the `Position` is within the bounds of the `RegularMesh`. However, the `get_indices` method that is called just after this error check already performs a within-bounds check (albeit with a different approach, not by comparing coordinate values to `lower_left` and `upper_right`, but instead comparing the computed x, y, z indices in the mesh against the range [1, `shape_[i]`] for each `i`.

So I think this can safely be deleted!