### PR TITLE
Adding optional dagmc to docker

### DIFF
--- a/.github/workflows/dockerhub-publish-dagmc.yml
+++ b/.github/workflows/dockerhub-publish-dagmc.yml
@@ -1,0 +1,34 @@
+name: dockerhub-publish-latest-dagmc
+
+on:
+  push:
+    branches: master
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: openmc/openmc:latest-dagmc
+          build-args: |
+            include_dagmc=true
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/dockerhub-publish-dagmc.yml
+++ b/.github/workflows/dockerhub-publish-dagmc.yml
@@ -29,6 +29,7 @@ jobs:
           tags: openmc/openmc:latest-dagmc
           build-args: |
             include_dagmc=true
+            compile_cores=2
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/dockerhub-publish-dev.yml
+++ b/.github/workflows/dockerhub-publish-dev.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           push: true
           tags: openmc/openmc:develop
+          build-args: |
+            compile_cores=2
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/dockerhub-publish-release-dagmc.yml
+++ b/.github/workflows/dockerhub-publish-release-dagmc.yml
@@ -32,6 +32,7 @@ jobs:
           tags: openmc/openmc:${{ env.RELEASE_VERSION }}-dagmc
           build-args: |
             include_dagmc=true
+            compile_cores=2
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/dockerhub-publish-release-dagmc.yml
+++ b/.github/workflows/dockerhub-publish-release-dagmc.yml
@@ -1,0 +1,37 @@
+name: dockerhub-publish-release-dagmc
+
+on:
+  push:
+    tags: 'v*.*.*'
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: openmc/openmc:${{ env.RELEASE_VERSION }}-dagmc
+          build-args: |
+            include_dagmc=true
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/dockerhub-publish-release.yml
+++ b/.github/workflows/dockerhub-publish-release.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           push: true
           tags: openmc/openmc:${{ env.RELEASE_VERSION }}
+          build-args: |
+            compile_cores=2
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           push: true
           tags: openmc/openmc:latest
+          build-args: |
+            compile_cores=2
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/name: dockerhub-publish-develop-dagmc.yml
+++ b/.github/workflows/name: dockerhub-publish-develop-dagmc.yml
@@ -29,6 +29,7 @@ jobs:
           tags: openmc/openmc:develop-dagmc
           build-args: |
             include_dagmc=true
+            compile_cores=2
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/name: dockerhub-publish-develop-dagmc.yml
+++ b/.github/workflows/name: dockerhub-publish-develop-dagmc.yml
@@ -1,0 +1,34 @@
+name: dockerhub-publish-develop-dagmc
+
+on:
+  push:
+    branches: develop
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: openmc/openmc:develop-dagmc
+          build-args: |
+            include_dagmc=true
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # docker build -t openmc_dagmc --build-arg include_dagmc=true .
 
 # To make use of multiple cores during the compile stages of the docker build
-# docker build -t openmc_dagmc --build-arg compile_cores=8
+# docker build -t openmc_dagmc --build-arg compile_cores=8 .
 
 FROM ubuntu:latest
 
@@ -58,8 +58,6 @@ RUN if [ "$include_dagmc" = "false" ] ; \
 # install addition packages required for DAGMC
 RUN if [ "$include_dagmc" = "true" ] ; \
     then apt-get --yes install libeigen3-dev ; \
-    apt-get --yes install libblas-dev ; \
-    apt-get --yes install liblapack-dev ; \
     apt-get --yes install libnetcdf-dev ; \
     apt-get --yes install libtbb-dev ; \
     apt-get --yes install libglfw3-dev ; \
@@ -89,7 +87,8 @@ RUN if [ "$include_dagmc" = "true" ] ; \
                 -DENABLE_NETCDF=ON \
                 -DBUILD_SHARED_LIBS=OFF \
                 -DENABLE_FORTRAN=OFF \
