### PR TITLE
Allow OpenMC to compile against fmt v9

### DIFF
--- a/include/openmc/position.h
+++ b/include/openmc/position.h
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <stdexcept> // for out_of_range
 
+#include "fmt/format.h"
 #include "openmc/array.h"
 #include "openmc/vector.h"
 
@@ -209,5 +210,15 @@ std::ostream& operator<<(std::ostream& os, Position a);
 using Direction = Position;
 
 } // namespace openmc
+
+template<>
+struct fmt::formatter<openmc::Position> : formatter<std::string> {
+  template<typename FormatContext>
+  auto format(const openmc::Position& pos, FormatContext& ctx)
+  {
+    return fmt::formatter<std::string>::format(
+      fmt::format("({}, {}, {})", pos.x, pos.y, pos.z), ctx);
+  }
+};
 
 #endif // OPENMC_POSITION_H


### PR DESCRIPTION
This fixes the build of OpenMC against `fmt` v9.x.
