### PR TITLE
fix typo in fmt string for a lattice error

### DIFF
--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -184,7 +184,7 @@ RectLattice::RectLattice(pugi::xml_node lat_node)
   std::vector<std::string> univ_words {split(univ_str)};
   if (univ_words.size() != nx*ny*nz) {
     fatal_error(fmt::format(
-      "Expected {} universes for a rectangular lattice of size {}x{]x{} but {} "
+      "Expected {} universes for a rectangular lattice of size {}x{}x{} but {} "
       "were specified.", nx*ny*nz,  nx, ny, nz, univ_words.size()));
   }
 


### PR DESCRIPTION
Currently, if you make a certain mistake while creating lattices, you get this from OpenMC:

```
 Reading settings XML file...
 Reading cross sections XML file...
 Reading materials XML file...
 Reading geometry XML file...
terminate called after throwing an instance of 'fmt::v6::format_error'
  what():  invalid format string
zsh: abort (core dumped)  openmc
```

This PR fixes that. Now, we get the correct error message:

```
 Reading settings XML file...
 Reading cross sections XML file...
 Reading materials XML file...
 Reading geometry XML file...
 ERROR: Expected 16 universes for a rectangular lattice of size 4x4x1 but 9 were
        specified.

```