### PR TITLE
Include error message in exception when openmc.run fails

### DIFF
--- a/openmc/executor.py
+++ b/openmc/executor.py
@@ -27,7 +27,12 @@ def _run(args, output, cwd):
     if p.returncode != 0:
         # Get error message from output and simplify whitespace
         output = ''.join(lines)
-        _, _, error_msg = output.partition('ERROR: ')
+        if 'ERROR: ' in output:
+            _, _, error_msg = output.partition('ERROR: ')
+        elif 'what()' in output:
+            _, _, error_msg = output.partition('what(): ')
+        else:
+            error_msg = 'OpenMC aborted unexpectedly.'
         error_msg = ' '.join(error_msg.split())
 
         raise RuntimeError(error_msg)

--- a/openmc/executor.py
+++ b/openmc/executor.py
@@ -25,8 +25,12 @@ def _run(args, output, cwd):
 
     # Raise an exception if return status is non-zero
     if p.returncode != 0:
-        raise subprocess.CalledProcessError(p.returncode, ' '.join(args),
-                                            ''.join(lines))
+        # Get error message from output and simplify whitespace
+        output = ''.join(lines)
+        _, _, error_msg = output.partition('ERROR: ')
+        error_msg = ' '.join(error_msg.split())
+
+        raise RuntimeError(error_msg)
 
 
 def plot_geometry(output=True, openmc_exec='openmc', cwd='.'):
@@ -43,7 +47,7 @@ def plot_geometry(output=True, openmc_exec='openmc', cwd='.'):
 
     Raises
     ------
-    subprocess.CalledProcessError
+    RuntimeError
         If the `openmc` executable returns a non-zero status
 
     """
@@ -70,7 +74,7 @@ def plot_inline(plots, openmc_exec='openmc', cwd='.', convert_exec='convert'):
 
     Raises
     ------
-    subprocess.CalledProcessError
+    RuntimeError
         If the `openmc` executable returns a non-zero status
 
     """
@@ -133,7 +137,7 @@ def calculate_volumes(threads=None, output=True, cwd='.',
 
     Raises
     ------
-    subprocess.CalledProcessError
+    RuntimeError
         If the `openmc` executable returns a non-zero status
 
     See Also
@@ -188,7 +192,7 @@ def run(particles=None, threads=None, geometry_debug=False,
 
     Raises
     ------
-    subprocess.CalledProcessError
+    RuntimeError
         If the `openmc` executable returns a non-zero status
 
     """

--- a/tests/unit_tests/test_source_file.py
+++ b/tests/unit_tests/test_source_file.py
@@ -73,6 +73,6 @@ def test_wrong_source_attributes(run_in_tmpdir):
 
     # When we run the model, it should error out with a message that includes
     # the names of the wrong attributes
-    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
         openmc.run()
-    assert 'platypus, axolotl, narwhal' in excinfo.value.output
+    assert 'platypus, axolotl, narwhal' in str(excinfo.value)


### PR DESCRIPTION
I've noticed that a lot of posts on our [discussion forum](https://openmc.discourse.group/) stem from users being confused about the `CalledProcessError` exception that is raised if `openmc.run` fails because the exception just tells them that `openmc` failed with a non-zero exit code. This PR changes the behavior so that a `RuntimeError` exception is raised instead, and it pulls the error message from stderr and uses it in the exception.