### PR TITLE
Fix for breaking change in coveralls-python 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         shell: bash
         run: |
           cpp-coveralls -i src -i include --exclude-pattern "/usr/*" --dump cpp_cov.json
-          coveralls --merge=cpp_cov.json
+          coveralls --merge=cpp_cov.json --service=github
 
   finish:
     needs: main


### PR DESCRIPTION
Submitting our coverage information to coveralls.io seems to have started failing as of about 12 hours ago, which exactly coincides with a new release of coveralls-python with a breaking change. Hopefully this PR should should fix it.