### PR TITLE
`.write_data_to_vtk()` method in meshes

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -633,20 +633,11 @@ class RegularMesh(StructuredMesh):
                 normalize the data by the volume of the mesh elements.
                 Defaults to True.
 
-        Raises:
-            RuntimeError: when no volume data is found and volume_normalisation
-                is required
-
         Returns:
             vtk.vtkStructuredGrid: the VTK object
         """
         import vtk
         from vtk.util import numpy_support as nps
-
-        if self.volumes is None and volume_normalization:
-            raise RuntimeError("No volume data is present on this "
-                               "unstructured mesh. Please load the "
-                               " mesh information from a statepoint file.")
 
         # check that the data sets are appropriately sized
         for label, dataset in datasets.items():
@@ -914,20 +905,11 @@ class RectilinearMesh(StructuredMesh):
                 normalize the data by the volume of the mesh elements.
                 Defaults to True.
 
-        Raises:
-            RuntimeError: when no volume data is found and volume_normalisation
-                is required
-
         Returns:
             vtk.vtkStructuredGrid: the VTK object
         """
         import vtk
         from vtk.util import numpy_support as nps
-
-        if self.volumes is None and volume_normalization:
-            raise RuntimeError("No volume data is present on this "
-                               "unstructured mesh. Please load the "
-                               " mesh information from a statepoint file.")
 
         # check that the data sets are appropriately sized
         for label, dataset in datasets.items():
@@ -1176,20 +1158,11 @@ class CylindricalMesh(StructuredMesh):
                 normalize the data by the volume of the mesh elements.
                 Defaults to True.
 
-        Raises:
-            RuntimeError: when no volume data is found and volume_normalisation
-                is required
-
         Returns:
             vtk.vtkStructuredGrid: the VTK object
         """
         import vtk
         from vtk.util import numpy_support as nps
-
-        if self.volumes is None and volume_normalization:
-            raise RuntimeError("No volume data is present on this "
-                               "unstructured mesh. Please load the "
-                               " mesh information from a statepoint file.")
 
         # check that the data sets are appropriately sized
         for label, dataset in datasets.items():
@@ -1440,20 +1413,11 @@ class SphericalMesh(StructuredMesh):
                 normalize the data by the volume of the mesh elements.
                 Defaults to True.
 
-        Raises:
-            RuntimeError: when no volume data is found and volume_normalisation
-                is required
-
         Returns:
             vtk.vtkStructuredGrid: the VTK object
         """
         import vtk
         from vtk.util import numpy_support as nps
-
-        if self.volumes is None and volume_normalization:
-            raise RuntimeError("No volume data is present on this "
-                               "unstructured mesh. Please load the "
-                               " mesh information from a statepoint file.")
 
         # check that the data sets are appropriately sized
         for label, dataset in datasets.items():

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -208,7 +208,6 @@ class StructuredMesh(MeshBase):
         volume_normalization : bool, optional
             Whether or not to normalize the data by
             the volume of the mesh elements.
-            Defaults to True.
 
         Raises
         ------

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -196,20 +196,29 @@ class StructuredMesh(MeshBase):
     def write_data_to_vtk(self, points, filename, datasets, volume_normalization=True):
         """Creates a VTK object of the mesh
 
-        Args:
-            points (list or np.array): List of (X,Y,Y) tuples.
-            filename (str): Name of the VTK file to write.
-            datasets (dict): Dictionary whose keys are the data labels
-                and values are the data sets.
-            volume_normalization (bool, optional): Whether or not to
-                normalize the data by the volume of the mesh elements.
-                Defaults to True.
+        Parameters
+        ----------
+        points : list or np.array
+            List of (X,Y,Y) tuples.
+        filename : str
+            Name of the VTK file to write.
+        datasets : dict
+            Dictionary whose keys are the data labels
+            and values are the data sets.
+        volume_normalization : bool, optional
+            Whether or not to normalize the data by
+            the volume of the mesh elements.
+            Defaults to True.
 
-        Raises:
-            RuntimeError: when the size of a dataset doesn't match the number of cells
+        Raises
+        ------
+        RuntimeError
+            When the size of a dataset doesn't match the number of cells
 
-        Returns:
-            vtk.vtkStructuredGrid: the VTK object
+        Returns
+        -------
+        vtk.vtkStructuredGrid
+            the VTK object
         """
 
         import vtk
@@ -688,16 +697,22 @@ class RegularMesh(StructuredMesh):
     def write_data_to_vtk(self, filename, datasets, volume_normalization=True):
         """Creates a VTK object of the mesh
 
-        Args:
-            filename (str): Name of the VTK file to write.
-            datasets (dict): Dictionary whose keys are the data labels
-                and values are the data sets.
-            volume_normalization (bool, optional): Whether or not to
-                normalize the data by the volume of the mesh elements.
-                Defaults to True.
+        Parameters
+        ----------
+        filename : str
+            Name of the VTK file to write.
+        datasets : dict
+            Dictionary whose keys are the data labels
+            and values are the data sets.
+        volume_normalization : bool, optional
+            Whether or not to normalize the data by
+            the volume of the mesh elements.
+            Defaults to True.
 
-        Returns:
-            vtk.vtkStructuredGrid: the VTK object
+        Returns
+        -------
+        vtk.vtkStructuredGrid
+            the VTK object
         """
 
         x_vals = np.linspace(
@@ -927,16 +942,22 @@ class RectilinearMesh(StructuredMesh):
     def write_data_to_vtk(self, filename, datasets, volume_normalization=True):
         """Creates a VTK object of the mesh
 
-        Args:
-            filename (str): Name of the VTK file to write.
-            datasets (dict): Dictionary whose keys are the data labels
-                and values are the data sets.
-            volume_normalization (bool, optional): Whether or not to
-                normalize the data by the volume of the mesh elements.
-                Defaults to True.
+        Parameters
+        ----------
+        filename : str
+            Name of the VTK file to write.
+        datasets : dict
+            Dictionary whose keys are the data labels
+            and values are the data sets.
+        volume_normalization : bool, optional
+            Whether or not to normalize the data by
+            the volume of the mesh elements.
+            Defaults to True.
 
-        Returns:
-            vtk.vtkStructuredGrid: the VTK object
+        Returns
+        -------
+        vtk.vtkStructuredGrid
+            the VTK object
         """
         # create points
         pts_cartesian = np.array([[x, y, z] for z in self.z_grid for y in self.y_grid for x in self.x_grid])
@@ -1142,16 +1163,22 @@ class CylindricalMesh(StructuredMesh):
     def write_data_to_vtk(self, filename, datasets, volume_normalization=True):
         """Creates a VTK object of the mesh
 
-        Args:
-            filename (str): Name of the VTK file to write.
-            datasets (dict): Dictionary whose keys are the data labels
-                and values are the data sets.
-            volume_normalization (bool, optional): Whether or not to
-                normalize the data by the volume of the mesh elements.
-                Defaults to True.
+        Parameters
+        ----------
+        filename : str
+            Name of the VTK file to write.
+        datasets : dict
+            Dictionary whose keys are the data labels
+            and values are the data sets.
+        volume_normalization : bool, optional
+            Whether or not to normalize the data by
+            the volume of the mesh elements.
+            Defaults to True.
 
-        Returns:
-            vtk.vtkStructuredGrid: the VTK object
+        Returns
+        -------
+        vtk.vtkStructuredGrid
+            the VTK object
         """
         # create points
         pts_cylindrical = np.array([[r, phi, z] for z in self.z_grid for phi in self.phi_grid for r in self.r_grid])
@@ -1361,16 +1388,22 @@ class SphericalMesh(StructuredMesh):
     def write_data_to_vtk(self, filename, datasets, volume_normalization=True):
         """Creates a VTK object of the mesh
 
-        Args:
-            filename (str): Name of the VTK file to write.
-            datasets (dict): Dictionary whose keys are the data labels
-                and values are the data sets.
-            volume_normalization (bool, optional): Whether or not to
-                normalize the data by the volume of the mesh elements.
-                Defaults to True.
+        Parameters
+        ----------
+        filename : str
+            Name of the VTK file to write.
+        datasets : dict
+            Dictionary whose keys are the data labels
+            and values are the data sets.
+        volume_normalization : bool, optional
+            Whether or not to normalize the data by
+            the volume of the mesh elements.
+            Defaults to True.
 
-        Returns:
-            vtk.vtkStructuredGrid: the VTK object
+        Returns
+        -------
+        vtk.vtkStructuredGrid
+            the VTK object
         """
 
         # create points

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -193,6 +193,51 @@ class StructuredMesh(MeshBase):
         s1 = (slice(1, None),)*ndim + (slice(None),)
         return (vertices[s0] + vertices[s1]) / 2
 
+    def write_data_to_vtk(self, points, filename, datasets, volume_normalization=True):
+        import vtk
+        from vtk.util import numpy_support as nps
+
+        # check that the data sets are appropriately sized
+        errmsg = "The size of the dataset {} should be equal to the number of cells"
+        for label, dataset in datasets.items():
+            if isinstance(dataset, np.ndarray):
+                if not dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]:
+                    raise RuntimeError(errmsg.format(label))
+            else:
+                if len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]:
+                    raise RuntimeError(errmsg.format(label))
+            cv.check_type('label', label, str)
+
+        vtk_grid = vtk.vtkStructuredGrid()
+
+        vtk_grid.SetDimensions(*self.dimension)
+
+        vtkPts = vtk.vtkPoints()
+        vtkPts.SetData(nps.numpy_to_vtk(points, deep=True))
+        vtk_grid.SetPoints(vtkPts)
+
+        # create VTK arrays for each of
+        # the data sets
+        for label, dataset in datasets.items():
+            dataset = np.asarray(dataset).flatten()
+
+            if volume_normalization:
+                dataset /= self.volumes.flatten()
+
+            dataset_array = vtk.vtkDoubleArray()
+            dataset_array.SetName(label)
+            dataset_array.SetArray(nps.numpy_to_vtk(dataset),
+                           dataset.size,
+                           True)
+            vtk_grid.GetCellData().AddArray(dataset_array)
+
+        # write the .vtk file
+        writer = vtk.vtkStructuredGridWriter()
+        writer.SetFileName(str(filename))
+        writer.SetInputData(vtk_grid)
+        writer.Write()
+
+        return vtk_grid
 
 class RegularMesh(StructuredMesh):
     """A regular Cartesian mesh in one, two, or three dimensions
@@ -635,23 +680,7 @@ class RegularMesh(StructuredMesh):
 
         Returns:
             vtk.vtkStructuredGrid: the VTK object
-        
-        Raises:
-            RuntimeError: when the size of a dataset doesn't match the number of cells 
         """
