### PR TITLE
Disable GNU extensions for CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,9 +455,10 @@ target_compile_options(openmc PRIVATE ${cxxflags})
 target_include_directories(openmc PRIVATE ${CMAKE_BINARY_DIR}/include)
 target_link_libraries(openmc libopenmc)
 
-# Ensure C++14 standard is used
+# Ensure C++14 standard is used and turn off GNU extensions
 target_compile_features(openmc PUBLIC cxx_std_14)
 target_compile_features(libopenmc PUBLIC cxx_std_14)
+set_target_properties(openmc libopenmc PROPERTIES CXX_EXTENSIONS OFF)
 
 #===============================================================================
 # Python package


### PR DESCRIPTION
A user [ran into a build issue](https://openmc.discourse.group/t/compile-error-no-match-for-operator/2065) using gcc 7 building the latest branch of OpenMC. I was able to trace this down to the fact that CMake will by default turn on GNU compiler extensions (`-std=gnu14` instead of `-std=c++14`), which apparently can cause a [conflict for complex literals](https://stackoverflow.com/a/51742831). The solution is to simply turn off GNU extensions using the `CXX_EXTENSIONS` target property.