### PR TITLE
added ability to find material names in DAG

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -708,7 +708,7 @@ class DAGMCUniverse(UniverseBase):
 
         Returns
         -------
-        materials : List[str]
+        materials : list of str
             Sorted list of material names present in the DAGMC h5m file
 
         """
@@ -717,10 +717,7 @@ class DAGMCUniverse(UniverseBase):
         material_tags_hex=dagmc_file_contents['/tstt/tags/NAME'].get('values')
         material_tags_ascii=[]
         for tag in material_tags_hex:
-            raw_tag=  np.array2string(tag)
-            tag_in_hex=raw_tag.replace("\\x00", '').replace("\\x", '')
-            tag_in_hex =tag_in_hex.lstrip("b'").rstrip("'")
-            candidate_tag = bytes.fromhex(tag_in_hex).decode()
+            candidate_tag = tag.tobytes().decode().replace('\x00', '')
             # tags might be for temperature or reflective surfaces
             if candidate_tag.startswith('mat:'):
                 # removes first 4 characters as openmc.Material name should be

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -647,6 +647,11 @@ class DAGMCUniverse(UniverseBase):
     bounding_box : 2-tuple of numpy.array
         Lower-left and upper-right coordinates of an axis-aligned bounding box
         of the universe.
+    material_name : list of str
+        Return a sorted list of materials names that are contained within the
+        DAGMC h5m file. This is useful when naming openmc.Material() objects
+        as each material name present in the DAGMC h5m file must have a
+        matching openmc.Material() with the same name.
 
         .. versionadded:: 0.13.1
     """
@@ -701,18 +706,6 @@ class DAGMCUniverse(UniverseBase):
 
     @property
     def material_names(self):
-        """Return the names of the materials that are contained within the
-         DAGMC h5m file. This is useful when naming openmc.Material() objects
-         as each material name present in the DAGMC h5m file must have a
-         matching openmc.Material() with the same name.
-
-        Returns
-        -------
-        materials : list of str
-            Sorted list of material names present in the DAGMC h5m file
-
-        """
-
         dagmc_file_contents = h5py.File(self.filename)
         material_tags_hex=dagmc_file_contents['/tstt/tags/NAME'].get('values')
         material_tags_ascii=[]

--- a/tests/unit_tests/dagmc/test_bounds.py
+++ b/tests/unit_tests/dagmc/test_bounds.py
@@ -71,3 +71,12 @@ def test_bounded_universe(request):
     surfaces = list(cells[0][1].region.get_surfaces().items())
     assert surfaces[0][1].type == "sphere"
     assert surfaces[0][1].id == 43
+
+
+def test_material_names(request):
+    """Checks that the DAGMCUniverse.material_names() returns a list of the
+    name present in the dagmc.h5m file in the expected order"""
+
+    u = openmc.DAGMCUniverse(Path(request.fspath).parent / "dagmc.h5m")
+
+    assert u.material_names == ['41', 'Graveyard', 'no-void fuel']


### PR DESCRIPTION
As discussed in issue #2229 this PR is an attempt to allow users to easily find the DAGMC material tags present in a DAGMCUniverse.

This is useful as the tags are needed when naming openmc.Material() objects used in the simulation and there is not an easy way of finding tags from a material file otherwise. openmc.Materials with the same names as the tags must exist for each tag otherwise the simulation fails.

There is this [handy micro package](https://github.com/fusion-energy/dagmc_h5m_file_inspector) I made a while back that uses MOAB to find tag names but no one wants to have to install another package for such a task and it would be much more convenient to have the material tags where they are needed. 

Also the method is proposed in the PR is nicer than the dagmc_h5m_file_inspector package as it makes use of h5py which is a openmc dependency already.

This PR is moving functionality from another one of my mico packages and improving it along the way.
