### PR TITLE
Polygon composite surface

### DIFF
--- a/docs/source/pythonapi/model.rst
+++ b/docs/source/pythonapi/model.rst
@@ -31,6 +31,7 @@ Composite Surfaces
    openmc.model.XConeOneSided
    openmc.model.YConeOneSided
    openmc.model.ZConeOneSided
+   openmc.model.Polygon
 
 TRISO Fuel Modeling
 -------------------

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -676,7 +676,6 @@ class Polygon(CompositeSurface):
         surfnames = []
         i = 0
         for surfset in self._surfsets:
-            print(surfset)
             for surf, op, on_boundary in surfset:
                 if on_boundary:
                     setattr(self, f'surface_{i}', surf)

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -634,17 +634,17 @@ class Polygon(CompositeSurface):
     ----------
     points : np.ndarray
         An Nx2 array of points defining the vertices of the polygon.
-    basis : str, {'rz', 'xy', 'yz', 'xz'}, optional
+    basis : {'rz', 'xy', 'yz', 'xz'}, optional
         2D basis set for the polygon.
 
     Attributes
     ----------
     points : np.ndarray
         An Nx2 array of points defining the vertices of the polygon.
-    basis : str, {'rz', 'xy', 'yz', 'xz'}
+    basis : {'rz', 'xy', 'yz', 'xz'}
         2D basis set for the polygon.
     regions : list of openmc.Region
-        A list of openmc.Region objects, one for each of the convex polygons
+        A list of :class:`openmc.Region` objects, one for each of the convex polygons
         formed during the decomposition of the input polygon.
     region : openmc.Union
         The union of all the regions comprising the polygon.
@@ -726,7 +726,7 @@ class Polygon(CompositeSurface):
     @property
     def _normals(self):
         """Generate the outward normal unit vectors for the polygon."""
-        rotation = np.array([[0, 1], [-1, 0]])
+        rotation = np.array([[0., 1.], [-1., 0.]])
         tangents = np.diff(self._points, axis=0, append=[self._points[0, :]])
         tangents /= np.linalg.norm(tangents, axis=-1, keepdims=True)
         return rotation.dot(tangents.T).T
@@ -735,7 +735,7 @@ class Polygon(CompositeSurface):
     def _equations(self):
         normals = self._normals
         equations = np.empty((normals.shape[0], 3))
-        equations[:, 0:2] = normals
+        equations[:, :2] = normals
         equations[:, 2] = -np.sum(normals*self.points, axis=-1)
         return equations
 

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -4,6 +4,7 @@ from math import sqrt, pi, sin, cos, isclose
 import numpy as np
 from scipy.spatial import ConvexHull, Delaunay
 from matplotlib.path import Path
