### PR TITLE
Use consistent naming for k-effective

### DIFF
--- a/docs/source/usersguide/depletion.rst
+++ b/docs/source/usersguide/depletion.rst
@@ -54,7 +54,7 @@ easy retrieval of k-effective, nuclide concentrations, and reaction rates over
 time::
 
     results = openmc.deplete.ResultsList.from_hdf5("depletion_results.h5")
-    time, keff = results.get_eigenvalue()
+    time, keff = results.get_keff()
 
 Note that the coupling between the transport solver and the transmutation solver
 happens in-memory rather than by reading/writing files on disk.

--- a/docs/source/usersguide/troubleshoot.rst
+++ b/docs/source/usersguide/troubleshoot.rst
@@ -81,7 +81,7 @@ it is recommended that data be extracted from statepoint files in a context mana
 .. code-block:: python
 
     with openmc.StatePoint('statepoint.10.h5') as sp:
-        k_eff = sp.k_combined
+        k_eff = sp.keff
 
 or that the :meth:`StatePoint.close` method is called before executing a subsequent
 OpenMC run.

--- a/examples/jezebel/jezebel.py
+++ b/examples/jezebel/jezebel.py
@@ -29,5 +29,5 @@ openmc.run()
 # Get the resulting k-effective value
 n = settings.batches
 with openmc.StatePoint(f'statepoint.{n}.h5') as sp:
-    keff = sp.k_combined
+    keff = sp.keff
     print(f'Final k-effective = {keff}')

--- a/examples/pincell_depletion/restart_depletion.py
+++ b/examples/pincell_depletion/restart_depletion.py
@@ -59,33 +59,33 @@ integrator.integrate()
 results = openmc.deplete.ResultsList.from_hdf5("depletion_results.h5")
 
 # Obtain K_eff as a function of time
-time, keff = results.get_eigenvalue()
+time, keff = results.get_keff(time_units='d')
 
 # Obtain U235 concentration as a function of time
-time, n_U235 = results.get_atoms(uo2, 'U235')
+uo2 = geometry.get_all_material_cells()[1]
+_, n_U235 = results.get_atoms(uo2, 'U235')
 
 # Obtain Xe135 capture reaction rate as a function of time
-time, Xe_capture = results.get_reaction_rate(uo2, 'Xe135', '(n,gamma)')
+_, Xe_capture = results.get_reaction_rate(uo2, 'Xe135', '(n,gamma)')
 
 ###############################################################################
 #                            Generate plots
 ###############################################################################
 
-days = 24*60*60
 fig, ax = plt.subplots()
-ax.errorbar(time/days, keff[:, 0], keff[:, 1], label="K-effective")
+ax.errorbar(time, keff[:, 0], keff[:, 1], label="K-effective")
 ax.set_xlabel("Time [d]")
 ax.set_ylabel("Keff")
 plt.show()
 
 fig, ax = plt.subplots()
-ax.plot(time/days, n_U235, label="U235")
+ax.plot(time, n_U235, label="U235")
 ax.set_xlabel("Time [d]")
 ax.set_ylabel("U235 atoms")
 plt.show()
 
 fig, ax = plt.subplots()
-ax.plot(time/days, Xe_capture, label="Xe135 capture")
+ax.plot(time, Xe_capture, label="Xe135 capture")
 ax.set_xlabel("Time [d]")
 ax.set_ylabel("Xe135 capture rate")
 plt.show()

--- a/examples/pincell_depletion/run_depletion.py
+++ b/examples/pincell_depletion/run_depletion.py
@@ -104,33 +104,32 @@ integrator.integrate()
 results = openmc.deplete.ResultsList.from_hdf5("depletion_results.h5")
 
 # Obtain K_eff as a function of time
-time, keff = results.get_eigenvalue()
+time, keff = results.get_keff(time_units='d')
 
 # Obtain U235 concentration as a function of time
-time, n_U235 = results.get_atoms(uo2, 'U235')
+_, n_U235 = results.get_atoms(uo2, 'U235')
 
 # Obtain Xe135 capture reaction rate as a function of time
