### PR TITLE
Ensure particles lost during event_calculate_xs are terminated

### DIFF
--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -95,12 +95,10 @@ void run_particle_restart()
   int64_t particle_seed;
   switch (previous_run_mode) {
   case RunMode::EIGENVALUE:
+  case RunMode::FIXED_SOURCE:
     particle_seed = (simulation::total_gen + overall_generation() - 1) *
                       settings::n_particles +
                     p.id();
-    break;
-  case RunMode::FIXED_SOURCE:
-    particle_seed = p.id();
     break;
   default:
     throw std::runtime_error {

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -679,6 +679,8 @@ void transport_history_based_single_particle(Particle& p)
 {
   while (true) {
     p.event_calculate_xs();
+    if (!p.alive())
+      break;
     p.event_advance();
     if (p.collision_distance() > p.boundary().distance) {
       p.event_cross_surface();


### PR DESCRIPTION
A user recently [ran into a problem](https://openmc.discourse.group/t/warning-could-not-find-the-cell-containing-particle-505877/1493) where a lost particle results in the code segfaulting. After some investigation, I realized the reason this happens is because the particle gets marked as lost during `Particle::event_calculate_xs`:
https://github.com/openmc-dev/openmc/blob/02239256f673ea1b0c73501ae1f2feac4a17d129/src/particle.cpp#L106-L110

Even though it's marked as lost, there is no check right now between `event_calculate_xs` and `event_advance` that a particle is actually still alive, and so we end up accessing memory that we shouldn't. The quick fix is to just add a check for `p.alive()` in between these events. There is a deeper geometry problem at hand that results in the particle getting lost in the first place, but that will take a bit more work to resolve. In the meantime, we should at least ensure that lost particles don't result in segfaults, which is the goal of this PR.