### PR TITLE
Dockerfile fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN git clone https://github.com/njoy/NJOY2016 /opt/NJOY2016 && \
 
 # Clone and install OpenMC without DAGMC
 RUN if [ "$include_dagmc" = "false" ] ; \
-    then git clone --recurse-submodules https://github.com/openmc-dev/openmc.git ; \
+    then git clone --recurse-submodules https://github.com/openmc-dev/openmc.git \
     /opt/openmc ; \
     cd /opt/openmc ; \
     mkdir -p build ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,7 @@ RUN git clone https://github.com/njoy/NJOY2016 /opt/NJOY2016 && \
 
 # Clone and install OpenMC without DAGMC
 RUN if [ "$include_dagmc" = "false" ] ; \
-    then git clone --recurse-submodules https://github.com/openmc-dev/openmc.git \
-    /opt/openmc ; \
+    then git clone --recurse-submodules https://github.com/openmc-dev/openmc.git /opt/openmc ; \
     cd /opt/openmc ; \
     mkdir -p build ; \
     cd build ; \


### PR DESCRIPTION
Looks like I missed a new rogue semicolon in my review of #1725 that is cutting the clone command short for Docker builds sans DAGMC. This sadly caused our [latest Docker build](https://github.com/openmc-dev/openmc/actions/runs/458315942) of the develop branch to fail.
