### PR TITLE
Add ability to get sources from `Decay` class

### DIFF
--- a/docs/source/pythonapi/data.rst
+++ b/docs/source/pythonapi/data.rst
@@ -61,6 +61,7 @@ Core Functions
 
     atomic_mass
     atomic_weight
+    combine_distributions
     decay_constant
     dose_coefficients
     gnd_name

--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -337,6 +337,7 @@ class Decay(EqualityMixin):
         self.modes = []
         self.spectra = {}
         self.average_energies = {}
+        self._sources = None
 
         # Get head record
         items = get_head_record(file_obj)

--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -511,11 +511,21 @@ class Decay(EqualityMixin):
         sources = {}
         name = self.nuclide['name']
         for particle, spectra in self.spectra.items():
-            # Only handle gammas for now
-            if particle not in ('gamma', 'xray'):
-                continue
-            # TODO: Set particle type based on 'particle' above
-            particle_type = 'photon'
+            # Set particle type based on 'particle' above
+            particle_type = {
+                'gamma': 'photon',
+                'beta-': 'electron',
+                'ec/beta+': 'positron',
+                'alpha': 'alpha',
+                'n': 'neutron',
+                'sf': 'fragment',
+                'p': 'proton',
+                'e-': 'electron',
+                'xray': 'photon',
+                'anti-neutrino': 'anti-neutrino',
+                'neutrino': 'neutrino',
+            }[particle]
+
             if particle_type not in sources:
                 sources[particle_type] = []
 

--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -316,6 +316,12 @@ class Decay(EqualityMixin):
         'excited_state', 'mass', 'stable', 'spin', and 'parity'.
     spectra : dict
         Resulting radiation spectra for each radiation type.
+    sources : dict
+        Radioactive decay source distributions represented as a dictionary
+        mapping particle types (e.g., 'photon') to instances of
+        :class:`openmc.stats.Univariate`.
+
+        .. versionadded:: 0.13.1
 
     """
     def __init__(self, ev_or_filename):
@@ -498,16 +504,14 @@ class Decay(EqualityMixin):
         """
         return cls(ev_or_filename)
 
-    def get_sources(self):
-        """Get radioactive decay source distributions
+    @property
+    def sources(self):
+        """Radioactive decay source distributions"""
+        # If property has been computed already, return it
+        # TODO: Replace with functools.cached_property when support is Python 3.9+
+        if self._sources is not None:
+            return self._sources
 
-        Returns
-        -------
-        sources : dict
-            Dictionary mapping particle types (e.g., 'photon') to instances of
-            :class:`openmc.stats.Univariate`
-
-        """
         sources = {}
         name = self.nuclide['name']
         decay_constant = self.decay_constant.n
@@ -563,6 +567,5 @@ class Decay(EqualityMixin):
             merged_sources[particle_type] = combine_distributions(
                 dist_list, [1.0]*len(dist_list))
 
-        return merged_sources
-
-
+        self._sources = merged_sources
+        return self._sources

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -96,9 +96,9 @@ class Discrete(Univariate):
 
     Attributes
     ----------
-    x : Iterable of float
+    x : numpy.ndarray
         Values of the random variable
-    p : Iterable of float
+    p : numpy.ndarray
         Discrete probability for each value
 
     """
@@ -123,7 +123,7 @@ class Discrete(Univariate):
         if isinstance(x, Real):
             x = [x]
         cv.check_type('discrete values', x, Iterable, Real)
-        self._x = x
+        self._x = np.array(x, dtype=float)
 
     @p.setter
     def p(self, p):
@@ -132,7 +132,7 @@ class Discrete(Univariate):
         cv.check_type('discrete probabilities', p, Iterable, Real)
         for pk in p:
             cv.check_greater_than('discrete probability', pk, 0.0, True)
-        self._p = p
+        self._p = np.array(p, dtype=float)
 
     def cdf(self):
         return np.insert(np.cumsum(self.p), 0, 0.0)
@@ -836,9 +836,9 @@ class Tabular(Univariate):
 
     Attributes
     ----------
-    x : Iterable of float
+    x : numpy.ndarray
         Tabulated values of the random variable
-    p : Iterable of float
+    p : numpy.ndarray
         Tabulated probabilities
     interpolation : {'histogram', 'linear-linear', 'linear-log', 'log-linear', 'log-log'}, optional
         Indicate whether the density function is constant between tabulated
@@ -871,7 +871,7 @@ class Tabular(Univariate):
     @x.setter
     def x(self, x):
         cv.check_type('tabulated values', x, Iterable, Real)
-        self._x = x
+        self._x = np.array(x, dtype=float)
 
     @p.setter
     def p(self, p):
@@ -879,7 +879,7 @@ class Tabular(Univariate):
         if not self._ignore_negative:
             for pk in p:
                 cv.check_greater_than('tabulated probability', pk, 0.0, True)
-        self._p = p
+        self._p = np.array(p, dtype=float)
 
     @interpolation.setter
     def interpolation(self, interpolation):
@@ -892,8 +892,8 @@ class Tabular(Univariate):
                                       'distributions using histogram or '
                                       'linear-linear interpolation')
         c = np.zeros_like(self.x)
-        x = np.asarray(self.x)
-        p = np.asarray(self.p)
+        x = self.x
+        p = self.p
 
         if self.interpolation == 'histogram':
             c[1:] = p[:-1] * np.diff(x)
@@ -933,7 +933,7 @@ class Tabular(Univariate):
 
     def normalize(self):
         """Normalize the probabilities stored on the distribution"""
-        self.p = np.asarray(self.p) / self.cdf().max()
+        self.p /= self.cdf().max()
 
     def sample(self, n_samples=1, seed=None):
         if not self.interpolation in ('histogram', 'linear-linear'):

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -224,6 +224,8 @@ class Discrete(Univariate):
     def integral(self):
         """Return integral of distribution
 
