### PR TITLE
Handle possibility of .ppm file in Universe.plot

### DIFF
--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -171,7 +171,9 @@ def _get_plot_image(plot, cwd):
     stem = plot.filename if plot.filename is not None else f'plot_{plot.id}'
     png_file = Path(cwd) / f'{stem}.png'
     if not png_file.exists():
-        raise FileNotFoundError(f"Could not find .png image for plot {plot.id}")
+        raise FileNotFoundError(
+            f"Could not find .png image for plot {plot.id}. Your version of "
+            "OpenMC may not be built against libpng.")
 
     return Image(str(png_file))
 

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -358,7 +358,10 @@ class Universe(UniverseBase):
             model.plot_geometry(False, cwd=tmpdir, openmc_exec=openmc_exec)
 
             # Read image from file
-            img = mpimg.imread(Path(tmpdir) / f'plot_{plot.id}.png')
+            img_path = Path(tmpdir) / f'plot_{plot.id}.png'
+            if not img_path.is_file():
+                img_path = img_path.with_suffix('.ppm')
+            img = mpimg.imread(img_path)
 
             # Create a figure sized such that the size of the axes within
             # exactly matches the number of pixels specified


### PR DESCRIPTION
This PR fixes a small issue whereby the `Universe.plot` method doesn't work if OpenMC wasn't built against libpng. This recently [caused trouble for a user](). I've also updated an error message in `Plot.to_ipython_image` that is raised if OpenMC wasn't built against libpng (in this case, we can't just check for a .ppm file because the `Image` class itself doesn't support it).