### PR TITLE
added reference to material class and xml output

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -91,11 +91,12 @@ class Material(IDManagerMixin):
     next_id = 1
     used_ids = set()
 
-    def __init__(self, material_id=None, name='', temperature=None):
+    def __init__(self, material_id=None, name='', temperature=None, reference=None):
         # Initialize class attributes
         self.id = material_id
         self.name = name
         self.temperature = temperature
+        self.reference = reference
         self._density = None
         self._density_units = 'sum'
         self._depletable = False
@@ -120,6 +121,7 @@ class Material(IDManagerMixin):
         string += '{: <16}=\t{}\n'.format('\tID', self._id)
         string += '{: <16}=\t{}\n'.format('\tName', self._name)
         string += '{: <16}=\t{}\n'.format('\tTemperature', self._temperature)
+        string += '{: <16}=\t{}\n'.format('\tReference', self._reference)
 
         string += '{: <16}=\t{}'.format('\tDensity', self._density)
         string += ' [{}]\n'.format(self._density_units)
@@ -148,6 +150,10 @@ class Material(IDManagerMixin):
     @property
     def temperature(self):
         return self._temperature
+
+    @property
+    def reference(self):
+        return self._reference
 
     @property
     def density(self):
@@ -219,6 +225,12 @@ class Material(IDManagerMixin):
         cv.check_type('Temperature for Material ID="{}"'.format(self._id),
                       temperature, (Real, type(None)))
         self._temperature = temperature
+
+    @reference.setter
+    def reference(self, reference):
+        cv.check_type('Reference for Material ID="{}"'.format(self._id),
+                      reference, (str, type(None)))
+        self._reference = reference
 
     @depletable.setter
     def depletable(self, depletable):
@@ -953,6 +965,10 @@ class Material(IDManagerMixin):
         # Create temperature XML subelement
         if self.temperature is not None:
             element.set("temperature", str(self.temperature))
+
+        # Create reference XML subelement
+        if self.reference is not None:
+            element.set("reference", str(self.reference))
 
         # Create density XML subelement
         if self._density is not None or self._density_units == 'sum':


### PR DESCRIPTION
Hi all

This is a tiny change to the Material.py file that allows one to add a string reference to a material.

## Motivation

Traceable materials have to be a good thing, ideally one would know where the material information such as density and isotopes came from. Adding a reference attribute to the Material class and printing in the xml file facilitates traceability.

## before

I would save information on the materials with a comment which would be lost in the xml file
```python
import openmc

my_mat=openmc.Material()
my_mat.temperature=500
# Don't forget this material came from PNNL material compendium revion 1. page 174
my_mat.add_element('Kr', 1)
my_mat.set_density('g/cm3', 0.003478)

all_mats=openmc.Materials([my_mat])
all_mats.export_to_xml()
```

## After

With this PR one can save information on the materials with a .reference property
```python
import openmc

my_mat=openmc.Material()
my_mat.temperature=500
my_mat.reference='material from PNNL material compendium revion 1. page 174'
my_mat.add_element('Kr', 1)
my_mat.set_density('g/cm3', 0.003478)

all_mats=openmc.Materials([my_mat])
all_mats.export_to_xml()
```

```xml
and it goes into the xml file

<?xml version='1.0' encoding='utf-8'?>
<materials>
  <material id="1" reference="material from PNNL material compendium revion 1. page 174" temperature="500">
    <density units="g/cm3" value="0.003478" />
    <nuclide ao="0.00355" name="Kr78" />
    <nuclide ao="0.02286" name="Kr80" />
    <nuclide ao="0.11593" name="Kr82" />
    <nuclide ao="0.115" name="Kr83" />
    <nuclide ao="0.56987" name="Kr84" />
    <nuclide ao="0.17279" name="Kr86" />
  </material>
</materials>
```

What do people think, is this a worth while idea.
