### PR TITLE
tracking endf.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ results_test.dat
 
 # HDF5 files
 *.h5
+!compton_profiles.h5
+!density_effect.h5
 
 # Build files
 src/CMakeCache.txt

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ scripts/G4EMLOW*/
 
 # Cython files
 *.c
+!endf.c
 *.html
 *.so
 


### PR DESCRIPTION
I just noticed that .c files are not tracked due to the .c line in the gitignore. This PR adds an exception for endf.c which we should perhaps track?