### PR TITLE
FilterType Enumerator

### DIFF
--- a/docs/source/pythonapi/base.rst
+++ b/docs/source/pythonapi/base.rst
@@ -120,7 +120,7 @@ Constructing Tallies
    openmc.MaterialFilter
    openmc.CellFilter
    openmc.CellFromFilter
-   openmc.CellbornFilter
+   openmc.CellBornFilter
    openmc.CellInstanceFilter
    openmc.CollisionFilter
    openmc.SurfaceFilter

--- a/include/openmc/tallies/filter.h
+++ b/include/openmc/tallies/filter.h
@@ -17,6 +17,33 @@
 
 namespace openmc {
 
+enum class FilterType {
+  AZIMUTHAL = 0,
+  CELLBORN,
+  CELLFROM,
+  CELL,
+  CELL_INSTANCE,
+  COLLISION,
+  DELAYEDGROUP,
+  DISTRIBCELL,
+  ENERGYFUNC,
+  ENERGY,
+  LEGENDRE,
+  MATCH,
+  MATERIAL,
+  MESH,
+  MESHSURFACE,
+  MU,
+  PARTICLE,
+  POLAR,
+  SPH_HARM,
+  SPTL_LEGENDRE,
+  SURFACE,
+  TIME,
+  UNIVERSE,
+  ZERNIKE,
+};
+
 //==============================================================================
 //! Modifies tally score events.
 //==============================================================================

--- a/include/openmc/tallies/filter.h
+++ b/include/openmc/tallies/filter.h
@@ -24,24 +24,25 @@ enum class FilterType {
   CELL,
   CELL_INSTANCE,
   COLLISION,
-  DELAYEDGROUP,
+  DELAYED_GROUP,
   DISTRIBCELL,
-  ENERGYFUNC,
+  ENERGY_FUNCTION,
   ENERGY,
+  ENERGY_OUT,
   LEGENDRE,
-  MATCH,
   MATERIAL,
   MESH,
-  MESHSURFACE,
+  MESH_SURFACE,
   MU,
   PARTICLE,
   POLAR,
-  SPH_HARM,
-  SPTL_LEGENDRE,
+  SPHERICAL_HARMONICS,
+  SPATIAL_LEGENDRE,
   SURFACE,
   TIME,
   UNIVERSE,
   ZERNIKE,
+  ZERNIKE_RADIAL
 };
 
 //==============================================================================
@@ -85,7 +86,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  virtual std::string type() const = 0;
+  virtual std::string type_str() const = 0;
+  virtual FilterType type() const = 0;
 
   //! Matches a tally event to a set of filter bins and weights.
   //!
@@ -99,7 +101,7 @@ public:
   //! Writes data describing this filter to an HDF5 statepoint group.
   virtual void to_statepoint(hid_t filter_group) const
   {
-    write_dataset(filter_group, "type", type());
+    write_dataset(filter_group, "type", type_str());
     write_dataset(filter_group, "n_bins", n_bins_);
   }
 

--- a/include/openmc/tallies/filter.h
+++ b/include/openmc/tallies/filter.h
@@ -18,7 +18,7 @@
 namespace openmc {
 
 enum class FilterType {
-  AZIMUTHAL = 0,
+  AZIMUTHAL,
   CELLBORN,
   CELLFROM,
   CELL,

--- a/include/openmc/tallies/filter_azimuthal.h
+++ b/include/openmc/tallies/filter_azimuthal.h
@@ -24,7 +24,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "azimuthal"; }
+  std::string type_str() const override { return "azimuthal"; }
+  FilterType type() const override { return FilterType::AZIMUTHAL; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_cell.h
+++ b/include/openmc/tallies/filter_cell.h
@@ -25,7 +25,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "cell"; }
+  std::string type_str() const override { return "cell"; }
+  FilterType type() const override { return FilterType::CELL; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_cell_instance.h
+++ b/include/openmc/tallies/filter_cell_instance.h
@@ -28,7 +28,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "cellinstance"; }
+  std::string type_str() const override { return "cellinstance"; }
+  FilterType type() const override { return FilterType::CELL_INSTANCE; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_cellborn.h
+++ b/include/openmc/tallies/filter_cellborn.h
@@ -16,7 +16,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "cellborn"; }
+  std::string type_str() const override { return "cellborn"; }
+  FilterType type() const override { return FilterType::CELLBORN; }
 
   void get_all_bins(const Particle& p, TallyEstimator estimator,
     FilterMatch& match) const override;

--- a/include/openmc/tallies/filter_cellborn.h
+++ b/include/openmc/tallies/filter_cellborn.h
@@ -11,7 +11,7 @@ namespace openmc {
 //! Specifies which cell the particle was born in.
 //==============================================================================
 
-class CellbornFilter : public CellFilter {
+class CellBornFilter : public CellFilter {
 public:
   //----------------------------------------------------------------------------
   // Methods

--- a/include/openmc/tallies/filter_cellfrom.h
+++ b/include/openmc/tallies/filter_cellfrom.h
@@ -16,7 +16,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "cellfrom"; }
+  std::string type_str() const override { return "cellfrom"; }
+  FilterType type() const override { return FilterType::CELLFROM; }
 
   void get_all_bins(const Particle& p, TallyEstimator estimator,
     FilterMatch& match) const override;

--- a/include/openmc/tallies/filter_collision.h
+++ b/include/openmc/tallies/filter_collision.h
@@ -23,7 +23,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "collision"; }
+  std::string type_str() const override { return "collision"; }
+  FilterType type() const override { return FilterType::COLLISION; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_delayedgroup.h
+++ b/include/openmc/tallies/filter_delayedgroup.h
@@ -25,7 +25,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "delayedgroup"; }
+  std::string type_str() const override { return "delayedgroup"; }
+  FilterType type() const override { return FilterType::DELAYED_GROUP; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_distribcell.h
+++ b/include/openmc/tallies/filter_distribcell.h
@@ -21,7 +21,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "distribcell"; }
+  std::string type_str() const override { return "distribcell"; }
+  FilterType type() const override { return FilterType::DISTRIBCELL; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_energy.h
+++ b/include/openmc/tallies/filter_energy.h
@@ -22,7 +22,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "energy"; }
+  std::string type_str() const override { return "energy"; }
+  FilterType type() const override { return FilterType::ENERGY; }
 
   void from_xml(pugi::xml_node node) override;
 
@@ -63,7 +64,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "energyout"; }
+  std::string type_str() const override { return "energyout"; }
+  FilterType type() const override { return FilterType::ENERGY_OUT; }
 
   void get_all_bins(const Particle& p, TallyEstimator estimator,
     FilterMatch& match) const override;

--- a/include/openmc/tallies/filter_energyfunc.h
+++ b/include/openmc/tallies/filter_energyfunc.h
@@ -24,7 +24,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "energyfunction"; }
+  std::string type_str() const override { return "energyfunction"; }
+  FilterType type() const override { return FilterType::ENERGY_FUNCTION; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_legendre.h
+++ b/include/openmc/tallies/filter_legendre.h
@@ -21,7 +21,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "legendre"; }
+  std::string type_str() const override { return "legendre"; }
+  FilterType type() const override { return FilterType::LEGENDRE; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_material.h
+++ b/include/openmc/tallies/filter_material.h
@@ -25,7 +25,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "material"; }
+  std::string type_str() const override { return "material"; }
+  FilterType type() const override { return FilterType::MATERIAL; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_mesh.h
+++ b/include/openmc/tallies/filter_mesh.h
@@ -24,7 +24,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "mesh"; }
+  std::string type_str() const override { return "mesh"; }
+  FilterType type() const override { return FilterType::MESH; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_meshsurface.h
+++ b/include/openmc/tallies/filter_meshsurface.h
@@ -10,7 +10,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "meshsurface"; }
+  std::string type_str() const override { return "meshsurface"; }
+  FilterType type() const override { return FilterType::MESH_SURFACE; }
 
   void get_all_bins(const Particle& p, TallyEstimator estimator,
     FilterMatch& match) const override;

--- a/include/openmc/tallies/filter_mu.h
+++ b/include/openmc/tallies/filter_mu.h
@@ -23,7 +23,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "mu"; }
+  std::string type_str() const override { return "mu"; }
+  FilterType type() const override { return FilterType::MU; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_particle.h
+++ b/include/openmc/tallies/filter_particle.h
@@ -21,7 +21,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "particle"; }
+  std::string type_str() const override { return "particle"; }
+  FilterType type() const override { return FilterType::PARTICLE; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_polar.h
+++ b/include/openmc/tallies/filter_polar.h
@@ -24,7 +24,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "polar"; }
+  std::string type_str() const override { return "polar"; }
+  FilterType type() const override { return FilterType::POLAR; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_sph_harm.h
+++ b/include/openmc/tallies/filter_sph_harm.h
@@ -25,7 +25,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "sphericalharmonics"; }
+  std::string type_str() const override { return "sphericalharmonics"; }
+  FilterType type() const override { return FilterType::SPHERICAL_HARMONICS; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_sptl_legendre.h
+++ b/include/openmc/tallies/filter_sptl_legendre.h
@@ -23,7 +23,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "spatiallegendre"; }
+  std::string type_str() const override { return "spatiallegendre"; }
+  FilterType type() const override { return FilterType::SPATIAL_LEGENDRE; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_surface.h
+++ b/include/openmc/tallies/filter_surface.h
@@ -25,7 +25,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "surface"; }
+  std::string type_str() const override { return "surface"; }
+  FilterType type() const override { return FilterType::SURFACE; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_time.h
+++ b/include/openmc/tallies/filter_time.h
@@ -22,7 +22,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "time"; }
+  std::string type_str() const override { return "time"; }
+  FilterType type() const override { return FilterType::TIME; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_universe.h
+++ b/include/openmc/tallies/filter_universe.h
@@ -25,7 +25,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "universe"; }
+  std::string type_str() const override { return "universe"; }
+  FilterType type() const override { return FilterType::UNIVERSE; }
 
   void from_xml(pugi::xml_node node) override;
 