+        .. versionadded:: 0.13.1
+
         Returns
         -------
         float
@@ -1041,6 +1043,8 @@ class Tabular(Univariate):
     def integral(self):
         """Return integral of distribution
 
+        .. versionadded: 0.13.1
+
         Returns
         -------
         float
@@ -1230,6 +1234,8 @@ class Mixture(Univariate):
     def integral(self):
         """Return integral of the distribution
 
+        .. versionadded:: 0.13.1
+
         Returns
         -------
         float
@@ -1249,6 +1255,8 @@ def combine_distributions(dists, probs):
     distribution. Multiple discrete distributions are merged into a single
     distribution and the remainder of the distributions are put into a
     :class:`~openmc.stats.Mixture` distribution.
+
+    .. versionadded:: 0.13.1
 
     Parameters
     ----------

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -220,6 +220,16 @@ class Discrete(Univariate):
         p_arr = np.array([p_merged[x] for x in x_arr])
         return cls(x_arr, p_arr)
 
+    def integral(self):
+        """Return integral of distribution
+
+        Returns
+        -------
+        float
+            Integral of discrete distribution
+        """
+        return np.sum(self.p)
+
 class Uniform(Univariate):
     """Distribution with constant probability over a finite interval [a,b]
 
@@ -1027,6 +1037,22 @@ class Tabular(Univariate):
         p = params[len(params)//2:]
         return cls(x, p, interpolation)
 
+    def integral(self):
+        """Return integral of distribution
+
+        Returns
+        -------
+        float
+            Integral of tabular distrbution
+        """
+        if self.interpolation == 'histogram':
+            return np.sum(np.diff(self.x) * self.p[:-1])
+        elif self.interpolation == 'linear-linear':
+            return np.trapz(self.p, self.x)
+        else:
+            raise NotImplementedError(
+                f'integral() not supported for {self.inteprolation} interpolation')
+
 
 class Legendre(Univariate):
     r"""Probability density given by a Legendre polynomial expansion
@@ -1199,3 +1225,16 @@ class Mixture(Univariate):
             distribution.append(Univariate.from_xml_element(pair.find("dist")))
 
         return cls(probability, distribution)
