### PR TITLE
helpful error message for excessive energy spectrum rejection rate

### DIFF
--- a/src/source.cpp
+++ b/src/source.cpp
@@ -201,13 +201,11 @@ SourceSite IndependentSource::sample(uint64_t* seed) const
       if (n_reject >= EXTSRC_REJECT_THRESHOLD &&
           static_cast<double>(n_accept) / n_reject <= EXTSRC_REJECT_FRACTION) {
         fatal_error("More than 95% of external source sites sampled were "
-                    "rejected. Please check your external source definition.");
+                    "rejected. Please check your external source's spatial "
+                    "definition.");
       }
     }
   }
-
-  // Increment number of accepted samples
-  ++n_accept;
 
   // Sample angle
   site.u = angle_->sample(seed);
@@ -233,10 +231,21 @@ SourceSite IndependentSource::sample(uint64_t* seed) const
     // Resample if energy falls outside minimum or maximum particle energy
     if (site.E < data::energy_max[p] && site.E > data::energy_min[p])
       break;
+
+    n_reject++;
+    if (n_reject >= EXTSRC_REJECT_THRESHOLD &&
+        static_cast<double>(n_accept) / n_reject <= EXTSRC_REJECT_FRACTION) {
+      fatal_error("More than 95% of external source sites sampled were "
+                  "rejected. Please check your external source energy spectrum "
+                  "definition.");
+    }
   }
 
   // Sample particle creation time
   site.time = time_->sample(seed);
+
+  // Increment number of accepted samples
+  ++n_accept;
 
   return site;
 }


### PR DESCRIPTION
This has OpenMC include rejection of sampling from the energy spectrum as counting towards the rejection rate counter. It's possible that a user can define a source energy spectrum that falls WAY outside the allowable energy ranges for a problem, and when this happens, OpenMC can become incredible slow for no apparent reason.

Created in [response to this](https://openmc.discourse.group/t/is-multigroup-mode-prohibitively-slow/2297).