### PR TITLE
pre c99 compatible endf.c parsing

### DIFF
--- a/openmc/data/endf.c
+++ b/openmc/data/endf.c
@@ -22,7 +22,8 @@ double cfloat_endf(const char* buffer, int n)
   // limit n to 11 characters
   n = n > 11 ? 11 : n;
 
-  for (int i = 0; i < n; ++i) {
+  int i;
+  for (i = 0; i < n; ++i) {
     char c = buffer[i];
 
     // Skip whitespace characters


### PR DESCRIPTION
So, as mentioned in the slack channel, a system I was trying to run on had picked gcc 4.something for compiling endf.c in openmc/data. Rather than figuring out how to make it use -std=c99 (and correspondingly a small change would go into our setup.py file), this small revision should let our endf.c file be compatible with gcc versions of yore.

(ignore the previous PR as i'd accidentally branched off of unmerged commits)