### PR TITLE
Fix package_data specification to include pyx files for Cython builds

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,6 @@ include schemas.xml
 include pyproject.toml
 include pytest.ini
 include docs/source/_templates/layout.html
-include docs/sphinxext/LICENSE
 global-include *.cmake
 global-include *.cmake.in
 global-include *.rst
@@ -20,8 +19,6 @@ recursive-include docs *.svg
 recursive-include docs *.tex
 recursive-include docs *.txt
 recursive-include docs Makefile
-recursive-include examples *.h5
-recursive-include examples *.png
 recursive-include examples *.cpp
 recursive-include examples *.py
 recursive-include examples *.xml
@@ -29,11 +26,7 @@ recursive-include include *.h
 recursive-include man *.1
 recursive-include openmc *.pyx
 recursive-include openmc *.c
-recursive-include src *.c
-recursive-include src *.cc
 recursive-include src *.cpp
-recursive-include src *.h
-recursive-include src *.hpp
 recursive-include src *.rnc
 recursive-include src *.rng
 recursive-include tests *.dat

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ kwargs = {
     # Data files and librarries
     'package_data': {
         'openmc.lib': ['libopenmc.{}'.format(suffix)],
-        'openmc.data': ['mass16.txt', 'BREMX.DAT', '*.h5'],
+        'openmc.data': ['mass16.txt', 'BREMX.DAT', '*.h5', '*.pyx'],
         'openmc.data.effective_dose': ['*.txt']
     },
 


### PR DESCRIPTION
This fixes building of a standalone distributable python package. Without this change, running a package build fails with the following:

```sh
% python3 -m build
...
  File "/tmp/build-env-3c6tysj8/lib/python3.7/site-packages/Cython/Build/Dependencies.py", line 816, in create_extension_list
    for file in nonempty(sorted(extended_iglob(filepattern)), "'%s' doesn't match any files" % filepattern):
  File "/tmp/build-env-3c6tysj8/lib/python3.7/site-packages/Cython/Build/Dependencies.py", line 114, in nonempty
    raise ValueError(error_msg)
ValueError: 'openmc/data/*.pyx' doesn't match any files
```