### PR TITLE
Changing get atoms arg to mat object

### DIFF
--- a/examples/pincell_depletion/restart_depletion.py
+++ b/examples/pincell_depletion/restart_depletion.py
@@ -62,10 +62,10 @@ results = openmc.deplete.ResultsList.from_hdf5("depletion_results.h5")
 time, keff = results.get_eigenvalue()
 
 # Obtain U235 concentration as a function of time
-time, n_U235 = results.get_atoms('1', 'U235')
+time, n_U235 = results.get_atoms(uo2, 'U235')
 
 # Obtain Xe135 capture reaction rate as a function of time
-time, Xe_capture = results.get_reaction_rate('1', 'Xe135', '(n,gamma)')
+time, Xe_capture = results.get_reaction_rate(uo2, 'Xe135', '(n,gamma)')
 
 ###############################################################################
 #                            Generate plots

--- a/examples/pincell_depletion/run_depletion.py
+++ b/examples/pincell_depletion/run_depletion.py
@@ -110,7 +110,7 @@ time, keff = results.get_eigenvalue()
 time, n_U235 = results.get_atoms('1', 'U235')
 
 # Obtain Xe135 capture reaction rate as a function of time
-time, Xe_capture = results.get_reaction_rate('1', 'Xe135', '(n,gamma)')
+time, Xe_capture = results.get_reaction_rate(uo2, 'Xe135', '(n,gamma)')
 
 ###############################################################################
 #                            Generate plots

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -558,7 +558,7 @@ class Operator(TransportOperator):
 
         for nuclide in geom_nuc_densities.keys():
             if nuclide in depl_nuc:
-                concentration = prev_res.get_atoms(mat_id, nuclide)[1][-1]
+                concentration = prev_res.get_atoms(mat, nuclide)[1][-1]
                 volume = prev_res[-1].volume[mat_id]
                 number = concentration / volume
             else:

--- a/openmc/deplete/reaction_rates.py
+++ b/openmc/deplete/reaction_rates.py
@@ -112,8 +112,8 @@ class ReactionRates(np.ndarray):
 
         Parameters
         ----------
-        mat : str
-            Material ID as a string
+        mat : openmc.Material
+            Material object to evaluate
         nuc : str
             Nuclide name
         rx : str
@@ -125,7 +125,7 @@ class ReactionRates(np.ndarray):
             Reaction rate corresponding to given material, nuclide, and reaction
 
         """
-        mat = self.index_mat[mat]
+        mat = self.index_mat[mat.id]
         nuc = self.index_nuc[nuc]
         rx = self.index_rx[rx]
         return self[mat, nuc, rx]
@@ -135,8 +135,8 @@ class ReactionRates(np.ndarray):
 
         Parameters
         ----------
-        mat : str
-            Material ID as a string
+        mat : openmc.Material
+            Material object to evaluate
         nuc : str
             Nuclide name
         rx : str
@@ -145,7 +145,7 @@ class ReactionRates(np.ndarray):
             Corresponding reaction rate to set
 
         """
-        mat = self.index_mat[mat]
+        mat = self.index_mat[mat.id]
         nuc = self.index_nuc[nuc]
         rx = self.index_rx[rx]
         self[mat, nuc, rx] = value

--- a/openmc/deplete/results_list.py
+++ b/openmc/deplete/results_list.py
@@ -80,7 +80,6 @@ class ResultsList(list):
             Concentration of specified nuclide in units of ``nuc_units``
 
         """
-        cv.check_value("mat", mat, Material)
         cv.check_value("time_units", time_units, {"s", "d", "min", "h"})
         cv.check_value("nuc_units", nuc_units,
                     {"atoms", "atom/b-cm", "atom/cm3"})
@@ -138,7 +137,6 @@ class ResultsList(list):
             Array of reaction rates
 
         """
-        cv.check_value("mat", mat, Material)
         times = np.empty_like(self, dtype=float)
         rates = np.empty_like(self, dtype=float)
 

--- a/openmc/deplete/results_list.py
+++ b/openmc/deplete/results_list.py
@@ -58,8 +58,8 @@ class ResultsList(list):
 
         Parameters
         ----------
-        mat : str
-            Material name to evaluate
+        mat : openmc.Material
+            Material object to evaluate
         nuc : str
             Nuclide name to evaluate
         nuc_units : {"atoms", "atom/b-cm", "atom/cm3"}, optional
