### PR TITLE
(tiny) Fix depletion restart example

### DIFF
--- a/docs/source/devguide/workflow.rst
+++ b/docs/source/devguide/workflow.rst
@@ -50,7 +50,7 @@ Contributing
 ------------
 
 Now that you understand the basic development workflow, let's discuss how an
-individual to contribute to development. Note that this would apply to both new
+individual can contribute to development. Note that this would apply to both new
 features and bug fixes. The general steps for contributing are as follows:
 
 1. Fork the main openmc repository from `openmc-dev/openmc`_. This will create a

--- a/examples/pincell_depletion/restart_depletion.py
+++ b/examples/pincell_depletion/restart_depletion.py
@@ -12,7 +12,7 @@ with openmc.StatePoint(statepoint) as sp:
     geometry = sp.summary.geometry
 
 # Load previous depletion results
-previous_results = openmc.deplete.ResultsList("depletion_results.h5")
+previous_results = openmc.deplete.ResultsList.from_hdf5("depletion_results.h5")
 
 ###############################################################################
 #                      Transport calculation settings


### PR DESCRIPTION
It seems that the example `delpetion_restart.py` currently fails on develop because the `ResultsList` class was at some point changed from taking the name of an HDF5 restart file in its `__init__` to having this file name passing through `from_hdf5`. It seems this example was never adjusted, which I found to be failing. I was thinking my code broke something, but luckily it turns out to be this tiny fix. :smile: 

Also, I have snuck in a small grammar fix in the contributing docs.