-time, Xe_capture = results.get_reaction_rate(uo2, 'Xe135', '(n,gamma)')
+_, Xe_capture = results.get_reaction_rate(uo2, 'Xe135', '(n,gamma)')
 
 ###############################################################################
 #                            Generate plots
 ###############################################################################
 
-days = 24*60*60
 fig, ax = plt.subplots()
-ax.errorbar(time/days, keff[:, 0], keff[:, 1], label="K-effective")
+ax.errorbar(time, keff[:, 0], keff[:, 1], label="K-effective")
 ax.set_xlabel("Time [d]")
 ax.set_ylabel("Keff")
 plt.show()
 
 fig, ax = plt.subplots()
-ax.plot(time/days, n_U235, label="U235")
+ax.plot(time, n_U235, label="U235")
 ax.set_xlabel("Time [d]")
 ax.set_ylabel("U235 atoms")
 plt.show()
 
 fig, ax = plt.subplots()
-ax.plot(time/days, Xe_capture, label="Xe135 capture")
+ax.plot(time, Xe_capture, label="Xe135 capture")
 ax.set_xlabel("Time [d]")
 ax.set_ylabel("Xe135 capture rate")
 plt.show()

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -725,7 +725,7 @@ class Operator(TransportOperator):
         rates.fill(0.0)
 
         # Get k and uncertainty
-        k_combined = ufloat(*openmc.lib.keff())
+        keff = ufloat(*openmc.lib.keff())
 
         # Extract tally bins
         nuclides = self._rate_helper.nuclides
@@ -779,7 +779,7 @@ class Operator(TransportOperator):
         # Store new fission yields on the chain
         self.chain.fission_yields = fission_yields
 
-        return OperatorResult(k_combined, rates)
+        return OperatorResult(keff, rates)
 
     def _get_nuclides_with_data(self, cross_sections):
         """Loads cross_sections.xml file to find nuclides with neutron data"""

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -50,7 +50,7 @@ class Results:
         Number of stages in simulation.
     data : numpy.ndarray
         Atom quantity, stored by stage, mat, then by nuclide.
-    proc_time: int
+    proc_time : int
         Average time spent depleting a material across all
         materials and processes
 

--- a/openmc/deplete/results_list.py
+++ b/openmc/deplete/results_list.py
@@ -1,6 +1,7 @@
 import numbers
 import bisect
 import math
+from warnings import warn
 
 import h5py
 import numpy as np
@@ -165,7 +166,7 @@ class ResultsList(list):
 
         return times, rates
 
-    def get_eigenvalue(self, time_units='s'):
+    def get_keff(self, time_units='s'):
         """Evaluates the eigenvalue from a results list.
 
         Parameters
@@ -197,14 +198,19 @@ class ResultsList(list):
         times = _get_time_as(times, time_units)
         return times, eigenvalues
 
+    def get_eigenvalue(self, time_units='s'):
+        warn("The get_eigenvalue(...) function has been renamed get_keff and "
+             "will be removed in a future version of OpenMC.", FutureWarning)
+        return self.get_keff(time_units)
+
+
     def get_depletion_time(self):
         """Return an array of the average time to deplete a material
 
         .. note::
-
-            Will have one fewer row than number of other methods,
-            like :meth:`get_eigenvalues`, because no depletion
-            is performed at the final transport stage
+            The return value will have one fewer values than several other
+            methods, such as :meth:`get_keff`, because no depletion is performed
+            at the final transport stage.
 
         Returns
         -------

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -593,7 +593,7 @@ class Library:
         self._nuclides = statepoint.summary.nuclides
 
         if statepoint.run_mode == 'eigenvalue':
-            self._keff = statepoint.k_combined.n
+            self._keff = statepoint.keff.n
 
         # Load tallies for each MGXS for each domain and mgxs type
         for domain in self.domains:

