### PR TITLE
Let endf.c work if cython picks an ancient version of gcc

### DIFF
--- a/include/openmc/shared_array.h
+++ b/include/openmc/shared_array.h
@@ -73,12 +73,12 @@ public:
   {
     // Atomically capture the index we want to write to
     int64_t idx;
-    #pragma omp atomic capture
+    #pragma omp atomic capture seq_cst
     idx = size_++;
 
     // Check that we haven't written off the end of the array
     if (idx >= capacity_) {
-      #pragma omp atomic write
+      #pragma omp atomic write seq_cst
       size_ = capacity_;
       return -1;
     }

--- a/openmc/data/endf.c
+++ b/openmc/data/endf.c
@@ -22,7 +22,8 @@ double cfloat_endf(const char* buffer, int n)
   // limit n to 11 characters
   n = n > 11 ? 11 : n;
 
-  for (int i = 0; i < n; ++i) {
+  int i;
+  for (i = 0; i < n; ++i) {
     char c = buffer[i];
 
     // Skip whitespace characters

--- a/openmc/executor.py
+++ b/openmc/executor.py
@@ -25,8 +25,12 @@ def _run(args, output, cwd):
 
     # Raise an exception if return status is non-zero
     if p.returncode != 0:
-        raise subprocess.CalledProcessError(p.returncode, ' '.join(args),
-                                            ''.join(lines))
+        # Get error message from output and simplify whitespace
+        output = ''.join(lines)
+        _, _, error_msg = output.partition('ERROR: ')
+        error_msg = ' '.join(error_msg.split())
+
+        raise RuntimeError(error_msg)
 
 
 def plot_geometry(output=True, openmc_exec='openmc', cwd='.'):
@@ -43,7 +47,7 @@ def plot_geometry(output=True, openmc_exec='openmc', cwd='.'):
 
     Raises
     ------
-    subprocess.CalledProcessError
+    RuntimeError
         If the `openmc` executable returns a non-zero status
 
     """
@@ -70,7 +74,7 @@ def plot_inline(plots, openmc_exec='openmc', cwd='.', convert_exec='convert'):
 
     Raises
     ------
-    subprocess.CalledProcessError
+    RuntimeError
         If the `openmc` executable returns a non-zero status
 
     """
@@ -133,7 +137,7 @@ def calculate_volumes(threads=None, output=True, cwd='.',
 
     Raises
     ------
-    subprocess.CalledProcessError
+    RuntimeError
         If the `openmc` executable returns a non-zero status
 
     See Also
@@ -188,7 +192,7 @@ def run(particles=None, threads=None, geometry_debug=False,
 
     Raises
     ------
-    subprocess.CalledProcessError
+    RuntimeError
         If the `openmc` executable returns a non-zero status
 
     """

--- a/tests/unit_tests/test_source_file.py
+++ b/tests/unit_tests/test_source_file.py
@@ -73,6 +73,6 @@ def test_wrong_source_attributes(run_in_tmpdir):
 
     # When we run the model, it should error out with a message that includes
     # the names of the wrong attributes
-    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
         openmc.run()
-    assert 'platypus, axolotl, narwhal' in excinfo.value.output
+    assert 'platypus, axolotl, narwhal' in str(excinfo.value)


### PR DESCRIPTION
So, as mentioned in the slack channel, a system I was trying to run on had picked gcc 4.something for compiling endf.c in openmc/data. Rather than figuring out how to make it use `-std=c99` (and correspondingly a small change would go into our setup.py file), this small revision should let our endf.c file be compatible with gcc versions of yore.