### PR TITLE
removed py3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,6 @@ jobs:
         vectfit: [n]
 
         include:
-          - python-version: 3.6
-            omp: n
-            mpi: n
           - python-version: 3.7
             omp: n
             mpi: n

--- a/docs/source/devguide/styleguide.rst
+++ b/docs/source/devguide/styleguide.rst
@@ -142,7 +142,7 @@ Style for Python code should follow PEP8_.
 
 Docstrings for functions and methods should follow numpydoc_ style.
 
-Python code should work with Python 3.6+.
+Python code should work with Python 3.7+.
 
 Use of third-party Python packages should be limited to numpy_, scipy_,
 matplotlib_, pandas_, and h5py_. Use of other third-party packages must be

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -511,7 +511,7 @@ to install the Python package in :ref:`"editable" mode <devguide_editable>`.
 Prerequisites
 -------------
 
-The Python API works with Python 3.6+. In addition to Python itself, the API
+The Python API works with Python 3.7+. In addition to Python itself, the API
 relies on a number of third-party packages. All prerequisites can be installed
 using Conda_ (recommended), pip_, or through the package manager in most Linux
 distributions.

--- a/setup.py
+++ b/setup.py
@@ -57,14 +57,14 @@ kwargs = {
         'Topic :: Scientific/Engineering'
         'Programming Language :: C++',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
 
     # Dependencies
-    'python_requires': '>=3.6',
+    'python_requires': '>=3.7',
     'install_requires': [
         'numpy>=1.9', 'h5py', 'scipy', 'ipython', 'matplotlib',
         'pandas', 'lxml', 'uncertainties'


### PR DESCRIPTION
This is a replacement for #2246 

As discussed briefly on the slack channel, end of life for python 3.6 was 2021-12-23 and it is now [unsupported by python](https://devguide.python.org/versions/) it might be time to remove support for python3.6 from OpenMC

[User survey suggests](
https://openmc.discourse.group/t/user-survey-python-version/2338) we have at least one py3.6 user so perhaps we should be cautious here but it would make updating the packaging easier and help support pip distribution in the future

Also saves a little CI effort