### PR TITLE
Warning fixes

### DIFF
--- a/include/openmc/hdf5_interface.h
+++ b/include/openmc/hdf5_interface.h
@@ -212,7 +212,7 @@ read_attribute(hid_t obj_id, const char* name, std::vector<std::string>& vec)
   // Read char data in attribute
   read_attr_string(obj_id, name, n, buffer);
 
-  for (int i = 0; i < m; ++i) {
+  for (decltype(m) i = 0; i < m; ++i) {
     // Determine proper length of string -- strlen doesn't work because
     // buffer[i] might not have any null characters
     std::size_t k = 0;
@@ -478,7 +478,7 @@ write_dataset(hid_t obj_id, const char* name,
   // Copy data into contiguous buffer
   char* temp = new char[n*m];
   std::fill(temp, temp + n*m, '\0');
-  for (int i = 0; i < n; ++i) {
+  for (decltype(n) i = 0; i < n; ++i) {
     std::copy(buffer[i].begin(), buffer[i].end(), temp + i*m);
   }
 

--- a/include/openmc/surface.h
+++ b/include/openmc/surface.h
@@ -145,7 +145,7 @@ public:
   virtual void to_hdf5(hid_t group_id) const = 0;
 
   //! Get the BoundingBox for this surface.
-  virtual BoundingBox bounding_box(bool pos_side) const { return {}; }
+  virtual BoundingBox bounding_box(bool /*pos_side*/) const { return {}; }
 };
 
 class CSGSurface : public Surface


### PR DESCRIPTION
These aren't particularly important changes, but after these surprisingly-few commits my personal paranoid build settings (```-Werror -Wall -Wextra``` plus more handpicked warnings) came up clean.

I chose the ```decltype``` solution in that first commit to try to make the change forwards-compatible (vs hard-coding a new index type) and minimally invasive (vs switching to a range for plus an offset variable), but it might not be the best solution.