-                -DCMAKE_INSTALL_PREFIX=/MOAB ; \
+                -DCMAKE_INSTALL_PREFIX=/MOAB \
+                -DENABLE_BLASLAPACK=OFF ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
     rm -rf * ; \
@@ -98,7 +97,8 @@ RUN if [ "$include_dagmc" = "true" ] ; \
                 -DENABLE_PYMOAB=ON \
                 -DENABLE_BLASLAPACK=OFF \
                 -DENABLE_FORTRAN=OFF \
-                -DCMAKE_INSTALL_PREFIX=/MOAB ; \
+                -DCMAKE_INSTALL_PREFIX=/MOAB \
+                -DENABLE_BLASLAPACK=OFF ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
     cd pymoab ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,16 @@
 # To build with OpenMC and DAGMC enabled
 # docker build -t openmc_dagmc --build-arg include_dagmc=true .
 
+# To make use of multiple cores during the compile stages of the docker build
+# docker build -t openmc_dagmc --build-arg compile_cores=8
+
 FROM ubuntu:latest
 
 # By default this Dockerfile builds OpenMC without dagmc
 ARG include_dagmc=false
+
+# By default one core is used to compile
+ARG compile_cores=1
 
 # Setup environment variables for Docker image
 ENV CC=/usr/bin/mpicc CXX=/usr/bin/mpicxx \
@@ -43,8 +49,8 @@ RUN if [ "$include_dagmc" = "false" ] ; \
     mkdir -p build ; \
     cd build ; \
     cmake -Doptimize=on -DHDF5_PREFER_PARALLEL=on .. ; \
-    make ; \
-    make install ; \
+    make -j"$compile_cores" ; \
+    make -j"$compile_cores" install ; \
     cd ..  ; \
     pip install -e .[test] ; \
     fi
@@ -67,8 +73,8 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     cd build ; \
     cmake .. -DCMAKE_INSTALL_PREFIX=.. \
         -DEMBREE_ISPC_SUPPORT=OFF ; \
-    make ; \
-    make install ; \
+    make -j"$compile_cores" ; \
+    make -j"$compile_cores" install ; \
     fi
 
 # Clone and install MOAB
@@ -84,8 +90,8 @@ RUN if [ "$include_dagmc" = "true" ] ; \
                 -DBUILD_SHARED_LIBS=OFF \
                 -DENABLE_FORTRAN=OFF \
                 -DCMAKE_INSTALL_PREFIX=/MOAB ; \
-    make ; \
-    make install ; \
+    make -j"$compile_cores" ; \
+    make -j"$compile_cores" install ; \
     rm -rf * ; \
     cmake ../moab -DBUILD_SHARED_LIBS=ON \
                 -DENABLE_HDF5=ON \
@@ -93,8 +99,8 @@ RUN if [ "$include_dagmc" = "true" ] ; \
                 -DENABLE_BLASLAPACK=OFF \
                 -DENABLE_FORTRAN=OFF \
                 -DCMAKE_INSTALL_PREFIX=/MOAB ; \
-    make ; \
-    make install ; \
+    make -j"$compile_cores" ; \
+    make -j"$compile_cores" install ; \
     cd pymoab ; \
     bash install.sh ; \
     python setup.py install ; \
@@ -110,8 +116,8 @@ RUN if [ "$include_dagmc" = "true" ] ; \
         -DMOAB_DIR=/MOAB \
         -DEMBREE_DIR=/embree/lib/cmake/embree-3.12.1 \
         -DEMBREE_ROOT=/embree/lib/cmake/embree-3.12.1 ; \
-    make ; \
-    make install ; \
+    make -j"$compile_cores" ; \
+    make -j"$compile_cores" install ; \
     fi
 
 # Clone and install DAGMC
@@ -126,7 +132,7 @@ RUN if [ "$include_dagmc" = "true" ] ; \
         -DMOAB_DIR=/MOAB \
         -DBUILD_STATIC_LIBS=OFF \
         -DBUILD_STATIC_EXE=OFF ; \