-        import vtk
-        from vtk.util import numpy_support as nps
-
-        # check that the data sets are appropriately sized
-        errmsg = "The size of the dataset {} should be equal to the number of cells"
-        for label, dataset in datasets.items():
-            if isinstance(dataset, np.ndarray):
-                if not dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]:
-                    raise RuntimeError(errmsg.format(label))
-            else:
-                if len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]:
-                    raise RuntimeError(errmsg.format(label))
-            cv.check_type('label', label, str)
 
         x_vals = np.linspace(
             self.lower_left[0],
@@ -668,39 +697,16 @@ class RegularMesh(StructuredMesh):
             self.upper_right[2],
             num=self.dimension[2] + 1,
         )
-        vtk_grid = vtk.vtkStructuredGrid()
-
-        vtk_grid.SetDimensions(len(x_vals), len(y_vals), len(z_vals))
 
         # create points
         pts_cartesian = np.array([[x, y, z] for z in z_vals for y in y_vals for x in x_vals])
 
-        vtkPts = vtk.vtkPoints()
-        vtkPts.SetData(nps.numpy_to_vtk(pts_cartesian, deep=True))
-        vtk_grid.SetPoints(vtkPts)
-
-        # create VTK arrays for each of
-        # the data sets
-        for label, dataset in datasets.items():
-            dataset = np.asarray(dataset).flatten()
-
-            if volume_normalization:
-                dataset /= self.volumes.flatten()
-
-            dataset_array = vtk.vtkDoubleArray()
-            dataset_array.SetName(label)
-            dataset_array.SetArray(nps.numpy_to_vtk(dataset),
-                           dataset.size,
-                           True)
-            vtk_grid.GetCellData().AddArray(dataset_array)
-
-        # write the .vtk file
-        writer = vtk.vtkStructuredGridWriter()
-        writer.SetFileName(str(filename))
-        writer.SetInputData(vtk_grid)
-        writer.Write()
-
-        return vtk_grid
+        return super().write_data_to_vtk(
+            points=pts_cartesian,
+            filename=filename,
+            datasets=datasets,
+            volume_normalization=volume_normalization
+        )
 
 def Mesh(*args, **kwargs):
     warnings.warn("Mesh has been renamed RegularMesh. Future versions of "
@@ -913,60 +919,16 @@ class RectilinearMesh(StructuredMesh):
 
         Returns:
             vtk.vtkStructuredGrid: the VTK object
-
-        Raises:
-            RuntimeError: when the size of a dataset doesn't match the number of cells 
         """
-        import vtk
-        from vtk.util import numpy_support as nps
-
-        # check that the data sets are appropriately sized
-        errmsg = "The size of the dataset {} should be equal to the number of cells"
-        for label, dataset in datasets.items():
-            if isinstance(dataset, np.ndarray):
-                if not dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]:
-                    raise RuntimeError(errmsg.format(label))
-            else:
-                if len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]:
-                    raise RuntimeError(errmsg.format(label))
-            cv.check_type('label', label, str)
-
-        x_vals = self.x_grid
-        y_vals = self.y_grid
-        z_vals = self.z_grid
-        vtk_grid = vtk.vtkStructuredGrid()
-
-        vtk_grid.SetDimensions(len(x_vals), len(y_vals), len(z_vals))
-
         # create points
-        pts_cartesian = np.array([[x, y, z] for z in z_vals for y in y_vals for x in x_vals])
+        pts_cartesian = np.array([[x, y, z] for z in self.z_grid for y in self.y_grid for x in self.x_grid])
 
-        vtkPts = vtk.vtkPoints()
-        vtkPts.SetData(nps.numpy_to_vtk(pts_cartesian, deep=True))
-        vtk_grid.SetPoints(vtkPts)
-
-        # create VTK arrays for each of
-        # the data sets
-        for label, dataset in datasets.items():
-            dataset = np.asarray(dataset).flatten()
-
-            if volume_normalization:
-                dataset /= self.volumes.flatten()
-
-            dataset_array = vtk.vtkDoubleArray()
-            dataset_array.SetName(label)
-            dataset_array.SetArray(nps.numpy_to_vtk(dataset),
-                           dataset.size,
-                           True)
-            vtk_grid.GetCellData().AddArray(dataset_array)
-
-        # write the .vtk file
-        writer = vtk.vtkStructuredGridWriter()
-        writer.SetFileName(filename)
-        writer.SetInputData(vtk_grid)
-        writer.Write()
-
-        return vtk_grid
+        return super().write_data_to_vtk(
+            points=pts_cartesian,
+            filename=filename,
+            datasets=datasets,
+            volume_normalization=volume_normalization
+        )
 
 
 class CylindricalMesh(StructuredMesh):
@@ -1172,28 +1134,7 @@ class CylindricalMesh(StructuredMesh):
 
         Returns:
             vtk.vtkStructuredGrid: the VTK object
-
-        Raises:
-            RuntimeError: when the size of a dataset doesn't match the number of cells 
         """
-        import vtk
-        from vtk.util import numpy_support as nps
-
-        # check that the data sets are appropriately sized
-        errmsg = "The size of the dataset {} should be equal to the number of cells"
-        for label, dataset in datasets.items():
-            if isinstance(dataset, np.ndarray):
-                if not dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]:
-                    raise RuntimeError(errmsg.format(label))
-            else:
-                if len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]:
-                    raise RuntimeError(errmsg.format(label))
-            cv.check_type('label', label, str)
-
-        vtk_grid = vtk.vtkStructuredGrid()
-
-        vtk_grid.SetDimensions(len(self.r_grid), len(self.phi_grid), len(self.z_grid))
-
         # create points
         pts_cylindrical = np.array([[r, phi, z] for z in self.z_grid for phi in self.phi_grid for r in self.r_grid])
         pts_cartesian = np.copy(pts_cylindrical)
