### PR TITLE
Check for macroscopic data in materials when running Universe.plot

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -334,6 +334,13 @@ class Universe(UniverseBase):
             if seed is not None:
                 model.settings.seed = seed
 
+            # Determine whether any materials contains macroscopic data and if
+            # so, set energy mode accordingly
+            for mat in self.get_all_materials().values():
+                if mat._macroscopic is not None:
+                    model.settings.energy_mode = 'multi-group'
+                    break
+
             # Create plot object matching passed arguments
             plot = openmc.Plot()
             plot.origin = origin


### PR DESCRIPTION
This PR addresses #2064. Now, when `Universe.plot()` is called, it will scan through all the materials present to see if one of them has macroscopic data and if so, the energy mode is set to multi-group. Note that when using `Universe.plot` with multigroup data, you'll need to have the `OPENMC_MG_CROSS_SECTIONS` environment variable set in advance.