### PR TITLE
Refactor read_input_xml

### DIFF
--- a/include/openmc/cross_sections.h
+++ b/include/openmc/cross_sections.h
@@ -70,6 +70,9 @@ void read_ce_cross_sections(const std::vector<std::vector<double>>& nuc_temps,
 //! Read cross_sections.xml and populate data libraries
 void read_ce_cross_sections_xml();
 
+//! Load nuclide and thermal scattering data
+void finalize_cross_sections();
+
 void library_clear();
 
 } // namespace openmc

--- a/include/openmc/geometry_aux.h
+++ b/include/openmc/geometry_aux.h
@@ -46,14 +46,9 @@ void get_temperatures(std::vector<std::vector<double>>& nuc_temps,
 
 //==============================================================================
 //! \brief Perform final setup for geometry
-//!
-//! \param[out] nuc_temps  Vector of temperatures for each nuclide
-//! \param[out] thermal_temps Vector of tempratures for each thermal scattering
-//!   table
 //==============================================================================
 
-void finalize_geometry(std::vector<std::vector<double>>& nuc_temps,
-  std::vector<std::vector<double>>& thermal_temps);
+void finalize_geometry();
 
 //==============================================================================
 //! Figure out which Universe is the root universe.

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -242,8 +242,7 @@ get_temperatures(std::vector<std::vector<double>>& nuc_temps,
 
 //==============================================================================
 
-void finalize_geometry(std::vector<std::vector<double>>& nuc_temps,
-  std::vector<std::vector<double>>& thermal_temps)
+void finalize_geometry()
 {
   // Perform some final operations to set up the geometry
   adjust_indices();
@@ -252,9 +251,6 @@ void finalize_geometry(std::vector<std::vector<double>>& nuc_temps,
 
   // Assign temperatures to cells that don't have temperatures already assigned
   assign_temperatures();
-
-  // Determine desired temperatures for each nuclide and S(a,b) table
-  get_temperatures(nuc_temps, thermal_temps);
 
   // Determine number of nested coordinate levels in the geometry
   model::n_coord_levels = maximum_levels(model::root_universe);

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -257,24 +257,11 @@ void read_input_xml()
   read_materials_xml();
   read_geometry_xml();
 
-  // Convert user IDs -> indices, assign temperatures
-  double_2dvec nuc_temps(data::nuclide_map.size());
-  double_2dvec thermal_temps(data::thermal_scatt_map.size());
-  finalize_geometry(nuc_temps, thermal_temps);
+  // Final geometry setup and assign temperatures
+  finalize_geometry();
 
-  if (settings::run_mode != RunMode::PLOTTING) {
-    simulation::time_read_xs.start();
-    if (settings::run_CE) {
-      // Read continuous-energy cross sections
-      read_ce_cross_sections(nuc_temps, thermal_temps);
-    } else {
-      // Create material macroscopic data for MGXS
-      set_mg_interface_nuclides_and_temps();
-      data::mg.init();
-      mark_fissionable_mgxs_materials();
-    }
-    simulation::time_read_xs.stop();
-  }
+  // Finalize cross sections having assigned temperatures
+  finalize_cross_sections();
 
   read_tallies_xml();
 


### PR DESCRIPTION
This PR is a small refactor of the method `read_input_xml` from initialization.cpp. The purpose of the refactor is to make all code therein contained within public methods, such that should a developer of an external code wish to perform a partial re-initialisation e.g. in the context of a tightly-coupled multiphysics application, this is made more feasible (i.e. the developer may call some subset of those methods).

The method `finalize_geometry` from geometry_aux.cpp  no longer takes arguments, as the function `get_temperatures` which utilises those arguments has been moved into a new method `finalize_cross_sections` that has been added to cross_sections.cpp.

There are no new tests as there should be no behaviour changes.