### PR TITLE
Miscellaneous bug fixes

### DIFF
--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -615,7 +615,8 @@ class ThermalScattering(EqualityMixin):
         ace_name, xs = ace.name.split('.')
         if not xs.endswith('t'):
             raise TypeError("{} is not a thermal scattering ACE table.".format(ace))
-        name = get_thermal_name(ace_name)
+        if name is None:
+            name = get_thermal_name(ace_name)
 
         # Assign temperature to the running list
         kTs = [ace.temperature*EV_PER_MEV]
@@ -783,9 +784,10 @@ class ThermalScattering(EqualityMixin):
 
             # Create instance from ACE tables within library
             lib = Library(kwargs['ace'])
-            data = cls.from_ace(lib.tables[0])
+            name = kwargs.get('table_name')
+            data = cls.from_ace(lib.tables[0], name=name)
             for table in lib.tables[1:]:
-                data.add_temperature_from_ace(table)
+                data.add_temperature_from_ace(table, name=name)
 
             # Load ENDF data to replace incoherent elastic
             if use_endf_data:

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -19,7 +19,6 @@ from warnings import warn
 from numpy import nonzero, empty, asarray
 from uncertainties import ufloat
 
-from openmc.data import DataLibrary
 from openmc.lib import MaterialFilter, Tally
 from openmc.checkvalue import check_type, check_greater_than
 from openmc.mpi import comm
@@ -70,10 +69,8 @@ class TransportOperator(ABC):
 
     Parameters
     ----------
-    chain_file : str, optional
-        Path to the depletion chain XML file.  Defaults to the file
-        listed under ``depletion_chain`` in
-        :envvar:`OPENMC_CROSS_SECTIONS` environment variable.
+    chain_file : str
+        Path to the depletion chain XML file
     fission_q : dict, optional
         Dictionary of nuclides and their fission Q values [eV]. If not given,
         values will be pulled from the ``chain_file``.
@@ -95,30 +92,12 @@ class TransportOperator(ABC):
         Results from a previous depletion calculation. ``None`` if no
         results are to be used.
     """
-    def __init__(self, chain_file=None, fission_q=None, dilute_initial=1.0e3,
+    def __init__(self, chain_file, fission_q=None, dilute_initial=1.0e3,
                  prev_results=None):
         self.dilute_initial = dilute_initial
         self.output_dir = '.'
 
         # Read depletion chain
-        if chain_file is None:
-            chain_file = os.environ.get("OPENMC_DEPLETE_CHAIN", None)
-            if chain_file is None:
-                data = DataLibrary.from_xml()
-                # search for depletion_chain path from end of list
-                for lib in reversed(data.libraries):
-                    if lib['type'] == 'depletion_chain':
-                        break
-                else:
-                    raise IOError(
-                        "No chain specified, either manually or "
-                        "under depletion_chain in environment variable "
-                        "OPENMC_CROSS_SECTIONS.")
-                chain_file = lib['path']
-            else:
-                warn("Use of OPENMC_DEPLETE_CHAIN is deprecated in favor "
-                     "of adding depletion_chain to OPENMC_CROSS_SECTIONS",
-                     FutureWarning)
         self.chain = Chain.from_xml(chain_file, fission_q)
         if prev_results is None:
             self.prev_res = None

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -700,14 +700,7 @@ class Material(IDManagerMixin):
         cv.check_type('S(a,b) fraction', fraction, Real)
         cv.check_greater_than('S(a,b) fraction', fraction, 0.0, True)
         cv.check_less_than('S(a,b) fraction', fraction, 1.0, True)
-
-        new_name = openmc.data.get_thermal_name(name)
-        if new_name != name:
-            msg = 'OpenMC S(a,b) tables follow the GND naming convention. ' \
-                  'Table "{}" is being renamed as "{}".'.format(name, new_name)
-            warnings.warn(msg)
-
-        self._sab.append((new_name, fraction))
+        self._sab.append((name, fraction))
 
     def make_isotropic_in_lab(self):
         self.isotropic = [x.name for x in self._nuclides]

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1,10 +1,11 @@
 from collections.abc import Iterable
+from contextlib import contextmanager
 from functools import lru_cache
 import os
 from pathlib import Path
 from numbers import Integral
+from tempfile import NamedTemporaryFile
 import time
-from contextlib import contextmanager
 
 import h5py
 
@@ -528,8 +529,11 @@ class Model:
         """
 
         # Setting tstart here ensures we don't pick up any pre-existing
