### PR TITLE
Remove recursion from find_cell_inner

### DIFF
--- a/include/openmc/geometry.h
+++ b/include/openmc/geometry.h
@@ -43,14 +43,11 @@ bool check_cell_overlap(Particle& p, bool error=true);
 //!
 //! \param p A particle to be located.  This function will populate the
 //!   geometry-dependent data fields of the particle.
-//! \param use_neighbor_lists If true, neighbor lists will be used to accelerate
-//!   the geometry search, but this only works if the cell attribute of the
-//!   particle's lowest coordinate level is valid and meaningful.
 //! \return True if the particle's location could be found and ascribed to a
 //!   valid geometry coordinate stack.
 //==============================================================================
-
-bool find_cell(Particle& p, bool use_neighbor_lists);
+bool brute_force_find_cell(Particle& p);
+bool neighbor_list_find_cell(Particle& p); // Only usable on surface crossings
 
 //==============================================================================
 //! Move a particle into a new lattice tile.

--- a/include/openmc/geometry.h
+++ b/include/openmc/geometry.h
@@ -46,7 +46,7 @@ bool check_cell_overlap(Particle& p, bool error=true);
 //! \return True if the particle's location could be found and ascribed to a
 //!   valid geometry coordinate stack.
 //==============================================================================
-bool brute_force_find_cell(Particle& p);
+bool exhaustive_find_cell(Particle& p);
 bool neighbor_list_find_cell(Particle& p); // Only usable on surface crossings
 
 //==============================================================================

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -182,7 +182,7 @@ T PlotBase::get_map() const {
         p.r()[in_i] = xyz[in_i] + in_pixel * x;
         p.n_coord_ = 1;
         // local variables
-        bool found_cell = brute_force_find_cell(p);
+        bool found_cell = exhaustive_find_cell(p);
         j = p.n_coord_ - 1;
         if (level >= 0) { j = level; }
         if (found_cell) {

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -182,7 +182,7 @@ T PlotBase::get_map() const {
         p.r()[in_i] = xyz[in_i] + in_pixel * x;
         p.n_coord_ = 1;
         // local variables
-        bool found_cell = find_cell(p, 0);
+        bool found_cell = brute_force_find_cell(p);
         j = p.n_coord_ - 1;
         if (level >= 0) { j = level; }
         if (found_cell) {

--- a/include/openmc/position.h
+++ b/include/openmc/position.h
@@ -51,6 +51,18 @@ struct Position {
     }
   }
 
+  // Access to x, y, or z by compile time known index (specializations below)
+  template<int i>
+  const double& get() const
+  {
+    throw std::out_of_range {"Index in Position must be between 0 and 2."};
+  }
+  template<int i>
+  double& get()
+  {
+    throw std::out_of_range {"Index in Position must be between 0 and 2."};
+  }
+
   // Other member functions
 
   //! Dot product of two vectors
@@ -76,6 +88,38 @@ struct Position {
   double y = 0.;
   double z = 0.;
 };
+
+// Compile-time known member index access functions
+template<>
+inline const double& Position::get<0>() const
+{
+  return x;
+}
+template<>
+inline const double& Position::get<1>() const
+{
+  return y;
+}
+template<>
+inline const double& Position::get<2>() const
+{
+  return z;
+}
+template<>
+inline double& Position::get<0>()
+{
+  return x;
+}
+template<>
+inline double& Position::get<1>()
+{
+  return y;
+}
+template<>
+inline double& Position::get<2>()
+{
+  return z;
+}
 
 // Binary operators
 inline Position operator+(Position a, Position b) { return a += b; }

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -275,6 +275,10 @@ bool brute_force_find_cell(Particle& p)
     p.n_coord_ = 1;
     i_universe = model::root_universe;
   }
+  // Reset all the deeper coordinate levels.
+  for (int i = p.n_coord_; i < p.coord_.size(); i++) {
+    p.coord_[i].reset();
+  }
   return find_cell_inner(p, nullptr);
 }
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -156,7 +156,7 @@ Particle::event_calculate_xs()
   // initiate a search for the current cell. This generally happens at the
   // beginning of the history and again for any secondary particles
   if (coord_[n_coord_ - 1].cell == C_NONE) {
-    if (!brute_force_find_cell(*this)) {
+    if (!exhaustive_find_cell(*this)) {
       this->mark_as_lost("Could not find the cell containing particle "
         + std::to_string(id_));
       return;
@@ -463,7 +463,7 @@ Particle::cross_surface()
   // Remove lower coordinate levels and assignment of surface
   surface_ = 0;
   n_coord_ = 1;
-  bool found = brute_force_find_cell(*this);
+  bool found = exhaustive_find_cell(*this);
 
   if (settings::run_mode != RunMode::PLOTTING && (!found)) {
     // If a cell is still not found, there are two possible causes: 1) there is
@@ -477,7 +477,7 @@ Particle::cross_surface()
     // Couldn't find next cell anywhere! This probably means there is an actual
     // undefined region in the geometry.
 
-    if (!brute_force_find_cell(*this)) {
+    if (!exhaustive_find_cell(*this)) {
       this->mark_as_lost("After particle " + std::to_string(id_) +
         " crossed surface " + std::to_string(surf->id_) +
         " it could not be located in any cell and it did not leak.");

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -156,7 +156,7 @@ Particle::event_calculate_xs()
   // initiate a search for the current cell. This generally happens at the
   // beginning of the history and again for any secondary particles
   if (coord_[n_coord_ - 1].cell == C_NONE) {
-    if (!find_cell(*this, false)) {
+    if (!brute_force_find_cell(*this)) {
       this->mark_as_lost("Could not find the cell containing particle "
         + std::to_string(id_));
       return;
@@ -454,7 +454,8 @@ Particle::cross_surface()
   }
 #endif
 
-  if (find_cell(*this, true)) return;
+  if (neighbor_list_find_cell(*this))
+    return;
 
   // ==========================================================================
   // COULDN'T FIND PARTICLE IN NEIGHBORING CELLS, SEARCH ALL CELLS
@@ -462,7 +463,7 @@ Particle::cross_surface()
   // Remove lower coordinate levels and assignment of surface
   surface_ = 0;
   n_coord_ = 1;
-  bool found = find_cell(*this, false);
+  bool found = brute_force_find_cell(*this);
 
   if (settings::run_mode != RunMode::PLOTTING && (!found)) {
     // If a cell is still not found, there are two possible causes: 1) there is
@@ -476,7 +477,7 @@ Particle::cross_surface()
     // Couldn't find next cell anywhere! This probably means there is an actual
     // undefined region in the geometry.
 
-    if (!find_cell(*this, false)) {
+    if (!brute_force_find_cell(*this)) {
       this->mark_as_lost("After particle " + std::to_string(id_) +
         " crossed surface " + std::to_string(surf->id_) +
         " it could not be located in any cell and it did not leak.");
@@ -553,7 +554,7 @@ Particle::cross_reflective_bc(const Surface& surf, Direction new_u)
   // (unless we're using a dagmc model, which has exactly one universe)
   if (!settings::dagmc) {
     n_coord_ = 1;
-    if (!find_cell(*this, true)) {
+    if (!neighbor_list_find_cell(*this)) {
       this->mark_as_lost("Couldn't find particle after reflecting from surface "
                          + std::to_string(surf.id_) + ".");
       return;
@@ -601,7 +602,7 @@ Particle::cross_periodic_bc(const Surface& surf, Position new_r,
   // Figure out what cell particle is in now
   n_coord_ = 1;
 
-  if (!find_cell(*this, true)) {
+  if (!neighbor_list_find_cell(*this)) {
     this->mark_as_lost("Couldn't find particle after hitting periodic "
       "boundary on surface " + std::to_string(surf.id_) + ". The normal vector "
       "of one periodic surface may need to be reversed.");

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -474,8 +474,8 @@ template<int i1, int i2> double
 axis_aligned_cylinder_evaluate(Position r, double offset1,
                                double offset2, double radius)
 {
-  const double r1 = r[i1] - offset1;
-  const double r2 = r[i2] - offset2;
+  const double r1 = r.get<i1>() - offset1;
+  const double r2 = r.get<i2>() - offset2;
   return r1*r1 + r2*r2 - radius*radius;
 }
 
@@ -486,12 +486,12 @@ template<int i1, int i2, int i3> double
 axis_aligned_cylinder_distance(Position r, Direction u,
      bool coincident, double offset1, double offset2, double radius)
 {
-  const double a = 1.0 - u[i1]*u[i1];  // u^2 + v^2
+  const double a = 1.0 - u.get<i1>() * u.get<i1>(); // u^2 + v^2
   if (a == 0.0) return INFTY;
 
-  const double r2 = r[i2] - offset1;
-  const double r3 = r[i3] - offset2;
-  const double k = r2 * u[i2] + r3 * u[i3];
+  const double r2 = r.get<i2>() - offset1;
+  const double r3 = r.get<i3>() - offset2;
+  const double k = r2 * u.get<i2>() + r3 * u.get<i3>();
   const double c = r2*r2 + r3*r3 - radius*radius;
   const double quad = k*k - a*c;
 
@@ -532,9 +532,9 @@ template<int i1, int i2, int i3> Direction
 axis_aligned_cylinder_normal(Position r, double offset1, double offset2)
 {
   Direction u;
-  u[i2] = 2.0 * (r[i2] - offset1);
-  u[i3] = 2.0 * (r[i3] - offset2);
-  u[i1] = 0.0;
+  u.get<i2>() = 2.0 * (r.get<i2>() - offset1);
+  u.get<i3>() = 2.0 * (r.get<i3>() - offset2);
+  u.get<i1>() = 0.0;
   return u;
 }
 
@@ -750,9 +750,9 @@ template<int i1, int i2, int i3> double
 axis_aligned_cone_evaluate(Position r, double offset1,
                            double offset2, double offset3, double radius_sq)
 {
-  const double r1 = r[i1] - offset1;
-  const double r2 = r[i2] - offset2;
-  const double r3 = r[i3] - offset3;
+  const double r1 = r.get<i1>() - offset1;
+  const double r2 = r.get<i2>() - offset2;
+  const double r3 = r.get<i3>() - offset3;
   return r2*r2 + r3*r3 - radius_sq*r1*r1;
 }
 
@@ -764,12 +764,13 @@ axis_aligned_cone_distance(Position r, Direction u,
      bool coincident, double offset1, double offset2, double offset3,
      double radius_sq)
 {
-  const double r1 = r[i1] - offset1;
-  const double r2 = r[i2] - offset2;
-  const double r3 = r[i3] - offset3;
-  const double a = u[i2]*u[i2] + u[i3]*u[i3]
-                   - radius_sq*u[i1]*u[i1];
-  const double k = r2*u[i2] + r3*u[i3] - radius_sq*r1*u[i1];
+  const double r1 = r.get<i1>() - offset1;
+  const double r2 = r.get<i2>() - offset2;
+  const double r3 = r.get<i3>() - offset3;
+  const double a = u.get<i2>() * u.get<i2>() + u.get<i3>() * u.get<i3>() -
+                   radius_sq * u.get<i1>() * u.get<i1>();
+  const double k =
+    r2 * u.get<i2>() + r3 * u.get<i3>() - radius_sq * r1 * u.get<i1>();
   const double c = r2*r2 + r3*r3 - radius_sq*r1*r1;
   double quad = k*k - a*c;
 
@@ -818,9 +819,9 @@ axis_aligned_cone_normal(Position r, double offset1, double offset2,
                          double offset3, double radius_sq)
 {
   Direction u;
-  u[i1] = -2.0 * radius_sq * (r[i1] - offset1);
-  u[i2] = 2.0 * (r[i2] - offset2);
-  u[i3] = 2.0 * (r[i3] - offset3);
+  u.get<i1>() = -2.0 * radius_sq * (r.get<i1>() - offset1);
+  u.get<i2>() = 2.0 * (r.get<i2>() - offset2);
+  u.get<i3>() = 2.0 * (r.get<i3>() - offset3);
   return u;
 }
 

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -135,7 +135,8 @@ std::vector<VolumeCalculation::Result> VolumeCalculation::execute() const
         p.u() = {0.5, 0.5, 0.5};
 
         // If this location is not in the geometry at all, move on to next block
-        if (!find_cell(p, false)) continue;
+        if (!brute_force_find_cell(p))
+          continue;
 
         if (domain_type_ == TallyDomain::MATERIAL) {
           if (p.material_ != MATERIAL_VOID) {

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -135,7 +135,7 @@ std::vector<VolumeCalculation::Result> VolumeCalculation::execute() const
         p.u() = {0.5, 0.5, 0.5};
 
         // If this location is not in the geometry at all, move on to next block
-        if (!brute_force_find_cell(p))
+        if (!exhaustive_find_cell(p))
           continue;
 
         if (domain_type_ == TallyDomain::MATERIAL) {


### PR DESCRIPTION
It seems that I'm getting stack overflow on GPU with `find_cell_inner` for problems with any nested universes, e.g. any lattice problem. `nvcc` warns me that it can't determine the required stack size for the recursive `find_cell_inner` function, so I'm hoping to merge these changes that remove the recursion from that function. It is concisely replaced as a loop, and should be relevant to anyone else hoping to get OpenMC running on GPUs with a programming model of their choice.

In addition, I broke up `find_cell` into two separate functions: `neighbor_list_find_cell` and `brute_force_find_cell` for two reasons. Firstly, the two code paths taken if `find_cell` with `use_neighbors` being false or true are completely different. Secondly, this is more expressive for someone reading a call to `find_cell` elsewhere. They don't know what a magicly sprinkled in `true` or `false` is, but the new names are very what's going on. Yes, it isn't strictly speaking "brute force" since universe partitioners might be used... but... it's the best name I could come up with. Maybe `exhaustive_find_cell`?

I also removed the part of the code where we reset lower coordinate levels before doing any cell finding work. I found this is totally unnecessary, and must have been there for debugging purposes in the past.

Lastly, I snuck in a little optimization regarding accessing members of `Position` with a compile-time-known index. The last approach used `operator[](int i)`, which to be fast (if i is known at compile time) depends on the compiler propagating that constant index through from the several templated surface intersection and normal functions in `surface.cpp`. The new function `get<int i>()` looks just like the `operator[]` method, but is guaranteed to pick the member variable to return at compile-time. I measured a 2% benefit in the hex lattice example with this on average over three runs, but that could just be in the noise. Adding this code is the cause of the net gain of +40ish lines of code here.