### PR TITLE
added optional nuclide to get_nuclide_atom_densities

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -829,15 +829,15 @@ class Material(IDManagerMixin):
         """Returns one or all nuclides in the material and their atomic
         densities in units of atom/b-cm
 
+        .. versionchanged:: 0.13.1
+            The values in the dictionary were changed from a tuple containing
+            the nuclide name and the density to just the density.
+
         Parameters
         ----------
         nuclides : str, optional
             Nuclide for which atom density is desired. If not specified, the
             atom density for each nuclide in the material is given.
-
-        .. versionchanged:: 0.13.1
-            The values in the dictionary were changed from a tuple containing
-            the nuclide name and the density to just the density.
 
         Returns
         -------

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -825,9 +825,15 @@ class Material(IDManagerMixin):
 
         return nuclides
 
-    def get_nuclide_atom_densities(self):
-        """Returns all nuclides in the material and their atomic densities in
-        units of atom/b-cm
+    def get_nuclide_atom_densities(self, nuclide: Optional[str] = None):
+        """Returns one or all nuclides in the material and their atomic
+        densities in units of atom/b-cm
+
+        Parameters
+        ----------
+        nuclides : str, optional
+            Nuclide for which atom density is desired. If not specified, the
+            atom density for the all the material is given.
 
         .. versionchanged:: 0.13.1
             The values in the dictionary were changed from a tuple containing
@@ -862,10 +868,11 @@ class Material(IDManagerMixin):
         nuc_densities = []
         nuc_density_types = []
 
-        for nuclide in self.nuclides:
-            nucs.append(nuclide.name)
-            nuc_densities.append(nuclide.percent)
-            nuc_density_types.append(nuclide.percent_type)
+        for loop_nuclide in self.nuclides:
+            if nuclide is None or nuclide == loop_nuclide.name:
+                nucs.append(loop_nuclide.name)
+                nuc_densities.append(loop_nuclide.percent)
+                nuc_density_types.append(loop_nuclide.percent_type)
 
         nucs = np.array(nucs)
         nuc_densities = np.array(nuc_densities)

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -833,7 +833,7 @@ class Material(IDManagerMixin):
         ----------
         nuclides : str, optional
             Nuclide for which atom density is desired. If not specified, the
-            atom density for the all the material is given.
+            atom density for each nuclide in the material is given.
 
         .. versionchanged:: 0.13.1
             The values in the dictionary were changed from a tuple containing
@@ -868,10 +868,10 @@ class Material(IDManagerMixin):
         nuc_densities = []
         nuc_density_types = []
 
-        for loop_nuclide in self.nuclides:
-            nucs.append(loop_nuclide.name)
-            nuc_densities.append(loop_nuclide.percent)
-            nuc_density_types.append(loop_nuclide.percent_type)
+        for nuc in self.nuclides:
+            nucs.append(nuc.name)
+            nuc_densities.append(nuc.percent)
+            nuc_density_types.append(nuc.percent_type)
 
         nucs = np.array(nucs)
         nuc_densities = np.array(nuc_densities)

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -869,10 +869,9 @@ class Material(IDManagerMixin):
         nuc_density_types = []
 
         for loop_nuclide in self.nuclides:
-            if nuclide is None or nuclide == loop_nuclide.name:
-                nucs.append(loop_nuclide.name)
-                nuc_densities.append(loop_nuclide.percent)
-                nuc_density_types.append(loop_nuclide.percent_type)
+            nucs.append(loop_nuclide.name)
+            nuc_densities.append(loop_nuclide.percent)
+            nuc_density_types.append(loop_nuclide.percent_type)
 
         nucs = np.array(nucs)
         nuc_densities = np.array(nuc_densities)
@@ -904,7 +903,8 @@ class Material(IDManagerMixin):
 
         nuclides = OrderedDict()
         for n, nuc in enumerate(nucs):
-            nuclides[nuc] = nuc_densities[n]
+            if nuclide is None or nuclide == nuc:
+                nuclides[nuc] = nuc_densities[n]
 
         return nuclides
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -984,11 +984,10 @@ class Material(IDManagerMixin):
 
         """
         mass_density = 0.0
