### PR TITLE
Add missing import in depletion module

### DIFF
--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -1,11 +1,12 @@
 """
 Class for normalizing fission energy deposition
 """
+import bisect
+from collections import defaultdict
 from copy import deepcopy
 from itertools import product
 from numbers import Real
-import bisect
-from collections import defaultdict
+import sys
 
 from numpy import dot, zeros, newaxis, asarray
 


### PR DESCRIPTION
Recently discovered that there is a missing `import sys` statement in the `helpers.py` module.