### PR TITLE
allowing materials from multiple burnup indexes

### DIFF
--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -359,17 +359,17 @@ class Results(list):
                 time, time_units, atol, rtol)
         )
 
-    def export_to_materials(self, burnup_index=None, nuc_with_data=None):
+    def export_to_materials(self, burnup_index, nuc_with_data=None):
         """Return openmc.Materials objects based on results at given burnup steps
 
         .. versionadded:: 0.12.1
 
         Parameters
         ----------
-        burn_index : int or Iterable of ints, optional
+        burn_index : int or Iterable of ints
             Index(es) of burnup step to evaluate. See also: get_step_where for
             obtaining burnup step indices from other data such as the time.
-            Defaults to None which returns materials from all burnup steps.
+            Set to None if the materials from all burnup steps are required.
         nuc_with_data : Iterable of str, optional
             Nuclides to include in resulting materials.
             This can be specified if not all nuclides appearing in
@@ -381,7 +381,7 @@ class Results(list):
 
         Returns
         -------
-        mat_file : Materials or iterable of Materials
+        mat_file : iterable of Materials
             Modified Materials instances containing depleted
             material data and original isotopic compositions of non-depletable
             materials
@@ -452,10 +452,6 @@ class Results(list):
                             mat.add_nuclide(nuc, atoms_per_barn_cm)
 
             materials.append(mat_file)
-
-        # Preserve previous behavior
-        if len(materials) == 1:
-            materials = materials[0]
 
         return materials
 

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -359,17 +359,17 @@ class Results(list):
                 time, time_units, atol, rtol)
         )
 
-    def export_to_materials(self, burnup_index=None, nuc_with_data=None) -> Materials:
-        """Return openmc.Materials object based on results at a given step
+    def export_to_materials(self, burnup_index=None, nuc_with_data=None):
+        """Return openmc.Materials objects based on results at given burnup steps
 
         .. versionadded:: 0.12.1
 
         Parameters
         ----------
-        burn_index : int, Iterable of ints, optional
+        burn_index : int or Iterable of ints, optional
             Index(es) of burnup step to evaluate. See also: get_step_where for
             obtaining burnup step indices from other data such as the time.
-            Defaults to None which returns materials from all burnup indices.
+            Defaults to None which returns materials from all burnup steps.
         nuc_with_data : Iterable of str, optional
             Nuclides to include in resulting materials.
             This can be specified if not all nuclides appearing in
@@ -381,8 +381,8 @@ class Results(list):
 
         Returns
         -------
-        mat_file : Materials
-            An iterable of modified Materials instance containing depleted
+        mat_file : Materials or iterable of Materials
+            Modified Materials instances containing depleted
             material data and original isotopic compositions of non-depletable
             materials
         """

--- a/tests/regression_tests/deplete_with_transport/test.py
+++ b/tests/regression_tests/deplete_with_transport/test.py
@@ -157,9 +157,9 @@ def test_depletion_results_to_material(run_in_tmpdir, problem):
     last_step_materials_list = res_ref.export_to_materials([-1])
     assert isinstance(last_step_materials_list, openmc.Materials)
     all_step_materials_default = res_ref.export_to_materials()
-    assert len(all_step_materials_default) == 3  # there are three time steps
+    assert len(all_step_materials_default) == 4
     all_step_materials = res_ref.export_to_materials(burnup_index=None)
-    assert len(all_step_materials) == 3  # there are three time steps
+    assert len(all_step_materials) == 4
     two_step_materials = res_ref.export_to_materials(burnup_index=[1, 2])
     assert len(two_step_materials) == 2
 

--- a/tests/regression_tests/deplete_with_transport/test.py
+++ b/tests/regression_tests/deplete_with_transport/test.py
@@ -151,6 +151,17 @@ def test_depletion_results_to_material(run_in_tmpdir, problem):
     # Export last step of depletion to its own openmc.Materials object,
     # using only nuclides available in the current nuclear data library
     last_step_materials = res_ref.export_to_materials(-1)
+    assert isinstance(last_step_materials, openmc.Materials)
+
+    # tests for different materials export options
+    last_step_materials_list = res_ref.export_to_materials([-1])
+    assert isinstance(last_step_materials_list, openmc.Materials)
+    all_step_materials_default = res_ref.export_to_materials()
+    assert len(all_step_materials_default) == 3  # there are three time steps
+    all_step_materials = res_ref.export_to_materials(burnup_index=None)
+    assert len(all_step_materials) == 3  # there are three time steps
+    two_step_materials = res_ref.export_to_materials(burnup_index=[1, 2])
+    assert len(two_step_materials) == 2
 
     # Export final depletion  step materials to XML
     output_xml_file = 'last_step_materials.xml'

--- a/tests/regression_tests/deplete_with_transport/test.py
+++ b/tests/regression_tests/deplete_with_transport/test.py
@@ -150,7 +150,7 @@ def test_depletion_results_to_material(run_in_tmpdir, problem):
 
     # Export last step of depletion to its own openmc.Materials object,
     # using only nuclides available in the current nuclear data library
-    last_step_materials = res_ref.export_to_materials(-1)
+    last_step_materials = res_ref.export_to_materials(-1)[0]
 
     # Export final depletion  step materials to XML
     output_xml_file = 'last_step_materials.xml'

--- a/tests/regression_tests/deplete_with_transport/test.py
+++ b/tests/regression_tests/deplete_with_transport/test.py
@@ -150,14 +150,13 @@ def test_depletion_results_to_material(run_in_tmpdir, problem):
 
     # Export last step of depletion to its own openmc.Materials object,
     # using only nuclides available in the current nuclear data library
-    last_step_materials = res_ref.export_to_materials(-1)
+    last_step_materials = res_ref.export_to_materials(-1)[0]
     assert isinstance(last_step_materials, openmc.Materials)
 
     # tests for different materials export options
     last_step_materials_list = res_ref.export_to_materials([-1])
-    assert isinstance(last_step_materials_list, openmc.Materials)
-    all_step_materials_default = res_ref.export_to_materials()
-    assert len(all_step_materials_default) == 4
+    assert len(last_step_materials_list) == 1
+    assert isinstance(last_step_materials_list[0], openmc.Materials)
     all_step_materials = res_ref.export_to_materials(burnup_index=None)
     assert len(all_step_materials) == 4
     two_step_materials = res_ref.export_to_materials(burnup_index=[1, 2])


### PR DESCRIPTION
This is an attempt to add support for exporting the materials from multiple burnup indexes.

Currently the depletion Results object has a method called ```export_to_materials``` which has a ```burnup_index``` argument and the ```burnup_index``` argument accepts an int.

This PR modifies the  ```export_to_materials``` method so that ```burnup_index``` can be an int or Iterable of ints or None (in which case it returns all burnup_index)

Here are some example use cases
```python
import openmc
import openmc.deplete

results = openmc.deplete.Results.from_hdf5('depletion_results.h5')

all_mats = results.export_to_materials(burnup_index=None) # returns materials from all burnup indexes
all_mats = results.export_to_materials() # returns materials from all burnup indexes as burnup_index defaults to None
some_mats = results.export_to_materials(burnup_index=[1,2,3])  # returns materials from several burnup indexes
one_mats = results.export_to_materials(burnup_index=[1])  # returns materials from a single burnup indexes
one_mats = results.export_to_materials(burnup_index=1)  # returns materials from a single burnup indexes preserving the current behavior
```

Sorry for all the line changes, most of the churn is just indentation

Closes #2120 