### PR TITLE
Keep numpy arrays until VTK file is written.

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -248,8 +248,10 @@ class StructuredMesh(MeshBase):
 
         # create VTK arrays for each of
         # the data sets
+        datasets_out = []
         for label, dataset in datasets.items():
             dataset = np.asarray(dataset).flatten()
+            datasets_out.append(dataset)
 
             if volume_normalization:
                 dataset /= self.volumes.flatten()
@@ -692,7 +694,7 @@ class RegularMesh(StructuredMesh):
         root_cell.fill = lattice
 
         return root_cell, cells
-    
+
     def write_data_to_vtk(self, filename, datasets, volume_normalization=True):
         """Creates a VTK object of the mesh
 
@@ -1605,7 +1607,7 @@ class UnstructuredMesh(MeshBase):
         Raises
         ------
             RuntimeError
-                when the size of a dataset doesn't match the number of cells 
+                when the size of a dataset doesn't match the number of cells
         """
 
         import vtk

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -248,6 +248,10 @@ class StructuredMesh(MeshBase):
 
         # create VTK arrays for each of
         # the data sets
+
+        # maintain a list of the datasets as added
+        # to the VTK arrays to ensure they persist
+        # in memory until the file is written
         datasets_out = []
         for label, dataset in datasets.items():
             dataset = np.asarray(dataset).flatten()


### PR DESCRIPTION
A user noted in #2130 that the same set of data gets written multiple times if more than one data set is provided to the `write_data_to_vtk` methods of our mesh classes in the Python API. This PR keeps those arrays in a list to ensure they persist until the file is written. @warm-considering, would you mind giving this a try to see if it fixes your problem?