### PR TITLE
Change how temperatures are selected when temperature_range is given

### DIFF
--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -90,14 +90,18 @@ Nuclide::Nuclide(hid_t group, const std::vector<double>& temperature)
   double T_min = n > 0 ? settings::temperature_range[0] : 0.0;
   double T_max = n > 0 ? settings::temperature_range[1] : INFTY;
   if (T_max > 0.0) {
-    for (int j = 0; j < temps_available.size() - 1; ++j) {
-      if ((T_min <= temps_available[j] && temps_available[j] < T_max) ||
-          (T_min <= temps_available[j+1] && temps_available[j+1] < T_max)) {
+    // For each interval (T_j, T_j+1), if either T_j or T_j+1 are within the
+    // temperature range, load data for *both* T_j and T_j+1
+    int n = temps_available.size();
+    for (int j = 0; j < n; ++j) {
+      if ((T_min <= temps_available[j] && temps_available[j] < T_max)) {
         int T_j = std::round(temps_available[j]);
-        int T_j1 = std::round(temps_available[j+1]);
         if (!contains(temps_to_read, T_j)) {
           temps_to_read.push_back(T_j);
         }
+      }
+      if (j < n - 1 && T_min <= temps_available[j+1] && temps_available[j+1] < T_max) {
+        int T_j1 = std::round(temps_available[j+1]);
         if (!contains(temps_to_read, T_j1)) {
           temps_to_read.push_back(T_j1);
         }

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -90,9 +90,17 @@ Nuclide::Nuclide(hid_t group, const std::vector<double>& temperature)
   double T_min = n > 0 ? settings::temperature_range[0] : 0.0;
   double T_max = n > 0 ? settings::temperature_range[1] : INFTY;
   if (T_max > 0.0) {
-    for (auto T : temps_available) {
-      if (T_min <= T && T <= T_max) {
-        temps_to_read.push_back(std::round(T));
+    for (int j = 0; j < temps_available.size() - 1; ++j) {
+      if ((T_min <= temps_available[j] && temps_available[j] < T_max) ||
+          (T_min <= temps_available[j+1] && temps_available[j+1] < T_max)) {
+        int T_j = std::round(temps_available[j]);
+        int T_j1 = std::round(temps_available[j+1]);
+        if (!contains(temps_to_read, T_j)) {
+          temps_to_read.push_back(T_j);
+        }
+        if (!contains(temps_to_read, T_j1)) {
+          temps_to_read.push_back(T_j1);
+        }
       }
     }
   }


### PR DESCRIPTION
OpenMC has an option to load cross sections within a range of temperatures, which is useful for multiphysics calculations. We use this routinely for our coupled neutronic-TH simulations using ENRICO, where we'll specify a range of something like 300–1500 K. The problem right now is that the end points are not treated exactly right. For example, if your library has cross sections at 200, 400, 900, 1200, and 1800 K and you specify a range of 300–1500, right now OpenMC will load the 400, 900, and 1200 K cross sections. This means that you could have temperatures within that 300–1500 range (e.g., 350 K or 1300 K) that don't work. @RonRahaman noticed this behavior recently when running some coupled simulations.

This PR changes the behavior when loading cross sections if `temperature_range` is specified such that the temperature points immediately outside the request range are also loaded. In the example above, that means the 200 and 1800 K cross sections would also be loaded so that all possible temperatures in the 300–1500 K would work.