### PR TITLE
Passing `openmc.Model` to depletion functions.

### DIFF
--- a/examples/pincell_depletion/run_depletion.py
+++ b/examples/pincell_depletion/run_depletion.py
@@ -84,9 +84,11 @@ settings.entropy_mesh = entropy_mesh
 #                   Initialize and run depletion calculation
 ###############################################################################
 
+model = openmc.Model(geometry=geometry, settings=settings)
+
 # Create depletion "operator"
 chain_file = './chain_simple.xml'
-op = openmc.deplete.Operator(geometry, settings, chain_file)
+op = openmc.deplete.Operator(model, chain_file)
 
 # Perform simulation using the predictor algorithm
 time_steps = [1.0, 1.0, 1.0, 1.0, 1.0]  # days

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -10,6 +10,7 @@ densities is all done in-memory instead of through the filesystem.
 import copy
 from collections import OrderedDict
 import os
+from typing import Type
 import xml.etree.ElementTree as ET
 from warnings import warn
 from pathlib import Path
@@ -196,6 +197,15 @@ class Operator(TransportOperator):
                  fission_yield_mode="constant", fission_yield_opts=None,
                  reaction_rate_mode="direct", reaction_rate_opts=None,
                  reduce_chain=False, reduce_chain_level=None):
+        # check for old call to constructor
+        if isinstance(model, openmc.Geometry):
+            msg = "As of version 0.13.0 openmc.deplete.Operator requires an " \
+                "openmc.Model object rather than the openmc.Geometry and " \
+                "openmc.Settings parameters. Please use the geometry and " \
+                "settings objects passed here to create a model with which " \
+                "to generate the depletion Operator."
+            raise TypeError(msg)
+
         check_value('fission yield mode', fission_yield_mode,
                     self._fission_helpers.keys())
         check_value('normalization mode', normalization_mode,

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -65,6 +65,10 @@ class Operator(TransportOperator):
     directly. Instead, an instance of this class is passed to an integrator
     class, such as :class:`openmc.deplete.CECMIntegrator`.
 
+    .. versionchanged:: 0.13.0
+        The geometry and settings parameters have been replaced with a
+        model parameter that takes an openmc.Model object
+
     Parameters
     ----------
     model : openmc.Model

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -618,8 +618,6 @@ class Operator(TransportOperator):
         through direct memory writing.
 
         """
-        materials = openmc.Materials(self.materials)
-
         # Sort nuclides according to order in AtomNumber object
         nuclides = list(self.number.nuclides)
         for mat in self.materials:
@@ -631,9 +629,9 @@ class Operator(TransportOperator):
             tree = ET.parse(str(mfile))
             xs = tree.find('cross_sections')
             if xs is not None:
-                materials.cross_sections = xs.text
+                self.materials.cross_sections = xs.text
 
-        materials.export_to_xml()
+        self.materials.export_to_xml()
 
     def _get_tally_nuclides(self):
         """Determine nuclides that should be tallied for reaction rates.

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -9,6 +9,7 @@ import copy
 import h5py
 import numpy as np
 
+import openmc
 from openmc.mpi import comm, MPI
 from .reaction_rates import ReactionRates
 
@@ -496,16 +497,23 @@ class Results:
 
         results.export_to_hdf5("depletion_results.h5", step_ind)
 
-    def transfer_volumes(self, geometry):
+    def transfer_volumes(self, model):
         """Transfers volumes from depletion results to geometry
 
         Parameters
         ----------
-        geometry : OpenMC geometry to be used in a depletion restart
+        model : OpenMC model to be used in a depletion restart
             calculation
 
         """
-        for cell in geometry.get_all_material_cells().values():
-            for material in cell.get_all_materials().values():
-                if material.depletable:
-                    material.volume = self.volume[str(material.id)]
+
+        if not model.materials:
+            materials = openmc.Materials(
+                model.geometry.get_all_materials().values()
+            )
+        else:
+            materials = model.materials
+
+        for material in materials:
+            if material.depletable:
+                material.volume = self.volume[str(material.id)]

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -326,7 +326,7 @@ class Model:
         with _change_directory(Path(directory)):
             with openmc.lib.quiet_dll(output):
                 depletion_operator = \
-                    dep.Operator(self.geometry, self.settings, **op_kwargs)
+                    dep.Operator(self, **op_kwargs)
 
             # Tell depletion_operator.finalize NOT to clear C API memory when
             # it is done

--- a/tests/regression_tests/deplete/test.py
+++ b/tests/regression_tests/deplete/test.py
@@ -49,9 +49,11 @@ def test_full(run_in_tmpdir, problem, multiproc):
     settings.seed = 1
     settings.verbosity = 1
 
+    model = openmc.Model(geometry=geometry, settings=settings)
+
     # Create operator
     chain_file = Path(__file__).parents[2] / 'chain_simple.xml'
-    op = openmc.deplete.Operator(geometry, settings, chain_file)
+    op = openmc.deplete.Operator(model, chain_file)
     op.round_number = True
 
     # Power and timesteps
@@ -170,7 +172,7 @@ def test_depletion_results_to_material(run_in_tmpdir, problem):
     diff_vs_expected = unified_diff(reference_lines, result_file_lines)
 
     # Check all lines match, printing errors along the way
-    success = True 
+    success = True
     for line in diff_vs_expected:
         success = False
         print(line.rstrip())

--- a/tests/unit_tests/test_deplete_activation.py
+++ b/tests/unit_tests/test_deplete_activation.py
@@ -65,7 +65,7 @@ def test_activation(run_in_tmpdir, model, reaction_rate_mode, reaction_rate_opts
 
     # Create transport operator
     op = openmc.deplete.Operator(
-        model.geometry, model.settings, 'test_chain.xml',
+        model, 'test_chain.xml',
         normalization_mode="source-rate",
         reaction_rate_mode=reaction_rate_mode,
         reaction_rate_opts=reaction_rate_opts,
@@ -142,9 +142,10 @@ def test_decay(run_in_tmpdir):
     chain.add_nuclide(sr89)
     chain.export_to_xml('test_chain.xml')
 
+    model = openmc.Model(geometry=geometry, settings=settings)
     # Create transport operator
     op = openmc.deplete.Operator(
-        geometry, settings, 'test_chain.xml', normalization_mode="source-rate"
+        model, 'test_chain.xml', normalization_mode="source-rate"
     )
 
     # Deplete with two decay steps

--- a/tests/unit_tests/test_transfer_volumes.py
+++ b/tests/unit_tests/test_transfer_volumes.py
@@ -40,7 +40,7 @@ def test_transfer_volumes(run_in_tmpdir):
     geometry = openmc.Geometry(root)
 
     # Transfer volumes
-    res[0].transfer_volumes(geometry)
+    res[0].transfer_volumes(openmc.Model(geometry))
 
     assert mat1.volume == 1.5
     assert mat2.volume is None


### PR DESCRIPTION
I took a crack at #1880, so I thought I'd create a draft PR so others could see what it looks like. This allows one to run depletion with DAGMC models where the depleted materials can either be specified on the model or gathered from the model's geometry.

Once we reach a conclusion on whether or not we'd like to incorporate this change, I'll either close it or clean it up accordingly.

Pinging @gonuke as he had a particular interest in this.