### PR TITLE
Tracks to vtk on object

### DIFF
--- a/openmc/tracks.py
+++ b/openmc/tracks.py
@@ -272,7 +272,7 @@ class Tracks(list):
         Parameters
         ----------
         filename : path-like
-            Name of the VTK file to write.
+            Name of the VTP file to write.
 
         Returns
         -------

--- a/openmc/tracks.py
+++ b/openmc/tracks.py
@@ -266,7 +266,7 @@ class Tracks(list):
             track.plot(ax)
         return ax
 
-    def write_tracks_to_vtk(self, filename):
+    def write_tracks_to_vtk(self, filename='tracks.vtk'):
         """Creates a VTK file of the tracks
 
         Parameters
@@ -286,12 +286,14 @@ class Tracks(list):
         points = vtk.vtkPoints()
         cells = vtk.vtkCellArray()
     
+        point_offset = 0
         for particle in self:
-            for state in particle.states:
-                points.InsertNextPoint(state['r'])
+            for pt in particle.particle_tracks:
+                for state in pt.states:
+                    points.InsertNextPoint(state['r'])
 
             # Create VTK line and assign points to line.
-            n = particle.states.size
+            n = pt.states.size
             line = vtk.vtkPolyLine()
             line.GetPointIds().SetNumberOfIds(n)
             for i in range(n):

--- a/openmc/tracks.py
+++ b/openmc/tracks.py
@@ -6,7 +6,7 @@ import h5py
 from .checkvalue import check_filetype_version
 from .source import SourceParticle, ParticleType
 
-
+from pathlib import Path
 ParticleTrack = namedtuple('ParticleTrack', ['particle', 'states'])
 ParticleTrack.__doc__ = """\
 Particle track information
@@ -266,18 +266,18 @@ class Tracks(list):
             track.plot(ax)
         return ax
 
-    def write_tracks_to_vtk(self, filename='tracks.vtk'):
-        """Creates a VTK file of the tracks
+    def write_tracks_to_vtk(self, filename=Path('tracks.vtk')):
+        """Creates a VTP file of the tracks
 
         Parameters
         ----------
-        filename : str
+        filename : path-like
             Name of the VTK file to write.
 
         Returns
         -------
-        vtk.vtkStructuredGrid
-            the VTK object
+        vtk.vtkPolyData
+            the VTK vtkPolyData object produced
         """
 
         import vtk
@@ -312,10 +312,10 @@ class Tracks(list):
             writer.SetInputData(data)
         else:
             writer.SetInput(data)
-        writer.SetFileName(filename)
+        writer.SetFileName(str(filename))  # SetFileName requires a string
         writer.Write()
 
-        return filename
+        return data
 
     @staticmethod
     def combine(track_files, path='tracks.h5'):

--- a/openmc/tracks.py
+++ b/openmc/tracks.py
@@ -7,6 +7,7 @@ from .checkvalue import check_filetype_version
 from .source import SourceParticle, ParticleType
 
 from pathlib import Path
+
 ParticleTrack = namedtuple('ParticleTrack', ['particle', 'states'])
 ParticleTrack.__doc__ = """\
 Particle track information
@@ -266,7 +267,7 @@ class Tracks(list):
             track.plot(ax)
         return ax
 
