### PR TITLE
Global Variance Reduction & Local Variance Reduction in OpenMC

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -129,6 +129,10 @@ public:
   // Data members
   int id_ {-1};     //!< User-specified ID
   int n_dimension_; //!< Number of dimensions
+  
+  // new in LVR
+  virtual void mesh_bins(Particle& p) const = 0;      //!< record the mesh bins intersected by the track
+  virtual bool arrived_target(Particle& p) const = 0; //!< check if the track arrived target region
 };
 
 class StructuredMesh : public Mesh {
@@ -164,6 +168,10 @@ public:
 
   void surface_bins_crossed(Position r0, Position r1, const Direction& u,
     vector<int>& bins) const override;
+  
+  // new in LVR
+  void mesh_bins(Particle& p) const override;      //!< record the mesh bins intersected by the track
+  bool arrived_target(Particle& p) const override; //!< check if the track arrived target region
 
   //! Determine which cell or surface bins were crossed by a particle
   //

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -54,6 +54,10 @@ struct SourceSite {
   ParticleType particle;
   int64_t parent_id;
   int64_t progeny_id;
+  
+  //new in LVR
+  std::vector<int> crossed_mesh;
+  std::vector<double> crossed_weight;
 };
 
 //! Saved ("banked") state of a particle, for nu-fission tallying
@@ -318,6 +322,10 @@ private:
 #endif
 
   int64_t n_progeny_ {0}; // Number of progeny produced by this particle
+  
+  // new in LVR
+  std::vector<int> crossed_mesh;
+  std::vector<double> crossed_weight;
 
 public:
   //==========================================================================
@@ -492,6 +500,19 @@ public:
       d = 0;
     }
   }
+  
+  // new in LVR
+  // add value
+  void add_crossed_mesh(int index) { crossed_mesh.push_back(index); }
+  void add_crossed_weight(double weight) { crossed_weight.push_back(weight); }
+  // get size
+  int crossed_mesh_size() { return crossed_mesh.size(); }
+  // get value
+  int crossed_mesh_value(int index) { return crossed_mesh[index]; }
+  double crossed_weight_value(int index) { return crossed_weight[index]; }
+  // reset vector
+  void reset_crossed_mesh() { crossed_mesh.clear(); }
+  void reset_crossed_weight() { crossed_weight.clear(); }
 };
 
 } // namespace openmc

--- a/include/openmc/simulation.h
+++ b/include/openmc/simulation.h
@@ -99,6 +99,19 @@ void transport_history_based();
 
 //! Simulate all particle histories using event-based parallelism
 void transport_event_based();
+  
+//new in GVR
+void openmc_generate_WW();
+void update_WW();
+void asynchronous_scheduling();
+//! Full initialization of a particle history in asynchronous scheduling
+void initialize_history_asynchronous(Particle& p, int64_t index_source, int Part);
+//! Simulate all particle histories using history-based parallelism
+void transport_history_based_asynchronous(int Part);
+
+//new in LVR
+void add_weight(Particle& p);  //!< add weight for the mesh cell that current particle crossed
+void add_score(Particle& p);   //!< add score for the mesh cell that scored particle crossed
 
 } // namespace openmc
 

--- a/include/openmc/weight_windows.h
+++ b/include/openmc/weight_windows.h
@@ -12,6 +12,8 @@
 #include "openmc/mesh.h"
 #include "openmc/particle.h"
 #include "openmc/vector.h"
