### PR TITLE
Make sure Chain.reduce preserves decay source information

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -1025,6 +1025,7 @@ class Chain:
             new_nuclide = Nuclide(previous.name)
             new_nuclide.half_life = previous.half_life
             new_nuclide.decay_energy = previous.decay_energy
+            new_nuclide.sources = previous.sources.copy()
             if hasattr(previous, '_fpy'):
                 new_nuclide._fpy = previous._fpy
 

--- a/tests/unit_tests/test_deplete_chain.py
+++ b/tests/unit_tests/test_deplete_chain.py
@@ -500,6 +500,7 @@ def test_reduce(gnd_simple_chain, endf_chain):
     assert u5_round0.n_decay_modes == ref_U5.n_decay_modes
     assert u5_round0.half_life == ref_U5.half_life
     assert u5_round0.decay_energy == ref_U5.decay_energy
+    assert u5_round0.sources == ref_U5.sources
     for newmode, refmode in zip(u5_round0.decay_modes, ref_U5.decay_modes):
         assert newmode.target is None
         assert newmode.type == refmode.type
@@ -522,6 +523,7 @@ def test_reduce(gnd_simple_chain, endf_chain):
     assert bareI5.n_decay_modes == ref_iodine.n_decay_modes
     assert bareI5.half_life == ref_iodine.half_life
     assert bareI5.decay_energy == ref_iodine.decay_energy
+    assert bareI5.sources == ref_iodine.sources
     for newmode, refmode in zip(bareI5.decay_modes, ref_iodine.decay_modes):
         assert newmode.target is None
         assert newmode.type == refmode.type


### PR DESCRIPTION
I just noticed that if you have a `deplete.Chain` with information in the new `sources` attribute, that information is lost if you call `Chain.reduce(...)`. This PR fixes that and updates a test with a corresponding check on the sources after calling `reduce`.