### PR TITLE
Prepare for version 0.13.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2021 Massachusetts Institute of Technology, UChicago Argonne
+Copyright (c) 2011-2022 Massachusetts Institute of Technology, UChicago Argonne
 LLC, and OpenMC contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,7 +62,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'OpenMC'
-copyright = '2011-2021, Massachusetts Institute of Technology, UChicago Argonne LLC, and OpenMC contributors'
+copyright = '2011-2022, Massachusetts Institute of Technology, UChicago Argonne LLC, and OpenMC contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -4,7 +4,7 @@
 License Agreement
 =================
 
-Copyright © 2011-2021 Massachusetts Institute of Technology, UChicago Argonne
+Copyright © 2011-2022 Massachusetts Institute of Technology, UChicago Argonne
 LLC, and OpenMC contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/docs/source/methods/geometry.rst
+++ b/docs/source/methods/geometry.rst
@@ -490,14 +490,14 @@ where
 .. math::
     :label: dist-xtorus-4
 
-    \begin{align*}
+    \begin{aligned}
     c_2 &= Du^2 + v^2 + w^2 \\
     c_1 &= 2(Du\bar{x} + v\bar{y} + w\bar{z}) \\
     c_0 &= D\bar{x}^2 + \bar{y}^2 + \bar{z}^2 + A^2 - C^2 \\
     c_2' &= 4A^2 (v^2 + w^2) \\
     c_1' &= 8A^2 (v\bar{y} + w\bar{z}) \\
     c_0' &= 4A^2(\bar{y}^2 + \bar{z}^2).
-    \end{align*}
+    \end{aligned}
 
 Expanding the left-hand side and collecting like powers of :math:`d` on one
 side, we obtain

--- a/docs/source/pythonapi/base.rst
+++ b/docs/source/pythonapi/base.rst
@@ -90,6 +90,7 @@ Building geometry
    openmc.Complement
    openmc.Cell
    openmc.Universe
+   openmc.DAGMCUniverse
    openmc.RectLattice
    openmc.HexLattice
    openmc.Geometry
@@ -143,6 +144,8 @@ Constructing Tallies
    openmc.ParticleFilter
    openmc.RegularMesh
    openmc.RectilinearMesh
+   openmc.CylindricalMesh
+   openmc.SphericalMesh
    openmc.UnstructuredMesh
    openmc.Trigger
    openmc.TallyDerivative

--- a/docs/source/pythonapi/capi.rst
+++ b/docs/source/pythonapi/capi.rst
@@ -13,10 +13,12 @@ Functions
    :template: myfunction.rst
 
    calculate_volumes
+   export_properties
    finalize
    find_cell
    find_material
    hard_reset
+   import_properties
    init
    iter_batches
    keff

--- a/docs/source/releasenotes/0.13.0.rst
+++ b/docs/source/releasenotes/0.13.0.rst
@@ -30,7 +30,7 @@ New Features
   :class:`~openmc.WeightWindows` class.
 - Users can now model axis-aligned tori using the :class:`~openmc.XTorus`,
   :class:`~openmc.YTorus`, and :class:`~openmc.ZTorus` classes.
-- DAGMC CAD-based geometries can now be placed in a single universe using
+- DAGMC CAD-based geometries can now be placed in a universe using
   :class:`~openmc.DAGMCUniverse`, allowing users to combine CSG and CAD-based
   geometry in a single model.
 - The C/C++ API has two new functions ``openmc_properties_export`` and

