### PR TITLE
[Fix] 'std::out_of_range' error

### DIFF
--- a/docs/source/io_formats/settings.rst
+++ b/docs/source/io_formats/settings.rst
@@ -751,7 +751,7 @@ This element has the following attributes/sub-elements:
 
     *Default*: None
 
-  :max_particles:
+  :max_surface_particles:
     An integer indicating the maximum number of particles to be banked on
     specified surfaces per processor. The size of source bank in
     ``surface_source.h5`` is limited to this value times the number of

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -88,7 +88,7 @@ extern RunMode run_mode;                 //!< Run mode (eigenvalue, fixed src, e
 extern std::unordered_set<int> sourcepoint_batch; //!< Batches when source should be written
 extern std::unordered_set<int> statepoint_batch; //!< Batches when state should be written
 extern std::unordered_set<int> source_write_surf_id; //!< Surface ids where sources will be written
-extern int64_t max_particles;            //!< maximum number of particles to be banked on surfaces per process
+extern int64_t max_surface_particles;    //!< maximum number of particles to be banked on surfaces per process
 extern TemperatureMethod temperature_method;           //!< method for choosing temperatures
 extern double temperature_tolerance;     //!< Tolerance in [K] on choosing temperatures
 extern double temperature_default;       //!< Default T in [K]

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -604,7 +604,7 @@ class Settings:
         cv.check_type('surface source writing options', surf_source_write, Mapping)
         for key, value in surf_source_write.items():
             cv.check_value('surface source writing key', key,
-                           ('surface_ids', 'max_particles'))
+                           ('surface_ids', 'max_surface_particles '))
             if key == 'surface_ids':
                 cv.check_type('surface ids for source banking', value,
                               Iterable, Integral)

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -152,8 +152,8 @@ class Settings:
 
         :surface_ids: List of surface ids at which crossing particles are to be
                    banked (int)
-        :max_particles: Maximum number of particles to be banked on surfaces
-                         per process (int)
+        :max_surface_particles: Maximum number of particles to be banked on 
+                   surfaces per process (int)
     survival_biasing : bool
         Indicate whether survival biasing is to be used
     tabular_legendre : dict
@@ -611,7 +611,7 @@ class Settings:
                 for surf_id in value:
                     cv.check_greater_than('surface id for source banking',
                                           surf_id, 0)
-            elif key == 'max_particles':
+            elif key == 'max_surface_particles':
                 cv.check_type('maximum particle banks on surfaces per process',
                               value, Integral)
                 cv.check_greater_than('maximum particle banks on surfaces per process',
@@ -955,8 +955,8 @@ class Settings:
                 subelement.text = ' '.join(
                     str(x) for x in self._surf_source_write['surface_ids'])
             if 'max_particles' in self._surf_source_write:
-                subelement = ET.SubElement(element, "max_particles")
-                subelement.text = str(self._surf_source_write['max_particles'])
+                subelement = ET.SubElement(element, "max_surface_particles")
+                subelement.text = str(self._surf_source_write['max_surface_particles'])
 
     def _create_confidence_intervals(self, root):
         if self._confidence_intervals is not None:
@@ -1230,12 +1230,12 @@ class Settings:
     def _surf_source_write_from_xml_element(self, root):
         elem = root.find('surf_source_write')
         if elem is not None:
-            for key in ('surface_ids', 'max_particles'):
+            for key in ('surface_ids', 'max_surface_particles'):
                 value = get_text(elem, key)
                 if value is not None:
                     if key == 'surface_ids':
                         value = [int(x) for x in value.split()]
-                    elif key in ('max_particles'):
+                    elif key in ('max_surface_particles'):
                         value = int(value)
                     self.surf_source_write[key] = value
 

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -604,7 +604,7 @@ class Settings:
         cv.check_type('surface source writing options', surf_source_write, Mapping)
         for key, value in surf_source_write.items():
             cv.check_value('surface source writing key', key,
-                           ('surface_ids', 'max_surface_particles '))
+                           ('surface_ids', 'max_surface_particles'))
             if key == 'surface_ids':
                 cv.check_type('surface ids for source banking', value,
                               Iterable, Integral)

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -954,7 +954,7 @@ class Settings:
                 subelement = ET.SubElement(element, "surface_ids")
                 subelement.text = ' '.join(
                     str(x) for x in self._surf_source_write['surface_ids'])
-            if 'max_particles' in self._surf_source_write:
+            if 'max_surface_particles' in self._surf_source_write:
                 subelement = ET.SubElement(element, "max_surface_particles")
                 subelement.text = str(self._surf_source_write['max_surface_particles'])
 

--- a/src/relaxng/settings.rng
+++ b/src/relaxng/settings.rng
@@ -670,10 +670,10 @@
             </attribute>
           </choice>
           <choice>
