### PR TITLE
Fix issue with assigning elemental carbon when using JEFF 3.3

### DIFF
--- a/openmc/element.py
+++ b/openmc/element.py
@@ -149,30 +149,28 @@ class Element(str):
             mutual_nuclides = sorted(list(mutual_nuclides))
             absent_nuclides = sorted(list(absent_nuclides))
 
-            # If all natural nuclides are present in the library,
-            # expand element using all natural nuclides
+            # If all naturally ocurring isotopes are present in the library,
+            # add them based on their abundance
             if len(absent_nuclides) == 0:
                 for nuclide in mutual_nuclides:
                     abundances[nuclide] = NATURAL_ABUNDANCE[nuclide]
 
-            # If no natural elements are present in the library, check if the
-            # 0 nuclide is present. If so, set the abundance to 1 for this
-            # nuclide. Else, raise an error.
-            elif len(mutual_nuclides) == 0:
-                nuclide_0 = self + '0'
-                if nuclide_0 in library_nuclides:
-                    abundances[nuclide_0] = 1.0
-                else:
-                    msg = 'Unable to expand element {0} because the cross '\
-                          'section library provided does not contain any of '\
-                          'the natural isotopes for that element.'\
-                          .format(self)
-                    raise ValueError(msg)
+            # If some naturally occurring isotopes are not present in the
+            # library, check if the "natural" nuclide (e.g., C0) is present. If
+            # so, set the abundance to 1 for this nuclide.
+            elif (self + '0') in library_nuclides:
+                abundances[self + '0'] = 1.0
 
-            # If some, but not all, natural nuclides are in the library, add
-            # the mutual nuclides. For the absent nuclides, add them based on
-            # our knowledge of the common cross section libraries
-            # (ENDF, JEFF, and JENDL)
+            elif len(mutual_nuclides) == 0:
+                msg = ('Unable to expand element {} because the cross '
+                       'section library provided does not contain any of '
+                       'the natural isotopes for that element.'
+                       .format(self))
+                raise ValueError(msg)
+
+            # If some naturally occurring isotopes are in the library, add them.
+            # For the absent nuclides, add them based on our knowledge of the
+            # common cross section libraries (ENDF, JEFF, and JENDL)
             else:
                 # Add the mutual isotopes
                 for nuclide in mutual_nuclides:


### PR DESCRIPTION
The following does not work if you have `OPENMC_CROSS_SECTIONS` set to a JEFF 3.3 library:
```Python
m = openmc.Material()
m.add_element('C', 1.0)
```
The reason is that, strangely, JEFF 3.3 has a C0 (natural) nuclide as well as C13. OpenMC sees C13 and then doesn't know what to do with the missing C12. I've changed the logic when doing element expansion to the following:
1. If all naturally occurring isotopes are present, use those
2. If some are missing and the "0" nuclide (e.g. C0) is present, use the "0" nuclide only
3. If all naturally occurring isotopes are missing, raise an exception
4. Otherwise, check for a select few known cases (e.g. O18 missing when using ENDF/B-VII.1) and handle accordingly
