### PR TITLE
Support for a single `model.xml` file

### DIFF
--- a/include/openmc/cross_sections.h
+++ b/include/openmc/cross_sections.h
@@ -62,6 +62,11 @@ extern vector<Library> libraries;
 //! libraries
 void read_cross_sections_xml();
 
+//! Read cross sections file (either XML or multigroup H5) and populate data
+//! libraries
+//! \param[in] root node of the cross_sections.xml
+void read_cross_sections_xml(pugi::xml_node root);
+
 //! Load nuclide and thermal scattering data from HDF5 files
 //
 //! \param[in] nuc_temps Temperatures for each nuclide in [K]

--- a/include/openmc/file_utils.h
+++ b/include/openmc/file_utils.h
@@ -11,7 +11,8 @@ namespace openmc {
 //! Determine if a path is a directory
 //! \param[in] path Path to check
 //! \return Whether the path is a directory
-inline bool is_dir(const std::string& path) {
+inline bool dir_exists(const std::string& path)
+{
   struct stat s;
   if (stat(path.c_str(), &s) != 0) return false;
 
@@ -23,8 +24,9 @@ inline bool is_dir(const std::string& path) {
 //! \return Whether file exists
 inline bool file_exists(const std::string& filename)
 {
-  // rule out file being a directory path
-  if (is_dir(filename)) return false;
+  // rule out file being a path to a directory
+  if (dir_exists(filename))
+    return false;
 
   std::ifstream s {filename};
   return s.good();

--- a/include/openmc/file_utils.h
+++ b/include/openmc/file_utils.h
@@ -3,15 +3,31 @@
 
 #include <fstream> // for ifstream
 #include <string>
+#include <sys/stat.h>
 
 namespace openmc {
+
+// TODO: replace with std::filesysem when switch to C++17 is made
+//! Determine if a path is a directory
+//! \param[in] path Path to check
+//! \return Whether the path is a directory
+inline bool is_dir(const std::string& path) {
+  struct stat s;
+  if (stat(path.c_str(), &s) != 0) return false;
+
+  return s.st_mode & S_IFDIR;
+}
 
 //! Determine if a file exists
 //! \param[in] filename Path to file
 //! \return Whether file exists
 inline bool file_exists(const std::string& filename)
 {
+  // rule out file being a directory path
+  if (is_dir(filename)) return false;
+
   std::ifstream s {filename};
+  s.seekg(0, std::ios::beg);
   return s.good();
 }
 

--- a/include/openmc/file_utils.h
+++ b/include/openmc/file_utils.h
@@ -7,7 +7,7 @@
 
 namespace openmc {
 
-// TODO: replace with std::filesysem when switch to C++17 is made
+// TODO: replace with std::filesystem when switch to C++17 is made
 //! Determine if a path is a directory
 //! \param[in] path Path to check
 //! \return Whether the path is a directory
@@ -27,7 +27,6 @@ inline bool file_exists(const std::string& filename)
   if (is_dir(filename)) return false;
 
   std::ifstream s {filename};
-  s.seekg(0, std::ios::beg);
   return s.good();
 }
 

--- a/include/openmc/geometry_aux.h
+++ b/include/openmc/geometry_aux.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "openmc/vector.h"
+#include "openmc/xml_interface.h"
 
 namespace openmc {
 
@@ -19,7 +20,12 @@ extern std::unordered_map<int32_t, std::unordered_map<int32_t, int32_t>>
 extern std::unordered_map<int32_t, int32_t> universe_level_counts;
 } // namespace model
 
+//! Read geometry from XML file
 void read_geometry_xml();
+
+//! Read geometry from XML node
+//! \param[in]  root node of geometry XML element
+void read_geometry_xml(pugi::xml_node root);
 
 //==============================================================================
 //! Replace Universe, Lattice, and Material IDs with indices.

--- a/include/openmc/geometry_aux.h
+++ b/include/openmc/geometry_aux.h
@@ -24,7 +24,7 @@ extern std::unordered_map<int32_t, int32_t> universe_level_counts;
 void read_geometry_xml();
 
 //! Read geometry from XML node
-//! \param[in]  root node of geometry XML element
+//! \param[in] root node of geometry XML element
 void read_geometry_xml(pugi::xml_node root);
 
 //==============================================================================

--- a/include/openmc/initialize.h
+++ b/include/openmc/initialize.h
@@ -11,8 +11,12 @@ int parse_command_line(int argc, char* argv[]);
 #ifdef OPENMC_MPI
 void initialize_mpi(MPI_Comm intracomm);
 #endif
+
+//! Read material, geometry, settings, and tallies from a single XML file
 bool read_model_xml();
-void read_input_xml();
+//! Read inputs from separate XML files
+void read_separate_xml_files();
+//! Write some output that occurs right after initialization
 void initial_output();
 
 } // namespace openmc

--- a/include/openmc/initialize.h
+++ b/include/openmc/initialize.h
@@ -21,8 +21,6 @@ void read_separate_xml_files();
 //! Write some output that occurs right after initialization
 void initial_output();
 
-
-std::string args_xml_filename {};
 } // namespace openmc
 
 #endif // OPENMC_INITIALIZE_H

--- a/include/openmc/initialize.h
+++ b/include/openmc/initialize.h
@@ -11,6 +11,7 @@ int parse_command_line(int argc, char* argv[]);
 #ifdef OPENMC_MPI
 void initialize_mpi(MPI_Comm intracomm);
 #endif
+bool read_model_xml();
 void read_input_xml();
 
 } // namespace openmc

--- a/include/openmc/initialize.h
+++ b/include/openmc/initialize.h
@@ -13,6 +13,7 @@ void initialize_mpi(MPI_Comm intracomm);
 #endif
 bool read_model_xml();
 void read_input_xml();
+void initial_output();
 
 } // namespace openmc
 

--- a/include/openmc/initialize.h
+++ b/include/openmc/initialize.h
@@ -1,6 +1,8 @@
 #ifndef OPENMC_INITIALIZE_H
 #define OPENMC_INITIALIZE_H
 
+#include <string>
+
 #ifdef OPENMC_MPI
 #include "mpi.h"
 #endif
@@ -19,6 +21,8 @@ void read_separate_xml_files();
 //! Write some output that occurs right after initialization
 void initial_output();
 
+
+std::string args_xml_filename {};
 } // namespace openmc
 
 #endif // OPENMC_INITIALIZE_H

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -221,6 +221,10 @@ double density_effect(const vector<double>& f, const vector<double>& e_b_sq,
 //! Read material data from materials.xml
 void read_materials_xml();
 
+//! Read material data XML node
+//! \param[in] root node of materials XML element
+void read_materials_xml(pugi::xml_node root);
+
 void free_memory_material();
 
 } // namespace openmc

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -279,6 +279,10 @@ void voxel_finalize(hid_t dspace, hid_t dset, hid_t memspace);
 //! Read plot specifications from a plots.xml file
 void read_plots_xml();
 
+//! Read plot specifications from an XML Node
+//! \param[in] XML node containing plot info
+void read_plots_xml(pugi::xml_node root);
+
 //! Clear memory
 void free_memory_plot();
 

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -127,8 +127,11 @@ extern double weight_survive;      //!< Survival weight after Russian roulette
 //==============================================================================
 
 //! Read settings from XML file
-//! \param[in] root XML node for <settings>
 void read_settings_xml();
+
+//! Read settings from XML node
+//! \param[in] root XML node for <settings>
+void read_settings_xml(pugi::xml_node root);
 
 void free_memory_settings();
 

--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -48,10 +48,10 @@ public:
   void set_nuclides(const vector<std::string>& nuclides);
 
   //! returns vector of indices corresponding to the tally this is called on
-  const vector<int32_t>& filters() const { return filters_; } 
+  const vector<int32_t>& filters() const { return filters_; }
 
   //! \brief Returns the tally filter at index i
-  int32_t filters(int i) const { return filters_[i]; } 
+  int32_t filters(int i) const { return filters_[i]; }
 
   void set_filters(gsl::span<Filter*> filters);
 
@@ -177,6 +177,10 @@ extern double global_tally_leakage;
 
 //! Read tally specification from tallies.xml
 void read_tallies_xml();
+
+//! Read tally specification from an XML node
+//! \param[in] root node of tallies XML element
+void read_tallies_xml(pugi::xml_node root);
 
 //! \brief Accumulate the sum of the contributions from each history within the
 //! batch to a new random variable

--- a/openmc/_xml.py
+++ b/openmc/_xml.py
@@ -11,7 +11,7 @@ def clean_indentation(element, level=0, spaces_per_level=2, trailing_indent=True
     spaces_per_level : int
         Number of spaces per indentation level (default 2)
     trailing_indent : bool
-        Whether or not to include an indentation after closing the element
+        Whether or not to add indentation after closing the element
 
     """
     i = "\n" + level*spaces_per_level*" "

--- a/openmc/_xml.py
+++ b/openmc/_xml.py
@@ -1,22 +1,36 @@
-def clean_indentation(element, level=0, spaces_per_level=2):
-    """
-    copy and paste from https://effbot.org/zone/element-lib.htm#prettyprint
-    it basically walks your tree and adds spaces and newlines so the tree is
-    printed in a nice way
+def clean_indentation(element, level=0, spaces_per_level=2, trailing_indent=True):
+    """Set indentation of XML element and its sub-elements.
+    Copied and pastee from https://effbot.org/zone/element-lib.htm#prettyprint.
+    It walks your tree and adds spaces and newlines so the tree is
+    printed in a nice way.
+
+    Parameters
+    ----------
+    level : int
+        Indentation level for the element passed in (default 0)
+    spaces_per_level : int
+        Number of spaces per indentation level (default 2)
+    trailing_indent : bool
+        Whether or not to include an indentation after closing the element
+
     """
     i = "\n" + level*spaces_per_level*" "
+
+    # ensure there's awlays some tail for the element passed in
+    if not element.tail:
+        element.tail = ""
 
     if len(element):
         if not element.text or not element.text.strip():
             element.text = i + spaces_per_level*" "
-        if not element.tail or not element.tail.strip():
+        if trailing_indent and (not element.tail or not element.tail.strip()):
             element.tail = i
         for sub_element in element:
             clean_indentation(sub_element, level+1, spaces_per_level)
         if not sub_element.tail or not sub_element.tail.strip():
             sub_element.tail = i
     else:
-        if level and (not element.tail or not element.tail.strip()):
+        if trailing_indent and level and (not element.tail or not element.tail.strip()):
             element.tail = i
 
 

--- a/openmc/_xml.py
+++ b/openmc/_xml.py
@@ -1,6 +1,6 @@
 def clean_indentation(element, level=0, spaces_per_level=2, trailing_indent=True):
     """Set indentation of XML element and its sub-elements.
-    Copied and pastee from https://effbot.org/zone/element-lib.htm#prettyprint.
+    Copied and pasted from https://effbot.org/zone/element-lib.htm#prettyprint.
     It walks your tree and adds spaces and newlines so the tree is
     printed in a nice way.
 
@@ -26,6 +26,8 @@ def clean_indentation(element, level=0, spaces_per_level=2, trailing_indent=True
         if trailing_indent and (not element.tail or not element.tail.strip()):
             element.tail = i
         for sub_element in element:
+            # `trailing_indent` intentionally not passed to the recursive call.
+            # it only applies to the element for the initial of this function.
             clean_indentation(sub_element, level+1, spaces_per_level)
         if not sub_element.tail or not sub_element.tail.strip():
             sub_element.tail = i

--- a/openmc/_xml.py
+++ b/openmc/_xml.py
@@ -16,7 +16,7 @@ def clean_indentation(element, level=0, spaces_per_level=2, trailing_indent=True
     """
     i = "\n" + level*spaces_per_level*" "
 
-    # ensure there's awlays some tail for the element passed in
+    # ensure there's always some tail for the element passed in
     if not element.tail:
         element.tail = ""
 

--- a/openmc/_xml.py
+++ b/openmc/_xml.py
@@ -26,8 +26,10 @@ def clean_indentation(element, level=0, spaces_per_level=2, trailing_indent=True
         if trailing_indent and (not element.tail or not element.tail.strip()):
             element.tail = i
         for sub_element in element:
-            # `trailing_indent` intentionally not passed to the recursive call.
-            # it only applies to the element for the initial of this function.
+            # `trailing_indent` is intentionally not forwarded to the recursive
+            # call. Any child element of the topmost clement should add
+            # indentation at the end to ensure its parent's indentation is
+            # correct.
             clean_indentation(sub_element, level+1, spaces_per_level)
         if not sub_element.tail or not sub_element.tail.strip():
             sub_element.tail = i

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -650,7 +650,7 @@ class Cell(IDManagerMixin):
         surfaces : dict
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
         materials : dict
-            Dictionary mapping material IDs to :class:`openmc.Material`
+            Dictionary mapping material ID strings to :class:`openmc.Material`
             instances (defined in :math:`openmc.Geometry.from_xml`)
         get_universe : function
             Function returning universe (defined in

--- a/openmc/executor.py
+++ b/openmc/executor.py
@@ -9,7 +9,7 @@ from .plots import _get_plot_image
 def _process_CLI_arguments(volume=False, geometry_debug=False, particles=None,
                            plot=False, restart_file=None, threads=None,
                            tracks=False, event_based=None,
-                           openmc_exec='openmc', mpi_args=None, input_file=None):
+                           openmc_exec='openmc', mpi_args=None, path_input=None):
     """Converts user-readable flags in to command-line arguments to be run with
     the OpenMC executable via subprocess.
 
@@ -42,7 +42,7 @@ def _process_CLI_arguments(volume=False, geometry_debug=False, particles=None,
     mpi_args : list of str, optional
         MPI execute command and any additional MPI arguments to pass,
         e.g. ['mpiexec', '-n', '8'].
-    input_file : str or Pathlike
+    path_input : str or Pathlike
         Name of a single XML input file for the OpenMC executable to read.
 
     .. versionadded:: 0.13.0
@@ -84,8 +84,8 @@ def _process_CLI_arguments(volume=False, geometry_debug=False, particles=None,
     if mpi_args is not None:
         args = mpi_args + args
 
-    if input_file is not None:
-        args += ['-i', input_file]
+    if path_input is not None:
+        args += [path_input]
 
     return args
 
@@ -95,6 +95,7 @@ def _run(args, output, cwd):
     p = subprocess.Popen(args, cwd=cwd, stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT, universal_newlines=True)
 
+    print(args)
     # Capture and re-print OpenMC output in real-time
     lines = []
     while True:
@@ -123,7 +124,7 @@ def _run(args, output, cwd):
         raise RuntimeError(error_msg)
 
 
-def plot_geometry(output=True, openmc_exec='openmc', cwd='.', input_file=None):
+def plot_geometry(output=True, openmc_exec='openmc', cwd='.', path_input=None):
     """Run OpenMC in plotting mode
 
     Parameters
@@ -134,7 +135,7 @@ def plot_geometry(output=True, openmc_exec='openmc', cwd='.', input_file=None):
         Path to OpenMC executable
     cwd : str, optional
         Path to working directory to run in
-    input_file : str
+    path_input : str
         Name of a single XML input file for the OpenMC executable to read.
 
     Raises
@@ -144,12 +145,12 @@ def plot_geometry(output=True, openmc_exec='openmc', cwd='.', input_file=None):
 
     """
     args = [openmc_exec, '-p']
-    if input_file is not None:
-        args += ['-i', input_file]
+    if path_input is not None:
+        args += ['-i', path_input]
     _run([openmc_exec, '-p'], output, cwd)
 
 
-def plot_inline(plots, openmc_exec='openmc', cwd='.', input_file=None):
+def plot_inline(plots, openmc_exec='openmc', cwd='.', path_input=None):
     """Display plots inline in a Jupyter notebook.
 
     .. versionchanged:: 0.13.0
@@ -165,7 +166,7 @@ def plot_inline(plots, openmc_exec='openmc', cwd='.', input_file=None):
         Path to OpenMC executable
     cwd : str, optional
         Path to working directory to run in
-    input_file : str
+    path_input : str
         Name of a single XML input file for the OpenMC executable to read.
 
     Raises
@@ -183,7 +184,7 @@ def plot_inline(plots, openmc_exec='openmc', cwd='.', input_file=None):
     openmc.Plots(plots).export_to_xml(cwd)
 
     # Run OpenMC in geometry plotting mode
-    plot_geometry(False, openmc_exec, cwd, input_file)
+    plot_geometry(False, openmc_exec, cwd, path_input)
 
     if plots is not None:
         images = [_get_plot_image(p, cwd) for p in plots]
@@ -192,7 +193,7 @@ def plot_inline(plots, openmc_exec='openmc', cwd='.', input_file=None):
 
 def calculate_volumes(threads=None, output=True, cwd='.',
                       openmc_exec='openmc', mpi_args=None,
-                      input_file=None):
+                      path_input=None):
     """Run stochastic volume calculations in OpenMC.
 
     This function runs OpenMC in stochastic volume calculation mode. To specify
@@ -223,7 +224,7 @@ def calculate_volumes(threads=None, output=True, cwd='.',
     cwd : str, optional
         Path to working directory to run in. Defaults to the current working
         directory.
-    input_file : str or Pathlike
+    path_input : str or Pathlike
         Name of a single XML input file for the OpenMC executable to read.
 
     Raises
@@ -239,7 +240,7 @@ def calculate_volumes(threads=None, output=True, cwd='.',
 
     args = _process_CLI_arguments(volume=True, threads=threads,
                                   openmc_exec=openmc_exec, mpi_args=mpi_args,
-                                  input_file=input_file)
+                                  path_input=path_input)
 
     _run(args, output, cwd)
 
@@ -247,7 +248,7 @@ def calculate_volumes(threads=None, output=True, cwd='.',
 def run(particles=None, threads=None, geometry_debug=False,
         restart_file=None, tracks=False, output=True, cwd='.',
         openmc_exec='openmc', mpi_args=None, event_based=False,
-        input_file=None):
+        path_input=None):
     """Run an OpenMC simulation.
 
     Parameters
@@ -282,7 +283,7 @@ def run(particles=None, threads=None, geometry_debug=False,
 
         .. versionadded:: 0.12
 
-    input_file : str or Pathlike
+    path_input : str or Pathlike
         Name of a single XML input file for the OpenMC executable to read.
 
     Raises
@@ -296,6 +297,6 @@ def run(particles=None, threads=None, geometry_debug=False,
         volume=False, geometry_debug=geometry_debug, particles=particles,
         restart_file=restart_file, threads=threads, tracks=tracks,
         event_based=event_based, openmc_exec=openmc_exec, mpi_args=mpi_args,
-        input_file=input_file)
+        path_input=path_input)
 
     _run(args, output, cwd)

--- a/openmc/executor.py
+++ b/openmc/executor.py
@@ -9,7 +9,7 @@ from .plots import _get_plot_image
 def _process_CLI_arguments(volume=False, geometry_debug=False, particles=None,
                            plot=False, restart_file=None, threads=None,
                            tracks=False, event_based=None,
-                           openmc_exec='openmc', mpi_args=None):
+                           openmc_exec='openmc', mpi_args=None, input_file=None):
     """Converts user-readable flags in to command-line arguments to be run with
     the OpenMC executable via subprocess.
 
@@ -42,6 +42,8 @@ def _process_CLI_arguments(volume=False, geometry_debug=False, particles=None,
     mpi_args : list of str, optional
         MPI execute command and any additional MPI arguments to pass,
         e.g. ['mpiexec', '-n', '8'].
+    input_file : str or Pathlike
+        Name of a single XML input file for the OpenMC executable to read.
 
     .. versionadded:: 0.13.0
 
@@ -82,6 +84,9 @@ def _process_CLI_arguments(volume=False, geometry_debug=False, particles=None,
     if mpi_args is not None:
         args = mpi_args + args
 
+    if input_file is not None:
+        args += ['-i', input_file]
+
     return args
 
 
@@ -118,7 +123,7 @@ def _run(args, output, cwd):
         raise RuntimeError(error_msg)
 
 
-def plot_geometry(output=True, openmc_exec='openmc', cwd='.'):
+def plot_geometry(output=True, openmc_exec='openmc', cwd='.', input_file=None):
     """Run OpenMC in plotting mode
 
     Parameters
@@ -129,6 +134,8 @@ def plot_geometry(output=True, openmc_exec='openmc', cwd='.'):
         Path to OpenMC executable
     cwd : str, optional
         Path to working directory to run in
+    input_file : str
+        Name of a single XML input file for the OpenMC executable to read.
 
     Raises
     ------
@@ -136,10 +143,13 @@ def plot_geometry(output=True, openmc_exec='openmc', cwd='.'):
         If the `openmc` executable returns a non-zero status
 
     """
+    args = [openmc_exec, '-p']
+    if input_file is not None:
+        args += ['-i', input_file]
     _run([openmc_exec, '-p'], output, cwd)
 
 
-def plot_inline(plots, openmc_exec='openmc', cwd='.'):
+def plot_inline(plots, openmc_exec='openmc', cwd='.', input_file=None):
     """Display plots inline in a Jupyter notebook.
 
     .. versionchanged:: 0.13.0
@@ -155,6 +165,8 @@ def plot_inline(plots, openmc_exec='openmc', cwd='.'):
         Path to OpenMC executable
     cwd : str, optional
         Path to working directory to run in
+    input_file : str
+        Name of a single XML input file for the OpenMC executable to read.
 
     Raises
     ------
@@ -171,7 +183,7 @@ def plot_inline(plots, openmc_exec='openmc', cwd='.'):
     openmc.Plots(plots).export_to_xml(cwd)
 
     # Run OpenMC in geometry plotting mode
-    plot_geometry(False, openmc_exec, cwd)
+    plot_geometry(False, openmc_exec, cwd, input_file)
 
     if plots is not None:
         images = [_get_plot_image(p, cwd) for p in plots]
@@ -179,7 +191,8 @@ def plot_inline(plots, openmc_exec='openmc', cwd='.'):
 
 
 def calculate_volumes(threads=None, output=True, cwd='.',
-                      openmc_exec='openmc', mpi_args=None):
+                      openmc_exec='openmc', mpi_args=None,
+                      input_file=None):
     """Run stochastic volume calculations in OpenMC.
 
     This function runs OpenMC in stochastic volume calculation mode. To specify
@@ -210,6 +223,8 @@ def calculate_volumes(threads=None, output=True, cwd='.',
     cwd : str, optional
         Path to working directory to run in. Defaults to the current working
         directory.
+    input_file : str or Pathlike
+        Name of a single XML input file for the OpenMC executable to read.
 
     Raises
     ------
@@ -223,14 +238,16 @@ def calculate_volumes(threads=None, output=True, cwd='.',
     """
 
     args = _process_CLI_arguments(volume=True, threads=threads,
-                                  openmc_exec=openmc_exec, mpi_args=mpi_args)
+                                  openmc_exec=openmc_exec, mpi_args=mpi_args,
+                                  input_file=input_file)
 
     _run(args, output, cwd)
 
 
 def run(particles=None, threads=None, geometry_debug=False,
         restart_file=None, tracks=False, output=True, cwd='.',
-        openmc_exec='openmc', mpi_args=None, event_based=False):
+        openmc_exec='openmc', mpi_args=None, event_based=False,
+        input_file=None):
     """Run an OpenMC simulation.
 
     Parameters
@@ -265,6 +282,9 @@ def run(particles=None, threads=None, geometry_debug=False,
 
         .. versionadded:: 0.12
 
+    input_file : str or Pathlike
+        Name of a single XML input file for the OpenMC executable to read.
+
     Raises
     ------
     RuntimeError
@@ -275,6 +295,7 @@ def run(particles=None, threads=None, geometry_debug=False,
     args = _process_CLI_arguments(
         volume=False, geometry_debug=geometry_debug, particles=particles,
         restart_file=restart_file, threads=threads, tracks=tracks,
-        event_based=event_based, openmc_exec=openmc_exec, mpi_args=mpi_args)
+        event_based=event_based, openmc_exec=openmc_exec, mpi_args=mpi_args,
+        input_file=input_file)
 
     _run(args, output, cwd)

--- a/openmc/executor.py
+++ b/openmc/executor.py
@@ -95,7 +95,6 @@ def _run(args, output, cwd):
     p = subprocess.Popen(args, cwd=cwd, stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT, universal_newlines=True)
 
-    print(args)
     # Capture and re-print OpenMC output in real-time
     lines = []
     while True:
@@ -146,7 +145,7 @@ def plot_geometry(output=True, openmc_exec='openmc', cwd='.', path_input=None):
     """
     args = [openmc_exec, '-p']
     if path_input is not None:
