### PR TITLE
Fixes missing version.h when getting OpenMC through FetchContent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ src/CMakeFiles/
 src/bin/
 src/cmake_install.cmake
 src/install_manifest.txt
+include/openmc/version.h
 
 # Nuclear data
 scripts/nndc

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ src/CMakeFiles/
 src/bin/
 src/cmake_install.cmake
 src/install_manifest.txt
-include/openmc/version.h
 
 # Nuclear data
 scripts/nndc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,8 @@ target_include_directories(libopenmc
 target_compile_options(libopenmc PRIVATE ${cxxflags})
 
 # Add include directory for configured version file
-target_include_directories(libopenmc PRIVATE ${CMAKE_BINARY_DIR}/include)
+target_include_directories(libopenmc
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
 
 if (HDF5_IS_PARALLEL)
   target_compile_definitions(libopenmc PRIVATE -DPHDF5)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(OPENMC_VERSION_MAJOR 0)
 set(OPENMC_VERSION_MINOR 13)
 set(OPENMC_VERSION_RELEASE 1)
 set(OPENMC_VERSION ${OPENMC_VERSION_MAJOR}.${OPENMC_VERSION_MINOR}.${OPENMC_VERSION_RELEASE})
-configure_file(include/openmc/version.h.in "${CMAKE_CURRENT_SOURCE_DIR}/include/openmc/version.h" @ONLY)
+configure_file(include/openmc/version.h.in "${CMAKE_BINARY_DIR}/include/openmc/version.h" @ONLY)
 
 # Setup output directories
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -495,3 +495,4 @@ install(FILES
 install(FILES man/man1/openmc.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 install(FILES LICENSE DESTINATION "${CMAKE_INSTALL_DOCDIR}" RENAME copyright)
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES "${CMAKE_BINARY_DIR}/include/openmc/version.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openmc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(OPENMC_VERSION_MAJOR 0)
 set(OPENMC_VERSION_MINOR 13)
 set(OPENMC_VERSION_RELEASE 1)
 set(OPENMC_VERSION ${OPENMC_VERSION_MAJOR}.${OPENMC_VERSION_MINOR}.${OPENMC_VERSION_RELEASE})
-configure_file(include/openmc/version.h.in "${CMAKE_BINARY_DIR}/include/openmc/version.h" @ONLY)
+configure_file(include/openmc/version.h.in "${CMAKE_CURRENT_SOURCE_DIR}/include/openmc/version.h" @ONLY)
 
 # Setup output directories
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -495,4 +495,3 @@ install(FILES
 install(FILES man/man1/openmc.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 install(FILES LICENSE DESTINATION "${CMAKE_INSTALL_DOCDIR}" RENAME copyright)
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(FILES "${CMAKE_BINARY_DIR}/include/openmc/version.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openmc)

--- a/include/openmc/version.h.in
+++ b/include/openmc/version.h.in
@@ -1,3 +1,6 @@
+#ifndef OPENMC_VERSION_H
+#define OPENMC_VERSION_H
+
 #include "openmc/array.h"
 
 namespace openmc {
@@ -12,3 +15,5 @@ constexpr std::array<int, 3> VERSION {VERSION_MAJOR, VERSION_MINOR, VERSION_RELE
 // clang-format on
 
 } // namespace openmc
+
+#endif // OPENMC_VERSION_H


### PR DESCRIPTION
This PR should fix #2062 . Instead of configuring `version.h` in the build directory, it would now be placed directly in the source directory. To make sure this never gets added to commits, I also added `include/openmc/version.h` to the gitignore. I also removed the last line in the cmake file explicitly installing `version.h` from the build directory, as this should automatically be done now when the include directory is installed.