### PR TITLE
Include volume in xml

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -634,6 +634,9 @@ class Cell(IDManagerMixin):
         if self.rotation is not None:
             element.set("rotation", ' '.join(map(str, self.rotation.ravel())))
 
+        if self.volume is not None:
+            element.set("volume", str(self.volume))
+
         return element
 
     @classmethod
@@ -687,6 +690,9 @@ class Cell(IDManagerMixin):
                 c.temperature = [float(t_i) for t_i in t.split()]
             else:
                 c.temperature = float(t)
+        v = get_text(elem, 'volume')
+        if v is not None:
+            c.volume = float(v)
         for key in ('temperature', 'rotation', 'translation'):
             value = get_text(elem, key)
             if value is not None:

--- a/tests/unit_tests/test_cell.py
+++ b/tests/unit_tests/test_cell.py
@@ -294,9 +294,11 @@ def test_to_xml_element(cell_with_lattice):
 
     c = cells[0]
     c.temperature = 900.0
+    c.volume = 1.0
     elem = c.create_xml_subelement(root)
     assert elem.get('region') == str(c.region)
     assert elem.get('temperature') == str(c.temperature)
+    assert elem.get('volume') == str(c.volume)
 
 
 @pytest.mark.parametrize("rotation", [


### PR DESCRIPTION
This PR just aims to make cell volumes able to be written/read to/from `geometry.xml` in the Python API.