### PR TITLE
Improve tests for checking sample means

### DIFF
--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -559,7 +559,9 @@ class Decay(EqualityMixin):
                     raise NotImplementedError("Multiple interpolation regions: {name}, {particle}")
                 interpolation = INTERPOLATION_SCHEME[f.interpolation[0]]
                 if interpolation not in ('histogram', 'linear-linear'):
-                    raise NotImplementedError("Continuous spectra with {interpolation} interpolation ({name}, {particle}) not supported")
+                    raise NotImplementedError(
+                        f"Continuous spectra with {interpolation} interpolation "
+                        f"({name}, {particle}) not supported")
 
                 intensity = spectra['continuous_normalization'].n
                 rates = decay_constant * intensity * f.y

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -179,7 +179,7 @@ Tabular::Tabular(pugi::xml_node node)
       interp_ = Interpolation::lin_lin;
     } else {
       openmc::fatal_error(
-        "Unknown interpolation type for distribution: " + temp);
+        "Unsupported interpolation type for distribution: " + temp);
     }
   } else {
     interp_ = Interpolation::histogram;

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -7,9 +7,12 @@ import openmc.stats
 
 
 def assert_sample_mean(samples, expected_mean):
-    std_dev = samples.std() / np.sqrt(samples.size)
-    assert np.abs(expected_mean - samples.mean()) < 3*std_dev
+    # Calculate sample standard deviation
+    std_dev = samples.std() / np.sqrt(samples.size - 1)
 
+    # Means should agree within 4 sigma 99.993% of the time. Note that this is
+    # expected to fail about 1 out of 16,000 times
+    assert np.abs(expected_mean - samples.mean()) < 4*std_dev
 
 
 def test_discrete():
@@ -40,9 +43,9 @@ def test_discrete():
     d3 = openmc.stats.Discrete(vals, probs)
 
     # sample discrete distribution and check that the mean of the samples is
-    # within 3 std. dev. of the expected mean
+    # within 4 std. dev. of the expected mean
     n_samples = 1_000_000
-    samples = d3.sample(n_samples, seed=100)
+    samples = d3.sample(n_samples)
     assert_sample_mean(samples, exp_mean)
 
 
@@ -86,11 +89,11 @@ def test_uniform():
     np.testing.assert_array_equal(t.p, [1/(b-a), 1/(b-a)])
     assert t.interpolation == 'histogram'
 
-    # Sample distribution and check that the mean of the samples is within 3
+    # Sample distribution and check that the mean of the samples is within 4
     # std. dev. of the expected mean
     exp_mean = 0.5 * (a + b)
     n_samples = 1_000_000
-    samples = d.sample(n_samples, seed=100)
+    samples = d.sample(n_samples)
     assert_sample_mean(samples, exp_mean)
 
 
@@ -105,12 +108,13 @@ def test_powerlaw():
     assert d.n == n
     assert len(d) == 3
 
-    exp_mean = 100.0 * (n+1) / (n+2)
+    # Determine mean of distribution
+    exp_mean = (n+1)*(b**(n+2) - a**(n+2))/((n+2)*(b**(n+1) - a**(n+1)))
 
     # sample power law distribution and check that the mean of the samples is
-    # within 3 std. dev. of the expected mean
+    # within 4 std. dev. of the expected mean
     n_samples = 1_000_000
-    samples = d.sample(n_samples, seed=100)
+    samples = d.sample(n_samples)
     assert_sample_mean(samples, exp_mean)
 
 
@@ -126,13 +130,13 @@ def test_maxwell():
     exp_mean = 3/2 * theta
 
     # sample maxwell distribution and check that the mean of the samples is
-    # within 3 std. dev. of the expected mean
+    # within 4 std. dev. of the expected mean
     n_samples = 1_000_000
-    samples = d.sample(n_samples, seed=100)
+    samples = d.sample(n_samples)
     assert_sample_mean(samples, exp_mean)
 
-    # A second sample with a different seed
-    samples_2 = d.sample(n_samples, seed=200)
+    # A second sample starting from a different seed
+    samples_2 = d.sample(n_samples)
     assert_sample_mean(samples_2, exp_mean)
     assert samples_2.mean() != samples.mean()
 
@@ -154,9 +158,9 @@ def test_watt():
     exp_mean = 3/2 * a + a**2 * b / 4
 
     # sample Watt distribution and check that the mean of the samples is within
-    # 3 std. dev. of the expected mean
+    # 4 std. dev. of the expected mean
     n_samples = 1_000_000
-    samples = d.sample(n_samples, seed=100)
+    samples = d.sample(n_samples)
     assert_sample_mean(samples, exp_mean)
 
 
@@ -176,28 +180,16 @@ def test_tabular():
     d = openmc.stats.Tabular(x, p)
 
     n_samples = 100_000
-    samples = d.sample(n_samples, seed=100)
-    diff = np.abs(samples - d.mean())
-    # within_1_sigma = np.count_nonzero(diff < samples.std())
-    # assert within_1_sigma / n_samples >= 0.68
-    within_2_sigma = np.count_nonzero(diff < 2*samples.std())
-    assert within_2_sigma / n_samples >= 0.95
-    within_3_sigma = np.count_nonzero(diff < 3*samples.std())
-    assert within_3_sigma / n_samples >= 0.99
+    samples = d.sample(n_samples)
+    assert_sample_mean(samples, d.mean())
 
     # test histogram sampling
     d = openmc.stats.Tabular(x, p, interpolation='histogram')
     d.normalize()
     assert d.integral() == pytest.approx(1.0)
 
-    samples = d.sample(n_samples, seed=100)
-    diff = np.abs(samples - d.mean())
-    # within_1_sigma = np.count_nonzero(diff < samples.std())
-    # assert within_1_sigma / n_samples >= 0.68
-    within_2_sigma = np.count_nonzero(diff < 2*samples.std())
-    assert within_2_sigma / n_samples >= 0.95
-    within_3_sigma = np.count_nonzero(diff < 3*samples.std())
-    assert within_3_sigma / n_samples >= 0.99
+    samples = d.sample(n_samples)
+    assert_sample_mean(samples, d.mean())
 
 
 def test_legendre():
@@ -361,15 +353,9 @@ def test_normal():
     assert len(d) == 2
 
     # sample normal distribution
-    n_samples = 10000
-    samples = d.sample(n_samples, seed=100)
-    samples = np.abs(samples - mean)
-    within_1_sigma = np.count_nonzero(samples < std_dev)
-    assert within_1_sigma / n_samples >= 0.68
-    within_2_sigma = np.count_nonzero(samples < 2*std_dev)
-    assert within_2_sigma / n_samples >= 0.95
-    within_3_sigma = np.count_nonzero(samples < 3*std_dev)
-    assert within_3_sigma / n_samples >= 0.99
+    n_samples = 100_000
+    samples = d.sample(n_samples)
+    assert_sample_mean(samples, mean)
 
 
 def test_muir():
@@ -386,15 +372,9 @@ def test_muir():
     assert isinstance(d, openmc.stats.Normal)
 
     # sample muir distribution
-    n_samples = 10000
-    samples = d.sample(n_samples, seed=100)
-    samples = np.abs(samples - mean)
-    within_1_sigma = np.count_nonzero(samples < d.std_dev)
-    assert within_1_sigma / n_samples >= 0.68
-    within_2_sigma = np.count_nonzero(samples < 2*d.std_dev)
-    assert within_2_sigma / n_samples >= 0.95
-    within_3_sigma = np.count_nonzero(samples < 3*d.std_dev)
-    assert within_3_sigma / n_samples >= 0.99
+    n_samples = 100_000
+    samples = d.sample(n_samples)
+    assert_sample_mean(samples, mean)
 
 
 def test_combine_distributions():


### PR DESCRIPTION
We have several tests in `tests/unit_tests/test_stats.py` that take a distribution, sample it a bunch of times, and then make an assertion that the sample mean should be "close" to the expected value. As some of you may know, one of these tests `test_mixture` has been failing periodically in CI. After digging into this a bit, my conclusion is that this failure is actually expected. We are checking the mean to be within 3σ, which means it should pass 99.73% of the time. However, that also means it is expected to fail 1 out of every 370 times, and because we have 10 different CI configurations (build flags, Python versions), that means it will fail 1 out of every 37 times, which is really not that infrequent. My solution in this PR is to just take out the check to 4σ, which means it will pass 99.993% of the time and fail 1 out of every 15,787 times.

Interestingly, other tests that use the same logic were not failing, and evidently this is solely because we were using a **fixed seed**. With a 4σ check, it seemed reasonable to me to remove those fix seeds and let it be truly random each time. When I did that, it actually turned up an error in one test (the expected mean was being calculated incorrectly for a power law distribution), which I've also fixed.

There's also an unrelated fix in this PR for a missing `f` prefix on an f-string.