### PR TITLE
Add extern function to delete a tally by its index in the tallies vector

### DIFF
--- a/docs/source/capi/index.rst
+++ b/docs/source/capi/index.rst
@@ -460,6 +460,14 @@ Functions
    :return: Return status (negative if an error occurs)
    :rtype: int
 
+.. c:function:: int openmc_remove_tally(int32_t index);
+
+   Given an index of a tally, remove it from the tallies vector
+   :param int index: Index in tallies vector
+   :return: Return status (negative if an error occurs)
+   :rtype: int
+
+
 .. c:function:: int openmc_run()
 
    Run a simulation

--- a/docs/source/capi/index.rst
+++ b/docs/source/capi/index.rst
@@ -462,11 +462,10 @@ Functions
 
 .. c:function:: int openmc_remove_tally(int32_t index);
 
-   Given an index of a tally, remove it from the tallies vector
-   :param int index: Index in tallies vector
+   Given an index of a tally, remove it from the tallies array
+   :param int index: Index in tallies array
    :return: Return status (negative if an error occurs)
    :rtype: int
-
 
 .. c:function:: int openmc_run()
 

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -118,6 +118,7 @@ int openmc_regular_mesh_get_params(
 int openmc_regular_mesh_set_dimension(int32_t index, int n, const int* dims);
 int openmc_regular_mesh_set_params(int32_t index, int n, const double* ll,
   const double* ur, const double* width);
+int openmc_remove_tally(int32_t id);
 int openmc_reset();
 int openmc_reset_timers();
 int openmc_run();

--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -47,9 +47,9 @@ public:
 
   void set_nuclides(const vector<std::string>& nuclides);
 
-  const vector<int32_t>& filters() const { return filters_; }
+  const vector<int32_t>& filters() const { return filters_; } // returns vector of inidices corresponding to the tally this is called on
 
-  int32_t filters(int i) const { return filters_[i]; }
+  int32_t filters(int i) const { return filters_[i]; } // i corresponds to the index of the filter for this tally
 
   void set_filters(gsl::span<Filter*> filters);
 

--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -50,7 +50,8 @@ public:
   //! returns vector of indices corresponding to the tally this is called on
   const vector<int32_t>& filters() const { return filters_; } 
 
-  int32_t filters(int i) const { return filters_[i]; } // i corresponds to the index of the filter for this tally
+  //! \brief Returns the tally filter at index i
+  int32_t filters(int i) const { return filters_[i]; } 
 
   void set_filters(gsl::span<Filter*> filters);
 

--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -47,7 +47,8 @@ public:
 
   void set_nuclides(const vector<std::string>& nuclides);
 
-  const vector<int32_t>& filters() const { return filters_; } // returns vector of inidices corresponding to the tally this is called on
+  //! returns vector of indices corresponding to the tally this is called on
+  const vector<int32_t>& filters() const { return filters_; } 
 
   int32_t filters(int i) const { return filters_[i]; } // i corresponds to the index of the filter for this tally
 

--- a/openmc/lib/tally.py
+++ b/openmc/lib/tally.py
@@ -87,6 +87,9 @@ _dll.openmc_tally_set_type.errcheck = _error_handler
 _dll.openmc_tally_set_writable.argtypes = [c_int32, c_bool]
 _dll.openmc_tally_set_writable.restype = c_int
 _dll.openmc_tally_set_writable.errcheck = _error_handler
+_dll.openmc_remove_tally_from_tallies.argtypes = [c_int32]
+_dll.openmc_remove_tally_from_tallies.restype = None
+_dll.openmc_remove_tally_from_tallies.errcheck = _error_handler
 _dll.tallies_size.restype = c_size_t
 
 

--- a/openmc/lib/tally.py
+++ b/openmc/lib/tally.py
@@ -87,9 +87,9 @@ _dll.openmc_tally_set_type.errcheck = _error_handler
 _dll.openmc_tally_set_writable.argtypes = [c_int32, c_bool]
 _dll.openmc_tally_set_writable.restype = c_int
 _dll.openmc_tally_set_writable.errcheck = _error_handler
-_dll.openmc_remove_tally_from_tallies.argtypes = [c_int32]
-_dll.openmc_remove_tally_from_tallies.restype = c_int
-_dll.openmc_remove_tally_from_tallies.errcheck = _error_handler
+_dll.openmc_remove_tally.argtypes = [c_int32]
+_dll.openmc_remove_tally.restype = c_int
+_dll.openmc_remove_tally.errcheck = _error_handler
 _dll.tallies_size.restype = c_size_t
 
 

--- a/openmc/lib/tally.py
+++ b/openmc/lib/tally.py
@@ -406,7 +406,7 @@ class _TallyMapping(Mapping):
         """Delete a tally from tally vector and remove the ID,index pair from tally"""
         _dll.openmc_remove_tally(self._get_tally_index(key))
 
-    def _get_tally_index(self,key):
+    def _get_tally_index(self, key):
         """Given the ID, return the index"""
         index = c_int32()
         try:

--- a/openmc/lib/tally.py
+++ b/openmc/lib/tally.py
@@ -88,7 +88,7 @@ _dll.openmc_tally_set_writable.argtypes = [c_int32, c_bool]
 _dll.openmc_tally_set_writable.restype = c_int
 _dll.openmc_tally_set_writable.errcheck = _error_handler
 _dll.openmc_remove_tally_from_tallies.argtypes = [c_int32]
-_dll.openmc_remove_tally_from_tallies.restype = None
+_dll.openmc_remove_tally_from_tallies.restype = c_int
 _dll.openmc_remove_tally_from_tallies.errcheck = _error_handler
 _dll.tallies_size.restype = c_size_t
 

--- a/openmc/lib/tally.py
+++ b/openmc/lib/tally.py
@@ -390,7 +390,7 @@ class Tally(_FortranObjectWithID):
 
 class _TallyMapping(Mapping):
     def __getitem__(self, key):
-        return Tally(index=self._get_tally_index(key))
+        return Tally(index=self[key])
 
     def __iter__(self):
         for i in range(len(self)):
@@ -404,16 +404,6 @@ class _TallyMapping(Mapping):
 
     def __delitem__(self, key):
         """Delete a tally from tally vector and remove the ID,index pair from tally"""
-        _dll.openmc_remove_tally(self._get_tally_index(key))
-
-    def _get_tally_index(self, key):
-        """Given the ID, return the index"""
-        index = c_int32()
-        try:
-            _dll.openmc_get_tally_index(key, index)
-        except (AllocationError, InvalidIDError) as e:
-            # __contains__ expects a KeyError to work correctly
-            raise KeyError(str(e))
-        return index.value
+        _dll.openmc_remove_tally(self[key]._index)
 
 tallies = _TallyMapping()

--- a/openmc/lib/tally.py
+++ b/openmc/lib/tally.py
@@ -390,7 +390,12 @@ class Tally(_FortranObjectWithID):
 
 class _TallyMapping(Mapping):
     def __getitem__(self, key):
-        return Tally(index=self[key])
+        index = c_int32()
+        try:
+            _dll.openmc_get_tally_index(key, index)
+        except (AllocationError, InvalidIDError) as e:
+            # __contains__ expects a KeyError to work correctly
+            raise KeyError(str(e))
 
     def __iter__(self):
         for i in range(len(self)):

--- a/openmc/lib/tally.py
+++ b/openmc/lib/tally.py
@@ -396,6 +396,7 @@ class _TallyMapping(Mapping):
         except (AllocationError, InvalidIDError) as e:
             # __contains__ expects a KeyError to work correctly
             raise KeyError(str(e))
+        return Tally(index=index.value)
 
     def __iter__(self):
         for i in range(len(self)):
@@ -410,5 +411,15 @@ class _TallyMapping(Mapping):
     def __delitem__(self, key):
         """Delete a tally from tally vector and remove the ID,index pair from tally"""
         _dll.openmc_remove_tally(self[key]._index)
+
+    def _get_tally_index(self,key):
+        """Given the ID, return the index"""
+        index = c_int32()
+        try:
+            _dll.openmc_get_tally_index(key, index)
+        except (AllocationError, InvalidIDError) as e:
+            # __contains__ expects a KeyError to work correctly
+            raise KeyError(str(e))
+        return index.value
 
 tallies = _TallyMapping()

--- a/openmc/lib/tally.py
+++ b/openmc/lib/tally.py
@@ -412,14 +412,4 @@ class _TallyMapping(Mapping):
         """Delete a tally from tally vector and remove the ID,index pair from tally"""
         _dll.openmc_remove_tally(self[key]._index)
 
-    def _get_tally_index(self,key):
-        """Given the ID, return the index"""
-        index = c_int32()
-        try:
-            _dll.openmc_get_tally_index(key, index)
-        except (AllocationError, InvalidIDError) as e:
-            # __contains__ expects a KeyError to work correctly
-            raise KeyError(str(e))
-        return index.value
-
 tallies = _TallyMapping()

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -1285,7 +1285,8 @@ extern "C" int openmc_remove_tally(int32_t id)
   model::tallies.erase(model::tallies.begin() + index);
 
   // after erasing tally, remove id from map
-  model::tally_map.remove(id) return 0;
+  model::tally_map.erase(id);
+  return 0;
 }
 
 } // namespace openmc

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -46,8 +46,7 @@ namespace openmc {
 //==============================================================================
 
 namespace model {
-// map: key (tally ID) to value (tally index)
-// index coresponds to the tally ID's position in the tallies vector
+//! a mapping of tally ID to index in the tallies vector
 std::unordered_map<int, int> tally_map;
 vector<unique_ptr<Tally>> tallies;
 vector<int> active_tallies;

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -1277,9 +1277,9 @@ extern "C" size_t tallies_size()
 extern "C" void openmc_remove_tally_from_tallies(int32_t id)
 {
   // query map for index corersponding to the given id
-  int index = model::tally_map[id];
-  // delete the tally
-  model::tallies.erase(index);
+  int32_t index = model::tally_map[id];
+  // delete the tally via iterator pointing to correct position
+  model::tallies.erase(model::tallies.begin() + index);
 }
 
 } // namespace openmc

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -1275,11 +1275,17 @@ extern "C" size_t tallies_size()
 // given a tally ID, remove it from the tallies vector
 extern "C" int openmc_remove_tally(int32_t id)
 {
+  // check that id is in the map
+  if (!model::tally_map.contains(id)) {
+    return OPENMC_INVALID_ID;
+  }
   // query map for index corersponding to the given id
   int32_t index = model::tally_map.at(id);
   // delete the tally via iterator pointing to correct position
   model::tallies.erase(model::tallies.begin() + index);
-  return 0;
+
+  // after erasing tally, remove id from map
+  model::tally_map.remove(id) return 0;
 }
 
 } // namespace openmc

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -1274,7 +1274,7 @@ extern "C" size_t tallies_size()
 }
 
 // given a tally ID, remove it from the tallies vector
