### PR TITLE
added specific_activity to openmc.Material

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -929,8 +929,10 @@ class Material(IDManagerMixin):
         
         if normalization == 'total':
             multiplier = self.volume
-        else:
-            multiplier = 1 if normalization == 'volume' else 1.0 / self.get_mass_density()
+        elif normalization == 'volume':
+            multiplier = 1
+        elif normalization == 'mass':
+            multiplier = 1.0 / self.get_mass_density()
             
         activity = {}
         for nuclide, atoms_per_bcm in self.get_nuclide_atom_densities().items():

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -928,9 +928,9 @@ class Material(IDManagerMixin):
 
         if units == 'Bq':
             multiplier = self.volume
-        elif units == 'Bq/g':
-            multiplier = 1
         elif units == 'Bq/cm3':
+            multiplier = 1
+        elif units == 'Bq/g':
             multiplier = 1.0 / self.get_mass_density()
 
         activity = {}

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -945,9 +945,9 @@ class Material(IDManagerMixin):
             activity in [Bq/g].
         """
         activity = {}
-        for nuclide, atoms in self.get_nuclide_atoms().items():
+        for nuclide, atoms in self.get_nuclide_atom_densities().items():
             inv_seconds = openmc.data.decay_constant(nuclide)
-            activity[nuclide] = (inv_seconds * atoms) / self.get_mass()
+            activity[nuclide] = (inv_seconds * atoms * 1.0e24) / self.density
         return activity
 
     def get_nuclide_atoms(self):

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -899,7 +899,7 @@ class Material(IDManagerMixin):
 
         return nuclides
 
-    def get_activity(self, normalization: str = 'total', by_nuclide: bool = False):
+    def get_activity(self, normalization: str = 'volume', by_nuclide: bool = False):
         """Returns the activity of the material or for each nuclide in the
         material in units of [Bq], [Bq/g] or [Bq/cc].
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -94,6 +94,9 @@ class Material(IDManagerMixin):
     activity : float
         Activity of the material in [Bq]. Requires that the :attr:`volume`
         attribute is set.
+    specific_activity : float
+        Activity of the material per unit mass in [Bq/kg]. Requires that the
+        :attr:`volume` and :attr:`density` attributes are set.
 
     """
 
@@ -154,6 +157,11 @@ class Material(IDManagerMixin):
     def activity(self):
         """Returns the total activity of the material in Becquerels."""
         return sum(self.get_nuclide_activity().values())
+
+    @property
+    def specific_activity(self):
+        """Returns the total specific activity of the material in Becquerels per gram."""
+        return sum(self.get_nuclide_specific_activity().values())
 
     @property
     def name(self):
@@ -923,6 +931,23 @@ class Material(IDManagerMixin):
         for nuclide, atoms in self.get_nuclide_atoms().items():
             inv_seconds = openmc.data.decay_constant(nuclide)
             activity[nuclide] = inv_seconds * atoms
+        return activity
+
+    def get_nuclide_specific_activity(self):
+        """Return specific activity in [Bq/g] for each nuclide in the material
+
+        .. versionadded:: 0.13.1
+
+        Returns
+        -------
+        dict
+            Dictionary whose keys are nuclide names and values are specific
+            activity in [Bq/g].
+        """
+        activity = {}
+        for nuclide, atoms in self.get_nuclide_atoms().items():
+            inv_seconds = openmc.data.decay_constant(nuclide)
+            activity[nuclide] = (inv_seconds * atoms) / self.get_mass()
         return activity
 
     def get_nuclide_atoms(self):

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -910,9 +910,10 @@ class Material(IDManagerMixin):
         units : {'Bq', 'Bq/g', 'Bq/cm3'}
             Specifies the type of activity to return, options include total
             activity [Bq], specific [Bq/g] or volumetric activity [Bq/cm3].
+            Default is volumetric activity [Bq/cm3].
         by_nuclide : bool
             Specifies if the activity should be returned for the material as a
-            whole or per nuclide.
+            whole or per nuclide. Default is False.
 
         Returns
         -------

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -899,18 +899,17 @@ class Material(IDManagerMixin):
 
         return nuclides
 
-    def get_activity(self, normalization: str = 'volume', by_nuclide: bool = False):
+    def get_activity(self, units: str = 'Bq/cm3', by_nuclide: bool = False):
         """Returns the activity of the material or for each nuclide in the
