### PR TITLE
`IsogonalOctagon` composite surface

### DIFF
--- a/docs/source/pythonapi/model.rst
+++ b/docs/source/pythonapi/model.rst
@@ -25,7 +25,7 @@ Composite Surfaces
    :nosignatures:
    :template: myclass.rst
 
-   openmc.model.Octagon
+   openmc.model.IsogonalOctagon
    openmc.model.RectangularParallelepiped
    openmc.model.RightCircularCylinder
    openmc.model.XConeOneSided

--- a/docs/source/pythonapi/model.rst
+++ b/docs/source/pythonapi/model.rst
@@ -25,12 +25,12 @@ Composite Surfaces
    :nosignatures:
    :template: myclass.rst
 
+   openmc.model.Octagon
    openmc.model.RectangularParallelepiped
    openmc.model.RightCircularCylinder
    openmc.model.XConeOneSided
    openmc.model.YConeOneSided
    openmc.model.ZConeOneSided
-   openmc.model.Octagon
 
 TRISO Fuel Modeling
 -------------------

--- a/docs/source/pythonapi/model.rst
+++ b/docs/source/pythonapi/model.rst
@@ -30,6 +30,7 @@ Composite Surfaces
    openmc.model.XConeOneSided
    openmc.model.YConeOneSided
    openmc.model.ZConeOneSided
+   openmc.model.Octagon
 
 TRISO Fuel Modeling
 -------------------

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -52,6 +52,7 @@ class CompositeSurface(ABC):
     def __neg__(self):
         """Return the negative half-space of the composite surface."""
 
+
 class IsogonalOctagon(CompositeSurface):
     """Infinite isogonal octagon composite surface
 
@@ -143,30 +144,29 @@ class IsogonalOctagon(CompositeSurface):
 
         # Orientation specific variables
         if axis == 'z':
-            coord_map = [0,1,2]
-            self.top = openmc.YPlane(y0=ctop, **kwargs)
-            self.bottom = openmc.YPlane(y0=cbottom, **kwargs)
-            self.right = openmc.XPlane(x0=cright, **kwargs)
-            self.left = openmc.XPlane(x0=cleft, **kwargs)
+            coord_map = [0, 1, 2]
+            self.top = openmc.YPlane(ctop, **kwargs)
+            self.bottom = openmc.YPlane(cbottom, **kwargs)
+            self.right = openmc.XPlane(cright, **kwargs)
+            self.left = openmc.XPlane(cleft, **kwargs)
         elif axis == 'y':
-            coord_map = [0,2,1]
-            self.top = openmc.ZPlane(z0=ctop, **kwargs)
-            self.bottom = openmc.ZPlane(z0=cbottom, **kwargs)
-            self.right = openmc.XPlane(x0=cright, **kwargs)
-            self.left = openmc.XPlane(x0=cleft, **kwargs)
+            coord_map = [0, 2, 1]
+            self.top = openmc.ZPlane(ctop, **kwargs)
+            self.bottom = openmc.ZPlane(cbottom, **kwargs)
+            self.right = openmc.XPlane(cright, **kwargs)
+            self.left = openmc.XPlane(cleft, **kwargs)
         elif axis == 'x':
-            coord_map = [2,0,1]
-            self.top = openmc.ZPlane(z0=ctop, **kwargs)
-            self.bottom = openmc.ZPlane(z0=cbottom, **kwargs)
-            self.right = openmc.YPlane(y0=cright, **kwargs)
-            self.left = openmc.YPlane(y0=cleft, **kwargs)
+            coord_map = [2, 0, 1]
+            self.top = openmc.ZPlane(ctop, **kwargs)
+            self.bottom = openmc.ZPlane(cbottom, **kwargs)
+            self.right = openmc.YPlane(cright, **kwargs)
+            self.left = openmc.YPlane(cleft, **kwargs)
 
         # Put our coordinates in (x,y,z) order
-        calibrated_points = []
         for p in points:
-            calibrated_points += [p[coord_map]]
+            p[:] = p[coord_map]
 
-        p1_ur, p2_ur, p3_ur, p1_lr, p2_lr, p3_lr = calibrated_points
+        #p1_ur, p2_ur, p3_ur, p1_lr, p2_lr, p3_lr = calibrated_points
 
         self.upper_right = openmc.Plane.from_points(p1_ur, p2_ur, p3_ur,
                                                     **kwargs)
@@ -176,7 +176,6 @@ class IsogonalOctagon(CompositeSurface):
                                                    **kwargs)
         self.upper_left = openmc.Plane.from_points(-p1_lr, -p2_lr, -p3_lr,
                                                    **kwargs)
-
 
     def __neg__(self):
         region1 = -self.top & +self.bottom & -self.right & +self.left
@@ -188,7 +187,6 @@ class IsogonalOctagon(CompositeSurface):
                 -self.lower_left & -self.upper_left
 
         return region1 & region2
-
 
     def __pos__(self):
         region1 = +self.top | -self.bottom | +self.right | -self.left

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -64,38 +64,37 @@ class CompositeSurface(ABC):
 class Octagon(CompositeSurface):
     """Infinite octogonal prism composite surface
 
