### PR TITLE
Source rejection by domain (cell, material, universe)

### DIFF
--- a/include/openmc/source.h
+++ b/include/openmc/source.h
@@ -80,13 +80,18 @@ public:
   Distribution* time() const { return time_.get(); }
 
 private:
+  // Domain types
+  enum class DomainType { UNIVERSE, MATERIAL, CELL };
+
+  // Data members
   ParticleType particle_ {ParticleType::neutron}; //!< Type of particle emitted
   double strength_ {1.0};                         //!< Source strength
   UPtrSpace space_;                               //!< Spatial distribution
   UPtrAngle angle_;                               //!< Angular distribution
   UPtrDist energy_;                               //!< Energy distribution
   UPtrDist time_;                                 //!< Time distribution
-  std::unordered_set<int32_t> cells_;             //!< Cells to reject from
+  DomainType domain_type_;                        //!< Domain type for rejection
+  std::unordered_set<int32_t> domain_ids_;        //!< Domains to reject from
 };
 
 //==============================================================================

--- a/include/openmc/source.h
+++ b/include/openmc/source.h
@@ -4,6 +4,8 @@
 #ifndef OPENMC_SOURCE_H
 #define OPENMC_SOURCE_H
 
+#include <unordered_set>
+
 #include "pugixml.hpp"
 
 #include "openmc/distribution_multi.h"
@@ -51,13 +53,15 @@ public:
 };
 
 //==============================================================================
-//! Source composed of independent spatial, angle, energy, and time distributions
+//! Source composed of independent spatial, angle, energy, and time
+//! distributions
 //==============================================================================
 
 class IndependentSource : public Source {
 public:
   // Constructors
-  IndependentSource(UPtrSpace space, UPtrAngle angle, UPtrDist energy, UPtrDist time);
+  IndependentSource(
+    UPtrSpace space, UPtrAngle angle, UPtrDist energy, UPtrDist time);
   explicit IndependentSource(pugi::xml_node node);
 
   //! Sample from the external source distribution
@@ -82,6 +86,7 @@ private:
   UPtrAngle angle_;                               //!< Angular distribution
   UPtrDist energy_;                               //!< Energy distribution
   UPtrDist time_;                                 //!< Time distribution
+  std::unordered_set<int32_t> cells_;             //!< Cells to reject from
 };
 
 //==============================================================================

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -217,19 +217,14 @@ SourceSite IndependentSource::sample(uint64_t* seed) const
         if (domain_type_ == DomainType::MATERIAL) {
           auto mat_index = p.material();
           if (mat_index != MATERIAL_VOID) {
-            if (contains(domain_ids_, model::materials[mat_index]->id())) {
-              found = true;
-            }
+            found = contains(domain_ids_, model::materials[mat_index]->id());
           }
         } else {
           for (const auto& coord : p.coord()) {
             auto id = (domain_type_ == DomainType::CELL)
                         ? model::cells[coord.cell]->id_
                         : model::universes[coord.universe]->id_;
-            if (contains(domain_ids_, id)) {
-              found = true;
-              break;
-            }
+            if (found = contains(domain_ids_, id)) break;
           }
         }
       }

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -16,8 +16,10 @@
 #include "openmc/bank.h"
 #include "openmc/capi.h"
 #include "openmc/cell.h"
+#include "openmc/container_util.h"
 #include "openmc/error.h"
 #include "openmc/file_utils.h"
+#include "openmc/geometry.h"
 #include "openmc/hdf5_interface.h"
 #include "openmc/material.h"
 #include "openmc/memory.h"
@@ -151,29 +153,36 @@ IndependentSource::IndependentSource(pugi::xml_node node)
       double p[] {1.0};
       time_ = UPtrDist {new Discrete {T, p, 1}};
     }
+
+    // Check for cells to reject from
+    if (check_for_node(node, "cells")) {
+      auto cells = get_node_array<int>(node, "cells");
+      cells_.insert(cells.cbegin(), cells.cend());
+    }
   }
 }
 
 SourceSite IndependentSource::sample(uint64_t* seed) const
 {
   SourceSite site;
+  site.particle = particle_;
 
   // Repeat sampling source location until a good site has been found
   bool found = false;
   int n_reject = 0;
   static int n_accept = 0;
+
   while (!found) {
     // Set particle type
-    site.particle = particle_;
+    Particle p;
+    p.type() = particle_;
+    p.u() = {0.0, 0.0, 1.0};
 
     // Sample spatial distribution
-    site.r = space_->sample(seed);
+    p.r() = space_->sample(seed);
 
     // Now search to see if location exists in geometry
-    int32_t cell_index, instance;
-    double xyz[] {site.r.x, site.r.y, site.r.z};
-    int err = openmc_find_cell(xyz, &cell_index, &instance);
-    found = (err != OPENMC_E_GEOMETRY);
+    found = exhaustive_find_cell(p);
 
     // Check if spatial site is in fissionable material
     if (found) {
@@ -181,15 +190,22 @@ SourceSite IndependentSource::sample(uint64_t* seed) const
       if (space_box) {
         if (space_box->only_fissionable()) {
           // Determine material
-          const auto& c = model::cells[cell_index];
-          auto mat_index =
-            c->material_.size() == 1 ? c->material_[0] : c->material_[instance];
-
+          auto mat_index = p.material();
           if (mat_index == MATERIAL_VOID) {
             found = false;
           } else {
-            if (!model::materials[mat_index]->fissionable_)
-              found = false;
+            found = model::materials[mat_index]->fissionable_;
+          }
+        }
+      }
+
+      // Rejection based on cells
+      if (!cells_.empty()) {
+        found = false;
+        for (const auto& coord : p.coord()) {
+          if (contains(cells_, model::cells[coord.cell]->id_)) {
+            found = true;
+            break;
           }
         }
       }
@@ -205,6 +221,8 @@ SourceSite IndependentSource::sample(uint64_t* seed) const
                     "definition.");
       }
     }