+//new
+#include "openmc/tallies/tally.h"
 
 namespace openmc {
 
@@ -42,6 +44,23 @@ namespace variance_reduction {
 
 extern std::unordered_map<int32_t, int32_t> ww_map;
 extern vector<unique_ptr<WeightWindows>> weight_windows;
+// new in GVR
+extern bool global_on;             //!< are GVR are enabled?
+extern vector<double> iteration;   //!< iteration during WW generation
+extern int32_t tally_idx;          //!< index in tallies vector
+extern int source_space;       //!< S vaule in the PS-GVR method
+extern int n_statistics;   //!< n_statistics vaule in the PS-GVR method
+extern int64_t nps_backup;
+// new in asynchronous
+extern int max_nps_per_task;       //!< maximum number of particles per task in the asynchronous scheduling function
+//new in LVR
+extern bool local_on;                     //!< are LVR are enabled?
+extern vector<double> target_lower_left;  //!< lower left point of the target 
+extern vector<double> target_upper_right; //!< upper right point of the target
+extern vector<double> total_weight;       //!< total weight for each mesh bin 
+extern vector<double> total_score;        //!< total score for each mesh bin
+extern double score_in_target;            //!< total score in the target region
+//
 
 } // namespace variance_reduction
 
@@ -95,6 +114,13 @@ public:
   // Accessors
   int32_t id() const { return id_; }
   const Mesh& mesh() const { return *model::meshes[mesh_idx_]; }
+  
+  // new in GVR
+  void calculate_WW();
+
+  // new in LVR
+  int get_energy_bin(double E);
+  int get_energy_size() {return energy_bounds_.size()-1;}
 
 private:
   // Data members

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -32,6 +32,8 @@
 #include "openmc/tallies/filter.h"
 #include "openmc/tallies/tally.h"
 #include "openmc/xml_interface.h"
+// new
+#include "openmc/weight_windows.h"
 
 #ifdef LIBMESH
 #include "libmesh/mesh_modification.h"
@@ -538,6 +540,198 @@ void StructuredMesh::surface_bins_crossed(
 
   // Perform the mesh raytrace with the helper class.
   raytrace_mesh(r0, r1, u, SurfaceAggregator(this, bins));
+}
+  
+// new in LVR
+void StructuredMesh::mesh_bins(Particle& p) const
+{
+  // Copy the starting and ending coordinates of the particle.
+  Position r0 {p.r_last()};
+  Position r1 {p.r()};
+  Direction u {p.u()};
+  double E = p.E();
+
+  // get the mesh bin in energy group
+  // if energy is not inside the energy group, exit here
+  int energy_bin = variance_reduction::weight_windows[0]->get_energy_bin(E);
+  if (energy_bin < 0) return;
+
+  // Compute the length of the entire track.
+  double total_distance = (r1 - r0).norm();
+  if (total_distance == 0.0)
+    return;
+
+  const int n = n_dimension_;
+
+  // Flag if position is inside the mesh
+  bool in_mesh;
+
+  // Position is r = r0 + u * traveled_distance, start at r0
+  double traveled_distance {0.0};
+
+  // Calculate index of current cell. Offset the position a tiny bit in
+  // direction of flight
+  MeshIndex ijk = get_indices(r0 + TINY_BIT * u, in_mesh);
+
+  // if track is very short, assume that it is completely inside one cell. Do not count it twice.
+  if (total_distance < 2 * TINY_BIT) return;
+
+  // Calculate initial distances to next surfaces in all three dimensions
+  std::array<MeshDistance, 3> distances;
+  for (int k = 0; k < n; ++k) {
+    distances[k] = distance_to_grid_boundary(ijk, k, r0, u, 0.0);
+  }
+
+  // Loop until r = r1 is eventually reached
+  while (true) {
+
+    if (in_mesh) {
+
+      // find surface with minimal distance to current position
+      const auto k = std::min_element(distances.begin(), distances.end()) -
+                     distances.begin();
+
+      // update position and leave, if we have reached end position
+      traveled_distance = distances[k].distance;
+      if (traveled_distance >= total_distance)
+        return;
+
+      // Update cell and calculate distance to next surface in k-direction.
+      // The two other directions are still valid!
+      ijk[k] = distances[k].next_index;
+      distances[k] =
+        distance_to_grid_boundary(ijk, k, r0, u, traveled_distance);
+
+      // Check if we have left the interior of the mesh
+      in_mesh = ((ijk[k] >= 1) && (ijk[k] <= shape_[k]));
+
+    } else { // not inside mesh
+
+      // For all directions outside the mesh, find the distance that we need to
+      // travel to reach the next surface. Use the largest distance, as only
+      // this will cross all outer surfaces.
+      int k_max {0};
+      for (int k = 0; k < n; ++k) {
+        if ((ijk[k] < 1 || ijk[k] > shape_[k]) &&
+            (distances[k].distance > traveled_distance)) {
+          traveled_distance = distances[k].distance;
+          k_max = k;
+        }
+      }
+
+      // If r1 is not inside the mesh, exit here
+      if (traveled_distance >= total_distance)
+        return;
+
+      // Calculate the new cell index and update all distances to next surfaces.
+      ijk = get_indices(r0 + (traveled_distance + TINY_BIT) * u, in_mesh);
+      for (int k = 0; k < n; ++k) {
+        distances[k] =
+          distance_to_grid_boundary(ijk, k, r0, u, traveled_distance);
+      }
+    }
+
+    // record the crossed_mesh and crossed_weight
+    if (in_mesh) {
+      int index = get_bin_from_indices(ijk) + energy_bin * n_bins();
+      p.add_crossed_mesh(index);
+      p.add_crossed_weight(p.wgt());
+    }
+  }
+}
+
+bool StructuredMesh::arrived_target(Particle& p) const
+{
+  // Copy the starting and ending coordinates of the particle.
+  Position r0 {p.r_last()};
+  Position r1 {p.r()};
+
+  // Copy coordinates of starting point
+  double x0 = r0.x;
+  double y0 = r0.y;
+  double z0 = r0.z;
+
+  // Copy coordinates of ending point
+  double x1 = r1.x;
+  double y1 = r1.y;
+  double z1 = r1.z;
+  
+  // Copy coordinates of target region lower_left
+  double xm0 = variance_reduction::target_lower_left[0];
+  double ym0 = variance_reduction::target_lower_left[1];
+  double zm0 = variance_reduction::target_lower_left[2];
+
+  // Copy coordinates of target region upper_right
+  double xm1 = variance_reduction::target_upper_right[0];
+  double ym1 = variance_reduction::target_upper_right[1];
+  double zm1 = variance_reduction::target_upper_right[2];
+
+  double min_dist = INFTY;
+
+  // Check if the starting point is inside the target region
+  // starting point is inside the target region, which means it has arrived the target before.
+  if ( (x0 >= xm0 && x0 <= xm1) && (y0 >= ym0 && y0 <= ym1) && (z0 >= zm0 && z0 <= zm1) ) return false;
+
+  // The starting point is outside the target region, check if the ending point is inside the target region.
+  if ( (x1 >= xm0 && x1 <= xm1) && (y1 >= ym0 && y1 <= ym1) && (z1 >= zm0 && z1 <= zm1) ) return true;
+
+  // If not, then check if this step is intersected with the target region
+  
+  // Check if line intersects left surface -- calculate the intersection point (y,z)
+  if ((x0 < xm0 && x1 > xm0) || (x0 > xm0 && x1 < xm0)) {
+    double yi = y0 + (xm0-x0) * (y1 - y0) / (x1 - x0);
+    double zi = z0 + (xm0-x0) * (z1 - z0) / (x1 - x0);
+    if (yi >= ym0 && yi < ym1 && zi >= zm0 && zi < zm1) {
+      check_intersection_point(xm0, x0, yi, y0, zi, z0, r0, min_dist);
+    }
+  }
+
+  // Check if line intersects back surface -- calculate the intersection point (x,z)
+  if ((y0 < ym0 && y1 > ym0) || (y0 > ym0 && y1 < ym0)) {
+    double xi = x0 + (ym0-y0) * (x1 - x0) / (y1 - y0);
+    double zi = z0 + (ym0-y0) * (z1 - z0) / (y1 - y0);
+    if (xi >= xm0 && xi < xm1 && zi >= zm0 && zi < zm1) {
+      check_intersection_point(xi, x0, ym0, y0, zi, z0, r0, min_dist);
+    }
+  }
+
+  // Check if line intersects bottom surface -- calculate the intersection point (x,y)
+  if ((z0 < zm0 && z1 > zm0) || (z0 > zm0 && z1 < zm0)) {
+    double xi = x0 + (zm0-z0) * (x1 - x0) / (z1 - z0);
+    double yi = y0 + (zm0-z0) * (y1 - y0) / (z1 - z0);
+    if (xi >= xm0 && xi < xm1 && yi >= ym0 && yi < ym1) {
+      check_intersection_point(xi, x0, yi, y0, zm0, z0, r0, min_dist);
+    }
+  }
+
+  // Check if line intersects right surface -- calculate the intersection point (y,z)
+  if ((x0 < xm1 && x1 > xm1) || (x0 > xm1 && x1 < xm1)) {
+    double yi = y0 + (xm1-x0) * (y1 - y0) / (x1 - x0);
+    double zi = z0 + (xm1-x0) * (z1 - z0) / (x1 - x0);
+    if (yi >= ym0 && yi < ym1 && zi >= zm0 && zi < zm1) {
+      check_intersection_point(xm1, x0, yi, y0, zi, z0, r0, min_dist);
+    }
+  }
+
+  // Check if line intersects front surface -- calculate the intersection point (x,z)
+  if ((y0 < ym1 && y1 > ym1) || (y0 > ym1 && y1 < ym1)) {
+    double xi = x0 + (ym1-y0) * (x1 - x0) / (y1 - y0);
+    double zi = z0 + (ym1-y0) * (z1 - z0) / (y1 - y0);
+    if (xi >= xm0 && xi < xm1 && zi >= zm0 && zi < zm1) {
+      check_intersection_point(xi, x0, ym1, y0, zi, z0, r0, min_dist);
+    }
+  }
+
+  // Check if line intersects top surface -- calculate the intersection point (x,y)
+  if ((z0 < zm1 && z1 > zm1) || (z0 > zm1 && z1 < zm1)) {
+    double xi = x0 + (zm1-z0) * (x1 - x0) / (z1 - z0);
+    double yi = y0 + (zm1-z0) * (y1 - y0) / (z1 - z0);
+    if (xi >= xm0 && xi < xm1 && yi >= ym0 && yi < ym1) {
+      check_intersection_point(xi, x0, yi, y0, zm1, z0, r0, min_dist);
+    }
+  }
+ 
+  return min_dist < INFTY;
 }
 
 //==============================================================================

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -24,6 +24,10 @@
 #include "openmc/timer.h"
 #include "openmc/track_output.h"
 
+//new in GVR
+#include "openmc/weight_windows.h"
+#include "openmc/math_functions.h"
+
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -39,6 +43,12 @@
 #include <cmath>
 #include <string>
 
+// for output the WWM in LVR
+#include <ios>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
 //==============================================================================
 // C API functions
 //==============================================================================
@@ -49,6 +59,14 @@
 
 int openmc_run()
 {
+// new in GVR
+  if (openmc::variance_reduction::global_on) {
+    openmc::simulation::time_total.start();
+    openmc_simulation_init();
+    openmc::openmc_generate_WW();
+  }
+//
+  
   openmc::simulation::time_total.start();
   openmc_simulation_init();
 
@@ -204,6 +222,23 @@ int openmc_next_batch(int* status)
 
     initialize_generation();
 
+#ifdef OPENMC_MPI
+    if (variance_reduction::global_on) asynchronous_scheduling();
+    else {
+      // Start timer for transport
+      simulation::time_transport.start();
+
+      // Transport loop
+      if (settings::event_based) {
+        transport_event_based();
+      } else {
+        transport_history_based();
+      }
+
+      // Accumulate time for transport
+      simulation::time_transport.stop();
+    }
+#else
     // Start timer for transport
     simulation::time_transport.start();
 
@@ -216,7 +251,7 @@ int openmc_next_batch(int* status)
 
     // Accumulate time for transport
     simulation::time_transport.stop();
-
+#endif
     finalize_generation();
   }
 
@@ -276,6 +311,9 @@ const RegularMesh* ufs_mesh {nullptr};
 
 vector<double> k_generation;
 vector<int64_t> work_index;
+  
+// new in asynchronous_scheduling
+vector<int64_t> work_per_task;
 
 } // namespace simulation
 
