### PR TITLE
propagated get_activity up to deplete.Results

### DIFF
--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -358,6 +358,42 @@ class Results(list):
                 time, time_units, atol, rtol)
         )
 
+    def get_activity(self, units: str = 'Bq/cm3', by_nuclide: bool = False, burnup_index=None):
+        """Returns the activity of each materail in each burnup index in the
+        each depletion. The activity can optionally be split into activity for
+        each nuclide in the materials.
+
+        .. versionadded:: 0.14.0
+
+        Parameters
+        ----------
+        units : {'Bq', 'Bq/g', 'Bq/cm3'}
+            Specifies the type of activity to return, options include total
+            activity [Bq], specific [Bq/g] or volumetric activity [Bq/cm3].
+            Default is volumetric activity [Bq/cm3].
+        by_nuclide : bool
+            Specifies if the activity should be returned for the material as a
+            whole or per nuclide. Default is False.
+        burn_index : int, Iterable of ints, optional
+            Index(es) of burnup step to evaluate. See also: get_step_where for
+            obtaining burnup step indices from other data such as the time.
+            Defaults to None which returns activities from all burnup indices.
+
+        Returns
+        -------
+        Iterable of Iterables of Union[dict, float]
+            If by_nuclide is True then a dictionary whose keys are nuclide
+            names and values are activity is returned. Otherwise the activity
+            of the material is returned as a float.
+        """
+
+        materials_at_each_burnstep = self.export_to_materials(burnup_index=burnup_index)
+
+        activities = []
+        for material in materials_at_each_burnstep:
+            activities.append(material.get_activity(units=units, by_nuclide=by_nuclide))
+        return activities
+
     def export_to_materials(self, burnup_index, nuc_with_data=None) -> Materials:
         """Return openmc.Materials object based on results at a given step
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1411,6 +1411,37 @@ class Materials(cv.CheckedList):
             # Write the closing tag for the root element.
             fh.write('</materials>\n')
 
+    def get_activity(self, units: str = 'Bq/cm3', by_nuclide: bool = False):
+        """Returns the activity of each material in the materials collection.
+        The activity can optionally be split into activity for each nuclide in
+        the material.
+
+        .. versionadded:: 0.14.0
+
+        Parameters
+        ----------
+        units : {'Bq', 'Bq/g', 'Bq/cm3'}
+            Specifies the type of activity to return, options include total
+            activity [Bq], specific [Bq/g] or volumetric activity [Bq/cm3].
+            Default is volumetric activity [Bq/cm3].
+        by_nuclide : bool
+            Specifies if the activity should be returned for the material as a
+            whole or per nuclide. Default is False.
+
+        Returns
+        -------
+        Iterable of Union[dict, float]
+            If by_nuclide is True then a dictionary whose keys are nuclide
+            names and values are activity is returned. Otherwise the activity
+            of the material is returned as a float.
+        """
+
+        activities = []
+        for material in self:
+            activity = material.get_activity(units=units, by_nuclide=by_nuclide)
+            activities.append(activity)
+        return activities
+
     @classmethod
     def from_xml(cls, path: Union[str, os.PathLike] = 'materials.xml'):
         """Generate materials collection from XML file


### PR DESCRIPTION
Currently we have ```openmc.material.get_activity``` which is handy but it would be even more convenient if ```openmc.Materials``` and ```openmc.deplete.Results``` also had a ```get_activity``` method. This appears to be [within the remit](https://github.com/openmc-dev/openmc/blob/a9aa761fbfa5023ac3bc9457592044d8e79df58c/openmc/deplete/results.py#L46-L47) of the ```openmc.deplete.Results``` but it would also make plotting the activity as a function of time super easy for users.

Currently to plot activity as a function of time from a depletion simulation requires a bit of familiarity with the code but it is possible.

```python
import openmc
import openmc.deplete
import matplotlib.pyplot as plt

depletion_results = openmc.deplete.Results.from_hdf5('depletion_results.h5')
all_activities = []
time_steps = depletion_results.get_times('d')
for counter in range(len(time_steps)):
    materials_at_timestep = depletion_results.export_to_materials(burnup_index=counter)
    for material in materials_at_timestep:
        activity = material.get_activity(units='Bq/cm3')
        all_activities.append(activity)

plt.plot(time_steps, all_activities)
plt.xlabel('time [days]')
plt.ylabel('activity [Bq/cm3]')
plt.show()
```
![openmc_depletion](https://user-images.githubusercontent.com/8583900/187433113-7c13c45d-9c63-4419-b3a9-915f7b95ecb8.png)

I think there might be an opportunity to decrease the amount of user effort required if this PR and PR #2202 are accepted then this user code would reduce to ...

```python
import openmc
import openmc.deplete
import matplotlib.pyplot as plt

depletion_results = openmc.deplete.Results.from_hdf5('depletion_results.h5')

plt.plot(depletion_results.get_times('d'), depletion_results.get_activity(units='Bq/cm3'))
plt.xlabel('time [days]')
plt.ylabel('activity [Bq/cm3]')
plt.show()
```

Marked this PR as a draft as it requires PR #2202 to be accepted first
