### PR TITLE
Remove some unnecessary indirection of data::materials and data::nuclides

### DIFF
--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -26,7 +26,7 @@ class Material;
 namespace model {
 
 extern std::unordered_map<int32_t, int32_t> material_map;
-extern std::vector<std::unique_ptr<Material>> materials;
+extern std::vector<Material> materials;
 
 } // namespace model
 
@@ -47,9 +47,11 @@ public:
 
   //----------------------------------------------------------------------------
   // Constructors, destructors, factory functions
-  Material() {};
   explicit Material(pugi::xml_node material_node);
-  ~Material();
+  Material() = default;
+  Material(Material&&) = default;
+  Material(Material const&) = default;
+  ~Material() = default;
 
   //----------------------------------------------------------------------------
   // Methods

--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -38,7 +38,9 @@ public:
 
   // Constructors/destructors
   Nuclide(hid_t group, const std::vector<double>& temperature);
-  ~Nuclide();
+  Nuclide(Nuclide&&) = default;
+  Nuclide(Nuclide const&) = default;
+  ~Nuclide() = default;
 
   //! Initialize logarithmic grid for energy searches
   void init_grid();
@@ -156,7 +158,7 @@ extern double temperature_min;
 extern double temperature_max;
 
 extern std::unordered_map<std::string, int> nuclide_map;
-extern std::vector<std::unique_ptr<Nuclide>> nuclides;
+extern std::vector<Nuclide> nuclides;
 
 } // namespace data
 

--- a/include/openmc/physics.h
+++ b/include/openmc/physics.h
@@ -52,7 +52,7 @@ void create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx);
 
 int sample_element(Particle& p);
 
-Reaction& sample_fission(int i_nuclide, Particle& p);
+Reaction const& sample_fission(int i_nuclide, Particle& p);
 
 void sample_photon_product(int i_nuclide, Particle& p, int* i_rx, int* i_product);
 

