### PR TITLE
Provide error message for missing DAGMC model file

### DIFF
--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -50,6 +50,9 @@ DAGUniverse::DAGUniverse(pugi::xml_node node)
 
   if (check_for_node(node, "filename")) {
     filename_ = get_node_value(node, "filename");
+    if (!file_exists(filename_)) {
+      fatal_error(fmt::format("DAGMC file '{}' could not be found", filename_));
+    }
   } else {
     fatal_error("Must specify a file for the DAGMC universe");
   }


### PR DESCRIPTION
A user noted that a missing or incorrect path for a DAGMC file results in an esoteric `std::string` message instead of something more informative. This PR remedies that.

Resolves #2067.