### PR TITLE
added element filter to get_nuclide

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -810,15 +810,18 @@ class Material(IDManagerMixin):
             List of nuclide names
         """
 
+        matching_nuclides = []
         if element:
-            matching_nuclides = []
             for nuclide in self._nuclides:
                 if re.split(r'(\d+)', nuclide.name)[0] == element:
-                    matching_nuclides.append(nuclide.name)
-            return list(set(matching_nuclides))
-
+                    if nuclide.name not in matching_nuclides:
+                        matching_nuclides.append(nuclide.name)
         else:
-            return list(set([x.name for x in self._nuclides]))
+            for nuclide in self._nuclides:
+                if nuclide.name not in matching_nuclides:
+                    matching_nuclides.append(nuclide.name)
+                        
+        return matching_nuclides
 
     def get_nuclide_densities(self):
         """Returns all nuclides in the material and their densities

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -795,16 +795,30 @@ class Material(IDManagerMixin):
 
         return sorted({re.split(r'(\d+)', i)[0] for i in self.get_nuclides()})
 
-    def get_nuclides(self):
-        """Returns all nuclides in the material
+    def get_nuclides(self, element: Optional[str] = None):
+        """Returns a list of all nuclides in the material, if the element
+        argument is specified then just nuclides of that element are returned.
+
+        Parameters
+        ----------
+        element : str
+            Specifies the element to match when searching through the nuclides
 
         Returns
         -------
         nuclides : list of str
             List of nuclide names
-
         """
-        return [x.name for x in self._nuclides]
+
+        if element:
+            matching_nuclides = []
+            for nuclide in self._nuclides:
+                if re.split(r'(\d+)', nuclide.name)[0] == element:
+                    matching_nuclides.append(nuclide.name)
+            return list(set(matching_nuclides))
+
+        else:
+            return list(set([x.name for x in self._nuclides]))
 
     def get_nuclide_densities(self):
         """Returns all nuclides in the material and their densities

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -308,11 +308,11 @@ def test_get_nuclides():
     assert mat.get_nuclides(element='Be') == []
 
     mat.add_element('Li', 1.0)
-    assert mat.get_nuclides() == ['Li7', 'Li6']
+    assert mat.get_nuclides() == ['Li6', 'Li7']
     assert mat.get_nuclides(element='Be') == []
 
     mat.add_element('Be', 1.0)
-    assert mat.get_nuclides() == ['Li7', 'Li6', 'Be9']
+    assert mat.get_nuclides() == ['Li6', 'Li7', 'Be9']
     assert mat.get_nuclides(element='Be') == ['Be9']
 
 

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -299,6 +299,23 @@ def test_isotropic():
     assert m2.isotropic == ['H1']
 
 
+def test_get_nuclides():
+    mat = openmc.Material()
+
+    mat.add_nuclide('Li6', 1.0)
+    assert mat.get_nuclides() == ['Li6']
+    assert mat.get_nuclides(element='Li') == ['Li6']
+    assert mat.get_nuclides(element='Be') == []
+
+    mat.add_element('Li', 1.0)
+    assert mat.get_nuclides() == ['Li7', 'Li6']
+    assert mat.get_nuclides(element='Be') == []
+
+    mat.add_element('Be', 1.0)
+    assert mat.get_nuclides() == ['Li7', 'Li6', 'Be9']
+    assert mat.get_nuclides(element='Be') == ['Be9']
+
+
 def test_get_elements():
     # test that zero elements exist on creation
     m = openmc.Material()


### PR DESCRIPTION
This is a new version of #2197  which attempted to add an element filter to the Material.get_nuclides(). This is useful when trying to identify nuclides of a certain element in the material. Longer term it will be useful when squashing nuclides to elements.

I also noticed that in certain cases we currently return a list with duplicate nuclides. So I modified the method to return a set. This makes the output more predictable for the user.

I couldn't actually see a unit test for this method so I added a new unit test to check existing functionality and new.
