### PR TITLE
Update troubleshooting guide, fix broken links

### DIFF
--- a/docs/source/devguide/workflow.rst
+++ b/docs/source/devguide/workflow.rst
@@ -119,8 +119,8 @@ pip_. From the root directory of the OpenMC repository, run:
     pip install -e .[test]
 
 This installs the OpenMC Python package in `"editable" mode
-<https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs>`_ so
-that 1) it can be imported from a Python interpreter and 2) any changes made are
+<https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs>`_ so that 1)
+it can be imported from a Python interpreter and 2) any changes made are
 immediately reflected in the installed version (that is, you don't need to keep
 reinstalling it). While the same effect can be achieved using the
 :envvar:`PYTHONPATH` environment variable, this is generally discouraged as it

--- a/docs/source/methods/cross_sections.rst
+++ b/docs/source/methods/cross_sections.rst
@@ -187,9 +187,10 @@ are represented using a multi-group library format specific to the OpenMC code.
 The format is described in the :ref:`mgxs_lib_spec`. The data itself can be
 prepared via traditional paths or directly from a continuous-energy OpenMC
 calculation by use of the Python API as is shown in an `example notebook
-<../examples/mg-mode-part-i.ipynb>`_. This multi-group library consists of
-meta-data (such as the energy group structure) and multiple `xsdata` objects
-which contains the required microscopic or macroscopic multi-group data.
+<https://nbviewer.jupyter.org/github/openmc-dev/openmc-notebooks/blob/main/mg-mode-part-i.ipynb>`_.
+This multi-group library consists of meta-data (such as the energy group
+structure) and multiple `xsdata` objects which contains the required microscopic
+or macroscopic multi-group data.
 
 At a minimum, the library must contain the absorption cross section
 (:math:`\sigma_{a,g}`) and a scattering matrix. If the problem is an eigenvalue
@@ -275,6 +276,6 @@ or even isotropic scattering.
 .. _MCNP: https://mcnp.lanl.gov
 .. _Serpent: http://montecarlo.vtt.fi
 .. _NJOY: https://www.njoy21.io/NJOY21/
-.. _ENDF/B data: https://www.nndc.bnl.gov/endf/b8.0/
+.. _ENDF/B data: https://www.nndc.bnl.gov/endf-b8.0/
 .. _Leppanen: https://doi.org/10.1016/j.anucene.2009.03.019
 .. _algorithms: http://ab-initio.mit.edu/wiki/index.php/Faddeeva_Package

--- a/docs/source/methods/neutron_physics.rst
+++ b/docs/source/methods/neutron_physics.rst
@@ -359,7 +359,7 @@ secondary energy and angle sampling.
 For a reaction with secondary products, it is necessary to determine the
 outgoing angle and energy of the products. For any reaction other than elastic
 and level inelastic scattering, the outgoing energy must be determined based on
-tabulated or parameterized data. The `ENDF-6 Format` specifies a
+tabulated or parameterized data. The `ENDF-6 Format`_ specifies a
 variety of ways that the secondary energy distribution can be represented. ENDF
 File 5 contains uncorrelated energy distribution whereas ENDF File 6 contains
 correlated energy-angle distributions. The ACE format specifies its own

--- a/docs/source/methods/neutron_physics.rst
+++ b/docs/source/methods/neutron_physics.rst
@@ -359,7 +359,7 @@ secondary energy and angle sampling.
 For a reaction with secondary products, it is necessary to determine the
 outgoing angle and energy of the products. For any reaction other than elastic
 and level inelastic scattering, the outgoing energy must be determined based on
-tabulated or parameterized data. The `ENDF-6 Format <endf102>`_ specifies a
+tabulated or parameterized data. The `ENDF-6 Format` specifies a
 variety of ways that the secondary energy distribution can be represented. ENDF
 File 5 contains uncorrelated energy distribution whereas ENDF File 6 contains
 correlated energy-angle distributions. The ACE format specifies its own
@@ -1416,8 +1416,7 @@ For incoherent elastic scattering, OpenMC has two methods for calculating the
 cosine of the angle of scattering. The first method uses the Debye-Waller
 integral, :math:`W'`, and the characteristic bound cross section as given
 directly in an ENDF-6 formatted file. In this case, the cosine of the angle of