--- a/include/openmc/tallies/filter_zernike.h
+++ b/include/openmc/tallies/filter_zernike.h
@@ -21,7 +21,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "zernike"; }
+  std::string type_str() const override { return "zernike"; }
+  FilterType type() const override { return FilterType::ZERNIKE; }
 
   void from_xml(pugi::xml_node node) override;
 
@@ -72,7 +73,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  std::string type() const override { return "zernikeradial"; }
+  std::string type_str() const override { return "zernikeradial"; }
+  FilterType type() const override { return FilterType::ZERNIKE_RADIAL; }
 
   void get_all_bins(const Particle& p, TallyEstimator estimator,
     FilterMatch& match) const override;

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -533,7 +533,7 @@ class CellFromFilter(WithIDFilter):
     expected_type = Cell
 
 
-class CellbornFilter(WithIDFilter):
+class CellBornFilter(WithIDFilter):
     """Bins tally events based on which cell the particle was born in.
 
     Parameters
@@ -555,6 +555,14 @@ class CellbornFilter(WithIDFilter):
 
     """
     expected_type = Cell
+
+
+# Temporary alias for CellbornFilter
+def CellbornFilter(*args, **kwargs):
+    warnings.warn('The name of "CellbornFilter" has changed to '
+                  '"CellBornFilter". "CellbornFilter" will be '
+                  'removed in the future.')
+    return CellBornFilter(*args, **kwargs)
 
 
 class CellInstanceFilter(Filter):

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -561,7 +561,7 @@ class CellBornFilter(WithIDFilter):
 def CellbornFilter(*args, **kwargs):
     warnings.warn('The name of "CellbornFilter" has changed to '
                   '"CellBornFilter". "CellbornFilter" will be '
-                  'removed in the future.')
+                  'removed in the future.', FutureWarning)
     return CellBornFilter(*args, **kwargs)
 
 

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -804,7 +804,7 @@ void write_unstructured_mesh_results()
     vector<std::string> tally_scores;
     for (auto filter_idx : tally->filters()) {
       auto& filter = model::tally_filters[filter_idx];
-      if (filter->type() != "mesh")
+      if (filter->type() != FilterType::MESH)
         continue;
 
       // check if the filter uses an unstructured mesh

--- a/src/tallies/filter.cpp
+++ b/src/tallies/filter.cpp
@@ -232,7 +232,7 @@ extern "C" int openmc_filter_get_type(int32_t index, char* type)
   if (int err = verify_filter(index))
     return err;
 
-  std::strcpy(type, model::tally_filters[index]->type().c_str());
+  std::strcpy(type, model::tally_filters[index]->type_str().c_str());
   return 0;
 }
 

