### PR TITLE
Adding auto bound for dagmcuniverse

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -660,8 +660,7 @@ class DAGMCUniverse(UniverseBase):
             coords = dagmc_file['tstt']['nodes']['coordinates'][()]
             lower_left_corner = coords.min(axis=0)
             upper_right_corner = coords.max(axis=0)
-            bounding_box = (lower_left_corner, upper_right_corner)
-            return bounding_box
+            return (lower_left_corner, upper_right_corner)
 
     @property
     def filename(self):

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from xml.etree import ElementTree as ET
 
+import h5py
 import numpy as np
 
 import openmc
@@ -630,6 +631,9 @@ class DAGMCUniverse(UniverseBase):
     auto_mat_ids : bool
         Set IDs automatically on initialization (True)  or report overlaps
         in ID space between OpenMC and UWUW materials (False)
+    bounding_box : 2-tuple of numpy.array
+        Lower-left and upper-right coordinates of an axis-aligned bounding box
+        of the universe.
     """
 
     def __init__(self,
@@ -649,6 +653,15 @@ class DAGMCUniverse(UniverseBase):
         string += '{: <16}=\t{}\n'.format('\tGeom', 'DAGMC')
         string += '{: <16}=\t{}\n'.format('\tFile', self.filename)
         return string
+
+    @property
+    def bounding_box(self):
+        dagmc_file = h5py.File(self.filename)
+        coords = dagmc_file['tstt']['nodes']['coordinates'][()]
+        lower_left_corner = coords.min(axis=0)
+        upper_right_corner = coords.max(axis=0)
+        bounding_box = (lower_left_corner, upper_right_corner)
+        return bounding_box
 
     @property
     def filename(self):

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -656,12 +656,12 @@ class DAGMCUniverse(UniverseBase):
 
     @property
     def bounding_box(self):
-        dagmc_file = h5py.File(self.filename)
-        coords = dagmc_file['tstt']['nodes']['coordinates'][()]
-        lower_left_corner = coords.min(axis=0)
-        upper_right_corner = coords.max(axis=0)
-        bounding_box = (lower_left_corner, upper_right_corner)
-        return bounding_box
+        with h5py.File(self.filename) as dagmc_file:
+            coords = dagmc_file['tstt']['nodes']['coordinates'][()]
+            lower_left_corner = coords.min(axis=0)
+            upper_right_corner = coords.max(axis=0)
+            bounding_box = (lower_left_corner, upper_right_corner)
+            return bounding_box
 
     @property
     def filename(self):

--- a/tests/regression_tests/dagmc/universes/test.py
+++ b/tests/regression_tests/dagmc/universes/test.py
@@ -46,6 +46,11 @@ class DAGMCUniverseTest(PyAPITestHarness):
         # create the DAGMC universe
         pincell_univ = openmc.DAGMCUniverse(filename='dagmc.h5m', auto_geom_ids=True)
 
+        # checks that the bounding box is calculated correctly
+        bounding_box = pincell_univ.bounding_box
+        assert bounding_box[0].tolist() == [-25., -25., -25.]
+        assert bounding_box[1].tolist() == [25., 25., 25.]
+
         # create a 2 x 2 lattice using the DAGMC pincell
         pitch = np.asarray((24.0, 24.0))
         lattice = openmc.RectLattice()

--- a/tests/regression_tests/dagmc/universes/test.py
+++ b/tests/regression_tests/dagmc/universes/test.py
@@ -51,6 +51,20 @@ class DAGMCUniverseTest(PyAPITestHarness):
         assert bounding_box[0].tolist() == [-25., -25., -25.]
         assert bounding_box[1].tolist() == [25., 25., 25.]
 
+        # checks that the bounding region is six surfaces each with a vacuum boundary type
+        b_region = pincell_univ.bounding_region(bounded_type='box', boundary_type='vacuum')
+        assert isinstance(b_region, openmc.Region)
+        assert len(b_region.get_surfaces()) == 6
+        for surface in list(b_region.get_surfaces().values()):
+            assert surface.boundary_type == 'vacuum'
+
+        # checks that the bounding region is a single surface with a reflective boundary type
+        b_region = pincell_univ.bounding_region(bounded_type='sphere', boundary_type='reflective')
+        assert isinstance(b_region, openmc.Region)
+        assert len(b_region.get_surfaces()) == 1
+        for surface in list(b_region.get_surfaces().values()):
+            assert surface.boundary_type == 'reflective'
+
         # create a 2 x 2 lattice using the DAGMC pincell
         pitch = np.asarray((24.0, 24.0))
         lattice = openmc.RectLattice()


### PR DESCRIPTION
As discussed with @pshriwise in issue #2104 and building on the work from PR #2111 this is another small PR that adds the ability to automatically generate a bounding region around a DAGMC geometry.

This would be useful for creating a spherical or box shaped vacuum surface to bound the DAGMC geometry or other uses (boundary type is user controllable)

This is based on some code from another micro package I made a while back :recycle: [here](https://github.com/fusion-energy/openmc-dagmc-wrapper/blob/9c4485d4f40e7df2bac5333be68fe6d4e0caa570/openmc_dagmc_wrapper/Geometry.py#L114-L153) and [here](https://github.com/fusion-energy/openmc-dagmc-wrapper/blob/9c4485d4f40e7df2bac5333be68fe6d4e0caa570/openmc_dagmc_wrapper/Geometry.py#L50-L55)

I've added some simple tests to the DAGMC universe test