### PR TITLE
`Material.add_components()` method

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -408,6 +408,8 @@ class Material(IDManagerMixin):
     def add_components(self, components: dict, percent_type: str = 'ao'):
         """ Add multiple elements or nuclides to a material
 
+        .. versionadded:: 0.13.1
+
         Parameters
         ----------
         components : dict of str to float or dict
@@ -442,17 +444,14 @@ class Material(IDManagerMixin):
                     raise ValueError("An entry in the dictionary does not have "
                                      "a required key: 'percent'")
 
-            percent = params.pop('percent')
-            args = (percent, percent_type)
+            params['percent_type'] = percent_type
 
             ## check if nuclide
             if str.isdigit(component[-1]):
-                self.add_nuclide(component, *args)
+                self.add_nuclide(component, **params)
             else: # is element
                 kwargs = params
-                self.add_element(component, *args, **kwargs)
-
-            params['percent'] = percent
+                self.add_element(component, **params)
 
     def remove_nuclide(self, nuclide: str):
         """Remove a nuclide from the material

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -414,11 +414,11 @@ class Material(IDManagerMixin):
 
         Examples
         --------
-        >> mat = openmc.Material()
-        >> components  = {'Li': (1.0, {'enrichment': 60.0, 'enrichment_target': 'Li7'}),
-                          'Fl': 1.0,
-                          'Be6': (0.5, 'wo')}
-        >> mat.add_elements_or_nuclides(components)
+        >>> mat = openmc.Material()
+        >>> components  = {'Li': (1.0, {'enrichment': 60.0, 'enrichment_target': 'Li7'}),
+        >>>               'Fl': 1.0,
+        >>>               'Be6': (0.5, 'wo')}
+        >>> mat.add_elements_or_nuclides(components)
 
         """
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -417,6 +417,18 @@ class Material(IDManagerMixin):
         for nuclide, (percent, percent_type) in nuclides.items():
                 self.add_nuclide(nuclide, percent, percent_type)
 
+    def add_elements(self, elements: dict):
+        """ Add multiple elements to a material
+
+        Parameters
+        ----------
+        elements : dict of str to tuple
+            Dictionary mapping element names to a tuple containing their
+            atom or weight percent.
+        """
+
+        for element, (percent, percent_type) in elements.items():
+                self.add_element(element, percent, percent_type)
     def remove_nuclide(self, nuclide: str):
         """Remove a nuclide from the material
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -403,6 +403,20 @@ class Material(IDManagerMixin):
 
         self._nuclides.append(NuclideTuple(nuclide, percent, percent_type))
 
+    def add_nuclides(self, nuclides: dict):
+        """ Add multiple nuclides to a material
+
+        Parameters
+        ----------
+        nuclides : dict of str to tuple
+            Dictionary mapping nuclide names to a tuple containing their
+            atom or weight percent.
+
+        """
+
+        for nuclide, (percent, percent_type) in nuclides.items():
+                self.add_nuclide(nuclide, percent, percent_type)
+
     def remove_nuclide(self, nuclide: str):
         """Remove a nuclide from the material
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -34,7 +34,9 @@ class Material(IDManagerMixin):
     To create a material, one should create an instance of this class, add
     nuclides or elements with :meth:`Material.add_nuclide` or
     :meth:`Material.add_element`, respectively, and set the total material
-    density with :meth:`Material.set_density()`. The material can then be
+    density with :meth:`Material.set_density()`. Alternatively, you can
+    use :meth:`Material.add_elements_or_nuclides()` to pass a dictionary
+    containing all the component information. The material can then be
     assigned to a cell using the :attr:`Cell.fill` attribute.
 
     Parameters

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -403,32 +403,41 @@ class Material(IDManagerMixin):
 
         self._nuclides.append(NuclideTuple(nuclide, percent, percent_type))
 
-    def add_nuclides(self, nuclides: dict):
-        """ Add multiple nuclides to a material
+    def add_elements_or_nuclides(self, components: dict):
+        """ Add multiple elements or nuclides to a material
 
         Parameters
         ----------
-        nuclides : dict of str to tuple
-            Dictionary mapping nuclide names to a tuple containing their
-            atom or weight percent.
+        components : dict of str to tuple
+            Dictionary mapping element or nuclide names to a tuple containing
+            their atom or weight percent, as well as any other arguments.
+
+        Examples
+        --------
+        >> mat = openmc.Material()
+        >> components  = {'Li': (1.0, {'enrichment': 60.0, 'enrichment_target': 'Li7'}),
+                          'Fl': 1.0,
+                          'Be6': (0.5, 'wo')}
+        >> mat.add_elements_or_nuclides(components)
 
         """
 