--- a/openmc/search.py
+++ b/openmc/search.py
@@ -12,7 +12,7 @@ _SCALAR_BRACKETED_METHODS = ['brentq', 'brenth', 'ridder', 'bisect']
 
 
 def _search_keff(guess, target, model_builder, model_args, print_iterations,
-                 print_output, guesses, results):
+                 run_args, guesses, results):
     """Function which will actually create our model, run the calculation, and
     obtain the result. This function will be passed to the root finding
     algorithm
@@ -31,8 +31,8 @@ def _search_keff(guess, target, model_builder, model_args, print_iterations,
     print_iterations : bool
         Whether or not to print the guess and the resultant keff during the
         iteration process.
-    print_output : bool
-        Whether or not to print the OpenMC output during the iterations.
+    run_args : dict
+        Keyword arguments to pass to :meth:`openmc.Model.run`.
     guesses : Iterable of Real
         Running list of guesses thus far, to be updated during the execution of
         this function.
@@ -51,7 +51,7 @@ def _search_keff(guess, target, model_builder, model_args, print_iterations,
     model = model_builder(guess, **model_args)
 
     # Run the model and obtain keff
-    sp_filepath = model.run(output=print_output)
+    sp_filepath = model.run(**run_args)
     with openmc.StatePoint(sp_filepath) as sp:
         keff = sp.keff
 
@@ -70,7 +70,7 @@ def _search_keff(guess, target, model_builder, model_args, print_iterations,
 def search_for_keff(model_builder, initial_guess=None, target=1.0,
                     bracket=None, model_args=None, tol=None,
                     bracketed_method='bisect', print_iterations=False,
-                    print_output=False, **kwargs):
+                    run_args=None, **kwargs):
     """Function to perform a keff search by modifying a model parametrized by a
     single independent variable.
 