-        material in units of [Bq], [Bq/g] or [Bq/cc].
+        material in units of [Bq], [Bq/g] or [Bq/cm3].
 
         .. versionadded:: 0.13.1
 
         Parameters
         ----------
-        normalization : {'total', 'mass', 'volume'}
-            Specifies the type of activity to return, 'total' will return the
-            material activity in [Bq], 'mass' returns the materials specific
-            activity in [Bq/g] and 'volume' returns the activity in [Bq/cc].
+        units : {'Bq', 'Bq/g', 'Bq/cm3'}
+            Specifies the type of activity to return, options include total
+            activity [Bq], specific [Bq/g] or volumetric activity [Bq/cm3].
         by_nuclide : bool
             Specifies if the activity should be returned for the material as a
             whole or per nuclide.
@@ -924,16 +923,16 @@ class Material(IDManagerMixin):
             of the material is returned as a float.
         """
 
-        cv.check_value('normalization', normalization, {'total', 'mass', 'volume'})
+        cv.check_value('units', units, {'Bq', 'Bq/g', 'Bq/cm3'})
         cv.check_type('by_nuclide', by_nuclide, bool)
-        
-        if normalization == 'total':
+
+        if units == 'Bq':
             multiplier = self.volume
-        elif normalization == 'volume':
+        elif units == 'Bq/g':
             multiplier = 1
-        elif normalization == 'mass':
+        elif units == 'Bq/cm3':
             multiplier = 1.0 / self.get_mass_density()
-            
+
         activity = {}
         for nuclide, atoms_per_bcm in self.get_nuclide_atom_densities().items():
             inv_seconds = openmc.data.decay_constant(nuclide)
@@ -943,7 +942,6 @@ class Material(IDManagerMixin):
             return activity
         else:
             return sum(activity.values())
-
 
     def get_nuclide_atoms(self):
         """Return number of atoms of each nuclide in the material

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -917,7 +917,6 @@ class Material(IDManagerMixin):
 
         Returns
         -------
-
         Union[dict, float]
             If by_nuclide is True then a dictionary whose keys are nuclide 
             names and values are activity is returned. Otherwise the activity
@@ -939,10 +938,7 @@ class Material(IDManagerMixin):
             inv_seconds = openmc.data.decay_constant(nuclide)
             activity[nuclide] = inv_seconds * 1e24 * atoms_per_bcm * multiplier
 
