### PR TITLE
Fix reading reference direction from XML for angular distributions

### DIFF
--- a/openmc/stats/multivariate.py
+++ b/openmc/stats/multivariate.py
@@ -148,9 +148,9 @@ class PolarAzimuthal(UnitSphere):
 
         """
         mu_phi = cls()
-        params = get_text(elem, 'parameters')
-        if params is not None:
-            mu_phi.reference_uvw = [float(x) for x in params.split()]
+        uvw = get_text(elem, 'reference_uvw')
+        if uvw is not None:
+            mu_phi.reference_uvw = [float(x) for x in uvw.split()]
         mu_phi.mu = Univariate.from_xml_element(elem.find('mu'))
         mu_phi.phi = Univariate.from_xml_element(elem.find('phi'))
         return mu_phi
@@ -242,9 +242,9 @@ class Monodirectional(UnitSphere):
 
         """
         monodirectional = cls()
-        params = get_text(elem, 'parameters')
-        if params is not None:
-            monodirectional.reference_uvw = [float(x) for x in params.split()]
+        uvw = get_text(elem, 'reference_uvw')
+        if uvw is not None:
+            monodirectional.reference_uvw = [float(x) for x in uvw.split()]
         return monodirectional
 
 

--- a/tests/unit_tests/test_source.py
+++ b/tests/unit_tests/test_source.py
@@ -1,6 +1,10 @@
+from math import pi
+
 import openmc
 import openmc.stats
-from math import pi
+import numpy as np
+from pytest import approx
+
 
 def test_source():
     space = openmc.stats.Point()
@@ -39,8 +43,8 @@ def test_spherical_uniform():
                                                         phis,
                                                         origin)
 
-    assert isinstance(sph_indep_function, openmc.stats.SphericalIndependent) 
-    
+    assert isinstance(sph_indep_function, openmc.stats.SphericalIndependent)
+
 
 def test_source_file():
     filename = 'source.h5'
@@ -59,3 +63,36 @@ def test_source_dlopen():
 
     elem = src.to_xml_element()
     assert 'library' in elem.attrib
+
+
+def test_source_xml_roundtrip():
+    # Create a source and write to an XML element
+    space = openmc.stats.Box([-5., -5., -5.], [5., 5., 5.])
+    energy = openmc.stats.Discrete([1.0e6, 2.0e6, 5.0e6], [0.3, 0.5, 0.2])
+    angle = openmc.stats.PolarAzimuthal(
+        mu=openmc.stats.Uniform(0., 1.),
+        phi=openmc.stats.Uniform(0., 2*pi),
+        reference_uvw=(0., 1., 0.)
+    )
+    src = openmc.Source(
+        space=space, angle=angle, energy=energy,
+        particle='photon', strength=100.0
+    )
+    elem = src.to_xml_element()
+
+    # Read from XML element and make sure data is preserved
+    new_src = openmc.Source.from_xml_element(elem)
+    assert isinstance(new_src.space, openmc.stats.Box)
+    np.testing.assert_allclose(new_src.space.lower_left, src.space.lower_left)
+    np.testing.assert_allclose(new_src.space.upper_right, src.space.upper_right)
+    assert isinstance(new_src.energy, openmc.stats.Discrete)
+    np.testing.assert_allclose(new_src.energy.x, src.energy.x)
+    np.testing.assert_allclose(new_src.energy.p, src.energy.p)
+    assert isinstance(new_src.angle, openmc.stats.PolarAzimuthal)
+    assert new_src.angle.mu.a == src.angle.mu.a
+    assert new_src.angle.mu.b == src.angle.mu.b
+    assert new_src.angle.phi.a == src.angle.phi.a
+    assert new_src.angle.phi.b == src.angle.phi.b
+    np.testing.assert_allclose(new_src.angle.reference_uvw, src.angle.reference_uvw)
+    assert new_src.particle == src.particle
+    assert new_src.strength == approx(src.strength)


### PR DESCRIPTION
I recently discovered that the `reference_uvw` attribute set on angular distributions (`openmc.stats.PolarAzimuthal` and `openmc.stats.Monodirectional`) doesn't roundtrip correctly. This PR fixes that and adds a unit test that would have caught this in the first place.