@@ -671,6 +709,71 @@ void broadcast_results()
   simulation::k_col_abs = temp[0];
   simulation::k_col_tra = temp[1];
   simulation::k_abs_tra = temp[2];
+
+  // Broadcast the weight and score vectors for LVR to generate WWM
+  if (variance_reduction::local_on) {
+    //Make copy of vector values
+    auto weights = variance_reduction::total_weight;
+    std::vector<double> weights_reduced(weights.size());
+
+    auto scores = variance_reduction::total_score;
+    std::vector<double> scores_reduced(scores.size());
+
+    // Reduce of vector results
+    MPI_Reduce(weights.data(), weights_reduced.data(), weights.size(),
+      MPI_DOUBLE, MPI_SUM, 0, mpi::intracomm);
+    MPI_Reduce(scores.data(), scores_reduced.data(), scores.size(),
+      MPI_DOUBLE, MPI_SUM, 0, mpi::intracomm);    
+
+    // Output the WWM
+    if (mpi::master) {
+      // find the mesh with max weight, which is the source mesh
+      vector<double> max_weight;
+      vector<int> max_mesh;
+      int mesh_size = variance_reduction::weight_windows[0]->mesh().n_bins();
+      int energy_size = variance_reduction::weight_windows[0]->get_energy_size();
+
+      // for each energy bin
+      for (int ee = 0; ee < energy_size; ee++) {
+        max_weight.push_back(-1.);
+        max_mesh.push_back(-1);
+        for (int mm = 0; mm < mesh_size; mm++) {
+          if (weights[mm+ee*mesh_size] > max_weight[ee]) {
+            max_weight[ee] = weights[mm+ee*mesh_size];
+            max_mesh[ee] = mm+ee*mesh_size;
+          }
+        }
+      }      
+
+      std::ofstream lower_ww;
+      lower_ww.open("lower_ww.out", std::ios::out | std::ios::trunc);
+      lower_ww<<"<lower_ww_bounds>"<<std::endl;
+
+      std::ofstream upper_ww;
+      upper_ww.open("upper_ww.out", std::ios::out | std::ios::trunc);
+      upper_ww<<"<upper_ww_bounds>"<<std::endl;
+
+      // for each energy bin
+      for (int ee = 0; ee < energy_size; ee++) {
+        for (int mm = 0; mm < mesh_size; mm++) {
+          double ww = -1.;
+          if (scores[mm+ee*mesh_size] != 0) {
+            ww = 0.5 * scores[max_mesh[ee]] / scores[mm+ee*mesh_size] * weights[mm+ee*mesh_size] / weights[max_mesh[ee]];
+          }
+          lower_ww<<ww<<"   ";
+          upper_ww<<5*ww<<"   ";
+
+          if ((mm+ee*mesh_size+1)%6 == 0) {
+            lower_ww<<std::endl;
+            upper_ww<<std::endl;     
+          }
+        }
+      }
+
+      lower_ww<<std::endl<<"</lower_ww_bounds>"<<std::endl;
+      upper_ww<<std::endl<<"</upper_ww_bounds>"<<std::endl;
+    }
+  }
 }
 
 #endif
