### PR TITLE
Kalbach-Mann slope calculation for ENDF files

### DIFF
--- a/docs/source/pythonapi/data.rst
+++ b/docs/source/pythonapi/data.rst
@@ -24,6 +24,7 @@ and product yields.
     FissionProductYields
     WindowedMultipole
     ProbabilityTables
+    AtomicRepresentation
 
 The following classes are used for storing atomic data (incident photon cross
 sections, atomic relaxation):
@@ -68,6 +69,7 @@ Core Functions
     thin
     water_density
     zam
+    return_kalbach_slope
 
 One-dimensional Functions
 -------------------------

--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -127,7 +127,7 @@ acer / %%%%%%%%%%%%%%%%%%%%%%%% Write out in ACE format %%%%%%%%%%%%%%%%%%%%%%%%
 1 0 1 .{ext} /
 '{library}: {zsymam} at {temperature}'/
 {mat} {temperature}
-1 1 {ismoothing}/
+1 1 {ismooth}/
 /
 """
 
@@ -383,7 +383,7 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
 
     # acer
     if acer:
-        ismoothing = int(smoothing)
+        ismooth = int(smoothing)
         nacer_in = nlast
         for i, temperature in enumerate(temperatures):
             # Extend input with an ACER run for each temperature

--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -127,7 +127,7 @@ acer / %%%%%%%%%%%%%%%%%%%%%%%% Write out in ACE format %%%%%%%%%%%%%%%%%%%%%%%%
 1 0 1 .{ext} /
 '{library}: {zsymam} at {temperature}'/
 {mat} {temperature}
-1 1/
+1 1 {ismoothing}/
 /
 """
 
