### PR TITLE
Clarify usage of MGXS.rxn_type in MGXS.print_xs methods

### DIFF
--- a/openmc/mgxs/mdgxs.py
+++ b/openmc/mgxs/mdgxs.py
@@ -124,12 +124,12 @@ class MDGXS(MGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -1012,12 +1012,12 @@ class ChiDelayed(MDGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -1536,12 +1536,12 @@ class DelayedNuFissionXS(MDGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -1680,12 +1680,12 @@ class Beta(MDGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -1878,12 +1878,12 @@ class DecayRate(MDGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -2196,12 +2196,12 @@ class MatrixMDGXS(MDGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -2800,12 +2800,12 @@ class DelayedNuFissionMatrixXS(MatrixMDGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -2815,6 +2815,6 @@ class DelayedNuFissionMatrixXS(MatrixMDGXS):
         super().__init__(domain, domain_type, energy_groups, delayed_groups,
                          by_nuclide, name, num_polar, num_azimuthal)
         self._rxn_type = 'delayed-nu-fission'
-        self._hdf5_key = 'delayed-nu-fission matrix'
+        self._mgxs_type = 'delayed-nu-fission matrix'
         self._estimator = 'analog'
         self._valid_estimators = ['analog']

--- a/openmc/mgxs/mdgxs.py
+++ b/openmc/mgxs/mdgxs.py
@@ -120,8 +120,16 @@ class MDGXS(MGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -605,7 +613,7 @@ class MDGXS(MGXS):
 
         # Build header for string with type and domain info
         string = 'Multi-Delayed-Group XS\n'
-        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.hdf5_key)
+        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.mgxs_type)
         string += '{0: <16}=\t{1}\n'.format('\tDomain Type', self.domain_type)
         string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
 
@@ -1000,8 +1008,16 @@ class ChiDelayed(MDGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -1516,8 +1532,16 @@ class DelayedNuFissionXS(MDGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -1652,8 +1676,16 @@ class Beta(MDGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -1842,8 +1874,16 @@ class DecayRate(MDGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -2152,8 +2192,16 @@ class MatrixMDGXS(MDGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -2477,7 +2525,7 @@ class MatrixMDGXS(MDGXS):
 
         # Build header for string with type and domain info
         string = 'Multi-Delayed-Group XS\n'
-        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.hdf5_key)
+        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.mgxs_type)
         string += '{0: <16}=\t{1}\n'.format('\tDomain Type', self.domain_type)
         string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
 
@@ -2748,8 +2796,16 @@ class DelayedNuFissionMatrixXS(MatrixMDGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 

--- a/openmc/mgxs/mdgxs.py
+++ b/openmc/mgxs/mdgxs.py
@@ -125,11 +125,6 @@ class MDGXS(MGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -1013,11 +1008,6 @@ class ChiDelayed(MDGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -1537,11 +1527,6 @@ class DelayedNuFissionXS(MDGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -1681,11 +1666,6 @@ class Beta(MDGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -1879,11 +1859,6 @@ class DecayRate(MDGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -2197,11 +2172,6 @@ class MatrixMDGXS(MDGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -2801,11 +2771,6 @@ class DelayedNuFissionMatrixXS(MatrixMDGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 

--- a/openmc/mgxs/mdgxs.py
+++ b/openmc/mgxs/mdgxs.py
@@ -605,7 +605,7 @@ class MDGXS(MGXS):
 
         # Build header for string with type and domain info
         string = 'Multi-Delayed-Group XS\n'
-        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.rxn_type)
+        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.hdf5_key)
         string += '{0: <16}=\t{1}\n'.format('\tDomain Type', self.domain_type)
         string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
 
@@ -2477,7 +2477,7 @@ class MatrixMDGXS(MDGXS):
 
         # Build header for string with type and domain info
         string = 'Multi-Delayed-Group XS\n'
-        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.rxn_type)
+        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.hdf5_key)
         string += '{0: <16}=\t{1}\n'.format('\tDomain Type', self.domain_type)
         string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
 

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -1725,7 +1725,7 @@ class MGXS:
 
         # Build header for string with type and domain info
         string = 'Multi-Group XS\n'
-        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.rxn_type)
+        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.hdf5_key)
         string += '{0: <16}=\t{1}\n'.format('\tDomain Type', self.domain_type)
         string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
 
@@ -2534,7 +2534,7 @@ class MatrixMGXS(MGXS):
 
         # Build header for string with type and domain info
         string = 'Multi-Group XS\n'
-        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.rxn_type)
+        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.hdf5_key)
         string += '{0: <16}=\t{1}\n'.format('\tDomain Type', self.domain_type)
         string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
 
@@ -5195,9 +5195,9 @@ class ScatterMatrixXS(MatrixMGXS):
         cv.check_value('xs_type', xs_type, ['macro', 'micro'])
 
         if self.correction != 'P0' and self.scatter_format == SCATTER_LEGENDRE:
-            rxn_type = '{0} (P{1})'.format(self.rxn_type, moment)
+            rxn_type = '{0} (P{1})'.format(self.hdf5_key, moment)
         else:
-            rxn_type = self.rxn_type
+            rxn_type = self.hdf5_key
 
         # Build header for string with type and domain info
         string = 'Multi-Group XS\n'
@@ -5953,10 +5953,6 @@ class Chi(MGXS):
                  num_azimuthal=1):
         super().__init__(domain, domain_type, groups, by_nuclide, name,
                          num_polar, num_azimuthal)
-        if not prompt:
-            self._rxn_type = 'chi'
-        else:
-            self._rxn_type = 'chi-prompt'
         self._estimator = 'analog'
         self._valid_estimators = ['analog']
         self.prompt = prompt
@@ -6031,10 +6027,10 @@ class Chi(MGXS):
         cv.check_type('prompt', prompt, bool)
         self._prompt = prompt
         if not self.prompt:
-            self._rxn_type = 'nu-fission'
+            self._rxn_type = 'chi'
             self._hdf5_key = 'chi'
         else:
-            self._rxn_type = 'prompt-nu-fission'
+            self._rxn_type = 'chi-prompt'
             self._hdf5_key = 'chi-prompt'
 
     def get_homogenized_mgxs(self, other_mgxs):

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -241,12 +241,12 @@ class MGXS:
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -628,7 +628,7 @@ class MGXS:
         warnings.warn(
             f'The {type(self).__name__}.hdf5_key attribute will be removed '
             f'in the future! Use {type(self).__name__}.mgxs_type instead',
-            DeprecationWarning)
+            FutureWarning)
         return self.mgxs_type
 
     @name.setter
@@ -2258,12 +2258,12 @@ class MatrixMGXS(MGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
     @property
@@ -2760,12 +2760,12 @@ class TotalXS(MGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -2906,12 +2906,12 @@ class TransportXS(MGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -3152,12 +3152,12 @@ class DiffusionCoefficient(TransportXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -3343,12 +3343,12 @@ class AbsorptionXS(MGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -3477,12 +3477,12 @@ class CaptureXS(MGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -3638,12 +3638,12 @@ class FissionXS(MGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -3814,12 +3814,12 @@ class KappaFissionXS(MGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -3953,12 +3953,12 @@ class ScatterXS(MGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -4105,12 +4105,12 @@ class ArbitraryXS(MGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -4245,12 +4245,12 @@ class ArbitraryMatrixXS(MatrixMGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -4455,12 +4455,12 @@ class ScatterMatrixXS(MatrixMGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -5550,12 +5550,12 @@ class MultiplicityMatrixXS(MatrixMGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -5731,12 +5731,12 @@ class ScatterProbabilityMatrix(MatrixMGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -5912,12 +5912,12 @@ class NuFissionMatrixXS(MatrixMGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -6078,12 +6078,12 @@ class Chi(MGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -6609,12 +6609,12 @@ class InverseVelocity(MGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
 
     """
 
@@ -6736,12 +6736,12 @@ class MeshSurfaceMGXS(MGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
     """
 
     def __init__(self, domain=None, domain_type=None, energy_groups=None,
@@ -7130,12 +7130,12 @@ class Current(MeshSurfaceMGXS):
         The name of this MGXS type, to be used when printing and
         indexing in an HDF5 data store
 
-        .. versionadded:: 0.14
+        .. versionadded:: 0.13.1
     hdf5_key : str
         The key used to index multi-group cross sections in an HDF5 data store.
         This will be replaced by mgxs_type in the future.
 
-        .. deprecated:: 0.13.0
+        .. deprecated:: 0.13.1
     """
 
     def __init__(self, domain=None, domain_type=None,

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -242,11 +242,6 @@ class MGXS:
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -622,14 +617,6 @@ class MGXS:
             return self._mgxs_type
         else:
             return self._rxn_type
-
-    @property
-    def hdf5_key(self):
-        warnings.warn(
-            f'The {type(self).__name__}.hdf5_key attribute will be removed '
-            f'in the future! Use {type(self).__name__}.mgxs_type instead',
-            FutureWarning)
-        return self.mgxs_type
 
     @name.setter
     def name(self, name):
@@ -2259,11 +2246,6 @@ class MatrixMGXS(MGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
     @property
@@ -2761,11 +2743,6 @@ class TotalXS(MGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -2907,11 +2884,6 @@ class TransportXS(MGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -3153,11 +3125,6 @@ class DiffusionCoefficient(TransportXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -3344,11 +3311,6 @@ class AbsorptionXS(MGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -3478,11 +3440,6 @@ class CaptureXS(MGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -3639,11 +3596,6 @@ class FissionXS(MGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -3815,11 +3767,6 @@ class KappaFissionXS(MGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -3954,11 +3901,6 @@ class ScatterXS(MGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -4106,11 +4048,6 @@ class ArbitraryXS(MGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -4246,11 +4183,6 @@ class ArbitraryMatrixXS(MatrixMGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -4456,11 +4388,6 @@ class ScatterMatrixXS(MatrixMGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -5551,11 +5478,6 @@ class MultiplicityMatrixXS(MatrixMGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -5732,11 +5654,6 @@ class ScatterProbabilityMatrix(MatrixMGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -5913,11 +5830,6 @@ class NuFissionMatrixXS(MatrixMGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -6079,11 +5991,6 @@ class Chi(MGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -6610,11 +6517,6 @@ class InverseVelocity(MGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
 
     """
 
@@ -6737,11 +6639,6 @@ class MeshSurfaceMGXS(MGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
     """
 
     def __init__(self, domain=None, domain_type=None, energy_groups=None,
@@ -7131,11 +7028,6 @@ class Current(MeshSurfaceMGXS):
         indexing in an HDF5 data store
 
         .. versionadded:: 0.13.1
-    hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store.
-        This will be replaced by mgxs_type in the future.
-
-        .. deprecated:: 0.13.1
     """
 
     def __init__(self, domain=None, domain_type=None,

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -237,8 +237,16 @@ class MGXS:
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -266,7 +274,7 @@ class MGXS:
         self._sparse = False
         self._loaded_sp = False
         self._derived = False
-        self._hdf5_key = None
+        self._mgxs_type = None
         self._valid_estimators = ESTIMATOR_TYPES
 
         self.name = name
@@ -305,7 +313,7 @@ class MGXS:
         clone._sparse = self.sparse
         clone._loaded_sp = self._loaded_sp
         clone._derived = self.derived
-        clone._hdf5_key = self._hdf5_key
+        clone._mgxs_type = self._mgxs_type
 
         clone._tallies = OrderedDict()
         for tally_type, tally in self.tallies.items():
@@ -609,11 +617,19 @@ class MGXS:
         return self._derived
 
     @property
-    def hdf5_key(self):
-        if self._hdf5_key is not None:
-            return self._hdf5_key
+    def mgxs_type(self):
+        if self._mgxs_type is not None:
+            return self._mgxs_type
         else:
             return self._rxn_type
+
+    @property
+    def hdf5_key(self):
+        warnings.warn(
+            f'The {type(self).__name__}.hdf5_key attribute will be removed '
+            f'in the future! Use {type(self).__name__}.mgxs_type instead',
+            DeprecationWarning)
+        return self.mgxs_type
 
     @name.setter
     def name(self, name):
@@ -1725,7 +1741,7 @@ class MGXS:
 
         # Build header for string with type and domain info
         string = 'Multi-Group XS\n'
-        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.hdf5_key)
+        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.mgxs_type)
         string += '{0: <16}=\t{1}\n'.format('\tDomain Type', self.domain_type)
         string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
 
@@ -1912,7 +1928,7 @@ class MGXS:
                 subdomain_group = domain_group
 
             # Create a separate HDF5 group for this cross section
-            rxn_group = subdomain_group.require_group(self.hdf5_key)
+            rxn_group = subdomain_group.require_group(self.mgxs_type)
 
             # Create a separate HDF5 group for each nuclide
             for j, nuclide in enumerate(nuclides):
@@ -2238,8 +2254,16 @@ class MatrixMGXS(MGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
     @property
@@ -2534,7 +2558,7 @@ class MatrixMGXS(MGXS):
 
         # Build header for string with type and domain info
         string = 'Multi-Group XS\n'
-        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.hdf5_key)
+        string += '{0: <16}=\t{1}\n'.format('\tReaction Type', self.mgxs_type)
         string += '{0: <16}=\t{1}\n'.format('\tDomain Type', self.domain_type)
         string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
 
@@ -2732,8 +2756,16 @@ class TotalXS(MGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -2870,8 +2902,16 @@ class TransportXS(MGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -3108,8 +3148,16 @@ class DiffusionCoefficient(TransportXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -3291,8 +3339,16 @@ class AbsorptionXS(MGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -3417,8 +3473,16 @@ class CaptureXS(MGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -3570,8 +3634,16 @@ class FissionXS(MGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -3738,8 +3810,16 @@ class KappaFissionXS(MGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -3869,8 +3949,16 @@ class ScatterXS(MGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -4013,8 +4101,16 @@ class ArbitraryXS(MGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -4145,8 +4241,16 @@ class ArbitraryMatrixXS(MatrixMGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -4347,8 +4451,16 @@ class ScatterMatrixXS(MatrixMGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -4705,17 +4817,17 @@ class ScatterMatrixXS(MatrixMGXS):
         if self.formulation == 'simple':
             if not nu:
                 self._rxn_type = 'scatter'
-                self._hdf5_key = 'scatter matrix'
+                self._mgxs_type = 'scatter matrix'
             else:
                 self._rxn_type = 'nu-scatter'
-                self._hdf5_key = 'nu-scatter matrix'
+                self._mgxs_type = 'nu-scatter matrix'
         else:
             if not nu:
                 self._rxn_type = 'scatter'
-                self._hdf5_key = 'consistent scatter matrix'
+                self._mgxs_type = 'consistent scatter matrix'
             else:
                 self._rxn_type = 'nu-scatter'
-                self._hdf5_key = 'consistent nu-scatter matrix'
+                self._mgxs_type = 'consistent nu-scatter matrix'
 
     @formulation.setter
     def formulation(self, formulation):
@@ -4725,15 +4837,15 @@ class ScatterMatrixXS(MatrixMGXS):
         if self.formulation == 'simple':
             self._valid_estimators = ['analog']
             if not self.nu:
-                self._hdf5_key = 'scatter matrix'
+                self._mgxs_type = 'scatter matrix'
             else:
-                self._hdf5_key = 'nu-scatter matrix'
+                self._mgxs_type = 'nu-scatter matrix'
         else:
             self._valid_estimators = ['tracklength']
             if not self.nu:
-                self._hdf5_key = 'consistent scatter matrix'
+                self._mgxs_type = 'consistent scatter matrix'
             else:
-                self._hdf5_key = 'consistent nu-scatter matrix'
+                self._mgxs_type = 'consistent nu-scatter matrix'
 
     @correction.setter
     def correction(self, correction):
@@ -5195,9 +5307,9 @@ class ScatterMatrixXS(MatrixMGXS):
         cv.check_value('xs_type', xs_type, ['macro', 'micro'])
 
         if self.correction != 'P0' and self.scatter_format == SCATTER_LEGENDRE:
-            rxn_type = '{0} (P{1})'.format(self.hdf5_key, moment)
+            rxn_type = '{0} (P{1})'.format(self.mgxs_type, moment)
         else:
-            rxn_type = self.hdf5_key
+            rxn_type = self.mgxs_type
 
         # Build header for string with type and domain info
         string = 'Multi-Group XS\n'
@@ -5434,8 +5546,16 @@ class MultiplicityMatrixXS(MatrixMGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -5607,8 +5727,16 @@ class ScatterProbabilityMatrix(MatrixMGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -5622,7 +5750,7 @@ class ScatterProbabilityMatrix(MatrixMGXS):
         super().__init__(domain, domain_type, groups, by_nuclide,
                          name, num_polar, num_azimuthal)
         self._rxn_type = 'scatter'
-        self._hdf5_key = 'scatter probability matrix'
+        self._mgxs_type = 'scatter probability matrix'
         self._estimator = 'analog'
         self._valid_estimators = ['analog']
 
@@ -5780,8 +5908,16 @@ class NuFissionMatrixXS(MatrixMGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -5792,10 +5928,10 @@ class NuFissionMatrixXS(MatrixMGXS):
                          num_polar, num_azimuthal)
         if not prompt:
             self._rxn_type = 'nu-fission'
-            self._hdf5_key = 'nu-fission matrix'
+            self._mgxs_type = 'nu-fission matrix'
         else:
             self._rxn_type = 'prompt-nu-fission'
-            self._hdf5_key = 'prompt-nu-fission matrix'
+            self._mgxs_type = 'prompt-nu-fission matrix'
         self._estimator = 'analog'
         self._valid_estimators = ['analog']
         self.prompt = prompt
@@ -5938,8 +6074,16 @@ class Chi(MGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -6028,10 +6172,10 @@ class Chi(MGXS):
         self._prompt = prompt
         if not self.prompt:
             self._rxn_type = 'chi'
-            self._hdf5_key = 'chi'
+            self._mgxs_type = 'chi'
         else:
             self._rxn_type = 'chi-prompt'
-            self._hdf5_key = 'chi-prompt'
+            self._mgxs_type = 'chi-prompt'
 
     def get_homogenized_mgxs(self, other_mgxs):
         """Construct a homogenized mgxs with other MGXS objects.
@@ -6461,8 +6605,16 @@ class InverseVelocity(MGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
 
     """
 
@@ -6580,8 +6732,16 @@ class MeshSurfaceMGXS(MGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
     """
 
     def __init__(self, domain=None, domain_type=None, energy_groups=None,
@@ -6966,8 +7126,16 @@ class Current(MeshSurfaceMGXS):
         Whether or not a statepoint file has been loaded with tally data
     derived : bool
         Whether or not the MGXS is merged from one or more other MGXS
+    mgxs_type : str
+        The name of this MGXS type, to be used when printing and
+        indexing in an HDF5 data store
+
+        .. versionadded:: 0.14
     hdf5_key : str
-        The key used to index multi-group cross sections in an HDF5 data store
+        The key used to index multi-group cross sections in an HDF5 data store.
+        This will be replaced by mgxs_type in the future.
+
+        .. deprecated:: 0.13.0
     """
 
     def __init__(self, domain=None, domain_type=None,


### PR DESCRIPTION
As noted in issue #2042, the ``MGXS.print_xs`` method (and versions in extended types) was not printing the most descriptive reaction type.  This change fixes the issue by using the correct ``MGXS.hdf5_key`` property instead of ``MGXS.rxn_type``, as ``MGXS.hdf5_key`` was always providing the correct value.

Since ``MGXS.hdf5_key`` attribute now is used for more than just the HDF5 file key when dumping an MGXS to an HDF5, it was renamed to a more applicable ``MGXS.mgxs_type``. This name makes sense as this value always provides a name of the MGXS type as opposed to a  In case any users were using this attribute in their code, a getter was added which simply provides ``MGXS.mgxs_type`` when ``MGXS.hdf5_key`` is requested, but a deprecation warning is raises.  I did check OpenMOC (the only known consumer of the output of ``MGXS.build_hdf5_store`` and confirmed they are not sensitive to the name of this attribute.

NOTE: when reviewing this, the application or purpose of the ``MGXS.rxn_type`` attribute seems to have been lost over time.  Sometimes it is used to set the applicable scores while in other cases it is not.  A subsequent PR should focus on clarifying the purpose of the ``MGXS.rxn_type`` parameter (especially now that ``MGXS.mgxs_type`` exists) and ensuring that is clarified and that it is always obeyed.

