### PR TITLE
`num_mesh_cells` property for all `StructuredMesh` classes

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -349,10 +349,6 @@ class RegularMesh(StructuredMesh):
                 return [(u - l) / d for u, l, d in zip(us, ls, dims)]
 
     @property
-    def num_mesh_cells(self):
-        return np.prod(self._dimension)
-
-    @property
     def volumes(self):
         """Return Volumes for every mesh cell
 

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -193,6 +193,10 @@ class StructuredMesh(MeshBase):
         s1 = (slice(1, None),)*ndim + (slice(None),)
         return (vertices[s0] + vertices[s1]) / 2
 
+    @property
+    def num_mesh_cells(self):
+        return np.prod(self.dimension)
+
     def write_data_to_vtk(self, points, filename, datasets, volume_normalization=True):
         """Creates a VTK object of the mesh
 
@@ -1546,6 +1550,7 @@ class UnstructuredMesh(MeshBase):
             raise RuntimeError("No information about this mesh has "
                                "been loaded from a statepoint file.")
         return len(self._centroids)
+
 
     @centroids.setter
     def centroids(self, centroids):

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -33,7 +33,7 @@ def test_write_data_to_vtk(mesh, tmpdir):
     # BUILD
     filename = Path(tmpdir) / "out.vtk"
 
-    data = np.random.random(mesh.dimension[0]*mesh.dimension[1]*mesh.dimension[2])
+    data = np.random.random(mesh.num_mesh_cells)
 
     # RUN
     mesh.write_data_to_vtk(filename=filename, datasets={"label1": data, "label2": data})
@@ -68,7 +68,7 @@ def test_write_data_to_vtk_size_mismatch(mesh):
     mesh : openmc.StructuredMesh
         The mesh to test
     """
-    right_size = mesh.dimension[0]*mesh.dimension[1]*mesh.dimension[2]
+    right_size = mesh.num_mesh_cells
     data = np.random.random(right_size + 1)
 
     expected_error_msg = "The size of the dataset label should be equal to the number of cells"


### PR DESCRIPTION
This PR fixes an inconsistency across `StructuredMesh` classes by making sure all of them have a `num_mesh_cells` property.