### PR TITLE
added element filter to get_nuclides

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -797,8 +797,9 @@ class Material(IDManagerMixin):
         return sorted({re.split(r'(\d+)', i)[0] for i in self.get_nuclides()})
 
     def get_nuclides(self, element: Optional[str] = None):
-        """Returns all nuclides in the material, if element is specified then
-        just nuclides of the specified element are returned.
+        """Returns a sorted list of all nuclides in the material, if the
+        argument element is specified then just nuclides of that element are
+        returned.
 
         Parameters
         ----------

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -15,6 +15,7 @@ import numpy as np
 
 import openmc
 import openmc.data
+from openmc.data import NATURAL_ABUNDANCE
 import openmc.checkvalue as cv
 from ._xml import clean_indentation, reorder_attributes
 from .mixin import IDManagerMixin
@@ -795,8 +796,14 @@ class Material(IDManagerMixin):
 
         return sorted({re.split(r'(\d+)', i)[0] for i in self.get_nuclides()})
 
-    def get_nuclides(self):
-        """Returns all nuclides in the material
+    def get_nuclides(self, element: Optional[str] = None):
+        """Returns all nuclides in the material, if element is specified then
+        just nuclides of the specified element are returned.
+
+        Parameters
+        ----------
+        element : str
+            Specifies the element to match when searching through the nuclides
 
         Returns
         -------
@@ -804,7 +811,15 @@ class Material(IDManagerMixin):
             List of nuclide names
 
         """
-        return [x.name for x in self._nuclides]
+        if element:
+            matching_nuclides = []
+            for nuclide in self._nuclides:
+                if re.split(r'(\d+)', nuclide.name)[0] == element:
+                    matching_nuclides.append(nuclide.name)
+            return sorted(set(matching_nuclides))
+
+        else:
+            return sorted(set([x.name for x in self._nuclides]))
 
     def get_nuclide_densities(self):
         """Returns all nuclides in the material and their densities

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -357,6 +357,21 @@ def test_get_nuclide_atoms():
     atoms = mat.get_nuclide_atoms()
     assert atoms['Li6'] == pytest.approx(mat.density * mat.volume)
 
+def test_get_nuclide():
+    mat = openmc.Material()
+
+    mat.add_nuclide('Li6', 1.0)
+    assert mat.get_nuclides() == ['Li6']
+    assert mat.get_nuclides(element='Li') == ['Li6']
+    assert mat.get_nuclides(element='Be') == []
+    
+    mat.add_element('Li', 1.0)
+    assert mat.get_nuclides() == ['Li6', 'Li7']
+    assert mat.get_nuclides(element='Be') == []
+    
+    mat.add_element('Be', 1.0)
+    assert mat.get_nuclides() == ['Be9', 'Li6', 'Li7']
+    assert mat.get_nuclides(element='Be') == ['Be9']
 
 def test_mass():
     m = openmc.Material()

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -357,7 +357,7 @@ def test_get_nuclide_atoms():
     atoms = mat.get_nuclide_atoms()
     assert atoms['Li6'] == pytest.approx(mat.density * mat.volume)
 
-def test_get_nuclide():
+def test_get_nuclides():
     mat = openmc.Material()
 
     mat.add_nuclide('Li6', 1.0)


### PR DESCRIPTION
This PR is an attempt to add an element filter to the ```Material.get_nuclides()```. This is useful when trying to identify nuclides of a certain element in the material. Longer term it will be useful when squashing nuclides to elements.

I also noticed that in certain cases we currently return a list with duplicate nuclides. So I modified the method to return a sorted set. This makes the output more predictable for the user.

I couldn't actually see a unit test for this method so I added a new unit test to check existing functionality and new.

