### PR TITLE
Use UTF-8 encoding when reading dose coefficient files

### DIFF
--- a/openmc/data/effective_dose/dose.py
+++ b/openmc/data/effective_dose/dose.py
@@ -23,7 +23,7 @@ def _load_dose_icrp116():
     """Load effective dose tables from text files"""
     for particle, filename in _FILES:
         path = Path(__file__).parent / filename
-        data = np.loadtxt(path, skiprows=3)
+        data = np.loadtxt(path, skiprows=3, encoding='utf-8')
         data[:, 0] *= 1e6   # Change energies to eV
         _DOSE_ICRP116[particle] = data
 


### PR DESCRIPTION
A user [pointed out](https://openmc.discourse.group/t/error-reading-dose-coefficients/2056) that on some systems, loading the ICRP-116 dose coefficient files may raise an exception due to an unspecified encoding and the use of a unicode character:
https://github.com/openmc-dev/openmc/blob/fe230168fb5651ba4373910b16f412ecd7b53287/openmc/data/effective_dose/photons.txt#L1

This PR simply specifies the correct encoding (UTF-8) on the call to `numpy.loadtxt`.