### PR TITLE
Remove alive_ data member on ParticleData

### DIFF
--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -363,7 +363,7 @@ public:
   const double& time() const { return time_; }
   double& time_last() { return time_last_; }
   const double& time_last() const { return time_last_; }
-  bool alive() { return wgt_ != 0.0; }
+  bool alive() const { return wgt_ != 0.0; }
 
   Position& r_last_current() { return r_last_current_; }
   const Position& r_last_current() const { return r_last_current_; }

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -235,7 +235,6 @@ private:
   double mu_;              //!< angle of scatter
   double time_ {0.0};      //!< time in [s]
   double time_last_ {0.0}; //!< previous time in [s]
-  bool alive_ {true};      //!< is particle alive?
 
   // Other physical data
   Position r_last_current_; //!< coordinates of the last collision or
@@ -309,7 +308,8 @@ private:
 
   // Weight window information
   int n_split_ {0}; // Number of times this particle has been split
-  double ww_factor_ {0.0}; // Particle-specific factor for on-the-fly weight window adjustment
+  double ww_factor_ {
+    0.0}; // Particle-specific factor for on-the-fly weight window adjustment
 
 // DagMC state variables
 #ifdef DAGMC
@@ -342,7 +342,6 @@ public:
   const LocalCoord& coord(int i) const { return coord_[i]; }
   const vector<LocalCoord>& coord() const { return coord_; }
 
-
   int& n_coord_last() { return n_coord_last_; }
   const int& n_coord_last() const { return n_coord_last_; }
   int& cell_last(int i) { return cell_last_[i]; }
@@ -364,7 +363,7 @@ public:
   const double& time() const { return time_; }
   double& time_last() { return time_last_; }
   const double& time_last() const { return time_last_; }
-  bool& alive() { return alive_; }
+  bool alive() { return wgt_ > 0.0; }
 
   Position& r_last_current() { return r_last_current_; }
   const Position& r_last_current() const { return r_last_current_; }

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -363,7 +363,7 @@ public:
   const double& time() const { return time_; }
   double& time_last() { return time_last_; }
   const double& time_last() const { return time_last_; }
-  bool alive() { return wgt_ > 0.0; }
+  bool alive() { return wgt_ != 0.0; }
 
   Position& r_last_current() { return r_last_current_; }
   const Position& r_last_current() const { return r_last_current_; }

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -86,7 +86,6 @@ void Particle::from_source(const SourceSite* src)
 {
   // Reset some attributes
   clear();
-  alive() = true;
   surface() = 0;
   cell_born() = C_NONE;
   material() = C_NONE;
@@ -333,7 +332,7 @@ void Particle::event_revive_from_secondary()
   if (n_event() == MAX_EVENTS) {
     warning("Particle " + std::to_string(id()) +
             " underwent maximum number of events.");
-    alive() = false;
+    wgt() = 0.0;
   }
 
   // Check for secondary particles if this particle is dead
@@ -483,9 +482,6 @@ void Particle::cross_surface()
 
 void Particle::cross_vacuum_bc(const Surface& surf)
 {
-  // Kill the particle
-  alive() = false;
-
   // Score any surface current tallies -- note that the particle is moved
   // forward slightly so that if the mesh boundary is on the surface, it is
   // still processed
@@ -500,6 +496,9 @@ void Particle::cross_vacuum_bc(const Surface& surf)
 
   // Score to global leakage tally
   keff_tally_leakage() += wgt();
+
+  // Kill the particle
+  wgt() = 0.0;
 
   // Display message
   if (settings::verbosity >= 10 || trace()) {
@@ -618,7 +617,7 @@ void Particle::mark_as_lost(const char* message)
   write_restart();
 
   // Increment number of lost particles
-  alive() = false;
+  wgt() = 0.0;
 #pragma omp atomic
   simulation::n_lost_particles += 1;
 

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -66,7 +66,6 @@ void collision(Particle& p)
   // Kill particle if energy falls below cutoff
   int type = static_cast<int>(p.type());
   if (p.E() < settings::energy_cutoff[type]) {
-    p.alive() = false;
     p.wgt() = 0.0;
   }
 
@@ -272,7 +271,7 @@ void sample_photon_reaction(Particle& p)
   int photon = static_cast<int>(ParticleType::photon);
   if (p.E() < settings::energy_cutoff[photon]) {
     p.E() = 0.0;
-    p.alive() = false;
+    p.wgt() = 0.0;
     return;
   }
 
@@ -397,7 +396,7 @@ void sample_photon_reaction(Particle& p)
         element.atomic_relaxation(i_shell, p);
         p.event() = TallyEvent::ABSORB;
         p.event_mt() = 533 + shell.index_subshell;
-        p.alive() = false;
+        p.wgt() = 0.0;
         p.E() = 0.0;
         return;
       }
@@ -423,7 +422,7 @@ void sample_photon_reaction(Particle& p)
 
     p.event() = TallyEvent::ABSORB;
     p.event_mt() = PAIR_PROD;
-    p.alive() = false;
+    p.wgt() = 0.0;
     p.E() = 0.0;
   }
 }