@@ -1201,32 +1142,12 @@ class CylindricalMesh(StructuredMesh):
         pts_cartesian[:, 0] = r * np.cos(phi)
         pts_cartesian[:, 1] = r * np.sin(phi)
 
-        vtkPts = vtk.vtkPoints()
-        vtkPts.SetData(nps.numpy_to_vtk(pts_cartesian, deep=True))
-        vtk_grid.SetPoints(vtkPts)
-
-        # create VTK arrays for each of
-        # the data sets
-        for label, dataset in datasets.items():
-            dataset = np.asarray(dataset).flatten()
-
-            if volume_normalization:
-                dataset /= self.volumes.flatten()
-
-            dataset_array = vtk.vtkDoubleArray()
-            dataset_array.SetName(label)
-            dataset_array.SetArray(nps.numpy_to_vtk(dataset),
-                           dataset.size,
-                           True)
-            vtk_grid.GetCellData().AddArray(dataset_array)
-
-
-        writer = vtk.vtkStructuredGridWriter()
-        writer.SetFileName(filename)
-        writer.SetInputData(vtk_grid)
-        writer.Write()
-
-        return vtk_grid
+        return super().write_data_to_vtk(
+            points=pts_cartesian,
+            filename=filename,
+            datasets=datasets,
+            volume_normalization=volume_normalization
+        )
 
 class SphericalMesh(StructuredMesh):
     """A 3D spherical mesh
@@ -1432,28 +1353,7 @@ class SphericalMesh(StructuredMesh):
 
         Returns:
             vtk.vtkStructuredGrid: the VTK object
-
-        Raises:
-            RuntimeError: when the size of a dataset doesn't match the number of cells 
         """
-        import vtk
-        from vtk.util import numpy_support as nps
-
-        # check that the data sets are appropriately sized
-        errmsg = "The size of the dataset {} should be equal to the number of cells"
-        for label, dataset in datasets.items():
-            if isinstance(dataset, np.ndarray):
-                if not dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]:
-                    raise RuntimeError(errmsg.format(label))
-            else:
-                if len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]:
-                    raise RuntimeError(errmsg.format(label))
-
-            cv.check_type('label', label, str)
-
-        vtk_grid = vtk.vtkStructuredGrid()
-
-        vtk_grid.SetDimensions(len(self.r_grid), len(self.theta_grid), len(self.phi_grid))
 
         # create points
         pts_spherical = np.array([[r, theta, phi] for phi in self.phi_grid for theta in self.theta_grid for r in self.r_grid])
@@ -1463,32 +1363,12 @@ class SphericalMesh(StructuredMesh):
         pts_cartesian[:, 1] = r * np.sin(phi) * np.sin(theta)
         pts_cartesian[:, 2] = r * np.cos(phi)
 
-        vtkPts = vtk.vtkPoints()
-        vtkPts.SetData(nps.numpy_to_vtk(pts_cartesian, deep=True))
-        vtk_grid.SetPoints(vtkPts)
-
-        # create VTK arrays for each of
-        # the data sets
-        for label, dataset in datasets.items():
-            dataset = np.asarray(dataset).flatten()
-
-            if volume_normalization:
-                dataset /= self.volumes.flatten()
-
-            dataset_array = vtk.vtkDoubleArray()
-            dataset_array.SetName(label)
-            dataset_array.SetArray(nps.numpy_to_vtk(dataset),
-                           dataset.size,
-                           True)
-            vtk_grid.GetCellData().AddArray(dataset_array)
-
-        # write the .vtk file
-        writer = vtk.vtkStructuredGridWriter()
-        writer.SetFileName(filename)
-        writer.SetInputData(vtk_grid)
-        writer.Write()
-
-        return vtk_grid
+        return super().write_data_to_vtk(
+            points=pts_cartesian,
+            filename=filename,
+            datasets=datasets,
+            volume_normalization=volume_normalization
+        )
 
 
 class UnstructuredMesh(MeshBase):

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -626,8 +626,16 @@ class RegularMesh(StructuredMesh):
         """Creates a VTK object of the mesh
 
         Args:
-            filename (str, optional): Name of the vtk file to write =
-                (must end with .vtk). Defaults to None.
+            filename (str): Name of the VTK file to write.
+            datasets (dict): Dictionary whose keys are the data labels
+                and values are the data sets.
+            volume_normalization (bool, optional): Whether or not to
+                normalize the data by the volume of the mesh elements.
+                Defaults to True.
+
+        Raises:
+            RuntimeError: when no volume data is found and volume_normalisation
+                is required
 
         Returns:
             vtk.vtkStructuredGrid: the VTK object
@@ -899,8 +907,16 @@ class RectilinearMesh(StructuredMesh):
         """Creates a VTK object of the mesh
 
         Args:
-            filename (str, optional): Name of the vtk file to write =
-                (must end with .vtk). Defaults to None.
+            filename (str): Name of the VTK file to write.
+            datasets (dict): Dictionary whose keys are the data labels
+                and values are the data sets.
+            volume_normalization (bool, optional): Whether or not to
+                normalize the data by the volume of the mesh elements.
+                Defaults to True.
+
+        Raises:
+            RuntimeError: when no volume data is found and volume_normalisation
+                is required
 
         Returns:
             vtk.vtkStructuredGrid: the VTK object
@@ -1153,8 +1169,16 @@ class CylindricalMesh(StructuredMesh):
         """Creates a VTK object of the mesh
 
         Args:
-            filename (str, optional): Name of the vtk file to write =
-                (must end with .vtk). Defaults to None.
+            filename (str): Name of the VTK file to write.
+            datasets (dict): Dictionary whose keys are the data labels
+                and values are the data sets.
+            volume_normalization (bool, optional): Whether or not to
+                normalize the data by the volume of the mesh elements.
+                Defaults to True.
+
+        Raises:
+            RuntimeError: when no volume data is found and volume_normalisation
+                is required
 
         Returns:
             vtk.vtkStructuredGrid: the VTK object
@@ -1409,8 +1433,16 @@ class SphericalMesh(StructuredMesh):
         """Creates a VTK object of the mesh
 
         Args:
-            filename (str, optional): Name of the vtk file to write =
-                (must end with .vtk). Defaults to None.
+            filename (str): Name of the VTK file to write.
+            datasets (dict): Dictionary whose keys are the data labels
+                and values are the data sets.
+            volume_normalization (bool, optional): Whether or not to
+                normalize the data by the volume of the mesh elements.
+                Defaults to True.
+
+        Raises:
+            RuntimeError: when no volume data is found and volume_normalisation
+                is required
 
         Returns:
             vtk.vtkStructuredGrid: the VTK object

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1108,15 +1108,12 @@ class CylindricalMesh(StructuredMesh):
         import vtk
         from vtk.util import numpy_support as nps
 
-        r_vals = self.r_grid
-        phi_vals = self.phi_grid
-        z_vals = self.z_grid
         vtk_grid = vtk.vtkStructuredGrid()
 
-        vtk_grid.SetDimensions(len(r_vals), len(phi_vals), len(z_vals))
+        vtk_grid.SetDimensions(len(self.r_grid), len(self.phi_grid), len(self.z_grid))
 
         # create points
-        pts_cylindrical = np.array([[r, phi, z] for z in z_vals for phi in phi_vals for r in r_vals])
+        pts_cylindrical = np.array([[r, phi, z] for z in self.z_grid for phi in self.phi_grid for r in self.r_grid])
         pts_cartesian = np.copy(pts_cylindrical)
         r, phi, z = pts_cylindrical[:, 0], pts_cylindrical[:, 1], pts_cylindrical[:, 2]
         pts_cartesian[:, 0] = r * np.cos(phi)

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1355,9 +1355,9 @@ class SphericalMesh(StructuredMesh):
         vtk_grid.SetDimensions(len(self.r_grid), len(self.theta_grid), len(self.phi_grid))
 
         # create points
