### PR TITLE
Typo fix in RectangularParallelepiped.__pos__ method.

### DIFF
--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -163,7 +163,7 @@ class RectangularParallelepiped(CompositeSurface):
         return +self.xmin & -self.xmax & +self.ymin & -self.ymax & +self.zmin & -self.zmax
 
     def __pos__(self):
-        return -self.xmin | +self.ymax | -self.ymin | +self.ymax | -self.zmin | +self.zmax
+        return -self.xmin | +self.xmax | -self.ymin | +self.ymax | -self.zmin | +self.zmax
 
 
 class XConeOneSided(CompositeSurface):


### PR DESCRIPTION
Addresses a user-reported issue related to using positive halfspaces of RectangularParallelepiped. Closes #1723.