### PR TITLE
Add Reaction::xs methods

### DIFF
--- a/include/openmc/reaction.h
+++ b/include/openmc/reaction.h
@@ -9,6 +9,7 @@
 #include "hdf5.h"
 #include <gsl/gsl-lite.hpp>
 
+#include "openmc/particle_data.h"
 #include "openmc/reaction_product.h"
 #include "openmc/vector.h"
 
@@ -26,6 +27,18 @@ public:
   //! \param[in] group HDF5 group containing reaction data
   //! \param[in] temperatures Desired temperatures for cross sections
   explicit Reaction(hid_t group, const vector<int>& temperatures);
+
+  //! Calculate cross section given temperautre/grid index, interpolation factor
+  //
+  //! \param[in] i_temp Temperature index
+  //! \param[in] i_grid Energy grid index
+  //! \param[in] interp_factor Interpolation factor between grid points
+  double xs(gsl::index i_temp, gsl::index i_grid, double interp_factor) const;
+
+  //! Calculate cross section
+  //
+  //! \param[in] micro Microscopic cross section cache
+  double xs(const NuclideMicroXS& micro) const;
 
   //! \brief Calculate reaction rate based on group-wise flux distribution
   //

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -541,23 +541,15 @@ Reaction& sample_fission(int i_nuclide, Particle& p)
     }
   }
 
-  // Get grid index and interpolatoin factor and sample fission cdf
-  int i_temp = p.neutron_xs(i_nuclide).index_temp;
-  int i_grid = p.neutron_xs(i_nuclide).index_grid;
-  double f = p.neutron_xs(i_nuclide).interp_factor;
+  // Get grid index and interpolation factor and sample fission cdf
+  const auto& micro = p.neutron_xs(i_nuclide);
   double cutoff = prn(p.current_seed()) * p.neutron_xs(i_nuclide).fission;
   double prob = 0.0;
 
   // Loop through each partial fission reaction type
   for (auto& rx : nuc->fission_rx_) {
-    // if energy is below threshold for this reaction, skip it
-    int threshold = rx->xs_[i_temp].threshold;
-    if (i_grid < threshold)
-      continue;
-
     // add to cumulative probability
-    prob += (1.0 - f) * rx->xs_[i_temp].value[i_grid - threshold] +
-            f * rx->xs_[i_temp].value[i_grid - threshold + 1];
+    prob += rx->xs(micro);
 
     // Create fission bank sites if fission occurs
     if (prob > cutoff)
@@ -573,25 +565,20 @@ void sample_photon_product(
   int i_nuclide, Particle& p, int* i_rx, int* i_product)
 {
   // Get grid index and interpolation factor and sample photon production cdf
-  int i_temp = p.neutron_xs(i_nuclide).index_temp;
-  int i_grid = p.neutron_xs(i_nuclide).index_grid;
-  double f = p.neutron_xs(i_nuclide).interp_factor;
-  double cutoff = prn(p.current_seed()) * p.neutron_xs(i_nuclide).photon_prod;
+  const auto& micro = p.neutron_xs(i_nuclide);
+  double cutoff = prn(p.current_seed()) * micro.photon_prod;
   double prob = 0.0;
 
   // Loop through each reaction type
   const auto& nuc {data::nuclides[i_nuclide]};
   for (int i = 0; i < nuc->reactions_.size(); ++i) {
-    const auto& rx = nuc->reactions_[i];
-    int threshold = rx->xs_[i_temp].threshold;
-
-    // if energy is below threshold for this reaction, skip it
-    if (i_grid < threshold)
-      continue;
-
     // Evaluate neutron cross section
-    double xs = ((1.0 - f) * rx->xs_[i_temp].value[i_grid - threshold] +
-                 f * (rx->xs_[i_temp].value[i_grid - threshold + 1]));
+    const auto& rx = nuc->reactions_[i];
+    double xs = rx->xs(micro);
+
+    // if cross section is zero for this reaction, skip it
+    if (xs == 0.0)
+      continue;
 
     for (int j = 0; j < rx->products_.size(); ++j) {
       if (rx->products_[j].particle_ == ParticleType::photon) {
@@ -663,8 +650,6 @@ void scatter(Particle& p, int i_nuclide)
   const auto& nuc {data::nuclides[i_nuclide]};
   const auto& micro {p.neutron_xs(i_nuclide)};
   int i_temp = micro.index_temp;
-  int i_grid = micro.index_grid;
-  double f = micro.interp_factor;
 
   // For tallying purposes, this routine might be called directly. In that
   // case, we need to sample a reaction via the cutoff variable
@@ -718,14 +703,8 @@ void scatter(Particle& p, int i_nuclide)
         fatal_error("Did not sample any reaction for nuclide " + nuc->name_);
       }
 
-      // if energy is below threshold for this reaction, skip it
-      const auto& xs {nuc->reactions_[i]->xs_[i_temp]};
-      if (i_grid < xs.threshold)
-        continue;
-
       // add to cumulative probability
-      prob += (1.0 - f) * xs.value[i_grid - xs.threshold] +
-              f * xs.value[i_grid - xs.threshold + 1];
+      prob += nuc->reactions_[i]->xs(micro);
     }
 
     // Perform collision physics for inelastic scattering

--- a/src/reaction.cpp
+++ b/src/reaction.cpp
@@ -65,6 +65,23 @@ Reaction::Reaction(hid_t group, const vector<int>& temperatures)
   }
 }
 
+double Reaction::xs(
+  gsl::index i_temp, gsl::index i_grid, double interp_factor) const
+{
+  // If energy is below threshold, return 0. Otherwise interpolate between
+  // nearest grid points
+  const auto& x = xs_[i_temp];
+  return (i_grid < x.threshold)
+           ? 0.0
+           : (1.0 - interp_factor) * x.value[i_grid - x.threshold] +
+               interp_factor * x.value[i_grid - x.threshold + 1];
+}
+
+double Reaction::xs(const NuclideMicroXS& micro) const
+{
+  return this->xs(micro.index_temp, micro.index_grid, micro.interp_factor);
+}
+
 double Reaction::collapse_rate(gsl::index i_temp,
   gsl::span<const double> energy, gsl::span<const double> flux,
   const vector<double>& grid) const


### PR DESCRIPTION
This PR adds two `Reaction::xs` methods that are intended to reduce duplicated code. This is something I had implemented in our (non-public) GPU port, so this PR just helps to reduce some of the code delta between that and the main `develop` branch.