-        pts_cylindrical = np.array([[r, theta, phi] for phi in self.phi_grid for theta in self.theta_grid for r in self.r_grid])
-        pts_cartesian = np.copy(pts_cylindrical)
-        r, theta, phi = pts_cylindrical[:, 0], pts_cylindrical[:, 1], pts_cylindrical[:, 2]
+        pts_spherical = np.array([[r, theta, phi] for phi in self.phi_grid for theta in self.theta_grid for r in self.r_grid])
+        pts_cartesian = np.copy(pts_spherical)
+        r, theta, phi = pts_spherical[:, 0], pts_spherical[:, 1], pts_spherical[:, 2]
         pts_cartesian[:, 0] = r * np.sin(phi) * np.cos(theta)
         pts_cartesian[:, 1] = r * np.sin(phi) * np.sin(theta)
         pts_cartesian[:, 2] = r * np.cos(phi)

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -714,21 +714,10 @@ class RegularMesh(StructuredMesh):
             the VTK object
         """
 
-        x_vals = np.linspace(
-            self.lower_left[0],
-            self.upper_right[0],
-            num=self.dimension[0] + 1,
-        )
-        y_vals = np.linspace(
-            self.lower_left[1],
-            self.upper_right[1],
-            num=self.dimension[1] + 1,
-        )
-        z_vals = np.linspace(
-            self.lower_left[2],
-            self.upper_right[2],
-            num=self.dimension[2] + 1,
-        )
+        ll, ur = self.lower_left, self.upper_right
+        x_vals = np.linspace(ll[0], ur[0], num=self.dimension[0] + 1)
+        y_vals = np.linspace(ll[1], ur[1], num=self.dimension[1] + 1)
+        z_vals = np.linspace(ll[2], ur[2], num=self.dimension[2] + 1)
 
         # create points
         pts_cartesian = np.array([[x, y, z] for z in z_vals for y in y_vals for x in x_vals])

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1169,7 +1169,14 @@ class CylindricalMesh(StructuredMesh):
             the VTK object
         """
         # create points
-        pts_cylindrical = np.array([[r, phi, z] for z in self.z_grid for phi in self.phi_grid for r in self.r_grid])
+        pts_cylindrical = np.array(
+            [
+                [r, phi, z]
+                for z in self.z_grid
+                for phi in self.phi_grid
+                for r in self.r_grid
+            ]
+        )
         pts_cartesian = np.copy(pts_cylindrical)
         r, phi = pts_cylindrical[:, 0], pts_cylindrical[:, 1]
         pts_cartesian[:, 0] = r * np.cos(phi)
@@ -1395,7 +1402,14 @@ class SphericalMesh(StructuredMesh):
         """
 
         # create points
-        pts_spherical = np.array([[r, theta, phi] for phi in self.phi_grid for theta in self.theta_grid for r in self.r_grid])
+        pts_spherical = np.array(
+            [
+                [r, theta, phi]
+                for phi in self.phi_grid
+                for theta in self.theta_grid
+                for r in self.r_grid
+            ]
+        )
         pts_cartesian = np.copy(pts_spherical)
         r, theta, phi = pts_spherical[:, 0], pts_spherical[:, 1], pts_spherical[:, 2]
         pts_cartesian[:, 0] = r * np.sin(phi) * np.cos(theta)

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -698,7 +698,7 @@ class RegularMesh(StructuredMesh):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the VTK file to write.
         datasets : dict
             Dictionary whose keys are the data labels
@@ -932,7 +932,7 @@ class RectilinearMesh(StructuredMesh):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the VTK file to write.
         datasets : dict
             Dictionary whose keys are the data labels
@@ -1153,7 +1153,7 @@ class CylindricalMesh(StructuredMesh):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the VTK file to write.
         datasets : dict
             Dictionary whose keys are the data labels
@@ -1385,7 +1385,7 @@ class SphericalMesh(StructuredMesh):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the VTK file to write.
         datasets : dict
             Dictionary whose keys are the data labels
@@ -1592,7 +1592,7 @@ class UnstructuredMesh(MeshBase):
 
         Parameters
         ----------
-        filename : str
+        filename : str or pathlib.Path
             Name of the VTK file to write.
         datasets : dict
             Dictionary whose keys are the data labels

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -895,7 +895,7 @@ class RectilinearMesh(StructuredMesh):
 
         return element
 
-    def vtk_grid(self, filename=None):
+    def write_data_to_vtk(self, filename, datasets, volume_normalization=True):
         """Creates a VTK object of the mesh
 
         Args:
@@ -907,6 +907,19 @@ class RectilinearMesh(StructuredMesh):
         """
         import vtk
         from vtk.util import numpy_support as nps
+
+        if self.volumes is None and volume_normalization:
+            raise RuntimeError("No volume data is present on this "
+                               "unstructured mesh. Please load the "
+                               " mesh information from a statepoint file.")
+
+        # check that the data sets are appropriately sized
+        for label, dataset in datasets.items():
+            if isinstance(dataset, np.ndarray):
+                assert dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]
+            else:
+                assert len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]
+            cv.check_type('label', label, str)
 
         x_vals = self.x_grid
         y_vals = self.y_grid
@@ -922,12 +935,26 @@ class RectilinearMesh(StructuredMesh):
         vtkPts.SetData(nps.numpy_to_vtk(pts_cartesian, deep=True))
         vtk_grid.SetPoints(vtkPts)
 
-        if filename:
-            # write the .vtk file
-            writer = vtk.vtkStructuredGridWriter()
-            writer.SetFileName(filename)
-            writer.SetInputData(vtk_grid)
-            writer.Write()
+        # create VTK arrays for each of
+        # the data sets
+        for label, dataset in datasets.items():
+            dataset = np.asarray(dataset).flatten()
+
+            if volume_normalization:
+                dataset /= self.volumes.flatten()
+
+            dataset_array = vtk.vtkDoubleArray()
+            dataset_array.SetName(label)
+            dataset_array.SetArray(nps.numpy_to_vtk(dataset),
+                           dataset.size,
+                           True)
+            vtk_grid.GetCellData().AddArray(dataset_array)
+
+        # write the .vtk file
+        writer = vtk.vtkStructuredGridWriter()
+        writer.SetFileName(filename)
+        writer.SetInputData(vtk_grid)
+        writer.Write()
 
         return vtk_grid
 

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1179,10 +1179,9 @@ class CylindricalMesh(StructuredMesh):
         # create points
         pts_cylindrical = np.array([[r, phi, z] for z in self.z_grid for phi in self.phi_grid for r in self.r_grid])
         pts_cartesian = np.copy(pts_cylindrical)
-        r, phi, z = pts_cylindrical[:, 0], pts_cylindrical[:, 1], pts_cylindrical[:, 2]
+        r, phi = pts_cylindrical[:, 0], pts_cylindrical[:, 1]
         pts_cartesian[:, 0] = r * np.cos(phi)
         pts_cartesian[:, 1] = r * np.sin(phi)
-        pts_cartesian[:, 2] = z
 
         vtkPts = vtk.vtkPoints()
         vtkPts.SetData(nps.numpy_to_vtk(pts_cartesian, deep=True))

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -635,16 +635,22 @@ class RegularMesh(StructuredMesh):
 
         Returns:
             vtk.vtkStructuredGrid: the VTK object
+        
+        Raises:
+            RuntimeError: when the size of a dataset doesn't match the number of cells 
         """
         import vtk
         from vtk.util import numpy_support as nps
 
         # check that the data sets are appropriately sized
+        errmsg = "The size of the dataset {} should be equal to the number of cells"
         for label, dataset in datasets.items():
             if isinstance(dataset, np.ndarray):
-                assert dataset.size == self.dimension[0] * self.dimension[1] * self.dimension[2]
+                if not dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]:
+                    raise RuntimeError(errmsg.format(label))
             else:
