### PR TITLE
Change ordering of halfspaces for RectangularParallelepiped

### DIFF
--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -451,10 +451,10 @@ class RectangularParallelepiped(CompositeSurface):
         self.zmax = openmc.ZPlane(z0=zmax, **kwargs)
 
     def __neg__(self):
-        return +self.xmin & -self.xmax & +self.ymin & -self.ymax & +self.zmin & -self.zmax
+        return -self.xmax & +self.xmin & -self.ymax & +self.ymin & -self.zmax & +self.zmin
 
     def __pos__(self):
-        return -self.xmin | +self.xmax | -self.ymin | +self.ymax | -self.zmin | +self.zmax
+        return +self.xmax | -self.xmin | +self.ymax | -self.ymin | +self.zmax | -self.zmin
 
 
 class XConeOneSided(CompositeSurface):

--- a/tests/regression_tests/torus/inputs_true.dat
+++ b/tests/regression_tests/torus/inputs_true.dat
@@ -3,7 +3,7 @@
   <cell id="1" material="1" region="-2" universe="1" />
   <cell id="2" material="1" region="-3" universe="1" />
   <cell id="3" material="1" region="-1" universe="1" />
-  <cell id="4" material="2" region="4 -5 6 -7 8 -9 2 3 1" universe="1" />
+  <cell id="4" material="2" region="-5 4 -7 6 -9 8 2 3 1" universe="1" />
   <surface coeffs="0.0 0.0 0.0 3 1.5 1" id="1" type="z-torus" />
   <surface coeffs="6 0.0 0.0 3 1.5 1" id="2" type="x-torus" />
   <surface coeffs="6 0.0 0.0 6 1 0.75" id="3" type="y-torus" />


### PR DESCRIPTION
This PR slightly modifies `__neg__` and `__pos__` for the `RectangularParallelepiped` composite surface. It makes no practical difference but it will help resolve an issue in our MCNP converter (openmc-dev/openmc_mcnp_adapter#1).