### PR TITLE
Fix the case where the yield is zero.

### DIFF
--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -1127,7 +1127,7 @@ void inelastic_scatter(const Nuclide& nuc, const Reaction& rx, Particle& p)
 
   // evaluate yield
   double yield = (*rx.products_[0].yield_)(E_in);
-  if (std::floor(yield) == yield) {
+  if (std::floor(yield) == yield && yield > 0) {
     // If yield is integral, create exactly that many secondary particles
     for (int i = 0; i < static_cast<int>(std::round(yield)) - 1; ++i) {
       p.create_secondary(p.wgt(), p.u(), p.E(), ParticleType::neutron);


### PR DESCRIPTION
Problem detected in the context of a code-to-code comparison between OpenMC and TRIPOLI-4:
- configuration: sphere of radius R = 30 cm containing the isotope ZR93 at 293K
- sphere irradiated at the center by an isotropic, mono-energy, point source (E_0 = 14.1 MeV)
- data from JEFF-3.3

For some isotopes, namely ZR93 at 293K, the sampled yield can be equal to 0 (namely for MT=5: interaction "n-other"). In such a case, it is necessary to deactivate the particle.