### PR TITLE
Added a space in a warning for multiplicity matrix values being 0

### DIFF
--- a/src/scattdata.cpp
+++ b/src/scattdata.cpp
@@ -49,7 +49,7 @@ void ScattData::base_init(int order, const xt::xtensor<int, 1>& in_gmin,
       // Raise a warning to the user if we did have to do the conversion
       std::string msg =
         std::to_string(num_converted) +
-        "entries in the Multiplicity Matrix were changed from 0 to 1";
+        " entries in the Multiplicity Matrix were changed from 0 to 1";
       warning(msg);
     }
 


### PR DESCRIPTION
A user question on discord (https://openmc.discourse.group/t/multigroup-multiplicity-matrix-message/1611) revealed that a space was missing in a warning message. this PR fixes this.