@@ -80,6 +80,7 @@ class ResultsList(list):
             Concentration of specified nuclide in units of ``nuc_units``
 
         """
+        cv.check_value("mat", mat, Material)
         cv.check_value("time_units", time_units, {"s", "d", "min", "h"})
         cv.check_value("nuc_units", nuc_units,
                     {"atoms", "atom/b-cm", "atom/cm3"})
@@ -90,7 +91,7 @@ class ResultsList(list):
         # Evaluate value in each region
         for i, result in enumerate(self):
             times[i] = result.time[0]
-            concentrations[i] = result[0, mat, nuc]
+            concentrations[i] = result[0, mat.id, nuc]
 
         # Unit conversions
         if time_units == "d":
@@ -102,7 +103,7 @@ class ResultsList(list):
 
         if nuc_units != "atoms":
             # Divide by volume to get density
-            concentrations /= self[0].volume[mat]
+            concentrations /= self[0].volume[mat.id]
             if nuc_units == "atom/b-cm":
                 # 1 barn = 1e-24 cm^2
                 concentrations *= 1e-24
@@ -122,8 +123,8 @@ class ResultsList(list):
 
         Parameters
         ----------
-        mat : str
-            Material name to evaluate
+        mat : openmc.Material
+            Material object to evaluate
         nuc : str
             Nuclide name to evaluate
         rx : str
@@ -137,13 +138,14 @@ class ResultsList(list):
             Array of reaction rates
 
         """
+        cv.check_value("mat", mat, Material)
         times = np.empty_like(self, dtype=float)
         rates = np.empty_like(self, dtype=float)
 
         # Evaluate value in each region
         for i, result in enumerate(self):
             times[i] = result.time[0]
-            rates[i] = result.rates[0].get(mat, nuc, rx) * result[0, mat, nuc]
+            rates[i] = result.rates[0].get(mat.id, nuc, rx) * result[0, mat.id, nuc]
 
         return times, rates
 

