### PR TITLE
Update volume calc types to mitigate overflow issues

### DIFF
--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -5,6 +5,7 @@
 #define OPENMC_CONSTANTS_H
 
 #include <cmath>
+#include <cstdint>
 #include <limits>
 
 #include "openmc/array.h"
@@ -342,7 +343,7 @@ enum class GeometryType { CSG, DAG };
 //==============================================================================
 // Volume Calculation Constants
 
-constexpr size_t SIZE_T_MAX {std::numeric_limits<size_t>::max()};
+constexpr uint64_t UINT64_T_MAX {std::numeric_limits<uint64_t>::max()};
 
 } // namespace openmc
 

--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -339,6 +339,11 @@ enum class RunMode {
 
 enum class GeometryType { CSG, DAG };
 
+//==============================================================================
+// Volume Calculation Constants
+
+constexpr size_t SIZE_T_MAX {std::numeric_limits<size_t>::max()};
+
 } // namespace openmc
 
 #endif // OPENMC_CONSTANTS_H

--- a/include/openmc/volume_calc.h
+++ b/include/openmc/volume_calc.h
@@ -1,6 +1,9 @@
 #ifndef OPENMC_VOLUME_CALC_H
 #define OPENMC_VOLUME_CALC_H
 
+#include <cstdint>
+#include <string>
+
 #include "openmc/array.h"
 #include "openmc/position.h"
 #include "openmc/tallies/trigger.h"
@@ -10,7 +13,6 @@
 #include "xtensor/xtensor.hpp"
 
 #include <gsl/gsl-lite.hpp>
