### PR TITLE
added DAGMCUniverse.bounding_region

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -767,11 +767,17 @@ class DAGMCUniverse(UniverseBase):
 
             return +lower_x & -upper_x & +lower_y & -upper_y & +lower_z & -upper_z
 
-    def bounded_universe(self, **kwargs):
+    def bounded_universe(self, bounding_cell_id=10000, **kwargs):
         """Returns an openmc.Universe filled with this DAGMCUniverse and bounded
         with a cell. Defaults to a box cell with a vacuum surface however this
         can be changed using the kwargs which are passed directly to
         DAGMCUniverse.bounding_region().
+
+        Parameters
+        ----------
+        bounding_cell_id : int
+            The cell ID number to use for the bounding cell, defaults to 1000 to reduce
+            the chance of overlapping ID numbers with the DAGMC geometry.
 
         Returns
         -------
@@ -779,7 +785,7 @@ class DAGMCUniverse(UniverseBase):
             Universe instance
         """
 
-        bounding_cell = openmc.Cell(fill=self, region=self.bounding_region(**kwargs))
+        bounding_cell = openmc.Cell(fill=self, id=bounding_cell_id, region=self.bounding_region(**kwargs))
         return openmc.Universe(cells=[bounding_cell])
 
     @classmethod

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -761,10 +761,18 @@ class DAGMCUniverse(UniverseBase):
 
             return +lower_x & -upper_x & +lower_y & -upper_y & +lower_z & -upper_z
 
-    def bounded_universe(self, **kwargs):
+    def bounded_universe(self, auto_geom_ids=True, **kwargs):
         """Returns an openmc.Universe filled with this DAGMCUniverse and bounded
-        with a cell. Defaults to a box cell with a vacuum surface. kwargs are
-        passed directly to DAGMCUniverse.bounding_region()
+        with a cell. Defaults to a box cell with a vacuum surface however this
+        can be changed using the kwargs which are passed directly to
+        DAGMCUniverse.bounding_region().
+
+        Parameters
+        ----------
+        auto_geom_ids : bool
+            Set IDs automatically on initialization (True) or report overlaps
+            in ID space between CSG and DAGMC (False). Defaults to True to avoid
+            overlapping ID numbers between the CSG and DAGMC geometry ID numbers
 
         Returns
         -------
@@ -772,6 +780,7 @@ class DAGMCUniverse(UniverseBase):
             Universe instance
         """
 
+        self.auto_geom_ids = auto_geom_ids
         bounding_cell = openmc.Cell(fill=self, region=self.bounding_region(**kwargs))
         return openmc.Universe(cells=[bounding_cell])
 

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -746,7 +746,13 @@ class DAGMCUniverse(UniverseBase):
             import math
             bounding_box_center = (bounding_box[0] + bounding_box[1])/2
             radius = math.dist(bounding_box[0], bounding_box[1])
-            bounding_surface = openmc.Sphere(x0=bounding_box_center[0], y0=bounding_box_center[1], z0=bounding_box_center[2], r=radius)
+            bounding_surface = openmc.Sphere(
+                x0=bounding_box_center[0],
+                y0=bounding_box_center[1],
+                z0=bounding_box_center[2],
+                boundary_type=boundary_type,
+                r=radius,
+            )
 
             return -bounding_surface
 

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -762,18 +762,18 @@ class DAGMCUniverse(UniverseBase):
             return +lower_x & -upper_x & +lower_y & -upper_y & +lower_z & -upper_z
 
     def bounded_universe(self, **kwargs):
-        """Returns an openmc.Cell that bounds the DAGMCUniverse and is filled
-        with the DAGMCUniverse. Defaults to a box cell with a vacuum surface.
-        kwargs are passed directly to DAGMCUniverse.bounding_region()
+        """Returns an openmc.Universe filled with this DAGMCUniverse and bounded
+        with a cell. Defaults to a box cell with a vacuum surface. kwargs are
+        passed directly to DAGMCUniverse.bounding_region()
 
         Returns
         -------
