### PR TITLE
added option for year as time units

### DIFF
--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -111,7 +111,8 @@ class Results(list):
         time_units : {"s", "min", "h", "d", "a"}, optional
             Units for the returned time array. Default is ``"s"`` to
             return the value in seconds. Other options are minutes ``"min"``,
-            hours ``"hours"``, days ``"d"``, years ``"a"``
+            hours ``"hours"``, days ``"d"``, years ``"a"`` (Julian year 365.25
+            days).
 
             .. versionadded:: 0.12
 
@@ -207,6 +208,7 @@ class Results(list):
         time_units : {"s", "d", "min", "h", "a"}, optional
             Desired units for the times array. Options are seconds ``"s"``
             minutes ``"min"``, hours ``"hours"``, days ``"d"``, years ``"a"``
+            (Julian year 365.25 days).
 
         Returns
         -------
@@ -275,7 +277,8 @@ class Results(list):
         time_units : {"s", "d", "min", "h", "a"}, optional
             Return the vector in these units. Default is to
             convert to days ``"d"``. Other options are seconds ``"s"``, minutes
-            ``"min"``, hours ``"hours"``, years ``"a"`` 
+            ``"min"``, hours ``"hours"``, years ``"a"`` (Julian year 365.25
+            days).
 
         Returns
         -------
@@ -315,6 +318,7 @@ class Results(list):
         time_units : {"s", "d", "min", "h", "a"}, optional
             Units on ``time``. Default: days ``"d"``. Other options are seconds
             ``"s"``, minutes ``"min"``, hours ``"hours"`` and years ``"a"``
+            (Julian year 365.25 days)
         atol : float, optional
             Absolute tolerance (in ``time_units``) if ``time`` is not
             found.

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -16,7 +16,7 @@ __all__ = ["Results", "ResultsList"]
 
 
 def _get_time_as(seconds, units):
-    if units == "y":
+    if units == "a":
         return seconds / (60 * 60 * 24 * 365.25)  # 365.25 due to the leap year
     if units == "d":
         return seconds / (60 * 60 * 24)
@@ -97,7 +97,7 @@ class Results(list):
             Units for the returned concentration. Default is ``"atoms"``
 
             .. versionadded:: 0.12
-        time_units : {"s", "min", "h", "d", "y"}, optional
+        time_units : {"s", "min", "h", "d", "a"}, optional
             Units for the returned time array. Default is ``"s"`` to
             return the value in seconds.
 
@@ -111,7 +111,7 @@ class Results(list):
             Concentration of specified nuclide in units of ``nuc_units``
 
         """
-        cv.check_value("time_units", time_units, {"s", "d", "min", "h", "y"})
+        cv.check_value("time_units", time_units, {"s", "d", "min", "h", "a"})
         cv.check_value("nuc_units", nuc_units,
                     {"atoms", "atom/b-cm", "atom/cm3"})
 
@@ -192,7 +192,7 @@ class Results(list):
 
         Parameters
         ----------
-        time_units : {"s", "d", "min", "h", "y"}, optional
+        time_units : {"s", "d", "min", "h", "a"}, optional
             Desired units for the times array
 
         Returns
@@ -205,7 +205,7 @@ class Results(list):
             1 contains the associated uncertainty
 
         """
-        cv.check_value("time_units", time_units, {"s", "d", "min", "h", "y"})
+        cv.check_value("time_units", time_units, {"s", "d", "min", "h", "a"})
 
         times = np.empty_like(self, dtype=float)
         eigenvalues = np.empty((len(self), 2), dtype=float)
@@ -259,7 +259,7 @@ class Results(list):
 
         Parameters
         ----------
-        time_units : {"s", "d", "min", "h", "y"}, optional
+        time_units : {"s", "d", "min", "h", "a"}, optional
             Return the vector in these units. Default is to
             convert to days
 
@@ -269,7 +269,7 @@ class Results(list):
             1-D vector of time points
 
         """
-        cv.check_value("time_units", time_units, {"s", "d", "min", "h", "y"})
+        cv.check_value("time_units", time_units, {"s", "d", "min", "h", "a"})
 
         times = np.fromiter(
             (r.time[0] for r in self),
@@ -298,7 +298,7 @@ class Results(list):
         ----------
         time : float
             Desired point in time
-        time_units : {"s", "d", "min", "h", "y"}, optional
+        time_units : {"s", "d", "min", "h", "a"}, optional
             Units on ``time``. Default: days
         atol : float, optional
             Absolute tolerance (in ``time_units``) if ``time`` is not

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -24,7 +24,7 @@ def _get_time_as(seconds, units):
         The time to convert expressed in seconds
     units : {"s", "min", "h", "d", "a"}
         The units to convert time into. Available options are seconds ``"s"``,
-        minutes ``"min"``, hours ``"hours"`` days ``"d"``, years ``"a"``
+        minutes ``"min"``, hours ``"h"`` days ``"d"``, Julian years ``"a"``
 
     """
     if units == "a":
