### PR TITLE
Return all bin indices for filters not specified in `Tally.get_filter_indices`

### DIFF
--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -1092,9 +1092,6 @@ class Tally(IDManagerMixin):
         for i, self_filter in enumerate(self.filters):
             # If a user-requested Filter, get the user-requested bins
             for j, test_filter in enumerate(filters):
-                if type(self_filter) is openmc.EnergyFunctionFilter:
-                    indices = [self_filter.get_bin_index(None)]
-                    break
                 if type(self_filter) is test_filter:
                     bins = filter_bins[j]
                     indices = np.array([self_filter.get_bin_index(b) for b in bins])


### PR DESCRIPTION
Introducing a change when providing all indices of a filter's bins in `Tally.get_filter_indices` for cases where the filter is not specified. Right now as the method collects bin indices for each filter on the `Tally` object, the method calls `Filter.get_bin_index` for every filter bin regardless of whether or not specific bins were specified on the filter in the function call in the `filters` argument.

The method should safely (and more quickly) be able to use a set of indices generated by `np.arange(len(bins))` for filters not specified in the `filters` argument. As I understand it, this array is what would be produced were we to perform the `Filter.get_bin_index` calls sequentially anyway since we want the full set of bins.

The downside here is that this approach bypasses some checking that occurs in each Filter's `get_bin_index` method. Looking at our current set of filters, it shouldn't be a problem, but there's a chance it might bite us in the future. Based on the patterns present for the `EnergyFunctionFilter`, however, I think the filter will be different enough that it will be clear what unique treatment is needed.