### PR TITLE
Switch math.log10 to numpy.log10 so test_lethargy_bin_width() passes

### DIFF
--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -1,4 +1,3 @@
-import math
 import numpy as np
 import openmc
 from pytest import fixture, approx

--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -252,6 +252,6 @@ def test_energy():
 def test_lethargy_bin_width():
     f = openmc.EnergyFilter.from_group_structure('VITAMIN-J-175')
     assert len(f.lethargy_bin_width) == 175
-    energy_bins = openmc.mgxs.GROUP_STRUCTURES['VITAMIN-J-175'] 
-    assert f.lethargy_bin_width[0] == math.log10(energy_bins[1]/energy_bins[0])
-    assert f.lethargy_bin_width[-1] == math.log10(energy_bins[-1]/energy_bins[-2])
+    energy_bins = openmc.mgxs.GROUP_STRUCTURES['VITAMIN-J-175']
+    assert f.lethargy_bin_width[0] == np.log10(energy_bins[1]/energy_bins[0])
+    assert f.lethargy_bin_width[-1] == np.log10(energy_bins[-1]/energy_bins[-2])


### PR DESCRIPTION
During local testing, `test_filters::test_lethargy_bin_width()` failed due to a disagreement about the last decimal place in an assert statement. It was suggested by @shimwell to switch the test's use of `math.log10` to `numpy.log10`. Locally, for me, this resolved the test to now pass, so I thought it may be a good idea to change this for everyone. See #2190 for full discussion.

This pass or fail probably depends on `numpy`/`python` version. I am using `python 3.10.5` and `numpy 1.23.0`. If anyone has hesitation about this switch, please feel free voice your concern. There may be good reasons to leave this as `math.log10 ` that I am unaware of.