### PR TITLE
Acceleration for Cell::find_parent_cells.

### DIFF
--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -169,6 +169,7 @@ public:
   //! Get all cell instances contained by this cell
   //! \param[in] instance Instance of the cell for which to get contained cells
   //! (default instance is zero)
+  //! \param[in] hint positional hint for determining the parent cells
   //! \return Map with cell indexes as keys and
   //! instances as values
   std::unordered_map<int32_t, vector<int32_t>> get_contained_cells(
@@ -176,8 +177,24 @@ public:
 
 protected:
   //! Determine the path to this cell instance in the geometry hierarchy
+  //! \param[in] instance of the cell to find parent cells for
+  //! \param[in] r position used to do a fast search for parent cells
+  //! \return parent cells
   vector<ParentCell> find_parent_cells(
-    int32_t instance, Position* hint = nullptr) const;
+    int32_t instance, const Position& r) const;
+
+  //! Determine the path to this cell instance in the geometry hierarchy
+  //! \param[in] instance of the cell to find parent cells for
+  //! \param[in] p particle used to do a fast search for parent cells
+  //! \return parent cells
+  vector<ParentCell> find_parent_cells(
+    int32_t instance, Particle& p) const;
+
+  //! Determine the path to this cell instance in the geometry hierarchy
+  //! \param[in] instance of the cell to find parent cells for
+  //! \return parent cells
+  vector<ParentCell> find_parent_cells_exhaustive(
+    int32_t instance) const;
 
   //! Inner function for retrieving contained cells
   void get_contained_cells_inner(

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -193,7 +193,7 @@ protected:
   //! Determine the path to this cell instance in the geometry hierarchy
   //! \param[in] instance of the cell to find parent cells for
   //! \return parent cells
-  vector<ParentCell> find_parent_cells_exhaustive(
+  vector<ParentCell> exhaustive_find_parent_cells(
     int32_t instance) const;
 
   //! Inner function for retrieving contained cells

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -172,11 +172,12 @@ public:
   //! \return Map with cell indexes as keys and
   //! instances as values
   std::unordered_map<int32_t, vector<int32_t>> get_contained_cells(
-    int32_t instance = 0) const;
+    int32_t instance = 0, Position* hint = nullptr) const;
 
 protected:
   //! Determine the path to this cell instance in the geometry hierarchy
-  vector<ParentCell> find_parent_cells(int32_t instance) const;
+  vector<ParentCell> find_parent_cells(
+    int32_t instance, Position* hint = nullptr) const;
 
   //! Inner function for retrieving contained cells
   void get_contained_cells_inner(

--- a/include/openmc/lattice.h
+++ b/include/openmc/lattice.h
@@ -99,6 +99,11 @@ public:
   virtual void get_indices(
     Position r, Direction u, array<int, 3>& result) const = 0;
 
+  //! \brief Compute the the flat index for a set of lattice cell indices
+  //! \param i_xyz The indices for a lattice cell
+  //! \return Flat index into the universes vector
+  virtual int get_flat_index(const array<int, 3>& i_xyz) const = 0;
+
   //! \brief Get coordinates local to a lattice tile.
   //! \param r A 3D Cartesian coordinate.
   //! \param i_xyz The indices for a lattice tile.
@@ -210,6 +215,8 @@ public:
 
   void get_indices(Position r, Direction u, array<int, 3>& result) const;
 
+  int get_flat_index(const array<int, 3>& i_xyz) const;
+
   Position get_local_position(Position r, const array<int, 3>& i_xyz) const;
 
   int32_t& offset(int map, array<int, 3> const& i_xyz);
@@ -244,6 +251,8 @@ public:
     Position r, Direction u, const array<int, 3>& i_xyz) const;
 
   void get_indices(Position r, Direction u, array<int, 3>& result) const;
+
+  int get_flat_index(const array<int, 3>& i_xyz) const;
 
   Position get_local_position(Position r, const array<int, 3>& i_xyz) const;
 

--- a/include/openmc/lattice.h
+++ b/include/openmc/lattice.h
@@ -100,8 +100,8 @@ public:
     Position r, Direction u, array<int, 3>& result) const = 0;
 
   //! \brief Compute the the flat index for a set of lattice cell indices
