### PR TITLE
A few small updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,8 +214,6 @@ add_subdirectory(vendor/xtensor)
 # GSL header-only library
 #===============================================================================
 
-set(GSL_LITE_OPT_INSTALL_COMPAT_HEADER ON CACHE BOOL
-  "Install MS-GSL compatibility header <gsl/gsl>")
 add_subdirectory(vendor/gsl-lite)
 
 # Make sure contract violations throw exceptions

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -244,14 +244,14 @@ public:
 
   explicit CSGCell(pugi::xml_node cell_node);
 
-  bool contains(Position r, Direction u, int32_t on_surface) const;
+  bool contains(Position r, Direction u, int32_t on_surface) const override;
 
   std::pair<double, int32_t> distance(
-    Position r, Direction u, int32_t on_surface, Particle* p) const;
+    Position r, Direction u, int32_t on_surface, Particle* p) const override;
 
   void to_hdf5_inner(hid_t group_id) const override;
 
-  BoundingBox bounding_box() const;
+  BoundingBox bounding_box() const override;
 
 protected:
   bool contains_simple(Position r, Direction u, int32_t on_surface) const;

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -10,7 +10,7 @@
 
 #include "hdf5.h"
 #include "pugixml.hpp"
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/constants.h"
 #include "openmc/memory.h" // for unique_ptr

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -6,7 +6,7 @@
 
 #include "pugixml.hpp"
 #include "xtensor/xtensor.hpp"
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 #include <hdf5.h>
 
 #include "openmc/bremsstrahlung.h"

--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -7,7 +7,7 @@
 #include <unordered_map>
 #include <utility> // for pair
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 #include <hdf5.h>
 
 #include "openmc/array.h"

--- a/include/openmc/photon.h
+++ b/include/openmc/photon.h
@@ -7,7 +7,7 @@
 #include "openmc/vector.h"
 
 #include "xtensor/xtensor.hpp"
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 #include <hdf5.h>
 
 #include <string>

--- a/include/openmc/reaction.h
+++ b/include/openmc/reaction.h
@@ -7,7 +7,7 @@
 #include <string>
 
 #include "hdf5.h"
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/reaction_product.h"
 #include "openmc/vector.h"

--- a/include/openmc/tallies/filter.h
+++ b/include/openmc/tallies/filter.h
@@ -6,7 +6,7 @@
 #include <unordered_map>
 
 #include "pugixml.hpp"
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/constants.h"
 #include "openmc/hdf5_interface.h"

--- a/include/openmc/tallies/filter_azimuthal.h
+++ b/include/openmc/tallies/filter_azimuthal.h
@@ -4,7 +4,7 @@
 #include "openmc/vector.h"
 #include <string>
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/tallies/filter.h"
 

--- a/include/openmc/tallies/filter_cell.h
+++ b/include/openmc/tallies/filter_cell.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <unordered_map>
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/tallies/filter.h"
 #include "openmc/vector.h"

--- a/include/openmc/tallies/filter_cell_instance.h
+++ b/include/openmc/tallies/filter_cell_instance.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <unordered_map>
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/cell.h"
 #include "openmc/tallies/filter.h"

--- a/include/openmc/tallies/filter_collision.h
+++ b/include/openmc/tallies/filter_collision.h
@@ -1,7 +1,7 @@
 #ifndef OPENMC_TALLIES_FILTER_COLLISIONS_H
 #define OPENMC_TALLIES_FILTER_COLLISIONS_H
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 #include <unordered_map>
 
 #include "openmc/tallies/filter.h"

--- a/include/openmc/tallies/filter_delayedgroup.h
+++ b/include/openmc/tallies/filter_delayedgroup.h
@@ -1,7 +1,7 @@
 #ifndef OPENMC_TALLIES_FILTER_DELAYEDGROUP_H
 #define OPENMC_TALLIES_FILTER_DELAYEDGROUP_H
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/tallies/filter.h"
 #include "openmc/vector.h"

--- a/include/openmc/tallies/filter_energy.h
+++ b/include/openmc/tallies/filter_energy.h
@@ -1,7 +1,7 @@
 #ifndef OPENMC_TALLIES_FILTER_ENERGY_H
 #define OPENMC_TALLIES_FILTER_ENERGY_H
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/tallies/filter.h"
 #include "openmc/vector.h"

