### PR TITLE
Adding pulse schedule plot

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -12,9 +12,7 @@ from numbers import Real, Integral
 from contextlib import contextmanager
 import os
 from pathlib import Path
-import sys
 import time
-from turtle import color
 from warnings import warn
 
 from numpy import nonzero, empty, asarray

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -35,6 +35,7 @@ __all__ = [
 _SECONDS_PER_MINUTE = 60
 _SECONDS_PER_HOUR = 60*60
 _SECONDS_PER_DAY = 24*60*60
+_SECONDS_PER_JULIAN_YEAR = 365.25*24*60*60
 
 OperatorResult = namedtuple('OperatorResult', ['k', 'rates'])
 OperatorResult.__doc__ = """\
@@ -530,11 +531,11 @@ class Integrator(ABC):
         each interval in :attr:`timesteps`
 
         .. versionadded:: 0.12.1
-    timestep_units : {'s', 'min', 'h', 'd', 'MWd/kg'}
+    timestep_units : {'s', 'min', 'h', 'd', 'a', 'MWd/kg'}
         Units for values specified in the `timesteps` argument. 's' means
-        seconds, 'min' means minutes, 'h' means hours, and 'MWd/kg' indicates
-        that the values are given in burnup (MW-d of energy deposited per
-        kilogram of initial heavy metal).
+        seconds, 'min' means minutes, 'h' means hours, 'a' means Julian years
+        and 'MWd/kg' indicates that the values are given in burnup (MW-d of
+        energy deposited per kilogram of initial heavy metal).
     solver : str or callable, optional
         If a string, must be the name of the solver responsible for
         solving the Bateman equations.  Current options are:
@@ -638,6 +639,8 @@ class Integrator(ABC):
                 seconds.append(timestep*_SECONDS_PER_HOUR)
             elif unit in ('d', 'day'):
                 seconds.append(timestep*_SECONDS_PER_DAY)
+            elif unit in ('a', 'year'):
+                seconds.append(timestep*_SECONDS_PER_JULIAN_YEAR)
             elif unit.lower() == 'mwd/kg':
                 watt_days_per_kg = 1e6*timestep
                 kilograms = 1e-3*operator.heavy_metal
@@ -869,7 +872,6 @@ class Integrator(ABC):
 
         axes[1].set_xlabel(f'Timesteps [{self.timestep_units}]')
         axes[1].set_ylim(0, 1)
-        axes[1].set_xticks(linear_time_steps)
         axes[1].get_yaxis().set_visible(False)
 
         return fig

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -592,7 +592,6 @@ class Integrator(ABC):
                         self._num_stages))
         self.operator = operator
         self.chain = operator.chain
-        self.timestep_units = timestep_units
 
         # Determine source rate and normalize units to W in using power
         if power is not None:
@@ -836,9 +835,17 @@ class Integrator(ABC):
 
         self.operator.finalize()
 
-    def plot(self):
+    def plot(self, timestep_units: str = 's'):
         """Plots the source strength as a function of time and the depletion
         timesteps on an adjacent subplot.
+
+        Parameters
+        ----------
+        timestep_units : {'s', 'min', 'h', 'd', 'a', 'MWd/kg'}
+            Units for values specified in the `timesteps` argument. 's' means
+            seconds, 'min' means minutes, 'h' means hours, 'a' means Julian
+            years and 'MWd/kg' indicates that the values are given in burnup
+            (MW-d of energy deposited per kilogram of initial heavy metal).
 
         Returns
         -------
@@ -853,7 +860,7 @@ class Integrator(ABC):
         linear_time_steps = [0]
 
         for time_step in self.timesteps:
-            current_time += _get_time_as(time_step, self.timestep_units)
+            current_time += _get_time_as(time_step, timestep_units)
             linear_time_steps.append(current_time)
 
         fig, axes = plt.subplots(2, 1,  gridspec_kw={'height_ratios': [3, 1]})
@@ -862,7 +869,7 @@ class Integrator(ABC):
         fig.subplots_adjust(hspace=.4)
 
         axes[0].set_ylabel('Neutron source rate [n/s]')
-        axes[0].set_xlabel(f'Time [{self.timestep_units}]')
+        axes[0].set_xlabel(f'Time [{timestep_units}]')
         axes[0].stairs(self.source_rates, linear_time_steps, linewidth=2)
 
         for timestep in linear_time_steps:
@@ -870,7 +877,7 @@ class Integrator(ABC):
             y_vals = [0, 1]  # arbitrary heights selected as axis has no y scale
             axes[1].plot(x_vals, y_vals, '-', color='red')
 
-        axes[1].set_xlabel(f'Timesteps [{self.timestep_units}]')
+        axes[1].set_xlabel(f'Timesteps [{timestep_units}]')
         axes[1].set_ylim(0, 1)
         axes[1].get_yaxis().set_visible(False)
 


### PR DESCRIPTION
I've just been using the nice deplete features and had the need to plot the source strength and timesteps used in the simulation for different pulse scenarios (e.g. maintenance, waste, high duty).

I wrote a little method that takes the timesteps linearizes them and plots them with the source strength in a subplot so one can see check the pulse schedule and timesteps are as expected.

I thought it might be handy for others (perhaps @eepeterson) so made this PR adds a ```.plot()``` method to the integrator class.

Here is an example plot of a 100% pulse for 20 seconds with a timestep in the middle followed by a cooling time and then a smaller ramped pulse with a short cooling time that has timestep readings with it.

![shimwell_integrator_plot](https://user-images.githubusercontent.com/8583900/186130675-e96dde7e-d058-4cc4-9a51-d4be6033363c.png)

Code to reporduce

```python
import openmc
import openmc.deplete
import matplotlib.pyplot as plt

material = openmc.Material()
material.add_nuclide('Fe59', 1)
material.volume = 100
material.depletable = True
materials = openmc.Materials([material])

model = openmc.Model()
model.materials = materials

operator = openmc.deplete.Operator(
        model=model,
        chain_file="chain-nndc-b7.1.xml",
        normalization_mode="source-rate"
    )

integrator = openmc.deplete.PredictorIntegrator(
    operator=operator,
    timesteps=[10, 10, 40, 10, 10, 4,6],
    source_rates=[100, 100, 0, 50, 80, 0,0],
    timestep_units='d',
)

integrator.plot()
plt.show()
```