### PR TITLE
Adding remove element method to material class

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -407,6 +407,23 @@ class Material(IDManagerMixin):
             if nuclide == nuc.name:
                 self.nuclides.remove(nuc)
 
+    def remove_element(self, element):
+        """Remove an element from the material
+
+        Parameters
+        ----------
+        element : str
+            Element to remove
+
+        """
+        cv.check_type('element', element, str)
+
+        # If the Material contains the element, delete it
+        for nuc in reversed(self.nuclides):
+            element_name = re.split(r'(\d+)', nuc)
+            if nuc == element_name:
+                self.nuclides.remove(nuc)
+
     def add_macroscopic(self, macroscopic):
         """Add a macroscopic to the material.  This will also set the
         density of the material to 1.0, unless it has been otherwise set,

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -420,8 +420,9 @@ class Material(IDManagerMixin):
 
         # If the Material contains the element, delete it
         for nuc in reversed(self.nuclides):
-            element_name = re.split(r'(\d+)', nuc)
-            if nuc == element_name:
+            element_name = re.split(r'(\d+)', nuc.name)[0]
+            print(element_name, element)
+            if element_name == element:
                 self.nuclides.remove(nuc)
 
     def add_macroscopic(self, macroscopic):

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -420,8 +420,7 @@ class Material(IDManagerMixin):
 
         # If the Material contains the element, delete it
         for nuc in reversed(self.nuclides):
-            element_name = re.split(r'(\d+)', nuc.name)[0]
-            print(element_name, element)
+            element_name = re.split(r'\d+', nuc.name)[0]
             if element_name == element:
                 self.nuclides.remove(nuc)
 

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -43,7 +43,7 @@ def test_remove_elements():
     m = openmc.Material()
     for elem, percent in [('Li', 1.0), ('Be', 1.0)]:
         m.add_element(elem, percent)
-    m.remove_nuclide('Li')
+    m.remove_element('Li')
     assert len(m.nuclides) == 1
     assert m.nuclides == ['Be9']
     assert m.nuclides[0].percent == 1.0

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -38,6 +38,17 @@ def test_remove_nuclide():
     assert m.nuclides[1].percent == 2.0
 
 
+def test_remove_elements():
+    """Test removing elements."""
+    m = openmc.Material()
+    for elem, percent in [('Li', 1.0), ('Be', 1.0)]:
+        m.add_element(elem, percent)
+    m.remove_nuclide('Li')
+    assert len(m.nuclides) == 1
+    assert m.nuclides == ['Be9']
+    assert m.nuclides[0].percent == 1.0
+
+
 def test_elements():
     """Test adding elements."""
     m = openmc.Material()

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -45,7 +45,7 @@ def test_remove_elements():
         m.add_element(elem, percent)
     m.remove_element('Li')
     assert len(m.nuclides) == 1
-    assert m.nuclides == ['Be9']
+    assert m.nuclides[0].name == 'Be9'
     assert m.nuclides[0].percent == 1.0
 
 


### PR DESCRIPTION
This PR adds the ability to remove an element from a material object.

This is very similar to the existing ```remove_nuclide``` method but applied to elements.

Unit test has been added

Discussed  further in issue #2087 