-    make install ; \
+    make -j"$compile_cores" install ; \
     rm -rf /DAGMC/dagmc /DAGMC/build ; \
     fi
 
@@ -139,8 +145,8 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     cmake -Doptimize=on -Ddagmc=ON \
         -DDAGMC_DIR=/DAGMC/ \
         -DHDF5_PREFER_PARALLEL=on ..  ; \
-    make  ; \
-    make install ; \
+    make -j"$compile_cores" ; \
+    make -j"$compile_cores" install ; \
     cd ..  ; \
     pip install -e .[test] ; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN if [ "$include_dagmc" = "true" ] ; \
                 -DENABLE_NETCDF=ON \
                 -DBUILD_SHARED_LIBS=OFF \
                 -DENABLE_FORTRAN=OFF \
-                -DCMAKE_INSTALL_PREFIX=/MOAB \
+                -DPYMOAB_PREFIX=/MOAB/build/pymoab \
                 -DENABLE_BLASLAPACK=OFF ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
@@ -97,13 +97,9 @@ RUN if [ "$include_dagmc" = "true" ] ; \
                 -DENABLE_PYMOAB=ON \
                 -DENABLE_BLASLAPACK=OFF \
                 -DENABLE_FORTRAN=OFF \
-                -DCMAKE_INSTALL_PREFIX=/MOAB \
                 -DENABLE_BLASLAPACK=OFF ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
-    cd pymoab ; \
-    bash install.sh ; \
-    python setup.py install ; \
     fi
 
 # Clone and install Double-Down
@@ -113,7 +109,7 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     mkdir build ; \
     cd build ; \
     cmake .. -DCMAKE_INSTALL_PREFIX=.. \
-             -DMOAB_DIR=/MOAB \
+             -DMOAB_DIR=/usr/local \
              -DEMBREE_DIR=/embree/lib/cmake/embree-3.12.1 ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
@@ -128,7 +124,7 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     cd build ; \
     cmake ../dagmc -DBUILD_TALLY=ON \
         -DCMAKE_INSTALL_PREFIX=/dagmc/ \
-        -DMOAB_DIR=/MOAB \
+        -DMOAB_DIR=/usr/local \
         -DBUILD_STATIC_LIBS=OFF \
         -DBUILD_STATIC_EXE=OFF ; \
     make -j"$compile_cores" install ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,8 @@ RUN if [ "$include_dagmc" = "false" ] ; \
     cd /opt/openmc ; \
     mkdir -p build ; \
     cd build ; \
-    cmake -Doptimize=on -DHDF5_PREFER_PARALLEL=on .. ; \
+    cmake -Doptimize=on \
+          -DHDF5_PREFER_PARALLEL=on .. ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
     cd ..  ; \
@@ -92,11 +93,11 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     make -j"$compile_cores" install ; \
     rm -rf * ; \
     cmake ../moab -DBUILD_SHARED_LIBS=ON \
-                -DENABLE_HDF5=ON \
-                -DENABLE_PYMOAB=ON \
-                -DENABLE_BLASLAPACK=OFF \
-                -DENABLE_FORTRAN=OFF \
-                -DENABLE_BLASLAPACK=OFF ; \
+                  -DENABLE_HDF5=ON \
+                  -DENABLE_PYMOAB=ON \
+                  -DENABLE_BLASLAPACK=OFF \
+                  -DENABLE_FORTRAN=OFF \
+                  -DENABLE_BLASLAPACK=OFF ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
     fi
@@ -122,10 +123,10 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     mkdir build ; \
     cd build ; \
     cmake ../dagmc -DBUILD_TALLY=ON \
