### PR TITLE
Allow control of C++ standard.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,11 +454,9 @@ target_compile_options(openmc PRIVATE ${cxxflags})
 target_include_directories(openmc PRIVATE ${CMAKE_BINARY_DIR}/include)
 target_link_libraries(openmc libopenmc)
 
-# Ensure C++14 standard is used. Starting with CMake 3.8, another way this could
-# be done is using the cxx_std_14 compiler feature.
-set_target_properties(
-    openmc libopenmc
-    PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
+# Ensure C++14 standard is used
+target_compile_features(openmc PUBLIC cxx_std_14)
+target_compile_features(libopenmc PUBLIC cxx_std_14)
 
 #===============================================================================
 # Python package

--- a/tests/regression_tests/external_moab/test.py
+++ b/tests/regression_tests/external_moab/test.py
@@ -37,8 +37,7 @@ def cpp_driver(request):
             add_executable(main main.cpp)
             find_package(OpenMC REQUIRED HINTS {})
             target_link_libraries(main OpenMC::libopenmc)
-            set_target_properties(main PROPERTIES CXX_STANDARD
-            14 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
+            target_compile_features(main PUBLIC cxx_std_14)
             set(CMAKE_CXX_FLAGS "-pedantic-errors")
             add_compile_definitions(DAGMC=1)
             """.format(openmc_dir)))


### PR DESCRIPTION
Use `cxx_std_14` feature to allow another application (in this case, Cardinal) to upgrade the C++ version. 

Closes #2039