### PR TITLE
Remove `MAX_WORD_LEN` and `MAX_LINE_LEN` constants.

### DIFF
--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -57,11 +57,6 @@ constexpr double FP_COINCIDENT {1e-12};
 constexpr int MAX_EVENTS {1000000};
 constexpr int MAX_SAMPLE {100000};
 
-// Maximum number of words in a single line, length of line, and length of
-// single word
-constexpr int MAX_LINE_LEN {250};
-constexpr int MAX_WORD_LEN {150};
-
 // Maximum number of external source spatial resamples to encounter before an
 // error is thrown.
 constexpr int EXTSRC_REJECT_THRESHOLD {10000};

--- a/include/openmc/hdf5_interface.h
+++ b/include/openmc/hdf5_interface.h
@@ -76,7 +76,7 @@ int dataset_ndims(hid_t dset);
 size_t dataset_typesize(hid_t obj_id, const char* name);
 hid_t file_open(const char* filename, char mode, bool parallel);
 void file_close(hid_t file_id);
-void get_name(hid_t obj_id, char* name);
+void get_name(hid_t obj_id, std::string& name);
 int get_num_datasets(hid_t group_id);
 int get_num_groups(hid_t group_id);
 void get_datasets(hid_t group_id, char* name[]);

--- a/src/hdf5_interface.cpp
+++ b/src/hdf5_interface.cpp
@@ -215,10 +215,12 @@ void file_close(hid_t file_id)
   H5Fclose(file_id);
 }
 
-void get_name(hid_t obj_id, char* name)
+void get_name(hid_t obj_id, std::string& name)
 {
   size_t size = 1 + H5Iget_name(obj_id, nullptr, 0);
-  H5Iget_name(obj_id, name, size);
+  name.resize(size);
+  // TODO: switch to name.data() when using C++17
+  H5Iget_name(obj_id, &name[0], size);
 }
 
 int get_num_datasets(hid_t group_id)

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -63,9 +63,8 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
   vector<int>& temps_to_read, int& order_dim)
 {
   // get name
-  char char_name[MAX_WORD_LEN];
-  get_name(xs_id, char_name);
-  std::string in_name {char_name};
+  std::string in_name;
+  get_name(xs_id, in_name);
   // remove the leading '/'
   in_name = in_name.substr(1);
 
@@ -168,8 +167,8 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
   // Load the remaining metadata
   AngleDistributionType in_scatter_format;
   if (attribute_exists(xs_id, "scatter_format")) {
-    std::string temp_str(MAX_WORD_LEN, ' ');
-    read_attr_string(xs_id, "scatter_format", MAX_WORD_LEN, &temp_str[0]);
+    std::string temp_str;
+    read_attribute(xs_id, "scatter_format", temp_str);
     to_lower(strtrim(temp_str));
     if (temp_str.compare(0, 8, "legendre") == 0) {
       in_scatter_format = AngleDistributionType::LEGENDRE;
@@ -185,8 +184,8 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
   }
 
   if (attribute_exists(xs_id, "scatter_shape")) {
-    std::string temp_str(MAX_WORD_LEN, ' ');
-    read_attr_string(xs_id, "scatter_shape", MAX_WORD_LEN, &temp_str[0]);
+    std::string temp_str;
+    read_attribute(xs_id, "scatter_shape", temp_str);
     to_lower(strtrim(temp_str));
     if (temp_str.compare(0, 14, "[g][g\'][order]") != 0) {
       fatal_error("Invalid scatter_shape option!");
@@ -223,8 +222,8 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
   int in_n_azi;
   bool in_is_isotropic = true;
   if (attribute_exists(xs_id, "representation")) {
-    std::string temp_str(MAX_WORD_LEN, ' ');
-    read_attr_string(xs_id, "representation", MAX_WORD_LEN, &temp_str[0]);
+    std::string temp_str;
+    read_attribute(xs_id, "representation", temp_str);
     to_lower(strtrim(temp_str));
     if (temp_str.compare(0, 5, "angle") == 0) {
       in_is_isotropic = false;


### PR DESCRIPTION
I was going through our constants today and noticed that these two were only used in a few places in the multi-group cross section code and realized we don't need them anymore. Getting rid of `MAX_WORD_LEN` required a small change in the function signature of `get_name` and `MAX_LINE_LEN` isn't needed with the right call to `read_attribute`.