-        for nuc, atoms_per_bcm in self.get_nuclide_atom_densities().items():
-            if nuclide is None or nuclide == nuc:
-                density_i = 1e24 * atoms_per_bcm * openmc.data.atomic_mass(nuc) \
-                            / openmc.data.AVOGADRO
-                mass_density += density_i
+        for nuc, atoms_per_bcm in self.get_nuclide_atom_densities(nuclide=nuclide).items():
+            density_i = 1e24 * atoms_per_bcm * openmc.data.atomic_mass(nuc) \
+                        / openmc.data.AVOGADRO
+            mass_density += density_i
         return mass_density
 
     def get_mass(self, nuclide: Optional[str] = None):

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -339,7 +339,7 @@ def test_get_nuclide_atom_densities(uo2):
         assert density > 0
 
 
-def test_get_specific_nuclide_atom_densities(uo2):
+def test_get_nuclide_atom_densities_specific(uo2):
     one_nuc = uo2.get_nuclide_atom_densities(nuclide='O16')
     assert list(one_nuc.keys()) == ['O16']
     assert list(one_nuc.values())[0] > 0

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -348,7 +348,6 @@ def test_get_specific_nuclide_atom_densities(uo2):
     assert all_nuc['O16'] == one_nuc['O16']
 
 
-
 def test_get_nuclide_atoms():
     mat = openmc.Material()
     mat.add_nuclide('Li6', 1.0)

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -341,9 +341,13 @@ def test_get_nuclide_atom_densities(uo2):
 
 def test_get_specific_nuclide_atom_densities(uo2):
     print(uo2)
-    nuc = uo2.get_nuclide_atom_densities(nuclide='O16')
-    assert list(nuc.keys()) == ['O16']
-    assert list(nuc.values())[0] > 0
+    one_nuc = uo2.get_nuclide_atom_densities(nuclide='O16')
+    assert list(one_nuc.keys()) == ['O16']
+    assert list(one_nuc.values())[0] > 0
+
+    all_nuc = uo2.get_nuclide_atom_densities()
+    assert all_nuc['O16'] == one_nuc['O16']
+
 
 
 def test_get_nuclide_atoms():

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -339,6 +339,13 @@ def test_get_nuclide_atom_densities(uo2):
         assert density > 0
 
 
+def test_get_specific_nuclide_atom_densities(uo2):
+    print(uo2)
+    nuc = uo2.get_nuclide_atom_densities(nuclide='O16')
+    assert list(nuc.keys()) == ['O16']
+    assert list(nuc.values())[0] > 0
+
+
 def test_get_nuclide_atoms():
     mat = openmc.Material()
     mat.add_nuclide('Li6', 1.0)

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -340,7 +340,6 @@ def test_get_nuclide_atom_densities(uo2):
 
 
 def test_get_specific_nuclide_atom_densities(uo2):
-    print(uo2)
     one_nuc = uo2.get_nuclide_atom_densities(nuclide='O16')
     assert list(one_nuc.keys()) == ['O16']
     assert list(one_nuc.values())[0] > 0


### PR DESCRIPTION
The ```openmc.Material.get_nuclide_atom_densities()``` currently returns all of the nuclide in the material.

Other methods such as ```openmc.Material.get_mass_density``` support the ability to specify the nuclide of interest and get a single nuclide back.

This PR adds a ```nuclide``` argument o the  ```openmc.Material.get_nuclide_atom_densities()``` method which is in keeping with the  ```openmc.Material.get_mass_density``` and will also be useful to some other use cases that I'm working on (figuring out if nuclide are in their natural abundance so they can be squashed to elements).

I've added to the doc string and added a simple test to the unit tests.