### PR TITLE
Two small bug fixes (fixed source nu-fission tally, stochastic volume calc)

### DIFF
--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -217,13 +217,11 @@ create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx)
     }
 
     // Write fission particles to nuBank
-    if (use_fission_bank) {
-      p.nu_bank_.emplace_back();
-      Particle::NuBank* nu_bank_entry = &p.nu_bank_.back();
-      nu_bank_entry->wgt              = site.wgt;
-      nu_bank_entry->E                = site.E;
-      nu_bank_entry->delayed_group    = site.delayed_group;
-    }
+    p.nu_bank_.emplace_back();
+    Particle::NuBank* nu_bank_entry = &p.nu_bank_.back();
+    nu_bank_entry->wgt              = site.wgt;
+    nu_bank_entry->E                = site.E;
+    nu_bank_entry->delayed_group    = site.delayed_group;
   }
 
   // If shared fission bank was full, and no fissions could be added,

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -176,13 +176,11 @@ create_fission_sites(Particle& p)
     }
 
     // Write fission particles to nuBank
-    if (use_fission_bank) {
-      p.nu_bank_.emplace_back();
-      Particle::NuBank* nu_bank_entry = &p.nu_bank_.back();
-      nu_bank_entry->wgt              = site.wgt;
-      nu_bank_entry->E                = site.E;
-      nu_bank_entry->delayed_group    = site.delayed_group;
-    }
+    p.nu_bank_.emplace_back();
+    Particle::NuBank* nu_bank_entry = &p.nu_bank_.back();
+    nu_bank_entry->wgt              = site.wgt;
+    nu_bank_entry->E                = site.E;
+    nu_bank_entry->delayed_group    = site.delayed_group;
   }
 
   // If shared fission bank was full, and no fissions could be added,


### PR DESCRIPTION
This PR includes two small bug fixes:
1. A user [reported an issue](https://openmc.discourse.group/t/could-openmc-not-generate-multi-group-cross-sections-in-fixed-source-mode/1094) in a fixed source calculation trying to compute multigroup cross sections. It turns out this is due to the use of an energyout filter in conjunction with the nu-fission score. This relies on the `nu_bank_` member of the `Particle` class, which was apparently not populated for fixed source simulations. I've changed it so that it is always populated now.
2. I discovered a plausible bug in stochastic volume calculations when results are being accumulated across multiple MPI processes. It's possible that if two MPI processes have a different set of domains that get hit during a calculation, when they are combined some of the results get left out. This can happen if the number of samples is very low -- generally with enough samples, each MPI process will hit every domain and so there's no issue. Nevertheless, this PR protects against this scenario and ensures the accumulation happens correctly. (I've also removed some use of variable length arrays, which are not permitted in the C++ standard)