### PR TITLE
added bin_log_width to EnergyFilter() to help with plotting

### DIFF
--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1324,6 +1324,13 @@ class EnergyFilter(RealFilter):
             cv.check_greater_than('filter value', v0, 0., equality=True)
             cv.check_greater_than('filter value', v1, 0., equality=True)
 
+    def bin_log_width(self):
+        """Returns the base 10 log width of energy bins which is useful when
+        plotting the normalized flux"""
+        bin_edges = np.unique(self.bins)
+        log_width = np.log10(bin_edges[1:]/bin_edges[:-1])
+        return log_width
+
     @classmethod
     def from_group_structure(cls, group_structure):
         """Construct an EnergyFilter instance from a standard group structure.

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1324,7 +1324,8 @@ class EnergyFilter(RealFilter):
             cv.check_greater_than('filter value', v0, 0., equality=True)
             cv.check_greater_than('filter value', v1, 0., equality=True)
 
-    def bin_lethargy(self):
+    @property
+    def lethargy_bin_width(self):
         """Calculates the base 10 log width of energy bins which is useful when
         plotting the normalized flux.
 
@@ -1333,9 +1334,7 @@ class EnergyFilter(RealFilter):
         numpy.array
             Array of bin widths
         """
-        bin_edges = np.unique(self.bins)
-        log_width = np.log10(bin_edges[1:]/bin_edges[:-1])
-        return log_width
+        return np.log10(self.bins[:, 1]/self.bins[:, 0])
 
     @classmethod
     def from_group_structure(cls, group_structure):

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1325,8 +1325,14 @@ class EnergyFilter(RealFilter):
             cv.check_greater_than('filter value', v1, 0., equality=True)
 
     def bin_log_width(self):
-        """Returns the base 10 log width of energy bins which is useful when
-        plotting the normalized flux"""
+        """Calculates the base 10 log width of energy bins which is useful when
+        plotting the normalized flux.
+
+        Returns
+        -------
+        numpy.array
+            Array of bin widths
+        """
         bin_edges = np.unique(self.bins)
         log_width = np.log10(bin_edges[1:]/bin_edges[:-1])
         return log_width

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1324,7 +1324,7 @@ class EnergyFilter(RealFilter):
             cv.check_greater_than('filter value', v0, 0., equality=True)
             cv.check_greater_than('filter value', v1, 0., equality=True)
 
-    def bin_log_width(self):
+    def bin_lethargy(self):
         """Calculates the base 10 log width of energy bins which is useful when
         plotting the normalized flux.
 

--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 import openmc
 from pytest import fixture, approx
@@ -241,8 +242,14 @@ def test_first_moment(run_in_tmpdir, box_model):
         assert first_score(sph_flux_tally) == approx(flux)
         assert first_score(zernike_tally) == approx(scatter)
 
-
 def test_energy():
     f = openmc.EnergyFilter.from_group_structure('CCFE-709')
     assert f.bins.shape == (709, 2)
     assert len(f.values) == 710
+
+def test_lethargy_bin_width():
+    f = openmc.EnergyFilter.from_group_structure('VITAMIN-J-175')
+    assert len(f.lethargy_bin_width) == 175
+    energy_bins = openmc.mgxs.GROUP_STRUCTURES['VITAMIN-J-175'] 
+    assert f.lethargy_bin_width[0] == math.log10(energy_bins[1]/energy_bins[0])
+    assert f.lethargy_bin_width[-1] == math.log10(energy_bins[-1]/energy_bins[-2])

--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -242,10 +242,12 @@ def test_first_moment(run_in_tmpdir, box_model):
         assert first_score(sph_flux_tally) == approx(flux)
         assert first_score(zernike_tally) == approx(scatter)
 
+
 def test_energy():
     f = openmc.EnergyFilter.from_group_structure('CCFE-709')
     assert f.bins.shape == (709, 2)
     assert len(f.values) == 710
+
 
 def test_lethargy_bin_width():
     f = openmc.EnergyFilter.from_group_structure('VITAMIN-J-175')


### PR DESCRIPTION
Just wondering if we can add a few lines to the ```EnergyFilter``` class that allows one to conveniently access the log bin width.

This can useful when plotting spectra

```python
import matplotlib.pyplot as plt

results = openmc.StatePoint(results_filename)
cell_tally = results.get_tally(name='cell_spectra_tally')
energy_filter = cell_tally.find_filter(filter_type=openmc.filter.EnergyFilter)

bin_boundaries = energy_filter.lethargy_bin_width()
flux = cell_tally.mean.flatten()
norm_flux = flux / bin_boundaries

plt.figure()
plt.step(energy_filter.values[:-1], norm_flux)
plt.xscale('log')
plt.yscale('log')
plt.ylabel('Flux per unit lethargy [n/cm2-s]')
plt.show()
```