### PR TITLE
Disallow non-current scores with a surface filter

### DIFF
--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -507,8 +507,11 @@ void Tally::set_scores(const vector<std::string>& scores)
   if (type_ == TallyType::SURFACE || type_ == TallyType::MESH_SURFACE) {
     if (scores_.size() != 1)
       fatal_error("Cannot tally other scores in the same tally as surface "
-        "currents");
+        "currents.");
   }
+  if ((surface_present || meshsurface_present) && scores_[0] != SCORE_CURRENT)
+    fatal_error("Cannot tally score other than 'current' when using a surface "
+      "or mesh-surface filter.");
 }
 
 void


### PR DESCRIPTION
If you specify a surface filter on a tally and ask for a score other than `current`, OpenMC will allow it even though it shouldn't (e.g., a user can ask for a surface flux, even though this is not yet implemented). This PR simply adds a fatal error if you try to specify a score other than `current` in conjunction with a surface (or mesh surface) tally.