### PR TITLE
Add constructor to create a libMesh mesh from a libMesh pointer, as opposed to a mesh input file

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -720,7 +720,7 @@ private:
   int get_bin_from_element(const libMesh::Elem* elem) const;
 
   // Data members
-  unique_ptr<libMesh::MeshBase> unique_m_; //!< pointer to the libMesh MeshBase instance, only used if mesh is created inside OpenMC
+  unique_ptr<libMesh::MeshBase> unique_m_ = nullptr; //!< pointer to the libMesh MeshBase instance, only used if mesh is created inside OpenMC
   libMesh::MeshBase* m_; //!< pointer to libMesh MeshBase instance, always set during intialization
   vector<unique_ptr<libMesh::PointLocatorBase>>
     pl_; //!< per-thread point locators

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -8,6 +8,7 @@
 
 #include "hdf5.h"
 #include "xtensor/xtensor.hpp"
+#include "pugixml.hpp"
 
 #include "openmc/memory.h" // for unique_ptr
 #include "openmc/particle.h"

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -704,7 +704,7 @@ public:
 
   double volume(int bin) const override;
 
-  libMesh::MeshBase * mesh_ptr() const;
+  libMesh::MeshBase* mesh_ptr() const { return m_; };
 
 private:
   void initialize() override;
@@ -720,7 +720,7 @@ private:
 
   // Data members
   unique_ptr<libMesh::MeshBase> unique_m_; //!< pointer to the libMesh MeshBase instance, only used if mesh is created inside OpenMC
-  libMesh::MeshBase * m_; //!< pointer to libMesh MeshBase instance, always set during intialization
+  libMesh::MeshBase* m_; //!< pointer to libMesh MeshBase instance, always set during intialization
   vector<unique_ptr<libMesh::PointLocatorBase>>
     pl_; //!< per-thread point locators
   unique_ptr<libMesh::EquationSystems>

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -7,13 +7,13 @@
 #include <unordered_map>
 
 #include "hdf5.h"
-#include "pugixml.hpp"
 #include "xtensor/xtensor.hpp"
 
 #include "openmc/memory.h" // for unique_ptr
 #include "openmc/particle.h"
 #include "openmc/position.h"
 #include "openmc/vector.h"
+#include "openmc/xml_interface.h"
 
 #ifdef DAGMC
 #include "moab/AdaptiveKDTree.hpp"

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -704,6 +704,8 @@ public:
 
   double volume(int bin) const override;
 
+  libMesh::MeshBase * mesh_ptr() const;
+
 private:
   void initialize() override;
   void set_mesh_pointer_from_filename(const std::string& filename);

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -53,7 +53,7 @@ extern vector<unique_ptr<Mesh>> meshes;
 
 #ifdef LIBMESH
 namespace settings {
-// used when creating new libMesh::Mesh instances
+// used when creating new libMesh::MeshBase instances
 extern unique_ptr<libMesh::LibMeshInit> libmesh_init;
 extern const libMesh::Parallel::Communicator* libmesh_comm;
 } // namespace settings