-            <element name="max_particles">
+            <element name="max_surface_particles">
               <data type="positiveInteger"/>
             </element>
-            <attribute name="max_particles">
+            <attribute name="max_surface_particles">
               <data type="positiveInteger"/>
             </attribute>
           </choice>

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -101,7 +101,7 @@ RunMode run_mode {RunMode::UNSET};
 std::unordered_set<int> sourcepoint_batch;
 std::unordered_set<int> statepoint_batch;
 std::unordered_set<int> source_write_surf_id;
-int64_t max_particles;
+int64_t max_surface_particles;
 TemperatureMethod temperature_method {TemperatureMethod::NEAREST};
 double temperature_tolerance {10.0};
 double temperature_default {293.6};
@@ -655,8 +655,8 @@ void read_settings_xml()
     }
 
     // Get maximum number of particles to be banked per surface
-    if (check_for_node(node_ssw, "max_particles")) {
-      max_particles = std::stoll(get_node_value(node_ssw, "max_particles"));
+    if (check_for_node(node_ssw, "max_surface_particles")) {
+      max_particles = std::stoll(get_node_value(node_ssw, "max_surface_particles"));
     }
   }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -656,7 +656,7 @@ void read_settings_xml()
 
     // Get maximum number of particles to be banked per surface
     if (check_for_node(node_ssw, "max_particles")) {
-      max_particles = std::stoi(get_node_value(node_ssw, "max_particles"));
+      max_particles = std::stoll(get_node_value(node_ssw, "max_particles"));
     }
   }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -656,7 +656,7 @@ void read_settings_xml()
 
     // Get maximum number of particles to be banked per surface
     if (check_for_node(node_ssw, "max_surface_particles")) {
-      max_particles = std::stoll(get_node_value(node_ssw, "max_surface_particles"));
+      max_surface_particles = std::stoll(get_node_value(node_ssw, "max_surface_particles"));
     }
   }
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -289,7 +289,7 @@ void allocate_banks()
 
   if (settings::surf_source_write) {
     // Allocate surface source bank
-    simulation::surf_source_bank.reserve(settings::max_particles);
+    simulation::surf_source_bank.reserve(settings::max_surface_particles);
   }
 
 }

--- a/tests/regression_tests/surface_source/inputs_true_write.dat
+++ b/tests/regression_tests/surface_source/inputs_true_write.dat
@@ -24,7 +24,7 @@
   </source>
   <surf_source_write>
     <surface_ids>1</surface_ids>
-    <max_particles>1000</max_particles>
+    <max_surface_particles>1000</max_surface_particles>
   </surf_source_write>
   <seed>1</seed>
 </settings>

--- a/tests/regression_tests/surface_source/test.py
+++ b/tests/regression_tests/surface_source/test.py
@@ -47,7 +47,7 @@ def model(request):
         openmc_model.settings.source = pt_src
 
         openmc_model.settings.surf_source_write = {'surface_ids': [1],
-                                                   'max_particles': 1000}
+                                                   'max_surface_particles': 1000}
     elif surf_source_op == 'read':
         openmc_model.settings.surf_source_read = {'path': 'surface_source_true.h5'}
 

--- a/tests/unit_tests/test_settings.py
+++ b/tests/unit_tests/test_settings.py
@@ -21,7 +21,7 @@ def test_export_to_xml(run_in_tmpdir):
                      'write': True, 'overwrite': True}
     s.statepoint = {'batches': [50, 150, 500, 1000]}
     s.surf_source_read = {'path': 'surface_source_1.h5'}
-    s.surf_source_write = {'surface_ids': [2], 'max_particles': 200}
+    s.surf_source_write = {'surface_ids': [2], 'max_surface_particles': 200}
     s.confidence_intervals = True
     s.ptables = True
     s.seed = 17

--- a/tests/unit_tests/test_settings.py
+++ b/tests/unit_tests/test_settings.py
@@ -79,7 +79,7 @@ def test_export_to_xml(run_in_tmpdir):
                              'write': True, 'overwrite': True}
     assert s.statepoint == {'batches': [50, 150, 500, 1000]}
     assert s.surf_source_read == {'path': 'surface_source_1.h5'}
-    assert s.surf_source_write == {'surface_ids': [2], 'max_particles': 200}
+    assert s.surf_source_write == {'surface_ids': [2], 'max_surface_particles': 200}
     assert s.confidence_intervals
     assert s.ptables
     assert s.seed == 17


### PR DESCRIPTION
Simple enough to fix `terminate called after throwing an instance of ‘std::out_of_range’` error now user can select up to ... well a lot like 1 trillion number of particles to bank per surface :)