### PR TITLE
add warnings about untrusted OpenMC models to user guide

### DIFF
--- a/docs/source/usersguide/basics.rst
+++ b/docs/source/usersguide/basics.rst
@@ -5,13 +5,13 @@ Basics of Using OpenMC
 ======================
 
 ----------------
-Creating a Model
+Running a Model
 ----------------
 
 When you build and install OpenMC, you will have an :ref:`scripts_openmc`
 executable on your system. When you run ``openmc``, the first thing it will do
 is look for a set of XML_ files that describe the model you want to
-simulation. Three of these files are required and another three are optional, as
+simulate. Three of these files are required and another three are optional, as
 described below.
 
 .. admonition:: Required
@@ -42,6 +42,10 @@ described below.
    :ref:`io_plots`
      This file gives specifications for producing slice or voxel plots of the
      geometry.
+
+.. warning::
+
+    OpenMC models should be treated as code, and it is important to be careful with code from untrusted sources.
 
 eXtensible Markup Language (XML)
 --------------------------------

--- a/docs/source/usersguide/scripts.rst
+++ b/docs/source/usersguide/scripts.rst
@@ -13,7 +13,13 @@ Executables and Scripts
 Once you have a model built (see :ref:`usersguide_basics`), you can either run
 the openmc executable directly from the directory containing your XML input
 files, or you can specify as a command-line argument the directory containing
-the XML input files. For example, if your XML input files are in the directory
+the XML input files.
+
+.. warning::
+
+    OpenMC models should be treated as code, and it is important to be careful with code from untrusted sources.
+
+For example, if your XML input files are in the directory
 ``/home/username/somemodel/``, one way to run the simulation would be:
 
 .. code-block:: sh


### PR DESCRIPTION
Closes #1775

I don't think the testing system builds copies of the docs, so here are screenshots of the new changes. I think they fit into the general flow of things well enough, and have been placed where new users are likely to come across one of them.

![2021-03-04-154128_742x931_scrot](https://user-images.githubusercontent.com/18088906/110027712-508fb780-7d00-11eb-9e64-77b583898ea1.png)

![2021-03-04-154637_744x422_scrot](https://user-images.githubusercontent.com/18088906/110027957-a4020580-7d00-11eb-8677-89ee34cd10b4.png)

