### PR TITLE
added bbox class method to regular mesh

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -279,6 +279,7 @@ class StructuredMesh(MeshBase):
 
         return vtk_grid
 
+
 class RegularMesh(StructuredMesh):
     """A regular Cartesian mesh in one, two, or three dimensions
 
@@ -506,6 +507,49 @@ class RegularMesh(StructuredMesh):
         mesh.lower_left = lattice.lower_left
         mesh.upper_right = lattice.lower_left + width
         mesh.dimension = shape*division
+
+        return mesh
+
+    @classmethod
+    def from_bounding_box(
+        cls,
+        bounding_box,
+        dimension=[100, 100, 100],
+        mesh_id=None,
+        name=''
+    ):
+        """Create mesh from an existing openmc cell, region, universe or
+        geometry by making use of the objects bounding box property.
+
+        Parameters
+        ----------
+        bounding_box : {openmc.Cell, openmc.Region, openmc.Universe, openmc.Geometry}
+            The object passed in will be used as a template for this mesh. The
+            bounding_box of the property of the object passed will be used to
+            set the lower_left and upper_right of the mesh instance
+        dimension : Iterable of int
+            The number of mesh cells in each direction.
+        mesh_id : int
+            Unique identifier for the mesh
+        name : str
+            Name of the mesh
+
+        Returns
+        -------
+        openmc.RegularMesh
+            RegularMesh instance
+
+        """
+        cv.check_type(
+            "bounding_box",
+            bounding_box,
+            (openmc.Cell, openmc.Region, openmc.Universe, openmc.Geometry),
+        )
+
+        mesh = cls(mesh_id, name)
+        mesh.lower_left = bounding_box.bounding_box[0]
+        mesh.upper_right = bounding_box.bounding_box[1]
+        mesh.dimension = dimension
 
         return mesh
 

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -511,9 +511,9 @@ class RegularMesh(StructuredMesh):
         return mesh
 
     @classmethod
-    def from_bounding_box(
+    def from_domain(
         cls,
-        bounding_box,
+        domain,
         dimension=[100, 100, 100],
         mesh_id=None,
         name=''
@@ -523,9 +523,9 @@ class RegularMesh(StructuredMesh):
 
         Parameters
         ----------
-        bounding_box : {openmc.Cell, openmc.Region, openmc.Universe, openmc.Geometry}
+        domain : {openmc.Cell, openmc.Region, openmc.Universe, openmc.Geometry}
             The object passed in will be used as a template for this mesh. The
-            bounding_box of the property of the object passed will be used to
+            domain of the property of the object passed will be used to
             set the lower_left and upper_right of the mesh instance
         dimension : Iterable of int
             The number of mesh cells in each direction.
@@ -541,14 +541,14 @@ class RegularMesh(StructuredMesh):
 
         """
         cv.check_type(
-            "bounding_box",
-            bounding_box,
+            "domain",
+            domain,
             (openmc.Cell, openmc.Region, openmc.Universe, openmc.Geometry),
         )
 
         mesh = cls(mesh_id, name)
-        mesh.lower_left = bounding_box.bounding_box[0]
-        mesh.upper_right = bounding_box.bounding_box[1]
+        mesh.lower_left = domain.bounding_box[0]
+        mesh.upper_right = domain.bounding_box[1]
         mesh.dimension = dimension
 
         return mesh

--- a/tests/unit_tests/test_mesh_from_bounding_box.py
+++ b/tests/unit_tests/test_mesh_from_bounding_box.py
@@ -1,0 +1,63 @@
+import numpy as np
+import openmc
+import pytest
+
+
+def test_mesh_from_cell():
+    """Tests a RegularMesh can be made from a Cell and the specified dimensions
+    are propagated through. Cell is not centralized"""
+    surface = openmc.Sphere(r=10, x0=2, y0=3, z0=5)
+    cell = openmc.Cell(region=-surface)
+
+    mesh = openmc.RegularMesh.from_bounding_box(cell, dimension=[7, 11, 13])
+    assert isinstance(mesh, openmc.RegularMesh)
+    assert np.array_equal(mesh.dimension, (7, 11, 13))
+    assert np.array_equal(mesh.lower_left, cell.bounding_box[0])
+    assert np.array_equal(mesh.upper_right, cell.bounding_box[1])
+
+
+def test_mesh_from_region():
+    """Tests a RegularMesh can be made from a Region and the default dimensions
+    are propagated through. Region is not centralized"""
+    surface = openmc.Sphere(r=1, x0=-5, y0=-3, z0=-2)
+    region = -surface
+
+    mesh = openmc.RegularMesh.from_bounding_box(region)
+    assert isinstance(mesh, openmc.RegularMesh)
+    assert np.array_equal(mesh.dimension, (100, 100, 100))  # default values
+    assert np.array_equal(mesh.lower_left, region.bounding_box[0])
+    assert np.array_equal(mesh.upper_right, region.bounding_box[1])
+
+
+def test_mesh_from_universe():
+    """Tests a RegularMesh can be made from a Universe and the default dimensions
+    are propagated through. Universe is centralized"""
+    surface = openmc.Sphere(r=42)
+    cell = openmc.Cell(region=-surface)
+    universe = openmc.Universe(cells=[cell])
+
+    mesh = openmc.RegularMesh.from_bounding_box(universe)
+    assert isinstance(mesh, openmc.RegularMesh)
+    assert np.array_equal(mesh.dimension, (100, 100, 100))  # default values
+    assert np.array_equal(mesh.lower_left, universe.bounding_box[0])
+    assert np.array_equal(mesh.upper_right, universe.bounding_box[1])
+
+
+def test_mesh_from_geometry():
+    """Tests a RegularMesh can be made from a Geometry and the default dimensions
+    are propagated through. Geometry is centralized"""
+    surface = openmc.Sphere(r=42)
+    cell = openmc.Cell(region=-surface)
+    universe = openmc.Universe(cells=[cell])
+    geometry = openmc.Geometry(universe)
+
+    mesh = openmc.RegularMesh.from_bounding_box(geometry)
+    assert isinstance(mesh, openmc.RegularMesh)
+    assert np.array_equal(mesh.dimension, (100, 100, 100))  # default values
+    assert np.array_equal(mesh.lower_left, geometry.bounding_box[0])
+    assert np.array_equal(mesh.upper_right, geometry.bounding_box[1])
+
+
+def test_error_from_unsupported_object():
+    with pytest.raises(TypeError):
+        openmc.RegularMesh.from_bounding_box("vacuum energy")

