### PR TITLE
adding bounding box property to DAGMCUniverse objects

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -660,8 +660,7 @@ class DAGMCUniverse(UniverseBase):
             coords = dagmc_file['tstt']['nodes']['coordinates'][()]
             lower_left_corner = coords.min(axis=0)
             upper_right_corner = coords.max(axis=0)
-            bounding_box = (lower_left_corner, upper_right_corner)
-            return bounding_box
+            return (lower_left_corner, upper_right_corner)
 
     @property
     def filename(self):

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from xml.etree import ElementTree as ET
 
+import h5py
 import numpy as np
 
 import openmc
@@ -630,6 +631,9 @@ class DAGMCUniverse(UniverseBase):
     auto_mat_ids : bool
         Set IDs automatically on initialization (True)  or report overlaps
         in ID space between OpenMC and UWUW materials (False)
+    bounding_box : 2-tuple of numpy.array
+        Lower-left and upper-right coordinates of an axis-aligned bounding box
+        of the universe.
     """
 
     def __init__(self,
@@ -649,6 +653,15 @@ class DAGMCUniverse(UniverseBase):
         string += '{: <16}=\t{}\n'.format('\tGeom', 'DAGMC')
         string += '{: <16}=\t{}\n'.format('\tFile', self.filename)
         return string
+
+    @property
+    def bounding_box(self):
+        dagmc_file = h5py.File(self.filename)
+        coords = dagmc_file['tstt']['nodes']['coordinates'][()]
+        lower_left_corner = coords.min(axis=0)
+        upper_right_corner = coords.max(axis=0)
+        bounding_box = (lower_left_corner, upper_right_corner)
+        return bounding_box
 
     @property
     def filename(self):

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -656,12 +656,12 @@ class DAGMCUniverse(UniverseBase):
 
     @property
     def bounding_box(self):
-        dagmc_file = h5py.File(self.filename)
-        coords = dagmc_file['tstt']['nodes']['coordinates'][()]
-        lower_left_corner = coords.min(axis=0)
-        upper_right_corner = coords.max(axis=0)
-        bounding_box = (lower_left_corner, upper_right_corner)
-        return bounding_box
+        with h5py.File(self.filename) as dagmc_file:
+            coords = dagmc_file['tstt']['nodes']['coordinates'][()]
+            lower_left_corner = coords.min(axis=0)
+            upper_right_corner = coords.max(axis=0)
+            bounding_box = (lower_left_corner, upper_right_corner)
+            return bounding_box
 
     @property
     def filename(self):

--- a/tests/regression_tests/dagmc/universes/test.py
+++ b/tests/regression_tests/dagmc/universes/test.py
@@ -46,6 +46,11 @@ class DAGMCUniverseTest(PyAPITestHarness):
         # create the DAGMC universe
         pincell_univ = openmc.DAGMCUniverse(filename='dagmc.h5m', auto_geom_ids=True)
 
+        # checks that the bounding box is calculated correctly
+        bounding_box = pincell_univ.bounding_box
+        assert bounding_box[0].tolist() == [-25., -25., -25.]
+        assert bounding_box[1].tolist() == [25., 25., 25.]
+
         # create a 2 x 2 lattice using the DAGMC pincell
         pitch = np.asarray((24.0, 24.0))
         lattice = openmc.RectLattice()


### PR DESCRIPTION
As discussed in issue #2104 it is relatively straight forward to add a bounding box method to the DAGMCUniverist class using h5py. This mirrors functionality already found in the ```Universe``` class.

if this PR is accepted this would make another micro package obsolete as there would be no need for [dagmc_bounding_box](https://github.com/fusion-energy/dagmc_bounding_box) :tada:

I've attributed the commits to @pshriwise as this is based on his code