### PR TITLE
improve clarity of parallel HDF5 error message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,9 @@ endif()
 find_package(HDF5 REQUIRED COMPONENTS C HL)
 if(HDF5_IS_PARALLEL)
   if(NOT MPI_ENABLED)
-    message(FATAL_ERROR "Parallel HDF5 must be used with MPI.")
+    message(FATAL_ERROR "Parallel HDF5 was detected, but the detected compiler,\
+     ${CMAKE_CXX_COMPILER}, does not support MPI. An MPI-capable compiler must \
+     be used with parallel HDF5.")
   endif()
   message(STATUS "Using parallel HDF5")
 endif()


### PR DESCRIPTION
So, if you had parallel HDF5 on a system but the compiler CMake detected does not support parallel HDF5, the previous error message was:

```
Parallel HDF5 was detected, but must be used with MPI.
```

I think this indeed exactly conveys the underlying issue, but is a bit terse. I had the MPI module loaded, so was quite confused when this error came up. Were the MPI header files not found? Library missing? Not really clear what aspect of MPI is missing with this message. The underlying cause is that the detected compiler was not an MPI wrapper. It may be obvious to an experienced developer, but I think this is less obvious to someone new to building their own code.

So, I propose we change the error message to look like:

```
CMake Error at CMakeLists.txt:90 (message):
  Parallel HDF5 was detected, but the detected compiler,
  /home/software/spack/gcc/8.3.0-xdjkb2mmftikxvoeeyaxtxcjtpltcgiz/bin/c++,
  does not support MPI.  An MPI-capable compiler must be used with parallel
  HDF5.
```