-    An octagonal prism is composed of eight surfaces. The prism is parallel to
-    the x, y, or z axis; two pars of surfaces are perpendicualr to the z and y,
-    x and z, or y and x axes, respectively.
+    An octagonal prism is composed of eight planar surfaces. The prism is
+    parallel to the x, y, or z axis; two pars of surfaces are perpendicular to
+    the y and z, x and z, or x and y axes, respectively.
 
-    This class
-    acts as a proper surface, meaning that unary `+` and `-` operators applied
-    to it will produce a half-space. The negative side is defined to be the
-    region inside of the octogonal prism.
+    This class acts as a proper surface, meaning that unary `+` and `-`
+    operators applied to it will produce a half-space. The negative side is
+    defined to be the region inside of the octogonal prism.
 
     Parameters
     ----------
-    center : 2-tuple
-        (q1,q2) coordinate for the center of the octagon. (q1,q2) pairs are
-        (x,y), (x,z), or (x,z).
+    center : iterable of float
+        (q1,q2) coordinate for the central axis of the octagon. (q1,q2) pairs
+        are (y,z), (x,z), or (x,y).
     r1 : float
-        Half-width of octagon across axis-perpendicualr sides
+        Half-width of octagon across axis-pendicular sides
     r2 : float
         Half-width of octagon across off-axis sides
     axis : {'x', 'y', 'z'}
-        Central axis of ocatgon. Defaults to 'z'
+        Central axis of octagon. Defaults to 'z'
     **kwargs
         Keyword arguments passed to underlying cylinder and plane classes
 
     Attributes
     ----------
-    top : openmc.ZPlane or openmc.XPlane
+    top : openmc.ZPlane or openmc.YPlane
         Top planar surface of octagon
-    bottom : openmc.ZPlane or openmc.XPlane
+    bottom : openmc.ZPlane or openmc.YPlane
         Bottom planar surface of octagon
-    right: openmc.YPlane or openmc.ZPlane
+    right: openmc.YPlane or openmc.XPlane
         Right planaer surface of octagon
-    left: openmc.YPlane or openmc.ZPlane
+    left: openmc.YPlane or openmc.XPlane
         Left planar surface of octagon
     upper_right : openmc.Plane
         Upper right planar surface of octagon

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -3,7 +3,7 @@ from copy import copy
 
 import openmc
 from openmc.checkvalue import check_greater_than, check_value
-from numpy import sqrt
+from numpy import sqrt, array
 
 class CompositeSurface(ABC):
     """Multiple primitive surfaces combined into a composite surface"""
@@ -161,18 +161,14 @@ class IsogonalOctagon(CompositeSurface):
             p_temp = []
             for i in coord_map:
                 p_temp += [p[i]]
-            calibrated_points += [p_temp]
+            calibrated_points += [array(p_temp)]
 
         p1_ur, p2_ur, p3_ur, p1_lr, p2_lr, p3_lr = calibrated_points
 
