### PR TITLE
Allow for use of redundant fission when adjusting KERMA in from_njoy

### DIFF
--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -877,7 +877,7 @@ class IncidentNeutron(EqualityMixin):
 
                 if f is not None:
                     # Replace fission KERMA with (EFR + EB)*sigma_f
-                    fission = data.reactions[18].xs[temp]
+                    fission = data[18].xs[temp]
                     kerma_fission = get_file3_xs(ev, 318, E)
                     kerma.y = kerma.y - kerma_fission + (
                         f.fragments(E) + f.betas(E)) * fission(E)


### PR DESCRIPTION
One-line bugfix here: I noticed recently when trying to use `IncidentNeutron.from_njoy` on the Pu237 evaluation in ENDF/B-VII.0 that it crashes on this line. The problem is that that evaluation uses MT=19 for fission and the ACE file produced doesn't redundantly store MT=18. The fix here is to use `data[18]`, which automatically calculates the redundant reaction cross section, instead of `data.reactions[18]`.