### PR TITLE
Make sure Material.decay_photon_energy works with no unstable nuclides

### DIFF
--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -1,10 +1,9 @@
 from collections.abc import Iterable
 from io import StringIO
 from math import log
-from pathlib import Path
 import re
+from typing import Optional
 from warnings import warn
-from xml.etree import ElementTree as ET
 
 import numpy as np
 from uncertainties import ufloat, UFloat
@@ -579,7 +578,7 @@ class Decay(EqualityMixin):
 _DECAY_PHOTON_ENERGY = {}
 
 
-def decay_photon_energy(nuclide: str) -> Univariate:
+def decay_photon_energy(nuclide: str) -> Optional[Univariate]:
     """Get photon energy distribution resulting from the decay of a nuclide
 
     This function relies on data stored in a depletion chain. Before calling it
@@ -595,9 +594,10 @@ def decay_photon_energy(nuclide: str) -> Univariate:
 
     Returns
     -------
-    openmc.stats.Univariate
-        Distribution of energies in [eV] of photons emitted from decay. Note
-        that the probabilities represent intensities, given as [decay/sec].
+    openmc.stats.Univariate or None
+        Distribution of energies in [eV] of photons emitted from decay, or None
+        if no photon source exists. Note that the probabilities represent
+        intensities, given as [decay/sec].
     """
     if not _DECAY_PHOTON_ENERGY:
         chain_file = openmc.config.get('chain_file')

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -92,10 +92,11 @@ class Material(IDManagerMixin):
     fissionable_mass : float
         Mass of fissionable nuclides in the material in [g]. Requires that the
         :attr:`volume` attribute is set.
-    decay_photon_energy : openmc.stats.Univariate
+    decay_photon_energy : openmc.stats.Univariate or None
         Energy distribution of photons emitted from decay of unstable nuclides
-        within the material. The integral of this distribution is the total
-        intensity of the photon source in [decay/sec].
+        within the material, or None if no photon source exists. The integral of
+        this distribution is the total intensity of the photon source in
+        [decay/sec].
 
         .. versionadded:: 0.14.0
 
@@ -264,7 +265,7 @@ class Material(IDManagerMixin):
         return density*self.volume
 
     @property
-    def decay_photon_energy(self) -> Univariate:
+    def decay_photon_energy(self) -> Optional[Univariate]:
         atoms = self.get_nuclide_atoms()
         dists = []
         probs = []
@@ -273,7 +274,7 @@ class Material(IDManagerMixin):
             if source_per_atom is not None:
                 dists.append(source_per_atom)
                 probs.append(num_atoms)
-        return openmc.data.combine_distributions(dists, probs)
+        return openmc.data.combine_distributions(dists, probs) if dists else None
 
     @classmethod
     def from_hdf5(cls, group: h5py.Group):

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -573,3 +573,9 @@ def test_decay_photon_energy():
     assert src.integral() == pytest.approx(sum(
         intensity(decay_photon_energy(nuc)) for nuc in m.get_nuclides()
     ))
+
+    # A material with no unstable nuclides should have no decay photon source
+    stable = openmc.Material()
+    stable.add_nuclide('Gd156', 1.0)
+    stable.volume = 1.0
+    assert stable.decay_photon_energy is None


### PR DESCRIPTION
This PR closes #2250 by ensuring that `Material.decay_photon_energy` works if only stable nuclides are present.