@@ -683,16 +786,57 @@ void free_memory_simulation()
 
 void transport_history_based_single_particle(Particle& p)
 {
+  // record the born mesh and the weight of source particle for LVR
+  if (variance_reduction::local_on) {
+    // get mesh index for particle's position
+    int index = variance_reduction::weight_windows[0]->mesh().get_bin(p.r());
+
+    // make sure particle is inside the mesh
+    if (index >= 0) {
+      // particle energy
+      double E = p.E();
+
+      // get the mesh bin in energy group
+      int energy_bin = variance_reduction::weight_windows[0]->get_energy_bin(E);
+
+      // check to make sure energy is in range, expects sorted energy values
+      if (energy_bin >= 0) {
+        // indices now points to the correct mesh bin for the given energy
+        index += energy_bin * variance_reduction::weight_windows[0]->mesh().n_bins();
+
+        //if (mpi::master) std::cout<<"record source with index = "<<index<<", weight = "<<p.wgt()<<std::endl;
+ 
+        // record the mesh & weight
+        p.add_crossed_mesh(index);
+        p.add_crossed_weight(p.wgt());
+      }
+    }
+  }
+  
   while (true) {
     p.event_calculate_xs();
     if (!p.alive())
       break;
     p.event_advance();
+    
+    // record the crossed mesh bin and the weight for each step
+    // and count score if the particle arrived target
+    if (variance_reduction::local_on) {
+      variance_reduction::weight_windows[0]->mesh().mesh_bins(p);
+      if (variance_reduction::weight_windows[0]->mesh().arrived_target(p)) add_score(p);
+    }
+    
     if (p.collision_distance() > p.boundary().distance) {
       p.event_cross_surface();
     } else {
       p.event_collide();
     }
+    
+    // count weight after the particle is dead
+    if (variance_reduction::local_on) {
+      if (!p.alive()) add_weight(p);
+    }
+    
     p.event_revive_from_secondary();
     if (!p.alive())
       break;
@@ -760,6 +904,330 @@ void transport_event_based()
     remaining_work -= n_particles;
     source_offset += n_particles;
   }
+}
+  
+
+// new in GVR
+void openmc_generate_WW() 
+{
+  using namespace openmc;
+
+  // Make sure simulation has been initialized
+  if (!simulation::initialized) {
+    set_errmsg("Simulation has not been initialized yet.");
+  }
+
+  initialize_batch();
+
+  // Backup for the total nps
+  variance_reduction::nps_backup = settings::n_batches * settings::n_particles;
+  int total_iteration_nps = 0;
+  
+
+  // =======================================================================
+  // LOOP OVER ITERATION FOR WW GENERATION
+  for (int i = 1; i <= variance_reduction::iteration.size(); ++i) {
+
+    // Reset the nps in each iteration
+    settings::n_particles = variance_reduction::iteration[i-1];
+    total_iteration_nps += settings::n_particles;
+    if (mpi::master) {
+      std::cout<<"-- Iteration "<<i<<"/"<<variance_reduction::iteration.size()<<" for WW generation by GVR. "
+               <<"   Set nps = "<<settings::n_particles<<" in this iteration, total nps: "<<total_iteration_nps<<std::endl;
+    }
+
+#ifdef OPENMC_MPI
+    // using asynchronous scheduling function in MPI mode
+    asynchronous_scheduling();
+#else
+    // Re-determine how much work each process should do, since the nps has been reset
+    calculate_work();
+
+    // Start timer for transport
+    simulation::time_transport.start();
+
+    // Transport loop
+    if (settings::event_based) {
+      transport_event_based();
+    } else {
+      transport_history_based();
+    }
+
+    // Accumulate time for transport
+    simulation::time_transport.stop();
+#endif
+
+    accumulate_tallies(); 
+
+#ifdef OPENMC_MPI
+    broadcast_results();
+#endif
+
+    // Calculate the lower WW bound with flux tally results
+    update_WW();
+
+    if (mpi::master) {
+      std::cout<<"-- Iteration "<<i<<"/"<<variance_reduction::iteration.size()<<" is end. Current time: "<<time_stamp()<<std::endl;
+    }
+  }
+
+  finalize_batch();
+
+  if (mpi::master) {
+    header("GVR WW generation", 6);
+    std::cout<<" Total "<<variance_reduction::iteration.size()<<" iteration are used with "<<total_iteration_nps<<" particles."<<std::endl;
+    std::cout<<" Total time : "<<simulation::time_total.elapsed()<<" seconds."<<std::endl;
+    std::cout<<" Current time: "<<time_stamp()<<std::endl;
+  }
+
+  // Reset the total nps
+  settings::n_particles = (variance_reduction::nps_backup - total_iteration_nps)/ settings::n_batches;  
+  if (mpi::master) {
+    std::cout<<" Reset nps: "<<settings::n_particles<<std::endl;
+  }
+
+  // Reset flags
+  simulation::initialized = false;
+
+  // Reset all tallies and timers
+  openmc_reset();
+  reset_timers();
+
+}
+
+void asynchronous_scheduling() 
+{
+  // Determine number of tasks
+  int number_of_task = 2 * mpi::n_procs;
+  int task_on_rank;
+  if (settings::n_particles/number_of_task > variance_reduction::max_nps_per_task) {
+    number_of_task = settings::n_particles / variance_reduction::max_nps_per_task;
+  }
+  if (mpi::master) {
+    std::cout<<"Asynchronous scheduling: Total "<<number_of_task<<" tasks in this simulation."<<std::endl;
+  }
+
+  // Determine minimum amount of particles to simulate on each task
+  int64_t min_work = settings::n_particles / number_of_task;
+
+  // Determine number of processors that have one extra particle
+  int64_t remainder = settings::n_particles % number_of_task;
+
+  int64_t i_bank = 0;
+  simulation::work_index.clear();
+  simulation::work_index.resize(number_of_task + 1);
+  simulation::work_index[0] = 0;
+  simulation::work_per_task.clear();
+  simulation::work_per_task.resize(number_of_task);
+  for (int i = 0; i < number_of_task; ++i) {
+    // Number of particles for task i
+    int64_t work_i = i < remainder ? min_work + 1 : min_work;
+
+    // Set nps of task i
+    simulation::work_per_task[i] = work_i;
+
+    // Set index into source bank for task i
+    i_bank += work_i;
+    simulation::work_index[i+1] = i_bank;
+  }
+  if (mpi::master) {
+    std::cout<<"Asynchronous scheduling: Tasks have been devided."<<std::endl;
+  }
+
+  // ---
+  // asynchronous scheduling
+  const int data_tag = 0;
+  const int result_tag = 1;
+  const int terminate_tag = 2;
+
+  int count; // count for the running processes
+  int Part;  // task number to dispatch
+  int finish_flag; // flag indicates the finished task on process
+  MPI_Status stat;
+
+  if (mpi::master) { // dispatch task in the master process
+    count = 0;
+    Part = 0;
+    finish_flag = 0;
+
+    // dispatch the first task for other processes
+    for (int i = 1; i < mpi::n_procs; i++) { 
+      MPI_Send(&Part,1,MPI_INT,i,data_tag,mpi::intracomm);
+      count++;
+      Part++;
+    }
+
+    do {
+      // dispatch task after any process have finished task
+      MPI_Recv(&finish_flag,1,MPI_INT,MPI_ANY_SOURCE,result_tag,mpi::intracomm,&stat);
+      --count;
+
+      if (Part < number_of_task) {
+        // if not all task has been dispatched, dispatch the next task to process
+        MPI_Send(&Part,1,MPI_INT,stat.MPI_SOURCE,data_tag,mpi::intracomm);
+        count++;
+        Part++;
+      } else {
+        // if all task has been dispatched, send the singal to terminate the simulation on process
+        MPI_Send(&Part,1,MPI_INT,stat.MPI_SOURCE,terminate_tag,mpi::intracomm);
+      }
+
+    } while (count > 0);
+
+  } else { // simulation in other process
+    // receive the first task
+    finish_flag = 0;
+    task_on_rank = 0;
+    MPI_Recv(&Part,1,MPI_INT,0,MPI_ANY_TAG,mpi::intracomm,&stat);
+
+    while (stat.MPI_TAG == data_tag) {
+      task_on_rank++;
+
+      // simulation task
+      simulation::work_per_rank = simulation::work_per_task[Part];
+      
+      // Start timer for transport
+      simulation::time_transport.start();
+
+      // Transport loop
+      if (settings::event_based) {
+        transport_event_based();
+      } else {
+        transport_history_based_asynchronous(Part);
+      }
+
+      // Accumulate time for transport
+      simulation::time_transport.stop();
+
+      // Send task-finished singal to master process and receive the next task
+      finish_flag = Part;
+      MPI_Send(&finish_flag,1,MPI_INT,0,result_tag,mpi::intracomm);
+      MPI_Recv(&Part,1,MPI_INT,0,MPI_ANY_TAG,mpi::intracomm,&stat);
+    }
+    std::cout<<"** Total "<<task_on_rank<<" task in rank "<<mpi::rank<<". Current time: "<<time_stamp()<<std::endl; 
+  }
+  // ---
+}
+
+void initialize_history_asynchronous(Particle& p, int64_t index_source, int Part)
+{
+  // set defaults
+  if (settings::run_mode == RunMode::EIGENVALUE) {
+    // set defaults for eigenvalue simulations from primary bank
+    p.from_source(&simulation::source_bank[index_source - 1]);
+  } else if (settings::run_mode == RunMode::FIXED_SOURCE) {
+    // initialize random number seed
+    int64_t id = (simulation::total_gen + overall_generation() - 1) *
+                   settings::n_particles +
+                 simulation::work_index[Part] + index_source;
+    uint64_t seed = init_seed(id, STREAM_SOURCE);
+    // sample from external source distribution or custom library then set
+    auto site = sample_external_source(&seed);
+    p.from_source(&site);
+  }
+  p.current_work() = index_source;
+
+  // set identifier for particle
+  p.id() = simulation::work_index[Part] + index_source;
+
+  // set progeny count to zero
+  p.n_progeny() = 0;
+
+  // Reset particle event counter
+  p.n_event() = 0;
+
+  // Reset split counter
+  p.n_split() = 0;
+
+  // Reset weight window ratio
+  p.ww_factor() = 0.0;
+
+  // set random number seed
+  int64_t particle_seed =
+    (simulation::total_gen + overall_generation() - 1) * settings::n_particles +
+    p.id();
+  init_particle_seeds(particle_seed, p.seeds());
+
+  // set particle trace
+  p.trace() = false;
+  if (simulation::current_batch == settings::trace_batch &&
+      simulation::current_gen == settings::trace_gen &&
+      p.id() == settings::trace_particle)
+    p.trace() = true;
+
+  // Set particle track.
+  p.write_track() = false;
+  if (settings::write_all_tracks) {
+    p.write_track() = true;
+  } else if (settings::track_identifiers.size() > 0) {
+    for (const auto& t : settings::track_identifiers) {
+      if (simulation::current_batch == t[0] &&
+          simulation::current_gen == t[1] && p.id() == t[2]) {
+        p.write_track() = true;
+        break;
+      }
+    }
+  }
+
+  // Display message if high verbosity or trace is on
+  if (settings::verbosity >= 9 || p.trace()) {
+    write_message("Simulating Particle {}", p.id());
+  }
+
+// Add paricle's starting weight to count for normalizing tallies later
+#pragma omp atomic
+  simulation::total_weight += p.wgt();
+
+  // Force calculation of cross-sections by setting last energy to zero
+  if (settings::run_CE) {
+    p.invalidate_neutron_xs();
+  }
+
+  // Prepare to write out particle track.
+  if (p.write_track())
+    add_particle_track(p);
+}
+
+void transport_history_based_asynchronous(int Part) 
+{
+#pragma omp parallel for schedule(runtime)
+  for (int64_t i_work = 1; i_work <= simulation::work_per_rank; ++i_work) {
+    Particle p;
+    initialize_history_asynchronous(p, i_work, Part);
+    transport_history_based_single_particle(p);
+  }
+}
+
+void update_WW() 
+{
+  using namespace openmc;
+  
+  if (model::tallies.empty()) return;
+
+  if (mpi::master) std::cout<<"Update the WW bounds . . ."<<std::endl;
+
+  variance_reduction::weight_windows[0]->calculate_WW();
+ 
+  if (mpi::master) std::cout<<"Update the WW bounds FINISH."<<std::endl;
+} 
+
+//new in LVR
+void add_weight(Particle& p)
+{
+  for (int i = 0; i < p.crossed_mesh_size(); i++) {
+    variance_reduction::total_weight[p.crossed_mesh_value(i)] += p.crossed_weight_value(i);
+  }
+  //if (mpi::master) std::cout<<"add weight, crossed_mesh_size = "<<p.crossed_mesh_size()<<std::endl;
+}
+
+void add_score(Particle& p)
+{
+  for (int i = 0; i < p.crossed_mesh_size(); i++) {
+    variance_reduction::total_score[p.crossed_mesh_value(i)] += p.wgt();
+  }
+  variance_reduction::score_in_target += p.wgt();
+  //if (mpi::master) 
+  std::cout<<"add score, crossed_mesh_size = "<<p.crossed_mesh_size()<<std::endl;
 }
 
 } // namespace openmc