-        # statepoint files in the output directory
-        tstart = time.time()
+        # statepoint files in the output directory -- just in case there are
+        # differences between the system clock and the filesystem, we get the
+        # time of a just-created temporary file
+        with NamedTemporaryFile() as fp:
+            tstart = Path(fp.name).stat().st_mtime
         last_statepoint = None
 
         # Operate in the provided working directory

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -46,12 +46,11 @@ vector<unique_ptr<Source>> external_sources;
 // IndependentSource implementation
 //==============================================================================
 
-IndependentSource::IndependentSource(UPtrSpace space, UPtrAngle angle, UPtrDist energy, UPtrDist time)
-  : space_{std::move(space)},
-    angle_{std::move(angle)},
-    energy_{std::move(energy)},
-    time_{std::move(time)}
-{ }
+IndependentSource::IndependentSource(
+  UPtrSpace space, UPtrAngle angle, UPtrDist energy, UPtrDist time)
+  : space_ {std::move(space)}, angle_ {std::move(angle)},
+    energy_ {std::move(energy)}, time_ {std::move(time)}
+{}
 
 IndependentSource::IndependentSource(pugi::xml_node node)
 {
@@ -150,7 +149,7 @@ IndependentSource::IndependentSource(pugi::xml_node node)
       // Default to a Constant time T=0
       double T[] {0.0};
       double p[] {1.0};
-      time_ = UPtrDist {new Discrete{T, p, 1}};
+      time_ = UPtrDist {new Discrete {T, p, 1}};
     }
   }
 }
@@ -238,7 +237,7 @@ SourceSite IndependentSource::sample(uint64_t* seed) const
 
   // Sample particle creation time
   site.time = time_->sample(seed);
-  
+
   return site;
 }
 

--- a/tests/unit_tests/test_deplete_operator.py
+++ b/tests/unit_tests/test_deplete_operator.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 from openmc.deplete.abc import TransportOperator
-from openmc.deplete.chain import Chain
+from openmc.deplete.chain import Chain, _find_chain_file
 
 BARE_XS_FILE = "bare_cross_sections.xml"
 CHAIN_PATH = Path(__file__).parents[1] / "chain_simple.xml"
@@ -31,7 +31,7 @@ def bare_xs(run_in_tmpdir):
     with open(BARE_XS_FILE, "w") as out:
         out.write(bare_xs_contents)
 
-    yield
+    yield BARE_XS_FILE
 
 
 class BareDepleteOperator(TransportOperator):
@@ -54,14 +54,10 @@ class BareDepleteOperator(TransportOperator):
         pass
 
 
-@mock.patch.dict(environ, {"OPENMC_CROSS_SECTIONS": BARE_XS_FILE})
 def test_operator_init(bare_xs):
-    """The test will set and unset environment variable OPENMC_CROSS_SECTIONS
-    to point towards a temporary dummy file. This file will be removed
-    at the end of the test, and only contains a
-    depletion_chain node."""
-    # force operator to read from OPENMC_CROSS_SECTIONS
-    bare_op = BareDepleteOperator(chain_file=None)
+    """The test uses a temporary dummy chain. This file will be removed
+    at the end of the test, and only contains a depletion_chain node."""
+    bare_op = BareDepleteOperator(_find_chain_file(bare_xs))
     act_chain = bare_op.chain
     ref_chain = Chain.from_xml(CHAIN_PATH)
     assert len(act_chain) == len(ref_chain)


### PR DESCRIPTION
This PR has a few small bug fixes:

1. There's a fix for #1945 so that you can pass `table_name` when caling `ThermalScattering.from_njoy` and it won't try to guess a name
2. A user [noticed](https://openmc.discourse.group/t/depletion-calculation-no-xsection-xml-error/1577) that when they tried to run a depletion calculation and specify cross sections using `Materials.cross_sections` (but not setting `OPENMC_CROSS_SECTIONS`) they ran into an exception. It turns out that the `Operator._get_nuclides_with_data` method always tried to find what nuclides have neutron data by just looking at the environment variable but not `Materials.cross_sections`. This has been fixed in this PR and I've tried to better encapsulate the logic for finding cross sections / depletion chains into single places (the `_find_cross_sections` and `_find_chain_file` functions).
3. There's a fix for #1939