### PR TITLE
Fix for centroid method in UnstructuredMesh class

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1476,7 +1476,7 @@ class UnstructuredMesh(MeshBase):
         Coordinates of the mesh vertices with array shape (n_elements, 3)
 
         .. versionadded:: 0.13.1
-    connectivity : numpy.ndarray 
+    connectivity : numpy.ndarray
         Connectivity of the elements with array shape (n_elements, 8)
 
         .. versionadded:: 0.13.1
@@ -1563,10 +1563,6 @@ class UnstructuredMesh(MeshBase):
         return np.sum(self.volumes)
 
     @property
-    def centroids(self):
-        return self._centroids
-
-    @property
     def vertices(self):
         return self._vertices
 
@@ -1628,8 +1624,8 @@ class UnstructuredMesh(MeshBase):
         Parameters
         ----------
         bin : int
-            Bin ID for the returned centroid 
-        
+            Bin ID for the returned centroid
+
         Returns
         -------
         numpy.ndarray
@@ -1637,6 +1633,8 @@ class UnstructuredMesh(MeshBase):
 
         """
         conn = self.connectivity[bin]
+        # remove invalid connectivity values
+        conn = conn[conn >= 0]
         coords = self.vertices[conn]
         return coords.mean(axis=0)
 

--- a/tests/regression_tests/unstructured_mesh/test.py
+++ b/tests/regression_tests/unstructured_mesh/test.py
@@ -37,6 +37,27 @@ class UnstructuredMeshTest(PyAPITestHarness):
 
     def _compare_results(self):
         with openmc.StatePoint(self._sp_name) as sp:
+            # check some properties of the unstructured mesh
+            umesh = None
+            for m in sp.meshes.values():
+                if isinstance(m, openmc.UnstructuredMesh):
+                    umesh = m
+            assert umesh is not None
+
+            # check that the first element centroid is correct
+            # this will depend on whether the tet mesh or hex mesh
+            # file is being used in this test
+            if umesh.element_types[0] == umesh._LINEAR_TET:
+                exp_vertex = (-10.0, -10.0, -10.0)
+                exp_centroid = (-8.75, -9.75, -9.25)
+            else:
+                exp_vertex = (-10.0, -10.0, 10.0)
+                exp_centroid = (-9.0, -9.0, 9.0)
+
+            np.testing.assert_array_equal(umesh.vertices[0], exp_vertex)
+            np.testing.assert_array_equal(umesh.centroid(0), exp_centroid)
+
+
             # loop over the tallies and get data
             for tally in sp.tallies.values():
                 # find the regular and unstructured meshes

--- a/tests/regression_tests/unstructured_mesh/test.py
+++ b/tests/regression_tests/unstructured_mesh/test.py
@@ -57,7 +57,6 @@ class UnstructuredMeshTest(PyAPITestHarness):
             np.testing.assert_array_equal(umesh.vertices[0], exp_vertex)
             np.testing.assert_array_equal(umesh.centroid(0), exp_centroid)
 
-
             # loop over the tallies and get data
             for tally in sp.tallies.values():
                 # find the regular and unstructured meshes


### PR DESCRIPTION
Someone pointed out that after #2103 unstructured mesh centroids were not being calculated correctly for tet meshes. This was caused by use of `-1` entries in the connectivity for tet elements when retrieving vertices. This corrects that problem and adds a check to the unstructured mesh regression test for the first vertex and centroid of the test meshes. 