### PR TITLE
Create a Plane in XY from x0, y0, and an angle.

### DIFF
--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -753,6 +753,38 @@ class Plane(PlaneMixin, Surface):
         d = np.dot(n, p1)
         return cls(a=a, b=b, c=c, d=d, **kwargs)
 
+    @classmethod
+    def from_xy_angle(cls, x0, y0, angle, degrees=False, **kwargs):
+        """Return a plane given a single xy-point and an angle.
+
+        Parameters
+        ----------
+        angle : float, optional
+            Angle CCW from the x-axis.
+        degrees : bool, optional
+            Whether the angle is in degrees. Otherwise, it is in radians.
+            Defaults to False.
+        x0 : float, optional
+            X-coordinate of the "center" of the plane. Defaults to 0.
+        y0 : float, optional
+            Y-coordinate of the "center" of the plane. Defaults to 0.
+        kwargs : dict
+            Keyword arguments passed to the :class:`Plane` constructor
+
+        Returns
+        -------
+        Plane
+            Plane that passes through the three points
+
+        """
+        if degrees:
+            angle = np.deg2rad(angle)
+        a = np.sin(angle)
+        b = np.cos(angle)
+        c = 0.
+        d = a*x0 + b*y0
+        return cls(a=a, b=b, c=c, d=d, **kwargs)
+
 
 class XPlane(PlaneMixin, Surface):
     """A plane perpendicular to the x axis of the form :math:`x - x_0 = 0`

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -754,7 +754,7 @@ class Plane(PlaneMixin, Surface):
         return cls(a=a, b=b, c=c, d=d, **kwargs)
 
     @classmethod
-    def from_xy_angle(cls, x0, y0, angle, degrees=False, **kwargs):
+    def from_xy_angle(cls, angle, degrees=False, x0=0., y0=0., **kwargs):
         """Return a plane given a single xy-point and an angle.
 
         Parameters

--- a/tests/unit_tests/test_surface.py
+++ b/tests/unit_tests/test_surface.py
@@ -66,6 +66,18 @@ def test_plane_from_points():
     assert s.d == 1.0
 
 
+def test_plane_from_xy_angle():
+    # Generate the plane which forms a 60-degree angle with the axis,
+    # centered at (+2.0, -1.0).
+    s = openmc.Plane.from_xy_angle(x0=2.0, y0=-1.0, angle=60, degrees=True)
+
+    # Confirm correct coefficients
+    assert np.isclose(s.a, np.sqrt(3.)/2)
+    assert np.isclose(s.b, 0.5)
+    assert s.c == 0.0
+    assert np.isclose(s.d, np.sqrt(3.) - 0.5)
+
+
 def test_xplane():
     s = openmc.XPlane(3., boundary_type='reflective')
     assert s.x0 == 3.


### PR DESCRIPTION
Frequently, one needs to make a plane for an angle while working in XY-space. Perhaps it would be useful as a class method of `Plane`. This pull request therefore implements `Plane.from_xy_angle()`.

A unit test is included for the following plane, which intersects (+2, -1) and makes a 60 degree angle with the x-axis.

![60-degrees](https://user-images.githubusercontent.com/19986691/161168747-affdca0f-77f7-4824-acea-56c69c345005.png)