-        -DCMAKE_INSTALL_PREFIX=/dagmc/ \
-        -DMOAB_DIR=/usr/local \
-        -DBUILD_STATIC_LIBS=OFF \
-        -DBUILD_STATIC_EXE=OFF ; \
+                   -DCMAKE_INSTALL_PREFIX=/dagmc/ \
+                   -DMOAB_DIR=/usr/local \
+                   -DBUILD_STATIC_LIBS=OFF \
+                   -DBUILD_STATIC_EXE=OFF ; \
     make -j"$compile_cores" install ; \
     rm -rf /DAGMC/dagmc /DAGMC/build ; \
     fi
@@ -136,9 +137,10 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     cd /opt/openmc ; \
     mkdir build ; \
     cd build ; \
-    cmake -Doptimize=on -Ddagmc=ON \
-        -DDAGMC_DIR=/DAGMC/ \
-        -DHDF5_PREFER_PARALLEL=on ..  ; \
+    cmake -Doptimize=on \
+          -Ddagmc=ON \
+          -DDAGMC_DIR=/DAGMC/ \
+          -DHDF5_PREFER_PARALLEL=on ..  ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
     cd ..  ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,11 +84,10 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     git clone  --single-branch --branch develop https://bitbucket.org/fathomteam/moab/ ; \
     cd build ; \
     cmake ../moab -DENABLE_HDF5=ON \
-                -DENABLE_NETCDF=ON \
-                -DBUILD_SHARED_LIBS=OFF \
-                -DENABLE_FORTRAN=OFF \
-                -DPYMOAB_PREFIX=/MOAB/build/pymoab \
-                -DENABLE_BLASLAPACK=OFF ; \
+                  -DENABLE_NETCDF=ON \
+                  -DBUILD_SHARED_LIBS=OFF \
+                  -DENABLE_FORTRAN=OFF \
+                  -DENABLE_BLASLAPACK=OFF ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
     rm -rf * ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,8 +114,7 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     cd build ; \
     cmake .. -DCMAKE_INSTALL_PREFIX=.. \
              -DMOAB_DIR=/MOAB \
-             -DEMBREE_DIR=/embree/lib/cmake/embree-3.12.1 \
-             -DEMBREE_ROOT=/embree/lib/cmake/embree-3.12.1 ; \
+             -DEMBREE_DIR=/embree/lib/cmake/embree-3.12.1 ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,9 @@ RUN if [ "$include_dagmc" = "true" ] ; \
                 -DCMAKE_INSTALL_PREFIX=/MOAB ; \
     make ; \
     make install ; \
+    cd pymoab ; \
+    bash install.sh ; \
+    python setup.py install ; \
     fi
 
 # Clone and install Double-Down

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,26 +60,11 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     apt-get --yes install libglfw3-dev ; \
     fi
 
-# perhaps not needed#
-# ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/hdf5/serial:$LD_LIBRARY_PATH
-
-RUN git clone https://github.com/embree/embree
-RUN git clone https://github.com/pshriwise/double-down
-RUN git clone -b develop https://github.com/svalinn/dagmc
-RUN git clone --recurse-submodules https://github.com/openmc-dev/openmc.git
-RUN cd $HOME && \
-    mkdir MOAB && \
-    cd MOAB && \
-    git clone  --single-branch --branch develop https://bitbucket.org/fathomteam/moab/
-
-
-RUN apt-get --yes install  
-
 
 # Clone and install Embree
 RUN if [ "$include_dagmc" = "true" ] ; \
     then echo installing embree ; \
-    # git clone https://github.com/embree/embree ; \
+    git clone https://github.com/embree/embree ; \
     cd embree ; \
     mkdir build ; \
     cd build ; \
@@ -92,26 +77,27 @@ RUN if [ "$include_dagmc" = "true" ] ; \
 
 # Clone and install MOAB
 RUN if [ "$include_dagmc" = "true" ] ; \
-    then mkdir MOAB ; \
-    mkdir build ; \
+    then pip install --upgrade numpy cython ; \
+    mkdir MOAB ; \
     cd MOAB ; \