-scattering can be sampled by inverting equation 7.4 from the `ENDF-6 Format
-Manual <endf102>`_:
+scattering can be sampled by inverting equation 7.4 from the `ENDF-6 Format`_:
 
 .. math::
     :label: incoherent-elastic-mu-exact
@@ -1752,7 +1751,7 @@ types.
 
 .. _PREPRO: https://www-nds.iaea.org/ndspub/endf/prepro/
 
-.. _endf102: https://www.oecd-nea.org/dbdata/data/manual-endf/endf102.pdf
+.. _ENDF-6 Format: https://www.oecd-nea.org/dbdata/data/manual-endf/endf102.pdf
 
 .. _Monte Carlo Sampler: https://permalink.lanl.gov/object/tr?what=info:lanl-repo/lareport/LA-09721-MS
 

--- a/docs/source/methods/tallies.rst
+++ b/docs/source/methods/tallies.rst
@@ -510,6 +510,6 @@ improve the estimate of the percentile.
 
 .. _Cauchy distribution: https://en.wikipedia.org/wiki/Cauchy_distribution
 
-.. _unpublished rational approximation: https://web.archive.org/web/20150926021742/http://home.online.no/~pjacklam/notes/invnorm/
+.. _unpublished rational approximation: https://stackedboxes.org/2017/05/01/acklams-normal-quantile-function/
 
 .. _MC21: http://www.osti.gov/bridge/servlets/purl/903083-HT5p1o/903083.pdf

--- a/docs/source/usersguide/cross_sections.rst
+++ b/docs/source/usersguide/cross_sections.rst
@@ -124,7 +124,7 @@ OpenMC.
 .. hint:: The :class:`IncidentNeutron` class allows you to view/modify cross
           sections, secondary angle/energy distributions, probability tables,
           etc. For a more thorough overview of the capabilities of this class,
-          see the `example notebook <../examples/nuclear-data.ipynb>`__.
+          see the `example notebook <https://nbviewer.jupyter.org/github/openmc-dev/openmc-notebooks/blob/main/nuclear-data.ipynb>`_.
 
 Manually Creating a Library from ENDF files
 -------------------------------------------
@@ -259,7 +259,7 @@ For an example of how to create a multi-group library, see the `example notebook
 .. _NNDC: https://www.nndc.bnl.gov/endf
 .. _MCNP: https://mcnp.lanl.gov
 .. _Serpent: http://montecarlo.vtt.fi
-.. _ENDF/B: https://www.nndc.bnl.gov/endf/b7.1/acefiles.html
+.. _ENDF/B: https://www.nndc.bnl.gov/endf-b7.1/acefiles.html
 .. _JEFF: https://www.oecd-nea.org/dbdata/jeff/jeff33/
 .. _TENDL: https://tendl.web.psi.ch/tendl_2017/tendl2017.html
 .. _Seltzer and Berger: https://doi.org/10.1016/0092-640X(86)90014-8

--- a/docs/source/usersguide/geometry.rst
+++ b/docs/source/usersguide/geometry.rst
@@ -478,10 +478,10 @@ OpenMC to verify that the model matches one's expectations.
 
 **Note:** DAGMC geometries used in OpenMC are currently required to be clean,
 meaning that all surfaces have been `imprinted and merged
-<https://svalinn.github.io/DAGMC/usersguide/trelis_workflow.html>`_
-successfully and that the model is `watertight
-<https://svalinn.github.io/DAGMC/usersguide/tools.html#make-watertight>`_. Future
-implementations of DAGMC geometry will support small volume overlaps and
+<https://svalinn.github.io/DAGMC/usersguide/cubit_basics.html>`_ successfully
+and that the model is `watertight
+<https://svalinn.github.io/DAGMC/usersguide/tools.html#make-watertight>`_.
+Future implementations of DAGMC geometry will support small volume overlaps and
 un-merged surfaces.
 
 Cell, Surface, and Material IDs

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -512,8 +512,9 @@ distributions.
       are used for several optional features in the API.
 
    `pandas <https://pandas.pydata.org/>`_
-      Pandas is used to generate tally DataFrames as demonstrated in
-      an `example notebook <../examples/pandas-dataframes.ipynb>`_.
+      Pandas is used to generate tally DataFrames as demonstrated in an `example
+      notebook
+      <https://nbviewer.jupyter.org/github/openmc-dev/openmc-notebooks/blob/main/pandas-dataframes.ipynb>`_.
 
    `h5py <http://www.h5py.org/>`_
       h5py provides Python bindings to the HDF5 library. Since OpenMC outputs

