### PR TITLE
changing element to element.title to catch lowercase entries

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -521,6 +521,8 @@ class Material(IDManagerMixin):
             if element is None:
                 msg = 'Element name "{}" not recognised'.format(el)
                 raise ValueError(msg)
+        else:
+            element = element.title()
 
         if self._macroscopic is not None:
             msg = 'Unable to add an Element to Material ID="{}" as a ' \

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -522,7 +522,18 @@ class Material(IDManagerMixin):
                 msg = 'Element name "{}" not recognised'.format(el)
                 raise ValueError(msg)
         else:
-            element = element.title()
+            if element[0].islower():
+                msg = 'Element name "{}" should start with an uppercase ' \
+                      'letter'.format(element)
+                raise ValueError(msg)
+            if len(element) == 2 and element[1].isupper():
+                msg = 'Element name "{}" should end with a lowercase ' \
+                      'letter'.format(element)
+                raise ValueError(msg)
+            # skips the first entry of ATOMIC_SYMBOL which is n for neutron
+            if element not in list(openmc.data.ATOMIC_SYMBOL.values())[1:]:
+                msg = 'Element name "{}" not recognised'.format(element)
+                raise ValueError(msg)
 
         if self._macroscopic is not None:
             msg = 'Unable to add an Element to Material ID="{}" as a ' \

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -54,6 +54,15 @@ def test_elements():
         m.add_element('U', 1.0, enrichment=70.0, enrichment_target='U235')
     with pytest.raises(ValueError):
         m.add_element('He', 1.0, enrichment=17.0, enrichment_target='He6')
+    with pytest.raises(ValueError):
+        m.add_element('li', 1.0)  # should fail as 1st char is lowercase
+    with pytest.raises(ValueError):
+        m.add_element('LI', 1.0)  # should fail as 2nd char is uppercase
+    with pytest.raises(ValueError):
+        m.add_element('Xx', 1.0)  # should fail as Xx is not an element
+    with pytest.raises(ValueError):
+        m.add_element('n', 1.0)  # check to avoid n for neutron being accepted
+
 
 def test_elements_by_name():
     """Test adding elements by name"""


### PR DESCRIPTION
A new OpenMC user messaged me the other day as they were having some trouble making Materials

They had accidentally been adding elements in the following way for a few hours and couldn't figure out what was wrong as there was no error or warning returned when the materials were made they had assumed the materials had been made correctly.

Situation 1 - no errors raised when material is made - resulting material has no elements
```python
import openmc
my_mat = openmc.Material()
my_mat.add_element('o', 2)
my_mat.add_element('c', 1)
```

Situation 2 - no errors raised when material is made - resulting material has only one of two elements
```python
import openmc
my_mat = openmc.Material()
my_mat.add_element('O', 2)
my_mat.add_element('c', 1)
```

I notice that if the user enters "Oxygen" or "oxygen" or even "OXYGen" then all options are accepted and result in oxygen being added. Perhaps we should do the same for symbols.

This tiny PR adds a ```.title()``` to the elements symbol so that it will always have the upper case first letter and lower case 2nd letter.

Alternatively if this idea is not popular then perhaps I can get the Add_element method to raise an error if the element symbol is not in the ```openmc.data.ELEMENT_SYMBOLS``` dictionary?