### PR DESCRIPTION
The PS-GVR method and the WWG function as LVR method have been implemented in this branch.

The modification of <settings.xml>:
  ```
<weight_windows>
    //--- this part remain the same as WWM inputs
    <id> </id>
    <mesh> </mesh>
    <particle_type> </particle_type>
    <energy_bins> </energy_bins>
    <lower_ww_bounds> </lower_ww_bounds>
    <upper_ww_bounds> </upper_ww_bounds>
    <survival> </survival>
    <max_lower_bound_ratio> </max_lower_bound_ratio>
    <max_split> </max_split>
    <weight_cutoff> </weight_cutoff>	
    // --- This part is the input for GVR
    <global>
      <tally> </tally>                       //!< id of the tally which used for flux-based WW calculation (PS-GVR)
      <iteration> </iteration>               //!< the iteration series for WW calculation
      <source_space> </source_space>         //!< S value in PS-GVR
      <n_statistics> </n_statistics>         //!< n_statistics value in PS-GVR
      <max_nps_per_task> </max_nps_per_task>  //!< the max number of particle histories in each task in the asynchronous scheduling	
    </global>
    //--- This part is the input for WWG (LVR)
    <local>
      <target_lower_left> </target_lower_left>      //!<  the lower left point of the target region
      <target_upper_right> </target_upper_right>    //!<   the upper right point of the target region
    </local>
  </weight_windows>
```