--- a/docs/source/usersguide/processing.rst
+++ b/docs/source/usersguide/processing.rst
@@ -34,29 +34,19 @@ as requested; it is used in many of the provided plotting utilities, OpenMC's
 regression test suite, and can be used in user-created scripts to carry out
 manipulations of the data.
 
-An `example notebook <../examples/post-processing.ipynb>`_ demonstrates how to
-extract data from a statepoint using the Python API.
+An `example notebook`_ demonstrates how to extract data from a statepoint using
+the Python API.
 
 Plotting in 2D
 --------------
 
-The `notebook example <../examples/post-processing.ipynb>`_ also demonstrates
-how to plot a structured mesh tally in two dimensions using the Python API. One
-can also use the :ref:`scripts_plot` script which provides an interactive GUI to
-explore and plot structured mesh tallies for any scores and filter bins.
+The `example notebook`_ also demonstrates how to plot a structured mesh tally in
+two dimensions using the Python API. One can also use the :ref:`scripts_plot`
+script which provides an interactive GUI to explore and plot structured mesh
+tallies for any scores and filter bins.
 
 .. image:: ../_images/plotmeshtally.png
    :width: 400px
-
-Getting Data into MATLAB
-------------------------
-
-There is currently no front-end utility to dump tally data to MATLAB files, but
-the process is straightforward. First extract the data using the Python API via
-``openmc.statepoint`` and then use the `Scipy MATLAB IO routines
-<https://docs.scipy.org/doc/scipy/reference/tutorial/io.html>`_ to save to a MAT
-file. Note that all arrays that are accessible in a statepoint are already in
-NumPy arrays that can be reshaped and dumped to MATLAB in one step.
 
 .. _usersguide_track:
 
@@ -101,5 +91,6 @@ For eigenvalue problems, OpenMC will store information on the fission source
 sites in the statepoint file by default. For each source site, the weight,
 position, sampled direction, and sampled energy are stored. To extract this data
 from a statepoint file, the ``openmc.statepoint`` module can be used. An
-`example notebook <../examples/post-processing.ipynb>`_ demontrates how to
-analyze and plot source information.
+`example notebook`_ demontrates how to analyze and plot source information.
+
+.. _example notebook: https://nbviewer.jupyter.org/github/openmc-dev/openmc-notebooks/blob/main/post-processing.ipynb

--- a/docs/source/usersguide/troubleshoot.rst
+++ b/docs/source/usersguide/troubleshoot.rst
@@ -15,13 +15,15 @@ error you are receiving is among the following options.
 Problems with Simulations
 -------------------------
 
-Segmentation Fault
-******************
+RuntimeError: OpenMC aborted unexpectedly.
+******************************************
 
-A segmentation fault occurs when the program tries to access a variable in
-memory that was outside the memory allocated for the program. The best way to
-debug a segmentation fault is to re-compile OpenMC with debug options turned
-on. Create a new build directory and type the following commands:
+This error usually indicates that OpenMC experienced a segmentation fault. A
+segmentation fault occurs when the program tries to access a variable in memory
+that was outside the memory allocated for the program. The best way to debug a
+segmentation fault is to :ref:`compile OpenMC from source <install_source>` with
+debug options turned on. Create a new build directory and type the following
+commands:
 
 .. code-block:: sh
 
@@ -33,6 +35,28 @@ Now when you re-run your problem, it should report exactly where the program
 failed. If after reading the debug output, you are still unsure why the program
 failed, post a message on the `OpenMC Discourse Forum
 <https://openmc.discourse.group/>`_.
+
+.. _troubleshoot_lost_particles:
+
+WARNING: After particle __ crossed surface __ it could not be located in any cell and it did not leak.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+During a simulation, particles can become "lost" if they reach a surface and
+there is no cell defined on the other side of the surface. It is important to
+ensure that 1) proper boundary conditions have been applied to the outer
+surfaces of your model and 2) all space in your model is filled with a cell,
+even regions that are void and have no material assigned to them.
+
+Please see the instructions in :ref:`troubleshoot_geometry` on how to resolve
+issues with lost particles.
+
+ERROR: Maximum number of lost particles has been reached.
+*********************************************************
+
+See the above description regarding :ref:`lost particles
+<troubleshoot_lost_particles>`. When too many particles are lost, the simulation
+will abort altogether. Again, please see the instructions in
+:ref:`troubleshoot_geometry` on how to resolve issues with lost particles.
 
 ERROR: No cross_sections.xml file was specified in settings.xml or in the OPENMC_CROSS_SECTIONS environment variable.
 *********************************************************************************************************************