@@ -111,8 +111,7 @@ class Results(list):
         time_units : {"s", "min", "h", "d", "a"}, optional
             Units for the returned time array. Default is ``"s"`` to
             return the value in seconds. Other options are minutes ``"min"``,
-            hours ``"hours"``, days ``"d"``, years ``"a"`` (Julian year 365.25
-            days).
+            hours ``"h"``, days ``"d"``, and Julian years ``"a"``.
 
             .. versionadded:: 0.12
 
@@ -206,9 +205,9 @@ class Results(list):
         Parameters
         ----------
         time_units : {"s", "d", "min", "h", "a"}, optional
-            Desired units for the times array. Options are seconds ``"s"``
-            minutes ``"min"``, hours ``"hours"``, days ``"d"``, years ``"a"``
-            (Julian year 365.25 days).
+            Desired units for the times array. Options are seconds ``"s"``,
+            minutes ``"min"``, hours ``"h"``, days ``"d"``, and Julian years
+            ``"a"``.
 
         Returns
         -------
@@ -277,8 +276,7 @@ class Results(list):
         time_units : {"s", "d", "min", "h", "a"}, optional
             Return the vector in these units. Default is to
             convert to days ``"d"``. Other options are seconds ``"s"``, minutes
-            ``"min"``, hours ``"hours"``, years ``"a"`` (Julian year 365.25
-            days).
+            ``"min"``, hours ``"h"``, days ``"d"``, and Julian years ``"a"``.
 
         Returns
         -------
@@ -317,8 +315,7 @@ class Results(list):
             Desired point in time
         time_units : {"s", "d", "min", "h", "a"}, optional
             Units on ``time``. Default: days ``"d"``. Other options are seconds
-            ``"s"``, minutes ``"min"``, hours ``"hours"`` and years ``"a"``
-            (Julian year 365.25 days)
+            ``"s"``, minutes ``"min"``, hours ``"h"`` and Julian years ``"a"``.
         atol : float, optional
             Absolute tolerance (in ``time_units``) if ``time`` is not
             found.

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -16,6 +16,17 @@ __all__ = ["Results", "ResultsList"]
 
 
 def _get_time_as(seconds, units):
+    """Converts the time in seconds to time in different units
+
+    Parameters
+    ----------
+    seconds : float
+        The time to convert expressed in seconds
+    units : {"s", "min", "h", "d", "a"}
+        The units to convert time into. Available options are seconds ``"s"``,
+        minutes ``"min"``, hours ``"hours"`` days ``"d"``, years ``"a"``
+
+    """
     if units == "a":
         return seconds / (60 * 60 * 24 * 365.25)  # 365.25 due to the leap year
     if units == "d":
@@ -99,7 +110,8 @@ class Results(list):
             .. versionadded:: 0.12
         time_units : {"s", "min", "h", "d", "a"}, optional
             Units for the returned time array. Default is ``"s"`` to
-            return the value in seconds.
+            return the value in seconds. Other options are minutes ``"min"``,
+            hours ``"hours"``, days ``"d"``, years ``"a"``
 
             .. versionadded:: 0.12
 
@@ -193,7 +205,8 @@ class Results(list):
         Parameters
         ----------
         time_units : {"s", "d", "min", "h", "a"}, optional
-            Desired units for the times array
+            Desired units for the times array. Options are seconds ``"s"``
+            minutes ``"min"``, hours ``"hours"``, days ``"d"``, years ``"a"``
 
         Returns
         -------
@@ -261,7 +274,8 @@ class Results(list):
         ----------
         time_units : {"s", "d", "min", "h", "a"}, optional
             Return the vector in these units. Default is to
-            convert to days
+            convert to days ``"d"``. Other options are seconds ``"s"``, minutes
+            ``"min"``, hours ``"hours"``, years ``"a"`` 
 
         Returns
         -------
@@ -299,7 +313,8 @@ class Results(list):
         time : float
             Desired point in time
         time_units : {"s", "d", "min", "h", "a"}, optional
-            Units on ``time``. Default: days
+            Units on ``time``. Default: days ``"d"``. Other options are seconds
+            ``"s"``, minutes ``"min"``, hours ``"hours"`` and years ``"a"``
         atol : float, optional
             Absolute tolerance (in ``time_units``) if ``time`` is not
             found.

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -16,6 +16,8 @@ __all__ = ["Results", "ResultsList"]
 
 
 def _get_time_as(seconds, units):
+    if units == "y":
+        return seconds / (60 * 60 * 24 * 365.25)  # 365.25 due to the leap year
     if units == "d":
         return seconds / (60 * 60 * 24)
     elif units == "h":
@@ -95,7 +97,7 @@ class Results(list):
             Units for the returned concentration. Default is ``"atoms"``
 
             .. versionadded:: 0.12
