### PR TITLE
Change to get_reshaped_data for consistency with mesh dimensions

### DIFF
--- a/openmc/arithmetic.py
+++ b/openmc/arithmetic.py
@@ -604,6 +604,10 @@ class AggregateFilter:
     def num_bins(self):
         return len(self.bins) if self.aggregate_filter else 0
 
+    @property
+    def shape(self):
+        return (self.num_bins,)
+
     @type.setter
     def type(self, filter_type):
         if filter_type not in _FILTER_TYPES:

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -102,6 +102,8 @@ class Filter(IDManagerMixin, metaclass=FilterMeta):
         Unique identifier for the filter
     num_bins : Integral
         The number of filter bins
+    shape : tuple
+        The shape of the filter
 
     """
 
@@ -204,6 +206,10 @@ class Filter(IDManagerMixin, metaclass=FilterMeta):
     @property
     def num_bins(self):
         return len(self.bins)
+
+    @property
+    def shape(self):
+        return (self.num_bins,)
 
     def check_bins(self, bins):
         """Make sure given bins are valid for this filter.
@@ -838,6 +844,10 @@ class MeshFilter(Filter):
                 self.bins = list(range(len(mesh.volumes)))
         else:
             self.bins = list(mesh.indices)
+
+    @property
+    def shape(self):
+        return self.mesh.dimension
 
     @property
     def translation(self):

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -847,6 +847,8 @@ class MeshFilter(Filter):
 
     @property
     def shape(self):
+        if isinstance(self, MeshSurfaceFilter):
+            return (self.num_bins,)
         return self.mesh.dimension
 
     @property
@@ -968,8 +970,6 @@ class MeshSurfaceFilter(MeshFilter):
 
     Attributes
     ----------
-    bins : Integral
-        The mesh ID
     mesh : openmc.MeshBase
         The mesh object that events will be tallied onto
     translation : Iterable of float
@@ -978,10 +978,8 @@ class MeshSurfaceFilter(MeshFilter):
     id : int
         Unique identifier for the filter
     bins : list of tuple
-
         A list of mesh indices / surfaces for each filter bin, e.g. [(1, 1,
         'x-min out'), (1, 1, 'x-min in'), ...]
-
     num_bins : Integral
         The number of filter bins
 

--- a/tests/unit_tests/test_filter_mesh.py
+++ b/tests/unit_tests/test_filter_mesh.py
@@ -1,6 +1,9 @@
+import math
+
 import numpy as np
-import openmc
 from uncertainties import unumpy
+
+import openmc
 
 
 def test_spherical_mesh_estimators(run_in_tmpdir):
@@ -62,7 +65,8 @@ def test_cylindrical_mesh_estimators(run_in_tmpdir):
     mat.add_nuclide('U235', 1.0)
     mat.set_density('g/cm3', 10.0)
 
-    cyl = openmc.model.RightCircularCylinder((0., 0., -5.), 10., 10.0, boundary_type='vacuum')
+    cyl = openmc.model.RightCircularCylinder((0., 0., -5.), 10., 10.0,
+                                             boundary_type='vacuum')
     cell = openmc.Cell(fill=mat, region=-cyl)
     model = openmc.Model()
     model.geometry = openmc.Geometry([cell])
@@ -107,3 +111,43 @@ def test_cylindrical_mesh_estimators(run_in_tmpdir):
     diff = unumpy.nominal_values(delta)
     std_dev = unumpy.std_devs(delta)
     assert np.all(diff < 3*std_dev)
+
+def test_get_reshaped_data(run_in_tmpdir):
+    """Test that expanding MeshFilter dimensions works as expected"""
+
+    mat = openmc.Material()
+    mat.add_nuclide('U235', 1.0)
+    mat.set_density('g/cm3', 10.0)
+
+    sphere = openmc.Sphere(r=10.0, boundary_type='vacuum')
+    cell = openmc.Cell(fill=mat, region=-sphere)
+    model = openmc.Model()
+    model.geometry = openmc.Geometry([cell])
+    model.settings.particles = 1_000
+    model.settings.inactive = 10
+    model.settings.batches = 20
+
+    sph_mesh = openmc.SphericalMesh()
+    sph_mesh.r_grid = np.linspace(0.0, 5.0**3, 20)**(1/3)
+    sph_mesh.theta_grid = np.linspace(0, math.pi, 4)
+    sph_mesh.phi_grid = np.linspace(0, 2*math.pi, 3)
+    tally1 = openmc.Tally()
+    efilter = openmc.EnergyFilter([0, 1e5, 1e8])
+    meshfilter = openmc.MeshFilter(sph_mesh)
+    assert meshfilter.shape == (19, 3, 2)
+    tally1.filters = [efilter, meshfilter]
+    tally1.scores = ['flux']
+
+    model.tallies = openmc.Tallies([tally1])
+
+    # Run OpenMC
+    sp_filename = model.run()
+
+    # Get flux tally as reshaped data
+    with openmc.StatePoint(sp_filename) as sp:
+        t1 = sp.tallies[tally1.id]
+        data1 = t1.get_reshaped_data()
+        data2 = t1.get_reshaped_data(expand_dims=True)
+
+    assert data1.shape == (2, 19*3*2, 1, 1)
+    assert data2.shape == (2, 19, 3, 2, 1, 1)


### PR DESCRIPTION
A number of users have been experiencing issues with mesh tallies because the dimension of a mesh can not be used directly to reshape the mesh tally results correctly. This is because when the mesh tally results are written to the statepoint file they are written flat with with the first index varying the fastest and the last the slowest (Fortran style indexing). When reading these results into the Python API for post processing, naively reshaping the results using `mesh.dimension` will give you the incorrect result. Short of refactoring either the Python API or the C++ side to be consistent with the other, one option would be to manipulate the shapes to be more sensible in the `get_reshaped_data` method as done in this PR.