### PR TITLE
moving from dagmc develop to latest tagged release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ RUN if [ "$include_dagmc" = "true" ] ; \
 RUN if [ "$include_dagmc" = "true" ] ; \
     then mkdir DAGMC ; \
     cd DAGMC ; \
-    git clone --single-branch --branch develop https://github.com/svalinn/DAGMC.git ; \
+    git clone --single-branch --branch 3.2.0 https://github.com/svalinn/DAGMC.git ; \
     mkdir build ; \
     cd build ; \
     cmake ../DAGMC -DBUILD_TALLY=ON \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN if [ "$include_dagmc" = "true" ] ; \
 
 # Clone and install Embree
 RUN if [ "$include_dagmc" = "true" ] ; \
-    then git clone --single-branch --branch master https://github.com/embree/embree.git ; \
+    then git clone --single-branch --branch v3.12.2 https://github.com/embree/embree.git ; \
     cd embree ; \
     mkdir build ; \
     cd build ; \
@@ -81,7 +81,7 @@ RUN if [ "$include_dagmc" = "true" ] ; \
     mkdir MOAB ; \
     cd MOAB ; \
     mkdir build ; \
-    git clone  --single-branch --branch master https://bitbucket.org/fathomteam/moab.git ; \
+    git clone  --single-branch --branch 5.2.1 https://bitbucket.org/fathomteam/moab.git ; \
     cd build ; \
     cmake ../moab -DENABLE_HDF5=ON \
                   -DENABLE_NETCDF=ON \


### PR DESCRIPTION
Perhaps overdue minor changed to the Dockerfile that tags a specific version of DAGMC.

Occasionally the develop branch [fails](https://app.circleci.com/pipelines/github/svalinn/DAGMC) to build, tagging the latest release is probably advisable

If people like tagged then this PR can be expanded to include tagged versions for other codes such as Embree MOAB