@@ -671,7 +671,8 @@ class LibMesh : public UnstructuredMesh {
 public:
   // Constructors
   LibMesh(pugi::xml_node node);
-  LibMesh(const std::string& filename, double length_multiplier = 1.0);
+  LibMesh(const std::string & filename, double length_multiplier = 1.0);
+  LibMesh(libMesh::MeshBase & input_mesh, double length_multiplier = 1.0);
 
   static const std::string mesh_lib_type;
 
@@ -705,6 +706,7 @@ public:
 
 private:
   void initialize() override;
+  void set_mesh_pointer_from_filename(const std::string& filename);
 
   // Methods
 
@@ -715,7 +717,8 @@ private:
   int get_bin_from_element(const libMesh::Elem* elem) const;
 
   // Data members
-  unique_ptr<libMesh::Mesh> m_; //!< pointer to the libMesh mesh instance
+  unique_ptr<libMesh::MeshBase> unique_m_; //!< pointer to the libMesh MeshBase instance, only used if mesh is created inside OpenMC
+  libMesh::MeshBase * m_; //!< pointer to libMesh MeshBase instance
   vector<unique_ptr<libMesh::PointLocatorBase>>
     pl_; //!< per-thread point locators
   unique_ptr<libMesh::EquationSystems>

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -718,7 +718,7 @@ private:
 
   // Data members
   unique_ptr<libMesh::MeshBase> unique_m_; //!< pointer to the libMesh MeshBase instance, only used if mesh is created inside OpenMC
-  libMesh::MeshBase * m_; //!< pointer to libMesh MeshBase instance
+  libMesh::MeshBase * m_; //!< pointer to libMesh MeshBase instance, always set during intialization
   vector<unique_ptr<libMesh::PointLocatorBase>>
     pl_; //!< per-thread point locators
   unique_ptr<libMesh::EquationSystems>

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2324,7 +2324,7 @@ const std::string LibMesh::mesh_lib_type = "libmesh";
 
 LibMesh::LibMesh(pugi::xml_node node) : UnstructuredMesh(node)
 {
-  std::string& filename = get_node_value(node, "filename");
+  std::string filename = get_node_value(node, "filename");
   double length_multiplier = std::stod(get_node_value(node, "length_multiplier"));
   set_mesh_pointer_from_filename(filename);
   set_length_multiplier(length_multiplier);

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2369,7 +2369,7 @@ void LibMesh::initialize()
     libMesh::MeshTools::Modification::scale(*m_, length_multiplier_);
   }
   // if OpenMC is managing the libMesh::MeshBase instance, prepare the mesh.
-  // Otherwise assume that it is prepared by it's owning application
+  // Otherwise assume that it is prepared by its owning application
   if (unique_m_) {
     m_->prepare_for_use();
   }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2324,6 +2324,7 @@ const std::string LibMesh::mesh_lib_type = "libmesh";
 
 LibMesh::LibMesh(pugi::xml_node node) : UnstructuredMesh(node)
 {
+  // filename_ and length_multiplier_ will already be set by the UnstructuredMesh constructor
   set_mesh_pointer_from_filename(filename_);
   set_length_multiplier(length_multiplier_);
   initialize();

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2332,6 +2332,9 @@ LibMesh::LibMesh(libMesh::MeshBase & input_mesh, double length_multiplier)
 {
   m_ = &input_mesh;
   set_length_multiplier(length_multiplier);
+  if (specified_length_multiplier_) {
+    libMesh::MeshTools::Modification::scale(*m_, length_multiplier_);
+  }
   initialize();
 }
 
@@ -2340,6 +2343,10 @@ LibMesh::LibMesh(const std::string& filename, double length_multiplier)
 {
   set_mesh_pointer_from_filename(filename);
   set_length_multiplier(length_multiplier);
+  if (specified_length_multiplier_) {
+    libMesh::MeshTools::Modification::scale(*m_, length_multiplier_);
+  }
+  m_->prepare_for_use();
   initialize();
 }
 
@@ -2361,12 +2368,6 @@ void LibMesh::initialize()
 
   // assuming that unstructured meshes used in OpenMC are 3D
   n_dimension_ = 3;
-
-  if (specified_length_multiplier_) {
-    libMesh::MeshTools::Modification::scale(*m_, length_multiplier_);
-  }
-
-  m_->prepare_for_use();
 
   // ensure that the loaded mesh is 3 dimensional
   if (m_->mesh_dimension() != n_dimension_) {
@@ -2563,6 +2564,11 @@ const libMesh::Elem& LibMesh::get_element_from_bin(int bin) const
 double LibMesh::volume(int bin) const
 {
   return m_->elem_ref(bin).volume();
+}
+
+libMesh::MeshBase * mesh_ptr() const
+{
+  return m_;
 }
 
 #endif // LIBMESH

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2366,6 +2366,8 @@ void LibMesh::initialize()
     libMesh::MeshTools::Modification::scale(*m_, length_multiplier_);
   }
 
+  m_->prepare_for_use()
+
   // ensure that the loaded mesh is 3 dimensional
   if (m_->mesh_dimension() != n_dimension_) {
     fatal_error(fmt::format("Mesh file {} specified for use in an unstructured "

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2566,11 +2566,6 @@ double LibMesh::volume(int bin) const
   return m_->elem_ref(bin).volume();
 }
 
-libMesh::MeshBase * mesh_ptr() const
-{
-  return m_;
-}
-
 #endif // LIBMESH
 
 //==============================================================================

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2324,8 +2324,8 @@ const std::string LibMesh::mesh_lib_type = "libmesh";
 
 LibMesh::LibMesh(pugi::xml_node node) : UnstructuredMesh(node)
 {
-  std::string& filename = node.get_node_value(node, "filename");
-  double length_multiplier = std::stod(node.get_node_value(node, "length_multiplier"));
+  std::string& filename = get_node_value(node, "filename");
+  double length_multiplier = std::stod(get_node_value(node, "length_multiplier"));
   set_mesh_pointer_from_filename(filename);
   set_length_multiplier(length_multiplier);
   if (specified_length_multiplier_) {

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2366,7 +2366,7 @@ void LibMesh::initialize()
     libMesh::MeshTools::Modification::scale(*m_, length_multiplier_);
   }
 
-  m_->prepare_for_use()
+  m_->prepare_for_use();
 
   // ensure that the loaded mesh is 3 dimensional
   if (m_->mesh_dimension() != n_dimension_) {

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2324,6 +2324,14 @@ const std::string LibMesh::mesh_lib_type = "libmesh";
 
 LibMesh::LibMesh(pugi::xml_node node) : UnstructuredMesh(node)
 {
+  std::string& filename = node.get_node_value(node, "filename");
+  double length_multiplier = std::stod(node.get_node_value(node, "length_multiplier"));
+  set_mesh_pointer_from_filename(filename);
+  set_length_multiplier(length_multiplier);
+  if (specified_length_multiplier_) {
+    libMesh::MeshTools::Modification::scale(*m_, length_multiplier_);
+  }
+  m_->prepare_for_use();
   initialize();
 }
 


### PR DESCRIPTION
This PR is a working implementation of Issue #2102. The changes made are to support Cardinal simulations, which would be the source of the libMesh pointer. This will facilitate both adaptive mesh refinement and core thermal expansion simulations, where Cardinal can modify the mesh and pass it around in-memory, without having to create a new output file / read an input file at each step. Closes #2102.