### PR TITLE
Adding set_strides() to openmc_simulation_init()

### DIFF
--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -97,6 +97,7 @@ int openmc_simulation_init()
 
   // Allocate tally results arrays if they're not allocated yet
   for (auto& t : model::tallies) {
+    t->set_strides();
     t->init_results();
   }
 

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -374,9 +374,6 @@ void Tally::set_filters(gsl::span<Filter*> filters)
       delayedgroup_filter_ = i;
     }
   }
-
-  // Set the strides.
-  set_strides();
 }
 
 void Tally::set_strides()


### PR DESCRIPTION
Closes #2181. For applications that change their mesh between OpenMC runs (e.g. AMR in Cardinal), it will be important to update the bins for the estimators, as their structure will have changed. When the bins change, `set_strides()` needs to be called again to make sure the xtensor multidimensional results array is sized properly to collect tallies during the next Monte Carlo simulation.

Originally, the thought was to move `set_strides() `away from `set_filters()`, but this caused errors in local tests. It will potentially add duplicate, unnecessary computations if `set_strides()` is called twice, but the filters and mesh are the same. This occurs before the histories start though and is not expected to cause a significant slowdown. 

It is possible, in theory, to refactor such that `set_strides()` is only called when the mesh/filters change, but the effort to get this right may not be worth the hassle. Especially when the simpler alternative isn't expected to concerningly degrade performance.