-        openmc.Cell
-            cell filled with the DAGMCUniverse
+        openmc.Universe
+            Universe instance
         """
 
         bounding_cell = openmc.Cell(fill=self, region=self.bounding_region(**kwargs))
-        return bounding_cell
+        return openmc.Universe(cells=[bounding_cell])
 
     @classmethod
     def from_hdf5(cls, group):

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -762,12 +762,18 @@ class DAGMCUniverse(UniverseBase):
             return +lower_x & -upper_x & +lower_y & -upper_y & +lower_z & -upper_z
 
     def bounded_universe(self, **kwargs):
-        """Returns an openmc.Universe filled with this DAGMCUniverse and bounded
-        with a cell. Defaults to a box cell with a vacuum surface. kwargs are
-        passed directly to DAGMCUniverse.bounding_region()"""
+        """Returns an openmc.Cell that bounds the DAGMCUniverse and is filled
+        with the DAGMCUniverse. Defaults to a box cell with a vacuum surface.
+        kwargs are passed directly to DAGMCUniverse.bounding_region()
+
+        Returns
+        -------
+        openmc.Cell
+            cell filled with the DAGMCUniverse
+        """
 
         bounding_cell = openmc.Cell(fill=self, region=self.bounding_region(**kwargs))
-        return openmc.Universe(cells=[bounding_cell])
+        return bounding_cell
 
     @classmethod
     def from_hdf5(cls, group):

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -785,7 +785,7 @@ class DAGMCUniverse(UniverseBase):
             Universe instance
         """
 
-        bounding_cell = openmc.Cell(fill=self, id=bounding_cell_id, region=self.bounding_region(**kwargs))
+        bounding_cell = openmc.Cell(fill=self, cell_id =bounding_cell_id, region=self.bounding_region(**kwargs))
         return openmc.Universe(cells=[bounding_cell])
 
     @classmethod

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -724,7 +724,7 @@ class DAGMCUniverse(UniverseBase):
         bounded_type : str
             The type of bounding surface(s) to use when constructing the region.
             Options include a single spherical surface (sphere) or a rectangle
-            made from siz planes (box).
+            made from six planes (box).
         boundary_type : str
             Boundary condition that defines the behavior for particles hitting
             the surface. Defaults to vacuum boundary condition. Passed into the
@@ -760,7 +760,7 @@ class DAGMCUniverse(UniverseBase):
             return +lower_x & -upper_x & +lower_y & -upper_y & +lower_z & -upper_z
 
     def bounded_universe(self, **kwargs):
-        """Returns an openmc.Universe filled with the DAGMCUniverse and bounded
+        """Returns an openmc.Universe filled with this DAGMCUniverse and bounded
         with a cell. Defaults to a box cell with a vacuum surface. kwargs are
         passed directly to DAGMCUniverse.bounding_region()"""
 

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -737,6 +737,8 @@ class DAGMCUniverse(UniverseBase):
 
         check_type('boundary type', boundary_type, str)
         check_value('boundary type', boundary_type, _BOUNDARY_TYPES)
+        check_type('bounded type', bounded_type, str)
+        check_value('bounded type', bounded_type, ('box', 'sphere'))
 
         bounding_box = self.bounding_box
 

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -767,18 +767,11 @@ class DAGMCUniverse(UniverseBase):
 
             return +lower_x & -upper_x & +lower_y & -upper_y & +lower_z & -upper_z
 
-    def bounded_universe(self, auto_geom_ids=True, **kwargs):
+    def bounded_universe(self, **kwargs):
         """Returns an openmc.Universe filled with this DAGMCUniverse and bounded
         with a cell. Defaults to a box cell with a vacuum surface however this
         can be changed using the kwargs which are passed directly to
         DAGMCUniverse.bounding_region().
-
-        Parameters
-        ----------
-        auto_geom_ids : bool
-            Set IDs automatically on initialization (True) or report overlaps
-            in ID space between CSG and DAGMC (False). Defaults to True to avoid
-            overlapping ID numbers between the CSG and DAGMC geometry ID numbers
 
         Returns
         -------
