### PR TITLE
Make sure weight window lower/upper bounds are flattened before writing to XML

### DIFF
--- a/openmc/weight_windows.py
+++ b/openmc/weight_windows.py
@@ -291,10 +291,10 @@ class WeightWindows(IDManagerMixin):
         subelement.text = ' '.join(str(e) for e in self.energy_bounds)
 
         subelement = ET.SubElement(element, 'lower_ww_bounds')
-        subelement.text = ' '.join(str(b) for b in self.lower_ww_bounds)
+        subelement.text = ' '.join(str(b) for b in self.lower_ww_bounds.ravel())
 
         subelement = ET.SubElement(element, 'upper_ww_bounds')
-        subelement.text = ' '.join(str(b) for b in self.upper_ww_bounds)
+        subelement.text = ' '.join(str(b) for b in self.upper_ww_bounds.ravel())
 
         subelement = ET.SubElement(element, 'survival_ratio')
         subelement.text = str(self.survival_ratio)

--- a/openmc/weight_windows.py
+++ b/openmc/weight_windows.py
@@ -291,10 +291,10 @@ class WeightWindows(IDManagerMixin):
         subelement.text = ' '.join(str(e) for e in self.energy_bounds)
 
         subelement = ET.SubElement(element, 'lower_ww_bounds')
-        subelement.text = ' '.join(str(b) for b in self.lower_ww_bounds.ravel())
+        subelement.text = ' '.join(str(b) for b in self.lower_ww_bounds.ravel('F'))
 
         subelement = ET.SubElement(element, 'upper_ww_bounds')
-        subelement.text = ' '.join(str(b) for b in self.upper_ww_bounds.ravel())
+        subelement.text = ' '.join(str(b) for b in self.upper_ww_bounds.ravel('F'))
 
         subelement = ET.SubElement(element, 'survival_ratio')
         subelement.text = str(self.survival_ratio)


### PR DESCRIPTION
A user [ran into a problem](https://openmc.discourse.group/t/using-mcnp-advantg-weight-windows/2088/3) using weight windows converted from a `wwinp` file. It looks like the problem is that the `WeightWindows` class stores `lower_ww_bounds` and `upper_ww_bounds` as multidimensional arrays but when writing to XML, it doesn't account for that properly. I think the fix is as simple as flattening the array -- @pshriwise can you confirm that this will write the lower/upper bounds in the correct order accounting for both mesh and energy index?