@@ -102,9 +102,11 @@ def search_for_keff(model_builder, initial_guess=None, target=1.0,
     print_iterations : bool
         Whether or not to print the guess and the result during the iteration
         process. Defaults to False.
-    print_output : bool
-        Whether or not to print the OpenMC output during the iterations.
-        Defaults to False.
+    run_args : dict, optional
+        Keyword arguments to pass to :meth:`openmc.Model.run`. Defaults to no
+        arguments.
+
+        .. versionadded:: 0.13.1
     **kwargs
         All remaining keyword arguments are passed to the root-finding
         method.
@@ -137,7 +139,10 @@ def search_for_keff(model_builder, initial_guess=None, target=1.0,
     cv.check_value('bracketed_method', bracketed_method,
                    _SCALAR_BRACKETED_METHODS)
     cv.check_type('print_iterations', print_iterations, bool)
-    cv.check_type('print_output', print_output, bool)
+    if run_args is None:
+        run_args = {}
+    else:
+        cv.check_type('run_args', run_args, dict)
     cv.check_type('model_builder', model_builder, Callable)
 
     # Run the model builder function once to make sure it provides the correct
@@ -188,7 +193,7 @@ def search_for_keff(model_builder, initial_guess=None, target=1.0,
 
     # Add information to be passed to the searching function
     args['args'] = (target, model_builder, model_args, print_iterations,
-                    print_output, guesses, results)
+                    run_args, guesses, results)
 
     # Create a new dictionary with the arguments from args and kwargs
     args.update(kwargs)

--- a/openmc/search.py
+++ b/openmc/search.py
@@ -53,7 +53,7 @@ def _search_keff(guess, target, model_builder, model_args, print_iterations,
     # Run the model and obtain keff
     sp_filepath = model.run(output=print_output)
     with openmc.StatePoint(sp_filepath) as sp:
-        keff = sp.k_combined
+        keff = sp.keff
 
     # Record the history
     guesses.append(guess)

--- a/openmc/statepoint.py
+++ b/openmc/statepoint.py
@@ -63,6 +63,8 @@ class StatePoint:
         datatype has fields 'name', 'sum', 'sum_sq', 'mean', and 'std_dev'.
     k_combined : uncertainties.UFloat
         Combined estimator for k-effective
+
+        .. deprecated:: 0.13.1
     k_col_abs : float
         Cross-product of collision and absorption estimates of k-effective
     k_col_tra : float
@@ -71,6 +73,10 @@ class StatePoint:
         Cross-product of absorption and tracklength estimates of k-effective
     k_generation : numpy.ndarray
         Estimate of k-effective for each batch/generation
+    keff : uncertainties.UFloat
+        Combined estimator for k-effective
+
+        .. versionadded:: 0.13.1
     meshes : dict
         Dictionary whose keys are mesh IDs and whose values are MeshBase objects
     n_batches : int
@@ -260,11 +266,19 @@ class StatePoint:
             return None
 
     @property
-    def k_combined(self):
+    def keff(self):
         if self.run_mode == 'eigenvalue':
             return ufloat(*self._f['k_combined'][()])
         else:
             return None
+
+    @property
+    def k_combined(self):
+        warnings.warn(
+            "The 'k_combined' property has been renamed to 'keff' and will be "
+            "removed in a future version of OpenMC.", FutureWarning
+        )
+        return self.keff
 
     @property
     def k_col_abs(self):

--- a/tests/regression_tests/deplete/test.py
+++ b/tests/regression_tests/deplete/test.py
@@ -115,16 +115,16 @@ def test_full(run_in_tmpdir, problem, multiproc):
 
     # Compare statepoint files with depletion results
 
-    t_test, k_test = res_test.get_eigenvalue()
-    t_ref, k_ref = res_ref.get_eigenvalue()
+    t_test, k_test = res_test.get_keff()
+    t_ref, k_ref = res_ref.get_keff()
     k_state = np.empty_like(k_ref)
 
     n_tallies = np.empty(N + 1, dtype=int)
 
     # Get statepoint files for all BOS points and EOL
     for n in range(N + 1):
-        statepoint = openmc.StatePoint("openmc_simulation_n{}.h5".format(n))
-        k_n = statepoint.k_combined
+        statepoint = openmc.StatePoint(f"openmc_simulation_n{n}.h5")
+        k_n = statepoint.keff
         k_state[n] = [k_n.nominal_value, k_n.std_dev]
         n_tallies[n] = len(statepoint.tallies)
     # Look for exact match pulling from statepoint and depletion_results

--- a/tests/regression_tests/entropy/test.py
+++ b/tests/regression_tests/entropy/test.py
@@ -14,7 +14,7 @@ class EntropyTestHarness(TestHarness):
         with StatePoint(statepoint) as sp:
             # Write out k-combined.
             outstr = 'k-combined:\n'
-            outstr += '{:12.6E} {:12.6E}\n'.format(sp.k_combined.n, sp.k_combined.s)
+            outstr += '{:12.6E} {:12.6E}\n'.format(sp.keff.n, sp.keff.s)
 
             # Write out entropy data.
             outstr += 'entropy:\n'

--- a/tests/regression_tests/mg_convert/test.py
+++ b/tests/regression_tests/mg_convert/test.py
@@ -145,7 +145,7 @@ class MGXSTestHarness(PyAPITestHarness):
                 # Write out k-combined.
                 outstr += 'k-combined:\n'
                 form = '{:12.6E} {:12.6E}\n'
-                outstr += form.format(sp.k_combined.n, sp.k_combined.s)
+                outstr += form.format(sp.keff.n, sp.keff.s)
 
         return outstr
 

--- a/tests/regression_tests/trigger_statepoint_restart/test.py
+++ b/tests/regression_tests/trigger_statepoint_restart/test.py
@@ -90,7 +90,7 @@ class TriggerStatepointRestartTestHarness(PyAPITestHarness):
             assert spfile
             with openmc.StatePoint(spfile) as sp:
                  sp_batchno_1 = sp.current_batch
-                 k_combined_1 = sp.k_combined
+                 keff_1 = sp.keff
             assert sp_batchno_1 > 5
             print('Last batch no = %d' % sp_batchno_1)
             self._write_inputs(self._get_inputs())
@@ -108,13 +108,13 @@ class TriggerStatepointRestartTestHarness(PyAPITestHarness):
             assert spfile
             with openmc.StatePoint(spfile) as sp:
                  sp_batchno_2 = sp.current_batch
-                 k_combined_2 = sp.k_combined
+                 keff_2 = sp.keff
             assert sp_batchno_2 > 5
             assert sp_batchno_1 == sp_batchno_2, \
                 'Different final batch number after restart'
             # need str() here as uncertainties.ufloat instances are always different
-            assert str(k_combined_1) == str(k_combined_2), \
-                'Different final k_combined after restart'
+            assert str(keff_1) == str(keff_2), \
+                'Different final keff after restart'
             self._write_inputs(self._get_inputs())
             self._compare_inputs()
             self._test_output_created()

--- a/tests/testing_harness.py
+++ b/tests/testing_harness.py
@@ -92,7 +92,7 @@ class TestHarness:
                 # Write out k-combined.
                 outstr += 'k-combined:\n'
                 form = '{0:12.6E} {1:12.6E}\n'
-                outstr += form.format(sp.k_combined.n, sp.k_combined.s)
+                outstr += form.format(sp.keff.n, sp.keff.s)
 
             # Write out tally data.
             for i, tally_ind in enumerate(sp.tallies):

--- a/tests/unit_tests/test_deplete_resultslist.py
+++ b/tests/unit_tests/test_deplete_resultslist.py
@@ -55,10 +55,10 @@ def test_get_reaction_rate(res):
     np.testing.assert_allclose(r, np.array(n_ref) * xs_ref)
 
 
-def test_get_eigenvalue(res):
-    """Tests evaluating eigenvalue."""
-    t, k = res.get_eigenvalue()
-    t_min, k = res.get_eigenvalue(time_units='min')
+def test_get_keff(res):
+    """Tests evaluating keff."""
+    t, k = res.get_keff()
+    t_min, k = res.get_keff(time_units='min')
 
     t_ref = [0.0, 1296000.0, 2592000.0, 3888000.0]
     k_ref = [1.21409662, 1.16518654, 1.25357797, 1.22611968]

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -293,14 +293,14 @@ def test_run(run_in_tmpdir, pin_model_attributes, mpi_intracomm):
     # C API execution modes and ensuring they give the same result.
     sp_path = test_model.run(output=False)
     with openmc.StatePoint(sp_path) as sp:
-        cli_keff = sp.k_combined
+        cli_keff = sp.keff
         cli_flux = sp.get_tally(id=1).get_values(scores=['flux'])[0, 0, 0]
         cli_fiss = sp.get_tally(id=1).get_values(scores=['fission'])[0, 0, 0]
 
     test_model.init_lib(output=False, intracomm=mpi_intracomm)
     sp_path = test_model.run(output=False)
     with openmc.StatePoint(sp_path) as sp:
-        lib_keff = sp.k_combined
+        lib_keff = sp.keff
         lib_flux = sp.get_tally(id=1).get_values(scores=['flux'])[0, 0, 0]
         lib_fiss = sp.get_tally(id=1).get_values(scores=['fission'])[0, 0, 0]
 

--- a/tests/unit_tests/test_temp_interp.py
+++ b/tests/unit_tests/test_temp_interp.py
@@ -147,7 +147,7 @@ def test_interpolation(model, method, temperature, fission_expected):
         assert abs(nu_fission_mean - nu*fission_expected) < 3*nu_fission_unc
 
         # Check that k-effective value matches expected
-        k = sp.k_combined
+        k = sp.keff
         if isnan(k.s):
             assert k.n == pytest.approx(nu*fission_expected)
         else:

--- a/tests/unit_tests/test_torus.py
+++ b/tests/unit_tests/test_torus.py
@@ -24,7 +24,7 @@ def get_torus_keff(cls, R, r, center=(0, 0, 0)):
 
     sp_path = model.run()
     with openmc.StatePoint(sp_path) as sp:
-        return sp.k_combined
+        return sp.keff
 
 
 @pytest.mark.parametrize("R,r", [(2.1, 2.0), (3.0, 1.0)])


### PR DESCRIPTION
Right now in our Python API, we have:
- `openmc.StatePoint.k_combined`
- `openmc.search_for_keff()`
- `openmc.lib.keff()`
- `openmc.deplete.ResultsList.get_eigenvalue()`

So, we effectively have three different names (k_combined, keff, eigenvalue) for the same thing. With the changes in this PR, we would have:
- `openmc.StatePoint.keff`
- `openmc.search_for_keff()` (unchanged)
- `openmc.lib.keff()` (unchanged)
- `openmc.deplete.ResultsList.get_keff()`

The older attributes/methods are retained for now but give deprecation warnings if you try to use them.