### PR TITLE
adding centroids and meshgrid methods to mesh classes

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -126,8 +126,8 @@ class MeshBase(IDManagerMixin, ABC):
             raise ValueError(f'Unrecognized mesh type "{mesh_type}" found.')
 
 
-class StructuredMesh(ABC):
-    """A mixin for structured mesh functionality
+class StructuredMesh(MeshBase):
+    """A base class for structured mesh functionality
 
     Parameters
     ----------
@@ -194,8 +194,7 @@ class StructuredMesh(ABC):
         return (vertices[s0] + vertices[s1]) / 2
 
 
-
-class RegularMesh(StructuredMesh, MeshBase):
+class RegularMesh(StructuredMesh):
     """A regular Cartesian mesh in one, two, or three dimensions
 
     Parameters
@@ -630,7 +629,7 @@ def Mesh(*args, **kwargs):
     return RegularMesh(*args, **kwargs)
 
 
-class RectilinearMesh(MeshBase):
+class RectilinearMesh(StructuredMesh):
     """A 3D rectilinear Cartesian mesh
 
     Parameters
@@ -823,7 +822,7 @@ class RectilinearMesh(MeshBase):
         return element
 
 
-class CylindricalMesh(MeshBase):
+class CylindricalMesh(StructuredMesh):
     """A 3D cylindrical mesh
 
     Parameters
@@ -1014,7 +1013,7 @@ class CylindricalMesh(MeshBase):
         return np.multiply.outer(np.outer(V_r, V_p), V_z)
 
 
-class SphericalMesh(MeshBase):
+class SphericalMesh(StructuredMesh):
     """A 3D spherical mesh
 
     Parameters

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -61,7 +61,6 @@ class MeshBase(IDManagerMixin, ABC):
         pass
 
     @property
-    @abstractmethod
     def vertices(self):
         """Return coordinates of mesh vertices.
 
@@ -75,7 +74,6 @@ class MeshBase(IDManagerMixin, ABC):
         return np.stack(np.meshgrid(*self._grids, indexing='ij'), axis=-1)
 
     @property
-    @abstractmethod
     def centroids(self):
         """Return coordinates of mesh element centroids.
 

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -145,8 +145,8 @@ class StructuredMesh(ABC):
 
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @property
     @abstractmethod

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -45,51 +45,6 @@ class MeshBase(IDManagerMixin, ABC):
     def name(self):
         return self._name
 
-    @property
-    @abstractmethod
-    def dimension(self):
-        pass
-
-    @property
-    @abstractmethod
-    def n_dimension(self):
-        pass
-
-    @property
-    @abstractmethod
-    def _grids(self):
-        pass
-
-    @property
-    def vertices(self):
-        """Return coordinates of mesh vertices.
-
-        Returns
-        -------
-        vertices : numpy.ndarray
-            Returns a numpy.ndarray representing the coordinates of the mesh
-            vertices with a shape equal to (dim1 + 1, ..., dimn + 1, ndim).
-
-        """
-        return np.stack(np.meshgrid(*self._grids, indexing='ij'), axis=-1)
-
-    @property
-    def centroids(self):
-        """Return coordinates of mesh element centroids.
-
-        Returns
-        -------
-        centroids : numpy.ndarray
-            Returns a numpy.ndarray representing the mesh element centroid
-            coordinates with a shape equal to (dim1, ..., dimn, ndim).
-
-        """
-        ndim = self.n_dimension
-        vertices = self.vertices
-        s0 = (slice(0, -1),)*ndim + (slice(None),)
-        s1 = (slice(1, None),)*ndim + (slice(None),)
-        return (vertices[s0] + vertices[s1]) / 2
-
     @name.setter
     def name(self, name):
         if name is not None:
@@ -171,7 +126,76 @@ class MeshBase(IDManagerMixin, ABC):
             raise ValueError(f'Unrecognized mesh type "{mesh_type}" found.')
 
 
-class RegularMesh(MeshBase):
+class StructuredMesh(ABC):
+    """A mixin for structured mesh functionality
+
+    Parameters
+    ----------
+    mesh_id : int
+        Unique identifier for the mesh
+    name : str
+        Name of the mesh
+
+    Attributes
+    ----------
+    id : int
+        Unique identifier for the mesh
+    name : str
+        Name of the mesh
+
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    @property
+    @abstractmethod
+    def dimension(self):
+        pass
+
+    @property
+    @abstractmethod
+    def n_dimension(self):
+        pass
+
+    @property
+    @abstractmethod
+    def _grids(self):
+        pass
+
+    @property
+    def vertices(self):
+        """Return coordinates of mesh vertices.
+
+        Returns
+        -------
+        vertices : numpy.ndarray
+            Returns a numpy.ndarray representing the coordinates of the mesh
+            vertices with a shape equal to (dim1 + 1, ..., dimn + 1, ndim).
+
+        """
+        return np.stack(np.meshgrid(*self._grids, indexing='ij'), axis=-1)
+
+    @property
+    def centroids(self):
+        """Return coordinates of mesh element centroids.
+
+        Returns
+        -------
+        centroids : numpy.ndarray
+            Returns a numpy.ndarray representing the mesh element centroid
+            coordinates with a shape equal to (dim1, ..., dimn, ndim).
+
+        """
+        ndim = self.n_dimension
+        vertices = self.vertices
+        s0 = (slice(0, -1),)*ndim + (slice(None),)
+        s1 = (slice(1, None),)*ndim + (slice(None),)
+        return (vertices[s0] + vertices[s1]) / 2
+
+
+
+class RegularMesh(StructuredMesh, MeshBase):
     """A regular Cartesian mesh in one, two, or three dimensions
 
     Parameters


### PR DESCRIPTION
This PR adds helper methods to the `openmc.MeshBase` subclasses that should be helpful in post-processing. Since I find myself reconstructing mesh coordinates in plotting scripts all the time, I thought it would be nice to get this directly from the mesh itself. This is also the first PR in a series of mesh API related changes I would like to implement to make mesh handling more uniform for some of the shutdown dose rate workflows we will be implementing soon. 

To keep this PR from changing too many things at once, the follow on PRs will include things like:
- adding grid arguments to constructors of all mesh classes
- adding translation and rotation methods to mesh classes