### PR TITLE
Add `inplace` option for Region.translate

### DIFF
--- a/openmc/data/reconstruct.pyx
+++ b/openmc/data/reconstruct.pyx
@@ -299,8 +299,8 @@ def reconstruct_slbw(slbw, double E):
         # Determine shift and penetration at modified energy
         if slbw._competitive[i]:
             Ex = E + slbw.q_value[l]*(A + 1)/A
-            rhoc = slbw.channel_radius[l](Ex)
-            rhochat = slbw.scattering_radius[l](Ex)
+            rhoc = k*slbw.channel_radius[l](Ex)
+            rhochat = k*slbw.scattering_radius[l](Ex)
             P_c, S_c = penetration_shift(l, rhoc)
             if Ex < 0:
                 P_c = 0

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -259,13 +259,16 @@ class Region(ABC):
         clone[:] = [n.clone(memo) for n in self]
         return clone
 
-    def translate(self, vector, memo=None):
+    def translate(self, vector, inplace=False, memo=None):
         """Translate region in given direction
 
         Parameters
         ----------
         vector : iterable of float
             Direction in which region should be translated
+        inplace : bool
+            Whether or not to return a region based on new surfaces or one based
+            on the original surfaces that have been modified.
         memo : dict or None
             Dictionary used for memoization. This parameter is used internally
             and should not be specified by the user.
@@ -279,7 +282,7 @@ class Region(ABC):
 
         if memo is None:
             memo = {}
-        return type(self)(n.translate(vector, memo) for n in self)
+        return type(self)(n.translate(vector, inplace, memo) for n in self)
 
     def rotate(self, rotation, pivot=(0., 0., 0.), order='xyz', inplace=False,
                memo=None):
@@ -308,7 +311,7 @@ class Region(ABC):
             :math:`\psi` about z. This corresponds to an x-y-z extrinsic
             rotation as well as a z-y'-x'' intrinsic rotation using Tait-Bryan
             angles :math:`(\phi, \theta, \psi)`.
-        inplace : boolean
+        inplace : bool
             Whether or not to return a new instance of Surface or to modify the
             coefficients of this Surface in place. Defaults to False.
         memo : dict or None
@@ -622,10 +625,10 @@ class Complement(Region):
         clone.node = self.node.clone(memo)
         return clone
 
-    def translate(self, vector, memo=None):
+    def translate(self, vector, inplace=False, memo=None):
         if memo is None:
             memo = {}
-        return type(self)(self.node.translate(vector, memo))
+        return type(self)(self.node.translate(vector, inplace, memo))
 
     def rotate(self, rotation, pivot=(0., 0., 0.), order='xyz', inplace=False,
                memo=None):

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -336,9 +336,9 @@ class Surface(IDManagerMixin, ABC):
         ----------
         vector : iterable of float
             Direction in which surface should be translated
-        inplace : boolean
+        inplace : bool
             Whether or not to return a new instance of this Surface or to
-            modify the coefficients of this Surface. Defaults to False
+            modify the coefficients of this Surface.
 
         Returns
         -------
@@ -374,7 +374,7 @@ class Surface(IDManagerMixin, ABC):
             :math:`\psi` about z. This corresponds to an x-y-z extrinsic
             rotation as well as a z-y'-x'' intrinsic rotation using Tait-Bryan
             angles :math:`(\phi, \theta, \psi)`.
-        inplace : boolean
+        inplace : bool
             Whether or not to return a new instance of Surface or to modify the
             coefficients of this Surface in place. Defaults to False.
 
@@ -568,9 +568,9 @@ class PlaneMixin:
         ----------
         vector : iterable of float
             Direction in which surface should be translated
-        inplace : boolean
+        inplace : bool
             Whether or not to return a new instance of a Plane or to modify the
-            coefficients of this plane. Defaults to False
+            coefficients of this plane.
 
         Returns
         -------
@@ -1012,9 +1012,8 @@ class QuadricMixin:
         ----------
         vector : iterable of float
             Direction in which surface should be translated
-        inplace : boolean
+        inplace : bool
             Whether to return a clone of the Surface or the Surface itself.
-            Defaults to False
 
         Returns
         -------
@@ -2563,7 +2562,7 @@ class Halfspace(Region):
         clone.surface = self.surface.clone(memo)
         return clone
 
-    def translate(self, vector, memo=None):
+    def translate(self, vector, inplace=False, memo=None):
         """Translate half-space in given direction
 
         Parameters
@@ -2585,7 +2584,7 @@ class Halfspace(Region):
         # If translated surface not in memo, add it
         key = (self.surface, tuple(vector))
         if key not in memo:
-            memo[key] = self.surface.translate(vector)
+            memo[key] = self.surface.translate(vector, inplace)
 
         # Return translated half-space
         return type(self)(memo[key], self.side)
@@ -2617,7 +2616,7 @@ class Halfspace(Region):
             :math:`\psi` about z. This corresponds to an x-y-z extrinsic
             rotation as well as a z-y'-x'' intrinsic rotation using Tait-Bryan
             angles :math:`(\phi, \theta, \psi)`.
-        inplace : boolean
+        inplace : bool
             Whether or not to return a new instance of Surface or to modify the
             coefficients of this Surface in place. Defaults to False.
         memo : dict or None

--- a/tests/unit_tests/test_region.py
+++ b/tests/unit_tests/test_region.py
@@ -208,3 +208,17 @@ def test_from_expression(reset):
     # Opening parenthesis immediately after halfspace
     r = openmc.Region.from_expression('1(2|-3)', surfs)
     assert str(r) == '(1 (2 | -3))'
+
+
+def test_translate_inplace():
+    sph = openmc.Sphere()
+    x = openmc.XPlane()
+    region = -sph & +x
+
+    # Translating a region should produce new surfaces
+    region2 = region.translate((0.5, -6.7, 3.9), inplace=False)
+    assert str(region) != str(region2)
+
+    # Translating a region in-place should *not* produce new surfaces
+    region3 = region.translate((0.5, -6.7, 3.9), inplace=True)
+    assert str(region) == str(region3)


### PR DESCRIPTION
A user [pointed out](https://openmc.discourse.group/t/region-translate-method-has-no-inplace-argument/2117/) that one can call `Region.rotate` with an `inplace` argument but the same is not true for `Region.translate`. This PR adds the `inplace` argument to `translate` and a quick test to confirm that it works as intended.

I also put an unrelated two-line fix for #907.