### PR TITLE
Fix Mixture.sample to account for intensities of underlying distributions

### DIFF
--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -61,12 +61,14 @@ def test_merge_discrete():
     assert merged.x == pytest.approx([0.0, 0.5, 1.0, 5.0, 10.0])
     assert merged.p == pytest.approx(
         [0.6*0.3, 0.4*0.4, 0.6*0.2 + 0.4*0.5, 0.4*0.1, 0.6*0.5])
+    assert merged.integral() == pytest.approx(1.0)
 
     # Probabilities add up but are not normalized
     d1 = openmc.stats.Discrete([3.0], [1.0])
     triple = openmc.stats.Discrete.merge([d1, d1, d1], [1.0, 2.0, 3.0])
     assert triple.x == pytest.approx([3.0])
     assert triple.p == pytest.approx([6.0])
+    assert triple.integral() == pytest.approx(6.0)
 
 
 def test_uniform():
@@ -186,6 +188,7 @@ def test_tabular():
     # test histogram sampling
     d = openmc.stats.Tabular(x, p, interpolation='histogram')
     d.normalize()
+    assert d.integral() == pytest.approx(1.0)
 
     samples = d.sample(n_samples, seed=100)
     diff = np.abs(samples - d.mean())
@@ -433,8 +436,9 @@ def test_combine_distributions():
     t2 = openmc.stats.Tabular([0., 1.], [0.0, 2.0])
     d1 = openmc.stats.Discrete([0.0], [1.0])
     combined = openmc.stats.combine_distributions([t1, t2, d1], [0.25, 0.25, 0.5])
+    assert combined.integral() == pytest.approx(1.0)
 
     # Sample the combined distribution and make sure the sample mean is within
     # uncertainty of the expected value
-    samples = combined.sample(1000)
+    samples = combined.sample(10_000)
     assert_sample_mean(samples, 0.25)


### PR DESCRIPTION
I was looking into why the `test_combine_distributions` test from test_stats.py might still fail, and although I don't have a good answer to that I did notice that the way we were handling sampling for the `Mixture` class is not quite right. If the underlying distributions stored in `Mixture` have non-unity integrals (intensities), those need to be accounted for when sampling the distributions. With that fixed in `Mixture.sample`, there is a corresponding change needed in `combine_distributions` (@eepeterson had suspected something was slightly off with how probabilities were being applied and he was correct in the end — mea culpa!).

I've also added a default `integral()` method for the `Univariate` class that returns 1.0. The only classes where the integral can be something other than 1 (Discrete, Tabular, Mixture) already have their own version of `integral()`.