### PR TITLE
Make sure basis gets set in Plot.from_geometry

### DIFF
--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -512,6 +512,7 @@ class Plot(IDManagerMixin):
         plot.origin = np.insert((lower_left + upper_right)/2,
                                 slice_index, slice_coord)
         plot.width = upper_right - lower_left
+        plot.basis = basis
         return plot
 
     def colorize(self, geometry, seed=1):

--- a/tests/unit_tests/test_plots.py
+++ b/tests/unit_tests/test_plots.py
@@ -58,6 +58,7 @@ def test_from_geometry():
         plot = openmc.Plot.from_geometry(geom, basis)
         assert plot.origin == pytest.approx((0., 0., 0.))
         assert plot.width == pytest.approx((width, width))
+        assert plot.basis == basis
 
 
 def test_highlight_domains():


### PR DESCRIPTION
A user [noted](https://openmc.discourse.group/t/questions-on-openmc-plotting/1896/3) that the `Plot.from_geometry` method doesn't seem to be respecting the `basis` argument passed to it. This PR fixes it so that the plot basis gets set accordingly.