### PR TITLE
format to f strings

### DIFF
--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -228,7 +228,7 @@ def atomic_mass(isotope):
         with open(mass_file, 'r') as ame:
             # Read lines in file starting at line 40
             for line in itertools.islice(ame, 39, None):
-                name = '{}{}'.format(line[20:22].strip(), int(line[16:19]))
+                name = f'{line[20:22].strip()}{int(line[16:19])}'
                 mass = float(line[96:99]) + 1e-6*float(
                     line[100:106] + '.' + line[107:112])
                 _ATOMIC_MASS[name.lower()] = mass
@@ -273,8 +273,7 @@ def atomic_weight(element):
     if weight > 0.:
         return weight
     else:
-        raise ValueError("No naturally-occurring isotopes for element '{}'."
-                         .format(element))
+        raise ValueError(f"No naturally-occurring isotopes for element '{element}'.")
 
 
 def half_life(isotope):
@@ -456,9 +455,8 @@ def gnd_name(Z, A, m=0):
 
     """
     if m > 0:
-        return '{}{}_m{}'.format(ATOMIC_SYMBOL[Z], A, m)
-    else:
-        return '{}{}'.format(ATOMIC_SYMBOL[Z], A)
+        return f'{ATOMIC_SYMBOL[Z]}{A}_m{m}'
+    return f'{ATOMIC_SYMBOL[Z]}{A}'
 
 
 def isotopes(element):
@@ -486,7 +484,7 @@ def isotopes(element):
     if len(element) > 2:
         symbol = ELEMENT_SYMBOL.get(element.lower())
         if symbol is None:
-            raise ValueError('Element name "{}" not recognised'.format(element))
+            raise ValueError(f'Element name "{element}" not recognised')
         element = symbol
 
     # Get the nuclides present in nature
@@ -515,12 +513,11 @@ def zam(name):
     try:
         symbol, A, state = _GND_NAME_RE.match(name).groups()
     except AttributeError:
-        raise ValueError("'{}' does not appear to be a nuclide name in GND "
-                         "format".format(name))
+        raise ValueError(f"'{name}' does not appear to be a nuclide name in "
+                         "GND format")
 
     if symbol not in ATOMIC_NUMBER:
-        raise ValueError("'{}' is not a recognized element symbol"
-                         .format(symbol))
+        raise ValueError(f"'{symbol}' is not a recognized element symbol")
 
     metastable = int(state[2:]) if state else 0
     return (ATOMIC_NUMBER[symbol], int(A), metastable)


### PR DESCRIPTION
While making use of the ```openmc.data.isotopes function``` I noticed a few ```.format``` occurrences. I thought I'd upgrades these in previous PRs (e.g. #1862). Looks like I missed a few. Here is a PR to replace a few more formats with f strings and save a few lines along the way.