### PR TITLE
use find_package(mpi) instead of relying on compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(openmc C CXX)
 
 # Set version numbers
@@ -30,6 +30,7 @@ option(OPENMC_ENABLE_PROFILE  "Compile with profiling flags"                    
 option(OPENMC_ENABLE_COVERAGE "Compile with coverage analysis flags"                 OFF)
 option(OPENMC_USE_DAGMC       "Enable support for DAGMC (CAD) geometry"              OFF)
 option(OPENMC_USE_LIBMESH     "Enable support for libMesh unstructured mesh tallies" OFF)
+option(OPENMC_USE_MPI         "Enable MPI"                                           OFF)
 
 #===============================================================================
 # Set a default build configuration if not explicitly specified
@@ -44,10 +45,9 @@ endif()
 # MPI for distributed-memory parallelism
 #===============================================================================
 
-set(MPI_ENABLED FALSE)
-if(${CMAKE_CXX_COMPILER} MATCHES "(mpi[^/]*|CC)$")
-  message(STATUS "Detected MPI wrapper: ${CMAKE_CXX_COMPILER}")
-  set(MPI_ENABLED TRUE)
+if(OPENMC_USE_MPI)
+  find_package(MPI REQUIRED)
+  include_directories(${MPI_CXX_INCLUDE_DIRS})
 endif()
 
 #===============================================================================
@@ -108,7 +108,7 @@ endif()
 
 find_package(HDF5 REQUIRED COMPONENTS C HL)
 if(HDF5_IS_PARALLEL)
-  if(NOT MPI_ENABLED)
+  if(NOT OPENMC_USE_MPI)
     message(FATAL_ERROR "Parallel HDF5 was detected, but the detected compiler,\
      ${CMAKE_CXX_COMPILER}, does not support MPI. An MPI-capable compiler must \
      be used with parallel HDF5.")
@@ -141,9 +141,15 @@ endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+if(OPENMC_USE_MPI)
+  list(APPEND cxxflags ${MPI_CXX_COMPILE_FLAGS})
+  list(APPEND ldflags  ${MPI_CXX_LINK_FLAGS})
+endif()
+
 if(OPENMC_ENABLE_PROFILE)
   list(APPEND cxxflags -g -fno-omit-frame-pointer)
 endif()
+
 if(OPENMC_ENABLE_COVERAGE)
   list(APPEND cxxflags --coverage)
   list(APPEND ldflags --coverage)
@@ -398,7 +404,7 @@ target_include_directories(libopenmc PRIVATE ${CMAKE_BINARY_DIR}/include)
 if (HDF5_IS_PARALLEL)
   target_compile_definitions(libopenmc PRIVATE -DPHDF5)
 endif()
-if (MPI_ENABLED)
+if (OPENMC_USE_MPI)
   target_compile_definitions(libopenmc PUBLIC -DOPENMC_MPI)
 endif()
 
@@ -438,6 +444,10 @@ endif()
 if (PNG_FOUND)
   target_compile_definitions(libopenmc PRIVATE USE_LIBPNG)
   target_link_libraries(libopenmc PNG::PNG)
+endif()
+
+if (OPENMC_USE_MPI)
+  target_link_libraries(libopenmc MPI::MPI_CXX)
 endif()
 
 #===============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,6 @@ endif()
 
 if(OPENMC_USE_MPI)
   find_package(MPI REQUIRED)
-  include_directories(${MPI_CXX_INCLUDE_DIRS})
 endif()
 
 #===============================================================================
@@ -140,11 +139,6 @@ if(OPENMC_USE_OPENMP)
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-if(OPENMC_USE_MPI)
-  list(APPEND cxxflags ${MPI_CXX_COMPILE_FLAGS})
-  list(APPEND ldflags  ${MPI_CXX_LINK_FLAGS})
-endif()
 
 if(OPENMC_ENABLE_PROFILE)
   list(APPEND cxxflags -g -fno-omit-frame-pointer)

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,7 @@ ENV LIBMESH_INSTALL_DIR=$HOME/LIBMESH
 ENV NJOY_REPO='https://github.com/njoy/NJOY2016'
 
 # Setup environment variables for Docker image
-ENV CC=/usr/bin/mpicc CXX=/usr/bin/mpicxx \
-    LD_LIBRARY_PATH=${DAGMC_INSTALL_DIR}/lib:$LD_LIBRARY_PATH \
+ENV LD_LIBRARY_PATH=${DAGMC_INSTALL_DIR}/lib:$LD_LIBRARY_PATH \
     OPENMC_CROSS_SECTIONS=/root/nndc_hdf5/cross_sections.xml \
     OPENMC_ENDF_DATA=/root/endf-b-vii.1 \
     DEBIAN_FRONTEND=noninteractive
@@ -179,6 +178,7 @@ RUN mkdir -p ${HOME}/OpenMC && cd ${HOME}/OpenMC \
     && mkdir build && cd build ; \
     if [ ${build_dagmc} = "on" ] && [ ${build_libmesh} = "on" ]; then \
         cmake ../openmc \
+            -DOPENMC_USE_MPI=on \
             -DHDF5_PREFER_PARALLEL=on \
             -DOPENMC_USE_DAGMC=on \
             -DOPENMC_USE_LIBMESH=on \
@@ -186,18 +186,21 @@ RUN mkdir -p ${HOME}/OpenMC && cd ${HOME}/OpenMC \
     fi ; \
     if [ ${build_dagmc} = "on" ] && [ ${build_libmesh} = "off" ]; then \
         cmake ../openmc \
+            -DOPENMC_USE_MPI=on \
             -DHDF5_PREFER_PARALLEL=on \
             -DOPENMC_USE_DAGMC=ON \
             -DCMAKE_PREFIX_PATH=${DAGMC_INSTALL_DIR} ; \
     fi ; \
     if [ ${build_dagmc} = "off" ] && [ ${build_libmesh} = "on" ]; then \
         cmake ../openmc \
+            -DOPENMC_USE_MPI=on \
             -DHDF5_PREFER_PARALLEL=on \
             -DOPENMC_USE_LIBMESH=on \
             -DCMAKE_PREFIX_PATH=${LIBMESH_INSTALL_DIR} ; \
     fi ; \
     if [ ${build_dagmc} = "off" ] && [ ${build_libmesh} = "off" ]; then \
         cmake ../openmc \
+            -DOPENMC_USE_MPI=on \
             -DHDF5_PREFER_PARALLEL=on ; \
     fi ; \
     make 2>/dev/null -j${compile_cores} install \

--- a/cmake/OpenMCConfig.cmake.in
+++ b/cmake/OpenMCConfig.cmake.in
@@ -21,3 +21,7 @@ find_package(PNG)
 if(NOT TARGET OpenMC::libopenmc)
   include("${OpenMC_CMAKE_DIR}/OpenMCTargets.cmake")
 endif()
+
+if(@OPENMC_USE_MPI@)
+  find_package(MPI REQUIRED)
+endif()

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -352,8 +352,12 @@ OPENMC_ENABLE_COVERAGE
   Compile and link code instrumented for coverage analysis. This is typically
   used in conjunction with gcov_. (Default: off)
 
+OPENMC_USE_MPI
+  Turns on compiling with MPI (default: off). For further information on MPI options,
+  please see the `FindMPI.cmake documentation <https://cmake.org/cmake/help/latest/module/FindMPI.html>`_.
+
 To set any of these options (e.g., turning on profiling), the following form
-should be used:
+should be used:ß
 
 .. code-block:: sh
 
@@ -382,16 +386,7 @@ Example of configuring for Debug mode:
 
 .. code-block:: sh
 
-    cmake -DCMAKE_BUILD_TYPE=Debug /path/to/openmc
-
-Compiling with MPI
-++++++++++++++++++
-
-To compile with MPI, use the `-DOPENMC_USE_MPI=on` cmake option. For example, in a bash shell:
-
-.. code-block:: sh
-
-    cmake -DOPENMC_USE_MPI=on /path/to/openmc
+    cmake -DCMAKE_BUILD_TYPE=Debug /path/to/openmcß
 
 Selecting HDF5 Installation
 +++++++++++++++++++++++++++

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -386,7 +386,7 @@ Example of configuring for Debug mode:
 
 .. code-block:: sh
 
-    cmake -DCMAKE_BUILD_TYPE=Debug /path/to/openmcß
+    cmake -DCMAKE_BUILD_TYPE=Debug /path/to/openmc
 
 Selecting HDF5 Installation
 +++++++++++++++++++++++++++

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -203,7 +203,7 @@ Prerequisites
       respectively. To link against a parallel HDF5 library, make sure to set
       the HDF5_PREFER_PARALLEL CMake option, e.g.::
 
-          CXX=mpicxx.mpich cmake -DHDF5_PREFER_PARALLEL=on ..
+          cmake -DHDF5_PREFER_PARALLEL=on -DOPENMC_USE_MPI=on ..
 
       Note that the exact package names may vary depending on your particular
       distribution and version.
@@ -263,7 +263,7 @@ Prerequisites
       installation should be specified as part of the ``CMAKE_PREFIX_PATH``
       variable.::
 
-          CXX=mpicxx cmake -DOPENMC_USE_LIBMESH=on -DCMAKE_PREFIX_PATH=/path/to/libmesh/installation
+          cmake -DOPENMC_USE_LIBMESH=on -DOPENMC_USE_MPI=on -DCMAKE_PREFIX_PATH=/path/to/libmesh/installation
 
       Note that libMesh is most commonly compiled with MPI support. If that
       is the case, then OpenMC should be compiled with MPI support as well.

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -357,7 +357,7 @@ OPENMC_USE_MPI
   please see the `FindMPI.cmake documentation <https://cmake.org/cmake/help/latest/module/FindMPI.html>`_.
 
 To set any of these options (e.g., turning on profiling), the following form
-should be used:ß
+should be used:
 
 .. code-block:: sh
 

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -387,7 +387,7 @@ Example of configuring for Debug mode:
 Compiling with MPI
 ++++++++++++++++++
 
-To compile with MPI, use the `-DOPENMC_USE_MPI=on` cmake flag. For example, in a bash shell:
+To compile with MPI, use the `-DOPENMC_USE_MPI=on` cmake option. For example, in a bash shell:
 
 .. code-block:: sh
 

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -387,20 +387,11 @@ Example of configuring for Debug mode:
 Compiling with MPI
 ++++++++++++++++++
 
-To compile with MPI, set the :envvar:`CXX` environment variable to the path to
-the MPI C++ wrapper. For example, in a bash shell:
+To compile with MPI, use the `-DOPENMC_USE_MPI=on` cmake flag. For example, in a bash shell:
 
 .. code-block:: sh
 
-    export CXX=mpicxx
-    cmake /path/to/openmc
-
-Note that in many shells, environment variables can be set for a single command,
-i.e.
-
-.. code-block:: sh
-
-    CXX=mpicxx cmake /path/to/openmc
+    cmake -DOPENMC_USE_MPI=on /path/to/openmc
 
 Selecting HDF5 Installation
 +++++++++++++++++++++++++++

--- a/tests/regression_tests/cpp_driver/test.py
+++ b/tests/regression_tests/cpp_driver/test.py
@@ -40,7 +40,7 @@ def cpp_driver(request):
     try:
         print("Building driver")
         # Run cmake/make to build the shared libary
-        subprocess.run(['cmake', os.path.pardir, '-DOPENMC_USE_MPI=' + mpi_arg], check=True)
+        subprocess.run(['cmake', os.path.pardir, f'-DOPENMC_USE_MPI={mpi_arg}'], check=True)
         subprocess.run(['make'], check=True)
         os.chdir(os.path.pardir)
 

--- a/tests/regression_tests/cpp_driver/test.py
+++ b/tests/regression_tests/cpp_driver/test.py
@@ -33,12 +33,14 @@ def cpp_driver(request):
     os.chdir(str(local_builddir))
 
     if config['mpi']:
-        os.environ['CXX'] = 'mpicxx'
+        mpi_arg = "On"
+    else:
+        mpi_arg = "Off"
 
     try:
         print("Building driver")
         # Run cmake/make to build the shared libary
-        subprocess.run(['cmake', os.path.pardir], check=True)
+        subprocess.run(['cmake', os.path.pardir, '-DOPENMC_USE_MPI=' + mpi_arg], check=True)
         subprocess.run(['make'], check=True)
         os.chdir(os.path.pardir)
 

--- a/tests/regression_tests/external_moab/test.py
+++ b/tests/regression_tests/external_moab/test.py
@@ -49,12 +49,14 @@ def cpp_driver(request):
     os.chdir(str(local_builddir))
 
     if config['mpi']:
-        os.environ['CXX'] = 'mpicxx'
+        mpi_arg = "On"
+    else:
+        mpi_arg = "Off"
 
     try:
         print("Building driver")
         # Run cmake/make to build the shared libary
-        subprocess.run(['cmake', os.path.pardir], check=True)
+        subprocess.run(['cmake', os.path.pardir, '-DOPENMC_USE_MPI=' + mpi_arg], check=True)
         subprocess.run(['make'], check=True)
         os.chdir(os.path.pardir)
 

--- a/tests/regression_tests/external_moab/test.py
+++ b/tests/regression_tests/external_moab/test.py
@@ -56,7 +56,7 @@ def cpp_driver(request):
     try:
         print("Building driver")
         # Run cmake/make to build the shared libary
-        subprocess.run(['cmake', os.path.pardir, '-DOPENMC_USE_MPI=' + mpi_arg], check=True)
+        subprocess.run(['cmake', os.path.pardir, f'-DOPENMC_USE_MPI={mpi_arg}'], check=True)
         subprocess.run(['make'], check=True)
         os.chdir(os.path.pardir)
 

--- a/tools/ci/gha-install.py
+++ b/tools/ci/gha-install.py
@@ -34,7 +34,7 @@ def install(omp=False, mpi=False, phdf5=False, dagmc=False, libmesh=False):
 
     # Use MPI wrappers when building in parallel
     if mpi:
-        os.environ['CXX'] = 'mpicxx'
+        cmake_cmd.append('-DOPENMC_USE_MPI=on')
 
     # Tell CMake to prefer parallel HDF5 if specified
     if phdf5:

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -32,7 +32,6 @@ fi
 if [[ $MPI == 'y' ]]; then
     pip install --no-binary=mpi4py mpi4py
 
-    export CC=mpicc
     export HDF5_MPI=ON
     export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich
     pip install --no-binary=h5py h5py

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -32,6 +32,7 @@ fi
 if [[ $MPI == 'y' ]]; then
     pip install --no-binary=mpi4py mpi4py
 
+    export CC=mpicc
     export HDF5_MPI=ON
     export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich
     pip install --no-binary=h5py h5py


### PR DESCRIPTION
I've implemented `find_package(MPI)` which is now a better/common practice for finding MPI rather than relying on setting the CXX compilers. This also bumps up the min cmake version to 3.10 which is when there was an overhaul of `FindMPI`.