### PR TITLE
Add a `__deepcopy__` method to the deplete.FissionYield class

### DIFF
--- a/openmc/deplete/nuclide.py
+++ b/openmc/deplete/nuclide.py
@@ -682,7 +682,7 @@ class FissionYield(Mapping):
             self.__class__.__name__, len(self))
 
     def __deepcopy__(self, memo):
-        result = FissionYield(self.products, np.copy(self.yields))
+        result = FissionYield(self.products, self.yields.copy())
         memo[id(self)] = result
         return result
 

--- a/openmc/deplete/nuclide.py
+++ b/openmc/deplete/nuclide.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     import xml.etree.ElementTree as ET
 
-from numpy import empty, searchsorted
+import numpy as np
 
 from openmc.checkvalue import check_type
 
@@ -470,7 +470,7 @@ class FissionYieldDistribution(Mapping):
         shared_prod = set.union(*(set(x) for x in fission_yields.values()))
         ordered_prod = sorted(shared_prod)
 
-        yield_matrix = empty((len(energies), len(shared_prod)))
+        yield_matrix = np.empty((len(energies), len(shared_prod)))
 
         for g_index, energy in enumerate(energies):
             prod_map = fission_yields[energy]
@@ -560,7 +560,7 @@ class FissionYieldDistribution(Mapping):
             return None
 
         products = sorted(overlap)
-        indices = searchsorted(self.products, products)
+        indices = np.searchsorted(self.products, products)
 
         # coerce back to dictionary to pass back to __init__
         new_yields = {}
@@ -680,6 +680,11 @@ class FissionYield(Mapping):
     def __repr__(self):
         return "<{} containing {} products and yields>".format(
             self.__class__.__name__, len(self))
+
+    def __deepcopy__(self, memo):
+        result = FissionYield(self.products, np.copy(self.yields))
+        memo[id(self)] = result
+        return result
 
     # Avoid greedy numpy operations like np.float64 * fission_yield
     # converting this to an array on the fly. Force __rmul__ and

--- a/tests/unit_tests/test_deplete_nuclide.py
+++ b/tests/unit_tests/test_deplete_nuclide.py
@@ -1,7 +1,7 @@
 """Tests for the openmc.deplete.Nuclide class."""
 
 import xml.etree.ElementTree as ET
-
+import copy
 import numpy as np
 import pytest
 from openmc.deplete import nuclide
@@ -335,3 +335,14 @@ def test_validate():
     assert "decay mode" in record[0].message.args[0]
     assert "0 reaction" in record[1].message.args[0]
     assert "1.0" in record[2].message.args[0]
+
+
+def test_deepcopy():
+    """Test deepcopying a FissionYield object"""
+    nuc = nuclide.FissionYield(products=("I129", "Sm149", "Xe135"), yields=np.array((0.001, 0.0003, 0.002)))
+    copied_nuc = copy.deepcopy(nuc)
+    # Check the deepcopy equals the original
+    assert copied_nuc == nuc
+    # Mutate the original and verify the copy remains intact
+    nuc *= 2
+    assert copied_nuc != nuc


### PR DESCRIPTION
The deplete.OpenMCOperator's `_calculate_reaction_rates` method is slowed down by the `self._yield_helper.weighted_yields(i)` call. Within this call, the entire fission yield is deepcopied when the `self.constant_yields` property is called. This deepcopy is then performed for each burnable material. This change significantly speeds up this process by instantiating a new object rather than deepcopying the original. 