### PR TITLE
Source of a Spherical Shell 

### DIFF
--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -119,6 +119,30 @@ private:
 };
 
 //==============================================================================
+//! Distribution of a Spherical Shell
+//==============================================================================
+
+class SpatialSphericalShell : public SpatialDistribution {
+public:
+  explicit SpatialSphericalShell(pugi::xml_node node);
+
+  //! Sample a position from the distribution
+  //! \param seed Pseudorandom number seed pointer
+  //! \return Sampled position
+  Position sample(uint64_t* seed) const;
+
+  // Properties
+  Position xyz() const { return xyz_; }
+  double radii_inner() const { return radii_inner_; }
+  double radii_outer() const { return radii_outer_; }
+
+private:
+  Position xyz_; //!< Single position at which sites are generated
+  double radii_inner_;
+  double radii_outer_;
+};
+
+//==============================================================================
 //! Distribution at a single point
 //==============================================================================
 

--- a/openmc/stats/multivariate.py
+++ b/openmc/stats/multivariate.py
@@ -372,7 +372,7 @@ class CartesianIndependent(Spatial):
 
 
 class SphericalIndependent(Spatial):
-    r"""Spatial distribution represented in spherical coordinates.
+    """Spatial distribution represented in spherical coordinates.
 
     This distribution allows one to specify coordinates whose :math:`r`,
     :math:`\theta`, and :math:`\phi` components are sampled independently from
@@ -612,6 +612,95 @@ class CylindricalIndependent(Spatial):
         z = Univariate.from_xml_element(elem.find('z'))
         origin = [float(x) for x in elem.get('origin').split()]
         return cls(r, phi, z, origin=origin)
+
+
+class SphericalShell(Spatial):
+    """Uniform distribution of coordinates in a spherical shell.
+
+    Parameters
+    ----------
+    radii : Iterable of float
+        inner and out radius of the spheres
+    upper_right : Iterable of float
+        center
+    only_fissionable : bool, optional
+        Whether spatial sites should only be accepted if they occur in
+        fissionable materials
+
+    Attributes
+    ----------
+    radii : Iterable of float
+        inner and out radius of the spheres
+    upper_right : Iterable of float
+        center
+    only_fissionable : bool, optional
+        Whether spatial sites should only be accepted if they occur in
+        fissionable materials
+
+    """
+    
+    def __init__(self, radii, xyz):
+        self.radii = radii
+        self.xyz = xyz
+
+    @property
+    def radii(self):
+        return self._radii
+
+    @property
+    def xyz(self):
+        return self._xyz
+
+    @radii.setter
+    def radii(self, radii):
+        cv.check_type('radii', radii, Iterable, Real)
+        cv.check_length('radii', radii, 2)
+        self._radii = radii
+
+    @xyz.setter
+    def xyz(self, xyz):
+        cv.check_type('xyz', xyz, Iterable, Real)
+        cv.check_length('xyz', xyz, 3)
+        self._xyz = xyz
+
+    def to_xml_element(self):
+        """Return XML representation of the box distribution
+
+        Returns
+        -------
+        element : xml.etree.ElementTree.Element
+            XML element containing box distribution data
+
+        """
+        element = ET.Element('space')
+        element.set("type", "sphericalshell")
+        params = ET.SubElement(element, "parameters")
+        params.text = ' '.join(map(str, self.radii)) + ' ' + \
+                      ' '.join(map(str, self.xyz))
+        
+
+        return element
+
+    @classmethod
+    def from_xml_element(cls, elem):
+        """Generate box distribution from an XML element
+
+        Parameters
+        ----------
+        elem : xml.etree.ElementTree.Element
+            XML element
+
+        Returns
+        -------
+        openmc.stats.SphericalShell
+            Box distribution generated from XML element
+
+        """
+        params = [float(x) for x in get_text(elem, 'parameters').split()]
+        radii = params[:len(params)//2]
+        xyz = params[len(params)//2:]
+        return cls(radii, xyz)
+
 
 
 class Box(Spatial):

--- a/openmc/stats/multivariate.py
+++ b/openmc/stats/multivariate.py
@@ -272,6 +272,8 @@ class Spatial(ABC):
             return SphericalIndependent.from_xml_element(elem)
         elif distribution == 'box' or distribution == 'fission':
             return Box.from_xml_element(elem)
+        elif distribution == 'sphericalshell':
+             return SphericalShell.from_xml_element(elem)
         elif distribution == 'point':
             return Point.from_xml_element(elem)
 

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -94,6 +94,8 @@ IndependentSource::IndependentSource(pugi::xml_node node)
         space_ = UPtrSpace {new SphericalIndependent(node_space)};
       } else if (type == "box") {
         space_ = UPtrSpace {new SpatialBox(node_space)};
+      } else if (type == "sphericalshell") {
+        space_ = UPtrSpace {new SpatialSphericalShell(node_space)};
       } else if (type == "fission") {
         space_ = UPtrSpace {new SpatialBox(node_space, true)};
       } else if (type == "point") {


### PR DESCRIPTION
### Implementation of a Spherical Shell Source 

When implementing more sophisticated sources, OpenMC provides the opportunity to define _Custom Parameterized Sources_  which need to be implemented in C++. Implementing them is not that easy, especially for beginners.

I think we could give the users more sources that can be used directly via the Python API.

Here I propose the source of a Spherical Shell which can be used as the following example:
```
source = openmc.Source()
source.space = openmc.stats.SphericalShell((2, 3), (0, 0, 0)) 
source.energy = openmc.stats.Discrete([1e6], [1]) 
source.particle = 'photon'  
```

The first tuple specifies the inner and outer radii of the spherical shell and the second its' center. If the inner radius is set to 0, we get a solid sphere as a source. 

You have to be careful when producing the source points uniformly distributed. I used the math described here:
https://math.stackexchange.com/questions/1111894/random-points-in-spherical-shell

I could add a regression test if there is interest in this feature. For now, I just have plotted the positions of the first 5 000 created points of a Spherical Shell with inner radius 2 and outer radius 3 (Figure) and analyzed their radii.

![shell_3d](https://user-images.githubusercontent.com/29277544/162699040-fdd2a60c-f89a-4c5f-8bb3-d4e2d04b9df5.png)

In addition, I would like to include the source of a hollow cylinder/disk. But first, I wanted to ask how the resonance of such a feature is.

