### PR TITLE
Merge RegularMesh and RectilinearMesh features into base class

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -116,7 +116,7 @@ public:
   //! \param[in] r Position to get indices for
   //! \param[out] ijk Array of mesh indices
   //! \param[out] in_mesh Whether position is in mesh
-  virtual void get_indices(Position r, int* ijk, bool* in_mesh) const = 0;
+  virtual void get_indices(Position r, int* ijk, bool* in_mesh) const;
 
   //! Get mesh indices corresponding to a mesh bin
   //
@@ -124,12 +124,19 @@ public:
   //! \param[out] ijk Mesh indices
   virtual void get_indices_from_bin(int bin, int* ijk) const = 0;
 
+  //! Get mesh index in a particular direction
+  //!
+  //! \param[in] r Position to get index for
+  //! \param[in] i Direction index
+  virtual int get_index_in_direction(Position r, int i) const = 0;
+
   //! Get a label for the mesh bin
   std::string bin_label(int bin) const override;
 
   // Data members
   xt::xtensor<double, 1> lower_left_; //!< Lower-left coordinates of mesh
   xt::xtensor<double, 1> upper_right_; //!< Upper-right coordinates of mesh
+  xt::xtensor<int, 1> shape_; //!< Number of mesh elements in each dimension
 };
 
 //==============================================================================
@@ -155,9 +162,9 @@ public:
 
   int get_bin_from_indices(const int* ijk) const override;
 
-  void get_indices(Position r, int* ijk, bool* in_mesh) const override;
-
   void get_indices_from_bin(int bin, int* ijk) const override;
+
+  int get_index_in_direction(Position r, int i) const override;
 
   int n_bins() const override;
 
@@ -189,7 +196,6 @@ public:
   // Data members
 
   double volume_frac_; //!< Volume fraction of each mesh element
-  xt::xtensor<int, 1> shape_; //!< Number of mesh elements in each dimension
   xt::xtensor<double, 1> width_; //!< Width of each mesh element
 
 private:
@@ -217,9 +223,9 @@ public:
 
   int get_bin_from_indices(const int* ijk) const override;
 
-  void get_indices(Position r, int* ijk, bool* in_mesh) const override;
-
   void get_indices_from_bin(int bin, int* ijk) const override;
+
+  int get_index_in_direction(Position r, int i) const override;
 
   int n_bins() const override;
 
@@ -239,9 +245,6 @@ public:
   //! \param[out] ijk Indices of the mesh bin containing the intersection point
   //! \return Whether the line segment connecting r0 and r1 intersects mesh
   bool intersects(Position& r0, Position r1, int* ijk) const;
-
-  // Data members
-  xt::xtensor<int, 1> shape_; //!< Number of mesh elements in each dimension
 
 private:
   std::vector<std::vector<double>> grid_;

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -105,6 +105,8 @@ public:
   StructuredMesh(pugi::xml_node node) : Mesh {node} {};
   virtual ~StructuredMesh() = default;
 
+  int get_bin(Position r) const override;
+
   //! Get bin given mesh indices
   //
   //! \param[in] Array of mesh indices
@@ -171,9 +173,7 @@ public:
   void surface_bins_crossed(const Particle& p, std::vector<int>& bins)
   const override;
 
-  int get_bin(Position r) const override;
-
-  int get_index_in_direction(Position r, int i) const override;
+  int get_index_in_direction(double r, int i) const override;
 
   int n_bins() const override;
 
@@ -215,9 +215,7 @@ public:
   void surface_bins_crossed(const Particle& p, std::vector<int>& bins)
   const override;
 
-  int get_bin(Position r) const override;
-
-  int get_index_in_direction(Position r, int i) const override;
+  int get_index_in_direction(double r, int i) const override;
 
   int n_bins() const override;
 

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -111,6 +111,9 @@ public:
 
   int n_surface_bins() const override;
 