-                assert len(dataset) == self.dimension[0] * self.dimension[1] * self.dimension[2]
+                if len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]:
+                    raise RuntimeError(errmsg.format(label))
             cv.check_type('label', label, str)
 
         x_vals = np.linspace(
@@ -907,16 +913,22 @@ class RectilinearMesh(StructuredMesh):
 
         Returns:
             vtk.vtkStructuredGrid: the VTK object
+
+        Raises:
+            RuntimeError: when the size of a dataset doesn't match the number of cells 
         """
         import vtk
         from vtk.util import numpy_support as nps
 
         # check that the data sets are appropriately sized
+        errmsg = "The size of the dataset {} should be equal to the number of cells"
         for label, dataset in datasets.items():
             if isinstance(dataset, np.ndarray):
-                assert dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]
+                if not dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]:
+                    raise RuntimeError(errmsg.format(label))
             else:
-                assert len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]
+                if len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]:
+                    raise RuntimeError(errmsg.format(label))
             cv.check_type('label', label, str)
 
         x_vals = self.x_grid
@@ -1160,16 +1172,22 @@ class CylindricalMesh(StructuredMesh):
 
         Returns:
             vtk.vtkStructuredGrid: the VTK object
+
+        Raises:
+            RuntimeError: when the size of a dataset doesn't match the number of cells 
         """
         import vtk
         from vtk.util import numpy_support as nps
 
         # check that the data sets are appropriately sized
+        errmsg = "The size of the dataset {} should be equal to the number of cells"
         for label, dataset in datasets.items():
             if isinstance(dataset, np.ndarray):
-                assert dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]
+                if not dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]:
+                    raise RuntimeError(errmsg.format(label))
             else:
-                assert len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]
+                if len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]:
+                    raise RuntimeError(errmsg.format(label))
             cv.check_type('label', label, str)
 
         vtk_grid = vtk.vtkStructuredGrid()
@@ -1414,16 +1432,23 @@ class SphericalMesh(StructuredMesh):
 
         Returns:
             vtk.vtkStructuredGrid: the VTK object
+
+        Raises:
+            RuntimeError: when the size of a dataset doesn't match the number of cells 
         """
         import vtk
         from vtk.util import numpy_support as nps
 
         # check that the data sets are appropriately sized
+        errmsg = "The size of the dataset {} should be equal to the number of cells"
         for label, dataset in datasets.items():
             if isinstance(dataset, np.ndarray):
-                assert dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]
+                if not dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]:
+                    raise RuntimeError(errmsg.format(label))
             else:
-                assert len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]
+                if len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]:
+                    raise RuntimeError(errmsg.format(label))
+
             cv.check_type('label', label, str)
 
         vtk_grid = vtk.vtkStructuredGrid()
@@ -1642,6 +1667,11 @@ class UnstructuredMesh(MeshBase):
         volume_normalization : bool
             Whether or not to normalize the data by the
             volume of the mesh elements
+
+        Raises
+        ------
+            RuntimeError
+                when the size of a dataset doesn't match the number of cells 
         """
 
         import vtk
@@ -1658,11 +1688,14 @@ class UnstructuredMesh(MeshBase):
                                " mesh information from a statepoint file.")
 
         # check that the data sets are appropriately sized
+        errmsg = "The size of the dataset {} should be equal to the number of cells"
         for label, dataset in datasets.items():
             if isinstance(dataset, np.ndarray):
-                assert dataset.size == self.n_elements
+                if not dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]:
+                    raise RuntimeError(errmsg.format(label))
             else:
-                assert len(dataset) == self.n_elements
+                if len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]:
+                    raise RuntimeError(errmsg.format(label))
             cv.check_type('label', label, str)
 
         # create data arrays for the cells/points

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -199,7 +199,7 @@ class StructuredMesh(MeshBase):
         Parameters
         ----------
         points : list or np.array
-            List of (X,Y,Y) tuples.
+            List of (X,Y,Z) tuples.
         filename : str
             Name of the VTK file to write.
         datasets : dict

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1324,7 +1324,7 @@ class SphericalMesh(StructuredMesh):
 
         return np.multiply.outer(np.outer(V_r, V_t), V_p)
 
-    def vtk_grid(self, filename=None):
+    def write_data_to_vtk(self, filename, datasets, volume_normalization=True):
         """Creates a VTK object of the mesh
 
         Args:
@@ -1336,6 +1336,19 @@ class SphericalMesh(StructuredMesh):
         """
         import vtk
         from vtk.util import numpy_support as nps
+
+        if self.volumes is None and volume_normalization:
+            raise RuntimeError("No volume data is present on this "
+                               "unstructured mesh. Please load the "
+                               " mesh information from a statepoint file.")
+
+        # check that the data sets are appropriately sized
+        for label, dataset in datasets.items():
+            if isinstance(dataset, np.ndarray):
+                assert dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]
+            else:
+                assert len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]
+            cv.check_type('label', label, str)
 
         vtk_grid = vtk.vtkStructuredGrid()
 
@@ -1353,12 +1366,26 @@ class SphericalMesh(StructuredMesh):
         vtkPts.SetData(nps.numpy_to_vtk(pts_cartesian, deep=True))
         vtk_grid.SetPoints(vtkPts)
 
-        if filename:
-            # write the .vtk file
-            writer = vtk.vtkStructuredGridWriter()
-            writer.SetFileName(filename)
-            writer.SetInputData(vtk_grid)
-            writer.Write()
+        # create VTK arrays for each of
+        # the data sets
+        for label, dataset in datasets.items():
+            dataset = np.asarray(dataset).flatten()
+
+            if volume_normalization:
+                dataset /= self.volumes.flatten()
+
+            dataset_array = vtk.vtkDoubleArray()
+            dataset_array.SetName(label)
+            dataset_array.SetArray(nps.numpy_to_vtk(dataset),
+                           dataset.size,
+                           True)
+            vtk_grid.GetCellData().AddArray(dataset_array)
+
+        # write the .vtk file
+        writer = vtk.vtkStructuredGridWriter()
+        writer.SetFileName(filename)
+        writer.SetInputData(vtk_grid)
+        writer.Write()
 
         return vtk_grid
 

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -194,6 +194,24 @@ class StructuredMesh(MeshBase):
         return (vertices[s0] + vertices[s1]) / 2
 
     def write_data_to_vtk(self, points, filename, datasets, volume_normalization=True):
+        """Creates a VTK object of the mesh
+
+        Args:
+            points (list or np.array): List of (X,Y,Y) tuples.
+            filename (str): Name of the VTK file to write.
+            datasets (dict): Dictionary whose keys are the data labels
+                and values are the data sets.
+            volume_normalization (bool, optional): Whether or not to
+                normalize the data by the volume of the mesh elements.
+                Defaults to True.
+
+        Raises:
+            RuntimeError: when the size of a dataset doesn't match the number of cells
+
+        Returns:
+            vtk.vtkStructuredGrid: the VTK object
+        """
+
         import vtk
         from vtk.util import numpy_support as nps
 

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -622,7 +622,7 @@ class RegularMesh(StructuredMesh):
 
         return root_cell, cells
     
-    def vtk_grid(self, filename=None):
+    def write_data_to_vtk(self, filename, datasets, volume_normalization=True):
         """Creates a VTK object of the mesh
 
         Args:
@@ -634,6 +634,19 @@ class RegularMesh(StructuredMesh):
         """
         import vtk
         from vtk.util import numpy_support as nps
