### PR TITLE
Remove unused source sampling timer

### DIFF
--- a/include/openmc/timer.h
+++ b/include/openmc/timer.h
@@ -21,7 +21,6 @@ extern Timer time_finalize;
 extern Timer time_inactive;
 extern Timer time_initialize;
 extern Timer time_read_xs;
-extern Timer time_sample_source;
 extern Timer time_statepoint;
 extern Timer time_tallies;
 extern Timer time_total;

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -293,8 +293,6 @@ openmc_statepoint_write(const char* filename, bool* write_source)
       write_dataset(runtime_group, "synchronizing fission bank", time_bank.elapsed());
       write_dataset(runtime_group, "sampling source sites", time_bank_sample.elapsed());
       write_dataset(runtime_group, "SEND-RECV source sites", time_bank_sendrecv.elapsed());
-    } else {
-      write_dataset(runtime_group, "sampling source sites", time_sample_source.elapsed());
     }
     write_dataset(runtime_group, "accumulating tallies", time_tallies.elapsed());
     write_dataset(runtime_group, "total", time_total.elapsed());

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -16,7 +16,6 @@ Timer time_finalize;
 Timer time_inactive;
 Timer time_initialize;
 Timer time_read_xs;
-Timer time_sample_source;
 Timer time_statepoint;
 Timer time_tallies;
 Timer time_total;
@@ -76,7 +75,6 @@ void reset_timers()
   simulation::time_inactive.reset();
   simulation::time_initialize.reset();
   simulation::time_read_xs.reset();
-  simulation::time_sample_source.reset();
   simulation::time_statepoint.reset();
   simulation::time_tallies.reset();
   simulation::time_total.reset();


### PR DESCRIPTION
This PR removes a timer for source sampling that used to be used in fixed source mode. Now that source sampling is handled during transport (for each particle individually rather than being accumulated in a bank first), this timer isn't used at all.