+  void bins_crossed(const Particle& p, std::vector<int>& bins,
+                    std::vector<double>& lengths) const override;
+
   //! Get bin given mesh indices
   //
   //! \param[in] Array of mesh indices
@@ -144,6 +147,18 @@ public:
   //! \return Whether the line segment connecting r0 and r1 intersects mesh
   virtual bool intersects(Position& r0, Position r1, int* ijk) const;
 
+  //! Get the coordinate for the mesh grid boundary in the positive direction
+  //!
+  //! \param[in] ijk Array of mesh indices
+  //! \param[in] i Direction index
+  virtual double positive_grid_boundary(int* ijk, int i) const = 0;
+
+  //! Get the coordinate for the mesh grid boundary in the negative direction
+  //!
+  //! \param[in] ijk Array of mesh indices
+  //! \param[in] i Direction index
+  virtual double negative_grid_boundary(int* ijk, int i) const = 0;
+
   //! Get a label for the mesh bin
   std::string bin_label(int bin) const override;
 
@@ -171,13 +186,14 @@ public:
 
   // Overriden methods
 
-  void bins_crossed(const Particle& p, std::vector<int>& bins,
-                    std::vector<double>& lengths) const override;
-
   void surface_bins_crossed(const Particle& p, std::vector<int>& bins)
   const override;
 
   int get_index_in_direction(double r, int i) const override;
+
+  double positive_grid_boundary(int* ijk, int i) const override;
+
+  double negative_grid_boundary(int* ijk, int i) const override;
 
   std::pair<std::vector<double>, std::vector<double>>
   plot(Position plot_ll, Position plot_ur) const override;
@@ -209,13 +225,14 @@ public:
 
   // Overriden methods
 
-  void bins_crossed(const Particle& p, std::vector<int>& bins,
-                    std::vector<double>& lengths) const override;
-
   void surface_bins_crossed(const Particle& p, std::vector<int>& bins)
   const override;
 
   int get_index_in_direction(double r, int i) const override;
+
+  double positive_grid_boundary(int* ijk, int i) const override;
+
+  double negative_grid_boundary(int* ijk, int i) const override;
 
   std::pair<std::vector<double>, std::vector<double>>
   plot(Position plot_ll, Position plot_ur) const override;

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -109,7 +109,7 @@ public:
   //
   //! \param[in] Array of mesh indices
   //! \return Mesh bin
-  virtual int get_bin_from_indices(const int* ijk) const = 0;
+  virtual int get_bin_from_indices(const int* ijk) const;
 
   //! Get mesh indices given a position
   //
@@ -159,8 +159,6 @@ public:
   const override;
 
   int get_bin(Position r) const override;
-
-  int get_bin_from_indices(const int* ijk) const override;
 
   void get_indices_from_bin(int bin, int* ijk) const override;
 
@@ -220,8 +218,6 @@ public:
   const override;
 
   int get_bin(Position r) const override;
-
-  int get_bin_from_indices(const int* ijk) const override;
 
   void get_indices_from_bin(int bin, int* ijk) const override;
 

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -107,6 +107,10 @@ public:
 
   int get_bin(Position r) const override;
 
+  int n_bins() const override;
+
+  int n_surface_bins() const override;
+
   //! Get bin given mesh indices
   //
   //! \param[in] Array of mesh indices
@@ -175,10 +179,6 @@ public:
 
   int get_index_in_direction(double r, int i) const override;
 
-  int n_bins() const override;
-
-  int n_surface_bins() const override;
-
   std::pair<std::vector<double>, std::vector<double>>
   plot(Position plot_ll, Position plot_ur) const override;
 
@@ -216,10 +216,6 @@ public:
   const override;
 
   int get_index_in_direction(double r, int i) const override;
-
-  int n_bins() const override;
-
-  int n_surface_bins() const override;
 
   std::pair<std::vector<double>, std::vector<double>>
   plot(Position plot_ll, Position plot_ur) const override;

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -122,7 +122,7 @@ public:
   //
   //! \param[in] bin Mesh bin
   //! \param[out] ijk Mesh indices
