### PR TITLE
Run CI tests on ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   main:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.8]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,16 @@ jobs:
         shell: bash
         run: |
           sudo apt -y update
-          sudo apt install -y libopenmpi-dev \
+          sudo apt install -y libmpich-dev \
                               libnetcdf-dev \
                               libpnetcdf-dev \
                               libhdf5-serial-dev \
-                              libhdf5-openmpi-dev \
+                              libhdf5-mpich-dev \
                               libeigen3-dev
+          sudo update-alternatives --set mpi /usr/bin/mpicc.mpich
+          sudo update-alternatives --set mpirun /usr/bin/mpirun.mpich
+          sudo update-alternatives --set mpi-x86_64-linux-gnu /usr/include/x86_64-linux-gnu/mpich
+
       -
         name: install
         shell: bash

--- a/openmc/data/function.py
+++ b/openmc/data/function.py
@@ -580,7 +580,7 @@ class Sum(EqualityMixin):
 
 
 class Regions1D(EqualityMixin):
-    """Piecewise composition of multiple functions.
+    r"""Piecewise composition of multiple functions.
 
     This class allows you to create a callable object which is composed
     of multiple other callable objects, each applying to a specific interval

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -995,7 +995,7 @@ class WindowedMultipole(EqualityMixin):
 
         out.windows = group['windows'][()]
 
-        out.broaden_poly = group['broaden_poly'][...].astype(np.bool)
+        out.broaden_poly = group['broaden_poly'][...].astype(bool)
         if out.broaden_poly.shape[0] != out.windows.shape[0]:
             raise ValueError(err.format('broaden_poly', 'windows'))
 

--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -2060,7 +2060,7 @@ class XSdata:
                 Np = self.num_polar
                 Na = self.num_azimuthal
 
-            g_out_bounds = np.zeros((Np, Na, G, 2), dtype=np.int)
+            g_out_bounds = np.zeros((Np, Na, G, 2), dtype=int)
             for p in range(Np):
                 for a in range(Na):
                     for g_in in range(G):

--- a/openmc/stats/multivariate.py
+++ b/openmc/stats/multivariate.py
@@ -493,7 +493,7 @@ class SphericalIndependent(Spatial):
         return cls(r, theta, phi, origin=origin)
 
 class CylindricalIndependent(Spatial):
-    """Spatial distribution represented in cylindrical coordinates.
+    r"""Spatial distribution represented in cylindrical coordinates.
 
     This distribution allows one to specify coordinates whose :math:`r`,
     :math:`\phi`, and :math:`z` components are sampled independently from

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -31,7 +31,7 @@ if [[ $MPI == 'y' ]]; then
 
     export CC=mpicc
     export HDF5_MPI=ON
-    export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+    export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich
     pip install --no-binary=h5py h5py
 fi
 


### PR DESCRIPTION
This PR updates GitHub Actions to use Ubuntu 20.04 for our CI tests. Currently, we are using Ubuntu 16.04 which is officially EOL this month, after which it's not clear how long it's going to supported on CI platforms.

In order to get tests working on Ubuntu 16.04, I had to switch our MPI implementation from OpenMPI to MPICH. We actually just switched to OpenMPI in #1820, but it looks like it's not going to work on Ubuntu 20.04. The problem is that recent versions of OpenMPI [do not allow recursive invocations of MPI_Init](https://bitbucket.org/mpi4py/mpi4py/issues/95/mpi4py-openmpi-300-breaks-subprocess), and this actually happens in our test suite from the following logic:
```Python
import subprocess
from mpi4py import MPI

subprocess.run(['mpiexec', '-n', ...])
```
Importing mpi4py actually initializes MPI in the current process, and then calling a subprocess with `mpiexec` does it again. MPICH thankfully handles this fine.

There's also a few fixes in here for warnings that are raised when the test suite is run.