### PR TITLE
Fix Region.from_expression when ")(" appears in region specification

### DIFF
--- a/openmc/region.py
+++ b/openmc/region.py
@@ -116,14 +116,20 @@ class Region(ABC):
                     # For everything other than intersection, add the operator
                     # to the list of tokens
                     tokens.append(expression[i])
+
+                    # If two parentheses appear immediately adjacent to one
+                    # another, we need an intersection between them
+                    if expression[i:i+2] == ')(':
+                        tokens.append(' ')
                 else:
                     # Find next non-space character
                     while expression[i+1] == ' ':
                         i += 1
 
-                    # If previous token is a halfspace or right parenthesis and next token
-                    # is not a left parenthese or union operator, that implies that the
-                    # whitespace is to be interpreted as an intersection operator
+                    # If previous token is a halfspace or right parenthesis and
+                    # next token is not a left parenthesis or union operator,
+                    # that implies that the whitespace is to be interpreted as
+                    # an intersection operator
                     if (i_start >= 0 or tokens[-1] == ')') and \
                        expression[i+1] not in ')|':
                         tokens.append(' ')

--- a/tests/unit_tests/test_region.py
+++ b/tests/unit_tests/test_region.py
@@ -200,3 +200,7 @@ def test_from_expression(reset):
     assert isinstance(r, openmc.Intersection)
     assert isinstance(r[1], openmc.Union)
     assert r[1][:] == [-s2, +s3]
+
+    # Make sure ")(" is handled correctly
+    r = openmc.Region.from_expression('(-1|2)(2|-3)', surfs)
+    assert str(r) == '((-1 | 2) (2 | -3))'


### PR DESCRIPTION
I just discovered there's a bug in `Region.from_expression` when the region specification being passed includes a left parenthesis immediately after a right parenthesis, `)(`. The correct behavior would be to add an intersection operator between the parenthesized expressions, but when there's no space between the parentheses it misses it currently. I added a test that covers this case along with a fix.