-        for nuclide, (percent, percent_type) in nuclides.items():
-                self.add_nuclide(nuclide, percent, percent_type)
+        for component, args in components.items():
+            cv.check_type('component', component, str)
+            percent_type = 'ao'
+            if isinstance(args, float):
+                args = (args,)
 
-    def add_elements(self, elements: dict):
-        """ Add multiple elements to a material
+            ## check if nuclide
+            if str.isdigit(component[-1]):
+                self.add_nuclide(component, *args)
+            else: # is element
+                kwargs = {}
+                if isinstance(args[-1], dict):
+                    kwargs = args[-1]
+                    args = args[:-1]
+                self.add_element(component, *args, **kwargs)
 
-        Parameters
-        ----------
-        elements : dict of str to tuple
-            Dictionary mapping element names to a tuple containing their
-            atom or weight percent.
-        """
-
-        for element, (percent, percent_type) in elements.items():
-                self.add_element(element, percent, percent_type)
     def remove_nuclide(self, nuclide: str):
         """Remove a nuclide from the material
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -35,7 +35,7 @@ class Material(IDManagerMixin):
     nuclides or elements with :meth:`Material.add_nuclide` or
     :meth:`Material.add_element`, respectively, and set the total material
     density with :meth:`Material.set_density()`. Alternatively, you can
-    use :meth:`Material.add_elements_or_nuclides()` to pass a dictionary
+    use :meth:`Material.add_components()` to pass a dictionary
     containing all the component information. The material can then be
     assigned to a cell using the :attr:`Cell.fill` attribute.
 
@@ -405,40 +405,54 @@ class Material(IDManagerMixin):
 
         self._nuclides.append(NuclideTuple(nuclide, percent, percent_type))
 
-    def add_elements_or_nuclides(self, components: dict):
+    def add_components(self, components: dict, percent_type: str = 'ao'):
         """ Add multiple elements or nuclides to a material
 
         Parameters
         ----------
-        components : dict of str to tuple
-            Dictionary mapping element or nuclide names to a tuple containing
-            their atom or weight percent, as well as any other arguments.
+        components : dict of str to float or dict
+            Dictionary mapping element or nuclide names to their atom or weight
+            percent. To specify enrichment of an element, the entry of
+            ``components`` for that element must instead be a dictionary
+            containing the keyword arguments as well as a value for
+            ``'percent'``
+        percent_type : {'ao', 'wo'}
+            'ao' for atom percent and 'wo' for weight percent
 
         Examples
         --------
         >>> mat = openmc.Material()
-        >>> components  = {'Li': (1.0, {'enrichment': 60.0, 'enrichment_target': 'Li7'}),
-        >>>               'Fl': 1.0,
-        >>>               'Be6': (0.5, 'wo')}
-        >>> mat.add_elements_or_nuclides(components)
+        >>> components  = {'Li': {'percent': 1.0,
+        >>>                       'enrichment': 60.0,
+        >>>                       'enrichment_target': 'Li7'},
+        >>>                'Fl': 1.0,
+        >>>                'Be6': 0.5}
+        >>> mat.add_components(components)
 
         """
 
-        for component, args in components.items():
+        for component, params in components.items():
             cv.check_type('component', component, str)
-            percent_type = 'ao'
-            if isinstance(args, float):
-                args = (args,)
+            if isinstance(params, float):
+                params = {'percent': params}
+
+            else:
+                cv.check_type('params', params, dict)
+                if 'percent' not in params:
+                    raise ValueError("An entry in the dictionary does not have "
+                                     "a required key: 'percent'")
+
+            percent = params.pop('percent')
+            args = (percent, percent_type)
 
             ## check if nuclide
             if str.isdigit(component[-1]):
                 self.add_nuclide(component, *args)
             else: # is element
-                kwargs = {}
-                if isinstance(args[-1], dict):
-                    kwargs = args[-1]
-                    args = args[:-1]
+                kwargs = params
                 self.add_element(component, *args, **kwargs)
+
+            params['percent'] = percent
 
     def remove_nuclide(self, nuclide: str):
         """Remove a nuclide from the material

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -25,31 +25,39 @@ def test_add_nuclide():
     with pytest.raises(ValueError):
         m.add_nuclide('H1', 1.0, 'oa')
 
-def test_add_nuclides():
-    """Test adding multipe nuclides at once"""
+def test_add_elements_or_nuclides():
+    """Test adding multipe elements or nuclides at once"""
     m = openmc.Material()
