### PR TITLE
Fix IO format documentation for surf_source_read/write

### DIFF
--- a/docs/source/io_formats/settings.rst
+++ b/docs/source/io_formats/settings.rst
@@ -731,27 +731,26 @@ attributes/sub-elements:
 
     *Default*: false
 
----------------------------
-``<surf_src_read>`` Element
----------------------------
+------------------------------
+``<surf_source_read>`` Element
+------------------------------
 
-The ``<surf_src_read>`` element specifies a surface source file for OpenMC to
-read source bank for initializing histories.
-This element has the following attributes/sub-elements:
+The ``<surf_source_read>`` element specifies a surface source file for OpenMC to
+read source bank for initializing histories. This element has the following
+attributes/sub-elements:
 
   :path:
     Absolute or relative path to a surface source file to read in source bank.
 
     *Default*: ``surface_source.h5`` in current working directory
 
-----------------------------
-``<surf_src_write>`` Element
-----------------------------
+-------------------------------
+``<surf_source_write>`` Element
+-------------------------------
 
-The ``<surf_src_write>`` element triggers OpenMC to bank particles crossing
+The ``<surf_source_write>`` element triggers OpenMC to bank particles crossing
 certain surfaces and write out the source bank in a separate file called
-``surface_source.h5``.
-This element has the following attributes/sub-elements:
+``surface_source.h5``. This element has the following attributes/sub-elements:
 
   :surface_ids:
     A list of integers separated by spaces indicating the unique IDs of surfaces


### PR DESCRIPTION
A [user noted](https://openmc.discourse.group/t/banking-particles-in-surface-source-h5/1661/3) that the I/O format documentation for surface source read/write information is not correct. This PR fixes that.