### PR TITLE
Update theory documentation regarding (n,γ) reactions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2020 Massachusetts Institute of Technology and OpenMC contributors
+Copyright (c) 2011-2021 Massachusetts Institute of Technology and OpenMC contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,7 +63,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'OpenMC'
-copyright = '2011-2020, Massachusetts Institute of Technology and OpenMC contributors'
+copyright = '2011-2021, Massachusetts Institute of Technology and OpenMC contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/io_formats/index.rst
+++ b/docs/source/io_formats/index.rst
@@ -44,7 +44,6 @@ Output Files
 
    statepoint
    source
-   surface_source
    summary
    depletion_results
    particle_restart

--- a/docs/source/io_formats/statepoint.rst
+++ b/docs/source/io_formats/statepoint.rst
@@ -162,5 +162,5 @@ All values are given in seconds and are measured on the master process.
              source sites between processes for load balancing.
            - **accumulating tallies** (*double*) -- Time spent communicating
              tally results and evaluating their statistics.
-          - **writing statepoints** (*double*) -- Time spent writing statepoint
-            files
+           - **writing statepoints** (*double*) -- Time spent writing statepoint
+             files

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -4,7 +4,7 @@
 License Agreement
 =================
 
-Copyright © 2011-2020 Massachusetts Institute of Technology and OpenMC contributors
+Copyright © 2011-2021 Massachusetts Institute of Technology and OpenMC contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/source/methods/cross_sections.rst
+++ b/docs/source/methods/cross_sections.rst
@@ -186,10 +186,10 @@ The data governing the interaction of particles with various nuclei or materials
 are represented using a multi-group library format specific to the OpenMC code.
 The format is described in the :ref:`mgxs_lib_spec`. The data itself can be
 prepared via traditional paths or directly from a continuous-energy OpenMC
-calculation by use of the Python API as is shown in the
-:ref:`notebook_mg_mode_part_i` example notebook. This multi-group library
-consists of meta-data (such as the energy group structure) and multiple `xsdata`
-objects which contains the required microscopic or macroscopic multi-group data.
+calculation by use of the Python API as is shown in an `example notebook
+<../examples/mg-mode-part-i.ipynb>`_. This multi-group library consists of
+meta-data (such as the energy group structure) and multiple `xsdata` objects
+which contains the required microscopic or macroscopic multi-group data.
 
 At a minimum, the library must contain the absorption cross section
 (:math:`\sigma_{a,g}`) and a scattering matrix. If the problem is an eigenvalue

--- a/docs/source/methods/neutron_physics.rst
+++ b/docs/source/methods/neutron_physics.rst
@@ -76,10 +76,11 @@ absorption cross section (this includes fission), and :math:`\sigma_f` is the
 total fission cross section. If this condition is met, then the neutron is
 killed and we proceed to simulate the next neutron from the source bank.
 
-No secondary particles from disappearance reactions such as photons or
-alpha-particles are produced or tracked. To truly capture the affects of gamma
-heating in a problem, it would be necessary to explicitly track photons
-originating from :math:`(n,\gamma)` and other reactions.
+Note that photons arising from :math:`(n,\gamma)` and other neutron reactions
+are not produced in a microscopically correct manner. Instead, photons are
+sampled probabilistically at each neutron collision, regardless of what reaction
+actually takes place. This is described in more detail in
+:ref:`photon_production`.
 
 ------------------
 Elastic Scattering

--- a/docs/source/methods/photon_physics.rst
+++ b/docs/source/methods/photon_physics.rst
@@ -1004,6 +1004,8 @@ direction of the incident charged particle, which is a reasonable approximation
 at higher energies when the bremsstrahlung radiation is emitted at small
 angles.
 
+.. _photon_production:
+
 -----------------
 Photon Production
 -----------------

--- a/docs/source/usersguide/cross_sections.rst
+++ b/docs/source/usersguide/cross_sections.rst
@@ -124,7 +124,7 @@ OpenMC.
 .. hint:: The :class:`IncidentNeutron` class allows you to view/modify cross
           sections, secondary angle/energy distributions, probability tables,
           etc. For a more thorough overview of the capabilities of this class,
-          see the :ref:`notebook_nuclear_data` example notebook.
+          see the `example notebook <../examples/nuclear-data.ipynb>`__.
 
 Manually Creating a Library from ENDF files
 -------------------------------------------
@@ -252,8 +252,8 @@ However, if  obtained or generated their own library, the user
 should set the :envvar:`OPENMC_MG_CROSS_SECTIONS` environment variable
 to the absolute path of the file library expected to used most frequently.
 
-For an example of how to create a multi-group library, see
-:ref:`notebook_mg_mode_part_i`.
+For an example of how to create a multi-group library, see the `example notebook
+<../examples/mg-mode-part-i.ipynb>`__.
 
 .. _NJOY: http://www.njoy21.io/
 .. _NNDC: https://www.nndc.bnl.gov/endf

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -12,11 +12,11 @@ Installation and Configuration
 Installing on Linux/Mac with conda-forge
 ----------------------------------------
 