--- a/docs/source/releasenotes/0.13.0.rst
+++ b/docs/source/releasenotes/0.13.0.rst
@@ -1,0 +1,100 @@
+====================
+What's New in 0.13.0
+====================
+
+.. currentmodule:: openmc
+
+-------
+Summary
+-------
+
+This release of OpenMC includes several noteworthy and unique features. Most
+importantly, mesh-based weight windows have been added and work with all
+supported mesh types (regular, rectilinear, cylindrical, spherical, and
+unstructured). Other additions include torus surfaces, an ability to place
+CAD-based geometries in universes, a feature to export/import physical
+properties, and a filter for particle time.
+
+There is one breaking changing in the Python API. The
+:class:`openmc.deplete.Operator` class used to accept :class:`~openmc.Geometry`
+and :class:`~openmc.Settings` objects as its first two arguments; users now need
+to pass a :class:`~openmc.model.Model` class instead.
+
+The minimum supported Python version is now 3.6.
+
+------------
+New Features
+------------
+
+- Variance reduction using mesh-based weight windows is now possible with the
+  :class:`~openmc.WeightWindows` class.
+- Users can now model axis-aligned tori using the :class:`~openmc.XTorus`,
+  :class:`~openmc.YTorus`, and :class:`~openmc.ZTorus` classes.
+- DAGMC CAD-based geometries can now be placed in a single universe using
+  :class:`~openmc.DAGMCUniverse`, allowing users to combine CSG and CAD-based
+  geometry in a single model.
+- The C/C++ API has two new functions ``openmc_properties_export`` and
+  ``openmc_properties_import`` with corresponding Python API bindings,
+  :func:`~openmc.lib.export_properties` and
+  :func:`~openmc.lib.import_properties`. These functions allow physical
+  properties (temperatures, densities, material compositions) to be written to
+  an HDF5 file and re-used for subsequent simulations.
+- A new :class:`~openmc.stats.PowerLaw` univariate distribution
+- The capabilities of the :class:`~openmc.Model` class have been substantially
+  expanded (e.g., the :meth:`~openmc.model.Model.deplete`,
+  :meth:`~openmc.model.Model.plot_geometry`, and
+  :meth:`~openmc.model.Model.rotate_cells` methods).
+- A new :class:`~openmc.TimeFilter` class that allows tallies to be filtered
+  by the particle's time, which is now tracked.
+- The :class:`~openmc.Source` class now allows you to specify a time
+  distribution.
+- The new :class:`~openmc.CylindricalMesh` and :class:`~openmc.SphericalMesh`
+  can be used for mesh tallies over cylidrical and spherical meshes,
+  respectively.
+- Geometry plotting, which used to produce the files in the unusual .ppm format,
+  now produces .png files by default.
+
+---------
+Bug Fixes
+---------
+
+- `Fix for shared fission bank memory errors <https://github.com/openmc-dev/openmc/pull/1856>`_
+- `Make sure properties export only happens from root process <https://github.com/openmc-dev/openmc/pull/1864>`_
+- `Fix pathlib use error in openmc-ace-to-hdf5 <https://github.com/openmc-dev/openmc/pull/1867>`_
+- `Fix DAGMC and libMesh variable in CMake config <https://github.com/openmc-dev/openmc/pull/1870>`_
+- `Fix bug associated with volume calc in MG mode <https://github.com/openmc-dev/openmc/pull/1889>`_
+- `Add missing Settings.write_initial_source property <https://github.com/openmc-dev/openmc/pull/1895>`_
+- `Bug fixes for specifying Materials.cross_sections <https://github.com/openmc-dev/openmc/pull/1898>`_
+- `Removing Legendre filter in diffusion coefficient results <https://github.com/openmc-dev/openmc/pull/1909>`_
+- `Ensure particles lost during event_calculate_xs are terminated <https://github.com/openmc-dev/openmc/pull/1911>`_
+- `Fixed parsing of xsdir entries with a continuation line <https://github.com/openmc-dev/openmc/pull/1913>`_
+- `openmc.RegularMesh attribute consistency <https://github.com/openmc-dev/openmc/pull/1922>`_
+- `Ensure secondary particles below energy cutoff are not created <https://github.com/openmc-dev/openmc/pull/1924>`_
+- `Allow compilation with g++ 11 <https://github.com/openmc-dev/openmc/pull/1938>`_
+- `Depletion-related bug fixes <https://github.com/openmc-dev/openmc/pull/1946>`_
+- `Miscellaneous bug fixes <https://github.com/openmc-dev/openmc/pull/1948>`_
+- `Fixes for various bugs <https://github.com/openmc-dev/openmc/pull/1949>`_
+- `Reset triggers in openmc_reset <https://github.com/openmc-dev/openmc/issues/1957>`_
+
+------------
+Contributors
+------------
+
+- `Hunter Belanger <https://github.com/HunterBelanger>`_
+- `Helen Brooks <https://github.com/helen-brooks>`_
+- `Andrew Davis <https://github.com/makeclean>`_
+- `Valerio Giusti <https://github.com/valeriogiusti>`_
+- `Jeff Hammond <https://github.com/jeffhammond>`_
+- `Yuan Hu <https://github.com/YuanHu-PKU-KIT>`_
+- `Andrew Johnson <https://github.com/drewejohnson>`_
+- `Miriam Kreher <https://github.com/mkreher13>`_
+- `Amanda Lund <https://github.com/amandalund>`_
+- `Adam Nelson <https://github.com/nelsonag>`_
+- `April Novak <https://github.com/aprilnovak>`_
+- `Ariful Islam Pranto <https://github.com/AI-Pranto>`_
+- `Gavin Ridley <https://github.com/gridley>`_
+- `Paul Romano <https://github.com/paulromano>`_
+- `Olaf Schumann <https://github.com/ojschumann>`_
+- `Jonathan Shimwell <https://github.com/Shimwell>`_
+- `Patrick Shriwise <https://github.com/pshriwise>`_
+- `John Tramm <https://github.com/jtramm>`_