-    def write_tracks_to_vtk(self, filename=Path('tracks.vtk')):
+    def write_tracks_to_vtk(self, filename=Path('tracks.vtp')):
         """Creates a VTP file of the tracks
 
         Parameters

--- a/scripts/openmc-track-to-vtk
+++ b/scripts/openmc-track-to-vtk
@@ -14,8 +14,8 @@ def _parse_args():
     # Create argument parser.
     parser = argparse.ArgumentParser(
         description='Convert particle track file(s) to a .pvtp file.')
-    parser.add_argument('input', metavar='IN', type=str, nargs='+',
-                        help='Input particle track data filename(s).')
+    parser.add_argument('input', metavar='IN', type=str,
+                        help='Input particle track data filename.')
     parser.add_argument('-o', '--out', metavar='OUT', type=str, dest='out',
                         help='Output VTK poly data filename.')
 
@@ -33,41 +33,9 @@ def main():
     elif not args.out.endswith('.pvtp'):
         args.out += '.pvtp'
 
-    # Initialize data arrays and offset.
-    points = vtk.vtkPoints()
-    cells = vtk.vtkCellArray()
-    point_offset = 0
-    for fname in args.input:
-        # Write coordinate values to points array.
-        track_file = openmc.Tracks(fname)
-        for track in track_file:
-            for particle in track:
-                for state in particle.states:
-                    points.InsertNextPoint(state['r'])
-
-                # Create VTK line and assign points to line.
-                n = particle.states.size
-                line = vtk.vtkPolyLine()
-                line.GetPointIds().SetNumberOfIds(n)
-                for i in range(n):
-                    line.GetPointIds().SetId(i, point_offset + i)
-                point_offset += n
-
-                # Add line to cell array
-                cells.InsertNextCell(line)
-
-    data = vtk.vtkPolyData()
-    data.SetPoints(points)
-    data.SetLines(cells)
-
-    writer = vtk.vtkXMLPPolyDataWriter()
-    if vtk.vtkVersion.GetVTKMajorVersion() > 5:
-        writer.SetInputData(data)
-    else:
-        writer.SetInput(data)
-    writer.SetFileName(args.out)
-    writer.Write()
-
+    # Write coordinate values to points array.
+    track_file = openmc.Tracks(args.input)
+    track_file.write_tracks_to_vtk(args.out)
 
 if __name__ == '__main__':
     main()

--- a/tests/unit_tests/test_tracks.py
+++ b/tests/unit_tests/test_tracks.py
@@ -144,6 +144,7 @@ def test_filter(sphere_model, run_in_tmpdir):
 
 
 def test_write_tracks_to_vtk(sphere_model):
+    vtk = pytest.importorskip('vtk')
     # Set maximum number of tracks per process to write
     sphere_model.settings.max_tracks = 25
     sphere_model.settings.photon_transport = True
@@ -152,7 +153,7 @@ def test_write_tracks_to_vtk(sphere_model):
     generate_track_file(sphere_model, tracks=True)
 
     tracks = openmc.Tracks('tracks.h5')
-    filename = tracks.write_tracks_to_vtk('tracks.vtk')
+    polydata = tracks.write_tracks_to_vtk('tracks.vtp')
 
-    assert filename == 'tracks.vtk'
-    assert Path('tracks.vtk').is_file()
+    assert isinstance(polydata, vtk.vtkPolyData)
+    assert Path('tracks.vtp').is_file()

--- a/tests/unit_tests/test_tracks.py
+++ b/tests/unit_tests/test_tracks.py
@@ -142,7 +142,8 @@ def test_filter(sphere_model, run_in_tmpdir):
     matches = tracks.filter(particle='bunnytron')
     assert matches == []
 
-def test_write_tracks_to_vtk():
+
+def test_write_tracks_to_vtk(sphere_model):
     # Set maximum number of tracks per process to write
     sphere_model.settings.max_tracks = 25
     sphere_model.settings.photon_transport = True

--- a/tests/unit_tests/test_tracks.py
+++ b/tests/unit_tests/test_tracks.py
@@ -141,3 +141,17 @@ def test_filter(sphere_model, run_in_tmpdir):
     assert matches == tracks
     matches = tracks.filter(particle='bunnytron')
     assert matches == []
+
+def test_write_tracks_to_vtk():
+    # Set maximum number of tracks per process to write
+    sphere_model.settings.max_tracks = 25
+    sphere_model.settings.photon_transport = True
+
+    # Run OpenMC to generate tracks.h5 file
+    generate_track_file(sphere_model, tracks=True)
+
+    tracks = openmc.Tracks('tracks.h5')
+    filename = tracks.write_tracks_to_vtk('tracks.vtk')
+
+    assert filename == 'tracks.vtk'
+    assert Path('tracks.vtk').is_file()


### PR DESCRIPTION
Currently there is a [script](https://github.com/openmc-dev/openmc/blob/develop/scripts/openmc-track-to-vtk) that one can run from the terminal on a tracks.h5 file.

This PR adds the ability to write vtk files of tracks from within the OpenMC Python API. This allows users to create the vtk file in the following manner

```python
import openmc
tracks = openmc.Tracks('tracks.h5')
tracks.write_tracks_to_vtk('tracks.vtk')
```

Part of the motivation for this is to make the production of track vtk files a little easier from jupyter notebooks with out the need for ```!``` to run scripts. ps I am also [viewing](https://itkwidgets.readthedocs.io/en/latest/integrations.html#vtk) the vtk files in jupyter so it can make a nice workshop example
