### PR TITLE
`openmc.RegularMesh` attribute consistency

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -148,7 +148,10 @@ class RegularMesh(MeshBase):
             return self._upper_right
         elif self._width is not None:
             if self._lower_left is not None and self._dimension is not None:
-                return self._lower_left + self._width * self._dimension
+                ls = self._lower_left
+                ws = self._width
+                dims = self._dimension
+                return [l + w * d for l, w, d in zip(ls, ws, dims)]
 
     @property
     def width(self):
@@ -156,7 +159,10 @@ class RegularMesh(MeshBase):
             return self._width
         elif self._upper_right is not None:
             if self._lower_left is not None and self._dimension is not None:
-                return (self._upper_right - self._lower_left)/self._dimension
+                us = self._upper_right
+                ls = self._lower_left
+                dims =  self._dimension
+                return [(u - l) / d for u, l, d in zip(us, ls, dims)]
 
     @property
     def num_mesh_cells(self):
@@ -196,7 +202,7 @@ class RegularMesh(MeshBase):
     def upper_right(self, upper_right):
         cv.check_type('mesh upper_right', upper_right, Iterable, Real)
         cv.check_length('mesh upper_right', upper_right, 1, 3)
-        self._upper_right = np.asarray(upper_right)
+        self._upper_right = upper_right
 
         if self._width is not None:
             self._width = None
@@ -206,7 +212,7 @@ class RegularMesh(MeshBase):
     def width(self, width):
         cv.check_type('mesh width', width, Iterable, Real)
         cv.check_length('mesh width', width, 1, 3)
-        self._width = np.asarray(width)
+        self._width = width
 
         if self._upper_right is not None:
             self._upper_right = None

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -199,10 +199,10 @@ class RegularMesh(MeshBase):
     def __repr__(self):
         string = super().__repr__()
         string += '{0: <16}{1}{2}\n'.format('\tDimensions', '=\t', self.n_dimension)
-        string += '{0: <16}{1}{2}\n'.format('\tMesh Cells', '=\t', self._dimension)
-        string += '{0: <16}{1}{2}\n'.format('\tWidth', '=\t', self._lower_left)
-        string += '{0: <16}{1}{2}\n'.format('\tOrigin', '=\t', self._upper_right)
-        string += '{0: <16}{1}{2}\n'.format('\tPixels', '=\t', self._width)
+        string += '{0: <16}{1}{2}\n'.format('\tVoxels', '=\t', self._dimension)
+        string += '{0: <16}{1}{2}\n'.format('\tLower left', '=\t', self._lower_left)
+        string += '{0: <16}{1}{2}\n'.format('\tUpper Right', '=\t', self._upper_right)
+        string += '{0: <16}{1}{2}\n'.format('\tWidth', '=\t', self._width)
         return string
 
     @classmethod
@@ -727,7 +727,7 @@ class UnstructuredMesh(MeshBase):
 
     @length_multiplier.setter
     def length_multiplier(self, length_multiplier):
-        cv.check_type("Unstructured mesh length multiplier", 
+        cv.check_type("Unstructured mesh length multiplier",
                                 length_multiplier,
                                 Real)
         self._length_multiplier = length_multiplier

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -206,7 +206,7 @@ class RegularMesh(MeshBase):
 
         if self._width is not None:
             self._width = None
-            raise Warning("Unsetting width attribute.")
+            warnings.warn("Unsetting width attribute.")
 
     @width.setter
     def width(self, width):
@@ -216,7 +216,7 @@ class RegularMesh(MeshBase):
 
         if self._upper_right is not None:
             self._upper_right = None
-            raise Warning("Unsetting upper_right attribute.")
+            warnings.warn("Unsetting upper_right attribute.")
 
     def __repr__(self):
         string = super().__repr__()

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -749,7 +749,7 @@ RegularMesh::RegularMesh(pugi::xml_node node) : StructuredMesh {node}
   }
 
   if (check_for_node(node, "width")) {
-    // Make sure both upper-right or width were specified
+    // Make sure one of upper-right or width were specified
     if (check_for_node(node, "upper_right")) {
       fatal_error("Cannot specify both <upper_right> and <width> on a mesh.");
     }
@@ -790,7 +790,7 @@ RegularMesh::RegularMesh(pugi::xml_node node) : StructuredMesh {node}
     // Set width
     width_ = xt::eval((upper_right_ - lower_left_) / shape_);
   } else {
-    fatal_error("Must specify either <upper_right> and <width> on a mesh.");
+    fatal_error("Must specify either <upper_right> or <width> on a mesh.");
   }
 
   // Set volume fraction


### PR DESCRIPTION
This updates a couple of `RegularMesh` attributes and how they are read from statepoint files. Only one of the internal `RegularMesh._upper_right` and `RegularMesh_width` attributes can be populated at one time. If one of these values is already set, updating the other will clear the former's old value. 

```python
In [3]: m.width = (10., 10., 10.)

In [4]: m.upper_right = (10, 10, 10)
---------------------------------------------------------------------------
Warning                                   Traceback (most recent call last)
<ipython-input-4-650b7a0ef70b> in <module>
----> 1 m.upper_right = (10, 10, 10)

~/opt/openmc/openmc/openmc/mesh.py in upper_right(self, upper_right)
    207         if self._width is not None:
    208             self._width = None
--> 209             raise Warning("Unsetting width attribute.")
    210 
    211     @width.setter

Warning: Unsetting width attribute.
```

(I'm on the fence about raising a `Warning` when this happens.)

When the unset property is requested (e.g. `width` is requested while `upper_right` is set), the property will be evaluated and returned if the `lower_left` and `dimension` attributes are also set. If not those properties are not present, `None` will be returned.

This also changes the `from_hdf5` method to preferentially read the width attribute without reading `upper_right`.

Closes #1921.

Lastly, this has a couple of comment typo fixes in `mesh.cpp` too.