-        args += ['-i', path_input]
+        args += [path_input]
     _run([openmc_exec, '-p'], output, cwd)
 
 

--- a/openmc/executor.py
+++ b/openmc/executor.py
@@ -43,7 +43,8 @@ def _process_CLI_arguments(volume=False, geometry_debug=False, particles=None,
         MPI execute command and any additional MPI arguments to pass,
         e.g. ['mpiexec', '-n', '8'].
     path_input : str or Pathlike
-        Name of a single XML input file for the OpenMC executable to read.
+        Path to a single XML file or a directory containing XML files for the
+        OpenMC executable to read.
 
     .. versionadded:: 0.13.0
 
@@ -135,7 +136,8 @@ def plot_geometry(output=True, openmc_exec='openmc', cwd='.', path_input=None):
     cwd : str, optional
         Path to working directory to run in
     path_input : str
-        Name of a single XML input file for the OpenMC executable to read.
+        Path to a single XML file or a directory containing XML files for the
+        OpenMC executable to read.
 
     Raises
     ------
@@ -146,7 +148,7 @@ def plot_geometry(output=True, openmc_exec='openmc', cwd='.', path_input=None):
     args = [openmc_exec, '-p']
     if path_input is not None:
         args += [path_input]
-    _run([openmc_exec, '-p'], output, cwd)
+    _run(args, output, cwd)
 
 
 def plot_inline(plots, openmc_exec='openmc', cwd='.', path_input=None):
@@ -166,7 +168,8 @@ def plot_inline(plots, openmc_exec='openmc', cwd='.', path_input=None):
     cwd : str, optional
         Path to working directory to run in
     path_input : str
-        Name of a single XML input file for the OpenMC executable to read.
+        Path to a single XML file or a directory containing XML files for the
+        OpenMC executable to read.
 
     Raises
     ------
@@ -224,7 +227,9 @@ def calculate_volumes(threads=None, output=True, cwd='.',
         Path to working directory to run in. Defaults to the current working
         directory.
     path_input : str or Pathlike
-        Name of a single XML input file for the OpenMC executable to read.
+        Path to a single XML file or a directory containing XML files for the
+        OpenMC executable to read.
+
 
     Raises
     ------
@@ -256,17 +261,17 @@ def run(particles=None, threads=None, geometry_debug=False,
         Number of particles to simulate per generation.
     threads : int, optional
         Number of OpenMP threads. If OpenMC is compiled with OpenMP threading
-        enabled, the default is implementation-dependent but is usually equal
-        to the number of hardware threads available (or a value set by the
+        enabled, the default is implementation-dependent but is usually equal to
+        the number of hardware threads available (or a value set by the
         :envvar:`OMP_NUM_THREADS` environment variable).
     geometry_debug : bool, optional
         Turn on geometry debugging during simulation. Defaults to False.
     restart_file : str, optional
         Path to restart file to use
     tracks : bool, optional
-        Enables the writing of particles tracks. The number of particle
-        tracks written to tracks.h5 is limited to 1000 unless
-        Settings.max_tracks is set. Defaults to False.
+        Enables the writing of particles tracks. The number of particle tracks
+        written to tracks.h5 is limited to 1000 unless Settings.max_tracks is
+        set. Defaults to False.
     output : bool
         Capture OpenMC output from standard out
     cwd : str, optional
@@ -275,15 +280,16 @@ def run(particles=None, threads=None, geometry_debug=False,
     openmc_exec : str, optional
         Path to OpenMC executable. Defaults to 'openmc'.
     mpi_args : list of str, optional
-        MPI execute command and any additional MPI arguments to pass,
-        e.g. ['mpiexec', '-n', '8'].
+        MPI execute command and any additional MPI arguments to pass, e.g.
+        ['mpiexec', '-n', '8'].
     event_based : bool, optional
         Turns on event-based parallelism, instead of default history-based
 
         .. versionadded:: 0.12
 
     path_input : str or Pathlike
-        Name of a single XML input file for the OpenMC executable to read.
+        Path to a single XML file or a directory containing XML files for the
+        OpenMC executable to read.
 
     Raises
     ------

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -256,9 +256,9 @@ class Geometry:
         ----------
         path : str, optional
             Path to geometry XML file
-        materials : dict
-            Dictionary mapping material ID strings to :class:`openmc.Material`
-            instances (defined in :math:`openmc.Geometry.from_xml`)
+        materials : openmc.Materials or None
+            Materials used to assign to cells. If None, an attempt is made to
+            generate it from the materials.xml file.
 
         Returns
         -------

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -179,6 +179,11 @@ class Geometry:
             Geometry object
 
         """
+        mats = dict()
+        if materials is not None:
+            mats.update({str(m.id): m for m in materials})
+        mats['void'] = None
+
         # Helper function for keeping a cache of Universe instances
         universes = {}
         def get_universe(univ_id):
@@ -236,7 +241,7 @@ class Geometry:
                             child_of[u].append(lat)
 
         for e in elem.findall('cell'):
-            c = openmc.Cell.from_xml_element(e, surfaces, materials, get_universe)
+            c = openmc.Cell.from_xml_element(e, surfaces, mats, get_universe)
             if c.fill_type in ('universe', 'lattice'):
                 child_of[c.fill].append(c)
 
@@ -266,17 +271,15 @@ class Geometry:
             Geometry object
 
         """
-        tree = ET.parse(path)
-        root = tree.getroot()
-
-         # Create dictionary to easily look up materials
+        # Create dictionary to easily look up materials
         if materials is None:
             filename = Path(path).parent / 'materials.xml'
             materials = openmc.Materials.from_xml(str(filename))
-        mats = {str(m.id): m for m in materials}
-        mats['void'] = None
 
-        return cls.from_xml_element(root, mats)
+        tree = ET.parse(path)
+        root = tree.getroot()
+
+        return cls.from_xml_element(root, materials)
 
     def find(self, point):
         """Find cells/universes/lattices which contain a given point

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -256,9 +256,9 @@ class Geometry:
         ----------
         path : str, optional
             Path to geometry XML file
-        materials : openmc.Materials or None
-            Materials used to assign to cells. If None, an attempt is made to
-            generate it from the materials.xml file.
+         materials : dict
+            Dictionary mapping material ID strings to :class:`openmc.Material`
+            instances (defined in :math:`openmc.Geometry.from_xml`)
 
         Returns
         -------

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -132,6 +132,7 @@ class Geometry:
 
         # Clean the indentation in the file to be user-readable
         xml.clean_indentation(element)
+        xml.reorder_attributes(element)  # TODO: Remove when support is Python 3.8+
 
         return element
 
@@ -157,7 +158,6 @@ class Geometry:
             p /= 'geometry.xml'
 
         # Write the XML Tree to the geometry.xml file
-        xml.reorder_attributes(root_element)  # TODO: Remove when support is Python 3.8+
         tree = ET.ElementTree(root_element)
         tree.write(str(p), xml_declaration=True, encoding='utf-8')
 

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -256,7 +256,7 @@ class Geometry:
         ----------
         path : str, optional
             Path to geometry XML file
-         materials : dict
+        materials : dict
             Dictionary mapping material ID strings to :class:`openmc.Material`
             instances (defined in :math:`openmc.Geometry.from_xml`)
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1449,7 +1449,7 @@ class Materials(cv.CheckedList):
         for material in self:
             material.make_isotropic_in_lab()
 
-    def _write_xml(self, file, header=True):
+    def _write_xml(self, file, header=True, level=0, spaces_per_level=2, trailing_indent=True):
         """Writes XML content of the materials to an open file handle.
 
         Parameters
@@ -1458,33 +1458,46 @@ class Materials(cv.CheckedList):
             Open file handle to write content into.
         header : bool
             Whether or not to write the XML header
+        level : int
+            Indentation level of materials element
+        spaces_per_level : int
+            Number of spaces per indentation
+        trailing_indentation : bool
+            Whether or not to write a trailing indentation for the materials element
+
         """
+        indentation = level*spaces_per_level*' '
         # Write the header and the opening tag for the root element.
         if header:
             file.write("<?xml version='1.0' encoding='utf-8'?>\n")
-        file.write('<materials>\n')
+        file.write(indentation+'<materials>\n')
 
         # Write the <cross_sections> element.
         if self.cross_sections is not None:
             element = ET.Element('cross_sections')
             element.text = str(self.cross_sections)
-            clean_indentation(element, level=1)
+            clean_indentation(element, level=level+1)
             element.tail = element.tail.strip(' ')
-            file.write('  ')
+            file.write((level+1)*spaces_per_level*' ')
             reorder_attributes(element)  # TODO: Remove when support is Python 3.8+
             ET.ElementTree(element).write(file, encoding='unicode')
 
         # Write the <material> elements.
         for material in sorted(self, key=lambda x: x.id):
             element = material.to_xml_element()
-            clean_indentation(element, level=1)
+            clean_indentation(element, level=level+1)
             element.tail = element.tail.strip(' ')
-            file.write('  ')
+            file.write((level+1)*spaces_per_level*' ')
             reorder_attributes(element)  # TODO: Remove when support is Python 3.8+
             ET.ElementTree(element).write(file, encoding='unicode')
 
         # Write the closing tag for the root element.
-        file.write('</materials>\n')
+        file.write(indentation+'</materials>\n')
+
+        # Write a trailing indentation for the next element
+        # at this level if needed
+        if trailing_indent:
+            file.write(indentation)
 
 
     def export_to_xml(self, path: PathLike = 'materials.xml'):

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1548,7 +1548,6 @@ class Materials(cv.CheckedList):
 
         return materials
 
-
     @classmethod
     def from_xml(cls, path: PathLike = 'materials.xml'):
         """Generate materials collection from XML file

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1449,16 +1449,19 @@ class Materials(cv.CheckedList):
         for material in self:
             material.make_isotropic_in_lab()
 
-    def _write_xml(self, file):
+    def _write_xml(self, file, header=True):
         """Writes XML content of the materials to an open file handle.
 
         Parameters
         ----------
         file : IOTextWrapper
             Open file handle to write content into.
+        header : bool
+            Whether or not to write the XML header
         """
         # Write the header and the opening tag for the root element.
-        file.write("<?xml version='1.0' encoding='utf-8'?>\n")
+        if header:
+            file.write("<?xml version='1.0' encoding='utf-8'?>\n")
         file.write('<materials>\n')
 
         # Write the <cross_sections> element.

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1509,6 +1509,34 @@ class Materials(cv.CheckedList):
             self._write_xml(fh)
 
     @classmethod
+    def from_xml_element(cls, elem):
+        """Generate materials collection from XML file
+
+        Parameters
+        ----------
+        elem : xml.etree.ElementTree.Element
+            XML element
+
+        Returns
+        -------
+        openmc.Materials
+            Materials collection
+
+        """
+        # Generate each material
+        materials = cls()
+        for material in elem.findall('material'):
+            materials.append(Material.from_xml_element(material))
+
+        # Check for cross sections settings
+        xs = elem.find('cross_sections')
+        if xs is not None:
+            materials.cross_sections = xs.text
+
+        return materials
+
+
+    @classmethod
     def from_xml(cls, path: PathLike = 'materials.xml'):
         """Generate materials collection from XML file
 
@@ -1526,14 +1554,4 @@ class Materials(cv.CheckedList):
         tree = ET.parse(path)
         root = tree.getroot()
 
-        # Generate each material
-        materials = cls()
-        for material in root.findall('material'):
-            materials.append(Material.from_xml_element(material))
-
-        # Check for cross sections settings
-        xs = tree.find('cross_sections')
-        if xs is not None:
-            materials.cross_sections = xs.text
-
-        return materials
+        return cls.from_xml_element(root)

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -205,30 +205,40 @@ class Model:
                 self._plots.append(plot)
 
     @classmethod
-    def from_xml(cls, *args, separate_xmls=True, **kwargs):
-        """Generate geometry from XML file
+    def from_xml(cls, geometry='geometry.xml', materials='materials.xml',
+                 settings='settings.xml', tallies='tallies.xml',
+                 plots='plots.xml'):
+        """Create model from existing XML files
 
         Parameters
         ----------
-        args : list
-            Positional arguments to be forwarded to
-            :func:`Model.from_separate_xmls` or :func:`Model.from_model_xml`.
-        separate_xmls : bool
-            Whether or not to read from a single or separate XML files.
-        kwargs : dict, optional
-            Keyword arguments to be forwarded to
-            :func:`Model.from_separate_xmls` or :func:`Model.from_model_xml`.
+        geometry : str
+            Path to geometry.xml file
+        materials : str
+            Path to materials.xml file
+        settings : str
+            Path to settings.xml file
+        tallies : str
+            Path to tallies.xml file
+
+            .. versionadded:: 0.13.0
+        plots : str
+            Path to plots.xml file
+
+            .. versionadded:: 0.13.0
 
         Returns
         -------
-        openmc.Geometry
-            Geometry object
+        openmc.model.Model
+            Model created from XML files
 
         """
-        if separate_xmls:
-            return cls.from_separate_xmls(*args, **kwargs)
-        else:
-            return cls.from_model_xml(*args, **kwargs)
+        materials = openmc.Materials.from_xml(materials)
+        geometry = openmc.Geometry.from_xml(geometry, materials)
+        settings = openmc.Settings.from_xml(settings)
+        tallies = openmc.Tallies.from_xml(tallies) if Path(tallies).exists() else None
+        plots = openmc.Plots.from_xml(plots) if Path(plots).exists() else None
+        return cls(geometry, materials, settings, tallies, plots)
 
     @classmethod
     def from_model_xml(cls, path='model.xml'):
@@ -264,42 +274,6 @@ class Model:
             model.plots = openmc.Plots.from_xml_element(root.find('plots'))
 
         return model
-
-    @classmethod
-    def from_separate_xmls(cls, geometry='geometry.xml', materials='materials.xml',
-                 settings='settings.xml', tallies='tallies.xml',
-                 plots='plots.xml'):
-        """Create model from existing XML files
-
-        Parameters
-        ----------
-        geometry : str
-            Path to geometry.xml file
-        materials : str
-            Path to materials.xml file
-        settings : str
-            Path to settings.xml file
-        tallies : str
-            Path to tallies.xml file
-
-            .. versionadded:: 0.13.0
-        plots : str
-            Path to plots.xml file
-
-            .. versionadded:: 0.13.0
-
-        Returns
-        -------
-        openmc.model.Model
-            Model created from XML files
-
-        """
-        materials = openmc.Materials.from_xml(materials)
-        geometry = openmc.Geometry.from_xml(geometry, materials)
-        settings = openmc.Settings.from_xml(settings)
-        tallies = openmc.Tallies.from_xml(tallies) if Path(tallies).exists() else None
-        plots = openmc.Plots.from_xml(plots) if Path(plots).exists() else None
-        return cls(geometry, materials, settings, tallies, plots)
 
     def init_lib(self, threads=None, geometry_debug=False, restart_file=None,
                  tracks=False, output=True, event_based=None, intracomm=None):

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -230,8 +230,9 @@ class Model:
 
         model.settings = openmc.Settings.from_xml_element(root.find('settings'))
         model.materials = openmc.Materials.from_xml_element(root.find('materials'))
+        materials = {str(m.id): m for m in model.materials}
         model.geometry = \
-        openmc.Geometry.from_xml_element(root.find('geometry'), model.materials)
+        openmc.Geometry.from_xml_element(root.find('geometry'), materials)
 
         if root.find('tallies'):
             model.tallies = openmc.Tallies.from_xml_element(root.find('tallies'))

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -208,11 +208,11 @@ class Model:
                 self._plots.append(plot)
 
     @classmethod
-    def from_xml(cls, separate_xmls=True, **kwargs):
+    def from_xml(cls, *args, separate_xmls=True, **kwargs):
         if separate_xmls:
-            return cls.from_separate_xmls(**kwargs)
+            return cls.from_separate_xmls(*args, **kwargs)
         else:
-            return cls.from_model_xml(**kwargs)
+            return cls.from_model_xml(*args, **kwargs)
 
     @classmethod
     def from_model_xml(cls, path='model.xml'):

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -228,8 +228,7 @@ class Model:
         model.settings = openmc.Settings.from_xml_element(root.find('settings'))
         model.materials = openmc.Materials.from_xml_element(root.find('materials'))
         materials = {str(m.id): m for m in model.materials}
-        model.geometry = \
-        openmc.Geometry.from_xml_element(root.find('geometry'), materials)
+        model.geometry = .Geometry.from_xml_element(root.find('geometry'), materials)
 
         # gather meshses from other classes before reading the tally node
         meshes = {}
@@ -542,8 +541,7 @@ class Model:
             materials = openmc.Materials(self.geometry.get_all_materials()
                                          .values())
 
-        with open(d, 'w', encoding='utf-8',
-                  errors='xmlcharrefreplace') as fh:
+        with open(d, 'w', encoding='utf-8', errors='xmlcharrefreplace') as fh:
             # write the XML header
             fh.write("<?xml version='1.0' encoding='utf-8'?>\n")
             fh.write("<model>\n")

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -259,7 +259,7 @@ class Model:
         materials = {str(m.id): m for m in model.materials}
         model.geometry = openmc.Geometry.from_xml_element(root.find('geometry'), materials)
 
-        # gather meshses from other classes before reading the tally node
+        # gather meshes from other classes before reading the tally node
         meshes = {}
         if model.settings.entropy_mesh is not None:
             meshes[model.settings.entropy_mesh.id] = model.settings.entropy_mesh

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -221,7 +221,6 @@ class Model:
             Geometry object
 
         """
-
         if separate_xmls or not Path(path).exists():
             return cls.from_separate_xmls(*args, **kwargs)
         else:

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -254,12 +254,12 @@ class Model:
 
         model = cls()
 
-        model.settings = openmc.Settings.from_xml_element(root.find('settings'))
+        meshes = {}
+        model.settings = openmc.Settings.from_xml_element(root.find('settings'), meshes)
         model.materials = openmc.Materials.from_xml_element(root.find('materials'))
         model.geometry = openmc.Geometry.from_xml_element(root.find('geometry'), model.materials)
 
         # gather meshes from other classes before reading the tally node
-        meshes = {}
         if model.settings.entropy_mesh is not None:
             meshes[model.settings.entropy_mesh.id] = model.settings.entropy_mesh
 

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -552,6 +552,9 @@ class Model:
         settings_element = self.settings.to_xml_element(memo)
         geometry_element = self.geometry.to_xml_element()
 
+        xml.clean_indentation(geometry_element, level=1)
+        xml.clean_indentation(settings_element, level=1)
+
         # If a materials collection was specified, export it. Otherwise, look
         # for all materials in the geometry and use that to automatically build
         # a collection.
@@ -567,16 +570,18 @@ class Model:
             fh.write("<model>\n")
             # Write the materials collection to the open XML file first.
             # This will write the XML header also
-            materials._write_xml(fh, False)
+            materials._write_xml(fh, False, level=1)
             # Write remaining elements as a tree
             ET.ElementTree(geometry_element).write(fh, encoding='unicode')
             ET.ElementTree(settings_element).write(fh, encoding='unicode')
 
             if self.tallies:
                 tallies_element = self.tallies.to_xml_element(memo)
+                xml.clean_indentation(tallies_element, level=1, trailing_indent=self.plots)
                 ET.ElementTree(tallies_element).write(fh, encoding='unicode')
             if self.plots:
                 plots_element = self.plots.to_xml_element()
+                xml.clean_indentation(plots_element, level=1, trailing_indent=False)
                 ET.ElementTree(plots_element).write(fh, encoding='unicode')
             fh.write("</model>\n")
 

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -496,13 +496,10 @@ class Model:
             self.plots.export_to_xml(d)
 
     def _export_to_single_xml(self, path='model.xml', remove_surfs=False):
-        """Export model to XML files.
+        """Export model to a single XML file.
 
         Parameters
         ----------
-        directory : str
-            Directory to write the model.xml file to. If it doesn't exist already, it
-            will be created.
         path : str or Pathlike
             Location of the XML file to write. Can be a directory or file path.
         remove_surfs : bool
@@ -530,8 +527,7 @@ class Model:
             # Can be used to modify tallies in case any surfaces are redundant
             redundant_surfaces = self.geometry.remove_redundant_surfaces()
 
-        memo = set()
-        settings_element = self.settings.to_xml_element(memo)
+        settings_element = self.settings.to_xml_element()
         geometry_element = self.geometry.to_xml_element()
 
         xml.clean_indentation(geometry_element, level=1)

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -444,9 +444,12 @@ class Model:
 
         with open(d, 'w', encoding='utf-8',
                   errors='xmlcharrefreplace') as fh:
+            # write the XML header
+            fh.write("<?xml version='1.0' encoding='utf-8'?>\n")
+            fh.write("<model>\n")
             # Write the materials collection to the open XML file first.
             # This will write the XML header also
-            materials._write_xml(fh)
+            materials._write_xml(fh, False)
             # Write remaining elements as a tree
             ET.ElementTree(geometry_element).write(fh, encoding='unicode')
             ET.ElementTree(settings_element).write(fh, encoding='unicode')
@@ -457,6 +460,7 @@ class Model:
             if self.plots:
                 plots_element = self.plots.to_xml_element()
                 ET.ElementTree(plots_element).write(fh, encoding='unicode')
+            fh.write("</model>\n")
 
     def import_properties(self, filename):
         """Import physical properties

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -469,7 +469,7 @@ class Model:
             Whether or not to remove redundant surfaces from the geometry when
             exporting.
         filename : str
-            Name of the single XML file to create (only used :math:`separate_xmls` if False)
+            Name of the single XML file to create (only used :math:`separate_xmls` is False)
 
             .. versionadded:: 0.13.1
 

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -527,7 +527,9 @@ class Model:
             # Can be used to modify tallies in case any surfaces are redundant
             redundant_surfaces = self.geometry.remove_redundant_surfaces()
 
-        settings_element = self.settings.to_xml_element()
+        # provide a memo to track which meshes have been written
+        mesh_memo = set()
+        settings_element = self.settings.to_xml_element(mesh_memo)
         geometry_element = self.geometry.to_xml_element()
 
         xml.clean_indentation(geometry_element, level=1)
@@ -554,7 +556,7 @@ class Model:
             ET.ElementTree(settings_element).write(fh, encoding='unicode')
 
             if self.tallies:
-                tallies_element = self.tallies.to_xml_element(memo)
+                tallies_element = self.tallies.to_xml_element(mesh_memo)
                 xml.clean_indentation(tallies_element, level=1, trailing_indent=self.plots)
                 ET.ElementTree(tallies_element).write(fh, encoding='unicode')
             if self.plots:

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -256,8 +256,7 @@ class Model:
 
         model.settings = openmc.Settings.from_xml_element(root.find('settings'))
         model.materials = openmc.Materials.from_xml_element(root.find('materials'))
-        materials = {str(m.id): m for m in model.materials}
-        model.geometry = openmc.Geometry.from_xml_element(root.find('geometry'), materials)
+        model.geometry = openmc.Geometry.from_xml_element(root.find('geometry'), model.materials)
 
         # gather meshes from other classes before reading the tally node
         meshes = {}
@@ -435,30 +434,7 @@ class Model:
                 depletion_operator.cleanup_when_done = True
                 depletion_operator.finalize()
 
-    def export_to_xml(self, directory='.', remove_surfs=False, separate_xmls=True, path='model.xml'):
-        """Export model to an XML file(s).
-
-        Parameters
-        ----------
-        directory : str
-            Directory to write XML files to. If it doesn't exist already, it
-            will be created. Only used if :math:`separate_xmls` is True.
-        remove_surfs : bool
-            Whether or not to remove redundant surfaces from the geometry when
-            exporting.
-        path : str
-            Path to an output filename or directory. Only used if :math:`separate_xmls` is False.
-
-            .. versionadded:: 0.13.1
-        separate_xmls : bool
-            Whether or not to write a single model.xml file or many XML files.
-        """
-        if separate_xmls:
-            self._export_to_separate_xmls(directory, remove_surfs)
-        else:
-            self._export_to_single_xml(path, remove_surfs)
-
-    def _export_to_separate_xmls(self, directory='.', remove_surfs=False):
+    def export_to_xml(self, directory='.', remove_surfs=False):
         """Export model to separate XML files.
 
         Parameters
@@ -495,13 +471,14 @@ class Model:
         if self.plots:
             self.plots.export_to_xml(d)
 
-    def _export_to_single_xml(self, path='model.xml', remove_surfs=False):
+    def export_to_model_xml(self, path='model.xml', remove_surfs=False):
         """Export model to a single XML file.
 
         Parameters
         ----------
         path : str or Pathlike
-            Location of the XML file to write. Can be a directory or file path.
+            Location of the XML file to write (default is 'model.xml'). Can be a
+            directory or file path.
         remove_surfs : bool
             Whether or not to remove redundant surfaces from the geometry when
             exporting.

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -450,7 +450,6 @@ class Model:
             Path to an output filename or directory. Only used if :math:`separate_xmls` is False.
 
             .. versionadded:: 0.13.1
-
         separate_xmls : bool
             Whether or not to write a single model.xml file or many XML files.
         """

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -208,7 +208,42 @@ class Model:
                 self._plots.append(plot)
 
     @classmethod
-    def from_xml(cls, geometry='geometry.xml', materials='materials.xml',
+    def from_xml(cls, separate_xmls=True, **kwargs):
+        if separate_xmls:
+            return cls.from_separate_xmls(**kwargs)
+        else:
+            return cls.from_model_xml(**kwargs)
+
+    @classmethod
+    def from_model_xml(cls, path='model.xml'):
+        """Create model from single XML file
+
+        Parameters
+        ----------
+        path : str or Pathlike
+            Path to model.xml file
+        """
+        tree = ET.parse(path)
+        root = tree.getroot()
+
+        model = cls()
+
+        model.settings = openmc.Settings.from_xml_element(root.find('settings'))
+        model.materials = openmc.Materials.from_xml_element(root.find('materials'))
+        model.geometry = \
+        openmc.Geometry.from_xml_element(root.find('geometry'), model.materials)
+
+        if tally_node := root.find('tallies'):
+            print(tally_node)
+            model.tallies = openmc.Tallies.from_xml_element(tally_node)
+
+        if plots_node := root.find('plots'):
+            model.plots = openmc.Plots.from_xml_element(plots_node)
+
+        return model
+
+    @classmethod
+    def from_separate_xmls(cls, geometry='geometry.xml', materials='materials.xml',
                  settings='settings.xml', tallies='tallies.xml',
                  plots='plots.xml'):
         """Create model from existing XML files

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -233,12 +233,11 @@ class Model:
         model.geometry = \
         openmc.Geometry.from_xml_element(root.find('geometry'), model.materials)
 
-        if tally_node := root.find('tallies'):
-            print(tally_node)
-            model.tallies = openmc.Tallies.from_xml_element(tally_node)
+        if root.find('tallies'):
+            model.tallies = openmc.Tallies.from_xml_element(root.find('tallies'))
 
-        if plots_node := root.find('plots'):
-            model.plots = openmc.Plots.from_xml_element(plots_node)
+        if root.find('plots'):
+            model.plots = openmc.Plots.from_xml_element(root.find('plots'))
 
         return model
 

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -911,6 +911,12 @@ class Plots(cv.CheckedList):
 
     def to_xml_element(self):
         """Create a 'plots' element to be written to an XML file.
+
+        Returns
+        -------
+        element : xml.etree.ElementTree.Element
+            XML element containing all plot elements
+
         """
         # Reset xml element tree
         self._plots_file.clear()

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -919,6 +919,7 @@ class Plots(cv.CheckedList):
 
         # Clean the indentation in the file to be user-readable
         clean_indentation(self._plots_file)
+        reorder_attributes(self._plots_file)  # TODO: Remove when support is Python 3.8+
 
         return self._plots_file
 
@@ -936,8 +937,8 @@ class Plots(cv.CheckedList):
         if p.is_dir():
             p /= 'plots.xml'
 
+        self.to_xml_element()
         # Write the XML Tree to the plots.xml file
-        reorder_attributes(self._plots_file)  # TODO: Remove when support is Python 3.8+
         tree = ET.ElementTree(self._plots_file)
         tree.write(str(p), xml_declaration=True, encoding='utf-8')
 
@@ -958,8 +959,8 @@ class Plots(cv.CheckedList):
         """
         # Generate each plot
         plots = cls()
-        for elem in elem.findall('plot'):
-            plots.append(Plot.from_xml_element(elem))
+        for e in elem.findall('plot'):
+            plots.append(Plot.from_xml_element(e))
         return plots
 
     @classmethod

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -942,6 +942,27 @@ class Plots(cv.CheckedList):
         tree.write(str(p), xml_declaration=True, encoding='utf-8')
 
     @classmethod
+    def from_xml_element(cls, elem):
+        """Generate plots collection from XML file
+
+        Parameters
+        ----------
+        elem : xml.etree.ElementTree.Element
+            XML element
+
+        Returns
+        -------
+        openmc.Plots
+            Plots collection
+
+        """
+        # Generate each plot
+        plots = cls()
+        for elem in elem.findall('plot'):
+            plots.append(Plot.from_xml_element(elem))
+        return plots
+
+    @classmethod
     def from_xml(cls, path='plots.xml'):
         """Generate plots collection from XML file
 
@@ -958,9 +979,6 @@ class Plots(cv.CheckedList):
         """
         tree = ET.parse(path)
         root = tree.getroot()
+        return cls.from_xml_element(root)
 
-        # Generate each plot
-        plots = cls()
-        for elem in root.findall('plot'):
-            plots.append(Plot.from_xml_element(elem))
-        return plots
+

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -909,14 +909,8 @@ class Plots(cv.CheckedList):
 
             self._plots_file.append(xml_element)
 
-    def export_to_xml(self, path='plots.xml'):
-        """Export plot specifications to an XML file.
-
-        Parameters
-        ----------
-        path : str
-            Path to file to write. Defaults to 'plots.xml'.
-
+    def to_xml_element(self):
+        """Create a 'plots' element to be written to an XML file.
         """
         # Reset xml element tree
         self._plots_file.clear()
@@ -926,6 +920,17 @@ class Plots(cv.CheckedList):
         # Clean the indentation in the file to be user-readable
         clean_indentation(self._plots_file)
 
+        return self._plots_file
+
+    def export_to_xml(self, path='plots.xml'):
+        """Export plot specifications to an XML file.
+
+        Parameters
+        ----------
+        path : str
+            Path to file to write. Defaults to 'plots.xml'.
+
+        """
         # Check if path is a directory
         p = Path(path)
         if p.is_dir():

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1539,6 +1539,63 @@ class Settings:
         if text is not None:
             self.max_tracks = int(text)
 
+    def to_xml_element(self):
+        """Create a 'settings' element to be written to an XML file.
+        """
+
+        # Reset xml element tree
+        element = ET.Element("settings")
+
+        self._create_run_mode_subelement(element)
+        self._create_particles_subelement(element)
+        self._create_batches_subelement(element)
+        self._create_inactive_subelement(element)
+        self._create_max_lost_particles_subelement(element)
+        self._create_rel_max_lost_particles_subelement(element)
+        self._create_generations_per_batch_subelement(element)
+        self._create_keff_trigger_subelement(element)
+        self._create_source_subelement(element)
+        self._create_output_subelement(element)
+        self._create_statepoint_subelement(element)
+        self._create_sourcepoint_subelement(element)
+        self._create_surf_source_read_subelement(element)
+        self._create_surf_source_write_subelement(element)
+        self._create_confidence_intervals(element)
+        self._create_electron_treatment_subelement(element)
+        self._create_energy_mode_subelement(element)
+        self._create_max_order_subelement(element)
+        self._create_photon_transport_subelement(element)
+        self._create_ptables_subelement(element)
+        self._create_seed_subelement(element)
+        self._create_survival_biasing_subelement(element)
+        self._create_cutoff_subelement(element)
+        self._create_entropy_mesh_subelement(element)
+        self._create_trigger_subelement(element)
+        self._create_no_reduce_subelement(element)
+        self._create_verbosity_subelement(element)
+        self._create_tabular_legendre_subelements(element)
+        self._create_temperature_subelements(element)
+        self._create_trace_subelement(element)
+        self._create_track_subelement(element)
+        self._create_ufs_mesh_subelement(element)
+        self._create_resonance_scattering_subelement(element)
+        self._create_volume_calcs_subelement(element)
+        self._create_create_fission_neutrons_subelement(element)
+        self._create_delayed_photon_scaling_subelement(element)
+        self._create_event_based_subelement(element)
+        self._create_max_particles_in_flight_subelement(element)
+        self._create_material_cell_offsets_subelement(element)
+        self._create_log_grid_bins_subelement(element)
+        self._create_write_initial_source_subelement(element)
+        self._create_weight_windows_subelement(element)
+        self._create_max_splits_subelement(element)
+        self._create_max_tracks_subelement(element)
+
+        # Clean the indentation in the file to be user-readable
+        clean_indentation(element)
+
+        return element
+
     def export_to_xml(self, path: PathLike = 'settings.xml'):
         """Export simulation settings to an XML file.
 
@@ -1548,57 +1605,7 @@ class Settings:
             Path to file to write. Defaults to 'settings.xml'.
 
         """
-
-        # Reset xml element tree
-        root_element = ET.Element("settings")
-
-        self._create_run_mode_subelement(root_element)
-        self._create_particles_subelement(root_element)
-        self._create_batches_subelement(root_element)
-        self._create_inactive_subelement(root_element)
-        self._create_max_lost_particles_subelement(root_element)
-        self._create_rel_max_lost_particles_subelement(root_element)
-        self._create_generations_per_batch_subelement(root_element)
-        self._create_keff_trigger_subelement(root_element)
-        self._create_source_subelement(root_element)
-        self._create_output_subelement(root_element)
-        self._create_statepoint_subelement(root_element)
-        self._create_sourcepoint_subelement(root_element)
-        self._create_surf_source_read_subelement(root_element)
-        self._create_surf_source_write_subelement(root_element)
-        self._create_confidence_intervals(root_element)
-        self._create_electron_treatment_subelement(root_element)
-        self._create_energy_mode_subelement(root_element)
-        self._create_max_order_subelement(root_element)
-        self._create_photon_transport_subelement(root_element)
-        self._create_ptables_subelement(root_element)
-        self._create_seed_subelement(root_element)
-        self._create_survival_biasing_subelement(root_element)
-        self._create_cutoff_subelement(root_element)
-        self._create_entropy_mesh_subelement(root_element)
-        self._create_trigger_subelement(root_element)
-        self._create_no_reduce_subelement(root_element)
-        self._create_verbosity_subelement(root_element)
-        self._create_tabular_legendre_subelements(root_element)
-        self._create_temperature_subelements(root_element)
-        self._create_trace_subelement(root_element)
-        self._create_track_subelement(root_element)
-        self._create_ufs_mesh_subelement(root_element)
-        self._create_resonance_scattering_subelement(root_element)
-        self._create_volume_calcs_subelement(root_element)
-        self._create_create_fission_neutrons_subelement(root_element)
-        self._create_delayed_photon_scaling_subelement(root_element)
-        self._create_event_based_subelement(root_element)
-        self._create_max_particles_in_flight_subelement(root_element)
-        self._create_material_cell_offsets_subelement(root_element)
-        self._create_log_grid_bins_subelement(root_element)
-        self._create_write_initial_source_subelement(root_element)
-        self._create_weight_windows_subelement(root_element)
-        self._create_max_splits_subelement(root_element)
-        self._create_max_tracks_subelement(root_element)
-
-        # Clean the indentation in the file to be user-readable
-        clean_indentation(root_element)
+        root_element = self.to_xml_element()
 
         # Check if path is a directory
         p = Path(path)

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1073,7 +1073,7 @@ class Settings:
                 subelement = ET.SubElement(element, key)
                 subelement.text = str(value)
 
-    def _create_entropy_mesh_subelement(self, root):
+    def _create_entropy_mesh_subelement(self, root, memo=None):
         if self.entropy_mesh is not None:
             # use default heuristic for entropy mesh if not set by user
             if self.entropy_mesh.dimension is None:
@@ -1207,15 +1207,20 @@ class Settings:
             elem = ET.SubElement(root, "write_initial_source")
             elem.text = str(self._write_initial_source).lower()
 
-    def _create_weight_windows_subelement(self, root):
+    def _create_weight_windows_subelement(self, root, memo=None):
         for ww in self._weight_windows:
             # Add weight window information
             root.append(ww.to_xml_element())
+
+            # check the memo for a mesh
+            if memo and ww.mesh.id in memo:
+                continue
 
             # See if a <mesh> element already exists -- if not, add it
             path = f"./mesh[@id='{ww.mesh.id}']"
             if root.find(path) is None:
                 root.append(ww.mesh.to_xml_element())
+                if memo is not None: memo.add(ww.mesh.id)
 
         if self._weight_windows_on is not None:
             elem = ET.SubElement(root, "weight_windows_on")
@@ -1539,7 +1544,7 @@ class Settings:
         if text is not None:
             self.max_tracks = int(text)
 
-    def to_xml_element(self):
+    def to_xml_element(self, memo=None):
         """Create a 'settings' element to be written to an XML file.
         """
 
@@ -1569,7 +1574,7 @@ class Settings:
         self._create_seed_subelement(element)
         self._create_survival_biasing_subelement(element)
         self._create_cutoff_subelement(element)
-        self._create_entropy_mesh_subelement(element)
+        self._create_entropy_mesh_subelement(element, memo)
         self._create_trigger_subelement(element)
         self._create_no_reduce_subelement(element)
         self._create_verbosity_subelement(element)
@@ -1587,7 +1592,7 @@ class Settings:
         self._create_material_cell_offsets_subelement(element)
         self._create_log_grid_bins_subelement(element)
         self._create_write_initial_source_subelement(element)
-        self._create_weight_windows_subelement(element)
+        self._create_weight_windows_subelement(element, memo)
         self._create_max_splits_subelement(element)
         self._create_max_tracks_subelement(element)
 

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1074,31 +1074,33 @@ class Settings:
                 subelement.text = str(value)
 
     def _create_entropy_mesh_subelement(self, root, mesh_memo=None):
-        if self.entropy_mesh is not None:
-            # use default heuristic for entropy mesh if not set by user
-            if self.entropy_mesh.dimension is None:
-                if self.particles is None:
-                    raise RuntimeError("Number of particles must be set in order to " \
-                      "use entropy mesh dimension heuristic")
-                else:
-                    n = ceil((self.particles / 20.0)**(1.0 / 3.0))
-                    d = len(self.entropy_mesh.lower_left)
-                    self.entropy_mesh.dimension = (n,)*d
+        if self.entropy_mesh is None:
+            return
 
-            # add mesh ID to this element
-            subelement = ET.SubElement(root, "entropy_mesh")
-            subelement.text = str(self.entropy_mesh.id)
+        # use default heuristic for entropy mesh if not set by user
+        if self.entropy_mesh.dimension is None:
+            if self.particles is None:
+                raise RuntimeError("Number of particles must be set in order to " \
+                    "use entropy mesh dimension heuristic")
+            else:
+                n = ceil((self.particles / 20.0)**(1.0 / 3.0))
+                d = len(self.entropy_mesh.lower_left)
+                self.entropy_mesh.dimension = (n,)*d
 
-            # If this mesh has already been written outside the
-            # settings element, skip writing it again
-            if mesh_memo and self.entropy_mesh.id in mesh_memo:
-                return
+        # add mesh ID to this element
+        subelement = ET.SubElement(root, "entropy_mesh")
+        subelement.text = str(self.entropy_mesh.id)
 
-            # See if a <mesh> element already exists -- if not, add it
-            path = f"./mesh[@id='{self.entropy_mesh.id}']"
-            if root.find(path) is None:
-                root.append(self.entropy_mesh.to_xml_element())
-                if mesh_memo is not None: mesh_memo.add(self.entropy_mesh.id)
+        # If this mesh has already been written outside the
+        # settings element, skip writing it again
+        if mesh_memo and self.entropy_mesh.id in mesh_memo:
+            return
+
+        # See if a <mesh> element already exists -- if not, add it
+        path = f"./mesh[@id='{self.entropy_mesh.id}']"
+        if root.find(path) is None:
+            root.append(self.entropy_mesh.to_xml_element())
+            if mesh_memo is not None: mesh_memo.add(self.entropy_mesh.id)
 
     def _create_trigger_subelement(self, root):
         if self._trigger_active is not None:
@@ -1149,15 +1151,21 @@ class Settings:
             element = ET.SubElement(root, "track")
             element.text = ' '.join(map(str, itertools.chain(*self._track)))
 
-    def _create_ufs_mesh_subelement(self, root):
-        if self.ufs_mesh is not None:
-            # See if a <mesh> element already exists -- if not, add it
-            path = f"./mesh[@id='{self.ufs_mesh.id}']"
-            if root.find(path) is None:
-                root.append(self.ufs_mesh.to_xml_element())
+    def _create_ufs_mesh_subelement(self, root, mesh_memo=None):
+        if self.ufs_mesh is None:
+            return
 
-            subelement = ET.SubElement(root, "ufs_mesh")
-            subelement.text = str(self.ufs_mesh.id)
+        subelement = ET.SubElement(root, "ufs_mesh")
+        subelement.text = str(self.ufs_mesh.id)
+
+        if mesh_memo and self.ufs_mesh.id in mesh_memo:
+            return
+
+        # See if a <mesh> element already exists -- if not, add it
+        path = f"./mesh[@id='{self.ufs_mesh.id}']"
+        if root.find(path) is None:
+            root.append(self.ufs_mesh.to_xml_element())
+            if mesh_memo is not None: mesh_memo.add(self.ufs_mesh.id)
 
     def _create_resonance_scattering_subelement(self, root):
         res = self.resonance_scattering

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1598,6 +1598,7 @@ class Settings:
 
         # Clean the indentation in the file to be user-readable
         clean_indentation(element)
+        reorder_attributes(element)  # TODO: Remove when support is Python 3.8+
 
         return element
 
@@ -1618,7 +1619,6 @@ class Settings:
             p /= 'settings.xml'
 
         # Write the XML Tree to the settings.xml file
-        reorder_attributes(root_element)  # TODO: Remove when support is Python 3.8+
         tree = ET.ElementTree(root_element)
         tree.write(str(p), xml_declaration=True, encoding='utf-8')
 

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1595,7 +1595,7 @@ class Settings:
         clean_indentation(element)
 
         return element
-    
+
     def export_to_xml(self, path: PathLike = 'settings.xml'):
         """Export simulation settings to an XML file.
 
@@ -1618,6 +1618,71 @@ class Settings:
         tree.write(str(p), xml_declaration=True, encoding='utf-8')
 
     @classmethod
+    def from_xml_element(cls, elem):
+        """Generate settings from XML element
+
+        Parameters
+        ----------
+        elem : xml.etree.ElementTree.Element
+            XML element
+
+        Returns
+        -------
+        openmc.Settings
+            Settings object
+
+        """
+        settings = cls()
+        settings._eigenvalue_from_xml_element(elem)
+        settings._run_mode_from_xml_element(elem)
+        settings._particles_from_xml_element(elem)
+        settings._batches_from_xml_element(elem)
+        settings._inactive_from_xml_element(elem)
+        settings._max_lost_particles_from_xml_element(elem)
+        settings._rel_max_lost_particles_from_xml_element(elem)
+        settings._generations_per_batch_from_xml_element(elem)
+        settings._keff_trigger_from_xml_element(elem)
+        settings._source_from_xml_element(elem)
+        settings._volume_calcs_from_xml_element(elem)
+        settings._output_from_xml_element(elem)
+        settings._statepoint_from_xml_element(elem)
+        settings._sourcepoint_from_xml_element(elem)
+        settings._surf_source_read_from_xml_element(elem)
+        settings._surf_source_write_from_xml_element(elem)
+        settings._confidence_intervals_from_xml_element(elem)
+        settings._electron_treatment_from_xml_element(elem)
+        settings._energy_mode_from_xml_element(elem)
+        settings._max_order_from_xml_element(elem)
+        settings._photon_transport_from_xml_element(elem)
+        settings._ptables_from_xml_element(elem)
+        settings._seed_from_xml_element(elem)
+        settings._survival_biasing_from_xml_element(elem)
+        settings._cutoff_from_xml_element(elem)
+        settings._entropy_mesh_from_xml_element(elem)
+        settings._trigger_from_xml_element(elem)
+        settings._no_reduce_from_xml_element(elem)
+        settings._verbosity_from_xml_element(elem)
+        settings._tabular_legendre_from_xml_element(elem)
+        settings._temperature_from_xml_element(elem)
+        settings._trace_from_xml_element(elem)
+        settings._track_from_xml_element(elem)
+        settings._ufs_mesh_from_xml_element(elem)
+        settings._resonance_scattering_from_xml_element(elem)
+        settings._create_fission_neutrons_from_xml_element(elem)
+        settings._delayed_photon_scaling_from_xml_element(elem)
+        settings._event_based_from_xml_element(elem)
+        settings._max_particles_in_flight_from_xml_element(elem)
+        settings._material_cell_offsets_from_xml_element(elem)
+        settings._log_grid_bins_from_xml_element(elem)
+        settings._write_initial_source_from_xml_element(elem)
+        settings._weight_windows_from_xml_element(elem)
+        settings._max_splits_from_xml_element(elem)
+        settings._max_tracks_from_xml_element(elem)
+
+        # TODO: Get volume calculations
+        return settings
+
+    @classmethod
     def from_xml(cls, path: PathLike = 'settings.xml'):
         """Generate settings from XML file
 
@@ -1636,54 +1701,4 @@ class Settings:
         """
         tree = ET.parse(path)
         root = tree.getroot()
-
-        settings = cls()
-        settings._eigenvalue_from_xml_element(root)
-        settings._run_mode_from_xml_element(root)
-        settings._particles_from_xml_element(root)
-        settings._batches_from_xml_element(root)
-        settings._inactive_from_xml_element(root)
-        settings._max_lost_particles_from_xml_element(root)
-        settings._rel_max_lost_particles_from_xml_element(root)
-        settings._generations_per_batch_from_xml_element(root)
-        settings._keff_trigger_from_xml_element(root)
-        settings._source_from_xml_element(root)
-        settings._volume_calcs_from_xml_element(root)
-        settings._output_from_xml_element(root)
-        settings._statepoint_from_xml_element(root)
-        settings._sourcepoint_from_xml_element(root)
-        settings._surf_source_read_from_xml_element(root)
-        settings._surf_source_write_from_xml_element(root)
-        settings._confidence_intervals_from_xml_element(root)
-        settings._electron_treatment_from_xml_element(root)
-        settings._energy_mode_from_xml_element(root)
-        settings._max_order_from_xml_element(root)
-        settings._photon_transport_from_xml_element(root)
-        settings._ptables_from_xml_element(root)
-        settings._seed_from_xml_element(root)
-        settings._survival_biasing_from_xml_element(root)
-        settings._cutoff_from_xml_element(root)
-        settings._entropy_mesh_from_xml_element(root)
-        settings._trigger_from_xml_element(root)
-        settings._no_reduce_from_xml_element(root)
-        settings._verbosity_from_xml_element(root)
-        settings._tabular_legendre_from_xml_element(root)
-        settings._temperature_from_xml_element(root)
-        settings._trace_from_xml_element(root)
-        settings._track_from_xml_element(root)
-        settings._ufs_mesh_from_xml_element(root)
-        settings._resonance_scattering_from_xml_element(root)
-        settings._create_fission_neutrons_from_xml_element(root)
-        settings._delayed_photon_scaling_from_xml_element(root)
-        settings._event_based_from_xml_element(root)
-        settings._max_particles_in_flight_from_xml_element(root)
-        settings._material_cell_offsets_from_xml_element(root)
-        settings._log_grid_bins_from_xml_element(root)
-        settings._write_initial_source_from_xml_element(root)
-        settings._weight_windows_from_xml_element(root)
-        settings._max_splits_from_xml_element(root)
-        settings._max_tracks_from_xml_element(root)
-
-        # TODO: Get volume calculations
-
-        return settings
+        return cls.from_xml_element(root)

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1560,8 +1560,6 @@ class Settings:
         mesh_memo : set of ints
             A set of mesh IDs to keep track of whether a mesh has already been written.
         """
-        # create a memo object if one isn't passed in already
-        mesh_memo = mesh_memo if mesh_memo else set()
         # Reset xml element tree
         element = ET.Element("settings")
 

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1595,7 +1595,7 @@ class Settings:
         clean_indentation(element)
 
         return element
-
+    
     def export_to_xml(self, path: PathLike = 'settings.xml'):
         """Export simulation settings to an XML file.
 

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3166,6 +3166,7 @@ class Tallies(cv.CheckedList):
 
         # Clean the indentation in the file to be user-readable
         clean_indentation(element)
+        reorder_attributes(element)  # TODO: Remove when support is Python 3.8+
 
         return element
 
@@ -3187,7 +3188,6 @@ class Tallies(cv.CheckedList):
             p /= 'tallies.xml'
 
         # Write the XML Tree to the tallies.xml file
-        reorder_attributes(root_element)  # TODO: Remove when support is Python 3.8+
         tree = ET.ElementTree(root_element)
         tree.write(str(p), xml_declaration=True, encoding='utf-8')
 

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3208,27 +3208,27 @@ class Tallies(cv.CheckedList):
         """
         # Read mesh elements
         meshes = {}
-        for elem in elem.findall('mesh'):
-            mesh = MeshBase.from_xml_element(elem)
+        for e in elem.findall('mesh'):
+            mesh = MeshBase.from_xml_element(e)
             meshes[mesh.id] = mesh
 
         # Read filter elements
         filters = {}
-        for elem in elem.findall('filter'):
-            filter = openmc.Filter.from_xml_element(elem, meshes=meshes)
+        for e in elem.findall('filter'):
+            filter = openmc.Filter.from_xml_element(e, meshes=meshes)
             filters[filter.id] = filter
 
         # Read derivative elements
         derivatives = {}
-        for elem in elem.findall('derivative'):
-            deriv = openmc.TallyDerivative.from_xml_element(elem)
+        for e in elem.findall('derivative'):
+            deriv = openmc.TallyDerivative.from_xml_element(e)
             derivatives[deriv.id] = deriv
 
         # Read tally elements
         tallies = []
-        for elem in elem.findall('tally'):
+        for e in elem.findall('tally'):
             tally = openmc.Tally.from_xml_element(
-                elem, filters=filters, derivatives=derivatives
+                e, filters=filters, derivatives=derivatives
             )
             tallies.append(tally)
 

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3199,6 +3199,10 @@ class Tallies(cv.CheckedList):
         ----------
         elem : xml.etree.ElementTree.Element
             XML element
+        meshes : dict or None
+            A dictionary with mesh IDs as keys and mesh instances as values that
+            have already been read from XML. Pre-existing meshes are used
+            and new meshes are added to when creating tally objects.
 
         Returns
         -------

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3155,6 +3155,21 @@ class Tallies(cv.CheckedList):
         for d in derivs:
             root_element.append(d.to_xml_element())
 
+    def to_xml_element(self):
+        """Creates a 'tallies' element to be written to an XML file.
+        """
+        element = ET.Element("tallies")
+        self._create_mesh_subelements(element)
+        self._create_filter_subelements(element)
+        self._create_tally_subelements(element)
+        self._create_derivative_subelements(element)
+
+        # Clean the indentation in the file to be user-readable
+        clean_indentation(element)
+
+        return element
+
+
     def export_to_xml(self, path='tallies.xml'):
         """Create a tallies.xml file that can be used for a simulation.
 
@@ -3164,15 +3179,7 @@ class Tallies(cv.CheckedList):
             Path to file to write. Defaults to 'tallies.xml'.
 
         """
-
-        root_element = ET.Element("tallies")
-        self._create_mesh_subelements(root_element)
-        self._create_filter_subelements(root_element)
-        self._create_tally_subelements(root_element)
-        self._create_derivative_subelements(root_element)
-
-        # Clean the indentation in the file to be user-readable
-        clean_indentation(root_element)
+        root_element = self.to_xml_element()
 
         # Check if path is a directory
         p = Path(path)

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -91,8 +91,7 @@ Library::Library(pugi::xml_node node, const std::string& directory)
 // Non-member functions
 //==============================================================================
 
-void read_cross_sections_xml()
-{
+void read_cross_sections_xml() {
   pugi::xml_document doc;
   std::string filename = settings::path_input + "materials.xml";
   // Check if materials.xml exists
@@ -104,6 +103,11 @@ void read_cross_sections_xml()
 
   auto root = doc.document_element();
 
+  read_cross_sections_xml(root);
+}
+
+void read_cross_sections_xml(pugi::xml_node root)
+{
   // Find cross_sections.xml file -- the first place to look is the
   // materials.xml file. If no file is found there, then we check the
   // OPENMC_CROSS_SECTIONS environment variable

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -40,8 +40,7 @@ void update_universe_cell_count(int32_t a, int32_t b)
   }
 }
 
-void read_geometry_xml()
-{
+void read_geometry_xml() {
   // Display output message
   write_message("Reading geometry XML file...", 5);
 
@@ -61,6 +60,11 @@ void read_geometry_xml()
   // Get root element
   pugi::xml_node root = doc.document_element();
 
+  read_geometry_xml(root);
+}
+
+void read_geometry_xml(pugi::xml_node root)
+{
   // Read surfaces, cells, lattice
   read_surfaces(root);
   read_cells(root);

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -348,7 +348,7 @@ bool read_model_xml() {
   auto other_inputs = {"materials.xml", "geometry.xml", "settings.xml", "tallies.xml", "plots.xml"};
   for (const auto& input : other_inputs) {
     if (file_exists(settings::path_input + input)) {
-      warning((fmt::format("Other XML file input(s) are present. These file will be ignored in favor of the {} file.", xml_filename));
+      warning((fmt::format("Other XML file input(s) are present. These file will be ignored in favor of the {} file.", xml_filename)));
       break;
     }
   }

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -298,14 +298,14 @@ void read_input_xml()
   std::string model_filename = settings::path_input + "model.xml";
   bool use_model_file = file_exists(model_filename);
   pugi::xml_node model_root;
+  pugi::xml_document doc;
   if (use_model_file) {
-    write_message("Found model.xml file.");
-    pugi::xml_document doc;
+    write_message("Reading model.xml...");
     auto result = doc.load_file(model_filename.c_str());
     if (!result) {
       fatal_error("Error processing model.xml file.");
     }
-    auto model_root = doc.document_element();
+    model_root = doc.document_element();
 
     auto other_inputs = {"materials.xml", "geometry.xml", "settings.xml", "tallies.xml", "plots.xml"};
     for (const auto& input : other_inputs) {
@@ -320,12 +320,14 @@ void read_input_xml()
     if (!check_for_node(model_root, "settings")) {
       fatal_error("No <settings> node present in the model.xml file.");
     }
-    read_settings_xml(model_root.child("settings"));
+    auto settings_root = model_root.child("settings");
+    read_settings_xml();
   } else {
     read_settings_xml();
   }
 
   read_cross_sections_xml();
+
   if (use_model_file) {
     if (!check_for_node(model_root, "materials")) {
       fatal_error("No <materials> node present in the model.xml file.");

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -283,7 +283,8 @@ int parse_command_line(int argc, char* argv[])
     settings::path_input = std::string(argv[last_flag + 1]);
 
     // check that the path is either a valid directory or file
-    if (!is_dir(settings::path_input) && !file_exists(settings::path_input)) {
+    if (!dir_exists(settings::path_input) &&
+        !file_exists(settings::path_input)) {
       fatal_error(fmt::format(
         "The path specified to the OpenMC executable '{}' does not exist.",
         settings::path_input));
@@ -309,7 +310,8 @@ bool read_model_xml() {
     model_filename.pop_back();
 
   // if the current filename is a directory, append the default model filename
-  if (is_dir(model_filename)) model_filename += "/model.xml";
+  if (dir_exists(model_filename))
+    model_filename += "/model.xml";
 
   // if this file doesn't exist, stop here
   if (!file_exists(model_filename)) return false;

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -284,7 +284,9 @@ int parse_command_line(int argc, char* argv[])
 
     // check that the path is either a valid directory or file
     if (!is_dir(settings::path_input) && !file_exists(settings::path_input)) {
-      fatal_error(fmt::format("The specified path '{}' does not exist.", settings::path_input));
+      fatal_error(fmt::format(
+        "The path specified to the OpenMC executable '{}' does not exist.",
+        settings::path_input));
     }
 
     // Add slash at end of directory if it isn't the
@@ -297,13 +299,14 @@ int parse_command_line(int argc, char* argv[])
 }
 
 bool read_model_xml() {
-  std::string model_filename = settings::path_input;
+  std::string model_filename =
+    settings::path_input.empty() ? "." : settings::path_input;
 
   // some string cleanup
-  // a trailing "/" is applied to path_input if it's present,
+  // a trailing "/" is applied to path_input if it's specified,
   // remove it for the first attempt at reading the input file
-  if (ends_with(model_filename, "/")) model_filename.pop_back();
-  if (model_filename.length() == 0) model_filename = ".";
+  if (ends_with(model_filename, "/"))
+    model_filename.pop_back();
 
   // if the current filename is a directory, append the default model filename
   if (is_dir(model_filename)) model_filename += "/model.xml";
@@ -313,7 +316,6 @@ bool read_model_xml() {
 
   // try to process the path input as an XML file
   pugi::xml_document doc;
-  // if the input is a file, try to read it
   if (!doc.load_file(model_filename.c_str())) {
     fatal_error(fmt::format(
       "Error reading from single XML input file '{}'", model_filename));

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -108,6 +108,9 @@ int openmc_init(int argc, char* argv[], const void* intracomm)
   // Read XML input files
   read_input_xml();
 
+  // Write some initial output under the header if needed
+  initial_output();
+
   // Check for particle restart run
   if (settings::particle_restart_run)
     settings::run_mode = RunMode::PARTICLE;
@@ -365,22 +368,6 @@ bool read_model_xml() {
   if (check_for_node(root, "plots"))
     read_plots_xml(root.child("plots"));
 
-  if (settings::run_mode == RunMode::PLOTTING) {
-    // Read plots.xml if it exists
-    if (mpi::master && settings::verbosity >= 5)
-      print_plot();
-
-  } else {
-    // Write summary information
-    if (mpi::master && settings::output_summary)
-      write_summary();
-
-    // Warn if overlap checking is on
-    if (mpi::master && settings::check_overlaps) {
-      warning("Cell overlap checking is ON.");
-    }
-  }
-
   return true;
 }
 
@@ -408,7 +395,10 @@ void read_input_xml()
   // Read the plots.xml regardless of plot mode in case plots are requested
   // via the API
   read_plots_xml();
+}
 
+void initial_output() {
+  // handle some final output
   if (settings::run_mode == RunMode::PLOTTING) {
     // Read plots.xml if it exists
     if (mpi::master && settings::verbosity >= 5)

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -359,11 +359,7 @@ bool read_model_xml() {
       fmt::format("No <materials> node present in the {} file.", xml_filename));
   }
 
-  // find materials node this object cannot be used after being passed to the
-  // cross section reading function below
-  auto materials_node = root.child("materials");
-  read_cross_sections_xml(materials_node);
-
+  read_cross_sections_xml(root.child("materials"));
   read_materials_xml(root.child("materials"));
 
   // Read geometry

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -352,7 +352,7 @@ bool read_model_xml() {
   auto other_inputs = {"materials.xml", "geometry.xml", "settings.xml", "tallies.xml", "plots.xml"};
   for (const auto& input : other_inputs) {
     if (file_exists(settings::path_input + input)) {
-      warning((fmt::format("Other XML file input(s) are present. These file "
+      warning((fmt::format("Other XML file input(s) are present. These files "
                            "will be ignored in favor of the {} file.",
         model_filename)));
       break;
@@ -371,7 +371,7 @@ bool read_model_xml() {
   // Read geometry
   if (!check_for_node(root, "geometry")) {
     fatal_error(fmt::format(
-      "No <geometry> node present in the model.xml_file.", model_filename));
+      "No <geometry> node present in the {} file.", model_filename));
   }
   read_geometry_xml(root.child("geometry"));
 

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -106,7 +106,7 @@ int openmc_init(int argc, char* argv[], const void* intracomm)
   openmc::openmc_set_seed(DEFAULT_SEED);
 
   // Read XML input files
-  if (!read_model_xml()) read_input_xml();
+  if (!read_model_xml()) read_separate_xml_files();
 
   // Write some initial output under the header if needed
   initial_output();
@@ -371,7 +371,7 @@ bool read_model_xml() {
   return true;
 }
 
-void read_input_xml()
+void read_separate_xml_files()
 {
   read_settings_xml();
   read_cross_sections_xml();

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -348,14 +348,15 @@ bool read_model_xml() {
   auto other_inputs = {"materials.xml", "geometry.xml", "settings.xml", "tallies.xml", "plots.xml"};
   for (const auto& input : other_inputs) {
     if (file_exists(settings::path_input + input)) {
-      warning(("Other XML file input(s) are present. These file will be ignored in favor of the model.xml file."));
+      warning((fmt::format("Other XML file input(s) are present. These file will be ignored in favor of the {} file.", xml_filename));
       break;
     }
   }
 
   // Read materials and cross sections
   if (!check_for_node(root, "materials")) {
-    fatal_error("No <materials> node present in the model.xml file.");
+    fatal_error(
+      fmt::format("No <materials> node present in the {} file.", xml_filename));
   }
   auto materials_node = root.child("materials");
   read_cross_sections_xml(materials_node);
@@ -363,7 +364,8 @@ bool read_model_xml() {
 
   // Read geometry
   if (!check_for_node(root, "geometry")) {
-    fatal_error("No <geometry> node present in the model.xml_file.");
+    fatal_error(fmt::format(
+      "No <geometry> node present in the model.xml_file.", xml_filename));
   }
   read_geometry_xml(root.child("geometry"));
 

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -282,7 +282,12 @@ int parse_command_line(int argc, char* argv[])
   if (argc > 1 && last_flag < argc - 1) {
     settings::path_input = std::string(argv[last_flag + 1]);
 
-    // Add slash at end of directory if it isn't there
+    // check that the path is either a valid directory or file
+    if (!is_dir(settings::path_input) && !file_exists(settings::path_input)) {
+      fatal_error(fmt::format("The specified path '{}' does not exist.", settings::path_input));
+    }
+
+    // Add slash at end of directory if it isn't the
     if (!ends_with(settings::path_input, "/")) {
       settings::path_input += "/";
     }
@@ -294,13 +299,17 @@ int parse_command_line(int argc, char* argv[])
 bool read_model_xml() {
   std::string model_filename = settings::path_input;
 
-  // if the path input isn't an existing file, assume its a directory
-  // and append the default model.xml filename
-  if (!file_exists(settings::path_input)) {
-    model_filename += "/model.xml";
-    if (!file_exists(model_filename))
-      return false;
-  }
+  // some string cleanup
+  // a trailing "/" is applied to path_input if it's present,
+  // remove it for the first attempt at reading the input file
+  if (ends_with(model_filename, "/")) model_filename.pop_back();
+  if (model_filename.length() == 0) model_filename = ".";
+
+  // if the current filename is a directory, append the default model filename
+  if (is_dir(model_filename)) model_filename += "/model.xml";
+
+  // if this file doesn't exist, stop here
+  if (!file_exists(model_filename)) return false;
 
   // try to process the path input as an XML file
   pugi::xml_document doc;
@@ -330,10 +339,7 @@ bool read_model_xml() {
       title();
   }
 
-  if (!args_xml_filename.empty())
-  write_message(fmt::format("Reaging user-specified input '{}'...", args_xml_filename), 5);
-  else
-  write_message("Reading model XML file...", 5);
+  write_message(fmt::format("Reading model XML file '{}' ...", model_filename), 5);
 
   read_settings_xml(settings_root);
 

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -106,7 +106,7 @@ int openmc_init(int argc, char* argv[], const void* intracomm)
   openmc::openmc_set_seed(DEFAULT_SEED);
 
   // Read XML input files
-  read_input_xml();
+  if (!read_model_xml()) read_input_xml();
 
   // Write some initial output under the header if needed
   initial_output();
@@ -373,9 +373,6 @@ bool read_model_xml() {
 
 void read_input_xml()
 {
-  // attempt to reach the model.xml file if present
-  if (read_model_xml()) return;
-
   read_settings_xml();
   read_cross_sections_xml();
   read_materials_xml();

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -358,8 +358,12 @@ bool read_model_xml() {
     fatal_error(
       fmt::format("No <materials> node present in the {} file.", xml_filename));
   }
+
+  // find materials node this object cannot be used after being passed to the
+  // cross section reading function below
   auto materials_node = root.child("materials");
   read_cross_sections_xml(materials_node);
+
   read_materials_xml(root.child("materials"));
 
   // Read geometry
@@ -411,7 +415,7 @@ void read_separate_xml_files()
 }
 
 void initial_output() {
-  // handle some final output
+  // write initial output
   if (settings::run_mode == RunMode::PLOTTING) {
     // Read plots.xml if it exists
     if (mpi::master && settings::verbosity >= 5)

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -1264,8 +1264,7 @@ double density_effect(const vector<double>& f, const vector<double>& e_b_sq,
   return delta - w_sq * (1.0 - beta_sq);
 }
 
-void read_materials_xml()
-{
+void read_materials_xml() {
   write_message("Reading materials XML file...", 5);
 
   pugi::xml_document doc;
@@ -1281,6 +1280,12 @@ void read_materials_xml()
 
   // Loop over XML material elements and populate the array.
   pugi::xml_node root = doc.document_element();
+
+  read_materials_xml(root);
+}
+
+void read_materials_xml(pugi::xml_node root)
+{
   for (pugi::xml_node material_node : root.children("material")) {
     model::materials.push_back(make_unique<Material>(material_node));
   }

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -124,8 +124,7 @@ extern "C" int openmc_plot_geometry()
   return 0;
 }
 
-void read_plots_xml()
-{
+void read_plots_xml() {
   // Check if plots.xml exists; this is only necessary when the plot runmode is
   // initiated. Otherwise, we want to read plots.xml because it may be called
   // later via the API. In that case, its ok for a plots.xml to not exist
@@ -141,6 +140,10 @@ void read_plots_xml()
   doc.load_file(filename.c_str());
 
   pugi::xml_node root = doc.document_element();
+}
+
+void read_plots_xml(pugi::xml_node root)
+{
   for (auto node : root.children("plot")) {
     model::plots.emplace_back(node);
     model::plot_map[model::plots.back().id_] = model::plots.size() - 1;

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -140,6 +140,8 @@ void read_plots_xml() {
   doc.load_file(filename.c_str());
 
   pugi::xml_node root = doc.document_element();
+
+  read_plots_xml(root);
 }
 
 void read_plots_xml(pugi::xml_node root)

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -243,14 +243,6 @@ void read_settings_xml() {
   // Get root element
   xml_node root = doc.document_element();
 
-  read_settings_xml(root);
-}
-
-void read_settings_xml(pugi::xml_node root)
-{
-  using namespace settings;
-  using namespace pugi;
-
   // Verbosity
   if (check_for_node(root, "verbosity")) {
     verbosity = std::stoi(get_node_value(root, "verbosity"));
@@ -262,11 +254,19 @@ void read_settings_xml(pugi::xml_node root)
     if (verbosity >= 2)
       title();
   }
+
   write_message("Reading settings XML file...", 5);
+
+  read_settings_xml(root);
+}
+
+void read_settings_xml(pugi::xml_node root)
+{
+  using namespace settings;
+  using namespace pugi;
 
   // Find if a multi-group or continuous-energy simulation is desired
   if (check_for_node(root, "energy_mode")) {
-  std::cout << "Here" << std::endl;
     std::string temp_str = get_node_value(root, "energy_mode", true, true);
     if (temp_str == "mg" || temp_str == "multi-group") {
       run_CE = false;
@@ -274,7 +274,6 @@ void read_settings_xml(pugi::xml_node root)
       run_CE = true;
     }
   }
-  std::cout << "Here" << std::endl;
 
   // Look for deprecated cross_sections.xml file in settings.xml
   if (check_for_node(root, "cross_sections")) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -266,6 +266,7 @@ void read_settings_xml(pugi::xml_node root)
 
   // Find if a multi-group or continuous-energy simulation is desired
   if (check_for_node(root, "energy_mode")) {
+  std::cout << "Here" << std::endl;
     std::string temp_str = get_node_value(root, "energy_mode", true, true);
     if (temp_str == "mg" || temp_str == "multi-group") {
       run_CE = false;
@@ -273,6 +274,7 @@ void read_settings_xml(pugi::xml_node root)
       run_CE = true;
     }
   }
+  std::cout << "Here" << std::endl;
 
   // Look for deprecated cross_sections.xml file in settings.xml
   if (check_for_node(root, "cross_sections")) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -211,13 +211,11 @@ void get_run_parameters(pugi::xml_node node_base)
   }
 }
 
-void read_settings_xml()
-{
+void read_settings_xml() {
   using namespace settings;
   using namespace pugi;
-
   // Check if settings.xml exists
-  std::string filename = path_input + "settings.xml";
+  std::string filename = settings::path_input + "settings.xml";
   if (!file_exists(filename)) {
     if (run_mode != RunMode::PLOTTING) {
       fatal_error(
@@ -244,6 +242,14 @@ void read_settings_xml()
 
   // Get root element
   xml_node root = doc.document_element();
+
+  read_settings_xml(root);
+}
+
+void read_settings_xml(pugi::xml_node root)
+{
+  using namespace settings;
+  using namespace pugi;
 
   // Verbosity
   if (check_for_node(root, "verbosity")) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -222,7 +222,8 @@ void read_settings_xml() {
         fmt::format("Settings XML file '{}' does not exist! In order "
                     "to run OpenMC, you first need a set of input files; at a "
                     "minimum, this "
-                    "includes settings.xml, geometry.xml, and materials.xml. "
+                    "includes settings.xml, geometry.xml, and materials.xml "
+                    "or a single XML file containing all of these files. "
                     "Please consult "
                     "the user's guide at https://docs.openmc.org for further "
                     "information.",

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -705,8 +705,7 @@ std::string Tally::nuclide_name(int nuclide_idx) const
 // Non-member functions
 //==============================================================================
 
-void read_tallies_xml()
-{
+void read_tallies_xml() {
   // Check if tallies.xml exists. If not, just return since it is optional
   std::string filename = settings::path_input + "tallies.xml";
   if (!file_exists(filename))
@@ -719,6 +718,11 @@ void read_tallies_xml()
   doc.load_file(filename.c_str());
   pugi::xml_node root = doc.document_element();
 
+  read_tallies_xml(root);
+}
+
+void read_tallies_xml(pugi::xml_node root)
+{
   // Check for <assume_separate> setting
   if (check_for_node(root, "assume_separate")) {
     settings::assume_separate = get_node_value_bool(root, "assume_separate");

--- a/tests/regression_tests/adj_cell_rotation/__init__.py
+++ b/tests/regression_tests/adj_cell_rotation/__init__.py
@@ -1,0 +1,2 @@
+
+from .test import model

--- a/tests/regression_tests/adj_cell_rotation/__init__.py
+++ b/tests/regression_tests/adj_cell_rotation/__init__.py
@@ -1,2 +1,0 @@
-
-from .test import model

--- a/tests/regression_tests/energy_laws/__init__.py
+++ b/tests/regression_tests/energy_laws/__init__.py
@@ -1,1 +1,0 @@
-from .test import model

--- a/tests/regression_tests/energy_laws/__init__.py
+++ b/tests/regression_tests/energy_laws/__init__.py
@@ -1,0 +1,1 @@
+from .test import model

--- a/tests/regression_tests/lattice_multiple/__init__.py
+++ b/tests/regression_tests/lattice_multiple/__init__.py
@@ -1,1 +1,0 @@
-from .test import model

--- a/tests/regression_tests/lattice_multiple/__init__.py
+++ b/tests/regression_tests/lattice_multiple/__init__.py
@@ -1,0 +1,1 @@
+from .test import model

--- a/tests/regression_tests/model_xml/adj_cell_rotation_inputs_true.dat
+++ b/tests/regression_tests/model_xml/adj_cell_rotation_inputs_true.dat
@@ -13,16 +13,16 @@
   <geometry>
     <cell id="1" material="1" region="-1" universe="1" />
     <cell id="2" material="2" region="1" universe="1" />
-    <cell id="3" fill="1" region="2 -3 4 -5 6 -8" rotation="10 20 30" universe="2" />
-    <cell id="4" fill="1" region="2 -3 4 -5 8 -7" translation="0 0 15" universe="2" />
-    <surface id="1" type="sphere" coeffs="1.0 0.0 0.0 5.0" />
-    <surface id="2" name="minimum x" type="x-plane" boundary="vacuum" coeffs="-7.5" />
-    <surface id="3" name="maximum x" type="x-plane" boundary="vacuum" coeffs="7.5" />
-    <surface id="4" name="minimum y" type="y-plane" boundary="vacuum" coeffs="-7.5" />
-    <surface id="5" name="maximum y" type="y-plane" boundary="vacuum" coeffs="7.5" />
-    <surface id="6" type="z-plane" boundary="vacuum" coeffs="-7.5" />
-    <surface id="7" type="z-plane" boundary="vacuum" coeffs="22.5" />
-    <surface id="8" type="z-plane" coeffs="7.5" />
+    <cell fill="1" id="3" region="2 -3 4 -5 6 -8" rotation="10 20 30" universe="2" />
+    <cell fill="1" id="4" region="2 -3 4 -5 8 -7" translation="0 0 15" universe="2" />
+    <surface coeffs="1.0 0.0 0.0 5.0" id="1" type="sphere" />
+    <surface boundary="vacuum" coeffs="-7.5" id="2" name="minimum x" type="x-plane" />
+    <surface boundary="vacuum" coeffs="7.5" id="3" name="maximum x" type="x-plane" />
+    <surface boundary="vacuum" coeffs="-7.5" id="4" name="minimum y" type="y-plane" />
+    <surface boundary="vacuum" coeffs="7.5" id="5" name="maximum y" type="y-plane" />
+    <surface boundary="vacuum" coeffs="-7.5" id="6" type="z-plane" />
+    <surface boundary="vacuum" coeffs="22.5" id="7" type="z-plane" />
+    <surface coeffs="7.5" id="8" type="z-plane" />
   </geometry>
   <settings>
     <run_mode>eigenvalue</run_mode>

--- a/tests/regression_tests/model_xml/adj_cell_rotation_inputs_true.dat
+++ b/tests/regression_tests/model_xml/adj_cell_rotation_inputs_true.dat
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='utf-8'?>
+<model>
+  <materials>
+    <material depletable="true" id="1">
+      <density units="g/cc" value="10.0" />
+      <nuclide ao="1.0" name="U235" />
+    </material>
+    <material id="2">
+      <density units="g/cc" value="0.1" />
+      <nuclide ao="0.1" name="H1" />
+    </material>
+  </materials>
+  <geometry>
+    <cell id="1" material="1" region="-1" universe="1" />
+    <cell id="2" material="2" region="1" universe="1" />
+    <cell id="3" fill="1" region="2 -3 4 -5 6 -8" rotation="10 20 30" universe="2" />
+    <cell id="4" fill="1" region="2 -3 4 -5 8 -7" translation="0 0 15" universe="2" />
+    <surface id="1" type="sphere" coeffs="1.0 0.0 0.0 5.0" />
+    <surface id="2" name="minimum x" type="x-plane" boundary="vacuum" coeffs="-7.5" />
+    <surface id="3" name="maximum x" type="x-plane" boundary="vacuum" coeffs="7.5" />
+    <surface id="4" name="minimum y" type="y-plane" boundary="vacuum" coeffs="-7.5" />
+    <surface id="5" name="maximum y" type="y-plane" boundary="vacuum" coeffs="7.5" />
+    <surface id="6" type="z-plane" boundary="vacuum" coeffs="-7.5" />
+    <surface id="7" type="z-plane" boundary="vacuum" coeffs="22.5" />
+    <surface id="8" type="z-plane" coeffs="7.5" />
+  </geometry>
+  <settings>
+    <run_mode>eigenvalue</run_mode>
+    <particles>10000</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
+    <source strength="1.0">
+      <space type="box">
+        <parameters>-4.0 -4.0 -4.0 4.0 4.0 4.0</parameters>
+      </space>
+    </source>
+  </settings>
+  </model>

--- a/tests/regression_tests/model_xml/energy_laws_inputs_true.dat
+++ b/tests/regression_tests/model_xml/energy_laws_inputs_true.dat
@@ -12,7 +12,7 @@
   </materials>
   <geometry>
     <cell id="1" material="1" region="-1" universe="1" />
-    <surface id="1" type="sphere" boundary="reflective" coeffs="0.0 0.0 0.0 100.0" />
+    <surface boundary="reflective" coeffs="0.0 0.0 0.0 100.0" id="1" type="sphere" />
   </geometry>
   <settings>
     <run_mode>eigenvalue</run_mode>

--- a/tests/regression_tests/model_xml/energy_laws_inputs_true.dat
+++ b/tests/regression_tests/model_xml/energy_laws_inputs_true.dat
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='utf-8'?>
+<model>
+  <materials>
+    <material depletable="true" id="1">
+      <density units="g/cm3" value="20.0" />
+      <nuclide ao="1.0" name="U233" />
+      <nuclide ao="1.0" name="Am244" />
+      <nuclide ao="1.0" name="H2" />
+      <nuclide ao="1.0" name="Na23" />
+      <nuclide ao="1.0" name="Ta181" />
+    </material>
+  </materials>
+  <geometry>
+    <cell id="1" material="1" region="-1" universe="1" />
+    <surface id="1" type="sphere" boundary="reflective" coeffs="0.0 0.0 0.0 100.0" />
+  </geometry>
+  <settings>
+    <run_mode>eigenvalue</run_mode>
+    <particles>1000</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
+  </settings>
+  </model>

--- a/tests/regression_tests/model_xml/inputs_true.dat
+++ b/tests/regression_tests/model_xml/inputs_true.dat
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='utf-8'?>
+<model>
+<materials>
+  <material depletable="true" id="1">
+    <density units="g/cc" value="10.0" />
+    <nuclide ao="1.0" name="U235" />
+  </material>
+  <material id="2">
+    <density units="g/cc" value="0.1" />
+    <nuclide ao="0.1" name="H1" />
+  </material>
+</materials>
+<geometry>
+  <cell id="1" material="1" region="-1" universe="1" />
+  <cell id="2" material="2" region="1" universe="1" />
+  <cell id="3" fill="1" region="2 -3 4 -5 6 -8" rotation="10 20 30" universe="2" />
+  <cell id="4" fill="1" region="2 -3 4 -5 8 -7" translation="0 0 15" universe="2" />
+  <surface id="1" type="sphere" coeffs="1.0 0.0 0.0 5.0" />
+  <surface id="2" name="minimum x" type="x-plane" boundary="vacuum" coeffs="-7.5" />
+  <surface id="3" name="maximum x" type="x-plane" boundary="vacuum" coeffs="7.5" />
+  <surface id="4" name="minimum y" type="y-plane" boundary="vacuum" coeffs="-7.5" />
+  <surface id="5" name="maximum y" type="y-plane" boundary="vacuum" coeffs="7.5" />
+  <surface id="6" type="z-plane" boundary="vacuum" coeffs="-7.5" />
+  <surface id="7" type="z-plane" boundary="vacuum" coeffs="22.5" />
+  <surface id="8" type="z-plane" coeffs="7.5" />
+</geometry>
+<settings>
+  <run_mode>eigenvalue</run_mode>
+  <particles>10000</particles>
+  <batches>10</batches>
+  <inactive>5</inactive>
+  <source strength="1.0">
+    <space type="box">
+      <parameters>-4.0 -4.0 -4.0 4.0 4.0 4.0</parameters>
+    </space>
+  </source>
+</settings>
+</model>

--- a/tests/regression_tests/model_xml/inputs_true.dat
+++ b/tests/regression_tests/model_xml/inputs_true.dat
@@ -1,38 +1,67 @@
 <?xml version='1.0' encoding='utf-8'?>
 <model>
-<materials>
-  <material depletable="true" id="1">
-    <density units="g/cc" value="10.0" />
-    <nuclide ao="1.0" name="U235" />
-  </material>
-  <material id="2">
-    <density units="g/cc" value="0.1" />
-    <nuclide ao="0.1" name="H1" />
-  </material>
-</materials>
-<geometry>
-  <cell id="1" material="1" region="-1" universe="1" />
-  <cell id="2" material="2" region="1" universe="1" />
-  <cell id="3" fill="1" region="2 -3 4 -5 6 -8" rotation="10 20 30" universe="2" />
-  <cell id="4" fill="1" region="2 -3 4 -5 8 -7" translation="0 0 15" universe="2" />
-  <surface id="1" type="sphere" coeffs="1.0 0.0 0.0 5.0" />
-  <surface id="2" name="minimum x" type="x-plane" boundary="vacuum" coeffs="-7.5" />
-  <surface id="3" name="maximum x" type="x-plane" boundary="vacuum" coeffs="7.5" />
-  <surface id="4" name="minimum y" type="y-plane" boundary="vacuum" coeffs="-7.5" />
-  <surface id="5" name="maximum y" type="y-plane" boundary="vacuum" coeffs="7.5" />
-  <surface id="6" type="z-plane" boundary="vacuum" coeffs="-7.5" />
-  <surface id="7" type="z-plane" boundary="vacuum" coeffs="22.5" />
-  <surface id="8" type="z-plane" coeffs="7.5" />
-</geometry>
-<settings>
-  <run_mode>eigenvalue</run_mode>
-  <particles>10000</particles>
-  <batches>10</batches>
-  <inactive>5</inactive>
-  <source strength="1.0">
-    <space type="box">
-      <parameters>-4.0 -4.0 -4.0 4.0 4.0 4.0</parameters>
-    </space>
-  </source>
-</settings>
+  <materials>
+    <material id="6">
+      <density units="g/cm3" value="2.6989" />
+      <nuclide ao="1.0" name="Al27" />
+    </material>
+  </materials>
+  <geometry>
+    <cell id="12" material="void" region="-16 17 -18" universe="10" />
+    <cell id="13" material="6" region="-16 18 -19" universe="10" />
+    <cell id="14" material="void" region="~(-16 17 -19)" universe="10" />
+    <surface id="16" type="x-cylinder" boundary="vacuum" coeffs="0.0 0.0 1.0" />
+    <surface id="17" type="x-plane" boundary="vacuum" coeffs="-1.0" />
+    <surface id="18" type="x-plane" coeffs="1.0" />
+    <surface id="19" type="x-plane" boundary="vacuum" coeffs="1000000000.0" />
+  </geometry>
+  <settings>
+    <run_mode>fixed source</run_mode>
+    <particles>10000</particles>
+    <batches>1</batches>
+    <source strength="1.0">
+      <space type="point">
+        <parameters>0 0 0</parameters>
+      </space>
+      <angle type="monodirectional" reference_uvw="1.0 0.0 0.0" />
+      <energy type="discrete">
+        <parameters>14000000.0 1.0</parameters>
+      </energy>
+    </source>
+    <electron_treatment>ttb</electron_treatment>
+    <photon_transport>true</photon_transport>
+    <cutoff>
+      <energy_photon>1000.0</energy_photon>
+    </cutoff>
+  </settings>
+  <tallies>
+    <filter id="1" type="surface">
+      <bins>16</bins>
+    </filter>
+    <filter id="2" type="particle">
+      <bins>neutron photon electron positron</bins>
+    </filter>
+    <tally id="1">
+      <filters>1 2</filters>
+      <scores>current</scores>
+    </tally>
+    <tally id="2">
+      <filters>2</filters>
+      <nuclides>Al27 total</nuclides>
+      <scores>total (n,gamma)</scores>
+      <estimator>tracklength</estimator>
+    </tally>
+    <tally id="3">
+      <filters>2</filters>
+      <nuclides>Al27 total</nuclides>
+      <scores>total heating (n,gamma)</scores>
+      <estimator>collision</estimator>
+    </tally>
+    <tally id="4">
+      <filters>2</filters>
+      <nuclides>Al27 total</nuclides>
+      <scores>total heating (n,gamma)</scores>
+      <estimator>analog</estimator>
+    </tally>
+  </tallies>
 </model>

--- a/tests/regression_tests/model_xml/lattice_multiple_inputs_true.dat
+++ b/tests/regression_tests/model_xml/lattice_multiple_inputs_true.dat
@@ -18,8 +18,8 @@
     <cell id="2" material="2" region="1" universe="1" />
     <cell id="3" material="1" region="-2" universe="2" />
     <cell id="4" material="2" region="2" universe="2" />
-    <cell id="5" fill="3" universe="4" />
-    <cell id="6" fill="5" region="3 -4 5 -6" universe="6" />
+    <cell fill="3" id="5" universe="4" />
+    <cell fill="5" id="6" region="3 -4 5 -6" universe="6" />
     <lattice id="3">
       <pitch>1.2 1.2</pitch>
       <outer>1</outer>
@@ -37,12 +37,12 @@
 4 4 
 4 4 </universes>
     </lattice>
-    <surface id="1" type="z-cylinder" coeffs="0.0 0.0 0.4" />
-    <surface id="2" type="z-cylinder" coeffs="0.0 0.0 0.5" />
-    <surface id="3" name="minimum x" type="x-plane" boundary="reflective" coeffs="-2.4" />
-    <surface id="4" name="maximum x" type="x-plane" boundary="reflective" coeffs="2.4" />
-    <surface id="5" name="minimum y" type="y-plane" boundary="reflective" coeffs="-2.4" />
-    <surface id="6" name="maximum y" type="y-plane" boundary="reflective" coeffs="2.4" />
+    <surface coeffs="0.0 0.0 0.4" id="1" type="z-cylinder" />
+    <surface coeffs="0.0 0.0 0.5" id="2" type="z-cylinder" />
+    <surface boundary="reflective" coeffs="-2.4" id="3" name="minimum x" type="x-plane" />
+    <surface boundary="reflective" coeffs="2.4" id="4" name="maximum x" type="x-plane" />
+    <surface boundary="reflective" coeffs="-2.4" id="5" name="minimum y" type="y-plane" />
+    <surface boundary="reflective" coeffs="2.4" id="6" name="maximum y" type="y-plane" />
   </geometry>
   <settings>
     <run_mode>eigenvalue</run_mode>

--- a/tests/regression_tests/model_xml/lattice_multiple_inputs_true.dat
+++ b/tests/regression_tests/model_xml/lattice_multiple_inputs_true.dat
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='utf-8'?>
+<model>
+  <materials>
+    <material depletable="true" id="1" name="UO2">
+      <density units="g/cm3" value="10.0" />
+      <nuclide ao="1.0" name="U235" />
+      <nuclide ao="2.0" name="O16" />
+    </material>
+    <material id="2" name="light water">
+      <density units="g/cm3" value="1.0" />
+      <nuclide ao="2.0" name="H1" />
+      <nuclide ao="1.0" name="O16" />
+      <sab name="c_H_in_H2O" />
+    </material>
+  </materials>
+  <geometry>
+    <cell id="1" material="1" region="-1" universe="1" />
+    <cell id="2" material="2" region="1" universe="1" />
+    <cell id="3" material="1" region="-2" universe="2" />
+    <cell id="4" material="2" region="2" universe="2" />
+    <cell id="5" fill="3" universe="4" />
+    <cell id="6" fill="5" region="3 -4 5 -6" universe="6" />
+    <lattice id="3">
+      <pitch>1.2 1.2</pitch>
+      <outer>1</outer>
+      <dimension>2 2</dimension>
+      <lower_left>-1.2 -1.2</lower_left>
+      <universes>
+2 1 
+1 1 </universes>
+    </lattice>
+    <lattice id="5">
+      <pitch>2.4 2.4</pitch>
+      <dimension>2 2</dimension>
+      <lower_left>-2.4 -2.4</lower_left>
+      <universes>
+4 4 
+4 4 </universes>
+    </lattice>
+    <surface id="1" type="z-cylinder" coeffs="0.0 0.0 0.4" />
+    <surface id="2" type="z-cylinder" coeffs="0.0 0.0 0.5" />
+    <surface id="3" name="minimum x" type="x-plane" boundary="reflective" coeffs="-2.4" />
+    <surface id="4" name="maximum x" type="x-plane" boundary="reflective" coeffs="2.4" />
+    <surface id="5" name="minimum y" type="y-plane" boundary="reflective" coeffs="-2.4" />
+    <surface id="6" name="maximum y" type="y-plane" boundary="reflective" coeffs="2.4" />
+  </geometry>
+  <settings>
+    <run_mode>eigenvalue</run_mode>
+    <particles>1000</particles>
+    <batches>10</batches>
+    <inactive>5</inactive>
+  </settings>
+  </model>

--- a/tests/regression_tests/model_xml/photon_production_inputs_true.dat
+++ b/tests/regression_tests/model_xml/photon_production_inputs_true.dat
@@ -23,7 +23,7 @@
       <space type="point">
         <parameters>0 0 0</parameters>
       </space>
-      <angle type="monodirectional" reference_uvw="1.0 0.0 0.0" />
+      <angle reference_uvw="1.0 0.0 0.0" type="monodirectional" />
       <energy type="discrete">
         <parameters>14000000.0 1.0</parameters>
       </energy>

--- a/tests/regression_tests/model_xml/photon_production_inputs_true.dat
+++ b/tests/regression_tests/model_xml/photon_production_inputs_true.dat
@@ -10,10 +10,10 @@
     <cell id="1" material="void" region="-1 2 -3" universe="1" />
     <cell id="2" material="1" region="-1 3 -4" universe="1" />
     <cell id="3" material="void" region="~(-1 2 -4)" universe="1" />
-    <surface id="1" type="x-cylinder" boundary="vacuum" coeffs="0.0 0.0 1.0" />
-    <surface id="2" type="x-plane" boundary="vacuum" coeffs="-1.0" />
-    <surface id="3" type="x-plane" coeffs="1.0" />
-    <surface id="4" type="x-plane" boundary="vacuum" coeffs="1000000000.0" />
+    <surface boundary="vacuum" coeffs="0.0 0.0 1.0" id="1" type="x-cylinder" />
+    <surface boundary="vacuum" coeffs="-1.0" id="2" type="x-plane" />
+    <surface coeffs="1.0" id="3" type="x-plane" />
+    <surface boundary="vacuum" coeffs="1000000000.0" id="4" type="x-plane" />
   </geometry>
   <settings>
     <run_mode>fixed source</run_mode>

--- a/tests/regression_tests/model_xml/photon_production_inputs_true.dat
+++ b/tests/regression_tests/model_xml/photon_production_inputs_true.dat
@@ -1,0 +1,67 @@
+<?xml version='1.0' encoding='utf-8'?>
+<model>
+  <materials>
+    <material id="1">
+      <density units="g/cm3" value="2.6989" />
+      <nuclide ao="1.0" name="Al27" />
+    </material>
+  </materials>
+  <geometry>
+    <cell id="1" material="void" region="-1 2 -3" universe="1" />
+    <cell id="2" material="1" region="-1 3 -4" universe="1" />
+    <cell id="3" material="void" region="~(-1 2 -4)" universe="1" />
+    <surface id="1" type="x-cylinder" boundary="vacuum" coeffs="0.0 0.0 1.0" />
+    <surface id="2" type="x-plane" boundary="vacuum" coeffs="-1.0" />
+    <surface id="3" type="x-plane" coeffs="1.0" />
+    <surface id="4" type="x-plane" boundary="vacuum" coeffs="1000000000.0" />
+  </geometry>
+  <settings>
+    <run_mode>fixed source</run_mode>
+    <particles>10000</particles>
+    <batches>1</batches>
+    <source strength="1.0">
+      <space type="point">
+        <parameters>0 0 0</parameters>
+      </space>
+      <angle type="monodirectional" reference_uvw="1.0 0.0 0.0" />
+      <energy type="discrete">
+        <parameters>14000000.0 1.0</parameters>
+      </energy>
+    </source>
+    <electron_treatment>ttb</electron_treatment>
+    <photon_transport>true</photon_transport>
+    <cutoff>
+      <energy_photon>1000.0</energy_photon>
+    </cutoff>
+  </settings>
+  <tallies>
+    <filter id="1" type="surface">
+      <bins>1</bins>
+    </filter>
+    <filter id="2" type="particle">
+      <bins>neutron photon electron positron</bins>
+    </filter>
+    <tally id="1">
+      <filters>1 2</filters>
+      <scores>current</scores>
+    </tally>
+    <tally id="2">
+      <filters>2</filters>
+      <nuclides>Al27 total</nuclides>
+      <scores>total (n,gamma)</scores>
+      <estimator>tracklength</estimator>
+    </tally>
+    <tally id="3">
+      <filters>2</filters>
+      <nuclides>Al27 total</nuclides>
+      <scores>total heating (n,gamma)</scores>
+      <estimator>collision</estimator>
+    </tally>
+    <tally id="4">
+      <filters>2</filters>
+      <nuclides>Al27 total</nuclides>
+      <scores>total heating (n,gamma)</scores>
+      <estimator>analog</estimator>
+    </tally>
+  </tallies>
+</model>

--- a/tests/regression_tests/model_xml/test.py
+++ b/tests/regression_tests/model_xml/test.py
@@ -1,0 +1,76 @@
+from difflib import unified_diff
+import filecmp
+import os
+
+import openmc
+import pytest
+
+from tests.testing_harness import PyAPITestHarness, colorize
+
+# use a few models from other tests to make sure the same results are
+# produced when using a single model.xml file as input
+from ..adj_cell_rotation import model as adj_cell_rotation_model
+from ..lattice_multiple import model as lattice_mult_model
+from ..energy_laws import model as energy_laws_model
+from ..photon_production import model as photon_prod_model
+
+
+class ModelXMLTestHarness(PyAPITestHarness):
+    """Accept a results file to check against and assume inputs_true is the contents of a model.xml file.
+    """
+    def __init__(self, model=None, inputs_true=None, results_true=None):
+        statepoint_name = f'statepoint.{model.settings.batches}.h5'
+        super().__init__(statepoint_name, model, inputs_true)
+
+        self.results_true = 'results_true.dat' if results_true is None else results_true
+
+    def _build_inputs(self):
+        self._model.export_to_xml(separate_xmls=False)
+
+    def _get_inputs(self):
+        return open('model.xml').read()
+
+    def _compare_inputs(self):
+        """Skip input comparisons for now
+        """
+        pass
+
+    def _compare_results(self):
+        """Make sure the current results agree with the reference."""
+        compare = filecmp.cmp('results_test.dat', self.results_true)
+        if not compare:
+            expected = open(self.results_true).readlines()
+            actual = open('results_test.dat').readlines()
+            diff = unified_diff(expected, actual, self.results_true,
+                                'results_test.dat')
+            print('Result differences:')
+            print(''.join(colorize(diff)))
+            os.rename('results_test.dat', 'results_error.dat')
+        assert compare, 'Results do not agree'
+
+    def _cleanup(self):
+        super()._cleanup()
+        if os.path.exists('model.xml'):
+            os.remove('model.xml')
+
+
+models = [
+'adj_cell_rotation_model',
+'lattice_mult_model',
+'energy_laws_model',
+'photon_prod_model'
+]
+paths = [
+'../adj_cell_rotation',
+'../lattice_multiple',
+'../energy_laws',
+'../photon_production'
+]
+
+
+@pytest.mark.parametrize("model, path", zip(models, paths))
+def test_model_xml(model, path, request):
+    inputs = path + "/inputs_true.dat"
+    results = path + "/results_true.dat"
+    harness = ModelXMLTestHarness(request.getfixturevalue(model), inputs, results)
+    harness.main()

--- a/tests/regression_tests/model_xml/test.py
+++ b/tests/regression_tests/model_xml/test.py
@@ -9,10 +9,10 @@ from tests.testing_harness import PyAPITestHarness, colorize
 
 # use a few models from other tests to make sure the same results are
 # produced when using a single model.xml file as input
-from ..adj_cell_rotation import model as adj_cell_rotation_model
-from ..lattice_multiple import model as lattice_mult_model
-from ..energy_laws import model as energy_laws_model
-from ..photon_production import model as photon_prod_model
+from ..adj_cell_rotation.test import model as adj_cell_rotation_model
+from ..lattice_multiple.test import model as lattice_mult_model
+from ..energy_laws.test import model as energy_laws_model
+from ..photon_production.test import model as photon_prod_model
 
 
 class ModelXMLTestHarness(PyAPITestHarness):

--- a/tests/regression_tests/model_xml/test.py
+++ b/tests/regression_tests/model_xml/test.py
@@ -81,7 +81,8 @@ def test_input_arg(run_in_tmpdir):
     openmc.run()
 
     # make sure the executable isn't falling back on the separate XMLs
-    [os.remove(f) for f in glob.glob('*.xml')]
+    for f in glob.glob('*.xml'):
+        os.remove(f)
     # now export to a single XML file with a custom name
     pincell.export_to_xml(path='pincell.xml', separate_xmls=False)
     assert Path('pincell.xml').exists()

--- a/tests/regression_tests/model_xml/test.py
+++ b/tests/regression_tests/model_xml/test.py
@@ -1,6 +1,8 @@
 from difflib import unified_diff
+import glob
 import filecmp
 import os
+from pathlib import Path
 
 import openmc
 import pytest
@@ -83,13 +85,17 @@ def test_input_arg(run_in_tmpdir):
     pincell.export_to_xml(separate_xmls=True)
     openmc.run()
 
+    # make sure the executable isn't falling back on the separate XMLs
+    [os.remove(f) for f in glob.glob('*.xml')]
     # now export to a single XML file with a custom name
-    pincell.export_to_xml(filename='pincell.xml', separate_xmls=False)
+    pincell.export_to_xml(path='pincell.xml', separate_xmls=False)
+    assert Path('pincell.xml').exists()
 
     # run by specifying that single file
-    openmc.run(input_file='pincell.xml')
+    openmc.run(path_input='pincell.xml')
 
     # now ensure we get an error for an incorrect filename,
     # even in the presence of other, valid XML files
+    pincell.export_to_xml(separate_xmls=True)
     with pytest.raises(RuntimeError, match='ex-em-ell.xml'):
-        openmc.run(input_file='ex-em-ell.xml')
+        openmc.run(path_input='ex-em-ell.xml')

--- a/tests/regression_tests/model_xml/test.py
+++ b/tests/regression_tests/model_xml/test.py
@@ -55,16 +55,16 @@ class ModelXMLTestHarness(PyAPITestHarness):
 
 
 models = [
-'adj_cell_rotation_model',
-'lattice_mult_model',
-'energy_laws_model',
-'photon_prod_model'
+    'adj_cell_rotation_model',
+    'lattice_mult_model',
+    'energy_laws_model',
+    'photon_prod_model'
 ]
 paths = [
-'../adj_cell_rotation',
-'../lattice_multiple',
-'../energy_laws',
-'../photon_production'
+    '../adj_cell_rotation',
+    '../lattice_multiple',
+    '../energy_laws',
+    '../photon_production'
 ]
 
 

--- a/tests/regression_tests/model_xml/test.py
+++ b/tests/regression_tests/model_xml/test.py
@@ -32,11 +32,6 @@ class ModelXMLTestHarness(PyAPITestHarness):
     def _get_inputs(self):
         return open('model.xml').read()
 
-    # def _compare_inputs(self):
-    #     """Skip input comparisons for now
-    #     """
-    #     pass
-
     def _compare_results(self):
         """Make sure the current results agree with the reference."""
         compare = filecmp.cmp('results_test.dat', self.results_true)

--- a/tests/regression_tests/model_xml/test.py
+++ b/tests/regression_tests/model_xml/test.py
@@ -10,9 +10,9 @@ from tests.testing_harness import PyAPITestHarness, colorize
 # use a few models from other tests to make sure the same results are
 # produced when using a single model.xml file as input
 from ..adj_cell_rotation.test import model as adj_cell_rotation_model
-from ..lattice_multiple.test import model as lattice_mult_model
+from ..lattice_multiple.test import model as lattice_multiple_model
 from ..energy_laws.test import model as energy_laws_model
-from ..photon_production.test import model as photon_prod_model
+from ..photon_production.test import model as photon_production_model
 
 
 class ModelXMLTestHarness(PyAPITestHarness):
@@ -30,10 +30,10 @@ class ModelXMLTestHarness(PyAPITestHarness):
     def _get_inputs(self):
         return open('model.xml').read()
 
-    def _compare_inputs(self):
-        """Skip input comparisons for now
-        """
-        pass
+    # def _compare_inputs(self):
+    #     """Skip input comparisons for now
+    #     """
+    #     pass
 
     def _compare_results(self):
         """Make sure the current results agree with the reference."""
@@ -54,25 +54,23 @@ class ModelXMLTestHarness(PyAPITestHarness):
             os.remove('model.xml')
 
 
-models = [
-    'adj_cell_rotation_model',
-    'lattice_mult_model',
-    'energy_laws_model',
-    'photon_prod_model'
-]
-paths = [
-    '../adj_cell_rotation',
-    '../lattice_multiple',
-    '../energy_laws',
-    '../photon_production'
+test_names = [
+    'adj_cell_rotation',
+    'lattice_multiple',
+    'energy_laws',
+    'photon_production'
 ]
 
 
-@pytest.mark.parametrize("model, path", zip(models, paths))
-def test_model_xml(model, path, request):
-    inputs = path + "/inputs_true.dat"
-    results = path + "/results_true.dat"
-    harness = ModelXMLTestHarness(request.getfixturevalue(model), inputs, results)
+@pytest.mark.parametrize("test_name", test_names, ids=lambda test: test)
+def test_model_xml(test_name, request):
+    openmc.reset_auto_ids()
+
+    test_path = '../' + test_name
+    results = test_path + "/results_true.dat"
+    inputs = test_name + "_inputs_true.dat"
+    model_name = test_name + "_model"
+    harness = ModelXMLTestHarness(request.getfixturevalue(model_name), inputs, results)
     harness.main()
 
 def test_input_arg(run_in_tmpdir):

--- a/tests/regression_tests/model_xml/test.py
+++ b/tests/regression_tests/model_xml/test.py
@@ -93,6 +93,5 @@ def test_input_arg(run_in_tmpdir):
 
     # now ensure we get an error for an incorrect filename,
     # even in the presence of other, valid XML files
-    with pytest.raises(RuntimeError) as execinfo:
+    with pytest.raises(RuntimeError, match='ex-em-ell.xml'):
         openmc.run(input_file='ex-em-ell.xml')
-        assert 'ex-em-ell.xml' in execinfo.value

--- a/tests/regression_tests/model_xml/test.py
+++ b/tests/regression_tests/model_xml/test.py
@@ -27,7 +27,7 @@ class ModelXMLTestHarness(PyAPITestHarness):
         self.results_true = 'results_true.dat' if results_true is None else results_true
 
     def _build_inputs(self):
-        self._model.export_to_xml(separate_xmls=False)
+        self._model.export_to_model_xml()
 
     def _get_inputs(self):
         return open('model.xml').read()
@@ -77,21 +77,24 @@ def test_input_arg(run_in_tmpdir):
     pincell.settings.particles = 100
 
     # export to separate XML files and run
-    pincell.export_to_xml(separate_xmls=True)
+    pincell.export_to_xml()
     openmc.run()
 
     # make sure the executable isn't falling back on the separate XMLs
     for f in glob.glob('*.xml'):
         os.remove(f)
     # now export to a single XML file with a custom name
-    pincell.export_to_xml(path='pincell.xml', separate_xmls=False)
+    pincell.export_to_model_xml('pincell.xml')
     assert Path('pincell.xml').exists()
 
     # run by specifying that single file
     openmc.run(path_input='pincell.xml')
 
+    # check that this works for plotting too
+    openmc.plot_geometry(path_input='pincell.xml')
+
     # now ensure we get an error for an incorrect filename,
     # even in the presence of other, valid XML files
-    pincell.export_to_xml(separate_xmls=True)
+    pincell.export_to_model_xml()
     with pytest.raises(RuntimeError, match='ex-em-ell.xml'):
         openmc.run(path_input='ex-em-ell.xml')

--- a/tests/regression_tests/model_xml/test.py
+++ b/tests/regression_tests/model_xml/test.py
@@ -93,5 +93,6 @@ def test_input_arg(run_in_tmpdir):
 
     # now ensure we get an error for an incorrect filename,
     # even in the presence of other, valid XML files
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as execinfo:
         openmc.run(input_file='ex-em-ell.xml')
+        assert 'ex-em-ell.xml' in execinfo.value

--- a/tests/regression_tests/model_xml/test.py
+++ b/tests/regression_tests/model_xml/test.py
@@ -74,3 +74,23 @@ def test_model_xml(model, path, request):
     results = path + "/results_true.dat"
     harness = ModelXMLTestHarness(request.getfixturevalue(model), inputs, results)
     harness.main()
+
+def test_input_arg(run_in_tmpdir):
+
+    pincell = openmc.examples.pwr_pin_cell()
+
+    pincell.settings.particles = 100
+
+    # export to separate XML files and run
+    pincell.export_to_xml(separate_xmls=True)
+    openmc.run()
+
+    # now export to a single XML file with a custom name
+    pincell.export_to_xml(filename='pincell.xml', separate_xmls=False)
+
+    # run by specifying that single file
+    openmc.run(input_file='pincell.xml')
+
+    # now ensure we get an error for an incorrect filename
+    with pytest.raises(RuntimeError):
+        openmc.run(input_file='ex-em-ell.xml')

--- a/tests/regression_tests/model_xml/test.py
+++ b/tests/regression_tests/model_xml/test.py
@@ -91,6 +91,7 @@ def test_input_arg(run_in_tmpdir):
     # run by specifying that single file
     openmc.run(input_file='pincell.xml')
 
-    # now ensure we get an error for an incorrect filename
+    # now ensure we get an error for an incorrect filename,
+    # even in the presence of other, valid XML files
     with pytest.raises(RuntimeError):
         openmc.run(input_file='ex-em-ell.xml')

--- a/tests/regression_tests/photon_production/__init__.py
+++ b/tests/regression_tests/photon_production/__init__.py
@@ -1,1 +1,0 @@
-from .test import model

--- a/tests/regression_tests/photon_production/__init__.py
+++ b/tests/regression_tests/photon_production/__init__.py
@@ -1,0 +1,1 @@
+from .test import model

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -7,6 +7,8 @@ import pytest
 import openmc
 import openmc.lib
 
+from .. import cdtemp
+
 
 @pytest.fixture(scope='function')
 def pin_model_attributes():
@@ -529,3 +531,22 @@ def test_calc_volumes(run_in_tmpdir, pin_model_attributes, mpi_intracomm):
     assert openmc.lib.materials[3].volume == mats[2].volume
 
     test_model.finalize_lib()
+
+def test_model_xml():
+
+    with cdtemp():
+        # load a model from examples
+        pwr_model = openmc.examples.pwr_core()
+
+        # export to separate XMLs manually
+        pwr_model.settings.export_to_xml('settings_ref.xml')
+        pwr_model.materials.export_to_xml('materials_ref.xml')
+        pwr_model.geometry.export_to_xml('geometry_ref.xml')
+
+        # now write and read a model.xml file
+        pwr_model.export_to_xml(separate_xmls=False)
+        new_model = openmc.Model.from_xml(separate_xmls=False)
+
+        # make sure we can also export this again to separate
+        # XML files
+        new_model.export_to_xml(separate_xmls=True)

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -530,21 +530,20 @@ def test_calc_volumes(run_in_tmpdir, pin_model_attributes, mpi_intracomm):
 
     test_model.finalize_lib()
 
-def test_model_xml():
+def test_model_xml(run_in_tmpdir):
 
-    with cdtemp():
-        # load a model from examples
-        pwr_model = openmc.examples.pwr_core()
+    # load a model from examples
+    pwr_model = openmc.examples.pwr_core()
 
-        # export to separate XMLs manually
-        pwr_model.settings.export_to_xml('settings_ref.xml')
-        pwr_model.materials.export_to_xml('materials_ref.xml')
-        pwr_model.geometry.export_to_xml('geometry_ref.xml')
+    # export to separate XMLs manually
+    pwr_model.settings.export_to_xml('settings_ref.xml')
+    pwr_model.materials.export_to_xml('materials_ref.xml')
+    pwr_model.geometry.export_to_xml('geometry_ref.xml')
 
-        # now write and read a model.xml file
-        pwr_model.export_to_xml(separate_xmls=False)
-        new_model = openmc.Model.from_xml(separate_xmls=False)
+    # now write and read a model.xml file
+    pwr_model.export_to_xml(separate_xmls=False)
+    new_model = openmc.Model.from_xml(separate_xmls=False)
 
-        # make sure we can also export this again to separate
-        # XML files
-        new_model.export_to_xml(separate_xmls=True)
+    # make sure we can also export this again to separate
+    # XML files
+    new_model.export_to_xml(separate_xmls=True)

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -543,7 +543,7 @@ def test_model_xml(run_in_tmpdir):
 
     # now write and read a model.xml file
     pwr_model.export_to_xml(separate_xmls=False)
-    new_model = openmc.Model.from_xml(separate_xmls=False)
+    new_model = openmc.Model.from_model_xml()
 
     # make sure we can also export this again to separate
     # XML files
@@ -553,17 +553,17 @@ def test_model_exec(run_in_tmpdir):
 
     pincell_model = openmc.examples.pwr_pin_cell()
 
-    pincell_model.export_to_xml(filename='pwr_pincell.xml', separate_xmls=False)
+    pincell_model.export_to_xml(path='pwr_pincell.xml', separate_xmls=False)
 
-    openmc.run(input_file='pwr_pincell.xml')
+    openmc.run(path_input='pwr_pincell.xml')
 
     with pytest.raises(RuntimeError, match='ex-em-ell.xml'):
-        openmc.run(input_file='ex-em-ell.xml')
+        openmc.run(path_input='ex-em-ell.xml')
 
     # test that a file in a different directory can be used
     os.mkdir('inputs')
-    pincell_model.export_to_xml(directory='./inputs', filename='pincell.xml', separate_xmls=False)
-    openmc.run(input_file='./inputs/pincell.xml')
+    pincell_model.export_to_xml(path='./inputs/pincell.xml', separate_xmls=False)
+    openmc.run(path_input='./inputs/pincell.xml')
 
     with pytest.raises(RuntimeError, match='input_dir'):
-        openmc.run(input_file='input_dir/pincell.xml')
+        openmc.run(path_input='input_dir/pincell.xml')

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -1,5 +1,6 @@
 from math import pi
 from pathlib import Path
+import os
 
 import numpy as np
 import pytest
@@ -547,3 +548,22 @@ def test_model_xml(run_in_tmpdir):
     # make sure we can also export this again to separate
     # XML files
     new_model.export_to_xml(separate_xmls=True)
+
+def test_model_exec(run_in_tmpdir):
+
+    pincell_model = openmc.examples.pwr_pin_cell()
+
+    pincell_model.export_to_xml(filename='pwr_pincell.xml', separate_xmls=False)
+
+    openmc.run(input_file='pwr_pincell.xml')
+
+    with pytest.raises(RuntimeError, match='ex-em-ell.xml'):
+        openmc.run(input_file='ex-em-ell.xml')
+
+    # test that a file in a different directory can be used
+    os.mkdir('inputs')
+    pincell_model.export_to_xml(directory='./inputs', filename='pincell.xml', separate_xmls=False)
+    openmc.run(input_file='./inputs/pincell.xml')
+
+    with pytest.raises(RuntimeError, match='input_dir'):
+        openmc.run(input_file='input_dir/pincell.xml')

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -542,18 +542,18 @@ def test_model_xml(run_in_tmpdir):
     pwr_model.geometry.export_to_xml('geometry_ref.xml')
 
     # now write and read a model.xml file
-    pwr_model.export_to_xml(separate_xmls=False)
+    pwr_model.export_to_model_xml()
     new_model = openmc.Model.from_model_xml()
 
     # make sure we can also export this again to separate
     # XML files
-    new_model.export_to_xml(separate_xmls=True)
+    new_model.export_to_xml()
 
-def test_model_exec(run_in_tmpdir):
+def test_single_xml_exec(run_in_tmpdir):
 
     pincell_model = openmc.examples.pwr_pin_cell()
 
-    pincell_model.export_to_xml(path='pwr_pincell.xml', separate_xmls=False)
+    pincell_model.export_to_model_xml('pwr_pincell.xml')
 
     openmc.run(path_input='pwr_pincell.xml')
 
@@ -562,7 +562,7 @@ def test_model_exec(run_in_tmpdir):
 
     # test that a file in a different directory can be used
     os.mkdir('inputs')
-    pincell_model.export_to_xml(path='./inputs/pincell.xml', separate_xmls=False)
+    pincell_model.export_to_model_xml('./inputs/pincell.xml')
     openmc.run(path_input='./inputs/pincell.xml')
 
     with pytest.raises(RuntimeError, match='input_dir'):

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -7,8 +7,6 @@ import pytest
 import openmc
 import openmc.lib
 
-from .. import cdtemp
-
 
 @pytest.fixture(scope='function')
 def pin_model_attributes():


### PR DESCRIPTION
This PR adds the ability to read a single input XML, `model.xml` as input. 

If this file is present, OpenMC will read the settings, materials, geometry, tallies, and plots from this file and ignore any other XML files present in the directory -- a warning will be displayed if those additional XMLs are present. If a `model.xml` file is absent, OpenMC will fall back to using the current set of separate XML files we rely on for input.

In the Python API, a `separate_xmls` keyword argument has been added to the `openmc.Model` `export_to_xml` and `from_xml` methods to support both reading and writing a single XML file or separate XML files. This should make it easy to either stick with the current workflow for input generation with multiple XML files or convert old inputs into a single `model.xml` file.

This PR is still a little rough (needs a fresh look in the morning and several tests), so I'm marking it as a draft for now.