--- a/include/openmc/tallies/filter_material.h
+++ b/include/openmc/tallies/filter_material.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <unordered_map>
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/tallies/filter.h"
 #include "openmc/vector.h"

--- a/include/openmc/tallies/filter_mu.h
+++ b/include/openmc/tallies/filter_mu.h
@@ -1,7 +1,7 @@
 #ifndef OPENMC_TALLIES_FILTER_MU_H
 #define OPENMC_TALLIES_FILTER_MU_H
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/tallies/filter.h"
 #include "openmc/vector.h"

--- a/include/openmc/tallies/filter_polar.h
+++ b/include/openmc/tallies/filter_polar.h
@@ -3,7 +3,7 @@
 
 #include <cmath>
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/tallies/filter.h"
 #include "openmc/vector.h"

--- a/include/openmc/tallies/filter_sph_harm.h
+++ b/include/openmc/tallies/filter_sph_harm.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/tallies/filter.h"
 

--- a/include/openmc/tallies/filter_surface.h
+++ b/include/openmc/tallies/filter_surface.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <unordered_map>
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/tallies/filter.h"
 #include "openmc/vector.h"

--- a/include/openmc/tallies/filter_universe.h
+++ b/include/openmc/tallies/filter_universe.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <unordered_map>
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/tallies/filter.h"
 #include "openmc/vector.h"

--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -10,7 +10,7 @@
 #include "pugixml.hpp"
 #include "xtensor/xfixed.hpp"
 #include "xtensor/xtensor.hpp"
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include <string>
 #include <unordered_map>

--- a/include/openmc/volume_calc.h
+++ b/include/openmc/volume_calc.h
@@ -9,7 +9,7 @@
 #include "pugixml.hpp"
 #include "xtensor/xtensor.hpp"
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 #include <string>
 
 namespace openmc {

--- a/openmc/deplete/nuclide.py
+++ b/openmc/deplete/nuclide.py
@@ -294,7 +294,8 @@ class Nuclide:
             for mode_type, daughter, br in self.decay_modes:
                 mode_elem = ET.SubElement(elem, 'decay')
                 mode_elem.set('type', mode_type)
-                mode_elem.set('target', daughter or "Nothing")
+                if daughter:
+                    mode_elem.set('target', daughter)
                 mode_elem.set('branching_ratio', str(br))
 
         elem.set('reactions', str(len(self.reactions)))

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -10,7 +10,7 @@
 #include <string>
 
 #include <fmt/core.h>
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/capi.h"
 #include "openmc/constants.h"

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2,7 +2,7 @@
 #include <algorithm> // for copy, equal, min, min_element
 #include <cmath>     // for ceil
 #include <cstddef>   // for size_t
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 #include <string>
 
 #ifdef OPENMC_MPI

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -5,7 +5,7 @@
 #include <utility>
 
 #include <fmt/core.h>
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/array.h"
 #include "openmc/container_util.h"

--- a/src/tallies/filter_mesh.cpp
+++ b/src/tallies/filter_mesh.cpp
@@ -1,7 +1,7 @@
 #include "openmc/tallies/filter_mesh.h"
 
 #include <fmt/core.h>
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/capi.h"
 #include "openmc/constants.h"

--- a/src/tallies/filter_sph_harm.cpp
+++ b/src/tallies/filter_sph_harm.cpp
@@ -3,7 +3,7 @@
 #include <utility> // For pair
 
 #include <fmt/core.h>
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/capi.h"
 #include "openmc/error.h"

--- a/src/tallies/filter_zernike.cpp
+++ b/src/tallies/filter_zernike.cpp
@@ -5,7 +5,7 @@
 #include <utility> // For pair
 
 #include <fmt/core.h>
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include "openmc/capi.h"
 #include "openmc/error.h"


### PR DESCRIPTION
This PR has a few small updates:
- gsl-lite includes were changed from `<gsl/gsl>` to `<gsl/gsl-lite.hpp>` as [recommended](https://github.com/gsl-lite/gsl-lite#using-gsl-lite-in-libraries)
- Add a few missing `override` specifiers in cell.h
- Update the fmt submodule (needed to work with IBM XL compiler on some machines)