-  virtual void get_indices_from_bin(int bin, int* ijk) const = 0;
+  virtual void get_indices_from_bin(int bin, int* ijk) const;
 
   //! Get mesh index in a particular direction
   //!
@@ -159,8 +159,6 @@ public:
   const override;
 
   int get_bin(Position r) const override;
-
-  void get_indices_from_bin(int bin, int* ijk) const override;
 
   int get_index_in_direction(Position r, int i) const override;
 
@@ -218,8 +216,6 @@ public:
   const override;
 
   int get_bin(Position r) const override;
-
-  void get_indices_from_bin(int bin, int* ijk) const override;
 
   int get_index_in_direction(Position r, int i) const override;
 

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -126,9 +126,17 @@ public:
 
   //! Get mesh index in a particular direction
   //!
-  //! \param[in] r Position to get index for
+  //! \param[in] r Coordinate to get index for
   //! \param[in] i Direction index
-  virtual int get_index_in_direction(Position r, int i) const = 0;
+  virtual int get_index_in_direction(double r, int i) const = 0;
+
+  //! Check where a line segment intersects the mesh and if it intersects at all
+  //
+  //! \param[in,out] r0 In: starting position, out: intersection point
+  //! \param[in] r1 Ending position
+  //! \param[out] ijk Indices of the mesh bin containing the intersection point
+  //! \return Whether the line segment connecting r0 and r1 intersects mesh
+  virtual bool intersects(Position& r0, Position r1, int* ijk) const;
 
   //! Get a label for the mesh bin
   std::string bin_label(int bin) const override;
@@ -137,6 +145,11 @@ public:
   xt::xtensor<double, 1> lower_left_; //!< Lower-left coordinates of mesh
   xt::xtensor<double, 1> upper_right_; //!< Upper-right coordinates of mesh
   xt::xtensor<int, 1> shape_; //!< Number of mesh elements in each dimension
+
+protected:
+  virtual bool intersects_1d(Position& r0, Position r1, int* ijk) const;
+  virtual bool intersects_2d(Position& r0, Position r1, int* ijk) const;
+  virtual bool intersects_3d(Position& r0, Position r1, int* ijk) const;
 };
 
 //==============================================================================
@@ -173,14 +186,6 @@ public:
 
   // New methods
 
-  //! Check where a line segment intersects the mesh and if it intersects at all
-  //
-  //! \param[in,out] r0 In: starting position, out: intersection point
-  //! \param[in] r1 Ending position
-  //! \param[out] ijk Indices of the mesh bin containing the intersection point
-  //! \return Whether the line segment connecting r0 and r1 intersects mesh
-  bool intersects(Position& r0, Position r1, int* ijk) const;
-
   //! Count number of bank sites in each mesh bin / energy bin
   //
   //! \param[in] bank Array of bank sites
@@ -193,11 +198,6 @@ public:
 
   double volume_frac_; //!< Volume fraction of each mesh element
   xt::xtensor<double, 1> width_; //!< Width of each mesh element
-
-private:
-  bool intersects_1d(Position& r0, Position r1, int* ijk) const;
-  bool intersects_2d(Position& r0, Position r1, int* ijk) const;
-  bool intersects_3d(Position& r0, Position r1, int* ijk) const;
 };
 
 
@@ -227,16 +227,6 @@ public:
   plot(Position plot_ll, Position plot_ur) const override;
 
   void to_hdf5(hid_t group) const override;
-
-  // New methods
-
-  //! Check where a line segment intersects the mesh and if it intersects at all
-  //
-  //! \param[in,out] r0 In: starting position, out: intersection point
-  //! \param[in] r1 Ending position
-  //! \param[out] ijk Indices of the mesh bin containing the intersection point
-  //! \return Whether the line segment connecting r0 and r1 intersects mesh
-  bool intersects(Position& r0, Position r1, int* ijk) const;
 
 private:
   std::vector<std::vector<double>> grid_;

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -102,14 +102,27 @@ StructuredMesh::bin_label(int bin) const {
   }
 }
 