-        if by_nuclide:
-            return activity
-        else:
-            return sum(activity.values())
+        return activity if by_nuclide else sum(activity.values())
 
     def get_nuclide_atoms(self):
         """Return number of atoms of each nuclide in the material

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -481,7 +481,7 @@ def test_activity_of_stable():
 
 
 def test_activity_of_tritium():
-    """Checks that 1g of tritium has the correct activity activity scaling"""
+    """Checks that 1g of tritium has the correct activity scaling"""
     m1 = openmc.Material()
     m1.add_nuclide("H3", 1)
     m1.set_density('g/cm3', 1)

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -471,16 +471,19 @@ def test_mix_materials():
     assert m5.density == pytest.approx(dens5)
 
 
-def test_activity_of_stable():
+def test_get_activity_of_stable_nuclides():
     """Creates a material with stable isotopes to checks the activity is 0"""
     m1 = openmc.Material()
     m1.add_element("Fe", 1)
-    m1.set_density('g/cm3', 1)
+    m1.set_density('g/cm3', 1.5)
+    # activity in Bq/cc and Bq/g should not require volume setting
+    assert m1.get_activity(normalization='volume') == 0
+    assert m1.get_activity(normalization='mass') == 0
     m1.volume = 1
     assert m1.get_activity() == 0
 
 
-def test_activity_of_tritium():
+def test_get_activity_of_tritium():
     """Checks that 1g of tritium has the correct activity scaling"""
     m1 = openmc.Material()
     m1.add_nuclide("H3", 1)
@@ -493,7 +496,7 @@ def test_activity_of_tritium():
     assert pytest.approx(m1.get_activity()) == 3.559778e14*2*3
 
 
-def test_activity_of_metastable():
+def test_get_activity_of_metastable():
     """Checks that 1 mol of a Tc99_m1 nuclides has the correct activity"""
     m1 = openmc.Material()
     m1.add_nuclide("Tc99_m1", 1)
@@ -502,7 +505,7 @@ def test_activity_of_metastable():
     assert pytest.approx(m1.get_activity(), rel=0.001) == 1.93e19
 
 
-def test_specific_activity_of_tritium():
+def test_get_activity_of_tritium_nuclides():
     """Checks that specific and volumetric activity of tritium are correct"""
     m1 = openmc.Material()
     m1.add_nuclide("H3", 1)

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -474,7 +474,7 @@ def test_mix_materials():
 def test_get_activity():
     """Tests the activity of stable, metastable and active materials"""
 
-    # Creates a material with stable isotopes to checks the activity is 0
+    # Creates a material with stable isotopes to check the activity is 0
     m1 = openmc.Material()
     m1.add_element("Fe", 0.7)
     m1.add_element("Li", 0.3)
@@ -506,15 +506,15 @@ def test_get_activity():
     # Checks that specific and volumetric activity of tritium are correct
     m4 = openmc.Material()
     m4.add_nuclide("H3", 1)
-    m4.set_density('g/cm3', 1)
-    assert m4.get_activity(normalization='mass') == 355978108155966.0  # [Bq/g]
+    m4.set_density('g/cm3', 1.5)
+    assert m4.get_activity(normalization='mass') == 355978108155966.0*2/3  # [Bq/g]
     assert m4.get_activity(normalization='mass', by_nuclide=True) == {
-        "H3": 355978108155966.0  # [Bq/g]
+        "H3": 355978108155966.0*2/3  # [Bq/g]
     }
-    assert m4.get_activity(normalization='volume') == 355978108155965.94 # [Bq/cc]
+    assert m4.get_activity(normalization='volume') == 355978108155965.94*3/2 # [Bq/cc]
     assert m4.get_activity(normalization='volume', by_nuclide=True) == {
-        "H3": 355978108155965.94 # [Bq/cc]
+        "H3": 355978108155965.94*3/2 # [Bq/cc]
     }
     # volume is required to calculate total activity
     m4.volume = 10.
-    assert m4.get_activity(normalization='total') == 3559781081559659.5 # [Bq]
+    assert m4.get_activity(normalization='total') == 355978108155965.94*3/2*10 # [Bq]

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -483,33 +483,33 @@ def test_get_activity():
     assert m1.get_activity(normalization='volume') == 0
     assert m1.get_activity(normalization='mass') == 0
     m1.volume = 1
-    assert m1.get_activity() == 0
+    assert m1.get_activity(normalization='total') == 0
 
     # Checks that 1g of tritium has the correct activity scaling
     m2 = openmc.Material()
     m2.add_nuclide("H3", 1)
     m2.set_density('g/cm3', 1)
     m2.volume = 1
-    assert pytest.approx(m2.get_activity()) == 3.559778e14
+    assert pytest.approx(m2.get_activity(normalization='total')) == 3.559778e14
     m2.set_density('g/cm3', 2)
-    assert pytest.approx(m2.get_activity()) == 3.559778e14*2
+    assert pytest.approx(m2.get_activity(normalization='total')) == 3.559778e14*2
     m2.volume = 3
-    assert pytest.approx(m2.get_activity()) == 3.559778e14*2*3
+    assert pytest.approx(m2.get_activity(normalization='total')) == 3.559778e14*2*3
 
     # Checks that 1 mol of a metastable nuclides has the correct activity
     m3 = openmc.Material()
     m3.add_nuclide("Tc99_m1", 1)
     m3.set_density('g/cm3', 1)
     m3.volume = 98.9
-    assert pytest.approx(m3.get_activity(), rel=0.001) == 1.93e19
+    assert pytest.approx(m3.get_activity(normalization='total'), rel=0.001) == 1.93e19
 
     # Checks that specific and volumetric activity of tritium are correct
     m4 = openmc.Material()
     m4.add_nuclide("H3", 1)
     m4.set_density('g/cm3', 1.5)
-    assert m4.get_activity(normalization='mass') == 355978108155966.0*2/3  # [Bq/g]
+    assert m4.get_activity(normalization='mass') == 355978108155965.94  # [Bq/g]
     assert m4.get_activity(normalization='mass', by_nuclide=True) == {
-        "H3": 355978108155966.0*2/3  # [Bq/g]
+        "H3": 355978108155965.94  # [Bq/g]
     }
     assert m4.get_activity(normalization='volume') == 355978108155965.94*3/2 # [Bq/cc]
     assert m4.get_activity(normalization='volume', by_nuclide=True) == {

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -481,12 +481,16 @@ def test_activity_of_stable():
 
 
 def test_activity_of_tritium():
-    """Checks that 1g of tritium has the correct activity"""
+    """Checks that 1g of tritium has the correct activity activity scaling"""
     m1 = openmc.Material()
     m1.add_nuclide("H3", 1)
     m1.set_density('g/cm3', 1)
     m1.volume = 1
     assert pytest.approx(m1.activity) == 3.559778e14
+    m1.set_density('g/cm3', 2)
+    assert pytest.approx(m1.activity) == 3.559778e14*2
+    m1.volume = 3
+    assert pytest.approx(m1.activity) == 3.559778e14*2*3
 
 
 def test_activity_of_metastable():
@@ -499,18 +503,9 @@ def test_activity_of_metastable():
 
 
 def test_specific_activity_of_tritium():
-    """Checks that specific activity stays the same for all volumes and
-    densities while activity changes proportionally to mass"""
+    """Checks that specific activity of tritium is correct"""
     m1 = openmc.Material()
     m1.add_nuclide("H3", 1)
     m1.set_density('g/cm3', 1)
-    m1.volume = 1
-    # activity and specific_activity are initially the same as we have 1g
-    assert pytest.approx(m1.specific_activity) == 3.559778e14
-    assert pytest.approx(m1.activity) == 3.559778e14
-    m1.set_density('g/cm3', 2)
-    assert pytest.approx(m1.specific_activity) == 3.559778e14
-    assert pytest.approx(m1.activity) == 3.559778e14*2
-    m1.volume = 3
-    assert pytest.approx(m1.specific_activity) == 3.559778e14
-    assert pytest.approx(m1.activity) == 3.559778e14*2*3
+    assert m1.specific_activity == 355978108155965.9
+    assert m1.get_nuclide_specific_activity() == {"H3": 355978108155965.9}

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -477,7 +477,7 @@ def test_activity_of_stable():
     m1.add_element("Fe", 1)
     m1.set_density('g/cm3', 1)
     m1.volume = 1
-    assert m1.activity == 0
+    assert m1.get_activity() == 0
 
 
 def test_activity_of_tritium():
@@ -486,11 +486,11 @@ def test_activity_of_tritium():
     m1.add_nuclide("H3", 1)
     m1.set_density('g/cm3', 1)
     m1.volume = 1
-    assert pytest.approx(m1.activity) == 3.559778e14
+    assert pytest.approx(m1.get_activity()) == 3.559778e14
     m1.set_density('g/cm3', 2)
-    assert pytest.approx(m1.activity) == 3.559778e14*2
+    assert pytest.approx(m1.get_activity()) == 3.559778e14*2
     m1.volume = 3
-    assert pytest.approx(m1.activity) == 3.559778e14*2*3
+    assert pytest.approx(m1.get_activity()) == 3.559778e14*2*3
 
 
 def test_activity_of_metastable():
@@ -499,13 +499,22 @@ def test_activity_of_metastable():
     m1.add_nuclide("Tc99_m1", 1)
     m1.set_density('g/cm3', 1)
     m1.volume = 98.9
-    assert pytest.approx(m1.activity, rel=0.001) == 1.93e19
+    assert pytest.approx(m1.get_activity(), rel=0.001) == 1.93e19
 
 
 def test_specific_activity_of_tritium():
-    """Checks that specific activity of tritium is correct"""
+    """Checks that specific and volumetric activity of tritium are correct"""
     m1 = openmc.Material()
     m1.add_nuclide("H3", 1)
     m1.set_density('g/cm3', 1)
-    assert m1.specific_activity == 355978108155965.9
-    assert m1.get_nuclide_specific_activity() == {"H3": 355978108155965.9}
+    assert m1.get_activity(normalization='mass') == 355978108155965.9  # [Bq/g]
+    assert m1.get_activity(normalization='mass', by_nuclide=True) == {
+        "H3": 355978108155965.9  # [Bq/g]
+    }
+    # volume is required to calculate total and volumetric activity
+    m1.volume = 10.
+    assert m1.get_activity(normalization='total') == 355978108155965.9*10. # [Bq]
+    assert m1.get_activity(normalization='volume') == 355978108155965.9/10. # [Bq/cc]
+    assert m1.get_activity(normalization='volume', by_nuclide=True) == {
+        "H3": 355978108155965.9/10. # [Bq/cc]
+    }

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -511,7 +511,6 @@ def test_get_activity():
     assert pytest.approx(m4.get_activity(normalization='mass', by_nuclide=True)["H3"]) == 355978108155965.94  # [Bq/g]
     assert pytest.approx(m4.get_activity(normalization='volume')) == 355978108155965.94*3/2 # [Bq/cc]
     assert pytest.approx(m4.get_activity(normalization='volume', by_nuclide=True)["H3"]) == 355978108155965.94*3/2 # [Bq/cc]
-    }
     # volume is required to calculate total activity
     m4.volume = 10.
     assert pytest.approx(m4.get_activity(normalization='total')) == 355978108155965.94*3/2*10 # [Bq]

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -507,14 +507,11 @@ def test_get_activity():
     m4 = openmc.Material()
     m4.add_nuclide("H3", 1)
     m4.set_density('g/cm3', 1.5)
-    assert m4.get_activity(normalization='mass') == 355978108155965.94  # [Bq/g]
-    assert m4.get_activity(normalization='mass', by_nuclide=True) == {
-        "H3": 355978108155965.94  # [Bq/g]
-    }
-    assert m4.get_activity(normalization='volume') == 355978108155965.94*3/2 # [Bq/cc]
-    assert m4.get_activity(normalization='volume', by_nuclide=True) == {
-        "H3": 355978108155965.94*3/2 # [Bq/cc]
+    assert pytest.approx(m4.get_activity(normalization='mass')) == 355978108155965.94  # [Bq/g]
+    assert pytest.approx(m4.get_activity(normalization='mass', by_nuclide=True)["H3"]) == 355978108155965.94  # [Bq/g]
+    assert pytest.approx(m4.get_activity(normalization='volume')) == 355978108155965.94*3/2 # [Bq/cc]
+    assert pytest.approx(m4.get_activity(normalization='volume', by_nuclide=True)["H3"]) == 355978108155965.94*3/2 # [Bq/cc]
     }
     # volume is required to calculate total activity
     m4.volume = 10.
-    assert m4.get_activity(normalization='total') == 355978108155965.94*3/2*10 # [Bq]
+    assert pytest.approx(m4.get_activity(normalization='total')) == 355978108155965.94*3/2*10 # [Bq]

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -480,37 +480,37 @@ def test_get_activity():
     m1.add_element("Li", 0.3)
     m1.set_density('g/cm3', 1.5)
     # activity in Bq/cc and Bq/g should not require volume setting
-    assert m1.get_activity(normalization='volume') == 0
-    assert m1.get_activity(normalization='mass') == 0
+    assert m1.get_activity(units='Bq/cm3') == 0
+    assert m1.get_activity(units='Bq/g') == 0
     m1.volume = 1
-    assert m1.get_activity(normalization='total') == 0
+    assert m1.get_activity(units='Bq') == 0
 
     # Checks that 1g of tritium has the correct activity scaling
     m2 = openmc.Material()
     m2.add_nuclide("H3", 1)
     m2.set_density('g/cm3', 1)
     m2.volume = 1
-    assert pytest.approx(m2.get_activity(normalization='total')) == 3.559778e14
+    assert pytest.approx(m2.get_activity(units='Bq')) == 3.559778e14
     m2.set_density('g/cm3', 2)
-    assert pytest.approx(m2.get_activity(normalization='total')) == 3.559778e14*2
+    assert pytest.approx(m2.get_activity(units='Bq')) == 3.559778e14*2
     m2.volume = 3
-    assert pytest.approx(m2.get_activity(normalization='total')) == 3.559778e14*2*3
+    assert pytest.approx(m2.get_activity(units='Bq')) == 3.559778e14*2*3
 
     # Checks that 1 mol of a metastable nuclides has the correct activity
     m3 = openmc.Material()
     m3.add_nuclide("Tc99_m1", 1)
     m3.set_density('g/cm3', 1)
     m3.volume = 98.9
-    assert pytest.approx(m3.get_activity(normalization='total'), rel=0.001) == 1.93e19
+    assert pytest.approx(m3.get_activity(units='Bq'), rel=0.001) == 1.93e19
 
     # Checks that specific and volumetric activity of tritium are correct
     m4 = openmc.Material()
     m4.add_nuclide("H3", 1)
     m4.set_density('g/cm3', 1.5)
-    assert pytest.approx(m4.get_activity(normalization='mass')) == 355978108155965.94  # [Bq/g]
-    assert pytest.approx(m4.get_activity(normalization='mass', by_nuclide=True)["H3"]) == 355978108155965.94  # [Bq/g]
-    assert pytest.approx(m4.get_activity(normalization='volume')) == 355978108155965.94*3/2 # [Bq/cc]
-    assert pytest.approx(m4.get_activity(normalization='volume', by_nuclide=True)["H3"]) == 355978108155965.94*3/2 # [Bq/cc]
+    assert pytest.approx(m4.get_activity(units='Bq/g')) == 355978108155965.94  # [Bq/g]
+    assert pytest.approx(m4.get_activity(units='Bq/g', by_nuclide=True)["H3"]) == 355978108155965.94  # [Bq/g]
+    assert pytest.approx(m4.get_activity(units='Bq/cm3')) == 355978108155965.94*3/2 # [Bq/cc]
+    assert pytest.approx(m4.get_activity(units='Bq/cm3', by_nuclide=True)["H3"]) == 355978108155965.94*3/2 # [Bq/cc]
     # volume is required to calculate total activity
     m4.volume = 10.
-    assert pytest.approx(m4.get_activity(normalization='total')) == 355978108155965.94*3/2*10 # [Bq]
+    assert pytest.approx(m4.get_activity(units='Bq')) == 355978108155965.94*3/2*10 # [Bq]

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -507,14 +507,14 @@ def test_specific_activity_of_tritium():
     m1 = openmc.Material()
     m1.add_nuclide("H3", 1)
     m1.set_density('g/cm3', 1)
-    assert m1.get_activity(normalization='mass') == 355978108155965.9  # [Bq/g]
+    assert m1.get_activity(normalization='mass') == 355978108155966.0  # [Bq/g]
     assert m1.get_activity(normalization='mass', by_nuclide=True) == {
-        "H3": 355978108155965.9  # [Bq/g]
+        "H3": 355978108155966.0  # [Bq/g]
     }
-    # volume is required to calculate total and volumetric activity
-    m1.volume = 10.
-    assert m1.get_activity(normalization='total') == 355978108155965.9*10. # [Bq]
-    assert m1.get_activity(normalization='volume') == 355978108155965.9/10. # [Bq/cc]
+    assert m1.get_activity(normalization='volume') == 355978108155965.94 # [Bq/cc]
     assert m1.get_activity(normalization='volume', by_nuclide=True) == {
-        "H3": 355978108155965.9/10. # [Bq/cc]
+        "H3": 355978108155965.94 # [Bq/cc]
     }
+    # volume is required to calculate total activity
+    m1.volume = 10.
+    assert m1.get_activity(normalization='total') == 3559781081559659.5 # [Bq]

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -496,3 +496,21 @@ def test_activity_of_metastable():
     m1.set_density('g/cm3', 1)
     m1.volume = 98.9
     assert pytest.approx(m1.activity, rel=0.001) == 1.93e19
+
+
+def test_specific_activity_of_tritium():
+    """Checks that specific activity stays the same for all volumes and
+    densities while activity changes proportionally to mass"""
+    m1 = openmc.Material()
+    m1.add_nuclide("H3", 1)
+    m1.set_density('g/cm3', 1)
+    m1.volume = 1
+    # activity and specific_activity are initially the same as we have 1g
+    assert pytest.approx(m1.specific_activity) == 3.559778e14
+    assert pytest.approx(m1.activity) == 3.559778e14
+    m1.set_density('g/cm3', 2)
+    assert pytest.approx(m1.specific_activity) == 3.559778e14
+    assert pytest.approx(m1.activity) == 3.559778e14*2
+    m1.volume = 3
+    assert pytest.approx(m1.specific_activity) == 3.559778e14
+    assert pytest.approx(m1.activity) == 3.559778e14*2*3


### PR DESCRIPTION
As proposed in issue #2141 it would be useful for decommissioning waste inventories to have the specific activity along with the activity of a material. ```openmc.Material.specific_activity``` has been added which returns the activity in Bq per gram. Some waste repositories have activity limits specified in Bq per gram for specific nuclides. 

This is a little more convenient for the user but it doesn't really save much to be honest as the user can divide by the material.get_mass() themselves. Just throwing in this tiny PR in case others also think the extra tiny amount of user convenience out weights the code bloat :smile: 