-`Conda <http://conda.pydata.org/docs/>`_ is an open source package management
-system and environment management system for installing multiple versions of
-software packages and their dependencies and switching easily between them. If
-you have `conda` installed on your system, OpenMC can be installed via the
-`conda-forge` channel. First, add the `conda-forge` channel with:
+Conda_ is an open source package management system and environment management
+system for installing multiple versions of software packages and their
+dependencies and switching easily between them. If you have `conda` installed on
+your system, OpenMC can be installed via the `conda-forge` channel. First, add
+the `conda-forge` channel with:
 
 .. code-block:: sh
 
@@ -25,16 +25,16 @@ you have `conda` installed on your system, OpenMC can be installed via the
 To list the versions of OpenMC that are available on the `conda-forge` channel,
 in your terminal window or an Anaconda Prompt run:
 
-.. code-block:: sh 
+.. code-block:: sh
 
     conda search openmc
-    
+
 OpenMC can then be installed with:
 
 .. code-block:: sh
 
     conda create -n openmc-env openmc
-    
+
 This will install OpenMC in a conda environment called `openmc-env`. To activate
 the environment, run:
 
@@ -424,7 +424,7 @@ distributions.
 
    `pandas <http://pandas.pydata.org/>`_
       Pandas is used to generate tally DataFrames as demonstrated in
-      :ref:`examples_pandas` example notebook.
+      an `example notebook <../examples/pandas-dataframes.ipynb>`_.
 
    `h5py <http://www.h5py.org/>`_
       h5py provides Python bindings to the HDF5 library. Since OpenMC outputs
@@ -509,7 +509,6 @@ schemas.xml file in your own OpenMC source directory.
 .. _GNU Emacs: http://www.gnu.org/software/emacs/
 .. _validation: https://en.wikipedia.org/wiki/XML_validation
 .. _RELAX NG: http://relaxng.org/
-.. _NNDC: http://www.nndc.bnl.gov/endf/b7.1/acefiles.html
-.. _ctest: http://www.cmake.org/cmake/help/v2.8.12/ctest.html
-.. _Conda: https://docs.conda.io/en/latest/
+.. _ctest: https://cmake.org/cmake/help/latest/manual/ctest.1.html
+.. _Conda: https://conda.io/en/latest/
 .. _pip: https://pip.pypa.io/en/stable/

--- a/docs/source/usersguide/processing.rst
+++ b/docs/source/usersguide/processing.rst
@@ -34,13 +34,13 @@ as requested; it is used in many of the provided plotting utilities, OpenMC's
 regression test suite, and can be used in user-created scripts to carry out
 manipulations of the data.
 
-An :ref:`example IPython notebook <notebook_post_processing>` demonstrates how
-to extract data from a statepoint using the Python API.
+An `example notebook <../examples/post-processing.ipynb>`_ demonstrates how to
+extract data from a statepoint using the Python API.
 
 Plotting in 2D
 --------------
 
-The :ref:`IPython notebook example <notebook_post_processing>` also demonstrates
+The `notebook example <../examples/post-processing.ipynb>`_ also demonstrates
 how to plot a structured mesh tally in two dimensions using the Python API. One
 can also use the :ref:`scripts_plot` script which provides an interactive GUI to
 explore and plot structured mesh tallies for any scores and filter bins.
@@ -101,5 +101,5 @@ For eigenvalue problems, OpenMC will store information on the fission source
 sites in the statepoint file by default. For each source site, the weight,
 position, sampled direction, and sampled energy are stored. To extract this data
 from a statepoint file, the ``openmc.statepoint`` module can be used. An
-:ref:`example IPython notebook <notebook_post_processing>` demontrates how to
+`example notebook <../examples/post-processing.ipynb>`_ demontrates how to
 analyze and plot source information.

--- a/man/man1/openmc.1
+++ b/man/man1/openmc.1
@@ -57,7 +57,7 @@ Indicates the default path to an HDF5 file that contains multi-group cross
 section libraries if the user has not specified the <cross_sections> tag in
 .I materials.xml\fP.
 .SH LICENSE
-Copyright \(co 2011-2020 Massachusetts Institute of Technology and OpenMC
+Copyright \(co 2011-2021 Massachusetts Institute of Technology and OpenMC
 contributors.
 .PP
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -74,7 +74,7 @@ void title()
   // Write version information
   fmt::print(
     "                   | The OpenMC Monte Carlo Code\n"
-    "         Copyright | 2011-2020 MIT and OpenMC contributors\n"
+    "         Copyright | 2011-2021 MIT and OpenMC contributors\n"
     "           License | https://docs.openmc.org/en/latest/license.html\n"
     "           Version | {}.{}.{}{}\n", VERSION_MAJOR, VERSION_MINOR,
     VERSION_RELEASE, VERSION_DEV ? "-dev" : "");
@@ -328,7 +328,7 @@ void print_version()
 #ifdef GIT_SHA1
     fmt::print("Git SHA1: {}\n", GIT_SHA1);
 #endif
-    fmt::print("Copyright (c) 2011-2020 Massachusetts Institute of "
+    fmt::print("Copyright (c) 2011-2021 Massachusetts Institute of "
       "Technology and OpenMC contributors\nMIT/X license at "
       "<https://docs.openmc.org/en/latest/license.html>\n");
   }


### PR DESCRIPTION
@makeclean pointed out in #1781 that our description of (n,γ) reactions is a little out of date as it claims no secondary photons are produced. I've updated that in this PR and fixed a few other documentation build warnings while I was at it. Also updated copyrights to 2021.