### PR TITLE
Update version pins for RTD documentation builds to fix rendering of bullet lists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,6 @@ on:
   workflow_dispatch:
 
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'examples/**'
-      - 'man/**'
-      - '**.md'
-      - CODEOWNERS
-      - LICENSE
     branches:
       - develop
       - master

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -1,4 +1,5 @@
-sphinx==4.3.0
+sphinx==5.0.2
+sphinx_rtd_theme==1.0.0
 sphinx-numfig
 jupyter
 sphinxcontrib-katex


### PR DESCRIPTION
This PR is intended to fix the rendering of bullet points in our documentation. For an example of what I mean, look [here](https://docs.openmc.org/en/latest/pythonapi/index.html). This is evidently related to some problems with sphinx/docutils/sphinx_rtd_theme, and the solution is to pin a recent version of sphinx_rtd_theme (more info [here](https://github.com/readthedocs/sphinx_rtd_theme/issues/1115)).