### PR TITLE
histogram plot with auto bins for source energy

### DIFF
--- a/openmc/source.py
+++ b/openmc/source.py
@@ -198,7 +198,7 @@ class Source:
             element.append(self.time.to_xml_element('time'))
         return element
 
-    def plot_energy(self, n_samples=10000, seed=None, axes=None):
+def plot_energy(self, n_samples=10000, seed=None, axes=None,  **kwargs):
         """Produce a histogram plot of source particle energy.
 
         Parameters
@@ -230,7 +230,7 @@ class Source:
         else:
             ax = axes
 
-        ax.hist(energy, bins='auto')
+        ax.hist(energy, bins='auto', **kwargs)
 
         return ax
 

--- a/openmc/source.py
+++ b/openmc/source.py
@@ -198,7 +198,7 @@ class Source:
             element.append(self.time.to_xml_element('time'))
         return element
 
-def plot_energy(self, n_samples=10000, seed=None, axes=None,  **kwargs):
+    def plot_energy(self, n_samples=10000, seed=None, axes=None,  **kwargs):
         """Produce a histogram plot of source particle energy.
 
         Parameters
@@ -223,8 +223,7 @@ def plot_energy(self, n_samples=10000, seed=None, axes=None,  **kwargs):
 
         # Setup axes is one wasn't passed
         if axes is None:
-            fig = plt.figure()
-            ax = plt.axes()
+            ax = plt.gca()
             ax.set_xlabel('Energy [eV]')
             ax.set_ylabel('Frequency')
         else:

--- a/openmc/source.py
+++ b/openmc/source.py
@@ -198,6 +198,43 @@ class Source:
             element.append(self.time.to_xml_element('time'))
         return element
 
+    def plot_energy(self, n_samples=10000, seed=None, axes=None):
+        """Produce a histogram plot of source particle energy.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of sampled values to generate
+        seed : int or None
+            Initial random number seed.
+        axes : matplotlib.axes.Axes, optional
+            Axes for plot
+
+        Returns
+        -------
+        axes : matplotlib.axes.Axes
+            Axes for plot
+
+        """
+
+        energy = self.energy.sample(n_samples=n_samples, seed=seed)
+
+        import matplotlib.pyplot as plt
+
+        # Setup axes is one wasn't passed
+        if axes is None:
+            fig = plt.figure()
+            ax = plt.axes()
+            ax.set_xlabel('Energy [eV]')
+            ax.set_ylabel('Frequency')
+        else:
+            ax = axes
+
+        ax.hist(energy, bins='auto')
+
+        return ax
+
+
     @classmethod
     def from_xml_element(cls, elem):
         """Generate source from an XML element


### PR DESCRIPTION
I find myself often plotting histograms of the source energy quite often and I thought this tiny snippet of code added to the source object might be handy for others. I quite like the auto binning that numpy does behind the scenes. I've followed the same plotting function layout that we see elsewhere in the code ([e.g. tracks.py](https://github.com/openmc-dev/openmc/blob/6549067c43bb00750fe4f3d772795217575380ea/openmc/tracks.py#L148-L179))

Plotting the source energy can then be performed with ```Source.plot_energy()```

This makes use of the ```sample``` method that @pshriwise recently added to the ```Univariate``` in PR #2080 and uses the same arg names ```n_samples``` and ```seed```.

Here is an example plot of the Muir DT fusion energy spectra

![openmc-source-plotter-fusion-energy](https://user-images.githubusercontent.com/8583900/177582042-e8343fe2-ff17-48bd-84fa-4635e8cedb7a.png)


```
import openmc
import matplotlib.pyplot as plt

my_source = openmc.Source()

my_source.energy = openmc.stats.Muir(e0=14080000.0, m_rat=5.0, kt=20000.0)

my_source.plot_energy()

plt.show()
```