--- a/tests/unit_tests/test_mesh_from_domain.py
+++ b/tests/unit_tests/test_mesh_from_domain.py
@@ -3,7 +3,7 @@ import openmc
 import pytest
 
 
-def test_mesh_from_cell():
+def test_reg_mesh_from_cell():
     """Tests a RegularMesh can be made from a Cell and the specified dimensions
     are propagated through. Cell is not centralized"""
     surface = openmc.Sphere(r=10, x0=2, y0=3, z0=5)
@@ -16,7 +16,7 @@ def test_mesh_from_cell():
     assert np.array_equal(mesh.upper_right, cell.bounding_box[1])
 
 
-def test_mesh_from_region():
+def test_reg_mesh_from_region():
     """Tests a RegularMesh can be made from a Region and the default dimensions
     are propagated through. Region is not centralized"""
     surface = openmc.Sphere(r=1, x0=-5, y0=-3, z0=-2)
@@ -29,7 +29,7 @@ def test_mesh_from_region():
     assert np.array_equal(mesh.upper_right, region.bounding_box[1])
 
 
-def test_mesh_from_universe():
+def test_reg_mesh_from_universe():
     """Tests a RegularMesh can be made from a Universe and the default dimensions
     are propagated through. Universe is centralized"""
     surface = openmc.Sphere(r=42)
@@ -43,7 +43,7 @@ def test_mesh_from_universe():
     assert np.array_equal(mesh.upper_right, universe.bounding_box[1])
 
 
-def test_mesh_from_geometry():
+def test_reg_mesh_from_geometry():
     """Tests a RegularMesh can be made from a Geometry and the default dimensions
     are propagated through. Geometry is centralized"""
     surface = openmc.Sphere(r=42)

--- a/tests/unit_tests/test_mesh_from_domain.py
+++ b/tests/unit_tests/test_mesh_from_domain.py
@@ -9,7 +9,7 @@ def test_mesh_from_cell():
     surface = openmc.Sphere(r=10, x0=2, y0=3, z0=5)
     cell = openmc.Cell(region=-surface)
 
-    mesh = openmc.RegularMesh.from_bounding_box(cell, dimension=[7, 11, 13])
+    mesh = openmc.RegularMesh.from_domain(cell, dimension=[7, 11, 13])
     assert isinstance(mesh, openmc.RegularMesh)
     assert np.array_equal(mesh.dimension, (7, 11, 13))
     assert np.array_equal(mesh.lower_left, cell.bounding_box[0])
@@ -22,7 +22,7 @@ def test_mesh_from_region():
     surface = openmc.Sphere(r=1, x0=-5, y0=-3, z0=-2)
     region = -surface
 
-    mesh = openmc.RegularMesh.from_bounding_box(region)
+    mesh = openmc.RegularMesh.from_domain(region)
     assert isinstance(mesh, openmc.RegularMesh)
     assert np.array_equal(mesh.dimension, (100, 100, 100))  # default values
     assert np.array_equal(mesh.lower_left, region.bounding_box[0])
@@ -36,7 +36,7 @@ def test_mesh_from_universe():
     cell = openmc.Cell(region=-surface)
     universe = openmc.Universe(cells=[cell])
 
-    mesh = openmc.RegularMesh.from_bounding_box(universe)
+    mesh = openmc.RegularMesh.from_domain(universe)
     assert isinstance(mesh, openmc.RegularMesh)
     assert np.array_equal(mesh.dimension, (100, 100, 100))  # default values
     assert np.array_equal(mesh.lower_left, universe.bounding_box[0])
@@ -51,7 +51,7 @@ def test_mesh_from_geometry():
     universe = openmc.Universe(cells=[cell])
     geometry = openmc.Geometry(universe)
 
-    mesh = openmc.RegularMesh.from_bounding_box(geometry)
+    mesh = openmc.RegularMesh.from_domain(geometry)
     assert isinstance(mesh, openmc.RegularMesh)
     assert np.array_equal(mesh.dimension, (100, 100, 100))  # default values
     assert np.array_equal(mesh.lower_left, geometry.bounding_box[0])
@@ -60,4 +60,4 @@ def test_mesh_from_geometry():
 
 def test_error_from_unsupported_object():
     with pytest.raises(TypeError):
-        openmc.RegularMesh.from_bounding_box("vacuum energy")
+        openmc.RegularMesh.from_domain("vacuum energy")


### PR DESCRIPTION
This PR is an attempt to add a class method to ```RegularMesh``` that allows construction of a regular mesh from a cell, region, universe or geometry.

Merging this PR closes #2210