+
+        if self.volumes is None and volume_normalization:
+            raise RuntimeError("No volume data is present on this "
+                               "unstructured mesh. Please load the "
+                               " mesh information from a statepoint file.")
+
+        # check that the data sets are appropriately sized
+        for label, dataset in datasets.items():
+            if isinstance(dataset, np.ndarray):
+                assert dataset.size == self.dimension[0] * self.dimension[1] * self.dimension[2]
+            else:
+                assert len(dataset) == self.dimension[0] * self.dimension[1] * self.dimension[2]
+            cv.check_type('label', label, str)
 
         x_vals = np.linspace(
             self.lower_left[0],
@@ -661,12 +674,26 @@ class RegularMesh(StructuredMesh):
         vtkPts.SetData(nps.numpy_to_vtk(pts_cartesian, deep=True))
         vtk_grid.SetPoints(vtkPts)
 
-        if filename:
-            # write the .vtk file
-            writer = vtk.vtkStructuredGridWriter()
-            writer.SetFileName(filename)
-            writer.SetInputData(vtk_grid)
-            writer.Write()
+        # create VTK arrays for each of
+        # the data sets
+        for label, dataset in datasets.items():
+            dataset = np.asarray(dataset).flatten()
+
+            if volume_normalization:
+                dataset /= self.volumes.flatten()
+
+            dataset_array = vtk.vtkDoubleArray()
+            dataset_array.SetName(label)
+            dataset_array.SetArray(nps.numpy_to_vtk(dataset),
+                           dataset.size,
+                           True)
+            vtk_grid.GetCellData().AddArray(dataset_array)
+
+        # write the .vtk file
+        writer = vtk.vtkStructuredGridWriter()
+        writer.SetFileName(filename)
+        writer.SetInputData(vtk_grid)
+        writer.Write()
 
         return vtk_grid
 

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -467,15 +467,6 @@ class Tally(IDManagerMixin):
             ValueError: if no MeshFilter with appropriate mesh was found 
                 (SphericalMesh not supported)
         """
-        try:
-            import vtk
-            import vtk.util.numpy_support as nps
-        except ModuleNotFoundError:
-            msg = 'Python package vtk was not found, please install vtk to use Tally.write_to_vtk.'
-            raise ModuleNotFoundError(msg)
-        except ImportError as err:
-            raise err
-
         # check that tally has a MeshFilter
         mesh = None
         for f in self.filters:
@@ -3324,7 +3315,14 @@ def voxels_to_vtk(x_vals, y_vals, z_vals, mean, std_dev, cylindrical=True):
     Returns:
         vtkStructuredGrid: a vtk object containing tally data on the appropriate grid
     """
-
+    try:
+        import vtk
+        import vtk.util.numpy_support as nps
+    except ModuleNotFoundError:
+        msg = 'Python package vtk was not found, please install vtk to use Tally.write_to_vtk.'
+        raise ModuleNotFoundError(msg)
+    except ImportError as err:
+        raise err
     # TODO: should this be a method of Tally?
 
     vtk_grid = vtk.vtkStructuredGrid()

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3332,6 +3332,7 @@ def voxels_to_vtk(x_vals, y_vals, z_vals, mean, std_dev, cylindrical=True):
         points_cartesian[:, 0] = r * np.cos(phi)
         points_cartesian[:, 1] = r * np.sin(phi)
         points_cartesian[:, 2] = z
+        points = points_cartesian
 
     vtkPts = vtk.vtkPoints()
     vtkPts.SetData(nps.numpy_to_vtk(points, deep=True))

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -460,6 +460,15 @@ class Tally(IDManagerMixin):
             self._sparse = False
 
     def write_to_vtk(self, filename):
+        """Writes the tally to a vtk file
+
+        Args:
+            filename (str): the filename (must end with .vtk)
+
+        Raises:
+            ValueError: if no MeshFilter with appropriate mesh was found 
+                (SphericalMesh not supported)
+        """
         # check that tally has a MeshFilter
         mesh = None
         for f in self.filters:
@@ -512,7 +521,7 @@ class Tally(IDManagerMixin):
                 std_dev=self.std_dev,
                 cylindrical=True,
             )
-        
+
         # write the .vtk file
         writer = vtk.vtkStructuredGridWriter()
         writer.SetFileName(filename)
@@ -3294,6 +3303,20 @@ class Tallies(cv.CheckedList):
 
 
 def voxels_to_vtk(x_vals, y_vals, z_vals, mean, std_dev, cylindrical=True):
+    """Creates a vtk object from a list of X, Y, Z values and mean/std_dev data.
+
+    Args:
+        x_vals (list): X values.
+        y_vals (list): Y values.
+        z_vals (list): Z values.
+        mean (np.array): the tally mean.
+        std_dev (np.array): the tally standard deviation.
+        cylindrical (bool, optional): If set to True, cylindrical coordinates
+            (r, phi, z) are assumed. Defaults to True.
+
+    Returns:
+        vtkStructuredGrid: a vtk object containing tally data on the appropriate grid
+    """
     vtk_grid = vtk.vtkStructuredGrid()
 
     vtk_grid.SetDimensions(len(x_vals), len(y_vals), len(z_vals))

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3013,54 +3013,6 @@ class Tally(IDManagerMixin):
         new_tally.sparse = self.sparse
         return new_tally
 
-    def write_to_vtk(self, filename):
-        """Writes the tally to a vtk file
-
-        Args:
-            filename (str): the filename (must end with .vtk)
-
-        Raises:
-            ValueError: if no MeshFilter was found
-        """
-        try:
-            import vtk
-        except ModuleNotFoundError:
-            msg = 'Python package vtk was not found, please install vtk to use Tally.write_to_vtk.'
-            raise ModuleNotFoundError(msg)
-        except ImportError as err:
-            raise err
-
-        # check that tally has a MeshFilter
-        mesh = None
-        for f in self.filters:
-            if isinstance(f, openmc.MeshFilter):
-                mesh = f.mesh
-                break
-
-        if not mesh:
-            raise ValueError(
-                "write_to_vtk requires a MeshFilter in the tally filters"
-            )
-
-        vtk_grid = mesh.vtk_grid()
-
-        # add mean and std dev data
-        mean_array = vtk.vtkDoubleArray()
-        mean_array.SetName("mean")
-        mean_array.SetArray(self.mean, self.mean.size, True)
-        vtk_grid.GetCellData().AddArray(mean_array)
-
-        std_dev_array = vtk.vtkDoubleArray()
-        std_dev_array.SetName("std_dev")
-        std_dev_array.SetArray(self.std_dev, self.std_dev.size, True)
-        vtk_grid.GetCellData().AddArray(std_dev_array)
-
-        # write the .vtk file
-        writer = vtk.vtkStructuredGridWriter()
-        writer.SetFileName(filename)
-        writer.SetInputData(vtk_grid)
-        writer.Write()
-
 
 class Tallies(cv.CheckedList):
     """Collection of Tallies used for an OpenMC simulation.

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -463,13 +463,13 @@ class Tally(IDManagerMixin):
         mesh = None
         for f in self.filters:
             if isinstance(f, openmc.MeshFilter):
-                if isinstance(f.mesh, (openmc.RegularMesh, openmc.CylindricalMesh)):
+                if isinstance(f.mesh, (openmc.RegularMesh, openmc.RectilinearMesh, openmc.CylindricalMesh)):
                     mesh = f.mesh
                     break
 
         if not mesh:
             raise ValueError(
-                "write_to_vtk only works with openmc.RegularMesh, openmc.CylindricalMesh"
+                "write_to_vtk only works with openmc.RegularMesh, openmc.RectilinearMesh, openmc.CylindricalMesh"
             )
 
         if isinstance(mesh, openmc.RegularMesh):
@@ -489,6 +489,15 @@ class Tally(IDManagerMixin):
                     mesh.upper_right[2],
                     num=mesh.dimension[2] + 1,
                 ),
+                mean=self.mean,
+                std_dev=self.std_dev,
+                cylindrical=False,
+            )
+        if isinstance(mesh, openmc.RectilinearMesh):
+            vtk_grid = voxels_to_vtk(
+                x_vals=mesh.x_grid,
+                y_vals=mesh.y_grid,
+                z_vals=mesh.z_grid,
                 mean=self.mean,
                 std_dev=self.std_dev,
                 cylindrical=False,

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -457,43 +457,6 @@ class Tally(IDManagerMixin):
                 self._std_dev = np.reshape(self._std_dev.toarray(), self.shape)
             self._sparse = False
 
-    def write_to_vtk(self, filename):
-        """Writes the tally to a vtk file
-
-        Args:
-            filename (str): the filename (must end with .vtk)
-
-        Raises:
-            ValueError: if no MeshFilter was found
-        """
-        try:
-            import vtk
-        except ModuleNotFoundError:
-            msg = 'Python package vtk was not found, please install vtk to use Tally.write_to_vtk.'
-            raise ModuleNotFoundError(msg)
-        except ImportError as err:
-            raise err
-
-        # check that tally has a MeshFilter
-        mesh = None
-        for f in self.filters:
-            if isinstance(f, openmc.MeshFilter):
-                mesh = f.mesh
-                break
-
-        if not mesh:
-            raise ValueError(
-                "write_to_vtk requires a MeshFilter in the tally filters"
-            )
-
-        vtk_grid = voxels_to_vtk(mesh, self.mean, self.std_dev)
-
-        # write the .vtk file
-        writer = vtk.vtkStructuredGridWriter()
-        writer.SetFileName(filename)
-        writer.SetInputData(vtk_grid)
-        writer.Write()
-
     def remove_score(self, score):
         """Remove a score from the tally
 
@@ -3049,6 +3012,43 @@ class Tally(IDManagerMixin):
         # If original tally was sparse, sparsify the diagonalized tally
         new_tally.sparse = self.sparse
         return new_tally
