### PR TITLE
Fix for SharedArray relaxed memory ordering problem

### DIFF
--- a/include/openmc/shared_array.h
+++ b/include/openmc/shared_array.h
@@ -73,12 +73,12 @@ public:
   {
     // Atomically capture the index we want to write to
     int64_t idx;
-    #pragma omp atomic capture
+    #pragma omp atomic capture seq_cst
     idx = size_++;
 
     // Check that we haven't written off the end of the array
     if (idx >= capacity_) {
-      #pragma omp atomic write
+      #pragma omp atomic write seq_cst
       size_ = capacity_;
       return -1;
     }


### PR DESCRIPTION
This PR is a fix for the possible race condition described in issue #1763. As I discussed in #1763, the fix does involve requiring use of an OpenMP clause that was added in the OpenMP 4.0 standard, so this fix can in theory reduce our ability to support older compilers. In my testing with gcc, I found that gcc version 4.8 did not support the `seq_cst` clause for OpenMP atomics that are required for this fix, but gcc version 5.5 did work.

One important note here was that I found that gcc version 4.8 could not compile OpenMC anyway due to issues with the xtensor library. From what I could tell, gcc 4.8 is so old that it does not support some of the newer C++ features required in xtensor.

Anyway, my take is that as we are already limited by xtensor's requirements, we are not really changing the current legacy compiler support status by adding the OpenMP 4.0 requirement.

I'll also add that it's possible that a race condition is not actually possible here, so this PR may not be necessary. However, memory ordering race conditions are kind of hard to think through, so it seems to be better safe than sorry -- especially given that any performance overhead for this should be negligible.