### PR TITLE
Allow meshes with same ID to appear in different files

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2568,7 +2568,7 @@ void read_meshes(pugi::xml_node root)
     int id = std::stoi(get_node_value(node, "id"));
     if (contains(mesh_ids, id)) {
       fatal_error(
-        "Two or more meshes use the same unique ID: " + std::to_string(id));
+        fmt::format("Two or more meshes use the same unique ID '{}' in the same input file", id));
     }
     mesh_ids.insert(id);
 


### PR DESCRIPTION
This PR partially addresses the issue described in #1906. With the changes here, it is now permitted to have the same mesh appear in multiple files (e.g., settings.xml and tallies.xml). There is still a check that two meshes with the same ID should not appear in the same file.

In principle, with these changes, you _could_ have a single copy of a mesh in your set of XML files and reference them throughout. That is, if I use the same mesh for Shannon entropy and in a mesh tally and then delete the mesh from the tallies.xml file, everything still works. But, it's a bit finicky because the mesh has to appear in the first file where it's used (in the order that OpenMC reads them). I think as we start using more complicated unstructured meshes, we'll still need a robust solution to the issue of duplicated information across files.