The modification for GVR:
```
1. in simulation.cpp:   
- openmc_generate_WW()   //!<  generate the WWM during iteration
- update_WW()            //!<  call the calculate_WW() in weight_windows.cpp to calculate the WWM based on the PS-GVR method
- asynchronous_scheduling()  //!< asynchronous scheduling for parallel calculation in GVR simulation
- initialize_history_asynchronous()  //!< initialize_history() which used in asynchronous scheduling
- transport_history_based_asynchronous() //!< transport_history_based()  which used in asynchronous scheduling

2. in weight_windows.cpp:  
- the inputs and global variables for GVR & LVR
- calculate_WW()  //!< calculate the WWM based on the PS-GVR method
```

The modification for LVR:
```
1. in particle_data.h:  
- two vectors (crossed_mesh, crossed_weight) to recode the mesh bin and the corresponding weight that particle crossed
- a few functions to operate these two vectors

2. in particle.cpp:  
- copy or reset the two vectors above for secondary or source particle

3. in mesh.cpp:  
- mesh_bins()          //!<  record the mesh bins intersected by the track         
- arrived_target()    //!< check if the track arrived target region

4. in simulation.cpp:  
- record the weight & score during particle transporting
- output the WWM into files
- add_weight()  //!< accumulate the weight
- add_score()   //!< accumulate the score
```

 For more detail about the PS-GVR and the asynchronous scheduling, please see 

