### PR TITLE
added mesh size and tally mean numbers to error message

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -216,7 +216,7 @@ class StructuredMesh(MeshBase):
 
         Raises
         ------
-        RuntimeError
+        ValueError
             When the size of a dataset doesn't match the number of mesh cells
 
         Returns
@@ -236,10 +236,10 @@ class StructuredMesh(MeshBase):
             )
             if isinstance(dataset, np.ndarray):
                 if not dataset.size == self.num_mesh_cells:
-                    raise RuntimeError(errmsg)
+                    raise ValueError(errmsg)
             else:
                 if len(dataset) == self.num_mesh_cells:
-                    raise RuntimeError(errmsg)
+                    raise ValueError(errmsg)
             cv.check_type('label', label, str)
 
         vtk_grid = vtk.vtkStructuredGrid()

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -230,14 +230,16 @@ class StructuredMesh(MeshBase):
 
         # check that the data sets are appropriately sized
         for label, dataset in datasets.items():
+            errmsg = (
+                f"The size of the dataset '{label}' ({dataset.size}) "
+                f"should be equal to the number of mesh cells ({self.num_mesh_cells})"
+            )
             if isinstance(dataset, np.ndarray):
-                num_cells = self.dimension[0] * self.dimension[1] * self.dimension[2]
-                if not dataset.size == num_cells:
-                    errmsg = "The size of the dataset '{}' ({}) should be equal to the number of mesh cells ({})"
-                    raise RuntimeError(errmsg.format(label, dataset.size, num_cells))
+                if not dataset.size == self.num_mesh_cells:
+                    raise RuntimeError(errmsg)
             else:
-                if len(dataset) == self.dimension[0] * self.dimension[1] * self.dimension[2]:
-                    raise RuntimeError(errmsg.format(label))
+                if len(dataset) == self.num_mesh_cells:
+                    raise RuntimeError(errmsg)
             cv.check_type('label', label, str)
 
         vtk_grid = vtk.vtkStructuredGrid()

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -229,11 +229,11 @@ class StructuredMesh(MeshBase):
         from vtk.util import numpy_support as nps
 
         # check that the data sets are appropriately sized
-        errmsg = "The size of the dataset '{}' ({}) should be equal to the number of mesh cells ({})"
         for label, dataset in datasets.items():
             if isinstance(dataset, np.ndarray):
                 num_cells = self.dimension[0] * self.dimension[1] * self.dimension[2]
                 if not dataset.size == num_cells:
+                    errmsg = "The size of the dataset '{}' ({}) should be equal to the number of mesh cells ({})"
                     raise RuntimeError(errmsg.format(label, dataset.size, num_cells))
             else:
                 if len(dataset) == self.dimension[0] * self.dimension[1] * self.dimension[2]:

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -217,7 +217,7 @@ class StructuredMesh(MeshBase):
         Raises
         ------
         RuntimeError
-            When the size of a dataset doesn't match the number of cells
+            When the size of a dataset doesn't match the number of mesh cells
 
         Returns
         -------
@@ -229,13 +229,14 @@ class StructuredMesh(MeshBase):
         from vtk.util import numpy_support as nps
 
         # check that the data sets are appropriately sized
-        errmsg = "The size of the dataset {} should be equal to the number of cells"
+        errmsg = "The size of the dataset {} ({}) should be equal to the number of mesh cells ({})"
         for label, dataset in datasets.items():
             if isinstance(dataset, np.ndarray):
-                if not dataset.size == self.dimension[0] * self.dimension[1]* self.dimension[2]:
-                    raise RuntimeError(errmsg.format(label))
+                num_cells = self.dimension[0] * self.dimension[1] * self.dimension[2]
+                if not dataset.size == num_cells:
+                    raise RuntimeError(errmsg.format(label, dataset.size, num_cells))
             else:
-                if len(dataset) == self.dimension[0] * self.dimension[1]* self.dimension[2]:
+                if len(dataset) == self.dimension[0] * self.dimension[1] * self.dimension[2]:
                     raise RuntimeError(errmsg.format(label))
             cv.check_type('label', label, str)
 

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -229,7 +229,7 @@ class StructuredMesh(MeshBase):
         from vtk.util import numpy_support as nps
 
         # check that the data sets are appropriately sized