-void
-StructuredMesh::get_indices(Position r, int* ijk, bool* in_mesh) const
+void StructuredMesh::get_indices(Position r, int* ijk, bool* in_mesh) const
 {
   *in_mesh = true;
   for (int i = 0; i < n_dimension_; ++i) {
     ijk[i] = get_index_in_direction(r, i);
 
     if (ijk[i] < 1 || ijk[i] > shape_[i]) *in_mesh = false;
+  }
+}
+
+int StructuredMesh::get_bin_from_indices(const int* ijk) const
+{
+  switch (n_dimension_) {
+  case 1:
+    return ijk[0] - 1;
+  case 2:
+    return (ijk[1] - 1)*shape_[0] + ijk[0] - 1;
+  case 3:
+    return ((ijk[2] - 1)*shape_[1] + (ijk[1] - 1))*shape_[0] + ijk[0] - 1;
+  default:
+    throw std::runtime_error{"Invalid number of mesh dimensions"};
   }
 }
 
@@ -208,20 +221,6 @@ int RegularMesh::get_bin(Position r) const
 
   // Convert indices to bin
   return get_bin_from_indices(ijk.data());
-}
-
-int RegularMesh::get_bin_from_indices(const int* ijk) const
-{
-  switch (n_dimension_) {
-  case 1:
-    return ijk[0] - 1;
-  case 2:
-    return (ijk[1] - 1)*shape_[0] + ijk[0] - 1;
-  case 3:
-    return ((ijk[2] - 1)*shape_[1] + (ijk[1] - 1))*shape_[0] + ijk[0] - 1;
-  default:
-    throw std::runtime_error{"Invalid number of mesh dimensions"};
-  }
 }
 
 int RegularMesh::get_index_in_direction(Position r, int i) const
@@ -1172,11 +1171,6 @@ int RectilinearMesh::get_bin(Position r) const
 
   // Convert indices to bin
   return get_bin_from_indices(ijk);
-}
-
-int RectilinearMesh::get_bin_from_indices(const int* ijk) const
-{
-  return ((ijk[2] - 1)*shape_[1] + (ijk[1] - 1))*shape_[0] + ijk[0] - 1;
 }
 
 int RectilinearMesh::get_index_in_direction(Position r, int i) const

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -152,6 +152,16 @@ int StructuredMesh::get_bin(Position r) const
   return get_bin_from_indices(ijk.data());
 }
 
