### PR TITLE
Raise error if WMP and photon transport are used together

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -802,6 +802,12 @@ void read_settings_xml()
   }
   if (check_for_node(root, "temperature_multipole")) {
     temperature_multipole = get_node_value_bool(root, "temperature_multipole");
+
+    // Multipole currently doesn't work with photon transport
+    if (temperature_multipole && photon_transport) {
+      fatal_error("Multipole data cannot currently be used in conjunction with "
+                  "photon transport.");
+    }
   }
   if (check_for_node(root, "temperature_range")) {
     auto range = get_node_array<double>(root, "temperature_range");


### PR DESCRIPTION
Right now, WMP does not work together with photon transport (#1418). If you try running a simulation with WMP and photon transport on, you'll get a segfault. This PR simply adds an error message so that we don't reach a segfault in that scenario.