### PR TITLE
Addition of C-API methods to set/get a Cell's rotation and translation 

### DIFF
--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -23,7 +23,7 @@ extern "C" {
   int openmc_cell_set_id(int32_t index, int32_t id);
   int openmc_cell_set_temperature(int32_t index, double T, const int32_t* instance, bool set_contained = false);
   int openmc_cell_set_translation(int32_t index, const double xyz[]);
-  int openmc_cell_set_rotation(int32_t index, const double rot[], const size_t rot_len);
+  int openmc_cell_set_rotation(int32_t index, const double rot[], size_t rot_len);
   int openmc_energy_filter_get_bins(int32_t index, const double** energies, size_t* n);
   int openmc_energy_filter_set_bins(int32_t index, size_t n, const double* energies);
   int openmc_energyfunc_filter_get_energy(int32_t index, size_t* n, const double** energy);

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -14,12 +14,14 @@ extern "C" {
   int openmc_cell_get_fill(int32_t index, int* type, int32_t** indices, int32_t* n);
   int openmc_cell_get_id(int32_t index, int32_t* id);
   int openmc_cell_get_temperature(int32_t index, const int32_t* instance, double* T);
+  int openmc_cell_get_translation(int32_t index, double xyz[]);
   int openmc_cell_get_name(int32_t index, const char** name);
   int openmc_cell_get_num_instances(int32_t index, int32_t* num_instances);
   int openmc_cell_set_name(int32_t index, const char* name);
   int openmc_cell_set_fill(int32_t index, int type, int32_t n, const int32_t* indices);
   int openmc_cell_set_id(int32_t index, int32_t id);
   int openmc_cell_set_temperature(int32_t index, double T, const int32_t* instance, bool set_contained = false);
+  int openmc_cell_set_translation(int32_t index, const double xyz[]);
   int openmc_energy_filter_get_bins(int32_t index, const double** energies, size_t* n);
   int openmc_energy_filter_set_bins(int32_t index, size_t n, const double* energies);
   int openmc_energyfunc_filter_get_energy(int32_t index, size_t* n, const double** energy);

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -15,6 +15,7 @@ extern "C" {
   int openmc_cell_get_id(int32_t index, int32_t* id);
   int openmc_cell_get_temperature(int32_t index, const int32_t* instance, double* T);
   int openmc_cell_get_translation(int32_t index, double xyz[]);
+  int openmc_cell_get_rotation(int32_t index, double rot[], size_t* n);
   int openmc_cell_get_name(int32_t index, const char** name);
   int openmc_cell_get_num_instances(int32_t index, int32_t* num_instances);
   int openmc_cell_set_name(int32_t index, const char* name);
@@ -22,6 +23,7 @@ extern "C" {
   int openmc_cell_set_id(int32_t index, int32_t id);
   int openmc_cell_set_temperature(int32_t index, double T, const int32_t* instance, bool set_contained = false);
   int openmc_cell_set_translation(int32_t index, const double xyz[]);
+  int openmc_cell_set_rotation(int32_t index, const double rot[], const size_t rot_len);
   int openmc_energy_filter_get_bins(int32_t index, const double** energies, size_t* n);
   int openmc_energy_filter_set_bins(int32_t index, size_t n, const double* energies);
   int openmc_energyfunc_filter_get_energy(int32_t index, size_t* n, const double** energy);

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -159,6 +159,10 @@ public:
   //!   temperatures.
   void set_temperature(double T, int32_t instance = -1, bool set_contained = false);
 
+  //! Set the rotation matrix of a cell instance
+  //! \param[in] rot The rotation matrix of length 3 or 9
+  void set_rotation(const vector<double>& rot);
+
   //! Get the name of a cell
   //! \return Cell name
   const std::string& name() const { return name_; };

--- a/openmc/lib/cell.py
+++ b/openmc/lib/cell.py
@@ -35,6 +35,9 @@ _dll.openmc_cell_get_temperature.errcheck = _error_handler
 _dll.openmc_cell_get_name.argtypes = [c_int32, POINTER(c_char_p)]
 _dll.openmc_cell_get_name.restype = c_int
 _dll.openmc_cell_get_name.errcheck = _error_handler
+_dll.openmc_cell_get_translation.argtypes = [c_int32, POINTER(c_double)]
+_dll.openmc_cell_get_translation.restype = c_int
+_dll.openmc_cell_get_translation.errcheck = _error_handler
 _dll.openmc_cell_set_name.argtypes = [c_int32, c_char_p]
 _dll.openmc_cell_set_name.restype = c_int
 _dll.openmc_cell_set_name.errcheck = _error_handler
@@ -49,6 +52,9 @@ _dll.openmc_cell_set_temperature.argtypes = [
     c_int32, c_double, POINTER(c_int32), c_bool]
 _dll.openmc_cell_set_temperature.restype = c_int
 _dll.openmc_cell_set_temperature.errcheck = _error_handler
+_dll.openmc_cell_set_translation.argtypes = [c_int32, POINTER(c_double)]
+_dll.openmc_cell_set_translation.restype = c_int
+_dll.openmc_cell_set_translation.errcheck = _error_handler
 _dll.openmc_get_cell_index.argtypes = [c_int32, POINTER(c_int32)]
 _dll.openmc_get_cell_index.restype = c_int
 _dll.openmc_get_cell_index.errcheck = _error_handler
@@ -212,6 +218,29 @@ class Cell(_FortranObjectWithID):
             instance = c_int32(instance)
 
         _dll.openmc_cell_set_temperature(self._index, T, instance, set_contained)
+
+    def get_translation(self):
+        """Get the translation vector of a cell
+
+        """
+
+        translation = np.zeros(3)
+        _dll.openmc_cell_get_translation(
+            self._index, translation.ctypes.data_as(POINTER(c_double)))
+        return translation
+
+    def set_translation(self, translation):
+        """Set the translation vector of a cell
+
+        Parameters
+        ----------
+        translation : numpy.ndarray
+            3-D translation vector
+
+        """
+
+        _dll.openmc_cell_set_translation(
+            self._index, translation.ctypes.data_as(POINTER(c_double)))
 
     @property
     def bounding_box(self):

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1309,7 +1309,7 @@ openmc_cell_set_id(int32_t index, int32_t id)
 extern "C" int openmc_cell_get_translation(int32_t index, double xyz[])
 {
   if (index >= 0 && index < model::cells.size()) {
-    auto& cell = openmc::model::cells[index];
+    auto& cell = model::cells[index];
     xyz[0] = cell->translation_.x;
     xyz[1] = cell->translation_.y;
     xyz[2] = cell->translation_.z;
@@ -1342,7 +1342,7 @@ extern "C" int openmc_cell_set_translation(int32_t index, const double xyz[])
 extern "C" int openmc_cell_get_rotation(int32_t index, double rot[], size_t* n)
 {
   if (index >= 0 && index < model::cells.size()) {
-    auto& cell = openmc::model::cells[index];
+    auto& cell = model::cells[index];
     *n = cell->rotation_.size();
     std::memcpy(rot, cell->rotation_.data(), *n * sizeof(cell->rotation_[0]));
     return 0;
@@ -1354,7 +1354,7 @@ extern "C" int openmc_cell_get_rotation(int32_t index, double rot[], size_t* n)
 
 //! Set the flattened rotation matrix of a cell
 extern "C" int openmc_cell_set_rotation(int32_t index, const double rot[],
-    const size_t rot_len)
+    size_t rot_len)
 {
   if (index >= 0 && index < model::cells.size()) {
     if (model::cells[index]->fill_ == C_NONE) {

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1318,6 +1318,12 @@ extern "C" int openmc_cell_get_translation(int32_t index, double xyz[])
 extern "C" int openmc_cell_set_translation(int32_t index, const double xyz[])
 {
   if (index >= 0 && index < model::cells.size()) {
+    if (model::cells[index]->fill_ == C_NONE) {
+      set_errmsg(fmt::format("Cannot apply a translation to cell {}"
+                             " because it is not filled with another universe",
+                             index));
+      return OPENMC_E_GEOMETRY;
+    }
     model::cells[index]->translation_ = Position(xyz);
     return 0;
   } else {

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1299,6 +1299,34 @@ openmc_cell_set_id(int32_t index, int32_t id)
   }
 }
 
+//! Return the translation vector of a cell
+extern "C" int openmc_cell_get_translation(int32_t index, double xyz[])
+{
+  if (index >= 0 && index < model::cells.size()) {
+    auto& cell = openmc::model::cells[index];
+    xyz[0] = cell->translation_.x;
+    xyz[1] = cell->translation_.y;
+    xyz[2] = cell->translation_.z;
+    return 0;
+  } else {
+    set_errmsg("Index in cells array is out of bounds.");
+    return OPENMC_E_OUT_OF_BOUNDS;
+  }
+}
+
+//! Set the translation vector of a cell
+extern "C" int openmc_cell_set_translation(int32_t index, const double xyz[])
+{
+  if (index >= 0 && index < model::cells.size()) {
+    model::cells[index]->translation_ = Position(xyz);
+    return 0;
+  } else {
+    set_errmsg("Index in cells array is out of bounds.");
+    return OPENMC_E_OUT_OF_BOUNDS;
+  }
+}
+
+//! Get the number of instances of the requested cell
 extern "C" int
 openmc_cell_get_num_instances(int32_t index, int32_t* num_instances)
 {

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -141,6 +141,12 @@ def test_properties_temperature(lib_init):
     openmc.lib.import_properties('properties.h5')
     assert cell.get_temperature() == pytest.approx(200.0)
 
+def test_cell_translation(lib_init):
+    cell = openmc.lib.cells[1]
+    assert cell.get_translation() == pytest.approx([0., 0., 0.])
+    cell.set_translation(np.array([1., 0., -1.]))
+    assert cell.get_translation() == pytest.approx([1., 0., -1.])
+
 
 def test_new_cell(lib_init):
     with pytest.raises(exc.AllocationError):

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -727,3 +727,18 @@ def test_cell_translation(pincell_model_w_univ, mpi_intracomm):
     # This time we *can* set it
     cell.set_translation(np.array([1., 0., -1.]))
     assert cell.get_translation() == pytest.approx([1., 0., -1.])
+
+
+def test_cell_rotation(pincell_model_w_univ):
+    # Cell 1 is filled with a material so we cannot rotate it, but we can get
+    # its rotation matrix (which will be the identity matrix)
+    cell = openmc.lib.cells[1]
+    assert cell.get_rotation() is None
+    with pytest.raises(exc.GeometryError, match='not filled with'):
+        cell.set_rotation(np.array([180., 0., 0.]))
+
+    # Now repeat with Cell 2 and we will be allowed to do it
+    cell = openmc.lib.cells[2]
+    assert cell.get_rotation() is None
+    cell.set_rotation(np.array([180., 0., 0.]))
+    assert cell.get_rotation() == pytest.approx([180., 0., 0.])

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -717,28 +717,28 @@ def test_cell_translation(pincell_model_w_univ, mpi_intracomm):
     # Cell 1 is filled with a material so it has a translation, but we can't
     # set it.
     cell = openmc.lib.cells[1]
-    assert cell.get_translation() == pytest.approx([0., 0., 0.])
+    assert cell.translation == pytest.approx([0., 0., 0.])
     with pytest.raises(exc.GeometryError, match='not filled with'):
-        cell.set_translation(np.array([1., 0., -1.]))
+        cell.translation = (1., 0., -1.)
 
     # Cell 2 was given a universe, so we can assign it a translation vector
     cell = openmc.lib.cells[2]
-    assert cell.get_translation() == pytest.approx([0., 0., 0.])
+    assert cell.translation == pytest.approx([0., 0., 0.])
     # This time we *can* set it
-    cell.set_translation(np.array([1., 0., -1.]))
-    assert cell.get_translation() == pytest.approx([1., 0., -1.])
+    cell.translation = (1., 0., -1.)
+    assert cell.translation == pytest.approx([1., 0., -1.])
 
 
 def test_cell_rotation(pincell_model_w_univ):
     # Cell 1 is filled with a material so we cannot rotate it, but we can get
     # its rotation matrix (which will be the identity matrix)
     cell = openmc.lib.cells[1]
-    assert cell.get_rotation() is None
+    assert cell.rotation == pytest.approx([0., 0., 0.])
     with pytest.raises(exc.GeometryError, match='not filled with'):
-        cell.set_rotation(np.array([180., 0., 0.]))
+        cell.rotation = (180., 0., 0.)
 
     # Now repeat with Cell 2 and we will be allowed to do it
     cell = openmc.lib.cells[2]
-    assert cell.get_rotation() is None
-    cell.set_rotation(np.array([180., 0., 0.]))
-    assert cell.get_rotation() == pytest.approx([180., 0., 0.])
+    assert cell.rotation == pytest.approx([0., 0., 0.])
+    cell.rotation = (180., 0., 0.)
+    assert cell.rotation == pytest.approx([180., 0., 0.])


### PR DESCRIPTION
As stated, this simple PR gives a user C-API access to a Cell's rotation and translation attributes. This can be useful for performing criticality searches as discussed in #1654 as this allows control device movement without going back through XML and re-initialization.

Unit tests are included in ``test_lib.py``.