### PR TITLE
added py3.9 and py3.10 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ['3.10']
         mpi: [n, y]
         omp: [n, y]
         dagmc: [n]
@@ -34,38 +34,35 @@ jobs:
         vectfit: [n]
 
         include:
-          - python-version: 3.6
-            omp: n
-            mpi: n
           - python-version: 3.7
             omp: n
             mpi: n
-          - dagmc: y
-            python-version: 3.8
-            mpi: y
-            omp: y
-          - libmesh: y
-            python-version: 3.8
-            mpi: y
-            omp: y
-          - libmesh: y
-            python-version: 3.8
-            mpi: n
-            omp: y
-          - event: y
-            python-version: 3.8
-            omp: y
-            mpi: n
-          - vectfit: y
-            python-version: 3.8
+          - python-version: 3.8
             omp: n
-            mpi: y
+            mpi: n
           - python-version: 3.9
             omp: n
             mpi: n
-          - python-version: '3.10'
-            omp: n
+          - dagmc: y
+            python-version: '3.10'
+            mpi: y
+            omp: y
+          - libmesh: y
+            python-version: '3.10'
+            mpi: y
+            omp: y
+          - libmesh: y
+            python-version: '3.10'
             mpi: n
+            omp: y
+          - event: y
+            python-version: '3.10'
+            omp: y
+            mpi: n
+          - vectfit: y
+            python-version: '3.10'
+            omp: n
+            mpi: y
     name: "Python ${{ matrix.python-version }} (omp=${{ matrix.omp }},
       mpi=${{ matrix.mpi }}, dagmc=${{ matrix.dagmc }},
       libmesh=${{ matrix.libmesh }}, event=${{ matrix.event }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,12 @@ jobs:
             python-version: 3.8
             omp: n
             mpi: y
+          - python-version: 3.9
+            omp: n
+            mpi: n
+          - python-version: '3.10'
+            omp: n
+            mpi: n
     name: "Python ${{ matrix.python-version }} (omp=${{ matrix.omp }},
       mpi=${{ matrix.mpi }}, dagmc=${{ matrix.dagmc }},
       libmesh=${{ matrix.libmesh }}, event=${{ matrix.event }}
@@ -78,7 +84,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ kwargs = {
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 
     # Dependencies


### PR DESCRIPTION
Following on from #2246 we could add a few new versions of python (3.9 and 3.10). I also tried to add py3.11 but it appears to be too new for the github actions we use. Perhaps 3.11 can be added later