### PR TITLE
make sure failed neighbor list searches trigger exhaustive searches

### DIFF
--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -96,8 +96,9 @@ find_cell_inner(Particle& p, const NeighborList* neighbor_list)
     // now know we should return false. This will trigger an
     // exhaustive search from neighbor_list_find_cell and make
     // the result from that be appended to the neighbor list.
-    if (!found)
-      return false;
+    if (!found) {
+      return found;
+    }
   }
 
   // Check successively lower coordinate levels until finding material fill
@@ -252,6 +253,7 @@ find_cell_inner(Particle& p, const NeighborList* neighbor_list)
       }
     }
     i_cell = C_NONE; // trip non-neighbor cell search at next iteration
+    found = false;
   }
 
   return found;

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -91,11 +91,25 @@ find_cell_inner(Particle& p, const NeighborList* neighbor_list)
         break;
       }
     }
+
+    // If we're attempting a neighbor list search and fail, we
+    // now know we should return false. This will trigger an
+    // exhaustive search from neighbor_list_find_cell and make
+    // the result from that be appended to the neighbor list.
+    if (!found)
+      return false;
   }
 
   // Check successively lower coordinate levels until finding material fill
   for (;;++p.n_coord_) {
-    // If neighbor lists did not find a cell, must do exhaustive search
+    // If we did not attempt to use neighbor lists, i_cell is still C_NONE.  In
+    // that case, we should now do an exhaustive search to find the right value
+    // of i_cell.
+    //
+    // Alternatively, neighbor list searches could have succeeded, but we found
+    // that the fill of the neighbor cell was another universe. As such, in the
+    // code below this conditional, we set i_cell back to C_NONE to indicate
+    // that.
     if (i_cell == C_NONE) {
       int i_universe = p.coord_[p.n_coord_-1].universe;
       const auto& univ {*model::universes[i_universe]};


### PR DESCRIPTION
Fixes #1827 

So, I slipped up slightly when removing recursion. I had assumed that if we try to iterate through neighbor lists, it will always touch the variable `i_cell` in find_cell_inner. Well, that's actually not true, since it's possible that the neighbor lists are empty, which in that case, i_cell will never be affected. As a result of this, we were never forming neighbor lists.

The fix to this is simple. If we're attempting a cell search based on neighbor lists, we should always return false if we failed to find the right cell in the neighbor list. This will cause an exhaustive search to happen, the result of which will be appended to the neighbor list.

Here is a simple 5x5 checkerboard input done directly using surfaces, so that the impact of neighbor lists is fairly high. On my computer, I saw the tracking rate go from around 190 kp/s to around 240 kp/s.

```
<?xml version='1.0' encoding='utf-8'?>
<geometry>
  <!-- 25 cells in total -->
  <cell material="1" id="1"  region="1 -5 3 -9" universe="0" />
  <cell material="2" id="2"  region="5 -6 3 -9" universe="0" />
  <cell material="1" id="3"  region="6 -7 3 -9" universe="0" />
  <cell material="2" id="4"  region="7 -8 3 -9" universe="0" />
  <cell material="1" id="5"  region="8 -2 3 -9" universe="0" />
  <cell material="2" id="6"  region="1 -5 9 -10" universe="0" />
  <cell material="1" id="7"  region="5 -6 9 -10" universe="0" />
  <cell material="2" id="8"  region="6 -7 9 -10" universe="0" />
  <cell material="1" id="9"  region="7 -8 9 -10" universe="0" />
  <cell material="2" id="10" region="8 -2 9 -10" universe="0" />
  <cell material="1" id="11" region="1 -5 10 -11" universe="0" />
  <cell material="2" id="12" region="5 -6 10 -11" universe="0" />
  <cell material="1" id="13" region="6 -7 10 -11" universe="0" />
  <cell material="2" id="14" region="7 -8 10 -11" universe="0" />
  <cell material="1" id="15" region="8 -2 10 -11" universe="0" />
  <cell material="2" id="16" region="1 -5 11 -12" universe="0" />
  <cell material="1" id="17" region="5 -6 11 -12" universe="0" />
  <cell material="2" id="18" region="6 -7 11 -12" universe="0" />
  <cell material="1" id="19" region="7 -8 11 -12" universe="0" />
  <cell material="2" id="20" region="8 -2 11 -12" universe="0" />
  <cell material="1" id="21" region="1 -5 12 -4" universe="0" />
  <cell material="2" id="22" region="5 -6 12 -4" universe="0" />
  <cell material="1" id="23" region="6 -7 12 -4" universe="0" />
  <cell material="2" id="24" region="7 -8 12 -4" universe="0" />
  <cell material="1" id="25" region="8 -2 12 -4" universe="0" />

  <surface boundary="reflective" coeffs="0" id="1" type="x-plane" />
  <surface boundary="reflective" coeffs="10" id="2" type="x-plane" />
  <surface boundary="reflective" coeffs="0" id="3" type="y-plane" />
  <surface boundary="reflective" coeffs="10" id="4" type="y-plane" />

  <surface coeffs="2" id="5"  type="x-plane" />
  <surface coeffs="4" id="6"  type="x-plane" />
  <surface coeffs="6" id="7"  type="x-plane" />
  <surface coeffs="8" id="8"  type="x-plane" />

  <surface coeffs="2" id="9"  type="y-plane" />
  <surface coeffs="4" id="10" type="y-plane" />
  <surface coeffs="6" id="11" type="y-plane" />
  <surface coeffs="8" id="12" type="y-plane" />
</geometry>
<?xml version='1.0' encoding='utf-8'?>
<materials>
  <material depletable="true" id="1" name="Fuel 3.1%" temperature="300">
    <density units="g/cc" value="10.30166" />
    <nuclide ao="1.9992419999999977" name="O16" />
    <nuclide ao="0.0007579999999999991" name="O17" />
    <nuclide ao="0.00028071399816198897" name="U234" />
    <nuclide ao="0.03140630756586438" name="U235" />
    <nuclide ao="0.9681691224623687" name="U238" />
    <nuclide ao="0.0001438559736051798" name="U236" />
  </material>
  <material id="2" name="Water" temperature="300">
    <density units="g/cc" value="0.7405820675158279" />
    <nuclide ao="0.0003217866044341838" name="B10" />
    <nuclide ao="0.001301758322075321" name="B11" />
    <nuclide ao="1.9964419358487546" name="H1" />
    <nuclide ao="0.00031097429822629077" name="H2" />
    <nuclide ao="0.9979980703970175" name="O16" />
    <nuclide ao="0.00037838467647285283" name="O17" />
  </material>
</materials>
<?xml version='1.0' encoding='utf-8'?>
<plots>
  <plot basis="xy" color_by="material" id="1" type="slice">
    <origin>5 5 0.5</origin>
    <width>10 10</width>
    <pixels>800 800</pixels>
  </plot>
</plots>
<?xml version='1.0' encoding='utf-8'?>
<settings>
  <run_mode>eigenvalue</run_mode>
  <particles>100000</particles>
  <batches>5</batches>
  <inactive>3</inactive>
  <source strength="1.0">
    <space type="box">
      <parameters>0 10 0 10 1 1</parameters>
    </space>
  </source>
</settings>

```