--- a/tests/unit_tests/test_deplete_activation.py
+++ b/tests/unit_tests/test_deplete_activation.py
@@ -108,7 +108,7 @@ def test_activation(run_in_tmpdir, model, reaction_rate_mode, reaction_rate_opts
 
     # Get resulting number of atoms
     results = openmc.deplete.ResultsList.from_hdf5('depletion_results.h5')
-    _, atoms = results.get_atoms(str(w.id), "W186")
+    _, atoms = results.get_atoms(w, "W186")
 
     assert atoms[0] == pytest.approx(n0)
     assert atoms[1] / atoms[0] == pytest.approx(0.5, rel=tolerance)
@@ -156,7 +156,7 @@ def test_decay(run_in_tmpdir):
 
     # Get resulting number of atoms
     results = openmc.deplete.ResultsList.from_hdf5('depletion_results.h5')
-    _, atoms = results.get_atoms(str(mat.id), "Sr89")
+    _, atoms = results.get_atoms(mat, "Sr89")
 
     # Ensure density goes down by a factor of 2 after each half-life
     assert atoms[1] / atoms[0] == pytest.approx(0.5)

--- a/tests/unit_tests/test_deplete_integrator.py
+++ b/tests/unit_tests/test_deplete_integrator.py
@@ -14,6 +14,7 @@ import numpy as np
 from uncertainties import ufloat
 import pytest
 
+from openmc import Material
 from openmc.mpi import comm
 from openmc.deplete import (
     ReactionRates, Results, ResultsList, OperatorResult, PredictorIntegrator,
@@ -179,8 +180,10 @@ def test_integrator(run_in_tmpdir, scheme):
     res = ResultsList.from_hdf5(
         operator.output_dir / "depletion_results.h5")
 
-    t1, y1 = res.get_atoms("1", "1")
-    t2, y2 = res.get_atoms("1", "2")
+    mat = Material(id=1)
+
+    t1, y1 = res.get_atoms(mat, "1")
+    t2, y2 = res.get_atoms(mat, "2")
 
     assert (t1 == [0.0, 0.75, 1.5]).all()
     assert y1 == pytest.approx(bundle.atoms_1)

--- a/tests/unit_tests/test_deplete_integrator.py
+++ b/tests/unit_tests/test_deplete_integrator.py
@@ -180,7 +180,7 @@ def test_integrator(run_in_tmpdir, scheme):
     res = ResultsList.from_hdf5(
         operator.output_dir / "depletion_results.h5")
 
-    mat = Material(id=1)
+    mat = Material()
 
     t1, y1 = res.get_atoms(mat, "1")
     t2, y2 = res.get_atoms(mat, "2")

--- a/tests/unit_tests/test_deplete_restart.py
+++ b/tests/unit_tests/test_deplete_restart.py
@@ -6,6 +6,7 @@ problem described in dummy_geometry.py.
 
 import pytest
 
+from openmc import Material
 import openmc.deplete
 
 from tests import dummy_operator
@@ -87,8 +88,10 @@ def test_restart(run_in_tmpdir, scheme):
     results = openmc.deplete.ResultsList.from_hdf5(
         operator.output_dir / "depletion_results.h5")
 
-    _t, y1 = results.get_atoms("1", "1")
-    _t, y2 = results.get_atoms("1", "2")
+    mat = openmc.Material(id=1)
+
+    _t, y1 = results.get_atoms(mat, "1")
+    _t, y2 = results.get_atoms(mat, "2")
 
     assert y1 == pytest.approx(bundle.atoms_1)
     assert y2 == pytest.approx(bundle.atoms_2)

--- a/tests/unit_tests/test_deplete_restart.py
+++ b/tests/unit_tests/test_deplete_restart.py
@@ -88,7 +88,7 @@ def test_restart(run_in_tmpdir, scheme):
     results = openmc.deplete.ResultsList.from_hdf5(
         operator.output_dir / "depletion_results.h5")
 
-    mat = openmc.Material(id=1)
+    mat = openmc.Material()
 
     _t, y1 = results.get_atoms(mat, "1")
     _t, y2 = results.get_atoms(mat, "2")

--- a/tests/unit_tests/test_deplete_resultslist.py
+++ b/tests/unit_tests/test_deplete_resultslist.py
@@ -19,7 +19,7 @@ def res():
 
 def test_get_atoms(res):
     """Tests evaluating single nuclide concentration."""
-    mat = openmc.Material(id=1)
+    mat = openmc.Material()
     t, n = res.get_atoms(mat, "Xe135")
 
     t_ref = np.array([0.0, 1296000.0, 2592000.0, 3888000.0])
@@ -47,7 +47,7 @@ def test_get_atoms(res):
 
 def test_get_reaction_rate(res):
     """Tests evaluating reaction rate."""
-    mat = openmc.Material(id=1)
+    mat = openmc.Material()
     t, r = res.get_reaction_rate(mat, "Xe135", "(n,gamma)")
 
     t_ref = [0.0, 1296000.0, 2592000.0, 3888000.0]

--- a/tests/unit_tests/test_deplete_resultslist.py
+++ b/tests/unit_tests/test_deplete_resultslist.py
@@ -5,6 +5,7 @@ from math import inf
 
 import numpy as np
 import pytest
+from openmc import Material
 import openmc.deplete
 
 
@@ -18,7 +19,8 @@ def res():
 
 def test_get_atoms(res):
     """Tests evaluating single nuclide concentration."""
-    t, n = res.get_atoms("1", "Xe135")
+    mat = openmc.Material(id=1)
+    t, n = res.get_atoms(mat, "Xe135")
 
     t_ref = np.array([0.0, 1296000.0, 2592000.0, 3888000.0])
     n_ref = np.array(
@@ -30,22 +32,23 @@ def test_get_atoms(res):
     # Check alternate units
     volume = res[0].volume["1"]
 
-    t_days, n_cm3 = res.get_atoms("1", "Xe135", nuc_units="atom/cm3", time_units="d")
+    t_days, n_cm3 = res.get_atoms(mat, "Xe135", nuc_units="atom/cm3", time_units="d")
 
     assert t_days == pytest.approx(t_ref / (60 * 60 * 24))
     assert n_cm3 == pytest.approx(n_ref / volume)
 
-    t_min, n_bcm = res.get_atoms("1", "Xe135", nuc_units="atom/b-cm", time_units="min")
+    t_min, n_bcm = res.get_atoms(mat, "Xe135", nuc_units="atom/b-cm", time_units="min")
     assert n_bcm == pytest.approx(n_cm3 * 1e-24)
     assert t_min == pytest.approx(t_ref / 60)
 
-    t_hour, _n = res.get_atoms("1", "Xe135", time_units="h")
+    t_hour, _n = res.get_atoms(mat, "Xe135", time_units="h")
     assert t_hour == pytest.approx(t_ref / (60 * 60))
 
 
 def test_get_reaction_rate(res):
     """Tests evaluating reaction rate."""
-    t, r = res.get_reaction_rate("1", "Xe135", "(n,gamma)")
+    mat = openmc.Material(id=1)
+    t, r = res.get_reaction_rate(mat, "Xe135", "(n,gamma)")
 
     t_ref = [0.0, 1296000.0, 2592000.0, 3888000.0]
     n_ref = [6.67473282e+08, 3.72442707e+14, 3.61129692e+14, 4.01920099e+14]


### PR DESCRIPTION
This PR is an attempt to fix issue #1970

I've changed the arguments for ```get_atoms``` and ```get_reaction_rate``` to accept ```openmc.Material``` objects instead of material id in str format as discussed in #1970

I've updated the used of get_atoms in the code :heavy_check_mark: 

I've updated the examples that use  ```get_atoms``` and ```get_reaction_rate``` but think that the pincell depletion might need further additions to get it working as the material uo2 is not directly available in the script. I guess there must be a way of getting the materials from a statepoint file so that is something for me to look into :eyes: 

I have updated many of the tests but there is one that I might need some help with to get this over the line. They are restarting and reading in depletion files, I should also read in the material objects from the file but have not done that before and am not sure if it is possible.

So a bit more to do but perhaps this is a reasonable start, what do you think @drewejohnson 