### PR TITLE
Do not use pugixml and fmt submodule if already found on system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,38 +144,25 @@ endif()
 # Update git submodules as needed
 #===============================================================================
 
-# Function that updates a git submodule, and double-checks that it exists
-function(update_git_submodule git_submodule_name)
-  execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init vendor/${git_submodule_name}
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                  RESULT_VARIABLE GIT_SUBMOD_RESULT)
-  if(NOT GIT_SUBMOD_RESULT EQUAL 0)
-    message(FATAL_ERROR "git submodule update --init failed with \
-      ${GIT_SUBMOD_RESULT} on ${git_submodule_name}, please checkout submodules")
-  endif()
-
-  # Double-check submodule indeed exists
-  if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/vendor/${git_submodule_name}/CMakeLists.txt")
-    message(FATAL_ERROR "The git submodule ${git_submodule_name} was not downloaded! GIT_SUBMODULE was \
-      turned off or failed. Please update the ${git_submodule_name} submodule and try again.")
-  endif()
-endfunction()
-
 find_package(Git)
 if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   option(GIT_SUBMODULE "Check submodules during build" ON)
   if(GIT_SUBMODULE)
     message(STATUS "Submodule update")
-    if (NOT fmt_FOUND)
-      update_git_submodule(fmt)
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    RESULT_VARIABLE GIT_SUBMOD_RESULT)
+    if(NOT GIT_SUBMOD_RESULT EQUAL 0)
+      message(FATAL_ERROR "git submodule update --init failed with \
+        ${GIT_SUBMOD_RESULT}, please checkout submodules")
     endif()
-    if (NOT pugixml_FOUND)
-      update_git_submodule(pugixml)
-    endif()
-    update_git_submodule(gsl-lite)
-    update_git_submodule(xtensor)
-    update_git_submodule(xtl)
   endif()
+endif()
+
+# Check to see if submodules exist (by checking one)
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/vendor/pugixml/CMakeLists.txt")
+  message(FATAL_ERROR "The git submodules were not downloaded! GIT_SUBMODULE was \
+    turned off or failed. Please update submodules and try again.")
 endif()
 
 #===============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,14 @@ if(dagmc)
 endif()
 
 #===============================================================================
+# Check for submodules perhaps already on system
+#===============================================================================
+
+# If not found, we just pull appropriate versions from github and build them.
+find_package(fmt QUIET)
+find_package(pugixml QUIET)
+
+#===============================================================================
 # HDF5 for binary output
 #===============================================================================
 
@@ -85,7 +93,7 @@ endif()
 # Set compile/link flags based on which compiler is being used
 #===============================================================================
 
-# Skip for Visual Stduio which has its own configurations through GUI
+# Skip for Visual Studio which has its own configurations through GUI
 if(NOT MSVC)
 
 if(openmp)
@@ -126,39 +134,56 @@ endif()
 # Update git submodules as needed
 #===============================================================================
 
+# Function that updates a git submodule, and double-checks that it exists
+function(update_git_submodule git_submodule_name)
+  execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init vendor/${git_submodule_name}
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  RESULT_VARIABLE GIT_SUBMOD_RESULT)
+  if(NOT GIT_SUBMOD_RESULT EQUAL 0)
+    message(FATAL_ERROR "git submodule update --init failed with \
+      ${GIT_SUBMOD_RESULT} on ${git_submodule_name}, please checkout submodules")
+  endif()
+
+  # Double-check submodule indeed exists
+  if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/vendor/${git_submodule_name}/CMakeLists.txt")
+    message(FATAL_ERROR "The git submodule ${git_submodule_name} was not downloaded! GIT_SUBMODULE was \
+      turned off or failed. Please update the ${git_submodule_name} submodule and try again.")
+  endif()
+endfunction()
+
 find_package(Git)
 if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   option(GIT_SUBMODULE "Check submodules during build" ON)
   if(GIT_SUBMODULE)
     message(STATUS "Submodule update")
-    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                    RESULT_VARIABLE GIT_SUBMOD_RESULT)
-    if(NOT GIT_SUBMOD_RESULT EQUAL 0)
-      message(FATAL_ERROR "git submodule update --init failed with \
-        ${GIT_SUBMOD_RESULT}, please checkout submodules")
+    if (NOT fmt_FOUND)
+      update_git_submodule(fmt)
     endif()
+    if (NOT pugixml_FOUND)
+      update_git_submodule(pugixml)
+    endif()
+    update_git_submodule(gsl-lite)
+    update_git_submodule(xtensor)
+    update_git_submodule(xtl)
   endif()
-endif()
-
-# Check to see if submodules exist (by checking one)
-if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/vendor/pugixml/CMakeLists.txt")
-  message(FATAL_ERROR "The git submodules were not downloaded! GIT_SUBMODULE was \
-    turned off or failed. Please update submodules and try again.")
 endif()
 
 #===============================================================================
 # pugixml library
 #===============================================================================
 
-add_subdirectory(vendor/pugixml)
+if (NOT pugixml_FOUND)
+  add_subdirectory(vendor/pugixml)
+endif()
 
 #===============================================================================
 # {fmt} library
 #===============================================================================
 
-set(FMT_INSTALL ON CACHE BOOL "Generate the install target.")
-add_subdirectory(vendor/fmt)
+if (NOT fmt_FOUND)
+  set(FMT_INSTALL ON CACHE BOOL "Generate the install target.")
+  add_subdirectory(vendor/fmt)
+endif()
 
 #===============================================================================
 # xtensor header-only library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,17 @@ endif()
 
 # If not found, we just pull appropriate versions from github and build them.
 find_package(fmt QUIET)
+if(fmt_FOUND)
+  message(STATUS "Found fmt: ${fmt_DIR} (version ${fmt_VERSION})")
+else()
+  message(STATUS "Did not find fmt, will use submodule instead")
+endif()
 find_package(pugixml QUIET)
+if(pugixml_FOUND)
+  message(STATUS "Found pugixml: ${pugixml_DIR}")
+else()
+  message(STATUS "Did not find pugixml, will use submodule instead")
+endif()
 
 #===============================================================================
 # HDF5 for binary output


### PR DESCRIPTION
Resolves #1756 

So, I've tried to maintain this little build script for arch-based distro users to easily install openmc:

https://aur.archlinux.org/packages/openmc-git/

And it seems a handful of people have used it.

One issue is that we currently have to mark `fmt` and `pugixml` as conflicting packages, because these may already be installed on the system, as someone has previously run into. This PR makes it so that we no longer have to mark these packages as conflicting in this build script by using the system-provided libraries if they're present.