### PR TITLE
Fix TimeFilter for very small time intervals with tracklength estimator

### DIFF
--- a/src/tallies/filter_time.cpp
+++ b/src/tallies/filter_time.cpp
@@ -55,12 +55,15 @@ void TimeFilter::get_all_bins(
     // the current track and find where it overlaps with time bins and score
     // accordingly
 
-    // Skip if time interval is zero
-    if (t_start == t_end)
-      return;
-
     // Determine first bin containing a portion of time interval
     auto i_bin = lower_bound_index(bins_.begin(), bins_.end(), t_start);
+
+    // If time interval is zero, add a match corresponding to the starting time
+    if (t_end == t_start) {
+      match.bins_.push_back(i_bin);
+      match.weights_.push_back(1.0);
+      return;
+    }
 
     // Find matching bins
     double dt_total = t_end - t_start;

--- a/tests/unit_tests/test_time_filter.py
+++ b/tests/unit_tests/test_time_filter.py
@@ -149,3 +149,39 @@ def test_time_filter_surface(model_surf, run_in_tmpdir):
 
         # After t0+ε, the current should be zero
         assert values[2] == 0.0
+
+
+def test_small_time_interval(run_in_tmpdir):
+    # Create a model with a photon source at 1.0e8 seconds. Based on the speed
+    # of the photon, the time intervals are on the order of 1e-9 seconds, which
+    # are effectively 0 when compared to the starting time of the photon.
+    mat = openmc.Material()
+    mat.add_element('N', 1.0)
+    mat.set_density('g/cm3', 0.001)
+    sph = openmc.Sphere(r=5.0, boundary_type='vacuum')
+    cell = openmc.Cell(fill=mat, region=-sph)
+    model = openmc.Model()
+    model.geometry = openmc.Geometry([cell])
+    model.settings.particles = 100
+    model.settings.batches = 10
+    model.settings.run_mode = 'fixed source'
+    model.settings.source = openmc.Source(
+        time=openmc.stats.Discrete([1.0e8], [1.0]),
+        particle='photon'
+    )
+
+    # Add tallies with and without a time filter that should match all particles
+    time_filter = openmc.TimeFilter([0.0, 1.0e100])
+    tally_with_filter = openmc.Tally()
+    tally_with_filter.filters = [time_filter]
+    tally_with_filter.scores = ['flux']
+    tally_without_filter = openmc.Tally()
+    tally_without_filter.scores = ['flux']
+    model.tallies.extend([tally_with_filter, tally_without_filter])
+
+    # Run the model and make sure the two tallies match
+    sp_filename = model.run()
+    with openmc.StatePoint(sp_filename) as sp:
+        flux_with = sp.tallies[tally_with_filter.id].mean.ravel()[0]
+        flux_without = sp.tallies[tally_without_filter.id].mean.ravel()[0]
+        assert flux_with == pytest.approx(flux_without)


### PR DESCRIPTION
This PR fixes #2156. The issue is as follows: if you have a source with a large time specified, e.g., 1.0e8 seconds, the time interval over a single track might be so small that the starting and ending time for that track are effectively the same. This is just a result of floating-point arithmetic because it's possible to have $t + Δt = t$ in if $Δt$ is small relative to $t$. Right now, such tracks will not get marked as match for a time filter even if the starting time is within a specified time bin. This is now fixed in `TimeFilter::get_all_bins` and for good measure, I've added a test that checks this particular condition.

Thanks to @tibetscarlett for identifying the issue and giving a proposed solution!