@@ -786,7 +779,6 @@ class DAGMCUniverse(UniverseBase):
             Universe instance
         """
 
-        self.auto_geom_ids = auto_geom_ids
         bounding_cell = openmc.Cell(fill=self, region=self.bounding_region(**kwargs))
         return openmc.Universe(cells=[bounding_cell])
 

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -713,6 +713,49 @@ class DAGMCUniverse(UniverseBase):
         dagmc_element.set('filename', self.filename)
         xml_element.append(dagmc_element)
 
+    def bounding_region(self, bounded_type='box', boundary_type='vacuum'):
+        """Creates a either a spherical or box shaped bounding region around
+        the DAGMC geometry.
+        Parameters
+        ----------
+        bounded_type : str
+            The type of bounding surface(s) to use when constructing the region.
+            Options include a single spherical surface (sphere) or a rectangle
+            made from siz planes (box).
+        boundary_type : str
+            Boundary condition that defines the behavior for particles hitting
+            the surface. Defaults to vacuum boundary condition. Passed into
+        Returns
+        -------
+        openmc.Region
+            Region instance
+        """
+
+        bounding_box = self.bounding_box
+
+        if bounded_type == 'sphere':
+            import math
+            bounding_box_center = (bounding_box[0] + bounding_box[1])/2
+            radius = math.dist(bounding_box[0], bounding_box[1])
+            bounding_surface = openmc.Sphere(x0=bounding_box_center[0], y0=bounding_box_center[1], z0=bounding_box_center[2], r=radius)
+
+            return -bounding_surface
+
+        if bounded_type == 'box':
+            # defines plane surfaces for all six faces of the bounding box
+            lower_x = openmc.XPlane(bounding_box[0][0], boundary_type=boundary_type)
+            upper_x = openmc.XPlane(bounding_box[1][0], boundary_type=boundary_type)
+            lower_y = openmc.YPlane(bounding_box[0][1], boundary_type=boundary_type)
+            upper_y = openmc.YPlane(bounding_box[1][1], boundary_type=boundary_type)
+            lower_z = openmc.ZPlane(bounding_box[0][2], boundary_type=boundary_type)
+            upper_z = openmc.ZPlane(bounding_box[1][2], boundary_type=boundary_type)
+
+            return +lower_x & -upper_x & +lower_y & -upper_y & +lower_z & -upper_z
+
+    def bounded_universe(self, **kwargs):
+        bounding_cell = openmc.Cell(fill=self, region=self.bounding_region(**kwargs))
+        return openmc.Universe(cells=[bounding_cell])
+
     @classmethod
     def from_hdf5(cls, group):
         """Create DAGMC universe from HDF5 group

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -12,9 +12,12 @@ import numpy as np
 
 import openmc
 import openmc.checkvalue as cv
+
 from ._xml import get_text
+from .checkvalue import check_type, check_value
 from .mixin import IDManagerMixin
 from .plots import _SVG_COLORS
+from .surface import _BOUNDARY_TYPES
 
 
 class UniverseBase(ABC, IDManagerMixin):
@@ -724,12 +727,16 @@ class DAGMCUniverse(UniverseBase):
             made from siz planes (box).
         boundary_type : str
             Boundary condition that defines the behavior for particles hitting
