### PR TITLE
Fix readthedocs build issue by pinning sphinx

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.9"
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements-rtd.txt

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -1,3 +1,4 @@
+sphinx==4.3.0
 sphinx-numfig
 jupyter
 sphinxcontrib-katex


### PR DESCRIPTION
Many of you may have noticed that documentation builds on readthedocs have been failing (see [here](https://github.com/readthedocs/readthedocs.org/issues/8616) if you're wondering why). This PR should fix this by pinning the version of Sphinx used for RTD builds.