### PR TITLE
ARG & ENV scoping fix in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,16 @@
 
 # sudo docker run image_name:tag_name or ID with no tag sudo docker run ID number
 
-FROM debian:bullseye-slim AS dependencies
+
+# global ARG as these ARGS are used in multiple stages
+# By default one core is used to compile
+ARG compile_cores=1
 
 # By default this Dockerfile builds OpenMC without DAGMC and LIBMESH support
 ARG build_dagmc=off
 ARG build_libmesh=off
 
-# By default one core is used to compile
-ARG compile_cores=1
+FROM debian:bullseye-slim AS dependencies
 
 # Set default value of HOME to /root
 ENV HOME=/root
@@ -56,7 +58,6 @@ ENV NJOY_REPO='https://github.com/njoy/NJOY2016'
 
 # Setup environment variables for Docker image
 ENV LD_LIBRARY_PATH=${DAGMC_INSTALL_DIR}/lib:$LD_LIBRARY_PATH \
-    OPENMC_CROSS_SECTIONS=/root/nndc_hdf5/cross_sections.xml \
     OPENMC_ENDF_DATA=/root/endf-b-vii.1 \
     DEBIAN_FRONTEND=noninteractive
 
@@ -175,9 +176,6 @@ ENV HOME=/root
 ARG openmc_branch=master
 ENV OPENMC_REPO='https://github.com/openmc-dev/openmc'
 
-ARG build_dagmc
-ARG build_libmesh
-
 ENV DAGMC_INSTALL_DIR=$HOME/DAGMC/
 ENV LIBMESH_INSTALL_DIR=$HOME/LIBMESH
 
@@ -219,6 +217,7 @@ RUN mkdir -p ${HOME}/OpenMC && cd ${HOME}/OpenMC \
 FROM build AS release
 
 ENV HOME=/root
+ENV OPENMC_CROSS_SECTIONS=/root/nndc_hdf5/cross_sections.xml
 
 # Download cross sections (NNDC and WMP) and ENDF data needed by test suite
 RUN ${HOME}/OpenMC/openmc/tools/ci/download-xs.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,6 @@ ARG compile_cores=1
 # Set default value of HOME to /root
 ENV HOME=/root
 
-# OpenMC variables
-ARG openmc_branch=master
-ENV OPENMC_REPO='https://github.com/openmc-dev/openmc'
-
 # Embree variables
 ENV EMBREE_TAG='v3.12.2'
 ENV EMBREE_REPO='https://github.com/embree/embree'
@@ -174,6 +170,17 @@ RUN if [ "$build_libmesh" = "on" ]; then \
 
 FROM dependencies AS build
 
+ENV HOME=/root
+
+ARG openmc_branch=master
+ENV OPENMC_REPO='https://github.com/openmc-dev/openmc'
+
+ARG build_dagmc
+ARG build_libmesh
+
+ENV DAGMC_INSTALL_DIR=$HOME/DAGMC/
+ENV LIBMESH_INSTALL_DIR=$HOME/LIBMESH
+
 # clone and install openmc
 RUN mkdir -p ${HOME}/OpenMC && cd ${HOME}/OpenMC \
     && git clone --shallow-submodules --recurse-submodules --single-branch -b ${openmc_branch} --depth=1 ${OPENMC_REPO} \
@@ -210,6 +217,8 @@ RUN mkdir -p ${HOME}/OpenMC && cd ${HOME}/OpenMC \
     && python -c "import openmc"
 
 FROM build AS release
+
+ENV HOME=/root
 
 # Download cross sections (NNDC and WMP) and ENDF data needed by test suite
 RUN ${HOME}/OpenMC/openmc/tools/ci/download-xs.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ ARG build_libmesh=off
 
 FROM debian:bullseye-slim AS dependencies
 
+ARG compile_cores
+ARG build_dagmc
+ARG build_libmesh
+
 # Set default value of HOME to /root
 ENV HOME=/root
 
@@ -176,6 +180,7 @@ ENV HOME=/root
 ARG openmc_branch=master
 ENV OPENMC_REPO='https://github.com/openmc-dev/openmc'
 
+ARG compile_cores
 ARG build_dagmc
 ARG build_libmesh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -176,6 +176,9 @@ ENV HOME=/root
 ARG openmc_branch=master
 ENV OPENMC_REPO='https://github.com/openmc-dev/openmc'
 
+ARG build_dagmc
+ARG build_libmesh
+
 ENV DAGMC_INSTALL_DIR=$HOME/DAGMC/
 ENV LIBMESH_INSTALL_DIR=$HOME/LIBMESH
 
@@ -185,6 +188,7 @@ RUN mkdir -p ${HOME}/OpenMC && cd ${HOME}/OpenMC \
     && mkdir build && cd build ; \
     if [ ${build_dagmc} = "on" ] && [ ${build_libmesh} = "on" ]; then \
         cmake ../openmc \
+            -DCMAKE_CXX_COMPILER=mpicxx \
             -DOPENMC_USE_MPI=on \
             -DHDF5_PREFER_PARALLEL=on \
             -DOPENMC_USE_DAGMC=on \
@@ -193,6 +197,7 @@ RUN mkdir -p ${HOME}/OpenMC && cd ${HOME}/OpenMC \
     fi ; \
     if [ ${build_dagmc} = "on" ] && [ ${build_libmesh} = "off" ]; then \
         cmake ../openmc \
+            -DCMAKE_CXX_COMPILER=mpicxx \
             -DOPENMC_USE_MPI=on \
             -DHDF5_PREFER_PARALLEL=on \
             -DOPENMC_USE_DAGMC=ON \
@@ -200,6 +205,7 @@ RUN mkdir -p ${HOME}/OpenMC && cd ${HOME}/OpenMC \
     fi ; \
     if [ ${build_dagmc} = "off" ] && [ ${build_libmesh} = "on" ]; then \
         cmake ../openmc \
+            -DCMAKE_CXX_COMPILER=mpicxx \
             -DOPENMC_USE_MPI=on \
             -DHDF5_PREFER_PARALLEL=on \
             -DOPENMC_USE_LIBMESH=on \
@@ -207,6 +213,7 @@ RUN mkdir -p ${HOME}/OpenMC && cd ${HOME}/OpenMC \
     fi ; \
     if [ ${build_dagmc} = "off" ] && [ ${build_libmesh} = "off" ]; then \
         cmake ../openmc \
+            -DCMAKE_CXX_COMPILER=mpicxx \
             -DOPENMC_USE_MPI=on \
             -DHDF5_PREFER_PARALLEL=on ; \
     fi ; \


### PR DESCRIPTION
Whilst investigating why I can't build the OpenMC Dockerfile I learned that staged builds limits ARG and ENV variable scopes. This was found when trying to understand why the "--build-arg openmc_branch" directive was apparently being ignored.

These changes create visibility of ARG values in the appropriate build stages. Declaration of ENV variables have been moved to the appropriate build stage. There may be a better solution, since it is convenient to have ENV variables declared together at the top of the file, but (certainly in my environment) this does not appear to work.

I do not believe this pull request presents a working Dockerfile - I'm still unable to build it, but the build certainly progresses further. (I've built the OpenMC docker image before, so my environment is capable.)