+import warnings
 
 import openmc
 from openmc.checkvalue import (check_greater_than, check_value,
@@ -701,6 +702,18 @@ class Polygon(CompositeSurface):
     @property
     def _surface_names(self):
         return self._surfnames
+
+    @CompositeSurface.boundary_type.setter
+    def boundary_type(self, boundary_type):
+        if boundary_type != 'transmission':
+            warnings.warn("Setting boundary_type to a value other than "
+                          "'transmission' on Polygon composite surfaces can "
+                          "result in unintended behavior. Please use the "
+                          "regions property of the Polygon to generate "
+                          "individual openmc.Cell objects to avoid unwanted "
+                          "behavior.")
+        for name in self._surface_names:
+            getattr(self, name).boundary_type = boundary_type
 
     @property
     def points(self):

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -849,7 +849,7 @@ class Polygon(CompositeSurface):
             facet_eq = np.array([dx, dy, c])
             on_boundary = any([np.allclose(facet_eq, eq) for eq in boundary_eqns])
             # Check if the facet is horizontal
-            if isclose(dx, 0):
+            if isclose(dx, 0, abs_tol=1e-8):
                 if basis in ('xz', 'yz', 'rz'):
                     surf = openmc.ZPlane(z0=-c/dy)
                 else:
@@ -857,7 +857,7 @@ class Polygon(CompositeSurface):
                 # if (0, 1).(dx, dy) < 0 we want positive halfspace instead
                 op = operator.pos if dy < 0 else operator.neg
             # Check if the facet is vertical
-            elif isclose(dy, 0):
+            elif isclose(dy, 0, abs_tol=1e-8):
                 if basis in ('xy', 'xz'):
                     surf = openmc.XPlane(x0=-c/dx)
                 elif basis == 'yz':

--- a/tests/unit_tests/test_surface_composite.py
+++ b/tests/unit_tests/test_surface_composite.py
@@ -315,6 +315,26 @@ def test_isogonal_octagon(axis, plane_tb, plane_lr, axis_idx):
     # Make sure repr works
     repr(s)
 
-@pytest.mark.parametrize("basis", [("xz",), ("yz",), ("xy",), ("rz",)])
-def test_polygon(basis=basis):
+def test_polygon():
+    # define a 5 pointed star centered on 1, 1
+    star = np.array([[1.        , 2.        ],
+                     [0.70610737, 1.4045085 ],
+                     [0.04894348, 1.30901699],
+                     [0.52447174, 0.8454915 ],
+                     [0.41221475, 0.19098301],
+                     [1.        , 0.5       ],
+                     [1.58778525, 0.19098301],
+                     [1.47552826, 0.8454915 ],
+                     [1.95105652, 1.30901699],
+                     [1.29389263, 1.4045085 ],
+                     [1.        , 2.        ]])
+    points_in = [(1, 1, 0), (0, 1, 1), (1, 0, 1), (.707, .707, 1)]
+    for i, basis in enumerate(('xy', 'yz', 'xz', 'rz')):
+        star_poly = openmc.model.Polygon(star, basis=basis)
+        assert points_in[i] in -star_poly
+        assert points_in[i] not in +star_poly
+        assert (0, 0, 0) not in -star_poly
+        if basis != 'rz':
+            assert(0, 0, 0) in -star_poly.offset(.6)
+
 

--- a/tests/unit_tests/test_surface_composite.py
+++ b/tests/unit_tests/test_surface_composite.py
@@ -314,3 +314,7 @@ def test_isogonal_octagon(axis, plane_tb, plane_lr, axis_idx):
 
     # Make sure repr works
     repr(s)
+
+@pytest.mark.parametrize("basis", [("xz",), ("yz",), ("xy",), ("rz",)])
+def test_polygon(basis=basis):
+

--- a/tests/unit_tests/test_surface_composite.py
+++ b/tests/unit_tests/test_surface_composite.py
@@ -335,6 +335,6 @@ def test_polygon():
         assert points_in[i] not in +star_poly
         assert (0, 0, 0) not in -star_poly
         if basis != 'rz':
-            assert(0, 0, 0) in -star_poly.offset(.6)
+            assert (0, 0, 0) in -star_poly.offset(.6)
 
 

--- a/tests/unit_tests/test_surface_composite.py
+++ b/tests/unit_tests/test_surface_composite.py
@@ -332,9 +332,10 @@ def test_polygon():
     for i, basis in enumerate(('xy', 'yz', 'xz', 'rz')):
         star_poly = openmc.model.Polygon(star, basis=basis)
         assert points_in[i] in -star_poly
+        assert any([points_in[i] in reg for reg in star_poly.regions])
         assert points_in[i] not in +star_poly
         assert (0, 0, 0) not in -star_poly
         if basis != 'rz':
-            assert (0, 0, 0) in -star_poly.offset(.6)
-
-
+            offset_star = star_poly.offset(.6)
+            assert (0, 0, 0) in -offset_star
+            assert any([(0, 0, 0) in reg for reg in offset_star.regions])


### PR DESCRIPTION
This PR is the addition of a `CompositeSurface` class for a generalized 2D polygon defined by a series of points, assumed to be connected by linear segments and closed. Essentially this class acts like any other surface and obeys the `CompositeSurface` protocol. It decomposes any polygon into a set of convex shapes, the union of which is the negative halfspace of the polygon and the complement of the union is the positive half space. You can also easily offset the polygon to form nested regions using the `openmc.model.subdivide` function. The following couple plots show the output of code similar to the following
```
polygon = openmc.model.Polygon(rz_points, basis='xz')
p1 = polygon.offset(2)
p2 = polygon.offset(4)
p3 = polygon.offset(6)
p4 = polygon.offset(7)
p5 = polygon.offset(10)
p5.boundary_type = 'vacuum'
regions = openmc.model.subdivide([polygon, p1, p2, p3, p4, p5])
cells = [openmc.Cell(region=r) for r in regions]
geom = openmc.Geometry(cells)
geom.export_to_xml(remove_surfs=True)
```
Nested vacuum vessel defined by a series of RZ points
![full_figure](https://user-images.githubusercontent.com/18011007/196010054-0c844d66-792d-4a41-a5bd-a327103809ba.png)

Zoomed in version of the above
![zoomed_figure](https://user-images.githubusercontent.com/18011007/196010058-031c1bd3-4e61-449d-9ef3-0c55b9aff08d.png)

Decomposition of polygon into convex subsets
![regions](https://user-images.githubusercontent.com/18011007/196010061-93fd4760-bf07-4c3a-b20b-7e4c3f314875.png)

There's still a little clean up that needs to happen and tests to write before this is really ready.