### PR TITLE
Fix overwritten variable in `ace.py::get_libraries_from_xsdata`

### DIFF
--- a/openmc/data/ace.py
+++ b/openmc/data/ace.py
@@ -573,11 +573,11 @@ def get_libraries_from_xsdata(path):
         List of paths to ACE libraries
     """
     xsdata = Path(path)
-    with open(xsdata, 'r') as xsdata:
+    with open(xsdata, 'r') as xsdata_file:
         # As in get_libraries_from_xsdir, we use a dict for O(1) membership
         # check while retaining insertion order
         libraries = OrderedDict()
-        for line in xsdata:
+        for line in xsdata_file:
             words = line.split()
             if len(words) >= 9:
                 lib = (xsdata.parent / words[8]).resolve()


### PR DESCRIPTION
This PR makes a small fix in `ace.py::get_libraries_from_xsdata` where a variable was being overwritten which caused an `AttributeError` that prevented execution of the `openmc-ace-to-hdf5` script using the `--xsdata` flag.

Specifically, this PR changes the name assigned to the `File` object `open(xsdata, 'r')` from `xsdata` to `xsdata_file`.

Closes #1993 