-    # git clone --depth 1 https://bitbucket.org/fathomteam/moab -b develop ; \
+    mkdir build ; \
+    git clone  --single-branch --branch develop https://bitbucket.org/fathomteam/moab/ ; \
     cd build ; \
-    cmake ../moab -DENABLE_HDF5=ON ; \
-                -DENABLE_NETCDF=ON ; \
-                -DBUILD_SHARED_LIBS=OFF ; \
-                -DENABLE_FORTRAN=OFF ; \
+    cmake ../moab -DENABLE_HDF5=ON \
+                -DENABLE_NETCDF=ON \
+                -DBUILD_SHARED_LIBS=OFF \
+                -DENABLE_FORTRAN=OFF \
                 -DCMAKE_INSTALL_PREFIX=/MOAB ; \
-    make -j4; \
+    make -j; \
     make install ; \
     rm -rf * ; \
-    cmake ../moab -DBUILD_SHARED_LIBS=ON ; \
-                -DENABLE_HDF5=ON ; \
-                -DENABLE_PYMOAB=ON ; \
-                -DENABLE_BLASLAPACK=OFF ; \
-                -DENABLE_FORTRAN=OFF ; \
+    cmake ../moab -DBUILD_SHARED_LIBS=ON \
+                -DENABLE_HDF5=ON \
+                -DENABLE_PYMOAB=ON \
+                -DENABLE_BLASLAPACK=OFF \
+                -DENABLE_FORTRAN=OFF \
                 -DCMAKE_INSTALL_PREFIX=/MOAB ; \
-    make -j4; \
+    make -j; \
     make install ; \
     fi
 
@@ -119,29 +105,30 @@ RUN if [ "$include_dagmc" = "true" ] ; \
 # Clone and install double-down
 RUN if [ "$include_dagmc" = "true" ] ; \
     then echo installing double-down ; \
-    # git clone https://github.com/pshriwise/double-down ; \
+    git clone https://github.com/pshriwise/double-down ; \
     cd double-down ; \
     mkdir build ; \
     cd build ; \
-    cmake .. -DCMAKE_INSTALL_PREFIX=.. ; \
-        -DMOAB_DIR=/MOAB ; \
-        -DEMBREE_DIR=/embree ; \
-        -DEMBREE_ROOT=/embree ; \
-    make ; \
-    make install ; \
+    cmake .. -DCMAKE_INSTALL_PREFIX=.. \
+        -DMOAB_DIR=/MOAB \
+        -DEMBREE_DIR=/embree/lib/cmake/embree-3.12.1 \
+        -DEMBREE_ROOT=/embree/lib/cmake/embree-3.12.1 ; \
+    make -j ; \
+    make -j install ; \
     fi
+
 
 # Clone and install DAGMC
 RUN if [ "$include_dagmc" = "true" ] ; \
     then mkdir DAGMC ; \
     cd DAGMC ; \
-    # git clone -b develop https://github.com/svalinn/dagmc ; \
+    git clone -b develop https://github.com/svalinn/dagmc ; \
     mkdir build ; \
     cd build ; \
-    cmake ../dagmc -DBUILD_TALLY=ON ; \
-        -DCMAKE_INSTALL_PREFIX=/DAGMC/ ; \
-        -DMOAB_DIR=/MOAB  ; \
-        -DBUILD_STATIC_LIBS=OFF ; \
+    cmake ../dagmc -DBUILD_TALLY=ON \
+        -DCMAKE_INSTALL_PREFIX=/dagmc/ \
+        -DMOAB_DIR=/MOAB \
+        -DBUILD_STATIC_LIBS=OFF \
         -DBUILD_STATIC_EXE=OFF ; \
     make -j install ; \
     rm -rf /DAGMC/dagmc /DAGMC/build ; \
@@ -151,7 +138,7 @@ RUN if [ "$include_dagmc" = "true" ] ; \
 # Clone and install OpenMC with DAGMC
 RUN if [ "$include_dagmc" = "true" ] ; \
     then echo installing openmc with dagmc ; \