--- a/src/bremsstrahlung.cpp
+++ b/src/bremsstrahlung.cpp
@@ -36,9 +36,9 @@ void thick_target_bremsstrahlung(Particle& p, double* E_lost)
   // Get bremsstrahlung data for this material and particle type
   BremsstrahlungData* mat;
   if (p.type_ == Particle::Type::positron) {
-    mat = &model::materials[p.material_]->ttb_->positron;
+    mat = &model::materials[p.material_].ttb_->positron;
   } else {
-    mat = &model::materials[p.material_]->ttb_->electron;
+    mat = &model::materials[p.material_].ttb_->electron;
   }
 
   double e = std::log(p.E_);

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -566,7 +566,7 @@ CSGCell::to_hdf5(hid_t cell_group) const
     std::vector<int32_t> mat_ids;
     for (auto i_mat : material_) {
       if (i_mat != MATERIAL_VOID) {
-        mat_ids.push_back(model::materials[i_mat]->id_);
+        mat_ids.push_back(model::materials[i_mat].id_);
       } else {
         mat_ids.push_back(MATERIAL_VOID);
       }

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -199,7 +199,7 @@ read_ce_cross_sections(const std::vector<std::vector<double>>& nuc_temps,
 
   // Read cross sections
   for (const auto& mat : model::materials) {
-    for (int i_nuc : mat->nuclide_) {
+    for (int i_nuc : mat.nuclide_) {
       // Find name of corresponding nuclide. Because we haven't actually loaded
       // data, we don't have the name available, so instead we search through
       // all key/value pairs in nuclide_map
@@ -218,7 +218,7 @@ read_ce_cross_sections(const std::vector<std::vector<double>>& nuc_temps,
 
   // Perform final tasks -- reading S(a,b) tables, normalizing densities
   for (auto& mat : model::materials) {
-    for (const auto& table : mat->thermal_tables_) {
+    for (const auto& table : mat.thermal_tables_) {
       // Get name of S(a,b) table
       int i_table = table.index_table;
       std::string& name = thermal_names[i_table];
@@ -247,7 +247,7 @@ read_ce_cross_sections(const std::vector<std::vector<double>>& nuc_temps,
     } // thermal_tables_
 
     // Finish setting up materials (normalizing densities, etc.)
-    mat->finalize();
+    mat.finalize();
   } // materials
 
   if (settings::photon_transport && settings::electron_treatment == ElectronTreatment::TTB) {

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -263,7 +263,7 @@ read_ce_cross_sections(const std::vector<std::vector<double>>& nuc_temps,
   if (settings::temperature_multipole) {
     bool mp_found = false;
     for (const auto& nuc : data::nuclides) {
-      if (nuc->multipole_) {
+      if (nuc.multipole_) {
         mp_found = true;
         break;
       }

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -106,12 +106,12 @@ void legacy_assign_material(const std::string& mat_string, DAGCell* c)
   bool mat_found_by_name = false;
   // attempt to find a material with a matching name
   for (const auto& m : model::materials) {
-    if (mat_string == m->name_) {
+    if (mat_string == m.name_) {
       // assign the material with that name
       if (!mat_found_by_name) {
         mat_found_by_name = true;
-        c->material_.push_back(m->id_);
-      // report error if more than one material is found
+        c->material_.push_back(m.id_);
+        // report error if more than one material is found
       } else {
         fatal_error(fmt::format(
           "More than one material found with name {}. Please ensure materials "
@@ -137,9 +137,9 @@ void legacy_assign_material(const std::string& mat_string, DAGCell* c)
     std::stringstream msg;
     msg << "DAGMC material " << mat_string << " was assigned";
     if (mat_found_by_name) {
-      msg << " using material name: " << m->name_;
+      msg << " using material name: " << m.name_;
     } else {
-      msg << " using material id: " << m->id_;
+      msg << " using material id: " << m.id_;
     }
     write_message(msg.str(), 10);
   }
@@ -264,7 +264,7 @@ void load_dagmc_geometry()
       double temp = std::stod(temp_value);
       c->sqrtkT_.push_back(std::sqrt(K_BOLTZMANN * temp));
     } else {
-      c->sqrtkT_.push_back(std::sqrt(K_BOLTZMANN * mat->temperature()));
+      c->sqrtkT_.push_back(std::sqrt(K_BOLTZMANN * mat.temperature()));
     }
 
   }

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -50,7 +50,8 @@ void free_event_queues(void)
 void dispatch_xs_event(int64_t buffer_idx)
 {
   Particle& p = simulation::particles[buffer_idx];
-  if (p.material_ == MATERIAL_VOID || !model::materials[p.material_]->fissionable_) {
+  if (p.material_ == MATERIAL_VOID ||
+      !model::materials[p.material_].fissionable_) {
     simulation::calculate_nonfuel_xs_queue.thread_safe_append({p, buffer_idx});
   } else {
     simulation::calculate_fuel_xs_queue.thread_safe_append({p, buffer_idx});

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -183,7 +183,7 @@ assign_temperatures()
         c->sqrtkT_.push_back(0);
       } else {
         const auto& mat {model::materials[i_mat]};
-        c->sqrtkT_.push_back(std::sqrt(K_BOLTZMANN * mat->temperature()));
+        c->sqrtkT_.push_back(std::sqrt(K_BOLTZMANN * mat.temperature()));
       }
     }
   }
@@ -218,7 +218,7 @@ get_temperatures(std::vector<std::vector<double>>& nuc_temps,
       }
 
       const auto& mat {model::materials[i_material]};
-      for (const auto& i_nuc : mat->nuclide_) {
+      for (const auto& i_nuc : mat.nuclide_) {
         for (double temperature : cell_temps) {
           // Add temperature if it hasn't already been added
           if (!contains(nuc_temps[i_nuc], temperature))
@@ -226,7 +226,7 @@ get_temperatures(std::vector<std::vector<double>>& nuc_temps,
         }
       }
 
-      for (const auto& table : mat->thermal_tables_) {
+      for (const auto& table : mat.thermal_tables_) {
         // Get index in data::thermal_scatt array
         int i_sab = table.index_table;
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -340,7 +340,7 @@ void Material::finalize()
 {
   // Set fissionable if any nuclide is fissionable
   for (const auto& i_nuc : nuclide_) {
-    if (data::nuclides[i_nuc]->fissionable_) {
+    if (data::nuclides[i_nuc].fissionable_) {
       fissionable_ = true;
       break;
     }
@@ -366,8 +366,8 @@ void Material::normalize_density()
   for (int i = 0; i < nuclide_.size(); ++i) {
     // determine atomic weight ratio
     int i_nuc = nuclide_[i];
-    double awr = settings::run_CE ?
-      data::nuclides[i_nuc]->awr_ : data::mg.nuclides_[i_nuc].awr;
+    double awr = settings::run_CE ? data::nuclides[i_nuc].awr_
+                                  : data::mg.nuclides_[i_nuc].awr;
 
     // if given weight percent, convert all values so that they are divided
     // by awr. thus, when a sum is done over the values, it's actually
@@ -386,8 +386,8 @@ void Material::normalize_density()
     double sum_percent = 0.0;
     for (int i = 0; i < nuclide_.size(); ++i) {
       int i_nuc = nuclide_[i];
-      double awr = settings::run_CE ?
-        data::nuclides[i_nuc]->awr_ : data::mg.nuclides_[i_nuc].awr;
+      double awr = settings::run_CE ? data::nuclides[i_nuc].awr_
+                                    : data::mg.nuclides_[i_nuc].awr;
       sum_percent += atom_density_(i)*awr;
     }
     sum_percent = 1.0 / sum_percent;
@@ -401,7 +401,7 @@ void Material::normalize_density()
   density_gpcc_ = 0.0;
   for (int i = 0; i < nuclide_.size(); ++i) {
     int i_nuc = nuclide_[i];
-    double awr = settings::run_CE ? data::nuclides[i_nuc]->awr_ : 1.0;
+    double awr = settings::run_CE ? data::nuclides[i_nuc].awr_ : 1.0;
     density_gpcc_ += atom_density_(i) * awr * MASS_NEUTRON / N_AVOGADRO;
   }
 }
@@ -423,7 +423,7 @@ void Material::init_thermal()
     // name
     bool found = false;
     for (int j = 0; j < nuclide_.size(); ++j) {
-      const auto& name {data::nuclides[nuclide_[j]]->name_};
+      const auto& name {data::nuclides[nuclide_[j]].name_};
       if (contains(data::thermal_scatt[table.index_table]->nuclides_, name)) {
         tables.push_back({table.index_table, j, table.fraction});
         found = true;
@@ -443,7 +443,7 @@ void Material::init_thermal()
     for (int k = j+1; k < tables.size(); ++k) {
       if (tables[j].index_nuclide == tables[k].index_nuclide) {
         int index = nuclide_[tables[j].index_nuclide];
-        auto name = data::nuclides[index]->name_;
+        auto name = data::nuclides[index].name_;
         fatal_error(name + " in material " + std::to_string(id_) + " was found "
           "in multiple thermal scattering tables. Each nuclide can appear in "
           "only one table per material.");
@@ -481,7 +481,7 @@ void Material::collision_stopping_power(double* s_col, bool positron)
 
   for (int i = 0; i < element_.size(); ++i) {
     const auto& elm = *data::elements[element_[i]];
-    double awr = data::nuclides[nuclide_[i]]->awr_;
+    double awr = data::nuclides[nuclide_[i]].awr_;
 
     // Get atomic density of nuclide given atom/weight percent
     double atom_density = (atom_density_[0] > 0.0) ?
@@ -595,7 +595,7 @@ void Material::init_bremsstrahlung()
     for (int i = 0; i < n; ++i) {
       // Get pointer to current element
       const auto& elm = *data::elements[element_[i]];
-      double awr = data::nuclides[nuclide_[i]]->awr_;
+      double awr = data::nuclides[nuclide_[i]].awr_;
 
       // Get atomic density and mass density of nuclide given atom/weight percent
       double atom_density = (atom_density_[0] > 0.0) ?
@@ -808,7 +808,7 @@ void Material::calculate_neutron_xs(Particle& p) const
         || p.sqrtkT_ != micro.last_sqrtkT
         || i_sab != micro.index_sab
         || sab_frac != micro.sab_frac) {
-      data::nuclides[i_nuclide]->calculate_xs(i_sab, i_grid, sab_frac, p);
+      data::nuclides[i_nuclide].calculate_xs(i_sab, i_grid, sab_frac, p);
     }
 
     // ======================================================================
@@ -913,7 +913,7 @@ void Material::set_density(double density, gsl::cstring_span units)
     density_gpcc_ = 0.0;
     for (int i = 0; i < nuclide_.size(); ++i) {
       int i_nuc = nuclide_[i];
-      double awr = data::nuclides[i_nuc]->awr_;
+      double awr = data::nuclides[i_nuc].awr_;
       density_gpcc_ += atom_density_(i) * awr * MASS_NEUTRON / N_AVOGADRO;
     }
   } else if (units == "g/cm3" || units == "g/cc") {
@@ -1011,7 +1011,7 @@ void Material::to_hdf5(hid_t group) const
   if (settings::run_CE) {
     for (int i = 0; i < nuclide_.size(); ++i) {
       int i_nuc = nuclide_[i];
-      nuc_names.push_back(data::nuclides[i_nuc]->name_);
+      nuc_names.push_back(data::nuclides[i_nuc].name_);
       nuc_densities.push_back(atom_density_(i));
     }
   } else {
@@ -1053,8 +1053,8 @@ void Material::add_nuclide(const std::string& name, double density)
   // Check if nuclide is already in material
   for (int i = 0; i < nuclide_.size(); ++i) {
     int i_nuc = nuclide_[i];
-    if (data::nuclides[i_nuc]->name_ == name) {
-      double awr = data::nuclides[i_nuc]->awr_;
+    if (data::nuclides[i_nuc].name_ == name) {
+      double awr = data::nuclides[i_nuc].awr_;
       density_ += density - atom_density_(i);
       density_gpcc_ += (density - atom_density_(i))
         * awr * MASS_NEUTRON / N_AVOGADRO;
@@ -1086,8 +1086,8 @@ void Material::add_nuclide(const std::string& name, double density)
   atom_density_ = atom_density;
 
   density_ += density;
-  density_gpcc_ += density * data::nuclides[i_nuc]->awr_
-    * MASS_NEUTRON / N_AVOGADRO;
+  density_gpcc_ +=
+    density * data::nuclides[i_nuc].awr_ * MASS_NEUTRON / N_AVOGADRO;
 }
 
 //==============================================================================

--- a/src/mgxs_interface.cpp
+++ b/src/mgxs_interface.cpp
@@ -122,25 +122,25 @@ void MgxsInterface::create_macro_xs()
   auto kTs = get_mat_kTs();
 
   // Force all nuclides in a material to be the same representation.
-  // Therefore type(nuclides[mat->nuclide_[0]]) dictates type(macroxs).
+  // Therefore type(nuclides[mat.nuclide_[0]]) dictates type(macroxs).
   // At the same time, we will find the scattering type, as that will dictate
   // how we allocate the scatter object within macroxs.
   for (int i = 0; i < model::materials.size(); ++i) {
     if (kTs[i].size() > 0) {
       // Convert atom_densities to a vector
       auto& mat {model::materials[i]};
-      std::vector<double> atom_densities(mat->atom_density_.begin(),
-        mat->atom_density_.end());
+      std::vector<double> atom_densities(
+        mat.atom_density_.begin(), mat.atom_density_.end());
 
       // Build array of pointers to nuclides's Mgxs objects needed for this
       // material
       std::vector<Mgxs*> mgxs_ptr;
-      for (int i_nuclide : mat->nuclide_) {
+      for (int i_nuclide : mat.nuclide_) {
         mgxs_ptr.push_back(&nuclides_[i_nuclide]);
       }
 
-      macro_xs_.emplace_back(mat->name_, kTs[i], mgxs_ptr, atom_densities,
-          num_energy_groups_, num_delayed_groups_);
+      macro_xs_.emplace_back(mat.name_, kTs[i], mgxs_ptr, atom_densities,
+        num_energy_groups_, num_delayed_groups_);
     } else {
       // Preserve the ordering of materials by including a blank entry
       macro_xs_.emplace_back();
@@ -262,7 +262,7 @@ void set_mg_interface_nuclides_and_temps()
 
   // Loop over materials to find xs and temperature to be read
   for (const auto& mat : model::materials) {
-    for (int i_nuc : mat->nuclide_) {
+    for (int i_nuc : mat.nuclide_) {
       std::string& name = nuclide_names[i_nuc];
 
       if (already_read.find(name) == already_read.end()) {
@@ -277,10 +277,10 @@ void set_mg_interface_nuclides_and_temps()
 void mark_fissionable_mgxs_materials()
 {
   // Loop over all files
-  for (const auto& mat : model::materials) {
-    for (int i_nuc : mat->nuclide_) {
+  for (auto& mat : model::materials) {
+    for (int i_nuc : mat.nuclide_) {
       if (data::mg.nuclides_[i_nuc].fissionable) {
-        mat->fissionable_ = true;
+        mat.fissionable_ = true;
       }
     }
   }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -592,8 +592,9 @@ write_tallies()
           deriv.diff_material);
         break;
       case DerivativeVariable::NUCLIDE_DENSITY:
-        fmt::print(tallies_out, " Nuclide density derivative Material {} Nuclide {}\n",
-          deriv.diff_material, data::nuclides[deriv.diff_nuclide]->name_);
+        fmt::print(tallies_out,
+          " Nuclide density derivative Material {} Nuclide {}\n",
+          deriv.diff_material, data::nuclides[deriv.diff_nuclide].name_);
         break;
       case DerivativeVariable::TEMPERATURE:
         fmt::print(tallies_out, " Temperature derivative Material {}\n",
@@ -639,7 +640,7 @@ write_tallies()
         } else {
           if (settings::run_CE) {
             fmt::print(tallies_out, "{0:{1}}{2}\n", "", indent + 1,
-              data::nuclides[i_nuclide]->name_);
+              data::nuclides[i_nuclide].name_);
           } else {
             fmt::print(tallies_out, "{0:{1}}{2}\n", "", indent + 1,
               data::mg.nuclides_[i_nuclide].name);

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -178,7 +178,7 @@ Particle::event_calculate_xs()
         // If the material is the same as the last material and the
         // temperature hasn't changed, we don't need to lookup cross
         // sections again.
-        model::materials[material_]->calculate_xs(*this);
+        model::materials[material_].calculate_xs(*this);
       }
     } else {
       // Get the MG data; unlike the CE case above, we have to re-calculate

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -449,13 +449,13 @@ int sample_nuclide(Particle& p)
 
   // Get pointers to nuclide/density arrays
   const auto& mat {model::materials[p.material_]};
-  int n = mat->nuclide_.size();
+  int n = mat.nuclide_.size();
 
   double prob = 0.0;
   for (int i = 0; i < n; ++i) {
     // Get atom density
-    int i_nuclide = mat->nuclide_[i];
-    double atom_density = mat->atom_density_[i];
+    int i_nuclide = mat.nuclide_[i];
+    double atom_density = mat.atom_density_[i];
 
     // Increment probability to compare to cutoff
     prob += atom_density * p.neutron_xs_[i_nuclide].total;
@@ -476,10 +476,10 @@ int sample_element(Particle& p)
   const auto& mat {model::materials[p.material_]};
 
   double prob = 0.0;
-  for (int i = 0; i < mat->element_.size(); ++i) {
+  for (int i = 0; i < mat.element_.size(); ++i) {
     // Find atom density
-    int i_element = mat->element_[i];
-    double atom_density = mat->atom_density_[i];
+    int i_element = mat.element_[i];
+    double atom_density = mat.atom_density_[i];
 
     // Determine microscopic cross section
     double sigma = atom_density * p.photon_xs_[i_element].total;
@@ -488,7 +488,7 @@ int sample_element(Particle& p)
     prob += sigma;
     if (prob > cutoff) {
       // Save which nuclide particle had collision with for tally purpose
-      p.event_nuclide_ = mat->nuclide_[i];
+      p.event_nuclide_ = mat.nuclide_[i];
 
       return i_element;
     }
@@ -709,9 +709,9 @@ void scatter(Particle& p, int i_nuclide)
 
   // Sample new outgoing angle for isotropic-in-lab scattering
   const auto& mat {model::materials[p.material_]};
-  if (!mat->p0_.empty()) {
-    int i_nuc_mat = mat->mat_nuclide_index_[i_nuclide];
-    if (mat->p0_[i_nuc_mat]) {
+  if (!mat.p0_.empty()) {
+    int i_nuc_mat = mat.mat_nuclide_index_[i_nuclide];
+    if (mat.p0_[i_nuc_mat]) {
       // Sample isotropic-in-lab outgoing direction
       double mu = 2.0*prn(p.current_seed()) - 1.0;
       double phi = 2.0*PI*prn(p.current_seed());

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -44,7 +44,7 @@ sample_reaction(Particle& p)
   // change when sampling fission sites. The following block handles all
   // absorption (including fission)
 
-  if (model::materials[p.material_]->fissionable_) {
+  if (model::materials[p.material_].fissionable_) {
     if (settings::run_mode == RunMode::EIGENVALUE  ||
        (settings::run_mode == RunMode::FIXED_SOURCE &&
         settings::create_fission_neutrons)) {

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -54,8 +54,8 @@ IdData::set_value(size_t y, size_t x, const Particle& p, int level) {
     data_(y, x, 1) = MATERIAL_VOID;
     return;
   } else if (c->type_ == Fill::MATERIAL) {
-    Material* m = model::materials.at(p.material_).get();
-    data_(y, x, 1) = m->id_;
+    Material const& m = model::materials.at(p.material_);
+    data_(y, x, 1) = m.id_;
   }
 }
 
@@ -72,8 +72,8 @@ PropertyData::set_value(size_t y, size_t x, const Particle& p, int level) {
   Cell* c = model::cells.at(p.coord_.at(p.n_coord_ - 1).cell).get();
   data_(y,x,0) = (p.sqrtkT_ * p.sqrtkT_) / K_BOLTZMANN;
   if (c->type_ != Fill::UNIVERSE && p.material_ != MATERIAL_VOID) {
-    Material* m = model::materials.at(p.material_).get();
-    data_(y,x,1) = m->density_gpcc_;
+    Material const& m = model::materials.at(p.material_);
+    data_(y, x, 1) = m.density_gpcc_;
   }
 }
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -566,12 +566,12 @@ void initialize_data()
   data::energy_max = {INFTY, INFTY};
   data::energy_min = {0.0, 0.0};
   for (const auto& nuc : data::nuclides) {
-    if (nuc->grid_.size() >= 1) {
+    if (nuc.grid_.size() >= 1) {
       int neutron = static_cast<int>(Particle::Type::neutron);
-      data::energy_min[neutron] = std::max(data::energy_min[neutron],
-        nuc->grid_[0].energy.front());
-      data::energy_max[neutron] = std::min(data::energy_max[neutron],
-        nuc->grid_[0].energy.back());
+      data::energy_min[neutron] =
+        std::max(data::energy_min[neutron], nuc.grid_[0].energy.front());
+      data::energy_max[neutron] =
+        std::min(data::energy_max[neutron], nuc.grid_[0].energy.back());
     }
   }
 
@@ -605,12 +605,12 @@ void initialize_data()
   for (const auto& nuc : data::nuclides) {
     // If a nuclide is present in a material that's not used in the model, its
     // grid has not been allocated
-    if (nuc->grid_.size() > 0) {
-      double max_E = nuc->grid_[0].energy.back();
+    if (nuc.grid_.size() > 0) {
+      double max_E = nuc.grid_[0].energy.back();
       int neutron = static_cast<int>(Particle::Type::neutron);
       if (max_E == data::energy_max[neutron]) {
         write_message(7, "Maximum neutron transport energy: {} eV for {}",
-          data::energy_max[neutron], nuc->name_);
+          data::energy_max[neutron], nuc.name_);
         if (mpi::master && data::energy_max[neutron] < 20.0e6) {
           warning("Maximum neutron energy is below 20 MeV. This may bias "
             "the results.");
@@ -622,7 +622,7 @@ void initialize_data()
 
   // Set up logarithmic grid for nuclides
   for (auto& nuc : data::nuclides) {
-    nuc->init_grid();
+    nuc.init_grid();
   }
   int neutron = static_cast<int>(Particle::Type::neutron);
   simulation::log_spacing = std::log(data::energy_max[neutron] /

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -99,7 +99,7 @@ int openmc_simulation_init()
 
   // Set up material nuclide index mapping
   for (auto& mat : model::materials) {
-    mat->init_nuclide_index();
+    mat.init_nuclide_index();
   }
 
   // Reset global variables -- this is done before loading state point (as that
@@ -155,7 +155,7 @@ int openmc_simulation_finalize()
 
   // Clear material nuclide mapping
   for (auto& mat : model::materials) {
-    mat->mat_nuclide_index_.clear();
+    mat.mat_nuclide_index_.clear();
   }
 
   // Increment total number of generations

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -205,7 +205,8 @@ Particle::Bank SourceDistribution::sample(uint64_t* seed) const
           if (mat_index == MATERIAL_VOID) {
             found = false;
           } else {
-            if (!model::materials[mat_index]->fissionable_) found = false;
+            if (!model::materials[mat_index].fissionable_)
+              found = false;
           }
         }
       }

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -123,8 +123,8 @@ openmc_statepoint_write(const char* filename, bool* write_source)
           write_dataset(deriv_group, "independent variable", "density");
         } else if (deriv.variable == DerivativeVariable::NUCLIDE_DENSITY) {
           write_dataset(deriv_group, "independent variable", "nuclide_density");
-          write_dataset(deriv_group, "nuclide",
-            data::nuclides[deriv.diff_nuclide]->name_);
+          write_dataset(
+            deriv_group, "nuclide", data::nuclides[deriv.diff_nuclide].name_);
         } else if (deriv.variable == DerivativeVariable::TEMPERATURE) {
           write_dataset(deriv_group, "independent variable", "temperature");
         } else {
@@ -214,7 +214,7 @@ openmc_statepoint_write(const char* filename, bool* write_source)
             nuclides.push_back("total");
           } else {
             if (settings::run_CE) {
-              nuclides.push_back(data::nuclides[i_nuclide]->name_);
+              nuclides.push_back(data::nuclides[i_nuclide].name_);
             } else {
               nuclides.push_back(data::mg.nuclides_[i_nuclide].name);
             }
@@ -749,7 +749,7 @@ void write_unstructured_mesh_results() {
           // generate a name for the value
           std::string nuclide_name = "total"; // start with total by default
           if (tally->nuclides_[i_nuc] > -1) {
-            nuclide_name = data::nuclides[tally->nuclides_[i_nuc]]->name_;
+            nuclide_name = data::nuclides[tally->nuclides_[i_nuc]].name_;
           }
 
           std::string score_name = tally->score_name(i_score);

--- a/src/summary.cpp
+++ b/src/summary.cpp
@@ -128,7 +128,7 @@ void write_materials(hid_t file)
 
   hid_t materials_group = create_group(file, "materials");
   for (const auto& mat : model::materials) {
-    mat->to_hdf5(materials_group);
+    mat.to_hdf5(materials_group);
   }
   close_group(materials_group);
 }

--- a/src/summary.cpp
+++ b/src/summary.cpp
@@ -54,8 +54,8 @@ void write_nuclides(hid_t file)
   for (int i = 0; i < data::nuclides.size(); ++i) {
     if (settings::run_CE) {
       const auto& nuc {data::nuclides[i]};
-      nuc_names.push_back(nuc->name_);
-      awrs.push_back(nuc->awr_);
+      nuc_names.push_back(nuc.name_);
+      awrs.push_back(nuc.awr_);
     } else {
       const auto& nuc {data::mg.nuclides_[i]};
       if (nuc.awr != MACROSCOPIC_AWR) {

--- a/src/tallies/derivative.cpp
+++ b/src/tallies/derivative.cpp
@@ -119,7 +119,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
     score *= flux_deriv;
     return;
   }
-  const Material& material {*model::materials[p.material_]};
+  const Material& material {model::materials[p.material_]};
   if (material.id_ != deriv.diff_material) {
     score *= flux_deriv;
     return;
@@ -560,7 +560,7 @@ score_track_derivative(Particle& p, double distance)
   // A void material cannot be perturbed so it will not affect flux derivatives.
   if (p.material_ == MATERIAL_VOID) return;
 
-  const Material& material {*model::materials[p.material_]};
+  const Material& material {model::materials[p.material_]};
 
   for (auto idx = 0; idx < model::tally_derivs.size(); idx++) {
     const auto& deriv = model::tally_derivs[idx];
@@ -609,7 +609,7 @@ void score_collision_derivative(Particle& p)
   // A void material cannot be perturbed so it will not affect flux derivatives.
   if (p.material_ == MATERIAL_VOID) return;
 
-  const Material& material {*model::materials[p.material_]};
+  const Material& material {model::materials[p.material_]};
 
   for (auto idx = 0; idx < model::tally_derivs.size(); idx++) {
     const auto& deriv = model::tally_derivs[idx];

--- a/src/tallies/derivative.cpp
+++ b/src/tallies/derivative.cpp
@@ -48,7 +48,7 @@ TallyDerivative::TallyDerivative(pugi::xml_node node)
     std::string nuclide_name = get_node_value(node, "nuclide");
     bool found = false;
     for (auto i = 0; i < data::nuclides.size(); ++i) {
-      if (data::nuclides[i]->name_ == nuclide_name) {
+      if (data::nuclides[i].name_ == nuclide_name) {
         found = true;
         diff_nuclide = i;
       }
@@ -311,7 +311,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
         for (i = 0; i < material.nuclide_.size(); ++i)
           if (material.nuclide_[i] == p.event_nuclide_) break;
 
-        const auto& nuc {*data::nuclides[p.event_nuclide_]};
+        const auto& nuc {data::nuclides[p.event_nuclide_]};
         if (!multipole_in_range(nuc, p.E_last_)) {
           score *= flux_deriv;
           break;
@@ -392,7 +392,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
     case TallyEstimator::COLLISION:
       if (i_nuclide != -1) {
         const auto& nuc {data::nuclides[i_nuclide]};
-        if (!multipole_in_range(*nuc, p.E_last_)) {
+        if (!multipole_in_range(nuc, p.E_last_)) {
           score *= flux_deriv;
           return;
         }
@@ -405,7 +405,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           double cum_dsig = 0;
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
-            const auto& nuc {*data::nuclides[i_nuc]};
+            const auto& nuc {data::nuclides[i_nuc]};
             if (multipole_in_range(nuc, p.E_last_)
                 && p.neutron_xs_[i_nuc].total) {
               double dsig_s, dsig_a, dsig_f;
@@ -416,7 +416,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           }
           score *= flux_deriv + cum_dsig / p.macro_xs_.total;
         } else if (p.neutron_xs_[i_nuclide].total) {
-          const auto& nuc {*data::nuclides[i_nuclide]};
+          const auto& nuc {data::nuclides[i_nuclide]};
           double dsig_s, dsig_a, dsig_f;
           std::tie(dsig_s, dsig_a, dsig_f)
             = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
@@ -433,7 +433,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           double cum_dsig = 0;
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
-            const auto& nuc {*data::nuclides[i_nuc]};
+            const auto& nuc {data::nuclides[i_nuc]};
             if (multipole_in_range(nuc, p.E_last_)
                 && (p.neutron_xs_[i_nuc].total
                 - p.neutron_xs_[i_nuc].absorption)) {
@@ -447,7 +447,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
             - p.macro_xs_.absorption);
         } else if (p.neutron_xs_[i_nuclide].total
                    - p.neutron_xs_[i_nuclide].absorption) {
-          const auto& nuc {*data::nuclides[i_nuclide]};
+          const auto& nuc {data::nuclides[i_nuclide]};
           double dsig_s, dsig_a, dsig_f;
           std::tie(dsig_s, dsig_a, dsig_f)
             = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
@@ -463,7 +463,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           double cum_dsig = 0;
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
-            const auto& nuc {*data::nuclides[i_nuc]};
+            const auto& nuc {data::nuclides[i_nuc]};
             if (multipole_in_range(nuc, p.E_last_)
                 && p.neutron_xs_[i_nuc].absorption) {
               double dsig_s, dsig_a, dsig_f;
@@ -474,7 +474,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           }
           score *= flux_deriv + cum_dsig / p.macro_xs_.absorption;
         } else if (p.neutron_xs_[i_nuclide].absorption) {
-          const auto& nuc {*data::nuclides[i_nuclide]};
+          const auto& nuc {data::nuclides[i_nuclide]};
           double dsig_s, dsig_a, dsig_f;
           std::tie(dsig_s, dsig_a, dsig_f)
             = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
@@ -490,7 +490,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           double cum_dsig = 0;
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
-            const auto& nuc {*data::nuclides[i_nuc]};
+            const auto& nuc {data::nuclides[i_nuc]};
             if (multipole_in_range(nuc, p.E_last_)
                 && p.neutron_xs_[i_nuc].fission) {
               double dsig_s, dsig_a, dsig_f;
@@ -501,7 +501,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           }
           score *= flux_deriv + cum_dsig / p.macro_xs_.fission;
         } else if (p.neutron_xs_[i_nuclide].fission) {
-          const auto& nuc {*data::nuclides[i_nuclide]};
+          const auto& nuc {data::nuclides[i_nuclide]};
           double dsig_s, dsig_a, dsig_f;
           std::tie(dsig_s, dsig_a, dsig_f)
             = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
@@ -517,7 +517,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           double cum_dsig = 0;
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto i_nuc = material.nuclide_[i];
-            const auto& nuc {*data::nuclides[i_nuc]};
+            const auto& nuc {data::nuclides[i_nuc]};
             if (multipole_in_range(nuc, p.E_last_)
                 && p.neutron_xs_[i_nuc].fission) {
               double nu = p.neutron_xs_[i_nuc].nu_fission
@@ -530,7 +530,7 @@ apply_derivative_to_score(const Particle& p, int i_tally, int i_nuclide,
           }
           score *= flux_deriv + cum_dsig / p.macro_xs_.nu_fission;
         } else if (p.neutron_xs_[i_nuclide].fission) {
-          const auto& nuc {*data::nuclides[i_nuclide]};
+          const auto& nuc {data::nuclides[i_nuclide]};
           double dsig_s, dsig_a, dsig_f;
           std::tie(dsig_s, dsig_a, dsig_f)
             = nuc.multipole_->evaluate_deriv(p.E_last_, p.sqrtkT_);
@@ -587,7 +587,7 @@ score_track_derivative(Particle& p, double distance)
 
     case DerivativeVariable::TEMPERATURE:
       for (auto i = 0; i < material.nuclide_.size(); ++i) {
-        const auto& nuc {*data::nuclides[material.nuclide_[i]]};
+        const auto& nuc {data::nuclides[material.nuclide_[i]]};
         if (multipole_in_range(nuc, p.E_last_)) {
           // phi is proportional to e^(-Sigma_tot * dist)
           // (1 / phi) * (d_phi / d_T) = - (d_Sigma_tot / d_T) * dist
@@ -636,7 +636,7 @@ void score_collision_derivative(Particle& p)
       if (material.nuclide_[i] != deriv.diff_nuclide) {
         fatal_error(fmt::format(
           "Could not find nuclide {} in material {} for tally derivative {}",
-          data::nuclides[deriv.diff_nuclide]->name_, material.id_, deriv.id));
+          data::nuclides[deriv.diff_nuclide].name_, material.id_, deriv.id));
       }
       // phi is proportional to Sigma_s
       // (1 / phi) * (d_phi / d_N) = (d_Sigma_s / d_N) / Sigma_s
@@ -648,7 +648,7 @@ void score_collision_derivative(Particle& p)
     case DerivativeVariable::TEMPERATURE:
       // Loop over the material's nuclides until we find the event nuclide.
       for (auto i_nuc : material.nuclide_) {
-        const auto& nuc {*data::nuclides[i_nuc]};
+        const auto& nuc {data::nuclides[i_nuc]};
         if (i_nuc == p.event_nuclide_ && multipole_in_range(nuc, p.E_last_)) {
           // phi is proportional to Sigma_s
           // (1 / phi) * (d_phi / d_T) = (d_Sigma_s / d_T) / Sigma_s

--- a/src/tallies/filter_material.cpp
+++ b/src/tallies/filter_material.cpp
@@ -60,14 +60,15 @@ MaterialFilter::to_statepoint(hid_t filter_group) const
 {
   Filter::to_statepoint(filter_group);
   std::vector<int32_t> material_ids;
-  for (auto c : materials_) material_ids.push_back(model::materials[c]->id_);
+  for (auto c : materials_)
+    material_ids.push_back(model::materials[c].id_);
   write_dataset(filter_group, "bins", material_ids);
 }
 
 std::string
 MaterialFilter::text_label(int bin) const
 {
-  return fmt::format("Material {}", model::materials[materials_[bin]]->id_);
+  return fmt::format("Material {}", model::materials[materials_[bin]].id_);
 }
 
 //==============================================================================

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -228,7 +228,7 @@ double score_fission_q(const Particle& p, int score_bin, const Tally& tally,
       return get_nuc_fission_q(nuc, p, score_bin) * atom_density * flux
              * p.neutron_xs_[i_nuclide].fission;
     } else if (p.material_ != MATERIAL_VOID) {
-      const Material& material {*model::materials[p.material_]};
+      const Material& material {model::materials[p.material_]};
       double score {0.0};
       for (auto i = 0; i < material.nuclide_.size(); ++i) {
         auto j_nuclide = material.nuclide_[i];
@@ -301,7 +301,7 @@ double score_neutron_heating(const Particle& p, const Tally& tally, double flux,
   } else {
     if (p.material_ != MATERIAL_VOID) {
       heating_xs = 0.0;
-      const Material& material {*model::materials[p.material_]};
+      const Material& material {model::materials[p.material_]};
       for (auto i = 0; i< material.nuclide_.size(); ++i) {
         int j_nuclide = material.nuclide_[i];
         double atom_density {material.atom_density_(i)};
@@ -825,7 +825,7 @@ score_general_ce(Particle& p, int i_tally, int start_index, int filter_index,
           score = 0.;
           // Add up contributions from each nuclide in the material.
           if (p.material_ != MATERIAL_VOID) {
-            const Material& material {*model::materials[p.material_]};
+            const Material& material {model::materials[p.material_]};
             for (auto i = 0; i < material.nuclide_.size(); ++i) {
               auto j_nuclide = material.nuclide_[i];
               auto atom_density = material.atom_density_(i);
@@ -949,7 +949,7 @@ score_general_ce(Particle& p, int i_tally, int start_index, int filter_index,
               {*dynamic_cast<DelayedGroupFilter*>(
               model::tally_filters[i_dg_filt].get())};
             if (p.material_ != MATERIAL_VOID) {
-              const Material& material {*model::materials[p.material_]};
+              const Material& material {model::materials[p.material_]};
               for (auto i = 0; i < material.nuclide_.size(); ++i) {
                 auto j_nuclide = material.nuclide_[i];
                 auto atom_density = material.atom_density_(i);
@@ -969,7 +969,7 @@ score_general_ce(Particle& p, int i_tally, int start_index, int filter_index,
           } else {
             score = 0.;
             if (p.material_ != MATERIAL_VOID) {
-              const Material& material {*model::materials[p.material_]};
+              const Material& material {model::materials[p.material_]};
               for (auto i = 0; i < material.nuclide_.size(); ++i) {
                 auto j_nuclide = material.nuclide_[i];
                 auto atom_density = material.atom_density_(i);
@@ -1115,7 +1115,7 @@ score_general_ce(Particle& p, int i_tally, int start_index, int filter_index,
               {*dynamic_cast<DelayedGroupFilter*>(
               model::tally_filters[i_dg_filt].get())};
             if (p.material_ != MATERIAL_VOID) {
-              const Material& material {*model::materials[p.material_]};
+              const Material& material {model::materials[p.material_]};
               for (auto i = 0; i < material.nuclide_.size(); ++i) {
                 auto j_nuclide = material.nuclide_[i];
                 auto atom_density = material.atom_density_(i);
@@ -1140,7 +1140,7 @@ score_general_ce(Particle& p, int i_tally, int start_index, int filter_index,
           } else {
             score = 0.;
             if (p.material_ != MATERIAL_VOID) {
-              const Material& material {*model::materials[p.material_]};
+              const Material& material {model::materials[p.material_]};
               for (auto i = 0; i < material.nuclide_.size(); ++i) {
                 auto j_nuclide = material.nuclide_[i];
                 auto atom_density = material.atom_density_(i);
@@ -1210,7 +1210,7 @@ score_general_ce(Particle& p, int i_tally, int start_index, int filter_index,
               * atom_density * flux;
           }
         } else if (p.material_ != MATERIAL_VOID) {
-          const Material& material {*model::materials[p.material_]};
+          const Material& material {model::materials[p.material_]};
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto j_nuclide = material.nuclide_[i];
             auto atom_density = material.atom_density_(i);
@@ -1248,7 +1248,7 @@ score_general_ce(Particle& p, int i_tally, int start_index, int filter_index,
         } else {
           score = 0.;
           if (p.material_ != MATERIAL_VOID) {
-            const Material& material {*model::materials[p.material_]};
+            const Material& material {model::materials[p.material_]};
             for (auto i = 0; i < material.nuclide_.size(); ++i) {
               auto j_nuclide = material.nuclide_[i];
               auto atom_density = material.atom_density_(i);
@@ -1302,7 +1302,7 @@ score_general_ce(Particle& p, int i_tally, int start_index, int filter_index,
         } else {
           score = 0.;
           if (p.material_ != MATERIAL_VOID) {
-            const Material& material {*model::materials[p.material_]};
+            const Material& material {model::materials[p.material_]};
             for (auto i = 0; i < material.nuclide_.size(); ++i) {
               auto j_nuclide = material.nuclide_[i];
               auto atom_density = material.atom_density_(i);
@@ -1394,7 +1394,7 @@ score_general_ce(Particle& p, int i_tally, int start_index, int filter_index,
         if (i_nuclide >= 0) {
           score = get_nuclide_xs(p, i_nuclide, score_bin) * atom_density * flux;
         } else if (p.material_ != MATERIAL_VOID) {
-          const Material& material {*model::materials[p.material_]};
+          const Material& material {model::materials[p.material_]};
           for (auto i = 0; i < material.nuclide_.size(); ++i) {
             auto j_nuclide = material.nuclide_[i];
             auto atom_density = material.atom_density_(i);
@@ -2085,7 +2085,7 @@ score_all_nuclides(Particle& p, int i_tally, double flux,
   int filter_index, double filter_weight)
 {
   const Tally& tally {*model::tallies[i_tally]};
-  const Material& material {*model::materials[p.material_]};
+  const Material& material {model::materials[p.material_]};
 
   // Score all individual nuclide reaction rates.
   for (auto i = 0; i < material.nuclide_.size(); ++i) {
@@ -2203,9 +2203,9 @@ void score_analog_tally_mg(Particle& p)
 
         double atom_density = 0.;
         if (i_nuclide >= 0) {
-          auto j = model::materials[p.material_]->mat_nuclide_index_[i_nuclide];
+          auto j = model::materials[p.material_].mat_nuclide_index_[i_nuclide];
           if (j == C_NONE) continue;
-          atom_density = model::materials[p.material_]->atom_density_(j);
+          atom_density = model::materials[p.material_].atom_density_(j);
         }
 
         score_general_mg(p, i_tally, i*tally.scores_.size(), filter_index,
@@ -2259,9 +2259,10 @@ score_tracklength_tally(Particle& p, double distance)
           double atom_density = 0.;
           if (i_nuclide >= 0) {
             if (p.material_ != MATERIAL_VOID) {
-              auto j = model::materials[p.material_]->mat_nuclide_index_[i_nuclide];
+              auto j =
+                model::materials[p.material_].mat_nuclide_index_[i_nuclide];
               if (j == C_NONE) continue;
-              atom_density = model::materials[p.material_]->atom_density_(j);
+              atom_density = model::materials[p.material_].atom_density_(j);
             }
           }
 
@@ -2328,9 +2329,10 @@ void score_collision_tally(Particle& p)
 
           double atom_density = 0.;
           if (i_nuclide >= 0) {
-            auto j = model::materials[p.material_]->mat_nuclide_index_[i_nuclide];
+            auto j =
+              model::materials[p.material_].mat_nuclide_index_[i_nuclide];
             if (j == C_NONE) continue;
-            atom_density = model::materials[p.material_]->atom_density_(j);
+            atom_density = model::materials[p.material_].atom_density_(j);
           }
 
           //TODO: consider replacing this "if" with pointers or templates

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -140,7 +140,7 @@ std::vector<VolumeCalculation::Result> VolumeCalculation::execute() const
         if (domain_type_ == TallyDomain::MATERIAL) {
           if (p.material_ != MATERIAL_VOID) {
             for (int i_domain = 0; i_domain < n; i_domain++) {
-              if (model::materials[p.material_]->id_ == domain_ids_[i_domain]) {
+              if (model::materials[p.material_].id_ == domain_ids_[i_domain]) {
                 this->check_hit(p.material_, indices[i_domain], hits[i_domain]);
                 break;
               }
@@ -268,11 +268,11 @@ std::vector<VolumeCalculation::Result> VolumeCalculation::execute() const
           if (i_material == MATERIAL_VOID) continue;
 
           const auto& mat = model::materials[i_material];
-          for (int k = 0; k < mat->nuclide_.size(); ++k) {
+          for (int k = 0; k < mat.nuclide_.size(); ++k) {
             // Accumulate nuclide density
-            int i_nuclide = mat->nuclide_[k];
-            atoms(i_nuclide, 0) += mat->atom_density_[k] * f;
-            atoms(i_nuclide, 1) += std::pow(mat->atom_density_[k], 2) * var_f;
+            int i_nuclide = mat.nuclide_[k];
+            atoms(i_nuclide, 0) += mat.atom_density_[k] * f;
+            atoms(i_nuclide, 1) += std::pow(mat.atom_density_[k], 2) * var_f;
           }
         }
 

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -407,7 +407,7 @@ void VolumeCalculation::to_hdf5(const std::string& filename,
 
     std::vector<std::string> nucnames;
     for (int i_nuc : result.nuclides) {
-      nucnames.push_back(data::nuclides[i_nuc]->name_);
+      nucnames.push_back(data::nuclides[i_nuc].name_);
     }
 
     // Create array of total # of atoms with uncertainty for each nuclide

--- a/src/wmp.cpp
+++ b/src/wmp.cpp
@@ -219,8 +219,8 @@ void check_wmp_version(hid_t file)
 void read_multipole_data(int i_nuclide)
 {
   // Look for WMP data in cross_sections.xml
-  const auto& nuc {data::nuclides[i_nuclide]};
-  auto it = data::library_map.find({Library::Type::wmp, nuc->name_});
+  auto& nuc {data::nuclides[i_nuclide]};
+  auto it = data::library_map.find({Library::Type::wmp, nuc.name_});
 
   // If no WMP library for this nuclide, just return
   if (it == data::library_map.end()) return;
@@ -230,15 +230,15 @@ void read_multipole_data(int i_nuclide)
   std::string& filename = data::libraries[idx].path_;
 
   // Display message
-  write_message(6, "Reading {} WMP data from {}", nuc->name_, filename);
+  write_message(6, "Reading {} WMP data from {}", nuc.name_, filename);
 
   // Open file and make sure version is sufficient
   hid_t file = file_open(filename, 'r');
   check_wmp_version(file);
 
   // Read nuclide data from HDF5
-  hid_t group = open_group(file, nuc->name_.c_str());
-  nuc->multipole_ = std::make_unique<WindowedMultipole>(group);
+  hid_t group = open_group(file, nuc.name_.c_str());
+  nuc.multipole_ = std::make_unique<WindowedMultipole>(group);
   close_group(group);
   file_close(file);
 }


### PR DESCRIPTION
Currently, data::nuclides and data::materials are both vectors of unique pointers to materials or nuclides. Neither of these classes are terribly big, and the storage of the class itself is negligible compared to other storage needs within OpenMC.

This PR removes the indirection here and modifies the aforementioned global variables to instead be vectors of their respective classes rather than vectors of pointers. This simplifies the GPU code some for me, and _maybe_ gave me a slight performance increase on a problem with not many nuclides. That could have just been changed by what was running on my computer at the time of each test though.

It's OK to close this if any developer believes that OpenMC will one day have polymorphic nuclides or materials. For now, that seems to certainly not be the case, and from what I can tell there's not going to be any addition of functionality like that going into the future.

Also, I found that the destructors which delete entries from the material and nuclide maps run when you erroneously if using the raw aforementioned classes in vectors rather than pointers. I had all tests passing on my machine when not doing these (I think) unnecessary removals from those global scope maps. So, the destructors for Material and Nuclide have been defaulted here as well.

EDIT: on second thought, maybe this isn't worth it. What are the reasons to use or not to use the vector of pointers approach when there's no polymorphism?