### PR TITLE
Fix for non-zero CDF start points in incoherent inelastic data

### DIFF
--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -696,7 +696,7 @@ class ThermalScattering(EqualityMixin):
                     # For this added outgoing energy (of 0 eV) we add a set of
                     # isotropic discrete angles.
                     dmu = 2. / n_mu
-                    mu = np.linsace(-1. + 0.5*dmu, 1. - 0.5*dmu, n_mu)
+                    mu = np.linspace(-1. + 0.5*dmu, 1. - 0.5*dmu, n_mu)
                     p_mu = 1. / n_mu * np.ones(n_mu)
                     mu_0 = Discrete(mu, p_mu)
                     mu_0.c = np.cumsum(p_mu)

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -670,11 +670,40 @@ class ThermalScattering(EqualityMixin):
                 mu_i = []
                 for j in range(n_energy_out[i]):
                     mu = ace.xss[idx + 4:idx + 4 + n_mu]
+                    # The equiprobable angles produced by NJOY are not always
+                    # sorted. This is problematic when the smearing algorithm
+                    # is applied when sampling the angles. We sort the angles
+                    # here, because they are equiprobable, so the order
+                    # doesn't mater.
+                    mu.sort()
                     p_mu = 1. / n_mu * np.ones(n_mu)
                     mu_ij = Discrete(mu, p_mu)
                     mu_ij.c = np.cumsum(p_mu)
                     mu_i.append(mu_ij)
                     idx += 3 + n_mu
+
+                # Check if the CDF for the outgoing energy distribution starts
+                # at 0. For NJOY and FRENDY evaluations, this is never the case,
+                # and can very rarely lead to negative energies when sampling
+                # the outgoing energy. From Eq. 7.6 of the ENDF manual, we can
+                # add the outgoing energy 0 eV, which has a PDF of 0 (and of
+                # course, a CDF of 0 as well).
+                if eout_i.c[0] > 0.:
+                    eout_i.x = np.insert(eout_i.x, 0, 0.)
+                    eout_i.p = np.insert(eout_i.p, 0, 0.)
+                    eout_i.c = np.insert(eout_i.c, 0, 0.)
+
+                    # For this added outgoing energy (of 0 eV) we add a set of
+                    # isotropic discrete angles.
+                    dmu = 2. / n_mu
+                    mu = np.linsace(-1. + 0.5*dmu, 1. - 0.5*dmu, n_mu)
+                    p_mu = 1. / n_mu * np.ones(n_mu)
+                    mu_0 = Discrete(mu, p_mu)
+                    mu_0.c = np.cumsum(p_mu)
+                    mu_i.insert(0, mu_0)
+                # We don't worry about renormalizing the outgoing energy PDF/CDF
+                # after this manipulation, because it never seems to be
+                # normalized to begin with (at least with NJOY).
 
                 energy_out.append(eout_i)
                 mu_out.append(mu_i)


### PR DESCRIPTION
TSLs which are processed with either NJOY or FRENDY (I don't know about other codes) have the odd peculiarity that for incoherent inelastic scattering, the CDF for the outgoing energy always starts at a value greater than zero (regardless of the incident energy in question). When sampling the outgoing energy, if the sampled random value $\xi < \text{CDF}[0] $, then the sampled outgoing energy can actually be negative ( I believe Coline might have mentioned this to you recently @paulromano ).

In PapillonNDL, I chose to handle this problem in the following manner: if the CDF does not start at 0, I then add a new point for outgoing energy = 0 eV, with a PDF of 0, and a CDF of 0. This choice should be correct according to Eq. 7.6 in the ENDF manual, for the double differential xs. While a new energy-PDF point has been added, I don't bother re-normalizing the distribution or re-computing the CDF, because in my experience, the CDF is never normalized to begin with, and this only changes the discrepancy by a factor which is generally much smaller than the current difference one gets when integrating the PDF. A set of discreet, equiprobable angles must also be created for this new outgoing energy of 0. I create a set of isotropically distributed discreet angles, as Eq. 7.6 also seems to imply that in the limit as $E' \rightarrow 0$, $\alpha \rightarrow \frac{E}{A_0kT}$, and the difference between $\alpha_\text{min}$ and $\alpha_\text{max}$ becomes smaller and smaller. When $\alpha_\text{max} - \alpha_\text{min}$ is very small, we can likely approximate $S(\alpha,\beta)$ as being a constant in $\alpha$, hence why I propose the isotropic distribution. It certainly isn't well defined to have a neutron with zero energy, and then to consider the angular distribution, but I think this is reasonable in this case.

In this PR, I have applied the same doctoring to the TSL data that I do in PapillonNDL.

In general, this change to the nuclear data is so small, I have not been able to notice any statistical difference when sampling the distributions (the CDF already starts at a very small value, even if it isn't zero). There is one exception to this however, which is found in the TSL for Mg at 20K from JEFF-3.3, at an incident energy near 1 eV. The two plots bellow compare the sampling from PapillonNDL with OpenMC (original and my proposed data doctoring).

![Mg-20K at 1 01eV-energy-orig](https://user-images.githubusercontent.com/29313793/199813555-19d0a0c7-f3b5-42d6-9872-cc655f31b8f0.png)

![Mg-20K at 1 01eV-energy-new](https://user-images.githubusercontent.com/29313793/199813724-72b6dfe9-8a53-48fd-9dfb-1ec0b3a7b3ae.png)

Here, we can see that applying this doctoring to the data leads to a very large difference in the outgoing energy distribution (this is also the case for the angular distribution as well, though I have not posted it here). Looking at the OpenMC results for the top image, we see a large peak which appears in the PDF at low outgoing energies. This is because the PDF in the tabulated data near 1eV appears to be increase when considering lower and lower outgoing energies. When this at point at outgoing energy 0 is added, with PDF and CDF of 0, this then "flattens" the triangle, and changes the lower end of the distribution drastically. The fact that the PDF is increasing as the outgoing energy decreases is not physically correct though (confirmed with the evaluator for the evaluation), and it appears to be a problem with how NJOY and FRENDY are processing the data. Since the TSL for Mg at 20K in it's original form is already un-physical, I do not see this effective change in the "un-physicalness" to be an issue myself; the same portion of particles end up with un-physical energies in the tail, it is just the shape of this un-physical tail which changes.

Apart from this odd case with Mg, I have yet to observe any statistically significant changes in other evaluations, and this change helps ensure that negative energies cannot occur. It is very rare that this occurs however, as the CDF does usually start at a very small value, so there is a very low probability of sampling in that vicinity.