-    # then git clone --recurse-submodules https://github.com/openmc-dev/openmc.git ; \
+    then git clone --recurse-submodules https://github.com/openmc-dev/openmc.git ; \
     /opt/openmc ; \
     cd /opt/openmc ; \
     mkdir -p build ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+# To build with OpenMC
+# docker build -t openmc .
+
+# To build with OpenMC and DAGMC enabled
+# docker build -t openmc_dagmc --build-arg include_dagmc=true .
+
 FROM ubuntu:latest
 
 # By default this Dockerfile builds OpenMC without dagmc
@@ -71,6 +77,7 @@ RUN if [ "$include_dagmc" = "true" ] ; \
                 -DCMAKE_INSTALL_RPATH=${hdf5_install_dir}:$HOME/MOAB ; \
     make ; \
     make install ; \
+    fi
 
 # Clone and install DAGMC
 RUN if [ "$include_dagmc" = "true" ] ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:latest
 
+# By default this Dockerfile builds OpenMC without dagmc
+ARG include_dagmc=false
+
 # Setup environment variables for Docker image
 ENV CC=/usr/bin/mpicc CXX=/usr/bin/mpicxx \
     PATH=/opt/openmc/bin:/opt/NJOY2016/build:$PATH \
@@ -26,12 +29,74 @@ RUN git clone https://github.com/njoy/NJOY2016 /opt/NJOY2016 && \
     mkdir build && cd build && \
     cmake -Dstatic=on .. && make 2>/dev/null && make install
 
-# Clone and install OpenMC
-RUN git clone --recurse-submodules https://github.com/openmc-dev/openmc.git \
-    /opt/openmc && cd /opt/openmc && mkdir -p build && cd build && \
-    cmake -Doptimize=on -DHDF5_PREFER_PARALLEL=on .. && \
-    make && make install && \
-    cd .. && pip install -e .[test]
+# Clone and install OpenMC without DAGMC
+RUN if [ "$include_dagmc" = "false" ] ; \
+    then git clone --recurse-submodules https://github.com/openmc-dev/openmc.git \
+    /opt/openmc ; \
+    cd /opt/openmc ; \
+    mkdir -p build ; \
+    cd build ; \
+    cmake -Doptimize=on -DHDF5_PREFER_PARALLEL=on .. ; \
+    make  ; \
+    make install ; \
+    cd ..  ; \
+    pip install -e .[test] ; \
+    fi
+
+# Clone and install MOAB
+RUN if [ "$include_dagmc" = "true" ] ; \
+    then mkdir -p MOAB/bld ; \
+    cd MOAB ; \
+    git clone --depth 1 https://bitbucket.org/fathomteam/moab -b Version5.1.0 ; \
+    cd bld ; \
+    cmake ../moab -DBUILD_SHARED_LIBS=OFF ; \
+                -DENABLE_HDF5=ON ; \
+                -DENABLE_BLASLAPACK=OFF ; \
+                -DENABLE_FORTRAN=OFF ; \
+                -DCMAKE_INSTALL_PREFIX=$HOME/MOAB ; \
+                -DCMAKE_C_COMPILER=${CC} ; \
+                -DCMAKE_CXX_COMPILER=${CXX} ; \
+                -DCMAKE_INSTALL_RPATH=${hdf5_install_dir}:$HOME/MOAB ; \
+    make ; \
+    make install ; \
+    rm -rf * ; \
+    cmake ../moab -DBUILD_SHARED_LIBS=ON ; \
+                -DENABLE_HDF5=ON ; \
+                -DENABLE_PYMOAB=ON ; \
+                -DENABLE_BLASLAPACK=OFF ; \
+                -DENABLE_FORTRAN=OFF ; \
+                -DCMAKE_INSTALL_PREFIX=$HOME/MOAB ; \
+                -DCMAKE_C_COMPILER=${CC} ; \
+                -DCMAKE_CXX_COMPILER=${CXX} ; \
+                -DCMAKE_INSTALL_RPATH=${hdf5_install_dir}:$HOME/MOAB ; \
+    make ; \
+    make install ; \
+
+# Clone and install DAGMC
+RUN if [ "$include_dagmc" = "true" ] ; \
+    then DAGMC && \
+    cd DAGMC && \
+    git clone -b develop https://github.com/svalinn/dagmc && \
+    mkdir build && \
+    cd build && \
+    cmake ../dagmc -DBUILD_TALLY=ON -DCMAKE_INSTALL_PREFIX=$DAGMC_INSTALL_DIR -DMOAB_DIR=$MOAB_INSTALL_DIR -DBUILD_STATIC_LIBS=OFF -DBUILD_STATIC_EXE=OFF && \
+    make -j install && \
+    rm -rf $HOME/DAGMC/dagmc $HOME/DAGMC/build ; \
+    fi
+
+# Clone and install OpenMC with DAGMC
+RUN if [ "$include_dagmc" = "true" ] ; \
+    then git clone --recurse-submodules https://github.com/openmc-dev/openmc.git \
+    /opt/openmc ; \
+    cd /opt/openmc ; \
+    mkdir -p build ; \
+    cd build ; \
+    cmake -Doptimize=on -Ddagmc=ON -DDAGMC_ROOT=$DAGMC_INSTALL_DIR -DHDF5_PREFER_PARALLEL=on .. && \
+    make  ; \
+    make install ; \
+    cd ..  ; \
+    pip install -e .[test] ; \
+    fi
 
 # Download cross sections (NNDC and WMP) and ENDF data needed by test suite
 RUN /opt/openmc/tools/ci/download-xs.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     mkdir build ; \
     cd build ; \
     cmake .. -DCMAKE_INSTALL_PREFIX=.. \
