### PR TITLE
added multi stages option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,7 +172,7 @@ RUN if [ "$build_libmesh" = "on" ]; then \
         && rm -rf ${LIBMESH_INSTALL_DIR}/build ${LIBMESH_INSTALL_DIR}/libmesh ; \
     fi
 
-FROM dependencies as build
+FROM dependencies AS build
 
 # clone and install openmc
 RUN mkdir -p ${HOME}/OpenMC && cd ${HOME}/OpenMC \
@@ -209,7 +209,7 @@ RUN mkdir -p ${HOME}/OpenMC && cd ${HOME}/OpenMC \
     && cd ../openmc && pip install .[test,depletion-mpi] \
     && python -c "import openmc"
 
-FROM build as release
+FROM build AS release
 
 # Download cross sections (NNDC and WMP) and ENDF data needed by test suite
 RUN ${HOME}/OpenMC/openmc/tools/ci/download-xs.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 
 # sudo docker run image_name:tag_name or ID with no tag sudo docker run ID number
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim AS dependencies
 
 # By default this Dockerfile builds OpenMC without DAGMC and LIBMESH support
 ARG build_dagmc=off
@@ -172,6 +172,8 @@ RUN if [ "$build_libmesh" = "on" ]; then \
         && rm -rf ${LIBMESH_INSTALL_DIR}/build ${LIBMESH_INSTALL_DIR}/libmesh ; \
     fi
 
+FROM dependencies as build
+
 # clone and install openmc
 RUN mkdir -p ${HOME}/OpenMC && cd ${HOME}/OpenMC \
     && git clone --shallow-submodules --recurse-submodules --single-branch -b ${openmc_branch} --depth=1 ${OPENMC_REPO} \
@@ -206,6 +208,8 @@ RUN mkdir -p ${HOME}/OpenMC && cd ${HOME}/OpenMC \
     make 2>/dev/null -j${compile_cores} install \
     && cd ../openmc && pip install .[test,depletion-mpi] \
     && python -c "import openmc"
+
+FROM build as release
 
 # Download cross sections (NNDC and WMP) and ENDF data needed by test suite
 RUN ${HOME}/OpenMC/openmc/tools/ci/download-xs.sh


### PR DESCRIPTION
Currently we have a nice dockerfile that builds OpenMC which is great

However there are cases where developers and users don't want every component of the docker image

For example:
- if we start to use code spaces then we might not want the source code to be compiled
- if someone is developing in a container they might just want the dependencies installed 
- users might want different nuclear data

This PR adds multi stage build flags to key parts of the Dockerfile

This will allow us to target specific build stages when building the dockerfile

```
# builds the image to completion, makes the same image that we currently have
docker build -t openmc_deps .

# builds an image with just the dependencies
docker build -t openmc_deps --target dependencies .

# builds an image with dependencies and compiled openmc but no nuclear data
docker build -t openmc_deps --target build .

# builds an image with dependencies, compiled openmc and nuclear data
docker build -t openmc_deps --target release .
```

What do you think @RemDelaporteMathurin would this help your use case