### PR TITLE
pinned NJOY version added import openmc test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -46,3 +46,6 @@ openmc/lib/plot.py @pshriwise
 
 # Resonance covariance
 openmc/data/resonance_covariance.py @icmeyer
+
+# Docker
+Dockerfile @shimwell

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,7 @@ RUN if [ "$build_dagmc" = "on" ]; then \
         && make 2>/dev/null -j${compile_cores} install \
         && cd pymoab && bash install.sh \
         && python setup.py install \
+        && python -c "import pymoab" \
         && rm -rf $HOME/MOAB ; \
         # Clone and install Double-Down
         mkdir -p $HOME/Double_down && cd $HOME/Double_down \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ ENV LIBMESH_REPO='https://github.com/libMesh/libmesh'
 ENV LIBMESH_INSTALL_DIR=$HOME/LIBMESH
 
 # NJOY variables
-ENV NJOY_TAG='2016.65'
 ENV NJOY_REPO='https://github.com/njoy/NJOY2016'
 
 # Setup environment variables for Docker image
@@ -80,7 +79,7 @@ RUN pip install --upgrade pip
 
 # Clone and install NJOY2016
 RUN cd $HOME \
-    && git clone --single-branch -b ${NJOY_TAG} --depth 1 ${NJOY_REPO} \
+    && git clone --single-branch --depth 1 ${NJOY_REPO} \
     && cd NJOY2016 \
     && mkdir build \
     && cd build \


### PR DESCRIPTION
Following on from PR #1977 this PR adds a tiny test to the Docker file to check that openmc is importable with the ```python -c "import openmc"``` line in the last layer of the docker image

If the python package for openmc is not installed correctly at this stage then we would see the following error and the docker file would fail to build
```
ModuleNotFoundError: No module named 'openmc'
```

I also noticed that we git clone specific tags of everything apart from NJOY, so refactored the NJOY clone to look more like the other git clones and pinned the version to the latest release.

Additionally I noticed DAGMC was not pinned to s a specific version so I also pinned that to the latest release.