> https://doi.org/10.1016/j.fusengdes.2021.112829

The work on LVR is from (https://doi.org/10.1016/j.net.2022.04.021). 

Currently, there is still a lack of tests for this GVR & LVR. Hope to see your advice on improving this code and the tests for this GVR & LVR.

Comments from my side.
When I wrote this GVR & LVR, I tried to not do any modifications to the original code, and make a bypass for me to achieve those functions I want to realize. This is quite useful for my own usage, but it may make the code redundant. I have a few thoughts about merging my "bypass" into the original code below：

> 1. For the asynchronous scheduling, I made a copy of `initialize_history()` and `transport_history_based()`, and modified it for the asynchronous scheduling. But the original `initialize_history()` and `transport_history_based()` could be modified to meet the requirement for both static and asynchronous scheduling. 
> 2. This asynchronous scheduling is actually not directly related to the GVR. It could be used in any simulation. So separating this asynchronous scheduling out may be better.
> 3. About the two vectors used in WWG, I wrote the `MPI_Reduce()` to accumulate the results on different ranks. If these two vectors could be assigned as tallies, it will be more consistent with the current codes.
> 4. About the WWM output in WWG, I wrote this part in the `broadcast_results()`. It definitely will be much better if this part is in the output.cpp.
> 5. About the tally used in GVR. I currently use a default that the order of filters is energy filter first and then mesh filter. This could be more flexible for different tally inputs.