### PR TITLE
allow ci to be skipped for non code files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'examples/**'
+      - 'man/**'
       - '**.md'
       - CODEOWNERS
       - LICENSE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
   workflow_dispatch:
 
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - CODEOWNERS
+      - LICENSE
     branches:
       - develop
       - master

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Code Coverage](https://coveralls.io/repos/github/openmc-dev/openmc/badge.svg?branch=develop)](https://coveralls.io/github/openmc-dev/openmc?branch=develop)
 [![dockerhub-publish-develop-dagmc](https://github.com/openmc-dev/openmc/workflows/dockerhub-publish-develop-dagmc/badge.svg)](https://github.com/openmc-dev/openmc/actions?query=workflow%3Adockerhub-publish-develop-dagmc)
 [![dockerhub-publish-develop](https://github.com/openmc-dev/openmc/workflows/dockerhub-publish-develop/badge.svg)](https://github.com/openmc-dev/openmc/actions?query=workflow%3Adockerhub-publish-develop)
+[![conda-pacakge](https://anaconda.org/conda-forge/openmc/badges/version.svg)](https://anaconda.org/conda-forge/openmc)
 
 The OpenMC project aims to provide a fully-featured Monte Carlo particle
 transport code based on modern methods. It is a constructive solid geometry,


### PR DESCRIPTION
This PR makes use of the ```paths-ignore:``` keyword in github actions. This allows us to avoid triggering the GitHub Actions CI when non code related files are changed. It might save some :electric_plug: :zap: in the long term.
