### PR TITLE
added optional scaling factor to vtk writing

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -719,7 +719,8 @@ class UnstructuredMesh(MeshBase):
         string += '{: <16}=\t{}\n'.format('\tMesh Library', self.mesh_lib)
         return string
 
-    def write_data_to_vtk(self, filename, datasets, volume_normalization=True):
+    def write_data_to_vtk(self, filename, datasets, volume_normalization=True,
+        scaling_factor=None):
         """Map data to the unstructured mesh element centroids
            to create a VTK point-cloud dataset.
 
@@ -733,6 +734,9 @@ class UnstructuredMesh(MeshBase):
         volume_normalization : bool
             Whether or not to normalize the data by the
             volume of the mesh elements
+        scaling_factor : float
+            An optional scaling factor to multiply the
+            data by
         """
 
         import vtk
@@ -784,6 +788,9 @@ class UnstructuredMesh(MeshBase):
 
             if volume_normalization:
                 dataset /= self.volumes.flatten()
+
+            if scaling_factor:
+                dataset *= scaling_factor
 
             array = vtk.vtkDoubleArray()
             array.SetName(label)


### PR DESCRIPTION
This PR is an attempt to add a scaling factor to the write_data_to_vtk function so that the tet mesh can be scaled by a user defined number. This could be useful when processing an unstructured mesh from a statepoint file for visualisation. I'm still not totally sure how to do the tet mesh extraction from a vtk file and make use of this write_data_to_vtk function as my moab mesh doesn't appear to have any centroids.

My use case for this is to get energy deposited in joules so I'm keen to scale the tally result by a conversion factor. I guess others might want heating in watts and would need to scale the result in a similar manner

What do you think @pshriwise