### PR TITLE
Improve DAGMC messages for missing materials

### DIFF
--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -486,13 +486,20 @@ void DAGUniverse::legacy_assign_material(
 
   // if no material was set using a name, assign by id
   if (!mat_found_by_name) {
+    bool found_by_id = true;
     try {
       auto id = std::stoi(mat_string);
+      if (model::material_map.find(id) == model::material_map.end())
+        found_by_id = false;
       c->material_.emplace_back(id);
     } catch (const std::invalid_argument&) {
+      found_by_id = false;
+    }
+
+    // report failure for failed int conversion or missing material
+    if (!found_by_id)
       fatal_error(fmt::format(
         "No material '{}' found for volume (cell) {}", mat_string, c->id_));
-    }
   }
 
   if (settings::verbosity >= 10) {

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -498,8 +498,9 @@ void DAGUniverse::legacy_assign_material(
 
     // report failure for failed int conversion or missing material
     if (!found_by_id)
-      fatal_error(fmt::format(
-        "No material '{}' found for volume (cell) {}", mat_string, c->id_));
+      fatal_error(
+        fmt::format("Material with name/ID '{}' not found for volume (cell) {}",
+          mat_string, c->id_));
   }
 
   if (settings::verbosity >= 10) {

--- a/tests/regression_tests/dagmc/legacy/test.py
+++ b/tests/regression_tests/dagmc/legacy/test.py
@@ -62,7 +62,7 @@ def test_missing_material_id(model):
     model.materials = model.materials[:-1]
     with pytest.raises(RuntimeError) as exec_info:
         model.run()
-    exp_error_msg = "Material with ID '41' not found for volume (cell) 3"
+    exp_error_msg = "Material with name/ID '41' not found for volume (cell) 3"
     assert exp_error_msg in str(exec_info.value)
 
 
@@ -71,7 +71,7 @@ def test_missing_material_name(model):
     model.materials = model.materials[1:]
     with pytest.raises(RuntimeError) as exec_info:
         model.run()
-    exp_error_msg = "No material 'no-void fuel' found for volume (cell) 1"
+    exp_error_msg = "Material with name/ID 'no-void fuel' not found for volume (cell) 1"
     assert exp_error_msg in str(exec_info.value)
 
 

--- a/tests/regression_tests/dagmc/legacy/test.py
+++ b/tests/regression_tests/dagmc/legacy/test.py
@@ -11,6 +11,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 def model():
+    openmc.reset_auto_ids()
 
     model = openmc.model.Model()
 
@@ -54,6 +55,24 @@ def model():
     model.materials = mats
 
     return model
+
+
+def test_missing_material_id(model):
+    # remove the last material, which is identified by ID in the DAGMC file
+    model.materials = model.materials[:-1]
+    with pytest.raises(RuntimeError) as exec_info:
+        model.run()
+    exp_error_msg = "Material with ID '41' not found for volume (cell) 3"
+    assert exp_error_msg in str(exec_info.value)
+
+
+def test_missing_material_name(model):
+    # remove the first material, which is identified by name in the DAGMC file
+    model.materials = model.materials[1:]
+    with pytest.raises(RuntimeError) as exec_info:
+        model.run()
+    exp_error_msg = "No material 'no-void fuel' found for volume (cell) 1"
+    assert exp_error_msg in str(exec_info.value)
 
 
 def test_dagmc(model):


### PR DESCRIPTION
This resolves #2278.

I've added an extra check that the ID generated from the material string will result in the same error message if it either can't be converted to an `int` or the material ID isn't present.

This also includes a couple of tests that ensure useful error messages appear when DAGMC materials can't be found by name or ID.