### PR TITLE
Minor docstring fixes for `openmc.ZCone` and `openmc.HexLattice`

### DIFF
--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -2056,8 +2056,8 @@ class HexLattice(Lattice):
 
         Returns
         -------
-        openmc.RectLattice
-            Rectangular lattice
+        openmc.HexLattice
+            Hexagonal lattice
 
         """
         n_rings = group['n_rings'][()]

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1968,7 +1968,7 @@ class YCone(QuadricMixin, Surface):
 
 
 class ZCone(QuadricMixin, Surface):
-    """A cone parallel to the x-axis of the form :math:`(x - x_0)^2 + (y - y_0)^2 =
+    """A cone parallel to the z-axis of the form :math:`(x - x_0)^2 + (y - y_0)^2 =
     r^2 (z - z_0)^2`.
 
     Parameters


### PR DESCRIPTION
This PR contains two small fixes to docstrings in `openmc.ZCone` and `openmc.HexLattice`. Specifically, this PR:
- changes `x-axis` to `z-axis` in the class docstring for `openmc.ZCone`
- changes `RectLattice` and `Rectangular` to `HexLattice` and `Hexagonal` in the docstring for `openmc.HexLattice.from_hdf5` 