### PR TITLE
assume cython is installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,7 @@ import sys
 import numpy as np
 
 from setuptools import setup, find_packages
-try:
-    from Cython.Build import cythonize
-    have_cython = True
-except ImportError:
-    have_cython = False
+from Cython.Build import cythonize
 
 
 # Determine shared library suffix
@@ -76,13 +72,9 @@ kwargs = {
         'test': ['pytest', 'pytest-cov', 'colorama'],
         'vtk': ['vtk'],
     },
+    # Cython is used to add resonance reconstruction and fast float_endf
+    'ext_modules': cythonize('openmc/data/*.pyx'),
+    'include_dirs': [np.get_include()]
 }
-
-# If Cython is present, add resonance reconstruction and fast float_endf
-if have_cython:
-    kwargs.update({
-        'ext_modules': cythonize('openmc/data/*.pyx'),
-        'include_dirs': [np.get_include()]
-    })
 
 setup(**kwargs)


### PR DESCRIPTION
Cython is in the pyproject.toml build requirements section

https://github.com/openmc-dev/openmc/blob/9a86c9c065e545a7ece086c34dc7dca38cfa9892/pyproject.toml#L2

Therefore I think it is safe to assume that cython is installed when building openmc with ```pip install .```

This allows us to remove some cython checking from the setup.py and simplify the setup.py a little bit.