### PR TITLE
Update minimum Python version to 3.6

### DIFF
--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -484,7 +484,7 @@ to install the Python package in :ref:`"editable" mode <devguide_editable>`.
 Prerequisites
 -------------
 
-The Python API works with Python 3.5+. In addition to Python itself, the API
+The Python API works with Python 3.6+. In addition to Python itself, the API
 relies on a number of third-party packages. All prerequisites can be installed
 using Conda_ (recommended), pip_, or through the package manager in most Linux
 distributions.

--- a/openmc/data/library.py
+++ b/openmc/data/library.py
@@ -146,10 +146,6 @@ class DataLibrary(EqualityMixin):
             raise ValueError("Either path or OPENMC_CROSS_SECTIONS "
                              "environmental variable must be set")
 
-        # Convert to string to support pathlib
-        # TODO: Remove when support is Python 3.6+ only
-        path = str(path)
-
         tree = ET.parse(path)
         root = tree.getroot()
         if root.find('directory') is not None:

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -158,11 +158,8 @@ class TransportOperator(ABC):
     def __enter__(self):
         # Save current directory and move to specific output directory
         self._orig_dir = os.getcwd()
-        if not self.output_dir.exists():
-            self.output_dir.mkdir()  # exist_ok parameter is 3.5+
-
-        # In Python 3.6+, chdir accepts a Path directly
-        os.chdir(str(self.output_dir))
+        self.output_dir.mkdir(exist_ok=True)
+        os.chdir(self.output_dir)
 
         return self.initial_condition()
 

--- a/setup.py
+++ b/setup.py
@@ -57,14 +57,14 @@ kwargs = {
         'Topic :: Scientific/Engineering'
         'Programming Language :: C++',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 
     # Dependencies
-    'python_requires': '>=3.5',
+    'python_requires': '>=3.6',
     'install_requires': [
         'numpy>=1.9', 'h5py', 'scipy', 'ipython', 'matplotlib',
         'pandas', 'lxml', 'uncertainties'

--- a/tests/regression_tests/mgxs_library_distribcell/test.py
+++ b/tests/regression_tests/mgxs_library_distribcell/test.py
@@ -68,8 +68,6 @@ class MGXSTestHarness(PyAPITestHarness):
         return outstr
 
 
-@pytest.mark.xfail(sys.version_info < (3, 6),
-                   reason="Pandas 1.0 API changed and requires Python 3.6+")
 def test_mgxs_library_distribcell():
     model = pwr_assembly()
     harness = MGXSTestHarness('statepoint.10.h5', model)

--- a/tests/unit_tests/test_deplete_fission_yields.py
+++ b/tests/unit_tests/test_deplete_fission_yields.py
@@ -43,12 +43,11 @@ def materials(tmpdir_factory):
         with lib.run_in_memory():
             yield [lib.Material(), lib.Material()]
     finally:
-        # Convert to strings as os.remove in py 3.5 doesn't support Paths
         for file_path in ("settings.xml", "geometry.xml", "materials.xml",
                           "summary.h5"):
-            os.remove(str(tmpdir / file_path))
+            os.remove(tmpdir / file_path)
         orig.chdir()
-        os.rmdir(str(tmpdir))
+        os.rmdir(tmpdir)
 
 
 def proxy_tally_data(tally, fill=None):


### PR DESCRIPTION
This PR proposes updating our minimum Python version to 3.6 (it is currently 3.5). Python 3.5 reached end of life in September 2020. Many other third-party packages have already dropped support, e.g. [numpy](https://numpy.org/devdocs/release/1.19.0-notes.html) (3.6+), [scipy](https://github.com/scipy/scipy/blob/master/INSTALL.rst.txt#prerequisites) (3.7+), and [pandas](https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#python-version-support) (3.7+). By bumping the minimum Python version to 3.6, developers will be allowed to use [f-strings](https://realpython.com/python-f-strings/) and other goodness from 3.6.