-extern "C" void remove_tally_from_tallies(int32_t id)
+extern "C" void openmc_remove_tally_from_tallies(int32_t id)
 {
   // query map for index corersponding to the given id
   int index = model::tally_map[id];

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -1273,12 +1273,13 @@ extern "C" size_t tallies_size()
 }
 
 // given a tally ID, remove it from the tallies vector
-extern "C" void openmc_remove_tally_from_tallies(int32_t id)
+extern "C" int openmc_remove_tally(int32_t id)
 {
   // query map for index corersponding to the given id
   int32_t index = model::tally_map[id];
   // delete the tally via iterator pointing to correct position
   model::tallies.erase(model::tallies.begin() + index);
+  return 0;
 }
 
 } // namespace openmc

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -1277,7 +1277,7 @@ extern "C" int openmc_remove_tally(int32_t id)
 {
   // check that id is in the map
   if (!model::tally_map.contains(id)) {
-    return OPENMC_INVALID_ID;
+    return OPENMC_E_INVALID_ID;
   }
   // query map for index corersponding to the given id
   int32_t index = model::tally_map.at(id);

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -47,7 +47,7 @@ namespace openmc {
 
 namespace model {
 // map: key (tally ID) to value (tally index)
-// index coresponds to the tally ID's posiition in the tallies vector
+// index coresponds to the tally ID's position in the tallies vector
 std::unordered_map<int, int> tally_map;
 vector<unique_ptr<Tally>> tallies;
 vector<int> active_tallies;

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -46,6 +46,8 @@ namespace openmc {
 //==============================================================================
 
 namespace model {
+// map: key (tally ID) to value (tally index)
+// index coresponds to the tally ID's posiition in the tallies vector
 std::unordered_map<int, int> tally_map;
 vector<unique_ptr<Tally>> tallies;
 vector<int> active_tallies;
@@ -1269,6 +1271,15 @@ extern "C" int openmc_global_tallies(double** ptr)
 extern "C" size_t tallies_size()
 {
   return model::tallies.size();
+}
+
+// given a tally ID, remove it from the tallies vector
+extern "C" void remove_tally_from_tallies(int32_t id)
+{
+  // query map for index corersponding to the given id
+  int index = model::tally_map[id];
+  // delete the tally
+  model::tallies.erase(index);
 }
 
 } // namespace openmc

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -1276,7 +1276,7 @@ extern "C" size_t tallies_size()
 extern "C" int openmc_remove_tally(int32_t id)
 {
   // query map for index corersponding to the given id
-  int32_t index = model::tally_map[id];
+  int32_t index = model::tally_map.at(id);
   // delete the tally via iterator pointing to correct position
   model::tallies.erase(model::tallies.begin() + index);
   return 0;

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -1276,7 +1276,7 @@ extern "C" size_t tallies_size()
 extern "C" int openmc_remove_tally(int32_t id)
 {
   // check that id is in the map
-  if (!model::tally_map.contains(id)) {
+  if (model::tally_map.count(id)!=1) {
     return OPENMC_E_INVALID_ID;
   }
   // query map for index corersponding to the given id

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -1273,19 +1273,18 @@ extern "C" size_t tallies_size()
 }
 
 // given a tally ID, remove it from the tallies vector
-extern "C" int openmc_remove_tally(int32_t id)
+extern "C" int openmc_remove_tally(int32_t index)
 {
   // check that id is in the map
-  if (model::tally_map.count(id)!=1) {
-    return OPENMC_E_INVALID_ID;
+  if (index <= 0 || index > model::tallies.size()) {
+    return OPENMC_E_OUT_OF_BOUNDS;
   }
-  // query map for index corersponding to the given id
-  int32_t index = model::tally_map.at(id);
+  // grab tally so it's ID can be obtained to remove the (ID,index) pair from tally_map
+  auto& tally = model::tallies[index];
+  model::tally_map.erase(tally->id_);
   // delete the tally via iterator pointing to correct position
   model::tallies.erase(model::tallies.begin() + index);
 
-  // after erasing tally, remove id from map
-  model::tally_map.erase(id);
   return 0;
 }
 

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -1276,7 +1276,7 @@ extern "C" size_t tallies_size()
 extern "C" int openmc_remove_tally(int32_t index)
 {
   // check that id is in the map
-  if (index <= 0 || index > model::tallies.size()) {
+  if (index < 0 || index > model::tallies.size()) {
     return OPENMC_E_OUT_OF_BOUNDS;
   }
   // grab tally so it's ID can be obtained to remove the (ID,index) pair from tally_map

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -1281,8 +1281,8 @@ extern "C" int openmc_remove_tally(int32_t index)
   }
   // grab tally so it's ID can be obtained to remove the (ID,index) pair from tally_map
   auto& tally = model::tallies[index];
-  model::tally_map.erase(tally->id_);
   // delete the tally via iterator pointing to correct position
+  // this calls the Tally destructor, removing the tally from the map as well
   model::tallies.erase(model::tallies.begin() + index);
 
   return 0;

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -339,16 +339,19 @@ def test_new_tally(lib_init):
     new_tally_with_id.scores = ['flux']
     assert len(openmc.lib.tallies) == 5
 
+
 def test_delete_tally(lib_init):
     # delete tally 10 which was added in the above test
     # check length is one less than before
-    openmc.lib.openmc_remove_tally(openmc.lib.get_tally_index(10))
+    del openmc.lib.tallies[10]
     assert len(openmc.lib.tallies) == 4
 
-def test_delete_invalid_id(lib_init):
-    # attempt to delete a tally that is guaranteed not to have a valid index
-    with pytest.raises(exc.InvalidIDError):
-        openmc.lib.openmc_remove_tally(np.max(id)+1)
+
+def test_invalid_tally_id(lib_init):
+    # attempt to access a tally that is guaranteed not to have a valid index
+    max_id = max(openmc.lib.tallies.keys())
+    with pytest.raises(KeyError):
+        openmc.lib.tallies[max_id+1]
 
 
 def test_tally_activate(lib_simulation_init):

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -339,19 +339,16 @@ def test_new_tally(lib_init):
     new_tally_with_id.scores = ['flux']
     assert len(openmc.lib.tallies) == 5
 
-def test_add_and_delete_tally(lib_init):
-    with pytest.raises(exc.AllocationError):
-        openmc.lib.Material(1)
-    new_tally = openmc.lib.Tally()
-    new_tally.scores = ['flux']
-    new_tally_with_id = openmc.lib.Tally(10)
-    new_tally_with_id.scores = ['flux']
-    assert len(openmc.lib.tallies) == 5
-    # delete tally and check length is one less than before
-    openmc_remove_tally(10)
+def test_delete_tally(lib_init):
+    # delete tally 10 which was added in the above test
+    # check length is one less than before
+    openmc.lib.openmc_remove_tally(openmc.lib.get_tally_index(10))
     assert len(openmc.lib.tallies) == 4
 
-# def test_delete_wrong_id():
+def test_delete_invalid_id(lib_init):
+    # attempt to delete a tally that is guaranteed not to have a valid index
+    with pytest.raises(exc.InvalidIDError):
+        openmc.lib.openmc_remove_tally(np.max(id)+1)
 
 
 def test_tally_activate(lib_simulation_init):

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -339,6 +339,20 @@ def test_new_tally(lib_init):
     new_tally_with_id.scores = ['flux']
     assert len(openmc.lib.tallies) == 5
 
+def test_add_and_delete_tally(lib_init):
+    with pytest.raises(exc.AllocationError):
+        openmc.lib.Material(1)
+    new_tally = openmc.lib.Tally()
+    new_tally.scores = ['flux']
+    new_tally_with_id = openmc.lib.Tally(10)
+    new_tally_with_id.scores = ['flux']
+    assert len(openmc.lib.tallies) == 5
+    # delete tally and check length is one less than before
+    openmc_remove_tally(10)
+    assert len(openmc.lib.tallies) == 4
+
+# def test_delete_wrong_id():
+
 
 def test_tally_activate(lib_simulation_init):
     t = openmc.lib.tallies[1]

--- a/tests/unit_tests/test_tallies.py
+++ b/tests/unit_tests/test_tallies.py
@@ -39,3 +39,6 @@ def test_xml_roundtrip(run_in_tmpdir):
     assert new_tally.triggers[0].trigger_type == tally.triggers[0].trigger_type
     assert new_tally.triggers[0].threshold == tally.triggers[0].threshold
     assert new_tally.triggers[0].scores == tally.triggers[0].scores
+    # delete tally and check that new_tallies now has length zero
+    new_tally.openmc_remove_tally_from_tallies(tally.id)
+    assert len(new_tallies) == 0

--- a/tests/unit_tests/test_tallies.py
+++ b/tests/unit_tests/test_tallies.py
@@ -39,6 +39,3 @@ def test_xml_roundtrip(run_in_tmpdir):
     assert new_tally.triggers[0].trigger_type == tally.triggers[0].trigger_type
     assert new_tally.triggers[0].threshold == tally.triggers[0].threshold
     assert new_tally.triggers[0].scores == tally.triggers[0].scores
-    # delete tally and check that new_tallies now has length zero
-    new_tally.openmc_remove_tally_from_tallies(tally.id)
-    assert len(new_tallies) == 0


### PR DESCRIPTION
Closes #2155. This PR adds a new function to `openmc/src/tallies/tally.cpp` with the signature `extern "C" void openmc_remove_tally_from_tallies(int32_t index)` that can delete a tally from the tally vector via its index. This will be useful in adaptive mesh refinement problems where a tally will need to be deleted and re-added to the problem every time the mesh, and thus the bins, change. Additionally, this function is added to the C++ API so it can be called, and it is tested in via a unit test in `openmc/tests/unit_tests/test_tallies.py`.

EDIT: After discussion in slack, it is likely possible to do AMR without this feature. Still, this is something worth adding to the C++ API. See #2162 for a future, low priority PR that cleans up the objects after a delete operation.