### PR TITLE
Fix for shared fission bank memory errors

### DIFF
--- a/src/bank.cpp
+++ b/src/bank.cpp
@@ -96,6 +96,10 @@ void sort_fission_bank()
     const auto& site = simulation::fission_bank[i];
     int64_t offset = site.parent_id - 1 - simulation::work_index[mpi::rank];
     int64_t idx = simulation::progeny_per_particle[offset] + site.progeny_id;
+    if (idx >= simulation::fission_bank.size()) {
+      fatal_error("Mismatch detected between sum of all particle progeny and "
+          "shared fission bank size.");
+    }
     sorted_bank[idx] = site;
   }
 

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -205,7 +205,7 @@ create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx)
       int64_t idx = simulation::fission_bank.thread_safe_append(site);
       if (idx == -1) {
         warning("The shared fission bank is full. Additional fission sites created "
-            "in this generation will not be banked. Results may be non-deteministic.");
+            "in this generation will not be banked. Results may be non-deterministic.");
 
         // Decrement number of particle progeny as storage was unsuccessful. This
         // step is needed so that the sum of all progeny is equal to the size

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -183,8 +183,8 @@ create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx)
   // or the secondary particle bank.
   bool use_fission_bank = (settings::run_mode == RunMode::EIGENVALUE);
 
-  // Counter for the number of fission sites successfully stored to a fission bank
-  // or secondary bank
+  // Counter for the number of fission sites successfully stored to the shared
+  // fission bank or the secondary particle bank
   int n_sites_stored;
 
   for (n_sites_stored = 0; n_sites_stored < nu; n_sites_stored++) {

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -167,8 +167,7 @@ create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx)
   int nu = static_cast<int>(nu_t);
   if (prn(p.current_seed()) <= (nu_t - nu)) ++nu;
 
-  // Begin banking the source neutrons
-  // First, if our bank is full then don't continue
+  // If no neutrons were produced then don't continue
   if (nu == 0) return;
 
   // Initialize the counter of delayed neutrons encountered for each delayed
@@ -179,13 +178,16 @@ create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx)
   p.nu_bank().clear();
 
   p.fission() = true;
-  int skipped = 0;
 
   // Determine whether to place fission sites into the shared fission bank
   // or the secondary particle bank.
   bool use_fission_bank = (settings::run_mode == RunMode::EIGENVALUE);
 
-  for (int i = 0; i < nu; ++i) {
+  // Counter for the number of fission sites successfully stored to a fission bank
+  // or secondary bank
+  int n_sites_stored;
+
+  for (n_sites_stored = 0; n_sites_stored < nu; n_sites_stored++) {
     // Initialize fission site object with particle data
     SourceSite site;
     site.r = p.r();
@@ -203,8 +205,14 @@ create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx)
       int64_t idx = simulation::fission_bank.thread_safe_append(site);
       if (idx == -1) {
         warning("The shared fission bank is full. Additional fission sites created "
-            "in this generation will not be banked.");
-        skipped++;
+            "in this generation will not be banked. Results may be non-deteministic.");
+
+        // Decrement number of particle progeny as storage was unsuccessful. This
+        // step is needed so that the sum of all progeny is equal to the size
+        // of the shared fission bank.
+        p.n_progeny()--;
+
+        // Break out of loop as no more sites can be added to fission bank
         break;
       }
     } else {
@@ -229,14 +237,14 @@ create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx)
 
   // If shared fission bank was full, and no fissions could be added,
   // set the particle fission flag to false.