-    nuclides = {'H1': (2.0, 'ao'),
-                'O16': (1.0, 'wo')}
-    m.add_nuclides(nuclides)
-
-    # wt-%
-    m = openmc.Material()
-    nuclides = {'H1': (2.0, 'wo'),
-                'O16': (1.0, 'wo')}
-    m.add_nuclides(nuclides)
-
-    # mixed
-    m = openmc.Material()
-    nuclides = {'H1': (2.0, 'ao'),
-                'O16': (1.0, 'wo')}
-    m.add_nuclides(nuclides)
-
-    with pytest.raises(TypeError):
-        m.add_nuclides({'H1': ('1.0', 'ao')})
-    with pytest.raises(TypeError):
-        m.add_nuclides({1.0: ('H1', 'wo')})
+    components = {'H1': 2.0,
+                'O16': (1.0, 'wo'),
+                'Zr': 1.0,
+                'O': (1.0, 'wo'),
+                'U': (1.0, {'enrichment': 4.5}),
+                'Li': (1.0, 'ao', {'enrichment': 60.0, 'enrichment_target': 'Li7'}),
+                'H': (1.0, 'ao', {'enrichment': 50.0, 'enrichment_target': 'H2', 'enrichment_type': 'wo'})}
+    m.add_elements_or_nuclides(components)
     with pytest.raises(ValueError):
-        m.add_nuclides({'H1': (1.0, 'oa')})
+        m.add_elements_or_nuclides({'U': (1.0, 'ao', {'enrichment': 100.0})})
+    with pytest.raises(ValueError):
+        m.add_elements_or_nuclides({'Pu': (1.0, 'ao', {'enrichment': 3.0})})
+    with pytest.raises(ValueError):
+        m.add_elements_or_nuclides({'U': (1.0, 'ao', {'enrichment': 70.0, 'enrichment_target': 'U235'})})
+    with pytest.raises(ValueError):
+        m.add_elements_or_nuclides({'He': (1.0, 'ao', {'enrichment': 17.0, 'enrichment_target': 'He6'})})
+    with pytest.raises(ValueError):
+        m.add_elements_or_nuclides({'li': (1.0, 'ao')})  # should fail as 1st char is lowercase
+    with pytest.raises(ValueError):
+        m.add_elements_or_nuclides({'LI': (1.0, 'ao')})  # should fail as 2nd char is uppercase
+    with pytest.raises(ValueError):
+        m.add_elements_or_nuclides({'Xx': (1.0, 'ao')})  # should fail as Xx is not an element
+    with pytest.raises(ValueError):
+        m.add_elements_or_nuclides({'n': (1.0, 'ao')})  # check to avoid n for neutron being accepted
+    with pytest.raises(TypeError):
+        m.add_elements_or_nuclides({'H1': ('1.0', 'ao')})
+    with pytest.raises(TypeError):
+        m.add_elements_or_nuclides({1.0: ('H1', 'wo')})
+    with pytest.raises(ValueError):
+        m.add_elements_or_nuclides({'H1': (1.0, 'oa')})
 
 
 def test_remove_nuclide():
@@ -75,7 +83,7 @@ def test_remove_elements():
     assert m.nuclides[0].percent == 1.0
 
 
-def test_elements():
+def test_add_element():
     """Test adding elements."""
     m = openmc.Material()
     m.add_element('Zr', 1.0)
@@ -99,7 +107,6 @@ def test_elements():
         m.add_element('Xx', 1.0)  # should fail as Xx is not an element
     with pytest.raises(ValueError):
         m.add_element('n', 1.0)  # check to avoid n for neutron being accepted
-
 
 def test_elements_by_name():
     """Test adding elements by name"""

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -25,39 +25,51 @@ def test_add_nuclide():
     with pytest.raises(ValueError):
         m.add_nuclide('H1', 1.0, 'oa')
 
-def test_add_elements_or_nuclides():
+def test_add_components():
     """Test adding multipe elements or nuclides at once"""
     m = openmc.Material()
     components = {'H1': 2.0,
-                'O16': (1.0, 'wo'),
-                'Zr': 1.0,
-                'O': (1.0, 'wo'),
-                'U': (1.0, {'enrichment': 4.5}),
-                'Li': (1.0, 'ao', {'enrichment': 60.0, 'enrichment_target': 'Li7'}),
-                'H': (1.0, 'ao', {'enrichment': 50.0, 'enrichment_target': 'H2', 'enrichment_type': 'wo'})}
-    m.add_elements_or_nuclides(components)
+                  'O16': 1.0,
+                  'Zr': 1.0,
+                  'O': 1.0,
+                  'U': {'percent': 1.0,
+                        'enrichment': 4.5},
+                  'Li': {'percent': 1.0,
+                         'enrichment': 60.0,
+                         'enrichment_target': 'Li7'},
+                  'H': {'percent': 1.0,
+                        'enrichment': 50.0,
+                        'enrichment_target': 'H2',
+                        'enrichment_type': 'wo'}}
+    m.add_components(components)
     with pytest.raises(ValueError):