+
+    def write_to_vtk(self, filename):
+        """Writes the tally to a vtk file
+
+        Args:
+            filename (str): the filename (must end with .vtk)
+
+        Raises:
+            ValueError: if no MeshFilter was found
+        """
+        try:
+            import vtk
+        except ModuleNotFoundError:
+            msg = 'Python package vtk was not found, please install vtk to use Tally.write_to_vtk.'
+            raise ModuleNotFoundError(msg)
+        except ImportError as err:
+            raise err
+
+        # check that tally has a MeshFilter
+        mesh = None
+        for f in self.filters:
+            if isinstance(f, openmc.MeshFilter):
+                mesh = f.mesh
+                break
+
+        if not mesh:
+            raise ValueError(
+                "write_to_vtk requires a MeshFilter in the tally filters"
+            )
+
+        vtk_grid = voxels_to_vtk(mesh, self.mean, self.std_dev)
+
+        # write the .vtk file
+        writer = vtk.vtkStructuredGridWriter()
+        writer.SetFileName(filename)
+        writer.SetInputData(vtk_grid)
+        writer.Write()
 
 
 class Tallies(cv.CheckedList):

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3296,7 +3296,6 @@ def voxels_to_vtk(mesh, mean, std_dev):
     system_of_coordinates = "cartesian"
 
     if isinstance(mesh, openmc.RegularMesh):
