### PR TITLE
Remove on-the-fly memory allocation from WMP (20% active cycle speedup on depleted lattice)

### DIFF
--- a/include/openmc/wmp.h
+++ b/include/openmc/wmp.h
@@ -73,7 +73,7 @@ public:
 
   // Constant data
   static constexpr int MAX_POLY_COEFFICIENTS =
-    10; //!< Max order of polynomial fit plus one
+    11; //!< Max order of polynomial fit plus one
 };
 
 //========================================================================

--- a/include/openmc/wmp.h
+++ b/include/openmc/wmp.h
@@ -70,6 +70,10 @@ public:
   xt::xtensor<int, 2> windows_; //!< Indices of pole at start/end of window
   xt::xtensor<double, 3> curvefit_; //!< Fitting function (reaction, coeff index, window index)
   xt::xtensor<bool, 1> broaden_poly_; //!< Whether to broaden curvefit
+
+  // Constant data
+  static constexpr int MAX_POLY_COEFFICIENTS =
+    10; //!< Max order of polynomial fit plus one
 };
 
 //========================================================================

--- a/src/wmp.cpp
+++ b/src/wmp.cpp
@@ -56,6 +56,13 @@ WindowedMultipole::WindowedMultipole(hid_t group)
       "array shape in WMP library for " + name_ + ".");
   }
   fit_order_ = curvefit_.shape()[1] - 1;
+
+  // Check the code is compiling to work with sufficiently high fit order
+  if (fit_order_ + 1 > MAX_POLY_COEFFICIENTS) {
+    fatal_error(fmt::format(
+      "Need to compile with WindowedMultipole::MAX_POLY_COEFFICIENTS = {}",
+      fit_order_ + 1));
+  }
 }
 
 std::tuple<double, double, double>
@@ -87,7 +94,7 @@ WindowedMultipole::evaluate(double E, double sqrtkT)
   if (sqrtkT > 0.0 && broaden_poly_(i_window)) {
     // Broaden the curvefit.
     double dopp = sqrt_awr_ / sqrtkT;
-    std::vector<double> broadened_polynomials(fit_order_ + 1);
+    std::array<double, MAX_POLY_COEFFICIENTS> broadened_polynomials;
     broaden_wmp_polynomials(E, dopp, fit_order_ + 1, broadened_polynomials.data());
     for (int i_poly = 0; i_poly < fit_order_ + 1; ++i_poly) {
       sig_s += curvefit_(i_window, i_poly, FIT_S) * broadened_polynomials[i_poly];


### PR DESCRIPTION
Hey everyone,

I was recently doing a little dive on how WMP works, getting ready to put it on GPU, and found that there is allocation of a `std::vector` in the evaluation routine for WMP. Obviously, this is creating a pretty big performance hit. I found that since only up to ten polynomial terms are needed (which is only Gd157 IIRC), this is more appropriate as a `std::array`.

For a test problem, I used a 17x17 depleted lattice where every pin is at a different temperature. Obviously, it's pretty heavy on XS lookup. Here are my active tracking rates using 300,000 particles per generation, over one inactive and one active generation.


| Pointwise XS Interpolation | WMP (original) | WMP (new) |
|------------------------------------|----------------------|-----------------|
| 4372 | 3494 | 4153 |

I observed only a 6% speedup during inactive cycles, but am seeing 20% speedup in tracking in active. Nice. I imagine this is going to be helpful to event-based mode as well, but haven't tested it there.