### PR TITLE
added lethargy method to EnergyFilter

### DIFF
--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1336,6 +1336,18 @@ class EnergyFilter(RealFilter):
         """
         return np.log10(self.bins[:, 1]/self.bins[:, 0])
 
+    def lethargy(self, energy):
+        """Calculates the base 10 log of the reference energy over the lower
+        energy bin edge for each energy bin. This is useful when plotting the
+        normalized flux.
+
+        Returns
+        -------
+        numpy.array
+            Array of lethargy values
+        """
+        return np.log10(energy/np.unique(self.bins[:-1]))
+
     @classmethod
     def from_group_structure(cls, group_structure):
         """Construct an EnergyFilter instance from a standard group structure.

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1346,7 +1346,7 @@ class EnergyFilter(RealFilter):
         numpy.array
             Array of lethargy values
         """
-        return np.log10(energy/np.unique(self.bins[:-1]))
+        return np.log10(energy/self.bins[:, 0]))
 
     @classmethod
     def from_group_structure(cls, group_structure):

--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -254,3 +254,12 @@ def test_lethargy_bin_width():
     energy_bins = openmc.mgxs.GROUP_STRUCTURES['VITAMIN-J-175']
     assert f.lethargy_bin_width[0] == np.log10(energy_bins[1]/energy_bins[0])
     assert f.lethargy_bin_width[-1] == np.log10(energy_bins[-1]/energy_bins[-2])
+
+
+def test_lethargy():
+    f = openmc.EnergyFilter.from_group_structure('VITAMIN-J-175')
+    assert len(f.lethargy(14e6)) == 175
+    energy_bins = openmc.mgxs.GROUP_STRUCTURES['VITAMIN-J-175']
+    assert f.lethargy(14e6)[0] == np.log10(14e6/energy_bins[0])
+    # last bin is skipped by lethargy() so test looks at 2nd to last
+    assert f.lethargy(14e6)[-1] == np.log10(14e6/energy_bins[-2])


### PR DESCRIPTION
Looking forward to the next openmc training course and remembering that we tend to get at least one question on plotting neutron spectra on a lethargy scale. I think we are reasonably well prepared for this question now that we have the ```.lethargy_bin_width()``` added by PR #2154 a while back.

During the review of PR #2154 the usual definition of lethargy was mentioned by @paulromano in https://github.com/openmc-dev/openmc/issues/2154#issuecomment-1208351160_

This PR attempts to add ```lethargy()``` method to the ```EnergyFilter``` and hopefully preempts one question / request in the next training course.

I attach a plot showing flux plotted with different normalization options and the script to reproduce
![flux_lethargy_comparision](https://user-images.githubusercontent.com/8583900/188890292-75319d4d-d4e5-4b21-aa61-d09dde79e191.png)


```python
import openmc
import matplotlib.pyplot as plt

my_material = openmc.Material(name='tungsten_water')
my_material.add_element('W', 0.001, percent_type='ao')
my_material.add_element('H', 1, percent_type='ao')
my_material.add_element('O', 2, percent_type='ao')
my_material.set_density('g/cm3', 1)
mats = openmc.Materials([my_material])

sphere_surface = openmc.Sphere(r=550, boundary_type='vacuum')

blanket_cell = openmc.Cell(region=-sphere_surface)
blanket_cell.fill = my_material

universe = openmc.Universe(cells=[blanket_cell])
geom = openmc.Geometry(universe)

sett = openmc.Settings()
sett.batches = 10
sett.particles = 100_000
sett.run_mode = 'fixed source'

source = openmc.Source()
source.space = openmc.stats.Point((0, 0, 0))
source.angle = openmc.stats.Isotropic()
source.energy = openmc.stats.Discrete([14e6], [1])
sett.source = source

neutron_particle_filter = openmc.ParticleFilter(['neutron'])
energy_filter = openmc.EnergyFilter.from_group_structure('CCFE-709')
cell_filter = openmc.CellFilter(blanket_cell) 

cell_spectra_tally = openmc.Tally(name='cell_spectra_tally')
cell_spectra_tally.scores = ['flux']
cell_spectra_tally.filters = [cell_filter, neutron_particle_filter, energy_filter]
tallies = openmc.Tallies([cell_spectra_tally])

model = openmc.model.Model(geom, mats, sett, tallies)
results_filename = model.run()

results = openmc.StatePoint(results_filename)
cell_tally = results.get_tally(name='cell_spectra_tally')
energy_filter = cell_tally.find_filter(filter_type=openmc.filter.EnergyFilter)

flux = cell_tally.mean.flatten()

bin_boundaries_1 = energy_filter.lethargy_bin_width
norm_flux_lbw = flux / bin_boundaries_1

bin_boundaries_2 = energy_filter.lethargy(14e6)
norm_flux_l = flux / bin_boundaries_2

fig, axs = plt.subplots(3)
fig.set_figheight(10)
fig.set_figwidth(10)

axs[0].step(energy_filter.values[:-1], norm_flux_lbw, label='flux lethargy bin width normalization')
axs[0].set_xscale('log')
axs[0].set_yscale('log')
axs[0].set_ylabel('Flux per unit lethargy\n(bin width)\n[n/cm2-s]')

axs[1].step(energy_filter.values[:-1], norm_flux_l, label='flux lethargy normalization')
axs[1].set_xscale('log')
axs[1].set_yscale('log')
axs[1].set_ylabel('Flux per unit lethargy\n(ref energy=14MeV)\n[n/cm2-s]')

axs[2].step(energy_filter.values[:-1], flux, label='flux')
axs[2].set_xscale('log')
axs[2].set_yscale('log')
axs[2].set_ylabel('Flux\n[n/cm2-s]')
axs[2].set_xlabel('Energy [ev]')

plt.savefig('flux_lethargy_comparision.png')
```