-        self.upper_right = openmc.Plane.from_points(p1_ur, p2_ur, p3_ur,
-                                                    **kwargs)
-        self.lower_right = openmc.Plane.from_points(p1_lr, p2_lr, p3_lr,
-                                                    **kwargs)
-        self.lower_left = openmc.Plane.from_points(-p1_ur, -p2_ur, -p3_ur,
-                                                   **kwargs)
-        self.upper_left = openmc.Plane.from_points(-p1_lr, -p2_lr, -p3_lr,
-                                                   **kwargs)
+        self.upper_right = openmc.Plane.from_points(p1_ur, p2_ur, p3_ur, **kwargs)
+        self.lower_right = openmc.Plane.from_points(p1_lr, p2_lr, p3_lr, **kwargs)
+        self.lower_left = openmc.Plane.from_points(-p1_ur, -p2_ur, -p3_ur,  **kwargs)
+        self.upper_left = openmc.Plane.from_points(-p1_lr, -p2_lr, -p3_lr, **kwargs)
 
 
     def __neg__(self):

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -109,7 +109,6 @@ class IsogonalOctagon(CompositeSurface):
                       'lower_right', 'upper_left')
 
     def __init__(self, center, r1, r2, axis='z', **kwargs):
-        self._axis = axis
         c1, c2 = center
 
         # Coords for axis-perpendicular planes

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -126,16 +126,16 @@ class IsogonalOctagon(CompositeSurface):
             raise ValueError(f'r1 is greater than sqrt(2) * r2. Octagon' + \
                              ' may be erroneous.')
 
-        L_perp_ax1 = (r2 * sqrt(2) - r1)
+        L_basis_ax = (r2 * sqrt(2) - r1)
 
         # Coords for quadrant planes
-        p1_ur = np.array([L_perp_ax1, r1, 0.])
-        p2_ur = np.array([r1, L_perp_ax1, 0.])
-        p3_ur = np.array([r1, L_perp_ax1, 1.])
+        p1_ur = np.array([L_basis_ax, r1, 0.])
+        p2_ur = np.array([r1, L_basis_ax, 0.])
+        p3_ur = np.array([r1, L_basis_ax, 1.])
 
-        p1_lr = np.array([r1, -L_perp_ax1, 0.])
-        p2_lr = np.array([L_perp_ax1, -r1, 0.])
-        p3_lr = np.array([L_perp_ax1, -r1, 1.])
+        p1_lr = np.array([r1, -L_basis_ax, 0.])
+        p2_lr = np.array([L_basis_ax, -r1, 0.])
+        p3_lr = np.array([L_basis_ax, -r1, 1.])
 
         points = [p1_ur, p2_ur, p3_ur, p1_lr, p2_lr, p3_lr]
 

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -1,9 +1,10 @@
 from abc import ABC, abstractmethod
 from copy import copy
+from math import sqrt
+from numpy import array
 
 import openmc
 from openmc.checkvalue import check_greater_than, check_value
-from numpy import sqrt, array
 
 class CompositeSurface(ABC):
     """Multiple primitive surfaces combined into a composite surface"""
@@ -74,7 +75,7 @@ class IsogonalOctagon(CompositeSurface):
         of cm
     r2 : float
         Half-width of octagon across its basis axis intersecting sides in
-        units of cm. Must be less than :math:`\sqrt{2} r_1`.
+        units of cm. Assumed to be less than :math:`r_1\sqrt{2}`.
     axis : {'x', 'y', 'z'}
         Central axis of octagon. Defaults to 'z'
     **kwargs
@@ -87,7 +88,7 @@ class IsogonalOctagon(CompositeSurface):
     bottom : openmc.ZPlane or openmc.YPlane
         Bottom planar surface of octagon
     right: openmc.YPlane or openmc.XPlane
-        Right planaer surface of octagon
+        Right planar surface of octagon
     left: openmc.YPlane or openmc.XPlane
         Left planar surface of octagon
     upper_right : openmc.Plane
@@ -119,7 +120,8 @@ class IsogonalOctagon(CompositeSurface):
 
         # Side lengths
         if (r2 > r1 * sqrt(2)):