-        errmsg = "The size of the dataset {} ({}) should be equal to the number of mesh cells ({})"
+        errmsg = "The size of the dataset '{}' ({}) should be equal to the number of mesh cells ({})"
         for label, dataset in datasets.items():
             if isinstance(dataset, np.ndarray):
                 num_cells = self.dimension[0] * self.dimension[1] * self.dimension[2]

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -231,8 +231,8 @@ class StructuredMesh(MeshBase):
         # check that the data sets are appropriately sized
         for label, dataset in datasets.items():
             errmsg = (
-                f"The size of the dataset '{label}' ({dataset.size}) "
-                f"should be equal to the number of mesh cells ({self.num_mesh_cells})"
+                f"The size of the dataset '{label}' ({dataset.size}) should be"
+                f" equal to the number of mesh cells ({self.num_mesh_cells})"
             )
             if isinstance(dataset, np.ndarray):
                 if not dataset.size == self.num_mesh_cells:

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -71,6 +71,9 @@ def test_write_data_to_vtk_size_mismatch(mesh):
     right_size = mesh.num_mesh_cells
     data = np.random.random(right_size + 1)
 
-    expected_error_msg = "The size of the dataset label should be equal to the number of cells"
+    expected_error_msg = (
+        f"The size of the dataset 'label' ({len(data)}) should be equal to "
+        f"the number of mesh cells ({mesh.num_mesh_cells})"
+    )
     with pytest.raises(RuntimeError, match=expected_error_msg):
         mesh.write_data_to_vtk(filename="out.vtk", datasets={"label": data})

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -28,6 +28,7 @@ spherical_mesh.r_grid = np.linspace(1, 2, num=30)
 spherical_mesh.phi_grid = np.linspace(0, np.pi, num=50)
 spherical_mesh.theta_grid = np.linspace(0, np.pi / 2, num=30)
 
+
 @pytest.mark.parametrize("mesh", [cylinder_mesh, regular_mesh, rectilinear_mesh, spherical_mesh])
 def test_write_data_to_vtk(mesh, tmpdir):
     # BUILD
@@ -43,7 +44,7 @@ def test_write_data_to_vtk(mesh, tmpdir):
 
     # read file
     reader = vtk.vtkStructuredGridReader()
-    reader.SetFileName(filename)
+    reader.SetFileName(str(filename))
     reader.Update()
 
     # check name of datasets
@@ -58,6 +59,7 @@ def test_write_data_to_vtk(mesh, tmpdir):
     assert nps.vtk_to_numpy(array1).size == data.size
     assert nps.vtk_to_numpy(array2).size == data.size
 
+
 @pytest.mark.parametrize("mesh", [cylinder_mesh, regular_mesh, rectilinear_mesh, spherical_mesh])
 def test_write_data_to_vtk_size_mismatch(mesh):
     """Checks that an error is raised when the size of the dataset
@@ -71,9 +73,12 @@ def test_write_data_to_vtk_size_mismatch(mesh):
     right_size = mesh.num_mesh_cells
     data = np.random.random(right_size + 1)
 
+    # Error message has \ in to escape characters that are otherwise recognized
+    # by regex. These are needed to make the test string match the error message
+    # string when using the match argument as that uses regular expression
     expected_error_msg = (
-        f"The size of the dataset 'label' ({len(data)}) should be equal to "
-        f"the number of mesh cells ({mesh.num_mesh_cells})"
+        f"The size of the dataset 'label' \({len(data)}\) should be equal to "
+        f"the number of mesh cells \({mesh.num_mesh_cells}\)"
     )
     with pytest.raises(RuntimeError, match=expected_error_msg):
         mesh.write_data_to_vtk(filename="out.vtk", datasets={"label": data})

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -80,5 +80,5 @@ def test_write_data_to_vtk_size_mismatch(mesh):
         f"The size of the dataset 'label' \({len(data)}\) should be equal to "
         f"the number of mesh cells \({mesh.num_mesh_cells}\)"
     )
-    with pytest.raises(RuntimeError, match=expected_error_msg):
+    with pytest.raises(ValueError, match=expected_error_msg):
         mesh.write_data_to_vtk(filename="out.vtk", datasets={"label": data})


### PR DESCRIPTION
While trying to write a mesh tally to a vtk file I found it useful to add some more information to the error message. This just helps users to identify the lengths of the mesh cells and the tally.mean which could give a better hint when debugging. In my case this helped me realize that I was sending a slice of the tally instead of the tally

before
```
RuntimeError: The size of the dataset mean should be equal to the number of cells
```

after
```
RuntimeError: The size of the dataset mean (625) should be equal to the number of mesh cells (15625)
```