### PR TITLE
Bump up number of samples in test_combine_distributions

### DIFF
--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -436,5 +436,5 @@ def test_combine_distributions():
 
     # Sample the combined distribution and make sure the sample mean is within
     # uncertainty of the expected value
-    samples = combined.sample(10)
+    samples = combined.sample(1000)
     assert_sample_mean(samples, 0.25)


### PR DESCRIPTION
Some of our CI runs have evidently been failing recently due to `test_combine_distributions` in `test_stats.py`. It looks like the problem is that a statistical check is performed on 10 samples drawn from a distribution. With only 10 samples, there's a lot of statistical noise, so it's not surprising that sometimes it fails. This PR simply bumps up the number of samples to 1000.