+
+    site.r = p.r();
   }
 
   // Sample angle

--- a/tests/unit_tests/test_source.py
+++ b/tests/unit_tests/test_source.py
@@ -131,6 +131,6 @@ def test_rejection(run_in_tmpdir):
     joint_region = cell1.region | cell2.region
     for p in particles:
         assert p.r in joint_region
-       assert p.r not in non_source_region
+        assert p.r not in non_source_region
 
     openmc.lib.finalize()

--- a/tests/unit_tests/test_source.py
+++ b/tests/unit_tests/test_source.py
@@ -110,7 +110,8 @@ def test_rejection(run_in_tmpdir):
     )
     cell1 = openmc.Cell(fill=mat, region=-sph1)
     cell2 = openmc.Cell(fill=mat, region=-sph2)
-    cell3 = openmc.Cell(region=+sph1 & +sph2 & -cube)
+    non_source_region = +sph1 & +sph2 & -cube
+    cell3 = openmc.Cell(region=non_source_region)
     model = openmc.Model()
     model.geometry = openmc.Geometry([cell1, cell2, cell3])
     model.settings.particles = 100
@@ -130,5 +131,6 @@ def test_rejection(run_in_tmpdir):
     joint_region = cell1.region | cell2.region
     for p in particles:
         assert p.r in joint_region
+       assert p.r not in non_source_region
 
     openmc.lib.finalize()

--- a/tests/unit_tests/test_source.py
+++ b/tests/unit_tests/test_source.py
@@ -1,6 +1,7 @@
 from math import pi
 
 import openmc
+import openmc.lib
 import openmc.stats
 import numpy as np
 from pytest import approx
@@ -96,3 +97,38 @@ def test_source_xml_roundtrip():
     np.testing.assert_allclose(new_src.angle.reference_uvw, src.angle.reference_uvw)
     assert new_src.particle == src.particle
     assert new_src.strength == approx(src.strength)
+
+
+def test_rejection(run_in_tmpdir):
+    # Model with two spheres inside a box
+    mat = openmc.Material()
+    mat.add_nuclide('H1', 1.0)
+    sph1 = openmc.Sphere(x0=3, r=1.0)
+    sph2 = openmc.Sphere(x0=-3, r=1.0)
+    cube = openmc.model.RectangularParallelepiped(
+        -5., 5., -5., 5., -5., 5., boundary_type='reflective'
+    )
+    cell1 = openmc.Cell(fill=mat, region=-sph1)
+    cell2 = openmc.Cell(fill=mat, region=-sph2)
+    cell3 = openmc.Cell(region=+sph1 & +sph2 & -cube)
+    model = openmc.Model()
+    model.geometry = openmc.Geometry([cell1, cell2, cell3])
+    model.settings.particles = 100
+    model.settings.batches = 10
+    model.settings.run_mode = 'fixed source'
+
+    # Set up a box source with rejection on the spherical cell
+    space = openmc.stats.Box(*cell3.bounding_box)
+    model.settings.source = openmc.Source(space=space, domains=[cell1, cell2])
+
+    # Load up model via openmc.lib and sample source
+    model.export_to_xml()
+    openmc.lib.init()
+    particles = openmc.lib.sample_external_source(1000)
+
+    # Make sure that all sampled sources are within one of the spheres
+    joint_region = cell1.region | cell2.region
+    for p in particles:
+        assert p.r in joint_region
+
+    openmc.lib.finalize()


### PR DESCRIPTION
This PR implements the ability to specify a set of a cells, materials, or universes that are used to "filter" sampled source sites and closes #1829. The way it works is:
1. The user specifies `Source(..., domains=[...])`, where `domains` is a list of either cells, materials, or universes that will be used for rejection.
2. At runtime, positions will be sampled from whatever spatial distribution was specified (e.g., `openmc.stats.Box`), but then those points will be checked against the list of domains, if present. If a point is not within the specified list of domains, it will be rejected.

The attribute handling for the `Source` class follows the same design as for the `VolumeCalculation` class. Namely, even though the constructor specifies `domains`, this is turned into `domain_type` and `domain_ids` attributes. This is done so that a `Source` object doesn't have to be inextricably linked to actual geometry objects.

@pshriwise and I discussed other overall design alternatives for this feature. In particular, we discussed the possibility of having a much more complex system based on rejection filters, which could be generalized to other uses (for example, rejection based on the energy or angle). We ended up steering away from that idea as it seemed a bit over-engineered, and our guess was that 99% of practical use-cases would just be simple spatial rejection, which is handled by a simpler design here.