### PR TITLE
Allow set_contained to be passed through C-API for cell temp

### DIFF
--- a/docs/source/capi/index.rst
+++ b/docs/source/capi/index.rst
@@ -105,7 +105,7 @@ Functions
    :return: Return status (negative if an error occurred)
    :rtype: int
 
-.. c:function:: int openmc_cell_set_temperature(index index, double T, const int32_t* instance)
+.. c:function:: int openmc_cell_set_temperature(index index, double T, const int32_t* instance, bool set_contained)
 
    Set the temperature of a cell.
 
@@ -113,6 +113,8 @@ Functions
    :param double T: Temperature in Kelvin
    :param instance: Which instance of the cell. To set the temperature for all
                     instances, pass a null pointer.
+   :param set_contained: If the cell is not filled by a material, whether to set the temperatures
+                         of all filled cells
    :type instance: const int32_t*
    :return: Return status (negative if an error occurred)
    :rtype: int

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -18,7 +18,7 @@ extern "C" {
   int openmc_cell_set_name(int32_t index, const char* name);
   int openmc_cell_set_fill(int32_t index, int type, int32_t n, const int32_t* indices);
   int openmc_cell_set_id(int32_t index, int32_t id);
-  int openmc_cell_set_temperature(int32_t index, double T, const int32_t* instance);
+  int openmc_cell_set_temperature(int32_t index, double T, const int32_t* instance, bool set_contained = false);
   int openmc_energy_filter_get_bins(int32_t index, const double** energies, size_t* n);
   int openmc_energy_filter_set_bins(int32_t index, size_t n, const double* energies);
   int openmc_energyfunc_filter_get_energy(int32_t index, size_t* n, const double** energy);

--- a/openmc/lib/cell.py
+++ b/openmc/lib/cell.py
@@ -1,7 +1,7 @@
 import sys
 
 from collections.abc import Mapping, Iterable
-from ctypes import c_int, c_int32, c_double, c_char_p, POINTER
+from ctypes import c_int, c_int32, c_double, c_char_p, POINTER, c_bool
 from weakref import WeakValueDictionary
 
 import numpy as np
@@ -43,7 +43,7 @@ _dll.openmc_cell_set_id.argtypes = [c_int32, c_int32]
 _dll.openmc_cell_set_id.restype = c_int
 _dll.openmc_cell_set_id.errcheck = _error_handler
 _dll.openmc_cell_set_temperature.argtypes = [
-    c_int32, c_double, POINTER(c_int32)]
+    c_int32, c_double, POINTER(c_int32), c_bool]
 _dll.openmc_cell_set_temperature.restype = c_int
 _dll.openmc_cell_set_temperature.errcheck = _error_handler
 _dll.openmc_get_cell_index.argtypes = [c_int32, POINTER(c_int32)]
@@ -171,7 +171,7 @@ class Cell(_FortranObjectWithID):
         _dll.openmc_cell_get_temperature(self._index, instance, T)
         return T.value
 
-    def set_temperature(self, T, instance=None):
+    def set_temperature(self, T, instance=None, set_contained=False):
         """Set the temperature of a cell
 
         Parameters
@@ -180,13 +180,16 @@ class Cell(_FortranObjectWithID):
             Temperature in K
         instance : int or None
             Which instance of the cell
+        set_contained: bool
+            If cell is not filled by a material, whether to set the temperature of
+            all filled cells
 
         """
 
         if instance is not None:
             instance = c_int32(instance)
 
-        _dll.openmc_cell_set_temperature(self._index, T, instance)
+        _dll.openmc_cell_set_temperature(self._index, T, instance, set_contained)
 
     @property
     def bounding_box(self):

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1092,7 +1092,7 @@ openmc_cell_set_fill(int32_t index, int type, int32_t n,
 }
 
 extern "C" int
-openmc_cell_set_temperature(int32_t index, double T, const int32_t* instance)
+openmc_cell_set_temperature(int32_t index, double T, const int32_t* instance, bool set_contained)
 {
   if (index < 0 || index >= model::cells.size()) {
     strcpy(openmc_err_msg, "Index in cells array is out of bounds.");
@@ -1101,7 +1101,7 @@ openmc_cell_set_temperature(int32_t index, double T, const int32_t* instance)
 
   int32_t instance_index = instance ? *instance : -1;
   try {
-    model::cells[index]->set_temperature(T, instance_index);
+    model::cells[index]->set_temperature(T, instance_index, set_contained);
   } catch (const std::exception& e) {
     set_errmsg(e.what());
     return OPENMC_E_UNASSIGNED;


### PR DESCRIPTION
Allows access to `set_contained` in the C-API, following the same convention that by default it is false.

Closes #1754