### PR TITLE
writing files to output folder

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -576,9 +576,12 @@ void write_tallies()
   if (model::tallies.empty())
     return;
 
+  // Set filename for tallies_out
+  filename = fmt::format("{}tallies.out", settings::path_output, w);
+
   // Open the tallies.out file.
   std::ofstream tallies_out;
-  tallies_out.open("tallies.out", std::ios::out | std::ios::trunc);
+  tallies_out.open(filename, std::ios::out | std::ios::trunc);
 
   // Loop over each tally.
   for (auto i_tally = 0; i_tally < model::tallies.size(); ++i_tally) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -577,7 +577,7 @@ void write_tallies()
     return;
 
   // Set filename for tallies_out
-  filename = fmt::format("{}tallies.out", settings::path_output, w);
+  filename = fmt::format("{}tallies.out", settings::path_output);
 
   // Open the tallies.out file.
   std::ofstream tallies_out;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -577,6 +577,7 @@ void write_tallies()
     return;
 
   // Set filename for tallies_out
+  std::string filename;
   filename = fmt::format("{}tallies.out", settings::path_output);
 
   // Open the tallies.out file.

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -577,8 +577,7 @@ void write_tallies()
     return;
 
   // Set filename for tallies_out
-  std::string filename;
-  filename = fmt::format("{}tallies.out", settings::path_output);
+  std::string filename = fmt::format("{}tallies.out", settings::path_output);
 
   // Open the tallies.out file.
   std::ofstream tallies_out;

--- a/src/summary.cpp
+++ b/src/summary.cpp
@@ -22,8 +22,11 @@ void write_summary()
   // Display output message
   write_message("Writing summary.h5 file...", 5);
 
+  // Set filename for summary file
+  filename = fmt::format("{}summary.h5", settings::path_output, w);
+
   // Create a new file using default properties.
-  hid_t file = file_open("summary.h5", 'w');
+  hid_t file = file_open(filename, 'w');
 
   write_header(file);
   write_nuclides(file);

--- a/src/summary.cpp
+++ b/src/summary.cpp
@@ -23,7 +23,7 @@ void write_summary()
   write_message("Writing summary.h5 file...", 5);
 
   // Set filename for summary file
-  filename = fmt::format("{}summary.h5", settings::path_output, w);
+  filename = fmt::format("{}summary.h5", settings::path_output);
 
   // Create a new file using default properties.
   hid_t file = file_open(filename, 'w');

--- a/src/summary.cpp
+++ b/src/summary.cpp
@@ -23,6 +23,7 @@ void write_summary()
   write_message("Writing summary.h5 file...", 5);
 
   // Set filename for summary file
+  std::string filename;
   filename = fmt::format("{}summary.h5", settings::path_output);
 
   // Create a new file using default properties.

--- a/src/summary.cpp
+++ b/src/summary.cpp
@@ -23,8 +23,7 @@ void write_summary()
   write_message("Writing summary.h5 file...", 5);
 
   // Set filename for summary file
-  std::string filename;
-  filename = fmt::format("{}summary.h5", settings::path_output);
+  std::string filename = fmt::format("{}summary.h5", settings::path_output);
 
   // Create a new file using default properties.
   hid_t file = file_open(filename, 'w');


### PR DESCRIPTION
As discussed in #1996 this PR is an attempt to allow the summary.h5 and tallies.out to be written to the output folder (if specified in the settings object) along with the other output files (statepoint..h5 and tracks....h5)