### PR TITLE
Improve error message if user doesn't set lattice universes

### DIFF
--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -852,6 +852,10 @@ class RectLattice(Lattice):
         if memo is not None:
             memo.add(self)
 
+        # Make sure universes have been assigned
+        if self.universes is None:
+            raise ValueError(f"Lattice {self.id} does not have universes assigned.")
+
         lattice_subelement = ET.Element("lattice")
         lattice_subelement.set("id", str(self._id))
 
@@ -876,7 +880,7 @@ class RectLattice(Lattice):
         lower_left = ET.SubElement(lattice_subelement, "lower_left")
         lower_left.text = ' '.join(map(str, self._lower_left))
 
-        # Export the Lattice nested Universe IDs - column major for Fortran
+        # Export the Lattice nested Universe IDs
         universe_ids = '\n'
 
         # 3D Lattices
@@ -1448,6 +1452,8 @@ class HexLattice(Lattice):
         center.text = ' '.join(map(str, self._center))
 
         # Export the Lattice nested Universe IDs.
+        if self.universes is None:
+            raise ValueError(f"Lattice {self.id} does not have universes assigned.")
 
         # 3D Lattices
         if self._num_axial is not None:

--- a/tests/unit_tests/test_lattice.py
+++ b/tests/unit_tests/test_lattice.py
@@ -361,3 +361,19 @@ def test_show_indices():
         assert len(lines) == 4*i - 3
         lines_x = openmc.HexLattice.show_indices(i, 'x').split('\n')
         assert len(lines) == 4*i - 3
+
+
+def test_unset_universes():
+    elem = ET.Element("dummy")
+
+    lattice = openmc.RectLattice()
+    lattice.lower_left = (-1., -1.)
+    lattice.pitch = (1., 1.)
+    with pytest.raises(ValueError):
+        lattice.create_xml_subelement(elem)
+
+    hex_lattice = openmc.HexLattice()
+    hex_lattice.center = (0., 0.)
+    hex_lattice.pitch = (1.,)
+    with pytest.raises(ValueError):
+        hex_lattice.create_xml_subelement(elem)


### PR DESCRIPTION
A user recently ran into an [issue](https://openmc.discourse.group/t/nonetype-object-is-not-subscriptable/1791/4) where they inadvertently didn't set universes on a lattice and then got a strange exception when trying to export their model. This PR simply improves the error message in this situation to give a clear indication of what is wrong.