-        m.add_elements_or_nuclides({'U': (1.0, 'ao', {'enrichment': 100.0})})
+        m.add_components({'U': {'percent': 1.0,
+                                'enrichment': 100.0}})
     with pytest.raises(ValueError):
-        m.add_elements_or_nuclides({'Pu': (1.0, 'ao', {'enrichment': 3.0})})
+        m.add_components({'Pu': {'percent': 1.0,
+                                 'enrichment': 3.0}})
     with pytest.raises(ValueError):
-        m.add_elements_or_nuclides({'U': (1.0, 'ao', {'enrichment': 70.0, 'enrichment_target': 'U235'})})
+        m.add_components({'U': {'percent': 1.0,
+                                'enrichment': 70.0,
+                                'enrichment_target':'U235'}})
     with pytest.raises(ValueError):
-        m.add_elements_or_nuclides({'He': (1.0, 'ao', {'enrichment': 17.0, 'enrichment_target': 'He6'})})
+        m.add_components({'He': {'percent': 1.0,
+                                 'enrichment': 17.0,
+                                 'enrichment_target': 'He6'}})
     with pytest.raises(ValueError):
-        m.add_elements_or_nuclides({'li': (1.0, 'ao')})  # should fail as 1st char is lowercase
+        m.add_components({'li': 1.0})  # should fail as 1st char is lowercase
     with pytest.raises(ValueError):
-        m.add_elements_or_nuclides({'LI': (1.0, 'ao')})  # should fail as 2nd char is uppercase
+        m.add_components({'LI': 1.0})  # should fail as 2nd char is uppercase
     with pytest.raises(ValueError):
-        m.add_elements_or_nuclides({'Xx': (1.0, 'ao')})  # should fail as Xx is not an element
+        m.add_components({'Xx': 1.0})  # should fail as Xx is not an element
     with pytest.raises(ValueError):
-        m.add_elements_or_nuclides({'n': (1.0, 'ao')})  # check to avoid n for neutron being accepted
+        m.add_components({'n': 1.0})  # check to avoid n for neutron being accepted
     with pytest.raises(TypeError):
-        m.add_elements_or_nuclides({'H1': ('1.0', 'ao')})
+        m.add_components({'H1': '1.0'})
     with pytest.raises(TypeError):
-        m.add_elements_or_nuclides({1.0: ('H1', 'wo')})
+        m.add_components({1.0: 'H1'}, percent_type = 'wo')
     with pytest.raises(ValueError):
-        m.add_elements_or_nuclides({'H1': (1.0, 'oa')})
+        m.add_components({'H1': 1.0}, percent_type = 'oa')
 
 
 def test_remove_nuclide():

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -25,6 +25,32 @@ def test_add_nuclide():
     with pytest.raises(ValueError):
         m.add_nuclide('H1', 1.0, 'oa')
 
+def test_add_nuclides():
+    """Test adding multipe nuclides at once"""
+    m = openmc.Material()
+    nuclides = {'H1': (2.0, 'ao'),
+                'O16': (1.0, 'wo')}
+    m.add_nuclides(nuclides)
+
+    # wt-%
+    m = openmc.Material()
+    nuclides = {'H1': (2.0, 'wo'),
+                'O16': (1.0, 'wo')}
+    m.add_nuclides(nuclides)
+
+    # mixed
+    m = openmc.Material()
+    nuclides = {'H1': (2.0, 'ao'),
+                'O16': (1.0, 'wo')}
+    m.add_nuclides(nuclides)
+
+    with pytest.raises(TypeError):
+        m.add_nuclides({'H1': ('1.0', 'ao')})
+    with pytest.raises(TypeError):
+        m.add_nuclides({1.0: ('H1', 'wo')})
+    with pytest.raises(ValueError):
+        m.add_nuclides({'H1': (1.0, 'oa')})
+
 
 def test_remove_nuclide():
     """Test removing nuclides."""
@@ -441,7 +467,7 @@ def test_activity_of_tritium():
     m1.add_nuclide("H3", 1)
     m1.set_density('g/cm3', 1)
     m1.volume = 1
-    assert pytest.approx(m1.activity) == 3.559778e14 
+    assert pytest.approx(m1.activity) == 3.559778e14
 
 
 def test_activity_of_metastable():


### PR DESCRIPTION
This PR adds a new method to the `Material` class, `add_components()`, which accepts a `dict` of components (elements or nuclides) in `{'ZA': percent}` format for nuclides and `{'ZA': percent}` or `{'ZA': **kwargs}`  format for elements.

Closes #2069 