### PR TITLE
adding helper method for EnergyFilter creation

### DIFF
--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1324,6 +1324,20 @@ class EnergyFilter(RealFilter):
             cv.check_greater_than('filter value', v0, 0., equality=True)
             cv.check_greater_than('filter value', v1, 0., equality=True)
 
+    @classmethod
+    def from_group_structure(cls, group_structure):
+        """Construct an EnergyFilter instance from a standard group structure.
+
+        Parameters
+        ----------
+        group_structure : str
+            Name of the group structure. Must be a valid key of
+            openmc.mgxs.GROUP_STRUCTURES dictionary.
+
+        """
+
+        return cls(openmc.mgxs.GROUP_STRUCTURES[group_structure.upper()])
+
 
 class EnergyoutFilter(EnergyFilter):
     """Bins tally events based on outgoing particle energy.

--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -240,3 +240,9 @@ def test_first_moment(run_in_tmpdir, box_model):
         assert first_score(sph_scat_tally) == scatter
         assert first_score(sph_flux_tally) == approx(flux)
         assert first_score(zernike_tally) == approx(scatter)
+
+
+def test_energy():
+    f = openmc.EnergyFilter.from_group_structure('CCFE-709')
+    assert f.bins.shape == (709, 2)
+    assert len(f.values) == 710


### PR DESCRIPTION
I found myself often grabbing a group structure from `openmc.mgxs.GROUP_STRUCTURES` and using it to create an `EnergyFilter` so I simply added a helper method so this can be done a little easier.