### PR TITLE
Add C API function for sampling external source and Python binding

### DIFF
--- a/docs/source/pythonapi/capi.rst
+++ b/docs/source/pythonapi/capi.rst
@@ -29,6 +29,7 @@ Functions
    reset
    run
    run_in_memory
+   sample_external_source
    simulation_init
    simulation_finalize
    source_bank

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -121,6 +121,7 @@ int openmc_regular_mesh_set_params(int32_t index, int n, const double* ll,
 int openmc_reset();
 int openmc_reset_timers();
 int openmc_run();
+int openmc_sample_external_source(size_t n, uint64_t* seed, void* sites);
 void openmc_set_seed(int64_t new_seed);
 int openmc_set_n_batches(
   int32_t n_batches, bool set_max_batches, bool add_statepoint_batch);

--- a/openmc/lib/math.py
+++ b/openmc/lib/math.py
@@ -1,11 +1,10 @@
 from ctypes import c_int, c_double, POINTER, c_uint64
+from random import getrandbits
 
 import numpy as np
 from numpy.ctypeslib import ndpointer
 
 from . import _dll
-
-from random import getrandbits
 
 
 _dll.t_percentile.restype = c_double
@@ -240,10 +239,10 @@ def maxwell_spectrum(T, prn_seed=None):
         Sampled outgoing energy
 
     """
-    
+
     if prn_seed is None:
         prn_seed = getrandbits(63)
-	
+
     return _dll.maxwell_spectrum(T, c_uint64(prn_seed))
 
 
@@ -265,7 +264,7 @@ def watt_spectrum(a, b, prn_seed=None):
         Sampled outgoing energy
 
     """
-    
+
     if prn_seed is None:
         prn_seed = getrandbits(63)
 
@@ -290,7 +289,7 @@ def normal_variate(mean_value, std_dev, prn_seed=None):
         Sampled outgoing normally distributed value
 
     """
-    
+
     if prn_seed is None:
         prn_seed = getrandbits(63)
 

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -399,4 +399,14 @@ void free_memory_source()
   model::external_sources.clear();
 }
 
+//==============================================================================
+// C API
+//==============================================================================
+
+extern "C" int openmc_sample_external_source(uint64_t* seed, SourceSite* site)
+{
+  *site = sample_external_source(seed);
+  return 0;
+}
+
 } // namespace openmc

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -403,9 +403,18 @@ void free_memory_source()
 // C API
 //==============================================================================
 
-extern "C" int openmc_sample_external_source(uint64_t* seed, SourceSite* site)
+extern "C" int openmc_sample_external_source(
+  size_t n, uint64_t* seed, void* sites)
 {
-  *site = sample_external_source(seed);
+  if (!sites || !seed) {
+    set_errmsg("Received null pointer.");
+    return OPENMC_E_INVALID_ARGUMENT;
+  }
+
+  auto sites_array = static_cast<SourceSite*>(sites);
+  for (size_t i = 0; i < n; ++i) {
+    sites_array[i] = sample_external_source(seed);
+  }
   return 0;
 }
 

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -807,3 +807,44 @@ def test_cell_rotation(pincell_model_w_univ, mpi_intracomm):
     cell.rotation = (180., 0., 0.)
     assert cell.rotation == pytest.approx([180., 0., 0.])
     openmc.lib.finalize()
+
+
+def test_sample_external_source(run_in_tmpdir, mpi_intracomm):
+    # Define a simple model and export
+    mat = openmc.Material()
+    mat.add_nuclide('U235', 1.0e-2)
+    sph = openmc.Sphere(r=100.0, boundary_type='vacuum')
+    cell = openmc.Cell(fill=mat, region=-sph)
+    model = openmc.Model()
+    model.geometry = openmc.Geometry([cell])
+    model.settings.source = openmc.Source(
+        space=openmc.stats.Box([-5., -5., -5.], [5., 5., 5.]),
+        angle=openmc.stats.Monodirectional((0., 0., 1.)),
+        energy=openmc.stats.Discrete([1.0e5], [1.0])
+    )
+    model.settings.particles = 1000
+    model.settings.batches = 10
+    model.export_to_xml()
+
+    # Sample some particles and make sure they match specified source
+    openmc.lib.init()
+    particles = openmc.lib.sample_external_source(10, prn_seed=3)
+    for p in particles:
+        assert -5. < p.r[0] < 5.
+        assert -5. < p.r[1] < 5.
+        assert -5. < p.r[2] < 5.
+        assert p.u[0] == 0.0
+        assert p.u[1] == 0.0
+        assert p.u[2] == 1.0
+        assert p.E == 1.0e5
+
+    # Using the same seed should produce the same particles
+    other_particles = openmc.lib.sample_external_source(10, prn_seed=3)
+    for p1, p2 in zip(particles, other_particles):
+        assert p1.r == p2.r
+        assert p1.u == p2.u
+        assert p1.E == p2.E
+        assert p1.time == p2.time
+        assert p1.wgt == p2.wgt
+
+    openmc.lib.finalize()


### PR DESCRIPTION
This PR adds a new `openmc_sample_external_source` C API function that wraps the existing `sample_external_source` function. Along with that there is a `openmc.lib.sample_external_source` Python binding that allows a user to arbitrarily sample a source. The Python function returns a list of `openmc.SourceParticle` objects, which can be fed into the existing `openmc.write_source_file` function to create a source file.

Closes #1537.

Development of this feature was sponsored by the wonderful folks at First Light Fusion :heart: 
<img src="https://user-images.githubusercontent.com/743095/179329306-3133f635-bee0-43d9-9809-8076aac912c5.png" width="200" alt="First Light Fusion"/>
Thanks @shimwell!