### PR TITLE
Add requirement to have njoy executable in test_kerma.

### DIFF
--- a/tests/unit_tests/test_data_neutron.py
+++ b/tests/unit_tests/test_data_neutron.py
@@ -219,6 +219,7 @@ def test_derived_products(am244):
     assert total_neutron.yield_(6e6) == pytest.approx(4.2558)
 
 
+@needs_njoy
 def test_kerma(run_in_tmpdir, am244, h2):
     # Make sure kerma w/ local photon is >= regular kerma
     for nuc in (am244, h2):


### PR DESCRIPTION
When running the unit test suite, all of my tests pass except for `test_kerma`, since I don't have an NJOY executable in my PATH.  The error message I see seems to suggest that this test error occurs because I don't have NJOY, but other tests that require NJOY are skipped (instead of erroring) with `@needs_njoy`.

```
>               raise child_exception_type(errno_num, err_msg, err_filename)
E               FileNotFoundError: [Errno 2] No such file or directory: 'njoy'

../../.pyenv/versions/3.8.5/lib/python3.8/subprocess.py:1702: FileNotFoundError
```

Please correct me if I am misunderstanding! After this change, all the unit tests pass for me.