+
+    def integral(self):
+        """Return integral of the distribution
+
+        Returns
+        -------
+        float
+            Integral of the distribution
+        """
+        return sum([
+            p*dist.integral()
+            for p, dist in zip(self.probability, self.distribution)
+        ])

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -1254,10 +1254,10 @@ def combine_distributions(dists, probs):
     """Combine distributions with specified probabilities
 
     This function can be used to combine multiple instances of
-    :class:`~openmc.stats.Discrete` and `~openmc.stats.Tabular` into a single
-    distribution. Multiple discrete distributions are merged into a single
-    distribution and the remainder of the distributions are put into a
-    :class:`~openmc.stats.Mixture` distribution.
+    :class:`~openmc.stats.Discrete` and `~openmc.stats.Tabular`. Multiple
+    discrete distributions are merged into a single distribution and the
+    remainder of the distributions are put into a :class:`~openmc.stats.Mixture`
+    distribution.
 
     .. versionadded:: 0.13.1
 

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -6,6 +6,12 @@ import openmc
 import openmc.stats
 
 
+def assert_sample_mean(samples, expected_mean):
+    std_dev = samples.std() / np.sqrt(samples.size)
+    assert np.abs(expected_mean - samples.mean()) < 3*std_dev
+
+
+
 def test_discrete():
     x = [0.0, 1.0, 10.0]
     p = [0.3, 0.2, 0.5]
@@ -33,13 +39,11 @@ def test_discrete():
 
     d3 = openmc.stats.Discrete(vals, probs)
 
-    # sample discrete distribution
+    # sample discrete distribution and check that the mean of the samples is
+    # within 3 std. dev. of the expected mean
     n_samples = 1_000_000
     samples = d3.sample(n_samples, seed=100)
-    # check that the mean of the samples is within 3 std. dev.
-    # of the expected mean
-    std_dev = samples.std() / np.sqrt(n_samples)
-    assert np.abs(exp_mean - samples.mean()) < 3*std_dev
+    assert_sample_mean(samples, exp_mean)
 
 
 def test_merge_discrete():
@@ -80,13 +84,12 @@ def test_uniform():
     np.testing.assert_array_equal(t.p, [1/(b-a), 1/(b-a)])
     assert t.interpolation == 'histogram'
 
+    # Sample distribution and check that the mean of the samples is within 3
+    # std. dev. of the expected mean
     exp_mean = 0.5 * (a + b)
     n_samples = 1_000_000
     samples = d.sample(n_samples, seed=100)
-    # check that the mean of the samples is within 3 std. dev.
-    # of the expected mean
-    std_dev = samples.std() / np.sqrt(n_samples)
-    assert np.abs(exp_mean - samples.mean()) < 3*std_dev
+    assert_sample_mean(samples, exp_mean)
 
 
 def test_powerlaw():
@@ -102,13 +105,11 @@ def test_powerlaw():
 
     exp_mean = 100.0 * (n+1) / (n+2)
 
-    # sample power law distribution
+    # sample power law distribution and check that the mean of the samples is
+    # within 3 std. dev. of the expected mean
     n_samples = 1_000_000
     samples = d.sample(n_samples, seed=100)
-    # check that the mean of the samples is within 3 std. dev.
-    # of the expected mean
-    std_dev = samples.std() / np.sqrt(n_samples)
-    assert np.abs(exp_mean - samples.mean()) < 3*std_dev
+    assert_sample_mean(samples, exp_mean)
 
 
 def test_maxwell():
@@ -122,21 +123,15 @@ def test_maxwell():
 
     exp_mean = 3/2 * theta
 
-    # sample maxwell distribution
+    # sample maxwell distribution and check that the mean of the samples is
+    # within 3 std. dev. of the expected mean
     n_samples = 1_000_000
     samples = d.sample(n_samples, seed=100)
-    # check that the mean of the samples is within 3 std. dev.
-    # of the expected mean
-    std_dev = samples.std() / np.sqrt(n_samples)
-    assert np.abs(exp_mean - samples.mean()) < 3*std_dev
+    assert_sample_mean(samples, exp_mean)
 
     # A second sample with a different seed
     samples_2 = d.sample(n_samples, seed=200)
-    # check that the mean of the samples is within 3 std. dev.
-    # of the expected mean
-    std_dev = samples_2.std() / np.sqrt(n_samples)
-    assert np.abs(exp_mean - samples_2.mean()) < 3*std_dev
-
+    assert_sample_mean(samples_2, exp_mean)
     assert samples_2.mean() != samples.mean()
 
 
@@ -156,13 +151,11 @@ def test_watt():
     # https://doi.org/10.1016/j.physletb.2003.09.048
     exp_mean = 3/2 * a + a**2 * b / 4
 
-    # sample Watt distribution
+    # sample Watt distribution and check that the mean of the samples is within
+    # 3 std. dev. of the expected mean
     n_samples = 1_000_000
     samples = d.sample(n_samples, seed=100)
-    # check that the mean of the samples is within 3 std. dev.
-    # of the expected mean
-    std_dev = samples.std() / np.sqrt(n_samples)
-    assert np.abs(exp_mean - samples.mean()) < 3*std_dev
+    assert_sample_mean(samples, exp_mean)
 
 
 def test_tabular():
@@ -227,6 +220,11 @@ def test_mixture():
     assert mix.probability == p
     assert mix.distribution == [d1, d2]
     assert len(mix) == 4
+
+    # Sample and make sure sample mean is close to expected mean
+    n_samples = 1_000_000
+    samples = mix.sample(n_samples)
+    assert_sample_mean(samples, (2.5 + 5.0)/2)
 
     elem = mix.to_xml_element('distribution')
 
@@ -427,3 +425,16 @@ def test_combine_distributions():
     assert isinstance(mixed, openmc.stats.Mixture)
     assert len(mixed.distribution) == 2
     assert len(mixed.probability) == 2
+
+    # Combine 1 discrete and 2 tabular -- the tabular distributions should
+    # combine to produce a uniform distribution with mean 0.5. The combined
+    # distribution should have a mean of 0.25.
+    t1 = openmc.stats.Tabular([0., 1.], [2.0, 0.0])
+    t2 = openmc.stats.Tabular([0., 1.], [0.0, 2.0])
+    d1 = openmc.stats.Discrete([0.0], [1.0])
+    combined = openmc.stats.combine_distributions([t1, t2, d1], [0.25, 0.25, 0.5])
+
+    # Sample the combined distribution and make sure the sample mean is within
+    # uncertainty of the expected value
+    samples = combined.sample(10)
+    assert_sample_mean(samples, 0.25)


### PR DESCRIPTION
This PR adds a `sources` property on the `openmc.data.Decay` class. This moves us one step closer to completing #1935. The `sources` property goes through all the listed spectra in the decay evaluation and turns them into proper probability distributions using classes from openmc.stats (namely `Tabular`, `Discrete`, and `Mixture`). Like particles (X-rays and gamma rays, for instance) are combined into a single distribution. Note that these distributions are not normalized to one; rather, their integral represents the intensity of the radiation (particles emitted per sec).