+int StructuredMesh::n_bins() const
+{
+  return xt::prod(shape_)();
+}
+
+int StructuredMesh::n_surface_bins() const
+{
+  return 4 * n_dimension_ * n_bins();
+}
+
 bool StructuredMesh::intersects(Position& r0, Position r1, int* ijk) const
 {
   switch(n_dimension_) {
@@ -484,18 +494,6 @@ RegularMesh::RegularMesh(pugi::xml_node node)
 int RegularMesh::get_index_in_direction(double r, int i) const
 {
   return std::ceil((r - lower_left_[i]) / width_[i]);
-}
-
-int RegularMesh::n_bins() const
-{
-  int n_bins = 1;
-  for (auto dim : shape_) n_bins *= dim;
-  return n_bins;
-}
-
-int RegularMesh::n_surface_bins() const
-{
-  return 4 * n_dimension_ * n_bins();
 }
 
 void RegularMesh::bins_crossed(const Particle& p, std::vector<int>& bins,
@@ -1165,16 +1163,6 @@ void RectilinearMesh::surface_bins_crossed(const Particle& p,
 int RectilinearMesh::get_index_in_direction(double r, int i) const
 {
   return lower_bound_index(grid_[i].begin(), grid_[i].end(), r) + 1;
-}
-
-int RectilinearMesh::n_bins() const
-{
-  return xt::prod(shape_)();
-}
-
-int RectilinearMesh::n_surface_bins() const
-{
-  return 4 * n_dimension_ * n_bins();
 }
 
 std::pair<std::vector<double>, std::vector<double>>

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -102,6 +102,17 @@ StructuredMesh::bin_label(int bin) const {
   }
 }
 
+void
+StructuredMesh::get_indices(Position r, int* ijk, bool* in_mesh) const
+{
+  *in_mesh = true;
+  for (int i = 0; i < n_dimension_; ++i) {
+    ijk[i] = get_index_in_direction(r, i);
+
+    if (ijk[i] < 1 || ijk[i] > shape_[i]) *in_mesh = false;
+  }
+}
+
 //==============================================================================
 // RegularMesh implementation
 //==============================================================================
@@ -213,16 +224,9 @@ int RegularMesh::get_bin_from_indices(const int* ijk) const
   }
 }
 
-void RegularMesh::get_indices(Position r, int* ijk, bool* in_mesh) const
+int RegularMesh::get_index_in_direction(Position r, int i) const
 {
-  // Find particle in mesh
-  *in_mesh = true;
-  for (int i = 0; i < n_dimension_; ++i) {
-    ijk[i] = std::ceil((r[i] - lower_left_[i]) / width_[i]);
-
-    // Check if indices are within bounds
-    if (ijk[i] < 1 || ijk[i] > shape_[i]) *in_mesh = false;
-  }
+  return std::ceil((r[i] - lower_left_[i]) / width_[i]);
 }
 
 void RegularMesh::get_indices_from_bin(int bin, int* ijk) const
@@ -1175,18 +1179,9 @@ int RectilinearMesh::get_bin_from_indices(const int* ijk) const
   return ((ijk[2] - 1)*shape_[1] + (ijk[1] - 1))*shape_[0] + ijk[0] - 1;
 }
 
-void RectilinearMesh::get_indices(Position r, int* ijk, bool* in_mesh) const
+int RectilinearMesh::get_index_in_direction(Position r, int i) const
 {
-  *in_mesh = true;
-
-  for (int i = 0; i < 3; ++i) {
-    if (r[i] < grid_[i].front() || r[i] > grid_[i].back()) {
-      ijk[i] = -1;
-      *in_mesh = false;
-    } else {
-      ijk[i] = lower_bound_index(grid_[i].begin(), grid_[i].end(), r[i]) + 1;
-    }
-  }
+  return lower_bound_index(grid_[i].begin(), grid_[i].end(), r[i]) + 1;
 }
 
 void RectilinearMesh::get_indices_from_bin(int bin, int* ijk) const

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -126,6 +126,20 @@ int StructuredMesh::get_bin_from_indices(const int* ijk) const
   }
 }
 
+void StructuredMesh::get_indices_from_bin(int bin, int* ijk) const
+{
+  if (n_dimension_ == 1) {
+    ijk[0] = bin + 1;
+  } else if (n_dimension_ == 2) {
+    ijk[0] = bin % shape_[0] + 1;
+    ijk[1] = bin / shape_[0] + 1;
+  } else if (n_dimension_ == 3) {
+    ijk[0] = bin % shape_[0] + 1;
+    ijk[1] = (bin % (shape_[0] * shape_[1])) / shape_[0] + 1;
+    ijk[2] = bin / (shape_[0] * shape_[1]) + 1;
+  }
+}
+
 //==============================================================================
 // RegularMesh implementation
 //==============================================================================
@@ -226,20 +240,6 @@ int RegularMesh::get_bin(Position r) const
 int RegularMesh::get_index_in_direction(Position r, int i) const
 {
   return std::ceil((r[i] - lower_left_[i]) / width_[i]);
-}
-
-void RegularMesh::get_indices_from_bin(int bin, int* ijk) const
-{
-  if (n_dimension_ == 1) {
-    ijk[0] = bin + 1;
-  } else if (n_dimension_ == 2) {
-    ijk[0] = bin % shape_[0] + 1;
-    ijk[1] = bin / shape_[0] + 1;
-  } else if (n_dimension_ == 3) {
-    ijk[0] = bin % shape_[0] + 1;
-    ijk[1] = (bin % (shape_[0] * shape_[1])) / shape_[0] + 1;
-    ijk[2] = bin / (shape_[0] * shape_[1]) + 1;
-  }
 }
 
 int RegularMesh::n_bins() const