-  if (nu == skipped) {
+  if (n_sites_stored == 0) {
     p.fission() = false;
     return;
   }
 
-  // If shared fission bank was full, but some fissions could be added,
-  // reduce nu accordingly
-  nu -= skipped;
+  // Set nu to the number of fission sites successfully stored. If the fission
+  // bank was not found to be full then these values are already equivalent.
+  nu = n_sites_stored;
 
   // Store the total weight banked for analog fission tallies
   p.n_bank() = nu;

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -164,7 +164,7 @@ create_fission_sites(Particle& p)
       int64_t idx = simulation::fission_bank.thread_safe_append(site);
       if (idx == -1) {
         warning("The shared fission bank is full. Additional fission sites created "
-            "in this generation will not be banked. Results may be non-deteministic.");
+            "in this generation will not be banked. Results may be non-deterministic.");
 
         // Decrement number of particle progeny as storage was unsuccessful. This
         // step is needed so that the sum of all progeny is equal to the size


### PR DESCRIPTION
This PR fixes Issue #1853.

### Issue

The issue was noticed by @paulromano for problems with eigenvalues far from 1.0 where a lot of fission sites can be generated. Essentially, there is a fixed limit to the number of fission sites that OpenMC stores in its shared fission bank that is heuristically set to 3x the number of particles simulated per batch.

This works fine for eigenvalues near 1.0, but for higher eigenvalue problems the bank can be prone to overflowing -- particularly on the first iteration when the starting guess for k is 1.0 such that the number of fission sites generated is not normalized downwards by a factor of the eigenvalue.

For small eigenvalues approaching 0.0, as we attempt to normalize the number of fission sites generated, this can mean that when a single (very unlikely) fission event occurs it can in theory generate a huge number of sites causing overflow if the shared fission array.

### Background: Shared Fission Bank Sorting

For reproducibility, we currently have an algorithm that sorts the fission bank at the end of each power iteration. There are a few ways of doing this, but the best way is to store a `n_progeny_` variable in the `Particle` object, which increments each time it generates a fission site. Fission sites are then annotated with the parent particle's unique ID as well as a progeny ID from the parent particle. At the end of the batch, sites are then sorted in primary order of parent particle ID and then secondary order of progeny ID. This ordering is notable as it is the same ordering that would be generated if a history-based simulation is run in serial. The sorting algorithm is also notable as it runs in O(n) time, which is faster than if sorting sites by spatial location (which would be O(nlogn)). 

### Cause

OpenMC currently checks and enforces that the shared fission bank does not overflow. In this event, an error message is printed warning the user but the simulation continues. Fission sites generated after the point of the shared array filling up are simply not stored. The problem with this is that there is an unaccounted for mismatch between the final size of the fission bank and the total number of progeny generated by all particles. This happens because the `n_progeny_` field of the `Particle` is incremented before attempting to append to the shared array. If the append fails due to the array being full then the fission site is not stored to the fission bank, yet the `n_progeny_` variable had still been incremented.

In practice, this meant that the sorting algorithm expected there to be more fission sites than were actually stored in the shared fission bank. As fission sites were shuffled during the sorting it would attempt to store them at (invalid) indices off the end of the array.

### Solution

The basic solution is quite easy -- we can simply decrement the particle's `n_progeny_` variable when a failed append operation occurs so that the total number of progeny generated and the size of the fission bank match correctly.

### Other Changes

- As part of PR #1461 I made some interface edits to the original shared fission bank implementation that caused this issue. The edits also ended up making the basic logic of the CE and ME `create_fission_sites()` functions somewhat awkward, and I felt this was a good opportunity to clean the logic up and add some comments to make the logic clearer. In particular, this meant better tracking of the number of fission sites being actually generated.

- I also added a check in the `sort_fission_bank()` function to ensure that we do not write off the end of the array again. While I no longer think it is possible to hit that condition with the other fixes in place, due to the (somewhat opaque) way the sorting algorithm interacts with the `n_progeny_` and particle ID variables I think the check is useful to prevent future regressions in the code.

- In fixing this bug, I also noticed that when the shared fission bank overflows the simulation will no longer be reproducible if run in parallel. This is because there is no way to enforce the order in which the fission sites will be generated, and as such there is no way to control which sites will actually make it into the limited capacity of the shared fission bank. Additionally, generating and attempting to append a fission site will make use of the particle's random number stream, meaning that whether or not the fission bank happened to be full will change the state of the random stream used for subsequent particle events. As a result, the "fission bank is full" warning message has been updated to make the non-deterministic effect clear to the user.

### Potential for New Regression Test

On the surface, it seems like a good idea to add a new test (e.g., the one @paulromano specified for #1853). However, given that filling up the fission bank results in non-reproducible results, this may be hard to do.
