### PR TITLE
Initialize geometry

### DIFF
--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -69,6 +69,7 @@ void openmc_get_tally_next_id(int32_t* id);
 int openmc_global_tallies(double** ptr);
 int openmc_hard_reset();
 int openmc_init(int argc, char* argv[], const void* intracomm);
+void openmc_initialize_geometry();
 bool openmc_is_statepoint_batch();
 int openmc_legendre_filter_get_order(int32_t index, int* order);
 int openmc_legendre_filter_set_order(int32_t index, int order);

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -50,6 +50,7 @@ _dll.openmc_hard_reset.errcheck = _error_handler
 _dll.openmc_init.argtypes = [c_int, POINTER(POINTER(c_char)), c_void_p]
 _dll.openmc_init.restype = c_int
 _dll.openmc_init.errcheck = _error_handler
+_dll.openmc_initialize_geometry.restype = None
 _dll.openmc_get_keff.argtypes = [POINTER(c_double*2)]
 _dll.openmc_get_keff.restype = c_int
 _dll.openmc_get_keff.errcheck = _error_handler
@@ -291,6 +292,10 @@ def init(args=None, intracomm=None, output=True):
         _dll.openmc_init(argc, argv, intracomm)
     openmc.lib.is_initialized = True
 
+
+def init_geom():
+    """Initialize OpenMC geometry only """
+    _dll.openmc_initialize_geometry()
 
 def is_statepoint_batch():
     """Return whether statepoint will be written in current batch or not.

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -85,6 +85,7 @@ int openmc_finalize()
   settings::material_cell_offsets = true;
   settings::max_particles_in_flight = 100000;
   settings::max_splits = 1000;
+  settings::max_tracks = 1000;
   settings::n_inactive = 0;
   settings::n_particles = -1;
   settings::output_summary = true;

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -85,7 +85,6 @@ int openmc_finalize()
   settings::material_cell_offsets = true;
   settings::max_particles_in_flight = 100000;
   settings::max_splits = 1000;
-  settings::max_tracks = 1000;
   settings::n_inactive = 0;
   settings::n_particles = -1;
   settings::output_summary = true;
@@ -198,4 +197,11 @@ int openmc_hard_reset()
   // Reset the random number generator state
   openmc::openmc_set_seed(DEFAULT_SEED);
   return 0;
+
+void openmc_initialize_geometry()
+{
+  free_memory_geometry();
+  free_memory_surfaces();
+  read_geometry_xml();
+  finalize_geometry();
 }


### PR DESCRIPTION
This PR originated from a need I currently had to reinitialize a geometry when running OpenMc in memory `openmc.lib`, but  without having to re-initialize all with `openmc.lib.init()` :point_right: [forum](https://openmc.discourse.group/t/openmc-lib-geometry/1815). 
In order to add this capability I simply defined a new function `openmc_initialize_geometry ` in `/openmc/src/finalize.cpp`, that free the memory assigned to the geometry and simply re-assign it. I then added it as an external function to `/openmc/include/capi.h` and link to the Python API through  `/openmc/lib/core.py`. 