--- a/docs/source/releasenotes/index.rst
+++ b/docs/source/releasenotes/index.rst
@@ -7,6 +7,7 @@ Release Notes
 .. toctree::
   :maxdepth: 1
 
+  0.13.0
   0.12.2
   0.12.1
   0.12.0

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -274,7 +274,9 @@ Prerequisites
 .. _MPICH: https://www.mpich.org
 .. _HDF5: https://www.hdfgroup.org/solutions/hdf5/
 .. _DAGMC: https://svalinn.github.io/DAGMC/index.html
+.. _MOAB: https://bitbucket.org/fathomteam/moab
 .. _libMesh: https://libmesh.github.io/
+.. _libpng: http://www.libpng.org/pub/png/libpng.html
 
 Obtaining the Source
 --------------------

--- a/examples/assembly/assembly.py
+++ b/examples/assembly/assembly.py
@@ -131,6 +131,8 @@ if __name__ == '__main__':
     parser.add_argument('--generate', action='store_true')
     parser.add_argument('--run', action='store_true')
     args = parser.parse_args()
+    if not args.generate and not args.run:
+        parser.print_help()
 
     if args.generate or args.run:
         model = assembly_model()

--- a/examples/custom_source/source_ring.cpp
+++ b/examples/custom_source/source_ring.cpp
@@ -10,9 +10,8 @@ class RingSource : public openmc::Source
   openmc::SourceSite sample(uint64_t* seed) const
   {
     openmc::SourceSite particle;
-    // wgt
+    // particle type
     particle.particle = openmc::ParticleType::neutron;
-    particle.wgt = 1.0;
     // position
     double angle = 2.0 * M_PI * openmc::prn(seed);
     double radius = 3.0;
@@ -22,7 +21,6 @@ class RingSource : public openmc::Source
     // angle
     particle.u = {1.0, 0.0, 0.0};
     particle.E = 14.08e6;
-    particle.delayed_group = 0;
     return particle;
   }
 };

