### PR TITLE
Fix documentation for several classes

### DIFF
--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -3,3 +3,9 @@ jupyter
 sphinxcontrib-katex
 sphinxcontrib-svg2pdfconverter
 nbsphinx
+numpy
+scipy
+h5py
+pandas
+uncertainties
+matplotlib

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,18 +21,9 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 from unittest.mock import MagicMock
 
 MOCK_MODULES = [
-    'numpy', 'numpy.polynomial', 'numpy.polynomial.polynomial',
-    'numpy.ctypeslib', 'scipy', 'scipy.sparse', 'scipy.sparse.linalg',
-    'scipy.interpolate', 'scipy.integrate', 'scipy.optimize', 'scipy.signal',
-    'scipy.special', 'scipy.stats', 'scipy.spatial', 'h5py', 'pandas',
-    'uncertainties', 'matplotlib', 'matplotlib.pyplot', 'openmoc',
-    'openmc.data.reconstruct', 'openmc.checkvalue'
+    'openmoc', 'openmc.data.reconstruct',
 ]
 sys.modules.update((mod_name, MagicMock()) for mod_name in MOCK_MODULES)
-
-import numpy as np
-np.ndarray = MagicMock
-np.polynomial.Polynomial = MagicMock
 
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
@drewejohnson pointed out that our autogenerated documentation currently lists the [wrong summary information](https://docs.openmc.org/en/latest/pythonapi/base.html) for the `Materials` class (a few others as well):

![image](https://user-images.githubusercontent.com/743095/98593397-b90de100-2298-11eb-9706-a587833a4617.png)

It turns out that this is because these classes subclass `CheckedList`, which is mocked out during documentation builds because of a problem it was causing in the depletion module (specifically, instantiation of `IPFCramSolver` which called one of the functions in `check_value` that required numpy). In this PR, I've fixed this by just requiring that our documentation builds on readthedocs actually have numpy (and other third-party packages) available, thus obviating the need to mock them. This approach should be much less error prone in the future; as you can see, there are now only two modules we need to mock out.