-        -DEMBREE_ISPC_SUPPORT=OFF ; \
+             -DEMBREE_ISPC_SUPPORT=OFF ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
     fi
@@ -113,9 +113,9 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     mkdir build ; \
     cd build ; \
     cmake .. -DCMAKE_INSTALL_PREFIX=.. \
-        -DMOAB_DIR=/MOAB \
-        -DEMBREE_DIR=/embree/lib/cmake/embree-3.12.1 \
-        -DEMBREE_ROOT=/embree/lib/cmake/embree-3.12.1 ; \
+             -DMOAB_DIR=/MOAB \
+             -DEMBREE_DIR=/embree/lib/cmake/embree-3.12.1 \
+             -DEMBREE_ROOT=/embree/lib/cmake/embree-3.12.1 ; \
     make -j"$compile_cores" ; \
     make -j"$compile_cores" install ; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN git clone https://github.com/njoy/NJOY2016 /opt/NJOY2016 && \
 
 # Clone and install OpenMC without DAGMC
 RUN if [ "$include_dagmc" = "false" ] ; \
-    then git clone --recurse-submodules https://github.com/openmc-dev/openmc.git \
+    then git clone --recurse-submodules https://github.com/openmc-dev/openmc.git ; \
     /opt/openmc ; \
     cd /opt/openmc ; \
     mkdir -p build ; \
@@ -55,16 +55,13 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     apt-get --yes install libblas-dev ; \
     apt-get --yes install liblapack-dev ; \
     apt-get --yes install libnetcdf-dev ; \
-    #apt-get --yes install libnetcdf13 ; \
     apt-get --yes install libtbb-dev ; \
     apt-get --yes install libglfw3-dev ; \
     fi
 
-
 # Clone and install Embree
 RUN if [ "$include_dagmc" = "true" ] ; \
-    then echo installing embree ; \
-    git clone https://github.com/embree/embree ; \
+    then git clone https://github.com/embree/embree ; \
     cd embree ; \
     mkdir build ; \
     cd build ; \
