### PR TITLE
Note MPI fork depletion analysis issues in MPI installation guide

### DIFF
--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -378,6 +378,17 @@ i.e.
 
     CXX=mpicxx cmake /path/to/openmc
 
+If you are doing depletion analysis, you may have to set
+
+.. code-block:: python
+
+    openmc.pool.USE_MULTIPROCESSING = False
+
+in your python file before making any calls to the integrator depending on whether
+or not your MPI is compatible with forking (e.g., see the `OpenMPI FAQ entry about
+forking <https://www.open-mpi.org/faq/?category=tuning#fork-warning>`_). If it is
+not compatible, and this in not set, random hangs and crashes can result.
+
 Selecting HDF5 Installation
 +++++++++++++++++++++++++++
 

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -382,7 +382,7 @@ If you are doing depletion analysis, you may have to set
 
 .. code-block:: python
 
-    openmc.pool.USE_MULTIPROCESSING = False
+    openmc.deplete.pool.USE_MULTIPROCESSING = False
 
 in your python file before making any calls to the integrator depending on whether
 or not your MPI is compatible with forking (e.g., see the `OpenMPI FAQ entry about


### PR DESCRIPTION
Spent a large amount of time discovering the MPI fork issue for one of Canadian HPC researchers. Here is a pull request to mention it in the installation section in the hopes it may help future HPC support staff (we tend not to dig into the manual much beyond building and basic running). Thanks!