-            raise ValueError(f'r2 must be less than {sqrt(2) * r1}')
+            raise Warning(f'r2 is greater than {sqrt(2) * r1}. Octagon may'
+                          'be erroneous.')
 
         L_perp_ax1 = (r2 * sqrt(2) - r1) * 2
         L_perp_ax2 = (r1 * sqrt(2) - r2) * 2

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -57,7 +57,7 @@ class IsogonalOctagon(CompositeSurface):
     """Infinite isogonal octagon composite surface
 
     An isogonal octagon is composed of eight planar surfaces. The prism is
-    parallel to the x, y, or z axis. The remaining two axes (y and z, x and z,
+    parallel to the x, y, or z axis. The remaining two axes (y and z, z and x,
     or x and y) serve as a basis for constructing the surfaces. Two surfaces
     are parallel to the first basis axis, two surfaces are parallel
     to the second basis axis, and the remaining four surfaces intersect both
@@ -71,7 +71,7 @@ class IsogonalOctagon(CompositeSurface):
     ----------
     center : iterable of float
         Coordinate for the central axis of the octagon in the
-        (y, z), (x, z), or (x, y) basis.
+        (y, z), (z, x), or (x, y) basis.
     r1 : float
         Half-width of octagon across its basis axis-parallel sides in units
         of cm. Assumed to be less than :math:`r_2\sqrt{2}`.
@@ -85,13 +85,13 @@ class IsogonalOctagon(CompositeSurface):
 
     Attributes
     ----------
-    top : openmc.ZPlane or openmc.YPlane
+    top : openmc.ZPlane, openmc.XPlane, or openmc.YPlane
         Top planar surface of octagon
-    bottom : openmc.ZPlane or openmc.YPlane
+    bottom : openmc.ZPlane, openmc.XPlane, or openmc.YPlane
         Bottom planar surface of octagon
-    right: openmc.YPlane or openmc.XPlane
+    right: openmc.YPlane, openmc.ZPlane, or openmc.XPlane
         Right planar surface of octagon
-    left: openmc.YPlane or openmc.XPlane
+    left: openmc.YPlane, openmc.ZPlane, or openmc.XPlane
         Left planar surface of octagon
     upper_right : openmc.Plane
         Upper right planar surface of octagon
@@ -150,11 +150,11 @@ class IsogonalOctagon(CompositeSurface):
             self.right = openmc.XPlane(cright, **kwargs)
             self.left = openmc.XPlane(cleft, **kwargs)
         elif axis == 'y':
-            coord_map = [0, 2, 1]
-            self.top = openmc.ZPlane(ctop, **kwargs)
-            self.bottom = openmc.ZPlane(cbottom, **kwargs)
-            self.right = openmc.XPlane(cright, **kwargs)
-            self.left = openmc.XPlane(cleft, **kwargs)
+            coord_map = [1, 2, 0]
+            self.top = openmc.XPlane(ctop, **kwargs)
+            self.bottom = openmc.XPlane(cbottom, **kwargs)
+            self.right = openmc.ZPlane(cright, **kwargs)
+            self.left = openmc.ZPlane(cleft, **kwargs)
         elif axis == 'x':
             coord_map = [2, 0, 1]
             self.top = openmc.ZPlane(ctop, **kwargs)
@@ -178,26 +178,14 @@ class IsogonalOctagon(CompositeSurface):
                                                    **kwargs)
 
     def __neg__(self):
-        region1 = -self.top & +self.bottom & -self.right & +self.left
-        if self._axis == 'y':
-            region2 = -self.upper_right & -self.lower_right & \
-                +self.lower_left & +self.upper_left
-        else:
-            region2 = +self.upper_right & +self.lower_right & \
-                -self.lower_left & -self.upper_left
-
-        return region1 & region2
+        return -self.top & +self.bottom & -self.right & +self.left & \
+            +self.upper_right & +self.lower_right & -self.lower_left & \
+            -self.upper_left
 
     def __pos__(self):
-        region1 = +self.top | -self.bottom | +self.right | -self.left
-        if self._axis == 'y':
-            region2 = +self.upper_right | +self.lower_right | \
-                -self.lower_left | -self.upper_left
-        else:
-            region2 = -self.upper_right | -self.lower_right | \
-                +self.lower_left | +self.upper_left
-
-        return region1 | region2
+        return +self.top | -self.bottom | +self.right | -self.left | \
+            -self.upper_right | -self.lower_right | +self.lower_left | \
+            +self.upper_left
 
 
 class RightCircularCylinder(CompositeSurface):

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -4,7 +4,6 @@ from math import sqrt
 from numpy import array
 
 import openmc
-import warnings
 from openmc.checkvalue import check_greater_than, check_value
 
 class CompositeSurface(ABC):
@@ -74,10 +73,10 @@ class IsogonalOctagon(CompositeSurface):
         (y, z), (z, x), or (x, y) basis.
     r1 : float
         Half-width of octagon across its basis axis-parallel sides in units
-        of cm. Assumed to be less than :math:`r_2\sqrt{2}`.
+        of cm. Must be less than :math:`r_2\sqrt{2}`.
     r2 : float
         Half-width of octagon across its basis axis intersecting sides in
-        units of cm. Assumed to be less than :math:`r_1\sqrt{2}`.
+        units of cm. Must be less than than :math:`r_1\sqrt{2}`.
     axis : {'x', 'y', 'z'}
         Central axis of octagon. Defaults to 'z'
     **kwargs
@@ -122,11 +121,11 @@ class IsogonalOctagon(CompositeSurface):
 
         # Side lengths
         if r2 > r1 * sqrt(2):
-            warnings.warn(f'r2 is greater than sqrt(2) * r1. Octagon may' + \
-                          ' be erroneous.')
+            raise ValueError(f'r2 is greater than sqrt(2) * r1. Octagon' + \
+                             ' may be erroneous.')
         if r1 > r2 * sqrt(2):
-            warnings.warn(f'r1 is greater than sqrt(2) * r2. Octagon may' + \
-                          ' be erroneous.')
+            raise ValueError(f'r1 is greater than sqrt(2) * r2. Octagon' + \
+                             ' may be erroneous.')
 
         L_perp_ax1 = (r2 * sqrt(2) - r1) * 2
         L_perp_ax2 = (r1 * sqrt(2) - r2) * 2
@@ -165,8 +164,6 @@ class IsogonalOctagon(CompositeSurface):
         # Put our coordinates in (x,y,z) order
         for p in points:
             p[:] = p[coord_map]
-
-        #p1_ur, p2_ur, p3_ur, p1_lr, p2_lr, p3_lr = calibrated_points
 
         self.upper_right = openmc.Plane.from_points(p1_ur, p2_ur, p3_ur,
                                                     **kwargs)

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -3,18 +3,8 @@ from copy import copy
 
 import openmc
 from openmc.checkvalue import check_greater_than, check_value
-from numpy import sqrt, cross, dot, array
-
-def _plane_from_points(p1, p2, p3):
-    # get plane from points p1, p2, p3
-    n = cross(p2 - p1, p3 - p1)
-    n0 = -p1
-    A = n[0]
-    B = n[1]
-    C = n[2]
-    D = dot(n, n0)
-
-    return [A, B, C, -D]
+import openmc.Plane.from_points as plane_from_points
+from numpy import sqrt
 
 class CompositeSurface(ABC):
     """Multiple primitive surfaces combined into a composite surface"""
@@ -164,19 +154,14 @@ class Octagon(CompositeSurface):
             p_temp = []
             for i in coord_map:
                 p_temp += [p[i]]
-            calibrated_points += [array(p_temp)]
+            calibrated_points += [p_temp]
 
         p1_ur, p2_ur, p3_ur, p1_lr, p2_lr, p3_lr = calibrated_points
 
-        upper_right_params = _plane_from_points(p1_ur, p2_ur, p3_ur)
-        lower_right_params = _plane_from_points(p1_lr, p2_lr, p3_lr)
-        lower_left_params = _plane_from_points(-p1_ur, -p2_ur, -p3_ur)
-        upper_left_params = _plane_from_points(-p1_lr, -p2_lr, -p3_lr)
-
-        self.upper_right = openmc.Plane(*tuple(upper_right_params), **kwargs)
-        self.lower_right = openmc.Plane(*tuple(lower_right_params), **kwargs)
-        self.lower_left = openmc.Plane(*tuple(lower_left_params), **kwargs)
-        self.upper_left = openmc.Plane(*tuple(upper_left_params), **kwargs)
+        self.upper_right = plane_from_points(p1_ur, p2_ur, p3_ur, **kwargs)
+        self.lower_right = plane_from_points(p1_lr, p2_lr, p3_lr, **kwargs)
+        self.lower_left = plane_from_points(-p1_ur, -p2_ur, -p3_ur, **kwargs)
+        self.upper_left = plane_from_points(-p1_lr, -p2_lr, -p3_lr, **kwargs)
 
 
     def __neg__(self):

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from copy import copy
 from math import sqrt
-from numpy import array
+import numpy as np
 
 import openmc
 from openmc.checkvalue import check_greater_than, check_value
@@ -88,9 +88,9 @@ class IsogonalOctagon(CompositeSurface):
         Top planar surface of octagon
     bottom : openmc.ZPlane, openmc.XPlane, or openmc.YPlane
         Bottom planar surface of octagon
-    right: openmc.YPlane, openmc.ZPlane, or openmc.XPlane
+    right : openmc.YPlane, openmc.ZPlane, or openmc.XPlane
         Right planar surface of octagon
-    left: openmc.YPlane, openmc.ZPlane, or openmc.XPlane
+    left : openmc.YPlane, openmc.ZPlane, or openmc.XPlane
         Left planar surface of octagon
     upper_right : openmc.Plane
         Upper right planar surface of octagon
@@ -126,17 +126,16 @@ class IsogonalOctagon(CompositeSurface):
             raise ValueError(f'r1 is greater than sqrt(2) * r2. Octagon' + \
                              ' may be erroneous.')
 
-        L_perp_ax1 = (r2 * sqrt(2) - r1) * 2
-        L_perp_ax2 = (r1 * sqrt(2) - r2) * 2
+        L_perp_ax1 = (r2 * sqrt(2) - r1)
 
         # Coords for quadrant planes
-        p1_ur = array([L_perp_ax1/2, r1, 0.])
-        p2_ur = array([r1, L_perp_ax1/2, 0.])
-        p3_ur = array([r1, L_perp_ax1/2, 1.])
+        p1_ur = np.array([L_perp_ax1, r1, 0.])
+        p2_ur = np.array([r1, L_perp_ax1, 0.])
+        p3_ur = np.array([r1, L_perp_ax1, 1.])
 
-        p1_lr = array([r1, -L_perp_ax1/2, 0.])
-        p2_lr = array([L_perp_ax1/2, -r1, 0.])
-        p3_lr = array([L_perp_ax1/2, -r1, 1.])
+        p1_lr = np.array([r1, -L_perp_ax1, 0.])
+        p2_lr = np.array([L_perp_ax1, -r1, 0.])
+        p3_lr = np.array([L_perp_ax1, -r1, 1.])
 
         points = [p1_ur, p2_ur, p3_ur, p1_lr, p2_lr, p3_lr]
 

--- a/tests/unit_tests/test_surface_composite.py
+++ b/tests/unit_tests/test_surface_composite.py
@@ -191,10 +191,10 @@ def test_isogonal_octagon(axis, plane_tb, plane_lr, axis_idx):
 
     # Check bounding box
     center = np.insert(center, axis_idx, np.inf)
-    xmax,ymax,zmax = center + r1
+    xmax, ymax, zmax = center + r1
     coord_min = center - r1
     coord_min[axis_idx] *= -1
-    xmin,ymin,zmin = coord_min
+    xmin, ymin, zmin = coord_min
     ll, ur = (+s).bounding_box
     assert np.all(np.isinf(ll))
     assert np.all(np.isinf(ur))

--- a/tests/unit_tests/test_surface_composite.py
+++ b/tests/unit_tests/test_surface_composite.py
@@ -160,9 +160,9 @@ def test_cone_one_sided(axis, point_pos, point_neg, ll_true):
     ]
 )
 def test_isogonal_octagon(axis, plane_tb, plane_lr, axis_idx):
-    center = np.array([0.,0.])
-    point_pos = np.array([0.8,0.8])
-    point_neg = np.array([0.7,0.7])
+    center = np.array([0., 0.])
+    point_pos = np.array([0.8, 0.8])
+    point_neg = np.array([0.7, 0.7])
     r1 = 1.
     r2 = 1.
     plane_top_bottom = getattr(openmc, plane_tb + "Plane")
@@ -219,6 +219,5 @@ def test_isogonal_octagon(axis, plane_tb, plane_lr, axis_idx):
 
     # Make sure repr works
     repr(s)
-
 
 

--- a/tests/unit_tests/test_surface_composite.py
+++ b/tests/unit_tests/test_surface_composite.py
@@ -217,6 +217,12 @@ def test_isogonal_octagon(axis, plane_tb, plane_lr, axis_idx):
     assert ur_t == pytest.approx(ur + t)
     assert ll_t == pytest.approx(ll + t)
 
+    # Check invalid r1, r2 combinations
+    with pytest.raises(ValueError):
+        openmc.model.IsogonalOctagon(center, r1=1.0, r2=10.)
+    with pytest.rasies(ValueError):
+        openmc.model.IsogonalOctagon(center, r1=10., r2=1.)
+
     # Make sure repr works
     repr(s)
 

--- a/tests/unit_tests/test_surface_composite.py
+++ b/tests/unit_tests/test_surface_composite.py
@@ -220,7 +220,7 @@ def test_isogonal_octagon(axis, plane_tb, plane_lr, axis_idx):
     # Check invalid r1, r2 combinations
     with pytest.raises(ValueError):
         openmc.model.IsogonalOctagon(center, r1=1.0, r2=10.)
-    with pytest.rasies(ValueError):
+    with pytest.raises(ValueError):
         openmc.model.IsogonalOctagon(center, r1=10., r2=1.)
 
     # Make sure repr works

--- a/tests/unit_tests/test_surface_composite.py
+++ b/tests/unit_tests/test_surface_composite.py
@@ -155,7 +155,7 @@ def test_cone_one_sided(axis, point_pos, point_neg, ll_true):
 @pytest.mark.parametrize(
     "axis, plane_tb, plane_lr, axis_idx", [
         ("x", "Z", "Y", 0),
-        ("y", "Z", "X", 1),
+        ("y", "X", "Z", 1),
         ("z", "Y", "X", 2),
     ]
 )

--- a/tests/unit_tests/test_surface_composite.py
+++ b/tests/unit_tests/test_surface_composite.py
@@ -159,7 +159,7 @@ def test_cone_one_sided(axis, point_pos, point_neg, ll_true):
         ("z", "Y", "X", 2),
     ]
 )
-def test_octagon(axis, plane_tb, plane_lr, axis_idx):
+def test_isogonal_octagon(axis, plane_tb, plane_lr, axis_idx):
     center = np.array([0.,0.])
     point_pos = np.array([0.8,0.8])
     point_neg = np.array([0.7,0.7])
@@ -167,7 +167,7 @@ def test_octagon(axis, plane_tb, plane_lr, axis_idx):
     r2 = 1.
     plane_top_bottom = getattr(openmc, plane_tb + "Plane")
     plane_left_right = getattr(openmc, plane_lr + "Plane")
-    s = openmc.model.Octagon(center, r1, r2, axis=axis)
+    s = openmc.model.IsogonalOctagon(center, r1, r2, axis=axis)
     assert isinstance(s.top, plane_top_bottom)
     assert isinstance(s.bottom, plane_top_bottom)
     assert isinstance(s.right, plane_left_right)


### PR DESCRIPTION
This PR adds a new `CompositeSurface` class, `IsogonalOctagon`, and associated unit tests. This PR also adds the `IsogonalOctagon` class to the Sphinx Docs.