### PR TITLE
added from domain to CylindricalMesh

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1154,7 +1154,7 @@ class CylindricalMesh(StructuredMesh):
         domain : {openmc.Cell, openmc.Region, openmc.Universe, openmc.Geometry}
             The object passed in will be used as a template for this mesh. The
             bounding box of the property of the object passed will be used to
-            set the The r_grid, z_grid ranges.
+            set the r_grid, z_grid ranges.
         dimension : Iterable of int
             The number of equally spaced mesh cells in each direction (r_grid,
             phi_grid, z_grid)

--- a/tests/unit_tests/test_mesh_from_domain.py
+++ b/tests/unit_tests/test_mesh_from_domain.py
@@ -16,6 +16,22 @@ def test_reg_mesh_from_cell():
     assert np.array_equal(mesh.upper_right, cell.bounding_box[1])
 
 
+def test_cylindrical_mesh_from_cell():
+    """Tests a CylindricalMesh can be made from a Cell and the specified
+    dimensions are propagated through. Cell is not centralized"""
+    cy_surface = openmc. openmc.ZCylinder(r=50)
+    z_surface_1 = openmc. openmc.ZPlane(z0=30)
+    z_surface_2 = openmc. openmc.ZPlane(z0=0)
+    cell = openmc.Cell(region=-cy_surface & -z_surface_1 & +z_surface_2)
+    mesh = openmc.CylindricalMesh.from_domain(cell, dimension=[2, 4, 3])
+
+    assert isinstance(mesh, openmc.CylindricalMesh)
+    assert np.array_equal(mesh.dimension, (2, 4, 3))
+    assert np.array_equal(mesh.r_grid, [0., 25., 50.])
+    assert np.array_equal(mesh.phi_grid, [0., 0.5*np.pi, np.pi, 1.5*np.pi, 2.*np.pi])
+    assert np.array_equal(mesh.z_grid, [0., 10., 20., 30.])
+
+
 def test_reg_mesh_from_region():
     """Tests a RegularMesh can be made from a Region and the default dimensions
     are propagated through. Region is not centralized"""
@@ -29,9 +45,25 @@ def test_reg_mesh_from_region():
     assert np.array_equal(mesh.upper_right, region.bounding_box[1])
 
 
+def test_cylindrical_mesh_from_region():
+    """Tests a CylindricalMesh can be made from a Region and the specified
+    dimensions are propagated through. Cell is centralized"""
+    cy_surface = openmc. openmc.ZCylinder(r=6)
+    z_surface_1 = openmc. openmc.ZPlane(z0=30)
+    z_surface_2 = openmc. openmc.ZPlane(z0=-30)
+    cell = openmc.Cell(region=-cy_surface & -z_surface_1 & +z_surface_2)
+    mesh = openmc.CylindricalMesh.from_domain(cell, dimension=[6, 2, 3])
+
+    assert isinstance(mesh, openmc.CylindricalMesh)
+    assert np.array_equal(mesh.dimension, (6, 2, 3))
+    assert np.array_equal(mesh.r_grid, [0., 1., 2., 3., 4., 5., 6.])
+    assert np.array_equal(mesh.phi_grid, [0., np.pi, 2.*np.pi])
+    assert np.array_equal(mesh.z_grid, [-30., -10., 10., 30.])
+
+
 def test_reg_mesh_from_universe():
-    """Tests a RegularMesh can be made from a Universe and the default dimensions
-    are propagated through. Universe is centralized"""
+    """Tests a RegularMesh can be made from a Universe and the default
+    dimensions are propagated through. Universe is centralized"""
     surface = openmc.Sphere(r=42)
     cell = openmc.Cell(region=-surface)
     universe = openmc.Universe(cells=[cell])
@@ -44,8 +76,8 @@ def test_reg_mesh_from_universe():
 
 
 def test_reg_mesh_from_geometry():
-    """Tests a RegularMesh can be made from a Geometry and the default dimensions
-    are propagated through. Geometry is centralized"""
+    """Tests a RegularMesh can be made from a Geometry and the default
+    dimensions are propagated through. Geometry is centralized"""
     surface = openmc.Sphere(r=42)
     cell = openmc.Cell(region=-surface)
     universe = openmc.Universe(cells=[cell])


### PR DESCRIPTION
This PR attempts to mirror the ```from_domain``` method recently added to ```RegularMesh``` (PR https://github.com/openmc-dev/openmc/pull/2217) to the ```CylindricalMesh```.

The bounding box of the domain (Cell, Region, Universe, Geometry) is used to set the upper values of ```r_grid``` and ```z_grid``` while the user is able to specify the number of dimensions.

I have also added a couple of unit tests.

User code would be
```python
mesh = openmc.CylindricalMesh.from_domain(cell, dimension=[6, 2, 3])
```