### PR TITLE
Added the import to openmc.lib to model.py while leaving it optional

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -14,7 +14,16 @@ import openmc
 from openmc.dummy_comm import DummyCommunicator
 from openmc.executor import _process_CLI_arguments
 from openmc.checkvalue import check_type, check_value
+
 from openmc.exceptions import InvalidIDError
+
+# Establish whether openmc.lib is available for downstream uses;
+# this avoids the need for extraneous try/import/except statements
+try:
+    import openmc.lib
+    _openmc_lib_present = True
+except ImportError:
+    _openmc_lib_present = False
 
 
 @contextmanager
@@ -137,7 +146,10 @@ class Model:
 
     @property
     def is_initialized(self):
-        return openmc.lib.is_initialized
+        if _openmc_lib_present:
+            return openmc.lib.is_initialized
+        else:
+            return False
 
     @geometry.setter
     def geometry(self, geometry):
@@ -512,7 +524,7 @@ class Model:
                 for arg_name, arg, default in zip(
                     ['threads', 'geometry_debug', 'restart_file', 'tracks'],
                     [threads, geometry_debug, restart_file, tracks],
-                    [None, False, None, False]):
+                        [None, False, None, False]):
                     if arg != default:
                         msg = f"{arg_name} must be set via Model.is_initialized(...)"
                         raise ValueError(msg)

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -236,11 +236,7 @@ class Model:
             MPI intracommunicator
         """
 
-        try:
-            import openmc.lib
-        except ImportError:
-            raise ImportError('openmc.lib must be available to '
-                'execute Model.init_lib(...)') from None
+        import openmc.lib
 
         # TODO: right now the only way to set most of the above parameters via
         # the C API are at initialization time despite use-cases existing to
@@ -280,11 +276,7 @@ class Model:
 
         """
 
-        try:
-            import openmc.lib
-        except ImportError:
-            raise ImportError('openmc.lib must be available to '
-                              'execute Model.finalize_lib(...)') from None
+        import openmc.lib
 
         openmc.lib.finalize()
 
@@ -422,11 +414,7 @@ class Model:
         openmc.lib.export_properties
 
         """
-        try:
-            import openmc.lib
-        except ImportError:
-            raise ImportError('openmc.lib must be available to '
-                              'execute Model.import_properties(...)') from None
+        import openmc.lib
 
         cells = self.geometry.get_all_cells()
         materials = self.geometry.get_all_materials()

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -11,7 +11,6 @@ import openmc
 from openmc.dummy_comm import DummyCommunicator
 from openmc.executor import _process_CLI_arguments
 from openmc.checkvalue import check_type, check_value
-
 from openmc.exceptions import InvalidIDError
 
 
@@ -237,6 +236,12 @@ class Model:
             MPI intracommunicator
         """
 
+        try:
+            import openmc.lib
+        except ImportError:
+            raise ImportError('openmc.lib must be available to '
+                'execute Model.init_lib(...)') from None
+
         # TODO: right now the only way to set most of the above parameters via
         # the C API are at initialization time despite use-cases existing to
         # set them for individual runs. For now this functionality is exposed
@@ -274,6 +279,12 @@ class Model:
         .. versionadded:: 0.13.0
 
         """
+
+        try:
+            import openmc.lib
+        except ImportError:
+            raise ImportError('openmc.lib must be available to '
+                              'execute Model.finalize_lib(...)') from None
 
         openmc.lib.finalize()
 
@@ -411,6 +422,12 @@ class Model:
         openmc.lib.export_properties
 
         """
+        try:
+            import openmc.lib
+        except ImportError:
+            raise ImportError('openmc.lib must be available to '
+                              'execute Model.import_properties(...)') from None
+
         cells = self.geometry.get_all_cells()
         materials = self.geometry.get_all_materials()
 
@@ -691,12 +708,13 @@ class Model:
         if obj_type == 'cell':
             by_name = self._cells_by_name
             by_id = self._cells_by_id
-            obj_by_id = openmc.lib.cells
+            if self.is_initialized:
+                obj_by_id = openmc.lib.cells
         else:
             by_name = self._materials_by_name
             by_id = self._materials_by_id
-            obj_by_id = openmc.lib.materials
-
+            if self.is_initialized:
+                obj_by_id = openmc.lib.materials
         # Get the list of ids to use if converting from names and accepting
         # only values that have actual ids
         ids = []

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1,11 +1,8 @@
 from collections.abc import Iterable
-import operator
 import os
 from pathlib import Path
 from numbers import Integral
 import time
-import warnings
-import subprocess
 from contextlib import contextmanager
 
 import h5py
@@ -16,14 +13,6 @@ from openmc.executor import _process_CLI_arguments
 from openmc.checkvalue import check_type, check_value
 
 from openmc.exceptions import InvalidIDError
-
-# Establish whether openmc.lib is available for downstream uses;
-# this avoids the need for extraneous try/import/except statements
-try:
-    import openmc.lib
-    _openmc_lib_present = True
-except ImportError:
-    _openmc_lib_present = False
 
 
 @contextmanager
@@ -146,9 +135,10 @@ class Model:
 
     @property
     def is_initialized(self):
-        if _openmc_lib_present:
+        try:
+            import openmc.lib
             return openmc.lib.is_initialized
-        else:
+        except ImportError:
             return False
 
     @geometry.setter
@@ -524,7 +514,8 @@ class Model:
                 for arg_name, arg, default in zip(
                     ['threads', 'geometry_debug', 'restart_file', 'tracks'],
                     [threads, geometry_debug, restart_file, tracks],
-                        [None, False, None, False]):
+                    [None, False, None, False]
+                ):
                     if arg != default:
                         msg = f"{arg_name} must be set via Model.is_initialized(...)"
                         raise ValueError(msg)


### PR DESCRIPTION
This PR fixes #1899 where openmc.lib was not necessarily available when executing the Model class. This was introduced in #1884.