@@ -62,22 +86,33 @@ it is recommended that data be extracted from statepoint files in a context mana
 or that the :meth:`StatePoint.close` method is called before executing a subsequent
 OpenMC run.
 
+.. _troubleshoot_geometry:
+
 Geometry Debugging
 ******************
 
-Overlapping Cells
-^^^^^^^^^^^^^^^^^
+To identify issues in your geometry, it is highly recommended to use the `OpenMC
+Plot Explorer <https://github.com/openmc-dev/plotter/>`_ GUI application. This
+application enables you to interactively explore a model, identify regions that
+may be missing a cell definition, and identify overlapping cells.
 
-For fast run times, normal simulations do not check if the geometry is
-incorrectly defined to have overlapping cells.  This can lead to incorrect
-results that may or may not be obvious when there are errors in the geometry
-input file.  The built-in 2D and 3D plotters will check for cell overlaps at
-the center of every pixel or voxel position they process, however this might
-not be a sufficient check to ensure correctly defined geometry.  For instance,
-if an overlap is of small aspect ratio, the plotting resolution might not be
-high enough to produce any pixels in the overlapping area.
+If you are having issues with lost particles, the following procedure may be
+helpful. If OpenMC reports, for example, that a particle reaching surface 50
+could not be located, look at your geometry.xml to see which cells have a region
+definition that includes surface 50, e.g.:
 
-To reliably validate a geometry input, it is best to run the problem in
+.. code-block:: xml
+
+    <cell id="10" material="5" region="-49 50 -51 52" />
+
+This may indicate that you need to define a cell on the other side of cell 10.
+At this point, using the OpenMC Plot Explorer to locate cell 10 may provide a
+visual clue as to whether there is a missing or overlapping cell near cell 10.
+Working with the unique integer IDs of cells may be cumbersome; if you provide
+names to your cells, these names will show up in the Plot Explorer, which will
+aid geometry debugging.
+
+Another method to check for overlapping cells in a geometry is to run the problem in
 geometry debugging mode with the ``-g``, ``-geometry-debug``, or
 ``--geometry-debug`` command-line options.  This will enable checks for
 overlapping cells at every move of each simulated particle.  Depending on the
@@ -91,33 +126,6 @@ where overlaps are checked for in that region.  The user should refer to the
 output after a geometry debug run to see how many checks were performed in each
 cell, and then adjust the number of starting particles or starting source
 distributions accordingly to achieve good coverage.
-
-ERROR: After particle __ crossed surface __ it could not be located in any cell and it did not leak.
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This error can arise either if a problem is specified with no boundary
-conditions or if there is an error in the geometry itself. First check to ensure
-that all of the outer surfaces of your geometry have been given vacuum or
-reflective boundary conditions. If proper boundary conditions have been applied
-and you still receive this error, it means that a surface/cell/lattice in your
-geometry has been specified incorrectly or is missing.
-
-The best way to debug this error is to turn on a trace for the particle getting
-lost. After the error message, the code will display what batch, generation, and
-particle number caused the error. In your settings.xml, add a :ref:`trace`
-followed by the batch, generation, and particle number. This will give you
-detailed output every time that particle enters a cell, crosses a boundary, or
-has a collision. For example, if you received this error at cycle 5, generation
-1, particle 4032, you would enter:
-
-.. code-block:: xml
-
-    <trace>5 1 4032</trace>
-
-For large runs it is often advantageous to run only the offending particle by
-using particle restart mode with the ``-r`` command-line option in conjunction
-with the particle restart files that are created when particles are lost with
-this error.
 
 Depletion
 *********


### PR DESCRIPTION
This PR updates our troubleshooting guide to include better information on how users can debug geomtery errors (namely, by using the openmc-plotter application). I've also fixed a whole bunch of broken links in our documentation and removed a small section talking about converting data to MATLAB.