--- a/examples/parameterized_custom_source/parameterized_source_ring.cpp
+++ b/examples/parameterized_custom_source/parameterized_source_ring.cpp
@@ -34,9 +34,8 @@ class RingSource : public openmc::Source {
     openmc::SourceSite sample(uint64_t* seed) const
     {
       openmc::SourceSite particle;
-      // wgt
+      // particle type
       particle.particle = openmc::ParticleType::neutron;
-      particle.wgt = 1.0;
       // position
       double angle = 2.0 * M_PI * openmc::prn(seed);
       double radius = this->radius_;
@@ -46,7 +45,6 @@ class RingSource : public openmc::Source {
       // angle
       particle.u = {1.0, 0.0, 0.0};
       particle.E = this->energy_;
-      particle.delayed_group = 0;
 
       return particle;
     }

--- a/man/man1/openmc.1
+++ b/man/man1/openmc.1
@@ -57,7 +57,7 @@ Indicates the default path to an HDF5 file that contains multi-group cross
 section libraries if the user has not specified the <cross_sections> tag in
 .I materials.xml\fP.
 .SH LICENSE
-Copyright \(co 2011-2021 Massachusetts Institute of Technology, UChicago
+Copyright \(co 2011-2022 Massachusetts Institute of Technology, UChicago
 Argonne LLC, and OpenMC contributors.
 .PP
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/man/man1/openmc.1
+++ b/man/man1/openmc.1
@@ -80,7 +80,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 The OpenMC source code is hosted on GitHub at
 https://github.com/openmc-dev/openmc. With a github account, you can submit issues
 directly on the github repository that will then be reviewed by OpenMC
-developers. Alternatively, you can send a bug report to
-.I openmc-users@googlegroups.com\fP.
+developers. Alternatively, you can post a message on the discussion forum at
+https://openmc.discourse.group.
 .SH AUTHOR
 Paul K. Romano (\fIpaul.k.romano@gmail.com\fP)

--- a/openmc/deplete/integrators.py
+++ b/openmc/deplete/integrators.py
@@ -21,11 +21,8 @@ class PredictorIntegrator(Integrator):
     mathematically defined as:
 
     .. math::
-        \begin{aligned}
-        y' &= A(y, t) y(t) \\
-        A_p &= A(y_n, t_n) \\
-        y_{n+1} &= \text{expm}(A_p h) y_n
-        \end{aligned}
+        \mathbf{n}_{i+1} = \exp\left(h\mathbf{A}(\mathbf{n}_i) \right) \mathbf{n}_i
+
     """
     _num_stages = 1
 
@@ -72,11 +69,10 @@ class CECMIntegrator(Integrator):
 
     .. math::
         \begin{aligned}
-        y' &= A(y, t) y(t) \\
-        A_p &= A(y_n, t_n) \\
-        y_m &= \text{expm}(A_p h/2) y_n \\
-        A_c &= A(y_m, t_n + h/2) \\
-        y_{n+1} &= \text{expm}(A_c h) y_n
+        \mathbf{n}_{i+1/2} &= \exp \left (\frac{h}{2}\mathbf{A}(\mathbf{n}_i)
+            \right) \mathbf{n}_i \\
+        \mathbf{n}_{i+1} &= \exp \left(h \mathbf{A}(\mathbf{n}_{i+1/2}) \right)
+            \mathbf{n}_i.
         \end{aligned}
     """
     _num_stages = 2
@@ -128,15 +124,18 @@ class CF4Integrator(Integrator):
 
     .. math::
         \begin{aligned}
-        F_1 &= h A(y_0) \\
-        y_1 &= \text{expm}(1/2 F_1) y_0 \\
-        F_2 &= h A(y_1) \\
-        y_2 &= \text{expm}(1/2 F_2) y_0 \\
-        F_3 &= h A(y_2) \\
-        y_3 &= \text{expm}(-1/2 F_1 + F_3) y_1 \\
-        F_4 &= h A(y_3) \\
-        y_4 &= \text{expm}( 1/4  F_1 + 1/6 F_2 + 1/6 F_3 - 1/12 F_4)
-               \text{expm}(-1/12 F_1 + 1/6 F_2 + 1/6 F_3 + 1/4  F_4) y_0
+        \mathbf{A}_1 &= h\mathbf{A}(\mathbf{n}_0) \\
+        \hat{\mathbf{n}}_1 &= \exp \left ( \frac{\mathbf{A}_1}{2} \right ) \\
+        \mathbf{A}_2 &= h\mathbf{A}(\hat{\mathbf{n}}_1) \\
+        \hat{\mathbf{n}}_2 &= \exp \left ( \frac{\mathbf{A}_2}{2} \right ) \\
+        \mathbf{A}_3 &= h \mathbf{A}(\hat{\mathbf{n}}_2) \\
+        \hat{\mathbf{n}}_3 &= \exp \left ( -\frac{\mathbf{A}_1}{2} + \mathbf{A}_3
+            \right ) \\
+        \mathbf{A}_4 &= h\mathbf{A}(\hat{\mathbf{n}}_3) \\
+        \mathbf{n}_{i+1} &= \exp \left ( \frac{\mathbf{A}_1}{4} + \frac{\mathbf{A}_2}{6}
+            + \frac{\mathbf{A}_3}{6} - \frac{\mathbf{A}_4}{12} \right )
+        \exp \left ( -\frac{\mathbf{A}_1}{12} + \frac{\mathbf{A}_2}{6} +
+            \frac{\mathbf{A}_3}{6} - \frac{\mathbf{A}_4}{4} \right ) \mathbf{n}_i.
         \end{aligned}
     """
     _num_stages = 4
@@ -208,12 +207,11 @@ class CELIIntegrator(Integrator):
 
     .. math::
         \begin{aligned}
-        y' &= A(y, t) y(t) \\
-        A_0 &= A(y_n, t_n) \\
-        y_p &= \text{expm}(h A_0) y_n \\
-        A_1 &= A(y_p, t_n + h) \\
-        y_{n+1} &= \text{expm}(\frac{h}{12} A_0 + \frac{5h}{12} A1)
-                   \text{expm}(\frac{5h}{12} A_0 + \frac{h}{12} A1) y_n
+        \mathbf{n}_{i+1}^p &= \exp \left ( h \mathbf{A}(\mathbf{n}_i ) \right ) \\
+        \mathbf{n}_{i+1} &= \exp \left( \frac{h}{12} \mathbf{A}(\mathbf{n}_i) +
+            \frac{5h}{12} \mathbf{A}(\mathbf{n}_{i+1}^p) \right)
+        \exp \left( \frac{5h}{12} \mathbf{A}(\mathbf{n}_i) +
+        \frac{h}{12} \mathbf{A}(\mathbf{n}_{i+1}^p) \right) \mathbf{n}_i.
         \end{aligned}
     """
     _num_stages = 2
@@ -270,14 +268,15 @@ class EPCRK4Integrator(Integrator):
 
     .. math::
         \begin{aligned}
-        F_1 &= h A(y_0) \\
-        y_1 &= \text{expm}(1/2 F_1) y_0 \\
-        F_2 &= h A(y_1) \\
-        y_2 &= \text{expm}(1/2 F_2) y_0 \\
-        F_3 &= h A(y_2) \\
-        y_3 &= \text{expm}(F_3) y_0 \\
-        F_4 &= h A(y_3) \\
-        y_4 &= \text{expm}(1/6 F_1 + 1/3 F_2 + 1/3 F_3 + 1/6 F_4) y_0
+        \mathbf{A}_1 &= h\mathbf{A}(\mathbf{n}_0) \\
+        \hat{\mathbf{n}}_1 &= \exp \left ( \frac{\mathbf{A}_1}{2} \right ) \\
+        \mathbf{A}_2 &= h\mathbf{A}(\hat{\mathbf{n}}_1) \\
+        \hat{\mathbf{n}}_2 &= \exp \left ( \frac{\mathbf{A}_2}{2} \right ) \\
+        \mathbf{A}_3 &= h \mathbf{A}(\hat{\mathbf{n}}_2) \\
+        \hat{\mathbf{n}}_3 &= \exp \left ( \mathbf{A}_3 \right ) \\
+        \mathbf{A}_4 &= h\mathbf{A}(\hat{\mathbf{n}}_3) \\
+        \mathbf{n}_{i+1} &= \exp \left ( \frac{\mathbf{A}_1}{6} + \frac{\mathbf{A}_2}{3}
+        + \frac{\mathbf{A}_3}{3} + \frac{\mathbf{A}_4}{6} \right ) \mathbf{n}_i.
         \end{aligned}
     """
     _num_stages = 4
@@ -345,20 +344,23 @@ class LEQIIntegrator(Integrator):
 
     .. math::
         \begin{aligned}
-        y' &= A(y, t) y(t) \\
-        A_{last} &= A(y_{n-1}, t_n - h_1) \\
-        A_0 &= A(y_n, t_n) \\
-        F_1 &= \frac{-h_2^2}{12h_1} A_{last} + \frac{h_2(6h_1+h_2)}{12h_1} A_0 \\
-        F_2 &= \frac{-5h_2^2}{12h_1} A_{last} + \frac{h_2(6h_1+5h_2)}{12h_1} A_0 \\
-        y_p &= \text{expm}(F_2) \text{expm}(F_1) y_n \\
-        A_1 &= A(y_p, t_n + h_2) \\
-        F_3 &= \frac{-h_2^3}{12 h_1 (h_1 + h_2)} A_{last} +
-              \frac{h_2 (5 h_1^2 + 6 h_2 h_1 + h_2^2)}{12 h_1 (h_1 + h_2)} A_0 +
-              \frac{h_2 h_1)}{12 (h_1 + h_2)} A_1 \\
-        F_4 &= \frac{-h_2^3}{12 h_1 (h_1 + h_2)} A_{last} +
-              \frac{h_2 (h_1^2 + 2 h_2 h_1 + h_2^2)}{12 h_1 (h_1 + h_2)} A_0 +
-              \frac{h_2 (5 h_1^2 + 4 h_2 h_1)}{12 h_1 (h_1 + h_2)} A_1 \\
-        y_{n+1} &= \text{expm}(F_4) \text{expm}(F_3) y_n
+        \mathbf{A}_{-1} &= \mathbf{A}(\mathbf{n}_{i-1}) \\
+        \mathbf{A}_0 &= \mathbf{A}(\mathbf{n}_i) \\
+        \mathbf{F}_1 &= \frac{-h_i}{12h_{i-1}} \mathbf{A}_{-1} + \frac{6h_{i-1}
+            + h_i}{12h_{i-1}} \mathbf{A}_0 \\
+        \mathbf{F}_2 &= \frac{-5h_i}{12h_{i-1}} \mathbf{A}_{-1} + \frac{6h_{i-1}
+            + 5h_i}{12h_{i-1}} \mathbf{A}_0 \\
+        \mathbf{n}_{i+1}^p &= \exp (h_i \mathbf{F}_1) \exp(h_i \mathbf{F}_2)
+            \mathbf{n}_i \\
+        \mathbf{A}_1 &= \mathbf{A}(\mathbf{n}_{i+1}^p) \\
+        \mathbf{F}_3 &= \frac{-h_i^2}{12 h_{i-1} (h_{i-1} + h_i)} \mathbf{A}_{-1} +
+              \frac{5 h_{i-1}^2 + 6 h_i h_{i-1} + h_i^2}{12 h_{i-1} (h_{i-1} +
+              h_i)} \mathbf{A}_0 + \frac{h_{i-1}}{12 (h_{i-1} + h_i)} \mathbf{A}_1 \\
+        \mathbf{F}_4 &= \frac{-h_i^2}{12 h_{i-1} (h_{i-1} + h_i)} \mathbf{A}_{-1} +
+              \frac{h_{i-1}^2 + 2 h_i h_{i-1} + h_i^2}{12 h_{i-1} (h_{i-1} + h_i)}
+              \mathbf{A}_0 + \frac{5 h_{i-1}^2 + 4 h_i h_{i-1}}{12 h_{i-1}
+              (h_{i-1} + h_i)} \mathbf{A}_1 \\
+        \mathbf{n}_{i+1} &= \exp(h_i \mathbf{F}_4) \exp(h_i \mathbf{F}_3) \mathbf{n}_i
         \end{aligned}
 
     It is initialized using the CE/LI algorithm.
@@ -591,4 +593,5 @@ integrator_by_name = {
     'si_celi': SICELIIntegrator,
     'si_leqi': SILEQIIntegrator,
     'celi': CELIIntegrator,
-    'leqi': LEQIIntegrator}
+    'leqi': LEQIIntegrator
+}

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -510,20 +510,20 @@ class CellFilter(WithIDFilter):
 
 
 class CellFromFilter(WithIDFilter):
-    """Bins tally on which Cell the neutron came from.
+    """Bins tally on which cell the particle came from.
 
     Parameters
     ----------
     bins : openmc.Cell, Integral, or iterable thereof
-        The Cell(s) to tally. Either openmc.Cell objects or their
-        Integral ID numbers can be used.
+        The cell(s) to tally. Either :class:`openmc.Cell` objects or their
+        integral ID numbers can be used.
     filter_id : int
         Unique identifier for the filter
 
     Attributes
     ----------
     bins : Integral or Iterable of Integral
-        openmc.Cell IDs.
+        Cell IDs.
     id : int
         Unique identifier for the filter
     num_bins : Integral
@@ -534,20 +534,20 @@ class CellFromFilter(WithIDFilter):
 
 
 class CellbornFilter(WithIDFilter):
-    """Bins tally events based on which Cell the neutron was born in.
+    """Bins tally events based on which cell the particle was born in.
 
     Parameters
     ----------
     bins : openmc.Cell, Integral, or iterable thereof
-        The birth Cells to tally. Either openmc.Cell objects or their
-        Integral ID numbers can be used.
+        The birth cells to tally. Either :class:`openmc.Cell` objects or their
+        integral ID numbers can be used.
     filter_id : int
         Unique identifier for the filter
 
     Attributes
     ----------
     bins : Iterable of Integral
-        openmc.Cell IDs.
+        Cell IDs.
     id : int
         Unique identifier for the filter
     num_bins : Integral

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1354,6 +1354,8 @@ class EnergyoutFilter(EnergyFilter):
 class TimeFilter(RealFilter):
     """Bins tally events based on the particle's time.
 
+    .. versionadded:: 0.13.0
+
     Parameters
     ----------
     values : iterable of float

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -144,8 +144,7 @@ def current_batch():
 def export_properties(filename=None, output=True):
     """Export physical properties.
 
-    .. versionchanged:: 0.13.0
-        The *output* argument was added.
+    .. versionadded:: 0.13.0
 
     Parameters
     ----------
@@ -227,6 +226,8 @@ def hard_reset():
 
 def import_properties(filename):
     """Import physical properties.
+
+    .. versionadded:: 0.13.0
 
     Parameters
     ----------

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -781,7 +781,7 @@ class Model:
         The rotation is only applied to cells filled with a universe.
 
         .. note:: If applying this change to a name that is not unique, then
-        the change will be applied to all objects of that name.
+                  the change will be applied to all objects of that name.
 
         .. versionadded:: 0.13.0
 
@@ -803,7 +803,7 @@ class Model:
         The translation is only applied to cells filled with a universe.
 
         .. note:: If applying this change to a name that is not unique, then
-        the change will be applied to all objects of that name.
+                  the change will be applied to all objects of that name.
 
         .. versionadded:: 0.13.0
 
@@ -825,7 +825,7 @@ class Model:
         """Update the density of a given set of materials to a new value
 
         .. note:: If applying this change to a name that is not unique, then
-        the change will be applied to all objects of that name.
+                  the change will be applied to all objects of that name.
 
         .. versionadded:: 0.13.0
 
@@ -848,7 +848,7 @@ class Model:
         """Update the temperature of a set of cells to the given value
 
         .. note:: If applying this change to a name that is not unique, then
-        the change will be applied to all objects of that name.
+                  the change will be applied to all objects of that name.
 
         .. versionadded:: 0.13.0
 
@@ -869,7 +869,7 @@ class Model:
         """Update the volume of a set of materials to the given value
 
         .. note:: If applying this change to a name that is not unique, then
-        the change will be applied to all objects of that name.
+                  the change will be applied to all objects of that name.
 
         .. versionadded:: 0.13.0
 

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1566,6 +1566,8 @@ class Settings:
     def from_xml(cls, path='settings.xml'):
         """Generate settings from XML file
 
+        .. versionadded:: 0.13.0
+
         Parameters
         ----------
         path : str, optional

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -244,10 +244,13 @@ class Uniform(Univariate):
         params = get_text(elem, 'parameters').split()
         return cls(*map(float, params))
 
+
 class PowerLaw(Univariate):
     """Distribution with power law probability over a finite interval [a,b]
-    
+
     The power law distribution has density function :math:`p(x) dx = c x^n dx`.
+
+    .. versionadded:: 0.13.0
 
     Parameters
     ----------
@@ -914,6 +917,8 @@ class Mixture(Univariate):
     def to_xml_element(self, element_name):
         """Return XML representation of the mixture distribution
 
+        .. versionadded:: 0.13.0
+
         Parameters
         ----------
         element_name : str
@@ -938,6 +943,8 @@ class Mixture(Univariate):
     @classmethod
     def from_xml_element(cls, elem):
         """Generate mixture distribution from an XML element
+
+        .. versionadded:: 0.13.0
 
         Parameters
         ----------

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -2193,6 +2193,8 @@ class XTorus(TorusMixin, Surface):
     r"""A torus of the form :math:`(x - x_0)^2/B^2 + (\sqrt{(y - y_0)^2 + (z -
     z_0)^2} - A)^2/C^2 - 1 = 0`.
 
+    .. versionadded:: 0.13.0
+
     Parameters
     ----------
     x0 : float
@@ -2262,6 +2264,8 @@ class YTorus(TorusMixin, Surface):
     r"""A torus of the form :math:`(y - y_0)^2/B^2 + (\sqrt{(x - x_0)^2 + (z -
     z_0)^2} - A)^2/C^2 - 1 = 0`.
 
+    .. versionadded:: 0.13.0
+
     Parameters
     ----------
     x0 : float
@@ -2330,6 +2334,8 @@ class YTorus(TorusMixin, Surface):
 class ZTorus(TorusMixin, Surface):
     r"""A torus of the form :math:`(z - z_0)^2/B^2 + (\sqrt{(x - x_0)^2 + (y -
     y_0)^2} - A)^2/C^2 - 1 = 0`.
+
+    .. versionadded:: 0.13.0
 
     Parameters
     ----------

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -869,6 +869,8 @@ class Tally(IDManagerMixin):
     def from_xml_element(cls, elem, **kwargs):
         """Generate tally object from an XML element
 
+        .. versionadded:: 0.13.0
+
         Parameters
         ----------
         elem : xml.etree.ElementTree.Element

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -629,6 +629,8 @@ class Universe(UniverseBase):
 class DAGMCUniverse(UniverseBase):
     """A reference to a DAGMC file to be used in the model.
 
+    .. versionadded:: 0.13.0
+
     Parameters
     ----------
     filename : str

--- a/openmc/volume.py
+++ b/openmc/volume.py
@@ -358,6 +358,8 @@ class VolumeCalculation:
     def from_xml_element(cls, elem):
         """Generate volume calculation object from an XML element
 
+        .. versionadded:: 0.13.0
+
         Parameters
         ----------
         elem : xml.etree.ElementTree.Element

--- a/openmc/weight_windows.py
+++ b/openmc/weight_windows.py
@@ -18,7 +18,7 @@ class WeightWindows(IDManagerMixin):
     This class enables you to specify weight window parameters that are used in
     a simulation. Multiple sets of weight windows can be defined for different
     meshes and different particles. An iterable of :class:`WeightWindows`
-    instances can be assigned to the :attr:`~openmc.Settings.weight_windows`
+    instances can be assigned to the :attr:`openmc.Settings.weight_windows`
     attribute, which is then exported to XML.
 
     Weight window lower/upper bounds are to be specified for each combination of

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ kwargs = {
 
     # Metadata
     'author': 'The OpenMC Development Team',
-    'author_email': 'openmc-dev@googlegroups.com',
+    'author_email': 'openmc@anl.gov',
     'description': 'OpenMC',
     'url': 'https://openmc.org',
     'download_url': 'https://github.com/openmc-dev/openmc/releases',

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -73,7 +73,7 @@ void title()
   // Write version information
   fmt::print(
     "                 | The OpenMC Monte Carlo Code\n"
-    "       Copyright | 2011-2021 MIT, UChicago Argonne LLC, and contributors\n"
+    "       Copyright | 2011-2022 MIT, UChicago Argonne LLC, and contributors\n"
     "         License | https://docs.openmc.org/en/latest/license.html\n"
     "         Version | {}.{}.{}{}\n",
     VERSION_MAJOR, VERSION_MINOR, VERSION_RELEASE, VERSION_DEV ? "-dev" : "");
@@ -335,7 +335,7 @@ void print_version()
 #ifdef GIT_SHA1
     fmt::print("Git SHA1: {}\n", GIT_SHA1);
 #endif
-    fmt::print("Copyright (c) 2011-2021 MIT, UChicago Argonne LLC, and "
+    fmt::print("Copyright (c) 2011-2022 MIT, UChicago Argonne LLC, and "
                "contributors\nMIT/X license at "
                "<https://docs.openmc.org/en/latest/license.html>\n");
   }


### PR DESCRIPTION
This PR makes some final changes before we officially release version 0.13.0:

- Adds release notes
- Adds missing documentation, missing `.. versionadded` tags
- Updates equations in docstrings for depletion integrators to be consistent with the [journal article](https://doi.org/10.1016/j.anucene.2020.107989) we wrote describing the implementation in OpenMC.
- Other cosmetic changes