@@ -73,7 +70,6 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     make ; \
     make install ; \
     fi
-
 
 # Clone and install MOAB
 RUN if [ "$include_dagmc" = "true" ] ; \
@@ -88,7 +84,7 @@ RUN if [ "$include_dagmc" = "true" ] ; \
                 -DBUILD_SHARED_LIBS=OFF \
                 -DENABLE_FORTRAN=OFF \
                 -DCMAKE_INSTALL_PREFIX=/MOAB ; \
-    make -j; \
+    make ; \
     make install ; \
     rm -rf * ; \
     cmake ../moab -DBUILD_SHARED_LIBS=ON \
@@ -97,15 +93,13 @@ RUN if [ "$include_dagmc" = "true" ] ; \
                 -DENABLE_BLASLAPACK=OFF \
                 -DENABLE_FORTRAN=OFF \
                 -DCMAKE_INSTALL_PREFIX=/MOAB ; \
-    make -j; \
+    make ; \
     make install ; \
     fi
 
-
-# Clone and install double-down
+# Clone and install Double-Down
 RUN if [ "$include_dagmc" = "true" ] ; \
-    then echo installing double-down ; \
-    git clone https://github.com/pshriwise/double-down ; \
+    then git clone https://github.com/pshriwise/double-down ; \
     cd double-down ; \
     mkdir build ; \
     cd build ; \
@@ -113,10 +107,9 @@ RUN if [ "$include_dagmc" = "true" ] ; \
         -DMOAB_DIR=/MOAB \
         -DEMBREE_DIR=/embree/lib/cmake/embree-3.12.1 \
         -DEMBREE_ROOT=/embree/lib/cmake/embree-3.12.1 ; \
-    make -j ; \
-    make -j install ; \
+    make ; \
+    make install ; \
     fi
-
 
 # Clone and install DAGMC
 RUN if [ "$include_dagmc" = "true" ] ; \
@@ -130,21 +123,18 @@ RUN if [ "$include_dagmc" = "true" ] ; \
         -DMOAB_DIR=/MOAB \
         -DBUILD_STATIC_LIBS=OFF \
         -DBUILD_STATIC_EXE=OFF ; \
-    make -j install ; \
+    make install ; \
     rm -rf /DAGMC/dagmc /DAGMC/build ; \
     fi
 
-
 # Clone and install OpenMC with DAGMC
 RUN if [ "$include_dagmc" = "true" ] ; \
-    then echo installing openmc with dagmc ; \
-    then git clone --recurse-submodules https://github.com/openmc-dev/openmc.git ; \
-    /opt/openmc ; \
+    then git clone --recurse-submodules https://github.com/openmc-dev/openmc.git /opt/openmc ; \
     cd /opt/openmc ; \
-    mkdir -p build ; \
+    mkdir build ; \
     cd build ; \
-    cmake -Doptimize=on -Ddagmc=ON ; \
-        -DDAGMC_DIR=/DAGMC/ ; \
+    cmake -Doptimize=on -Ddagmc=ON \
+        -DDAGMC_DIR=/DAGMC/ \
         -DHDF5_PREFER_PARALLEL=on ..  ; \
     make  ; \
     make install ; \


### PR DESCRIPTION
This PR contains an updated dockerfile that allows optional building of OpenMC with [DAGMC](https://github.com/svalinn/DAGMC)

This PR has been discussed in issue #1709 with advice from @pshriwise and @makeclean 

There are a few other files to go with the updated Dockerfile.

There are three yml files that will help keep the docker images on dockerhub that contain this optional dagmc build upto date in a similar manner to #1678 

This is a nice install of DAGMC as it includes some packages that speed up DAGMC such as double-down and Embree. Thanks to @makeclean for a nice sample script.

Also the use of FORTRAN is avoided in the MOAB build through the use of the DENABLE_FORTRAN option. Thanks to @bam241 for a nice example of how to do that.