### PR TITLE
DAGMC error message and documentation update.

### DIFF
--- a/docs/source/io_formats/geometry.rst
+++ b/docs/source/io_formats/geometry.rst
@@ -406,3 +406,14 @@ Each ``<dagmc_universe>`` element can have the following attributes or sub-eleme
     A required string indicating the file to be loaded representing the DAGMC universe.
 
     *Default*: None
+
+
+  .. note:: A geometry.xml file containing only a DAGMC model for a file named `dagmc.h5m` (no CSG)
+            looks as follows
+
+            .. code-block:: xml
+
+              <?xml version='1.0' encoding='utf-8'?>
+              <geometry>
+                <dagmc_universe filename="dagmc.h5m" id="1" />
+              </geometry>

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -713,7 +713,13 @@ int32_t next_cell(
 
 namespace openmc {
 
-void read_dagmc_universes(pugi::xml_node node) {};
+void read_dagmc_universes(pugi::xml_node node)
+{
+  if (check_for_node(node, "dagmc_universe")) {
+    fatal_error("DAGMC Universes are present but OpenMC was not configured"
+                "with DAGMC");
+  }
+};
 void check_dagmc_root_univ() {};
 
 } // namespace openmc


### PR DESCRIPTION
Currently, if a user tries to run a problem that contains only DAGMC geometry

```xml
<?xml version='1.0' encoding='utf-8'?>
<geometry>
  <dagmc_universe filename="dagmc.h5m" id="1" />
</geometry>
```


 without configuring OpenMC to use DAGMC they get the message

```
 ERROR: No cells were found in the geometry.xml file
```

, which isn't very informative.

I've updated the body of `read_dagmc_universes` when `DAGMC` is disabled to produce a more useful error message if DAGMC XML nodes are present.

Additionally, I've added an example of what a `geometry.xml` file would look like if the geometry were made up of one DAGMC universe as the root universe in the documentation for the `geometry.xml` file spec.

