### PR TITLE
Fix parallel execution of `MicroXS.from_model()`

### DIFF
--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -5,6 +5,7 @@ nuclide names as row indices and reaction names as column indices.
 """
 
 import tempfile
+import os
 from pathlib import Path
 from copy import deepcopy
 
@@ -91,7 +92,11 @@ class MicroXS(DataFrame):
         model.tallies = tallies
 
         # create temporary run
-        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp_dir:
+        if 'TMPDIR' in os.environ:
+            d = tempfile.gettempdir()
+        else:
+            d = Path.cwd()
+        with tempfile.TemporaryDirectory(dir=d) as temp_dir:
             if run_kwargs is None:
                 run_kwargs = {}
             run_kwargs.setdefault('cwd', temp_dir)

--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -4,6 +4,7 @@ A pandas.DataFrame storing microscopic cross section data with
 nuclide names as row indices and reaction names as column indices.
 """
 
+import tempfile
 from pathlib import Path
 from copy import deepcopy
 
@@ -35,8 +36,6 @@ class MicroXS(DataFrame):
                    chain_file,
                    dilute_initial=1.0e3,
                    energy_bounds=(0, 20e6),
-                   init_lib=False,
-                   lib_kwargs=None,
                    run_kwargs=None):
         """Generate a one-group cross-section dataframe using
         OpenMC. Note that the ``openmc`` executable must be compiled.
@@ -59,11 +58,6 @@ class MicroXS(DataFrame):
             Reaction names to tally
         energy_bound : 2-tuple of float, optional
             Bounds for the energy group.
-        init_lib : bool, optional
-            Decide if we use the OpenMC C++ API to initialize the model
-            in memory. Recommended to set as `True` if executing in parallel.
-        lib_kwargs : dict, optional
-            Keywork arguments for :meth:`openmc.model.Model.init_lib()`
         run_kwargs : dict, optional
             Keyword arguments for :meth:`openmc.model.Model.run()`
 
@@ -97,17 +91,15 @@ class MicroXS(DataFrame):
         model.tallies = tallies
 
         # create temporary run
-        if run_kwargs is None:
-            run_kwargs = {}
-        if init_lib:
-            if lib_kwargs is None:
-                lib_kwargs = {}
-            model.init_lib(**lib_kwargs)
-        statepoint_path = model.run(**run_kwargs)
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp_dir:
+            if run_kwargs is None:
+                run_kwargs = {}
+            run_kwargs.setdefault('cwd', temp_dir)
+            statepoint_path = model.run(**run_kwargs)
 
-        with StatePoint(statepoint_path) as sp:
-            for rx in xs:
-                xs[rx].load_from_statepoint(sp)
+            with StatePoint(statepoint_path) as sp:
+                for rx in xs:
+                    xs[rx].load_from_statepoint(sp)
 
         # Build the DataFrame
         series = {}
@@ -118,8 +110,6 @@ class MicroXS(DataFrame):
         # Revert to the original tallies and materials
         model.tallies = original_tallies
         model.materials = original_materials
-        # write the original model to xml files
-        model.export_to_xml()
 
         return cls(series)
 

--- a/tests/regression_tests/microxs/test.py
+++ b/tests/regression_tests/microxs/test.py
@@ -1,4 +1,5 @@
 """Test one-group cross section generation"""
+import os
 from pathlib import Path
 
 import numpy as np
@@ -44,9 +45,11 @@ def model():
 
     return openmc.Model(geometry, materials, settings)
 
-
-def test_from_model(model):
+@pytest.mark.parametrize("tmpdir_env_var", [True, False])
+def test_from_model(model, tmpdir_env_var):
     ref_xs = MicroXS.from_csv('test_reference.csv')
+    if tmpdir_env_var:
+        os.environ['TMPDIR'] = Path.cwd().resolve().as_posix()
     test_xs = MicroXS.from_model(model, model.materials[0], CHAIN_FILE)
 
     np.testing.assert_allclose(test_xs, ref_xs, rtol=1e-11)


### PR DESCRIPTION
This PR explicitly specifies the location of the temporary directory used in `MicroXS.from_model()`. In practice this has resolved the issues we see in #2177 and #2172.

closes #2177
closes #2172 