### PR TITLE
Add a cache system for the depletion material reaction rates tally

### DIFF
--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -147,7 +147,6 @@ class DirectReactionRateHelper(ReactionRateHelper):
     def __init__(self, n_nuc, n_react):
         super().__init__(n_nuc, n_react)
         self._rate_tally = None
-        self._rate_tally_means = None
 
         # Automatically pre-calculate reaction rates for depletion
         openmc.lib.settings.need_depletion_rx = True
@@ -176,18 +175,20 @@ class DirectReactionRateHelper(ReactionRateHelper):
         self._rate_tally.writable = False
         self._rate_tally.scores = scores
         self._rate_tally.filters = [MaterialFilter(materials)]
+        self._rate_tally_means_cache = None
 
     @property
     def rate_tally_means(self):
         # If the mean cache is empty, fill it once with this transport cycle's results
-        if self._rate_tally_means is None:
-            self._rate_tally_means = self._rate_tally.mean
-        return self._rate_tally_means
+        if self._rate_tally_means_cache is None:
+            self._rate_tally_means_cache = self._rate_tally.mean
+        return self._rate_tally_means_cache
 
     def reset_tally_means(self):
-        """Reset the cached mean rate tallies. This step must be performed after each transport cycle
+        """Reset the cached mean rate tallies.
+        This step must be performed after each transport cycle
         """
-        self._rate_tally_means = None
+        self._rate_tally_means_cache = None
 
     def get_material_rates(self, mat_id, nuc_index, react_index):
         """Return an array of reaction rates for a material
@@ -318,7 +319,8 @@ class FluxCollapseHelper(ReactionRateHelper):
         return self._flux_tally_means_cache
 
     def reset_tally_means(self):
-        """Reset the cached mean rate and flux tallies. This step must be performed after each transport cycle
+        """Reset the cached mean rate and flux tallies.
+        This step must be performed after each transport cycle
         """
         self._flux_tally_means_cache = None
         if self._reactions_direct:

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -179,6 +179,8 @@ class DirectReactionRateHelper(ReactionRateHelper):
 
     @property
     def rate_tally_means(self):
+        """The mean results of the tally of every material's reaction rates for this cycle
+        """
         # If the mean cache is empty, fill it once with this transport cycle's results
         if self._rate_tally_means_cache is None:
             self._rate_tally_means_cache = self._rate_tally.mean
@@ -186,7 +188,9 @@ class DirectReactionRateHelper(ReactionRateHelper):
 
     def reset_tally_means(self):
         """Reset the cached mean rate tallies.
-        This step must be performed after each transport cycle
+        .. note::
+            
+                This step must be performed after each transport cycle
         """
         self._rate_tally_means_cache = None
 
@@ -306,6 +310,8 @@ class FluxCollapseHelper(ReactionRateHelper):
 
     @property
     def rate_tally_means(self):
+        """The mean results of the tally of every material's reaction rates for this cycle
+        """
         # If the mean cache is empty, fill it once with this transport cycle's results
         if self._rate_tally_means_cache is None:
             self._rate_tally_means_cache = self._rate_tally.mean
@@ -320,12 +326,13 @@ class FluxCollapseHelper(ReactionRateHelper):
 
     def reset_tally_means(self):
         """Reset the cached mean rate and flux tallies.
-        This step must be performed after each transport cycle
+        .. note::
+            
+                This step must be performed after each transport cycle
         """
         self._flux_tally_means_cache = None
         if self._reactions_direct:
             self._rate_tally_means_cache = None
-
 
     def get_material_rates(self, mat_index, nuc_index, react_index):
         """Return an array of reaction rates for a material

--- a/openmc/deplete/independent_operator.py
+++ b/openmc/deplete/independent_operator.py
@@ -303,6 +303,10 @@ class IndependentOperator(OpenMCOperator):
             """Unused in this case"""
             pass
 
+        def reset_tally_means(self):
+            """Unused in this case"""
+            pass
+
         def get_material_rates(self, mat_id, nuc_index, react_index):
             """Return 2D array of [nuclide, reaction] reaction rates
 

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -507,6 +507,9 @@ class OpenMCOperator(TransportOperator):
 
         fission_ind = rates.index_rx.get("fission")
 
+        # Reset the cached material reaction rates tallies
+        self._rate_helper.reset_tally_means()
+
         # Extract results
         for i, mat in enumerate(self.local_mats):
             # Get tally index


### PR DESCRIPTION
With each burnable material, the reaction rates tallies are read from the DLL when accessing the `_rate_tally.mean`. Then, the specific material desired is indexed from this tally. This causes the transmutation time to significantly increase with the depletable material count. This proposed change reads the tally results once per transmutation cycle and stores the results in a cache. The cache is then used for all subsequent depletable materials when accessing their rates. At the beginning of each cycle, the cache is reset so the new tally results can be read back in.