### PR TITLE
Update Dataset.value calls for h5py v3.0

### DIFF
--- a/scripts/openmc-track-to-vtk
+++ b/scripts/openmc-track-to-vtk
@@ -46,7 +46,7 @@ def main():
         n_coords = track.attrs['n_coords']
         coords = []
         for i in range(n_particles):
-            coords.append(track['coordinates_' + str(i + 1)].value)
+            coords.append(track['coordinates_' + str(i + 1)][()])
             for j in range(n_coords[i]):
                 points.InsertNextPoint(coords[i][j,:])
 

--- a/tests/regression_tests/plot/test.py
+++ b/tests/regression_tests/plot/test.py
@@ -42,10 +42,10 @@ class PlotTestHarness(TestHarness):
                 # Add voxel data to results
                 with h5py.File(fname, 'r') as fh:
                     outstr += fh.attrs['filetype']
-                    outstr += fh.attrs['num_voxels'].tostring()
-                    outstr += fh.attrs['lower_left'].tostring()
-                    outstr += fh.attrs['voxel_width'].tostring()
-                    outstr += fh['data'].value.tostring()
+                    outstr += fh.attrs['num_voxels'].tobytes()
+                    outstr += fh.attrs['lower_left'].tobytes()
+                    outstr += fh.attrs['voxel_width'].tobytes()
+                    outstr += fh['data'][()].tobytes()
 
         # Hash the information and return.
         sha512 = hashlib.sha512()

--- a/tests/regression_tests/plot_overlaps/test.py
+++ b/tests/regression_tests/plot_overlaps/test.py
@@ -42,10 +42,10 @@ class PlotTestHarness(TestHarness):
                 # Add voxel data to results
                 with h5py.File(fname, 'r') as fh:
                     outstr += fh.attrs['filetype']
-                    outstr += fh.attrs['num_voxels'].tostring()
-                    outstr += fh.attrs['lower_left'].tostring()
-                    outstr += fh.attrs['voxel_width'].tostring()
-                    outstr += fh['data'].value.tostring()
+                    outstr += fh.attrs['num_voxels'].tobytes()
+                    outstr += fh.attrs['lower_left'].tobytes()
+                    outstr += fh.attrs['voxel_width'].tobytes()
+                    outstr += fh['data'][()].tobytes()
 
         # Hash the information and return.
         sha512 = hashlib.sha512()

--- a/tests/regression_tests/plot_voxel/test.py
+++ b/tests/regression_tests/plot_voxel/test.py
@@ -23,7 +23,7 @@ class PlotVoxelTestHarness(TestHarness):
 
         check_call(['../../../scripts/openmc-voxel-to-vtk'] +
                    glob.glob('plot_4.h5'))
-                
+
     def _test_output_created(self):
         """Make sure *.ppm has been created."""
         for fname in self._plot_names:
@@ -44,10 +44,10 @@ class PlotVoxelTestHarness(TestHarness):
                 # Add voxel data to results
                 with h5py.File(fname, 'r') as fh:
                     outstr += fh.attrs['filetype']
-                    outstr += fh.attrs['num_voxels'].tostring()
-                    outstr += fh.attrs['lower_left'].tostring()
-                    outstr += fh.attrs['voxel_width'].tostring()
-                    outstr += fh['data'].value.tostring()
+                    outstr += fh.attrs['num_voxels'].tobytes()
+                    outstr += fh.attrs['lower_left'].tobytes()
+                    outstr += fh.attrs['voxel_width'].tobytes()
+                    outstr += fh['data'][()].tobytes()
 
         # Hash the information and return.
         sha512 = hashlib.sha512()


### PR DESCRIPTION
Ci is [currently broken](https://travis-ci.com/github/openmc-dev/openmc/builds/191087483) due to changes in the latest release of `h5py`.

From the `h5py` 3.0 [release notes](https://travis-ci.com/github/openmc-dev/openmc/builds/191087483) under "Breaking changes & deprecations":

> The deprecated Dataset.value property was removed. Use ds[()] to read all data from any dataset.

We were using the `Dataset.value` call in the plotting test files and the `openmc-track-to-vtk` script. These have all been updated here.