### PR TITLE
Update copyright to include UChicago Argonne, LLC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2021 Massachusetts Institute of Technology, UChicago Argonne,
+Copyright (c) 2011-2021 Massachusetts Institute of Technology, UChicago Argonne
 LLC, and OpenMC contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright (c) 2011-2021 Massachusetts Institute of Technology and OpenMC contributors
+Copyright (c) 2011-2021 Massachusetts Institute of Technology, UChicago Argonne,
+LLC, and OpenMC contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,7 +62,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'OpenMC'
-copyright = '2011-2021, Massachusetts Institute of Technology, UChicago Argonne, LLC, and OpenMC contributors'
+copyright = '2011-2021, Massachusetts Institute of Technology, UChicago Argonne LLC, and OpenMC contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,7 +62,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'OpenMC'
-copyright = '2011-2021, Massachusetts Institute of Technology and OpenMC contributors'
+copyright = '2011-2021, Massachusetts Institute of Technology, UChicago Argonne, LLC, and OpenMC contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -4,7 +4,7 @@
 License Agreement
 =================
 
-Copyright © 2011-2021 Massachusetts Institute of Technology, UChicago Argonne,
+Copyright © 2011-2021 Massachusetts Institute of Technology, UChicago Argonne
 LLC, and OpenMC contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -4,7 +4,8 @@
 License Agreement
 =================
 
-Copyright © 2011-2021 Massachusetts Institute of Technology and OpenMC contributors
+Copyright © 2011-2021 Massachusetts Institute of Technology, UChicago Argonne,
+LLC, and OpenMC contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/man/man1/openmc.1
+++ b/man/man1/openmc.1
@@ -58,7 +58,7 @@ section libraries if the user has not specified the <cross_sections> tag in
 .I materials.xml\fP.
 .SH LICENSE
 Copyright \(co 2011-2021 Massachusetts Institute of Technology, UChicago
-Argonne, LLC, and OpenMC contributors.
+Argonne LLC, and OpenMC contributors.
 .PP
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/man/man1/openmc.1
+++ b/man/man1/openmc.1
@@ -57,8 +57,8 @@ Indicates the default path to an HDF5 file that contains multi-group cross
 section libraries if the user has not specified the <cross_sections> tag in
 .I materials.xml\fP.
 .SH LICENSE
-Copyright \(co 2011-2021 Massachusetts Institute of Technology and OpenMC
-contributors.
+Copyright \(co 2011-2021 Massachusetts Institute of Technology, UChicago
+Argonne, LLC, and OpenMC contributors.
 .PP
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -73,7 +73,7 @@ void title()
   // Write version information
   fmt::print(
     "                 | The OpenMC Monte Carlo Code\n"
-    "       Copyright | 2011-2021 MIT, UChicago Argonne, LLC and contributors\n"
+    "       Copyright | 2011-2021 MIT, UChicago Argonne LLC, and contributors\n"
     "         License | https://docs.openmc.org/en/latest/license.html\n"
     "         Version | {}.{}.{}{}\n",
     VERSION_MAJOR, VERSION_MINOR, VERSION_RELEASE, VERSION_DEV ? "-dev" : "");
@@ -335,7 +335,7 @@ void print_version()
 #ifdef GIT_SHA1
     fmt::print("Git SHA1: {}\n", GIT_SHA1);
 #endif
-    fmt::print("Copyright (c) 2011-2021 MIT, UChicago Argonne, LLC, and "
+    fmt::print("Copyright (c) 2011-2021 MIT, UChicago Argonne LLC, and "
                "contributors\nMIT/X license at "
                "<https://docs.openmc.org/en/latest/license.html>\n");
   }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -72,26 +72,26 @@ void title()
 
   // Write version information
   fmt::print(
-    "                   | The OpenMC Monte Carlo Code\n"
-    "         Copyright | 2011-2021 MIT and OpenMC contributors\n"
-    "           License | https://docs.openmc.org/en/latest/license.html\n"
-    "           Version | {}.{}.{}{}\n",
+    "                 | The OpenMC Monte Carlo Code\n"
+    "       Copyright | 2011-2021 MIT, UChicago Argonne, LLC and contributors\n"
+    "         License | https://docs.openmc.org/en/latest/license.html\n"
+    "         Version | {}.{}.{}{}\n",
     VERSION_MAJOR, VERSION_MINOR, VERSION_RELEASE, VERSION_DEV ? "-dev" : "");
 #ifdef GIT_SHA1
-  fmt::print("          Git SHA1 | {}\n", GIT_SHA1);
+  fmt::print("        Git SHA1 | {}\n", GIT_SHA1);
 #endif
 
   // Write the date and time
-  fmt::print("         Date/Time | {}\n", time_stamp());
+  fmt::print("       Date/Time | {}\n", time_stamp());
 
 #ifdef OPENMC_MPI
   // Write number of processors
-  fmt::print("     MPI Processes | {}\n", mpi::n_procs);
+  fmt::print("   MPI Processes | {}\n", mpi::n_procs);
 #endif
 
 #ifdef _OPENMP
   // Write number of OpenMP threads
-  fmt::print("    OpenMP Threads | {}\n", omp_get_max_threads());
+  fmt::print("  OpenMP Threads | {}\n", omp_get_max_threads());
 #endif
   std::cout << std::endl;
 }
@@ -335,8 +335,8 @@ void print_version()
 #ifdef GIT_SHA1
     fmt::print("Git SHA1: {}\n", GIT_SHA1);
 #endif
-    fmt::print("Copyright (c) 2011-2021 Massachusetts Institute of "
-               "Technology and OpenMC contributors\nMIT/X license at "
+    fmt::print("Copyright (c) 2011-2021 MIT, UChicago Argonne, LLC, and "
+               "contributors\nMIT/X license at "
                "<https://docs.openmc.org/en/latest/license.html>\n");
   }
 }


### PR DESCRIPTION
We recently went through the software release process at Argonne for contributions that ANL employees have made. Since these amount to a significant fraction of the code at this point (probably 20-30%), it makes sense to call out UChicago Argonne, LLC specifically in the copyright. For those unfamiliar with copyright law -- no copyright assignment is made when someone opens a PR, so copyright ownership of contributions are retained by the owners (hence UChicago Argonne, LLC for contributions that are made by people employed at Argonne as part of their employment). This PR simply adds UChicago Argonne, LLC to the copyright line.

Pinging @bforget as the current copyright "owner"