-        time_units : {"s", "min", "h", "d"}, optional
+        time_units : {"s", "min", "h", "d", "y"}, optional
             Units for the returned time array. Default is ``"s"`` to
             return the value in seconds.
 
@@ -109,7 +111,7 @@ class Results(list):
             Concentration of specified nuclide in units of ``nuc_units``
 
         """
-        cv.check_value("time_units", time_units, {"s", "d", "min", "h"})
+        cv.check_value("time_units", time_units, {"s", "d", "min", "h", "y"})
         cv.check_value("nuc_units", nuc_units,
                     {"atoms", "atom/b-cm", "atom/cm3"})
 
@@ -190,7 +192,7 @@ class Results(list):
 
         Parameters
         ----------
-        time_units : {"s", "d", "h", "min"}, optional
+        time_units : {"s", "d", "min", "h", "y"}, optional
             Desired units for the times array
 
         Returns
@@ -203,7 +205,7 @@ class Results(list):
             1 contains the associated uncertainty
 
         """
-        cv.check_value("time_units", time_units, {"s", "d", "min", "h"})
+        cv.check_value("time_units", time_units, {"s", "d", "min", "h", "y"})
 
         times = np.empty_like(self, dtype=float)
         eigenvalues = np.empty((len(self), 2), dtype=float)
@@ -257,7 +259,7 @@ class Results(list):
 
         Parameters
         ----------
-        time_units : {"s", "d", "h", "min"}, optional
+        time_units : {"s", "d", "min", "h", "y"}, optional
             Return the vector in these units. Default is to
             convert to days
 
@@ -267,7 +269,7 @@ class Results(list):
             1-D vector of time points
 
         """
-        cv.check_value("time_units", time_units, {"s", "d", "min", "h"})
+        cv.check_value("time_units", time_units, {"s", "d", "min", "h", "y"})
 
         times = np.fromiter(
             (r.time[0] for r in self),
@@ -296,7 +298,7 @@ class Results(list):
         ----------
         time : float
             Desired point in time
-        time_units : {"s", "d", "min", "h"}, optional
+        time_units : {"s", "d", "min", "h", "y"}, optional
             Units on ``time``. Default: days
         atol : float, optional
             Absolute tolerance (in ``time_units``) if ``time`` is not

--- a/tests/unit_tests/test_deplete_resultslist.py
+++ b/tests/unit_tests/test_deplete_resultslist.py
@@ -77,7 +77,7 @@ def test_get_steps(unit):
     results = openmc.deplete.Results()
     # Time in units of unit
     times = np.linspace(0, 100, num=5)
-    if unit == "y":
+    if unit == "a":
         conversion_to_seconds = 60 * 60 * 24 * 365.25
     elif unit == "d":
         conversion_to_seconds = 60 * 60 * 24

--- a/tests/unit_tests/test_deplete_resultslist.py
+++ b/tests/unit_tests/test_deplete_resultslist.py
@@ -70,7 +70,7 @@ def test_get_keff(res):
     np.testing.assert_allclose(k[:, 1], u_ref)
 
 
-@pytest.mark.parametrize("unit", ("s", "d", "min", "h", "y"))
+@pytest.mark.parametrize("unit", ("s", "d", "min", "h", "a"))
 def test_get_steps(unit):
     # Make a Results full of near-empty Result instances
     # Just fill out a time schedule

--- a/tests/unit_tests/test_deplete_resultslist.py
+++ b/tests/unit_tests/test_deplete_resultslist.py
@@ -70,14 +70,16 @@ def test_get_keff(res):
     np.testing.assert_allclose(k[:, 1], u_ref)
 
 
-@pytest.mark.parametrize("unit", ("s", "d", "min", "h"))
+@pytest.mark.parametrize("unit", ("s", "d", "min", "h", "y"))
 def test_get_steps(unit):
     # Make a Results full of near-empty Result instances
     # Just fill out a time schedule
     results = openmc.deplete.Results()
     # Time in units of unit
     times = np.linspace(0, 100, num=5)
-    if unit == "d":
+    if unit == "y":
+        conversion_to_seconds = 60 * 60 * 24 * 365.25
+    elif unit == "d":
         conversion_to_seconds = 60 * 60 * 24
     elif unit == "h":
         conversion_to_seconds = 60 * 60


### PR DESCRIPTION
Just wondering if we could add another unit of years to the ```openmc.deplete.Results.get_times()```

We currently have seconds, minutes, hours, days but it would be useful to have years for long term waste depletion studies.

For my particular use case I'm irradiating a material to ascertaining if it exceeds the low level waste limits after a cooling time / decay time of multiple years.

I also spotted that the dictionary of times was different in a few places so I've put it in a consistent order ```{"s", "d", "min", "h", "y"}``` throughout the results.py file