### PR TITLE
Bug fix for rare infinite loop when finding cell after surface crossing

### DIFF
--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -454,9 +454,7 @@ void Particle::cross_surface()
   // ==========================================================================
   // COULDN'T FIND PARTICLE IN NEIGHBORING CELLS, SEARCH ALL CELLS
 
-  // Remove lower coordinate levels and assignment of surface
-  auto surface_index = surface();
-  surface() = 0;
+  // Remove lower coordinate levels
   n_coord() = 1;
   bool found = exhaustive_find_cell(*this);
 
@@ -466,6 +464,7 @@ void Particle::cross_surface()
     // the particle is really traveling tangent to a surface, if we move it
     // forward a tiny bit it should fix the problem.
 
+    surface() = 0;
     n_coord() = 1;
     r() += TINY_BIT * u();
 
@@ -479,9 +478,6 @@ void Particle::cross_surface()
       return;
     }
   }
-
-  // Reassign surface to avoid tracking errors
-  surface() = surface_index;
 }
 
 void Particle::cross_vacuum_bc(const Surface& surf)

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -455,6 +455,7 @@ void Particle::cross_surface()
   // COULDN'T FIND PARTICLE IN NEIGHBORING CELLS, SEARCH ALL CELLS
 
   // Remove lower coordinate levels and assignment of surface
+  auto surface_index = surface();
   surface() = 0;
   n_coord() = 1;
   bool found = exhaustive_find_cell(*this);
@@ -478,6 +479,9 @@ void Particle::cross_surface()
       return;
     }
   }
+
+  // Reassign surface to avoid tracking errors
+  surface() = surface_index;
 }
 
 void Particle::cross_vacuum_bc(const Surface& surf)


### PR DESCRIPTION
I've been working with an OpenMC version of the ITER E-lite model and have found that OpenMC can run into an infinite loop in the following circumstance:

- When a particle crosses a surface, it first checks neighboring cells to see whether the particle is entering any of them.
- If the neighboring cell search fails (which happens very infrequently), it does a more exhaustive search that includes all cells in the particle's current universe. However, when it does this search, it **marks the particle as not being on any surface**.
- After the next cell is found from the exhaustive search, it goes on to calculate the distance to the next boundary. However, because the particle no longer thinks it's on a surface, the distance to the surface that it originally crossed ends up being very small but positive. Thus, it tries to cross the same surface again and ends up going through the same logic in an infinite loop.

The solution I've proposed here is to not reset the `surface_` attribute on the particle when doing the exhaustive find cell search. Unfortunately this situation is so rare that I can't come up with a test for it, but I can attest that it does prevent the infinite loop bug on the ITER model.