-        print('coucou')
         x_vals = np.linspace(
             mesh.lower_left[0],
             mesh.upper_right[0],

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -471,9 +471,12 @@ class Tally(IDManagerMixin):
         try:
             import vtk
             import vtk.util.numpy_support as nps
-        except ImportError:
+        except ModuleNotFoundError:
             msg = 'Python package vtk was not found, please install vtk to use Tally.write_to_vtk.'
-            raise ImportError(msg)
+            raise ModuleNotFoundError(msg)
+        except ImportError as err:
+            raise err
+
         mesh = None
         for f in self.filters:
             if isinstance(f, openmc.MeshFilter):

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3341,11 +3341,23 @@ def voxels_to_vtk(x_vals, y_vals, z_vals, mean, std_dev, cylindrical=True):
     # add mean and std dev data
     mean_array = vtk.vtkDoubleArray()
     mean_array.SetName("mean")
+    if mean is None:
+        mean = np.zeros(
+            (len(x_vals) - 1)
+            * (len(y_vals) - 1)
+            * (len(z_vals) - 1)
+        )
     mean_array.SetArray(mean, mean.size, True)
     vtk_grid.GetCellData().AddArray(mean_array)
 
     std_dev_array = vtk.vtkDoubleArray()
     std_dev_array.SetName("std_dev")
+    if std_dev is None:
+        std_dev = np.zeros(
+            (len(x_vals) - 1)
+            * (len(y_vals) - 1)
+            * (len(z_vals) - 1)
+        )
     std_dev_array.SetArray(std_dev, std_dev.size, True)
     vtk_grid.GetCellData().AddArray(std_dev_array)
 

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -8,8 +8,6 @@ from pathlib import Path
 from xml.etree import ElementTree as ET
 
 import h5py
-import vtk
-import vtk.util.numpy_support as nps
 import numpy as np
 import pandas as pd
 import scipy.sparse as sps
@@ -470,6 +468,12 @@ class Tally(IDManagerMixin):
                 (SphericalMesh not supported)
         """
         # check that tally has a MeshFilter
+        try:
+            import vtk
+            import vtk.util.numpy_support as nps
+        except ImportError:
+            msg = 'Python package vtk was not found, please install vtk to use Tally.write_to_vtk.'
+            raise ImportError(msg)
         mesh = None
         for f in self.filters:
             if isinstance(f, openmc.MeshFilter):

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3321,7 +3321,6 @@ def voxels_to_vtk(mesh, mean, std_dev):
         z_vals = mesh.z_grid
         system_of_coordinates = "cylindrical"
     else:
-        print(type(mesh))
         raise ValueError(
                 "voxels_to_vtk only works with openmc.RegularMesh, openmc.RectilinearMesh, openmc.CylindricalMesh"
             )

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -467,7 +467,6 @@ class Tally(IDManagerMixin):
             ValueError: if no MeshFilter with appropriate mesh was found 
                 (SphericalMesh not supported)
         """
-        # check that tally has a MeshFilter
         try:
             import vtk
             import vtk.util.numpy_support as nps
@@ -477,6 +476,7 @@ class Tally(IDManagerMixin):
         except ImportError as err:
             raise err
 
+        # check that tally has a MeshFilter
         mesh = None
         for f in self.filters:
             if isinstance(f, openmc.MeshFilter):

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3317,6 +3317,9 @@ def voxels_to_vtk(x_vals, y_vals, z_vals, mean, std_dev, cylindrical=True):
     Returns:
         vtkStructuredGrid: a vtk object containing tally data on the appropriate grid
     """
+
+    # TODO: should this be a method of Tally?
+
     vtk_grid = vtk.vtkStructuredGrid()
 
     vtk_grid.SetDimensions(len(x_vals), len(y_vals), len(z_vals))

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -32,7 +32,7 @@ def test_write_data_to_vtk(mesh, tmpdir):
     # BUILD
     filename = Path(tmpdir) / "out.vtk"
 
-    data = np.random.random(mesh.num_mesh_cells)
+    data = np.random.random(mesh.dimension[0]*mesh.dimension[1]*mesh.dimension[2])
 
     # RUN
     mesh.write_data_to_vtk(filename=filename, datasets={"label1": data, "label2": data})

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -1,5 +1,6 @@
 import numpy as np
 from os.path import exists
+from pathlib import Path
 import pytest
 import vtk
 from vtk.util import numpy_support as nps

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -1,7 +1,8 @@
 import numpy as np
 from pathlib import Path
 import pytest
-import vtk
+
+vtk = pytest.importorskip("vtk")
 from vtk.util import numpy_support as nps
 
 import openmc

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -1,5 +1,4 @@
 import numpy as np
-from os.path import exists
 from pathlib import Path
 import pytest
 import vtk

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -57,3 +57,18 @@ def test_write_data_to_vtk(mesh, tmpdir):
     # check size of datasets
     assert nps.vtk_to_numpy(array1).size == data.size
     assert nps.vtk_to_numpy(array2).size == data.size
+
+@pytest.mark.parametrize("mesh", [cylinder_mesh, regular_mesh, rectilinear_mesh, spherical_mesh])
+def test_write_data_to_vtk_size_mismatch(mesh):
+    """Checks that an error is raised when the size of the dataset
+    doesn't match the mesh number of cells
+
+    Args:
+        mesh (openmc.StructuredMesh): the mesh to test
+    """
+    right_size = mesh.dimension[0]*mesh.dimension[1]*mesh.dimension[2]
+    data = np.random.random(right_size + 1)
+
+    expected_error_msg = "The size of the dataset label should be equal to the number of cells"
+    with pytest.raises(RuntimeError, match=expected_error_msg):
+        mesh.write_data_to_vtk(filename="out.vtk", datasets={"label": data})

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -63,8 +63,10 @@ def test_write_data_to_vtk_size_mismatch(mesh):
     """Checks that an error is raised when the size of the dataset
     doesn't match the mesh number of cells
 
-    Args:
-        mesh (openmc.StructuredMesh): the mesh to test
+    Parameters
+    ----------
+    mesh : openmc.StructuredMesh
+        The mesh to test
     """
     right_size = mesh.dimension[0]*mesh.dimension[1]*mesh.dimension[2]
     data = np.random.random(right_size + 1)

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -1,0 +1,35 @@
+import numpy as np
+from os.path import exists
+import pytest
+
+import openmc
+
+
+regular_mesh = openmc.RegularMesh()
+regular_mesh.lower_left = (0, 0, 0)
+regular_mesh.upper_right = (1, 1, 1)
+regular_mesh.dimension = [30, 20, 10]
+
+rectilinear_mesh = openmc.RectilinearMesh()
+rectilinear_mesh.x_grid = np.linspace(1, 2, num=30)
+rectilinear_mesh.y_grid = np.linspace(1, 2, num=30)
+rectilinear_mesh.z_grid = np.linspace(1, 2, num=30)
+
+cylinder_mesh = openmc.CylindricalMesh()
+cylinder_mesh.r_grid = np.linspace(1, 2, num=30)
+cylinder_mesh.phi_grid = np.linspace(0, np.pi, num=50)
+cylinder_mesh.z_grid = np.linspace(0, 1, num=30)
+
+spherical_mesh = openmc.SphericalMesh()
+spherical_mesh.r_grid = np.linspace(1, 2, num=30)
+spherical_mesh.phi_grid = np.linspace(0, np.pi, num=50)
+spherical_mesh.theta_grid = np.linspace(0, np.pi / 2, num=30)
+
+@pytest.mark.parametrize("mesh", [cylinder_mesh, regular_mesh, rectilinear_mesh, spherical_mesh])
+def test_write_data_to_vtk(mesh, tmpdir):
+    filename = tmpdir / "out.vtk"
+
+    data = np.random.random(mesh.dimension[0]*mesh.dimension[1]*mesh.dimension[2])
+
+    mesh.write_data_to_vtk(filename=filename, datasets={"label": data})
+    assert exists(filename)

--- a/tests/unit_tests/test_tallies.py
+++ b/tests/unit_tests/test_tallies.py
@@ -76,7 +76,12 @@ rectilinear_mesh.x_grid = np.linspace(0, 1)
 rectilinear_mesh.y_grid = np.linspace(0, 1)
 rectilinear_mesh.z_grid = np.linspace(0, 1)
 
-@pytest.mark.parametrize("mesh", [cylinder_mesh, regular_mesh, rectilinear_mesh])
+spherical_mesh = openmc.SphericalMesh()
+spherical_mesh.r_grid = np.linspace(1, 2)
+spherical_mesh.phi_grid = np.linspace(1, 2)
+spherical_mesh.theta_grid = np.linspace(1, 2)
+
+@pytest.mark.parametrize("mesh", [cylinder_mesh, regular_mesh, rectilinear_mesh, spherical_mesh])
 def test_write_to_vtk(mesh, tmpdir):
     # build
     tally = openmc.Tally()
@@ -96,18 +101,4 @@ def test_write_to_vtk_raises_error_when_no_meshfilter():
     # test
     expected_err_msg = "write_to_vtk requires a MeshFilter in the tally filters"
     with pytest.raises(ValueError, match=expected_err_msg):
-        tally.write_to_vtk("out.vtk")
-
-
-def test_voxel_to_vtk_raises_error_with_wrong_mesh():
-    # build
-    tally = openmc.Tally()
-    spherical_mesh = openmc.SphericalMesh()
-    spherical_mesh.r_grid = np.linspace(1, 2)
-    spherical_mesh.phi_grid = np.linspace(1, 2)
-    spherical_mesh.theta_grid = np.linspace(1, 2)
-    tally.filters = [openmc.MeshFilter(spherical_mesh)]
-    # test
-    expected_err_msg = "vtk_grid not implemented for SphericalMesh"
-    with pytest.raises(NotImplementedError, match=expected_err_msg):
         tally.write_to_vtk("out.vtk")

--- a/tests/unit_tests/test_tallies.py
+++ b/tests/unit_tests/test_tallies.py
@@ -1,4 +1,8 @@
 import numpy as np
+import pytest
+import vtk
+from os.path import exists
+
 import openmc
 
 
@@ -38,3 +42,61 @@ def test_xml_roundtrip(run_in_tmpdir):
     assert new_tally.triggers[0].trigger_type == tally.triggers[0].trigger_type
     assert new_tally.triggers[0].threshold == tally.triggers[0].threshold
     assert new_tally.triggers[0].scores == tally.triggers[0].scores
+
+
+cylinder_mesh = openmc.CylindricalMesh()
+cylinder_mesh.r_grid = np.linspace(1, 2, num=30)
+cylinder_mesh.phi_grid = np.linspace(0, np.pi / 2, num=50)
+cylinder_mesh.z_grid = np.linspace(0, 1, num=30)
+
+regular_mesh = openmc.RegularMesh()
+regular_mesh.lower_left = [0, 0, 0]
+regular_mesh.upper_right = [1, 1, 1]
+regular_mesh.dimension = [10, 5, 6]
+
+rectilinear_mesh = openmc.RectilinearMesh()
+rectilinear_mesh.x_grid = np.linspace(0, 1)
+rectilinear_mesh.y_grid = np.linspace(0, 1)
+rectilinear_mesh.z_grid = np.linspace(0, 1)
+
+
+@pytest.mark.parametrize("mesh", [cylinder_mesh, regular_mesh, rectilinear_mesh])
+def test_voxels_to_vtk(mesh):
+    vtk_grid = openmc.voxels_to_vtk(mesh, mean=None, std_dev=None)
+    assert isinstance(vtk_grid, vtk.vtkStructuredGrid)
+
+
+@pytest.mark.parametrize("mesh", [cylinder_mesh, regular_mesh, rectilinear_mesh])
+def test_write_to_vtk(mesh, tmpdir):
+    # build
+    tally = openmc.Tally()
+    tally.filters = [openmc.MeshFilter(mesh)]
+    filename = tmpdir / "out.vtk"
+    # run
+    tally.write_to_vtk(filename)
+    # test
+    assert exists(filename)
+
+
+def test_write_to_vtk_raises_error_when_no_meshfilter():
+    # build
+    tally = openmc.Tally()
+
+    # test
+    expected_err_msg = "write_to_vtk requires a MeshFilter in the tally filters"
+    with pytest.raises(ValueError, match=expected_err_msg):
+        tally.write_to_vtk("out.vtk")
+
+
+def test_voxel_to_vtk_raises_error_with_wrong_mesh():
+    # build
+    tally = openmc.Tally()
+    spherical_mesh = openmc.SphericalMesh()
+    spherical_mesh.r_grid = np.linspace(1, 2)
+    spherical_mesh.phi_grid = np.linspace(1, 2)
+    spherical_mesh.theta_grid = np.linspace(1, 2)
+    tally.filters = [openmc.MeshFilter(spherical_mesh)]
+    # test
+    expected_err_msg = "voxels_to_vtk only works with openmc.RegularMesh, openmc.RectilinearMesh, openmc.CylindricalMesh"
+    with pytest.raises(ValueError, match=expected_err_msg):
+        tally.write_to_vtk("out.vtk")


### PR DESCRIPTION
Hi all,

This is my first _real_ contribution to OpenMC 🎉 

**Current**
I have been using `CylindricalMesh` filters for a while now (with @shimwell on fusion applications), and thought tallies using it could use a "to vtk" method to avoid external repetitive scripting.
Moreover, the `openmc-voxel-to-vtk` script seems to only handle `RegularMesh`.

**New behaviour**
This PR adds a `write_data_to_vtk` method to the classes `RegularMesh,` `CylindricalMesh` and `RectilinearMesh` and `SphericalMesh` on the similar structure to `UnstructuredMesh.write_data_to_vtk` (thanks @pshriwise for the tip).

**Usage**

```python
import openmc
import numpy as np

cylinder_mesh = openmc.CylindricalMesh()
cylinder_mesh.r_grid = np.linspace(1, 2, num=30)
cylinder_mesh.phi_grid = np.linspace(0, np.pi, num=50)
cylinder_mesh.z_grid = np.linspace(0, 1, num=30)

data = np.random.random(
    (cylinder_mesh.dimension[0]*cylinder_mesh.dimension[1]*cylinder_mesh.dimension[2])
)
cylinder_mesh.write_data_to_vtk(
    filename="cylindrical.vtk",
    datasets={"mean": data, "std_dev": data},
    volume_normalization=False,
)
```

cylindrical.vtk
![image](https://user-images.githubusercontent.com/40028739/176426224-3a458392-761a-4703-a219-aff9cbbe4fc1.png)


Equivalent for `SphericalMesh`

![image](https://user-images.githubusercontent.com/40028739/176426291-4d478da0-b4fc-425d-8caf-f4c154a4cc19.png)

**Limitations**
- For tallies with `CylindricalMesh` or `SphericalMesh` filters, the angular discretisation doesn't look great with too few elements. @pshriwise seems to have a solution for that 💪 

![image](https://user-images.githubusercontent.com/40028739/176211959-599df59e-6da7-4065-9cde-6549563ce3e0.png)

