### PR TITLE
Fix a corner case in Region.from_expression

### DIFF
--- a/docs/source/methods/neutron_physics.rst
+++ b/docs/source/methods/neutron_physics.rst
@@ -1403,7 +1403,7 @@ given analytically by
 .. math::
     :label: coherent-elastic-angle
 
-    \mu = 1 - \frac{E_i}{E}
+    \mu = 1 - \frac{2E_i}{E}
 
 where :math:`E_i` is the energy of the Bragg edge that scattered the neutron.
 

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -106,6 +106,11 @@ class Region(ABC):
                 # If special character appears immediately after a non-operator,
                 # create a token with the appropriate half-space
                 if i_start >= 0:
+                    # When an opening parenthesis appears after a non-operator,
+                    # there's an implicit intersection operator between them
+                    if expression[i] == '(':
+                        tokens.append(' ')
+
                     j = int(expression[i_start:i])
                     if j < 0:
                         tokens.append(-surfaces[abs(j)])

--- a/tests/unit_tests/test_region.py
+++ b/tests/unit_tests/test_region.py
@@ -204,3 +204,7 @@ def test_from_expression(reset):
     # Make sure ")(" is handled correctly
     r = openmc.Region.from_expression('(-1|2)(2|-3)', surfs)
     assert str(r) == '((-1 | 2) (2 | -3))'
+
+    # Opening parenthesis immediately after halfspace
+    r = openmc.Region.from_expression('1(2|-3)', surfs)
+    assert str(r) == '(1 (2 | -3))'


### PR DESCRIPTION
If you pass the expression `1(2|-3)` to `Region.from_expression` right now, it doesn't recognize that there's an implicit intersection operator between the `1` and the `(`. This PR fixes this behavior to correctly insert the intersection operator between them and is accompanied by a (previously failing) test case.

Once again, this bug was found as a result of working with the ITER E-lite model.