@@ -248,7 +248,8 @@ def make_pendf(filename, pendf='pendf', error=0.001, stdout=False):
 
 def make_ace(filename, temperatures=None, acer=True, xsdir=None,
              output_dir=None, pendf=False, error=0.001, broadr=True,
-             heatr=True, gaspr=True, purr=True, evaluation=None, **kwargs):
+             heatr=True, gaspr=True, purr=True, evaluation=None,
+             smoothing=True, **kwargs):
     """Generate incident neutron ACE file from an ENDF file
 
     File names can be passed to
@@ -298,6 +299,8 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
     evaluation : openmc.data.endf.Evaluation, optional
         If the ENDF file contains multiple material evaluations, this argument
         indicates which evaluation should be used.
+    smoothing : bool, optional
+        If the smoothing option in ACER is on (1) or off (0) in the card 6.
     **kwargs
         Keyword arguments passed to :func:`openmc.data.njoy.run`
 
@@ -380,6 +383,10 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
 
     # acer
     if acer:
+        if smoothing is True:
+            ismoothing = 1
+        else:
+            ismoothing = 0
         nacer_in = nlast
         for i, temperature in enumerate(temperatures):
             # Extend input with an ACER run for each temperature

--- a/openmc/data/reaction.py
+++ b/openmc/data/reaction.py
@@ -82,7 +82,7 @@ def _get_products(ev, mt):
 
     Raises
     ------
-    IOError:
+    IOError
         When the Kalbach-Mann systematics is used, but the product
         is not defined in the 'center-of-mass' system. The breakup logic
         is not implemented which can lead to this error being raised while

--- a/openmc/data/reaction.py
+++ b/openmc/data/reaction.py
@@ -80,6 +80,14 @@ def _get_products(ev, mt):
     mt : int
         The MT value of the reaction to get products for
 
+    Raises
+    ------
+    IOError:
+        When the Kalbach-Mann systematics is used, but the product
+        is not defined in the 'center-of-mass' system. The breakup logic
+        is not implemented which can lead to this error being raised while
+        the definition of the product is correct.
+
     Returns
     -------
     products : list of openmc.data.Product
@@ -141,7 +149,26 @@ def _get_products(ev, mt):
             if lang == 1:
                 p.distribution = [CorrelatedAngleEnergy.from_endf(file_obj)]
             elif lang == 2:
-                p.distribution = [KalbachMann.from_endf(file_obj)]
+                # Products need to be described in the center-of-mass system
+                product_center_of_mass = False
+                if reference_frame == 'center-of-mass':
+                    product_center_of_mass = True
+                elif reference_frame == 'light-heavy':
+                    product_center_of_mass = (awr <= 4.0)
+                # TODO: 'breakup' logic not implemented
+
+                if product_center_of_mass is False:
+                    raise IOError(
+                        "Kalbach-Mann representation must be defined in the "
+                        "'center-of-mass' system"
+                    )
+
+                zat = ev.target["atomic_number"] * 1000 + ev.target["mass_number"]
+                projectile_mass = ev.projectile["mass"]
+                p.distribution = [KalbachMann.from_endf(file_obj,
+                                                        za,
+                                                        zat,
+                                                        projectile_mass)]
 
         elif law == 2:
             # Discrete two-body scattering

--- a/tests/unit_tests/test_data_kalbach_mann.py
+++ b/tests/unit_tests/test_data_kalbach_mann.py
@@ -1,0 +1,280 @@
+"""Test of the Kalbach-Mann slope calculation when data are
+retrieved from ENDF files."""
+
+import os
+import pytest
+import numpy as np
+
+from openmc.data import IncidentNeutron
+from openmc.data import AtomicRepresentation
+from openmc.data.kalbach_mann import _BREAKING_ENERGY_TRITON
+from openmc.data.kalbach_mann import _M_TRITON
+from openmc.data.kalbach_mann import _SM_TRITON
+from openmc.data.kalbach_mann import _calculate_separation_energy
+from openmc.data.kalbach_mann import _return_emission_channel_energy
+from openmc.data.kalbach_mann import _return_entrance_channel_energy
+from openmc.data.kalbach_mann import _calculate_kalbach_slope
+from openmc.data import return_kalbach_slope
+from openmc.data import KalbachMann
+
+from . import needs_njoy
+
+
+@pytest.fixture(scope='module')
+def neutron():
+    """Neutron AtomicRepresentation."""
+    return AtomicRepresentation(z=0, a=1)
+
+
+@pytest.fixture(scope='module')
+def triton():
+    """Triton AtomicRepresentation."""
+    return AtomicRepresentation(z=1, a=3)
+
+
+@pytest.fixture(scope='module')
+def b10():
+    """B10 AtomicRepresentation."""
+    return AtomicRepresentation(z=5, a=10)
+
+
+@pytest.fixture(scope='module')
+def c12():
+    """C12 AtomicRepresentation."""
+    return AtomicRepresentation(z=6, a=12)
+
+
+@pytest.fixture(scope='module')
+def c13():
+    """C13 AtomicRepresentation."""
+    return AtomicRepresentation(z=6, a=13)
+
+
+@pytest.fixture(scope='module')
+def na23():
+    """Na23 AtomicRepresentation."""
+    return AtomicRepresentation(z=11, a=23)
+
+
+def test_atomic_representation(neutron, triton, b10, c12, c13, na23):
+    """Test the AtomicRepresentation class."""
+    # Test instanciation from_iza
+    assert b10 == AtomicRepresentation.from_iza(5010)
+
+    # Test instanciation from_iza using IZA translation
+    assert c12 == AtomicRepresentation.from_iza(6000)
+
+    # Test addition
+    assert c13 + b10 == na23
+
+    # Test substraction
+    assert c13 - c12 == neutron
+    assert c13 - b10 == triton
+
+    # Test properties when no information for Kalbach-Mann are given
+    assert c13.a == 13
+    assert c13.z == 6
+    assert c13.n == 7
+    assert c13.breaking_energy is None
+    assert c13.M is None
+    assert c13.m is None
+    assert c13.iza == 6013
+
+    # Test properties when information for Kalbach-Mann are given
+    assert triton.a == 3
+    assert triton.z == 1
+    assert triton.n == 2
+    assert triton.breaking_energy == _BREAKING_ENERGY_TRITON
+    assert triton.M == _M_TRITON
+    assert triton.m == _SM_TRITON
+    assert triton.iza == 1003
+
+    # Test instanciation errors
+    with pytest.raises(IOError):
+        AtomicRepresentation(z=5, a=1)
+    with pytest.raises(ValueError):
+        AtomicRepresentation(z=-1, a=1)
+    with pytest.raises(IOError):
+        AtomicRepresentation(z=5, a=0)
+    with pytest.raises(IOError):
+        AtomicRepresentation(z=5, a=-2)
+    with pytest.raises(OSError):
+        neutron - triton
+
+
+def test__calculate_separation_energy(triton, b10, c13):
+    """Comparison to hand-calculations on a simple example."""
+    assert _calculate_separation_energy(
+        compound=c13,
+        nucleus=b10,
+        particle=triton
+    ) == pytest.approx(18.6880713)
+
+
+def test__return_entrance_channel_energy():
+    """Comparison to hand-calculations on a simple example."""
+    assert _return_entrance_channel_energy(
+        e_p=5.2,
+        awr_t=13.7,
+        awr_p=7.2
+    ) == pytest.approx(3.4086124)
+
+
+def test__return_emission_channel_energy():
+    """Comparison to hand-calculations on a simple example."""
+    assert _return_emission_channel_energy(
+        e_e=6.8,
+        awr_r=49.2,
+        awr_e=5.4
+    ) == pytest.approx(7.5463415)
+
+
+def test__calculate_kalbach_slope(neutron, triton, b10, c12, c13):
+    """Comparison to hand-calculations for n + c12 -> c13 -> triton + b10."""
+    energy_projectile = 10.2  # [eV]
+    energy_emitted = 5.4  # [eV]
+
+    assert _calculate_kalbach_slope(
+        energy_projectile=energy_projectile,
+        energy_emitted=energy_emitted,
+        projectile=neutron,
+        target=c12,
+        compound=c13,
+        emitted=triton,
+        residual=b10
+    ) == pytest.approx(0.8409921475)
+
+
+def test_return_kalbach_slope():
+    """Comparison to hand-calculations for n + c12 -> c13 -> triton + b10."""
+    energy_projectile = 10.2  # [eV]
+    energy_emitted = 5.4  # [eV]
+
+    # Check that NotImplementedError is raised if the projectile is not
+    # a neutron
+    with pytest.raises(NotImplementedError):
+        return_kalbach_slope(
+            energy_projectile=energy_projectile,
+            energy_emitted=energy_emitted,
+            iza_projectile=1000,
+            iza_emitted=1,
+            iza_target=6012
+        )
+
+    assert return_kalbach_slope(
+        energy_projectile=energy_projectile,
+        energy_emitted=energy_emitted,
+        iza_projectile=1,
+        iza_emitted=1003,
+        iza_target=6012
+    ) == pytest.approx(0.8409921475)
+
+
+@pytest.mark.parametrize(
+    "hdf5_filename, endf_type, endf_filename", [
+        ('O16.h5', 'neutrons', 'n-008_O_016.endf'),
+        ('Ca46.h5', 'neutrons', 'n-020_Ca_046.endf'),
+        ('Hg204.h5', 'neutrons', 'n-080_Hg_204.endf')
+    ]
+)
+def test_comparison_slope_hdf5(hdf5_filename, endf_type, endf_filename):
+    """Test the calculation of the Kalbach-Mann slope done by OpenMC
+    by comparing it to HDF5 data. The test is based on the first product
+    of MT=5 (neutron). The isotopes tested have been selected because the
+    corresponding products in ENDF/B-VII.1 are described using MF=6, LAW=1,
+    LANG=2 (ie. Kalbach-Mann systematics) and the slope is not given
+    explicitly.
+
+    If an error occurs during the "validity check", this means that
+    the nuclear data evaluation has evolved and the distribution might
+    no longer be described using Kalbach-Mann systematics. Another
+    isotope needs to be identified and tested.
+
+    Warning: This test is valid as long as ENDF files are not directly
+    used to generate the HDF5 files used in the tests.
+
+    """
+    # HDF5 data
+    hdf5_directory = os.path.dirname(os.environ['OPENMC_CROSS_SECTIONS'])
+    hdf5_path = os.path.join(hdf5_directory, hdf5_filename)
+    hdf5_data = IncidentNeutron.from_hdf5(hdf5_path)
+    hdf5_product = hdf5_data[5].products[0]
+    hdf5_distribution = hdf5_product.distribution[0]
+
+    # ENDF data
+    endf_directory = os.environ['OPENMC_ENDF_DATA']
+    endf_path = os.path.join(endf_directory, endf_type, endf_filename)
+    endf_data = IncidentNeutron.from_endf(endf_path)
+    endf_product = endf_data[5].products[0]
+    endf_distribution = endf_product.distribution[0]
+
+    # Validity check
+    assert isinstance(endf_distribution, KalbachMann)
+    assert isinstance(hdf5_distribution, KalbachMann)
+    assert endf_product.particle == hdf5_product.particle
+    assert len(endf_distribution.slope) == len(hdf5_distribution.slope)
+
+    # Results check
+    for i, hdf5_slope in enumerate(hdf5_distribution.slope):
+
+        assert endf_distribution._calculated_slope[i] is True
+
+        np.testing.assert_array_almost_equal(
+            endf_distribution.slope[i].y,
+            hdf5_slope.y,
+            decimal=6
+        )
+
+
+@needs_njoy
+@pytest.mark.parametrize(
+    "endf_type, endf_filename", [
+        ('neutrons', 'n-008_O_016.endf'),
+        ('neutrons', 'n-020_Ca_046.endf'),
+        ('neutrons', 'n-080_Hg_204.endf')
+    ]
+)
+def test_comparison_slope_njoy(endf_type, endf_filename):
+    """Test the calculation of the Kalbach-Mann slope done by OpenMC
+    by comparing it to an NJOY calculation. The test is based on
+    the first product of MT=5 (neutron). The isotopes tested have
+    been selected because the corresponding products in ENDF/B-VII.1
+    are described using MF=6, LAW=1, LANG=2 (ie. Kalbach-Mann
+    systematics) and the slope is not given explicitly.
+
+    If an error occurs during the "validity check", this means that
+    the nuclear data evaluation has evolved and the distribution might
+    no longer be described using Kalbach-Mann systematics. Another
+    isotope needs to be identified and tested.
+
+    """
+    endf_directory = os.environ['OPENMC_ENDF_DATA']
+    endf_path = os.path.join(endf_directory, endf_type, endf_filename)
+
+    # ENDF data
+    endf_data = IncidentNeutron.from_endf(endf_path)
+    endf_product = endf_data[5].products[0]
+    endf_distribution = endf_product.distribution[0]
+
+    # NJOY data
+    njoy_data = IncidentNeutron.from_njoy(endf_path, heatr=False, gaspr=False,
+                                          purr=False, smoothing=False)
+    njoy_product = njoy_data[5].products[0]
+    njoy_distribution = njoy_product.distribution[0]
+
+    # Validity check
+    assert isinstance(endf_distribution, KalbachMann)
+    assert isinstance(njoy_distribution, KalbachMann)
+    assert endf_product.particle == njoy_product.particle
+    assert len(endf_distribution.slope) == len(njoy_distribution.slope)
+
+    # Results check
+    for i, njoy_slope in enumerate(njoy_distribution.slope):
+
+        assert endf_distribution._calculated_slope[i] is True
+
+        np.testing.assert_array_almost_equal(
+            endf_distribution.slope[i].y,
+            njoy_slope.y,
+            decimal=6
+        )


### PR DESCRIPTION
Hi everyone,

This PR enables the calculation of the slope parameter of a Kalbach-Mann distribution when it is not provided in an ENDF file. This calculation is already used in NJOY2016 to produce ACE files from ENDF files, and described in the ENDF-6 Formats Manual.

In this PR, the calculation is only valid if the projectile is a neutron. To check if the projectile is a neutron, the projectile mass is retrieved from the ENDF evaluation and compared to 1. Having access to the ZA identifier (Zx1000 +A) would be better, but I have not been able to find a way to retrieve it.

The calculation is performed as defined in the ENDF-6 Manual, BNL-203218-2018-INRE, Revision 215, File 6 description for LAW=1 and LANG=2. One exception to this, is that the entrance and emission channel energies are not calculated with the AWR number, but approximated with the number of mass instead.

The development is tested against HDF5 files and NJOY calculations for 3 isotopes, MT=5, and neutron as projectile and emitted particle. Because ENDF files can not be used directly to produce HDF5 files for the moment, the test against HDF5 files makes sense. However, if this limitation is lifted, the test is no longer valid as we could potentially end up comparing the same values. In my opinion, the test against NJOY is sufficient, but I wanted to provide both for discussion.

The AtomicRepresentation class has been developed to simplify the manipulation of isotopes from their ZA identifier. For the moment, this class is stored in the kalbach_mann module which does not seem ideal, but it could easily be stored in its own module.

Additionally, a new “smoothing” parameter has been added to the make_ace function. The objective is to be able to remove the smoothing option in the ACER call, so that distributions from ENDF and ACE files share the same energy grid and can be compared directly.