### PR TITLE
Fix errorneous behavior when adding metastable nuclides via `add_components`

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -438,8 +438,7 @@ class Material(IDManagerMixin):
             params['percent_type'] = percent_type
 
             ## check if nuclide
-            if str.isdigit(component[-1]) or (component[-1] == 'm'
-                                              and str.isdigit(component[-2])):
+            if not str.isalpha():
                 self.add_nuclide(component, **params)
             else: # is element
                 kwargs = params

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -438,7 +438,8 @@ class Material(IDManagerMixin):
             params['percent_type'] = percent_type
 
             ## check if nuclide
-            if str.isdigit(component[-1]):
+            if str.isdigit(component[-1]) or (component[-1] == 'm'
+                                              and str.isdigit(component[-2])):
                 self.add_nuclide(component, **params)
             else: # is element
                 kwargs = params

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -438,7 +438,7 @@ class Material(IDManagerMixin):
             params['percent_type'] = percent_type
 
             ## check if nuclide
-            if not str.isalpha():
+            if not component.isalpha():
                 self.add_nuclide(component, **params)
             else: # is element
                 kwargs = params

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -32,7 +32,7 @@ def test_add_components():
                   'O16': 1.0,
                   'Zr': 1.0,
                   'O': 1.0,
-                  'Ag110m': 1.0,
+                  'Ag110_m1': 1.0,
                   'U': {'percent': 1.0,
                         'enrichment': 4.5},
                   'Li': {'percent': 1.0,

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -32,6 +32,7 @@ def test_add_components():
                   'O16': 1.0,
                   'Zr': 1.0,
                   'O': 1.0,
+                  'Ag110m': 1.0,
                   'U': {'percent': 1.0,
                         'enrichment': 4.5},
                   'Li': {'percent': 1.0,


### PR DESCRIPTION
When writing `add_components`, I seem to have forgotten to test whether it worked with metastable nuclides. The previous version of the function incorrectly sent metastable nuclides to the `add_elements` function, which resulted in an error. This PR fixes that behavior and adds a metastable case to the unit test.