-#include <string>
 
 namespace openmc {
 
@@ -69,7 +71,8 @@ private:
   //! \param[in] i_material Index in global materials vector
   //! \param[in,out] indices Vector of material indices
   //! \param[in,out] hits Number of hits corresponding to each material
-  void check_hit(int i_material, vector<int>& indices, vector<int>& hits) const;
+  void check_hit(
+    int i_material, vector<uint64_t>& indices, vector<uint64_t>& hits) const;
 };
 
 //==============================================================================

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -99,9 +99,9 @@ vector<VolumeCalculation::Result> VolumeCalculation::execute() const
 {
   // Shared data that is collected from all threads
   int n = domain_ids_.size();
-  vector<vector<int>> master_indices(
+  vector<vector<int32_t>> master_indices(
     n); // List of material indices for each domain
-  vector<vector<int>> master_hits(
+  vector<vector<size_t>> master_hits(
     n); // Number of hits for each material in each domain
   int iterations = 0;
 
@@ -281,7 +281,7 @@ vector<VolumeCalculation::Result> VolumeCalculation::execute() const
 #endif
 
       if (mpi::master) {
-        int total_hits = 0;
+        size_t total_hits = 0;
         for (int j = 0; j < master_indices[i_domain].size(); ++j) {
           total_hits += master_hits[i_domain][j];
           double f =

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -227,7 +227,7 @@ vector<VolumeCalculation::Result> VolumeCalculation::execute() const
 
     // warn user if total sample size is greater than what the size_t type can
     // represent
-    if (total_samples > UINT64_T_MAX) {
+    if (total_samples == UINT64_T_MAX) {
       warning("The number of samples has exceeded the type used to track hits. "
               "Volume "
               "results may be inaccurate.");

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -99,16 +99,16 @@ vector<VolumeCalculation::Result> VolumeCalculation::execute() const
 {
   // Shared data that is collected from all threads
   int n = domain_ids_.size();
-  vector<vector<int32_t>> master_indices(
+  vector<vector<uint64_t>> master_indices(
     n); // List of material indices for each domain
-  vector<vector<size_t>> master_hits(
+  vector<vector<uint64_t>> master_hits(
     n); // Number of hits for each material in each domain
   int iterations = 0;
 
   // Divide work over MPI processes
-  size_t min_samples = n_samples_ / mpi::n_procs;
-  size_t remainder = n_samples_ % mpi::n_procs;
-  size_t i_start, i_end;
+  uint64_t min_samples = n_samples_ / mpi::n_procs;
+  uint64_t remainder = n_samples_ % mpi::n_procs;
+  uint64_t i_start, i_end;
   if (mpi::rank < remainder) {
     i_start = (min_samples + 1) * mpi::rank;
     i_end = i_start + min_samples + 1;
@@ -123,14 +123,14 @@ vector<VolumeCalculation::Result> VolumeCalculation::execute() const
 #pragma omp parallel
     {
       // Variables that are private to each thread
-      vector<vector<int>> indices(n);
-      vector<vector<int>> hits(n);
+      vector<vector<uint64_t>> indices(n);
+      vector<vector<uint64_t>> hits(n);
       Particle p;
 
 // Sample locations and count hits
 #pragma omp for
       for (size_t i = i_start; i < i_end; i++) {
-        int64_t id = iterations * n_samples_ + i;
+        uint64_t id = iterations * n_samples_ + i;
         uint64_t seed = init_seed(id, STREAM_VOLUME);
 
         p.n_coord() = 1;
@@ -223,12 +223,13 @@ vector<VolumeCalculation::Result> VolumeCalculation::execute() const
     // bump iteration counter and get total number
     // of samples at this point
     iterations++;
-    size_t total_samples = iterations * n_samples_;
+    uint64_t total_samples = iterations * n_samples_;
 
     // warn user if total sample size is greater than what the size_t type can
     // represent
-    if (total_samples > SIZE_T_MAX) {
-      warning("The number of samples has exceeded the size_t type. Volume "
+    if (total_samples > UINT64_T_MAX) {
+      warning("The number of samples has exceeded the type used to track hits. "
+              "Volume "
               "results may be inaccurate.");
     }
 
@@ -253,10 +254,11 @@ vector<VolumeCalculation::Result> VolumeCalculation::execute() const
       if (mpi::master) {
         for (int j = 1; j < mpi::n_procs; j++) {
           int q;
+          // retrieve results
           MPI_Recv(
-            &q, 1, MPI_INTEGER, j, 2 * j, mpi::intracomm, MPI_STATUS_IGNORE);
-          vector<int> buffer(2 * q);
-          MPI_Recv(buffer.data(), 2 * q, MPI_INTEGER, j, 2 * j + 1,
+            &q, 1, MPI_UINT64_T, j, 2 * j, mpi::intracomm, MPI_STATUS_IGNORE);
+          vector<uint64_t> buffer(2 * q);
+          MPI_Recv(buffer.data(), 2 * q, MPI_UINT64_T, j, 2 * j + 1,
             mpi::intracomm, MPI_STATUS_IGNORE);
           for (int k = 0; k < q; ++k) {
             bool already_added = false;
@@ -275,14 +277,14 @@ vector<VolumeCalculation::Result> VolumeCalculation::execute() const
         }
       } else {
         int q = master_indices[i_domain].size();
-        vector<int> buffer(2 * q);
+        vector<uint64_t> buffer(2 * q);
         for (int k = 0; k < q; ++k) {
           buffer[2 * k] = master_indices[i_domain][k];
           buffer[2 * k + 1] = master_hits[i_domain][k];
         }
 
-        MPI_Send(&q, 1, MPI_INTEGER, 0, 2 * mpi::rank, mpi::intracomm);
-        MPI_Send(buffer.data(), 2 * q, MPI_INTEGER, 0, 2 * mpi::rank + 1,
+        MPI_Send(&q, 1, MPI_UINT64_T, 0, 2 * mpi::rank, mpi::intracomm);
+        MPI_Send(buffer.data(), 2 * q, MPI_UINT64_T, 0, 2 * mpi::rank + 1,
           mpi::intracomm);
       }
 #endif
@@ -471,7 +473,7 @@ void VolumeCalculation::to_hdf5(
 }
 
 void VolumeCalculation::check_hit(
-  int i_material, vector<int>& indices, vector<int>& hits) const
+  int i_material, vector<uint64_t>& indices, vector<uint64_t>& hits) const
 {
 
   // Check if this material was previously hit and if so, increment count

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -225,6 +225,13 @@ vector<VolumeCalculation::Result> VolumeCalculation::execute() const
     iterations++;
     size_t total_samples = iterations * n_samples_;
 
+    // warn user if total sample size is greater than what the size_t type can
+    // represent
+    if (total_samples > SIZE_T_MAX) {
+      warning("The number of samples has exceeded the size_t type. Volume "
+              "results may be inaccurate.");
+    }
+
     // reset
     double trigger_val = -INFTY;
 


### PR DESCRIPTION
A couple of users reported [negative volume values] for a volume calculation. This turned out to be caused by an overflow of the `int` type used to track the total number of hits for domains in the calculation causing the sign to flip and the resulting volume to be calculated incorrectly. 

This PR updates a couple of types to used to track the number of accumulated per domain to `size_t` to mitigate this problem. There are ways to accommodate even more samples, but they would require a more complex solution than this. 