### PR TITLE
Proposed fix for std::cout sync bug in output.cpp

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -93,7 +93,7 @@ void title()
   // Write number of OpenMP threads
   fmt::print("  OpenMP Threads | {}\n", omp_get_max_threads());
 #endif
-  std::cout << std::endl;
+  fmt::print("\n");
 }
 
 //==============================================================================
@@ -133,7 +133,7 @@ void header(const char* msg, int level)
 
   // Print header based on verbosity level.
   if (settings::verbosity >= level)
-    std::cout << '\n' << out << "\n" << std::endl;
+    fmt::print("\n{}\n\n", out);
 }
 
 //==============================================================================
@@ -379,7 +379,7 @@ void print_generation()
   if (n > 1) {
     fmt::print("   {:8.5f} +/-{:8.5f}", simulation::keff, simulation::keff_std);
   }
-  std::cout << std::endl;
+  fmt::print("\n");
 }
 
 //==============================================================================
@@ -546,7 +546,7 @@ void print_results()
     fmt::print(" Leakage Fraction           = {:.5f}\n",
       gt(GlobalTally::LEAKAGE, TallyResult::SUM) / n);
   }
-  std::cout << std::endl;
+  fmt::print("\n");
 }
 
 //==============================================================================


### PR DESCRIPTION
When a non-MPI version of the code is compiled and run, print to std::cout is corrupted. Carriage returns appear in the wrong places, and data columns appear as a single line. This behaviour has not been seen when compiled for MPI.

One possible fix presented here replaces the offending stream directs of the form std::cout << std::endl with calls to fmt::print. The problem appears to be mixing the two output methods. Alternative fixes are probably possible.

I've not been able to explain his behaviour, or why compiling with MPI corrects the issue. Presumably fmtlib maintains its own print buffer for performance which is flushed at a different rate to std::cout. A possible complicating factor is that std::endl both introduces a carriage return _and_ flushes the buffer. Perhaps compiling with MPI overrides the default std::cout behaviour.

I've left references to std::cout in other areas of the code. It may be prudent to remove them.

I've been unable to test this code since I can't get the Dockerfile to compile. However, since these are trivial changes I've decided to submit these changes for your review.