### PR TITLE
Add pass-through to allow plotting geometry on existing axes

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -272,7 +272,7 @@ class Universe(UniverseBase):
 
     def plot(self, origin=(0., 0., 0.), width=(1., 1.), pixels=(200, 200),
              basis='xy', color_by='cell', colors=None, seed=None,
-             openmc_exec='openmc', **kwargs):
+             openmc_exec='openmc', axes=None, **kwargs):
         """Display a slice plot of the universe.
 
         Parameters
@@ -302,6 +302,7 @@ class Universe(UniverseBase):
             Seed for the random number generator
         openmc_exec : str
             Path to OpenMC executable.
+        axes : matplotlib.Axes to draw to
 
             .. versionadded:: 0.13.1
         **kwargs
@@ -360,18 +361,18 @@ class Universe(UniverseBase):
 
             # Create a figure sized such that the size of the axes within
             # exactly matches the number of pixels specified
-            if kwargs.get("ax") is None:
+            if axes is None:
                 px = 1/plt.rcParams['figure.dpi']
-                fig, ax = plt.subplots()
+                fig, axes = plt.subplots()
                 params = fig.subplotpars
                 width = pixels[0]*px/(params.right - params.left)
                 height = pixels[0]*px/(params.top - params.bottom)
                 fig.set_size_inches(width, height)
             else:
-                ax = kwargs.pop("ax")
+                pass
 
             # Plot image and return the axes
-            return ax.imshow(img, extent=(x_min, x_max, y_min, y_max), **kwargs)
+            return axes.imshow(img, extent=(x_min, x_max, y_min, y_max), **kwargs)
 
     def add_cell(self, cell):
         """Add a cell to the universe.

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -302,7 +302,8 @@ class Universe(UniverseBase):
             Seed for the random number generator
         openmc_exec : str
             Path to OpenMC executable.
-        axes : matplotlib.Axes to draw to
+        axes : matplotlib.Axes
+            Axes to draw to
 
             .. versionadded:: 0.13.1
         **kwargs

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -360,12 +360,15 @@ class Universe(UniverseBase):
 
             # Create a figure sized such that the size of the axes within
             # exactly matches the number of pixels specified
-            px = 1/plt.rcParams['figure.dpi']
-            fig, ax = plt.subplots()
-            params = fig.subplotpars
-            width = pixels[0]*px/(params.right - params.left)
-            height = pixels[0]*px/(params.top - params.bottom)
-            fig.set_size_inches(width, height)
+            if kwargs.get("ax") is None:
+                px = 1/plt.rcParams['figure.dpi']
+                fig, ax = plt.subplots()
+                params = fig.subplotpars
+                width = pixels[0]*px/(params.right - params.left)
+                height = pixels[0]*px/(params.top - params.bottom)
+                fig.set_size_inches(width, height)
+            else:
+                ax = kwargs.pop("ax")
 
             # Plot image and return the axes
             return ax.imshow(img, extent=(x_min, x_max, y_min, y_max), **kwargs)

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -368,8 +368,6 @@ class Universe(UniverseBase):
                 width = pixels[0]*px/(params.right - params.left)
                 height = pixels[0]*px/(params.top - params.bottom)
                 fig.set_size_inches(width, height)
-            else:
-                pass
 
             # Plot image and return the axes
             return axes.imshow(img, extent=(x_min, x_max, y_min, y_max), **kwargs)


### PR DESCRIPTION
Just what it says on the tin. Allows passing matplotlib axes to universe.plot(), and defaults to current behavior if no axes are passed.