-            the surface. Defaults to vacuum boundary condition. Passed into
+            the surface. Defaults to vacuum boundary condition. Passed into the
+            surface construction.
         Returns
         -------
         openmc.Region
             Region instance
         """
+
+        check_type('boundary type', boundary_type, str)
+        check_value('boundary type', boundary_type, _BOUNDARY_TYPES)
 
         bounding_box = self.bounding_box
 
@@ -753,6 +760,10 @@ class DAGMCUniverse(UniverseBase):
             return +lower_x & -upper_x & +lower_y & -upper_y & +lower_z & -upper_z
 
     def bounded_universe(self, **kwargs):
+        """Returns an openmc.Universe filled with the DAGMCUniverse and bounded
+        with a cell. Defaults to a box cell with a vacuum surface. kwargs are
+        passed directly to DAGMCUniverse.bounding_region()"""
+
         bounding_cell = openmc.Cell(fill=self, region=self.bounding_region(**kwargs))
         return openmc.Universe(cells=[bounding_cell])
 

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -183,9 +183,9 @@ void DAGUniverse::init_geometry()
     } else {
       warning(fmt::format("DAGMC Cell IDs: {}", dagmc_ids_for_dim(3)));
       fatal_error(fmt::format("Cell ID {} exists in both DAGMC Universe {} "
-                              "and the CSG geometry. Setting auto_geom_ids
-                              to True when initiating the DAGMC Universe may
-                              resolve this issue",
+                              "and the CSG geometry. Setting auto_geom_ids "
+                              "to True when initiating the DAGMC Universe may "
+                              "resolve this issue",
         c->id_, this->id_));
     }
 

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -183,7 +183,9 @@ void DAGUniverse::init_geometry()
     } else {
       warning(fmt::format("DAGMC Cell IDs: {}", dagmc_ids_for_dim(3)));
       fatal_error(fmt::format("Cell ID {} exists in both DAGMC Universe {} "
-                              "and the CSG geometry.",
+                              "and the CSG geometry. Setting auto_geom_ids
+                              to True when initiating the DAGMC Universe may
+                              resolve this issue",
         c->id_, this->id_));
     }
 

--- a/tests/regression_tests/dagmc/universes/inputs_true.dat
+++ b/tests/regression_tests/dagmc/universes/inputs_true.dat
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
 <geometry>
-  <cell fill="10" id="13" region="9 -10 11 -12 13 -14" universe="11" />
+  <cell fill="12" id="14" region="22 -23 24 -25 26 -27" universe="13" />
   <dagmc_universe auto_geom_ids="true" filename="dagmc.h5m" id="9" />
-  <lattice id="10">
+  <lattice id="12">
     <pitch>24.0 24.0</pitch>
     <dimension>2 2</dimension>
     <lower_left>-24.0 -24.0</lower_left>
@@ -10,12 +10,12 @@
 9 9 
 9 9 </universes>
   </lattice>
-  <surface boundary="reflective" coeffs="-24.0" id="9" name="left" type="x-plane" />
-  <surface boundary="reflective" coeffs="24.0" id="10" name="right" type="x-plane" />
-  <surface boundary="reflective" coeffs="-24.0" id="11" name="front" type="y-plane" />
-  <surface boundary="reflective" coeffs="24.0" id="12" name="back" type="y-plane" />
-  <surface boundary="reflective" coeffs="-10.0" id="13" name="bottom" type="z-plane" />
-  <surface boundary="reflective" coeffs="10.0" id="14" name="top" type="z-plane" />
+  <surface boundary="reflective" coeffs="-24.0" id="22" name="left" type="x-plane" />
+  <surface boundary="reflective" coeffs="24.0" id="23" name="right" type="x-plane" />
+  <surface boundary="reflective" coeffs="-24.0" id="24" name="front" type="y-plane" />
+  <surface boundary="reflective" coeffs="24.0" id="25" name="back" type="y-plane" />
+  <surface boundary="reflective" coeffs="-10.0" id="26" name="bottom" type="z-plane" />
+  <surface boundary="reflective" coeffs="10.0" id="27" name="top" type="z-plane" />
 </geometry>
 <?xml version='1.0' encoding='utf-8'?>
 <materials>

--- a/tests/regression_tests/dagmc/universes/inputs_true.dat
+++ b/tests/regression_tests/dagmc/universes/inputs_true.dat
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <geometry>
-  <cell fill="12" id="14" region="22 -23 24 -25 26 -27" universe="13" />
+  <cell fill="12" id="13" region="22 -23 24 -25 26 -27" universe="13" />
   <dagmc_universe auto_geom_ids="true" filename="dagmc.h5m" id="9" />
   <lattice id="12">
     <pitch>24.0 24.0</pitch>

--- a/tests/regression_tests/dagmc/universes/test.py
+++ b/tests/regression_tests/dagmc/universes/test.py
@@ -46,6 +46,13 @@ class DAGMCUniverseTest(PyAPITestHarness):
         # create the DAGMC universe
         pincell_univ = openmc.DAGMCUniverse(filename='dagmc.h5m', auto_geom_ids=True)
 
+        # creates another DAGMC universe, this time with within a bounded cell
+        bound_pincell_cell = openmc.DAGMCUniverse(filename='dagmc.h5m').bounded_universe()
+        # uses the bound_dag_cell as the root argument to test the type checks in openmc.Geometry
+        bound_pincell_geometry = openmc.Geometry(root=[bound_pincell_cell])
+        # assigns the bound_dag_geometry to the model to test the type checks in model.Geometry setter
+        model.Geometry = bound_pincell_geometry
+
         # checks that the bounding box is calculated correctly
         bounding_box = pincell_univ.bounding_box
         assert bounding_box[0].tolist() == [-25., -25., -25.]

--- a/tests/regression_tests/dagmc/universes/test.py
+++ b/tests/regression_tests/dagmc/universes/test.py
@@ -51,6 +51,20 @@ class DAGMCUniverseTest(PyAPITestHarness):
         assert bounding_box[0].tolist() == [-25., -25., -25.]
         assert bounding_box[1].tolist() == [25., 25., 25.]
 
+        # checks that the bounding region is six surfaces each with a vacuum boundary type
+        b_region = pincell_univ.bounding_region(bounded_type='box', boundary_type='vacuum')
+        assert isinstance(b_region, openmc.Region)
+        assert len(b_region.get_surfaces()) == 6
+        for surface in list(b_region.get_surfaces().values()):
+            assert surface.boundary_type == 'vacuum'
+
+        # checks that the bounding region is a single surface with a reflective boundary type
+        b_region = pincell_univ.bounding_region(bounded_type='sphere', boundary_type='reflective')
+        assert isinstance(b_region, openmc.Region)
+        assert len(b_region.get_surfaces()) == 1
+        for surface in list(b_region.get_surfaces().values()):
+            assert surface.boundary_type == 'reflective'
+
         # create a 2 x 2 lattice using the DAGMC pincell
         pitch = np.asarray((24.0, 24.0))
         lattice = openmc.RectLattice()

--- a/tests/regression_tests/dagmc/universes/test.py
+++ b/tests/regression_tests/dagmc/universes/test.py
@@ -47,9 +47,9 @@ class DAGMCUniverseTest(PyAPITestHarness):
         pincell_univ = openmc.DAGMCUniverse(filename='dagmc.h5m', auto_geom_ids=True)
 
         # creates another DAGMC universe, this time with within a bounded cell
-        bound_pincell_cell = openmc.DAGMCUniverse(filename='dagmc.h5m').bounded_universe()
+        bound_pincell_universe = openmc.DAGMCUniverse(filename='dagmc.h5m').bounded_universe()
         # uses the bound_dag_cell as the root argument to test the type checks in openmc.Geometry
-        bound_pincell_geometry = openmc.Geometry(root=[bound_pincell_cell])
+        bound_pincell_geometry = openmc.Geometry(root=bound_pincell_universe)
         # assigns the bound_dag_geometry to the model to test the type checks in model.Geometry setter
         model.Geometry = bound_pincell_geometry
 


### PR DESCRIPTION
As discussed with @pshriwise in issue #2104 and building on the work from PR #2111 this is another small PR that adds the ability to automatically generate a bounding region around a DAGMC geometry.

This adds the ```DAGMCUniverse.bounding_region()``` method

This would be useful for creating a spherical or box shaped vacuum surface to bound the DAGMC geometry or other uses (boundary type is user controllable)

This is based on some code from another micro package I made a while back :recycle: [here](https://github.com/fusion-energy/openmc-dagmc-wrapper/blob/9c4485d4f40e7df2bac5333be68fe6d4e0caa570/openmc_dagmc_wrapper/Geometry.py#L114-L153) and [here](https://github.com/fusion-energy/openmc-dagmc-wrapper/blob/9c4485d4f40e7df2bac5333be68fe6d4e0caa570/openmc_dagmc_wrapper/Geometry.py#L50-L55)

I've added some simple tests to the DAGMC universe test and type checking


Current method of bringing a graveyard free DAGMC geometry file into to OpenMC
```python
# makes use of the dagmc geometry
dag_univ = openmc.DAGMCUniverse("dagmc.h5m")

# creates an edge of universe boundary at a large radius
vac_surf = openmc.Sphere(r=10000, surface_id=9999, boundary_type="vacuum")

# specifies the region as below the universe boundary
region = -vac_surf

# creates a cell from the region and fills the cell with the dagmc geometry
containing_cell = openmc.Cell(cell_id=9999, region=region, fill=dag_univ)

model = openmc.Model()
model.geometry = openmc.Geometry(root=[containing_cell])
```


method possible with this PR of bringing a DAGMC geometry file into to OpenMC
```python
# loads up dagmc file and automatically bounds the geometry with a vacuum surface
bound_dag_univ= openmc.DAGMCUniverse("dagmc.h5m").bounded_universe()

model = openmc.Model()
model.geometry = openmc.Geometry(root=bound_dag_univ)
```