@@ -438,7 +437,7 @@ void sample_electron_reaction(Particle& p)
   }
 
   p.E() = 0.0;
-  p.alive() = false;
+  p.wgt() = 0.0;
   p.event() = TallyEvent::ABSORB;
 }
 
@@ -459,7 +458,7 @@ void sample_positron_reaction(Particle& p)
   p.create_secondary(p.wgt(), -u, MASS_ELECTRON_EV, ParticleType::photon);
 
   p.E() = 0.0;
-  p.alive() = false;
+  p.wgt() = 0.0;
   p.event() = TallyEvent::ABSORB;
 }
 
@@ -634,7 +633,7 @@ void absorption(Particle& p, int i_nuclide)
                                      p.neutron_xs(i_nuclide).absorption;
       }
 
-      p.alive() = false;
+      p.wgt() = 0.0;
       p.event() = TallyEvent::ABSORB;
       p.event_mt() = N_DISAPPEAR;
     }

--- a/src/physics_common.cpp
+++ b/src/physics_common.cpp
@@ -15,7 +15,6 @@ void russian_roulette(Particle& p, double weight_survive)
     p.wgt() = weight_survive;
   } else {
     p.wgt() = 0.;
-    p.alive() = false;
   }
 }
 

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -226,7 +226,7 @@ void absorption(Particle& p)
     if (p.macro_xs().absorption > prn(p.current_seed()) * p.macro_xs().total) {
       p.keff_tally_absorption() +=
         p.wgt() * p.macro_xs().nu_fission / p.macro_xs().absorption;
-      p.alive() = false;
+      p.wgt() = 0.0;
       p.event() = TallyEvent::ABSORB;
     }
   }

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -2319,8 +2319,7 @@ void score_collision_tally(Particle& p)
 
 void score_surface_tally(Particle& p, const vector<int>& tallies)
 {
-  // No collision, so no weight change when survival biasing
-  double flux = p.wgt();
+  double current = p.wgt_last();
 
   for (auto i_tally : tallies) {
     auto& tally {*model::tallies[i_tally]};
@@ -2341,7 +2340,7 @@ void score_surface_tally(Particle& p, const vector<int>& tallies)
       // Loop over scores.
       // There is only one score type for current tallies so there is no need
       // for a further scoring function.
-      double score = flux * filter_weight;
+      double score = current * filter_weight;
       for (auto score_index = 0; score_index < tally.scores_.size();
            ++score_index) {
 #pragma omp atomic

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -52,7 +52,6 @@ void apply_weight_windows(Particle& p)
 
   // first check to see if particle should be killed for weight cutoff
   if (p.wgt() < weight_window.weight_cutoff) {
-    p.alive() = false;
     p.wgt() = 0.0;
     return;
   }


### PR DESCRIPTION
@gridley This PR follows up on your comment on my earlier PR about removing the `alive_` data member on `ParticleData` and instead considering particles with `wgt() == 0` to be dead. With some very small tweaks (e.g., using `wgt_last` for surface tallies), it works just fine. Thanks again for the idea!