--- a/src/tallies/filter.cpp
+++ b/src/tallies/filter.cpp
@@ -115,7 +115,7 @@ Filter* Filter::create(const std::string& type, int32_t id)
   } else if (type == "cell") {
     return Filter::create<CellFilter>(id);
   } else if (type == "cellborn") {
-    return Filter::create<CellbornFilter>(id);
+    return Filter::create<CellBornFilter>(id);
   } else if (type == "cellfrom") {
     return Filter::create<CellFromFilter>(id);
   } else if (type == "cellinstance") {

--- a/src/tallies/filter_cell.cpp
+++ b/src/tallies/filter_cell.cpp
@@ -80,7 +80,7 @@ extern "C" int openmc_cell_filter_get_bins(
     return err;
 
   const auto& filt = model::tally_filters[index].get();
-  if (filt->type() != "cell") {
+  if (filt->type() != FilterType::CELL) {
     set_errmsg("Tried to get cells from a non-cell filter.");
     return OPENMC_E_INVALID_TYPE;
   }

--- a/src/tallies/filter_cellborn.cpp
+++ b/src/tallies/filter_cellborn.cpp
@@ -4,7 +4,7 @@
 
 namespace openmc {
 
-void CellbornFilter::get_all_bins(
+void CellBornFilter::get_all_bins(
   const Particle& p, TallyEstimator estimator, FilterMatch& match) const
 {
   auto search = map_.find(p.cell_born());
@@ -14,7 +14,7 @@ void CellbornFilter::get_all_bins(
   }
 }
 
-std::string CellbornFilter::text_label(int bin) const
+std::string CellBornFilter::text_label(int bin) const
 {
   return "Birth Cell " + std::to_string(model::cells[cells_[bin]]->id_);
 }

--- a/src/tallies/filter_mesh.cpp
+++ b/src/tallies/filter_mesh.cpp
@@ -16,7 +16,7 @@ void MeshFilter::from_xml(pugi::xml_node node)
   auto bins_ = get_node_array<int32_t>(node, "bins");
   if (bins_.size() != 1) {
     fatal_error(
-      "Only one mesh can be specified per " + type() + " mesh filter.");
+      "Only one mesh can be specified per " + type_str() + " mesh filter.");
   }
 
   auto id = bins_[0];
@@ -158,7 +158,8 @@ extern "C" int openmc_mesh_filter_get_translation(
 
   // Check the filter type
   const auto& filter = model::tally_filters[index];
-  if (filter->type() != "mesh" && filter->type() != "meshsurface") {
+  if (filter->type() != FilterType::MESH &&
+      filter->type() != FilterType::MESH_SURFACE) {
     set_errmsg("Tried to get a translation from a non-mesh-based filter.");
     return OPENMC_E_INVALID_TYPE;
   }
@@ -182,7 +183,8 @@ extern "C" int openmc_mesh_filter_set_translation(
 
   const auto& filter = model::tally_filters[index];
   // Check the filter type
-  if (filter->type() != "mesh" && filter->type() != "meshsurface") {
+  if (filter->type() != FilterType::MESH &&
+      filter->type() != FilterType::MESH_SURFACE) {
     set_errmsg("Tried to set mesh on a non-mesh-based filter.");
     return OPENMC_E_INVALID_TYPE;
   }

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -140,16 +140,18 @@ Tally::Tally(pugi::xml_node node)
       particle_filter_index = i_filter;
 
     // Change the tally estimator if a filter demands it
-    std::string filt_type = f->type();
-    if (filt_type == "energyout" || filt_type == "legendre") {
+    FilterType filt_type = f->type();
+    if (filt_type == FilterType::ENERGY_OUT ||
+        filt_type == FilterType::LEGENDRE) {
       estimator_ = TallyEstimator::ANALOG;
-    } else if (filt_type == "sphericalharmonics") {
+    } else if (filt_type == FilterType::SPHERICAL_HARMONICS) {
       auto sf = dynamic_cast<SphericalHarmonicsFilter*>(f);
       if (sf->cosine() == SphericalHarmonicsCosine::scatter) {
         estimator_ = TallyEstimator::ANALOG;
       }
-    } else if (filt_type == "spatiallegendre" || filt_type == "zernike" ||
-               filt_type == "zernikeradial") {
+    } else if (filt_type == FilterType::SPATIAL_LEGENDRE ||
+               filt_type == FilterType::ZERNIKE ||
+               filt_type == FilterType::ZERNIKE_RADIAL) {
       estimator_ = TallyEstimator::COLLISION;
     }
   }

--- a/tests/regression_tests/tallies/test.py
+++ b/tests/regression_tests/tallies/test.py
@@ -40,7 +40,7 @@ def test_tallies():
 
     cellborn_tally = Tally()
     cellborn_tally.filters = [
-        CellbornFilter((model.geometry.get_all_cells()[10],
+        CellBornFilter((model.geometry.get_all_cells()[10],
                         model.geometry.get_all_cells()[21],
                         22, 23))]  # Test both Cell objects and ids
     cellborn_tally.scores = ['total']


### PR DESCRIPTION
Resolves #2292.

This adds a `FilterType` enumerator. It is used to replace the return type of the `Filter::type` static method. The string identifiers have been moved to the `Filter::type_str()` method, which is still used to write the filter type to the statepoint file.