### PR TITLE
Prevent pugixml from being found via PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,13 +54,13 @@ endif()
 #===============================================================================
 
 # If not found, we just pull appropriate versions from github and build them.
-find_package(fmt QUIET)
+find_package(fmt QUIET NO_SYSTEM_ENVIRONMENT_PATH)
 if(fmt_FOUND)
   message(STATUS "Found fmt: ${fmt_DIR} (version ${fmt_VERSION})")
 else()
   message(STATUS "Did not find fmt, will use submodule instead")
 endif()
-find_package(pugixml QUIET)
+find_package(pugixml QUIET NO_SYSTEM_ENVIRONMENT_PATH)
 if(pugixml_FOUND)
   message(STATUS "Found pugixml: ${pugixml_DIR}")
 else()


### PR DESCRIPTION
This PR fixes #1789. The problem is that if you have an installation of OpenMC on your `PATH` environment variable, performing a new build of OpenMC will pick up some libraries from the other installation which causes problems at link-time. I've changed the call to `find_package` for pugixml and fmt so that it omits directories from `PATH` during the search. If you have `pugixml` installed in a system directory, it should still be able to find and link against it fine.