### PR TITLE
Some small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.o
 *.log
 *.out
+*.pkl
 
 # Compiler python objects
 *.pyc

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -785,7 +785,7 @@ class DAGMCUniverse(UniverseBase):
             Universe instance
         """
 
-        bounding_cell = openmc.Cell(fill=self, cell_id =bounding_cell_id, region=self.bounding_region(**kwargs))
+        bounding_cell = openmc.Cell(fill=self, cell_id=bounding_cell_id, region=self.bounding_region(**kwargs))
         return openmc.Universe(cells=[bounding_cell])
 
     @classmethod

--- a/tests/regression_tests/cpp_driver/test.py
+++ b/tests/regression_tests/cpp_driver/test.py
@@ -48,8 +48,8 @@ def cpp_driver(request):
 
     finally:
         # Remove local build directory when test is complete
-        shutil.rmtree('build')
-        os.remove('CMakeLists.txt')
+        shutil.rmtree(request.node.path.parent / 'build')
+        os.remove(request.node.path.parent / 'CMakeLists.txt')
 
 
 @pytest.fixture


### PR DESCRIPTION
This is a smattering of fixes I've come across when reviewing PRs or looking up something in the code:

  - Ignore Python pickle files (`*.pkl`) so plotter save files are unlikely to be added to the repo accidentally
  - Use the full path for removal of the `build` directory and `CMakeLists.txt` file generated by the C++ API regression test
  - Small formatting fix in `universe.py`