@@ -1176,13 +1176,6 @@ int RectilinearMesh::get_bin(Position r) const
 int RectilinearMesh::get_index_in_direction(Position r, int i) const
 {
   return lower_bound_index(grid_[i].begin(), grid_[i].end(), r[i]) + 1;
-}
-
-void RectilinearMesh::get_indices_from_bin(int bin, int* ijk) const
-{
-  ijk[0] = bin % shape_[0] + 1;
-  ijk[1] = (bin % (shape_[0] * shape_[1])) / shape_[0] + 1;
-  ijk[2] = bin / (shape_[0] * shape_[1]) + 1;
 }
 
 int RectilinearMesh::n_bins() const

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -140,6 +140,18 @@ void StructuredMesh::get_indices_from_bin(int bin, int* ijk) const
   }
 }
 
+int StructuredMesh::get_bin(Position r) const
+{
+  // Determine indices
+  std::vector<int> ijk(n_dimension_);
+  bool in_mesh;
+  get_indices(r, ijk.data(), &in_mesh);
+  if (!in_mesh) return -1;
+
+  // Convert indices to bin
+  return get_bin_from_indices(ijk.data());
+}
+
 bool StructuredMesh::intersects(Position& r0, Position r1, int* ijk) const
 {
   switch(n_dimension_) {
@@ -467,18 +479,6 @@ RegularMesh::RegularMesh(pugi::xml_node node)
 
   // Set volume fraction
   volume_frac_ = 1.0/xt::prod(shape_)();
-}
-
-int RegularMesh::get_bin(Position r) const
-{
-  // Determine indices
-  std::vector<int> ijk(n_dimension_);
-  bool in_mesh;
-  get_indices(r, ijk.data(), &in_mesh);
-  if (!in_mesh) return -1;
-
-  // Convert indices to bin
-  return get_bin_from_indices(ijk.data());
 }
 
 int RegularMesh::get_index_in_direction(double r, int i) const
@@ -1160,18 +1160,6 @@ void RectilinearMesh::surface_bins_crossed(const Particle& p,
     // Calculate new coordinates
     r0 += distance * u;
   }
-}
-
-int RectilinearMesh::get_bin(Position r) const
-{
-  // Determine indices
-  int ijk[3];
-  bool in_mesh;
-  get_indices(r, ijk, &in_mesh);
-  if (!in_mesh) return -1;
-
-  // Convert indices to bin
-  return get_bin_from_indices(ijk);
 }
 
 int RectilinearMesh::get_index_in_direction(double r, int i) const


### PR DESCRIPTION
This MR puts as much of the functionality common to the `RegularMesh` and `RectilinearMesh` classes into their shared base class, `StructuredMesh`, with the addition of a few minor member access functions that capture the (small) differences that existed between these classes in the first place.

Functionality that has been moved up to the `StructuredMesh` class:

- `intersects`
- `bins_crossed`
- various query methods, `get_bin_from_indices`, `get_indices`, `get_indices_from_bin1`, `n_bins`, `n_surface_bins`, `get_bin`

New abstract methods in `StructuredMesh` (overridden by `RegularMesh` and `RectilinearMesh` that made this refactoring possible):

- `get_index_in_direction`: get mesh index for given Position in a particular coordinate direction
- `positive_grid_boundary`: coordinate of next grid boundary for positive direction
- `negative_grid_boundary`: coordinate of next grid boundary for negative direction

The only method that can probably still be refactored that I didn't touch is the `surface_bins_crossed` method, because there are non-trivial differences between the two implementations. Will do this in a future PR!

This deletes about 250 lines from `src/mesh.cpp` without any loss of functionality.