-  //! \param i_xyz The indices for a lattice cell
-  //! \return Flat index into the universes vector
+  //! \param i_xyz The indices for a lattice cell.
+  //! \return Flat index into the universes vector.
   virtual int get_flat_index(const array<int, 3>& i_xyz) const = 0;
 
   //! \brief Get coordinates local to a lattice tile.

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -341,6 +341,8 @@ public:
   const int& cell_instance() const { return cell_instance_; }
   LocalCoord& coord(int i) { return coord_[i]; }
   const LocalCoord& coord(int i) const { return coord_[i]; }
+  const vector<LocalCoord>& coord() const { return coord_; }
+
 
   int& n_coord_last() { return n_coord_last_; }
   const int& n_coord_last() const { return n_coord_last_; }

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1317,13 +1317,64 @@ struct ParentCellStack {
 };
 
 vector<ParentCell> Cell::find_parent_cells(
-  int32_t instance, Position* hint) const
+  int32_t instance, const Position& r) const {
+
+  // create a temporary particle
+  Particle dummy_particle {};
+  dummy_particle.clear();
+  dummy_particle.r() = r;
+  dummy_particle.u() = {0., 0., 1.};
+
+  return find_parent_cells(instance, dummy_particle);
+}
+
+vector<ParentCell> Cell::find_parent_cells(
+  int32_t instance, Particle& p) const {
+  // look up the particle's location
+  openmc::exhaustive_find_cell(p);
+  const auto& coords = p.coord();
+
+  // build a parent cell stack from the particle coordinates
+  ParentCellStack stack;
+  bool cell_found = false;
+  for (auto it = coords.begin(); it != coords.end(); it++) {
+    const auto& coord = *it;
+    auto& cell = model::cells[coord.cell];
+    // if the cell at this level matches the current cell, stop adding to the stack
+    if (coord.cell == model::cell_map[this->id_]) {
+      cell_found = true;
+      break;
+    }
+
+    // if filled with a lattice, get the lattice index from the next
+    // level in the coordinates to push to the stack
+    int lattice_idx = C_NONE;
+    if (cell->type_ == Fill::LATTICE) {
+      const auto& next_coord = *(it + 1);
+      lattice_idx = model::lattices[next_coord.lattice]->get_flat_index(next_coord.lattice_i);
+    }
+    stack.push(coord.universe, {coord.cell, lattice_idx});
+  }
+
+  // if this loop finished because the cell was found and
+  // the instance matches the one requested in the call
+  // we have the correct path and can return the stack
+  if (cell_found && stack.compute_instance(this->distribcell_index_) == instance) {
+    return stack.parent_cells();
+  }
+
+  // fall back on an exhaustive search for the cell's parents
+  return find_parent_cells_exhaustive(instance);
+}
+
+
+vector<ParentCell> Cell::find_parent_cells_exhaustive(
+  int32_t instance) const
 {
   ParentCellStack stack;
   // start with this cell's universe
   int32_t prev_univ_idx;
   int32_t univ_idx = this->universe_;
-  bool hint_used = false;
 
   while (true) {
     const auto& univ = model::universes[univ_idx];
@@ -1352,38 +1403,26 @@ vector<ParentCell> Cell::find_parent_cells(
         const auto& lattice = model::lattices[cell->fill_];
         const auto& lattice_univs = lattice->universes_;
 
-        // if a hint position is provided, look up the lattice cell
-        // for that position
-        if (hint && !hint_used) {
-          std::array<int, 3> hint_idx;
-          lattice->get_indices(*hint, Direction(0.0, 0.0, 0.0), hint_idx);
-          int hint_offset = lattice->get_flat_index(hint_idx);
-          if (univ_idx == lattice_univs[hint_offset]) {
-            hint_used = true;
-            stack.push(univ_idx, {model::cell_map[cell->id_], hint_offset});
-          }
-        } else {
-          // start search for universe
-          auto lat_it = lattice_univs.begin();
-          while (true) {
-            // find the next lattice cell with this universe
-            lat_it = std::find(lat_it, lattice_univs.end(), univ_idx);
-            if (lat_it == lattice_univs.end())
-              break;
-
-            int lattice_idx = lat_it - lattice_univs.begin();
-
-            // move iterator forward one to avoid finding the same entry
-            lat_it++;
-            if (stack.visited(
-                  univ_idx, {model::cell_map[cell->id_], lattice_idx}))
-              continue;
-
-            // add this cell and lattice index to the stack and exit loop
-            stack.push(univ_idx, {model::cell_map[cell->id_], lattice_idx});
-            univ_idx = cell->universe_;
+        // start search for universe
+        auto lat_it = lattice_univs.begin();
+        while (true) {
+          // find the next lattice cell with this universe
+          lat_it = std::find(lat_it, lattice_univs.end(), univ_idx);
+          if (lat_it == lattice_univs.end())
             break;
-          }
+
+          int lattice_idx = lat_it - lattice_univs.begin();
+
+          // move iterator forward one to avoid finding the same entry
+          lat_it++;
+          if (stack.visited(
+                univ_idx, {model::cell_map[cell->id_], lattice_idx}))
+            continue;
+
+          // add this cell and lattice index to the stack and exit loop
+          stack.push(univ_idx, {model::cell_map[cell->id_], lattice_idx});
+          univ_idx = cell->universe_;
+          break;
         }
       }
       // if we've updated the universe, break
@@ -1426,7 +1465,14 @@ std::unordered_map<int32_t, vector<int32_t>> Cell::get_contained_cells(
     return contained_cells;
 
   // find the pathway through the geometry to this cell
-  vector<ParentCell> parent_cells = this->find_parent_cells(instance, hint);
+  vector<ParentCell> parent_cells;
+
+  // if a positional hint is provided, attempt to do a fast lookup
+  // of the parent cells
+  if (hint)
+    parent_cells = find_parent_cells(instance, *hint);
+  else
+    parent_cells = find_parent_cells_exhaustive(instance);
 
   // if this cell is filled w/ a material, it contains no other cells
   if (type_ != Fill::MATERIAL) {

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1364,11 +1364,11 @@ vector<ParentCell> Cell::find_parent_cells(
   }
 
   // fall back on an exhaustive search for the cell's parents
-  return find_parent_cells_exhaustive(instance);
+  return exhaustive_find_parent_cells(instance);
 }
 
 
-vector<ParentCell> Cell::find_parent_cells_exhaustive(
+vector<ParentCell> Cell::exhaustive_find_parent_cells(
   int32_t instance) const
 {
   ParentCellStack stack;
@@ -1472,7 +1472,7 @@ std::unordered_map<int32_t, vector<int32_t>> Cell::get_contained_cells(
   if (hint)
     parent_cells = find_parent_cells(instance, *hint);
   else
-    parent_cells = find_parent_cells_exhaustive(instance);
+    parent_cells = exhaustive_find_parent_cells(instance);
 
   // if this cell is filled w/ a material, it contains no other cells
   if (type_ != Fill::MATERIAL) {

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1321,7 +1321,6 @@ vector<ParentCell> Cell::find_parent_cells(
 
   // create a temporary particle
   Particle dummy_particle {};
-  dummy_particle.clear();
   dummy_particle.r() = r;
   dummy_particle.u() = {0., 0., 1.};
 
@@ -1331,7 +1330,7 @@ vector<ParentCell> Cell::find_parent_cells(
 vector<ParentCell> Cell::find_parent_cells(
   int32_t instance, Particle& p) const {
   // look up the particle's location
-  openmc::exhaustive_find_cell(p);
+  exhaustive_find_cell(p);
   const auto& coords = p.coord();
 
   // build a parent cell stack from the particle coordinates
@@ -1339,7 +1338,7 @@ vector<ParentCell> Cell::find_parent_cells(
   bool cell_found = false;
   for (auto it = coords.begin(); it != coords.end(); it++) {
     const auto& coord = *it;
-    auto& cell = model::cells[coord.cell];
+    const auto& cell = model::cells[coord.cell];
     // if the cell at this level matches the current cell, stop adding to the stack
     if (coord.cell == model::cell_map[this->id_]) {
       cell_found = true;
@@ -1469,10 +1468,8 @@ std::unordered_map<int32_t, vector<int32_t>> Cell::get_contained_cells(
 
   // if a positional hint is provided, attempt to do a fast lookup
   // of the parent cells
-  if (hint)
-    parent_cells = find_parent_cells(instance, *hint);
-  else
-    parent_cells = exhaustive_find_parent_cells(instance);
+  parent_cells = hint ? find_parent_cells(instance, *hint)
+                      : exhaustive_find_parent_cells(instance);
 
   // if this cell is filled w/ a material, it contains no other cells
   if (type_ != Fill::MATERIAL) {

--- a/src/lattice.cpp
+++ b/src/lattice.cpp
@@ -215,9 +215,7 @@ RectLattice::RectLattice(pugi::xml_node lat_node) : Lattice {lat_node}
 
 int32_t const& RectLattice::operator[](array<int, 3> const& i_xyz)
 {
-  int indx =
-    n_cells_[0] * n_cells_[1] * i_xyz[2] + n_cells_[0] * i_xyz[1] + i_xyz[0];
-  return universes_[indx];
+  return universes_[get_flat_index(i_xyz)];
 }
 
 //==============================================================================
@@ -321,6 +319,12 @@ void RectLattice::get_indices(
       result[2] = std::floor(iz_);
     }
   }
+}
+
+int RectLattice::get_flat_index(const array<int, 3>& i_xyz) const
+{
+  return n_cells_[0] * n_cells_[1] * i_xyz[2] + n_cells_[0] * i_xyz[1] +
+         i_xyz[0];
 }
 
 //==============================================================================
@@ -662,9 +666,7 @@ void HexLattice::fill_lattice_y(const vector<std::string>& univ_words)
 
 int32_t const& HexLattice::operator[](array<int, 3> const& i_xyz)
 {
-  int indx = (2 * n_rings_ - 1) * (2 * n_rings_ - 1) * i_xyz[2] +
-             (2 * n_rings_ - 1) * i_xyz[1] + i_xyz[0];
-  return universes_[indx];
+  return universes_[get_flat_index(i_xyz)];
 }
 
 //==============================================================================
@@ -927,6 +929,12 @@ void HexLattice::get_indices(
   // update outgoing indices
   result[0] += i1_chg;
   result[1] += i2_chg;
+}
+
+int HexLattice::get_flat_index(const array<int, 3>& i_xyz) const
+{
+  return (2 * n_rings_ - 1) * (2 * n_rings_ - 1) * i_xyz[2] +
+         (2 * n_rings_ - 1) * i_xyz[1] + i_xyz[0];
 }
 
 //==============================================================================


### PR DESCRIPTION
In Cardinal, cells in the OpenMC domain are mapped to a MOOSE mesh mirror using element centroids for transfer of heating values out and temperature feedback in. It is possible to use non material-filled cells are used as tally regions for heating. When temperatures are passed into OpenMC, updating temperatures on tally cells that aren't material-filled has no affect on the simulation, so the contained cells (and instances) under the tally cell are gathered using the `Cell::get_contained_cells` method. Because the tally cell is a specific instance of a cell, we require the entire path through the geometry to compute the correct contained cell instances under the tally cell. In `Cell::find_parent_cells`, the path from the root to the tally cell instance is currently discovered by a search for the right path "upward" through the universe/latttice levels (from the tally cell instance to the root universe of the geometry). This can be extremely slow if one or more lattices exist in those levels of the geometry.

The element centroids (or vertex averages) originally used to map the tally cells can be used to greatly accelerate this search, however, and are already associated with the correct tally cell in Cardinal when the contained cells are requested. By passing the centroid as a  "hint" to the `Cell::find_parent_cells` method OpenMC can perform a `find_cell` operation to determine the path from the root universe to the tally cell instance much faster than the brute search. In case a faulty hint is provided to the method, the cell instance at the appropriate level of the geometry can be checked. If the cell instance is incorrect, the method will fall back on the exhaustive search.

Note: The original `Cell::find_parent_cell` has been renamed `Cell::exhaustive_find_parent_cell`.