### PR TITLE
Update libmesh version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ENV DAGMC_REPO='https://github.com/svalinn/DAGMC'
 ENV DAGMC_INSTALL_DIR=$HOME/DAGMC/
 
 # LIBMESH variables
-ENV LIBMESH_TAG='v1.6.0'
+ENV LIBMESH_TAG='v1.7.1'
 ENV LIBMESH_REPO='https://github.com/libMesh/libmesh'
 ENV LIBMESH_INSTALL_DIR=$HOME/LIBMESH
 

--- a/tools/ci/gha-install-libmesh.sh
+++ b/tools/ci/gha-install-libmesh.sh
@@ -5,7 +5,7 @@ set -ex
 # libMESH install
 pushd $HOME
 mkdir LIBMESH && cd LIBMESH
-git clone https://github.com/libmesh/libmesh -b v1.7.0 --recurse-submodules
+git clone https://github.com/libmesh/libmesh -b v1.7.1 --recurse-submodules
 mkdir build && cd build
 export METHODS="opt"
 


### PR DESCRIPTION
We're getting some Dockerfile build failures due to the recent merging of #1915. This PR simply updates the version of libmesh in the Dockerfile to use the new interface required by #1915.