### PR TITLE
Prevent out-of-bounds memory access on Compton profile data

### DIFF
--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -226,8 +226,9 @@ PhotonInteraction::PhotonInteraction(hid_t group)
 
   // Create Compton profile CDF
   auto n_profile = data::compton_profile_pz.size();
-  profile_cdf_ = xt::empty<double>({n_shell, n_profile});
-  for (int i = 0; i < profile_pdf_.shape(0); ++i) {
+  auto n_shell_compton = profile_pdf_.shape(0);
+  profile_cdf_ = xt::empty<double>({n_shell_compton, n_profile});
+  for (int i = 0; i < n_shell_compton; ++i) {
     double c = 0.0;
     profile_cdf_(i, 0) = 0.0;
     for (int j = 0; j < n_profile - 1; ++j) {
@@ -409,6 +410,13 @@ void PhotonInteraction::compton_scatter(double alpha, bool doppler,
         double E_out;
         this->compton_doppler(alpha, *mu, &E_out, i_shell, seed);
         *alpha_out = E_out / MASS_ELECTRON_EV;
+
+        // It's possible for the Compton profile data to have more shells than
+        // there are in the ENDF data. Make sure the shell index doesn't end up
+        // out of bounds.
+        if (*i_shell >= shells_.size()) {
+          *i_shell = -1;
+        }
       } else {
         *i_shell = -1;
       }


### PR DESCRIPTION
A user [reported a problem](https://openmc.discourse.group/t/openmc-aborted-by-settings-photon-transport/2344) whereby when they included Ir193 in a model and ran it with photon transport on, a segfault occurred. It turns out that the problem is due to a mismatch between the number of electron subshells in the ENDF photoatomic data and the Compton profile data (see #1942). Iridium is evidently the only case where the Compton profile data has _more_ shells listed than the ENDF photoatomic data, which causes an out of bounds memory access on this line:
https://github.com/openmc-dev/openmc/blob/765df9115f58624bd77c6304435c4f5166df67be/src/photon.cpp#L232
because we were incorrectly using the number of shells from the photoatomic data to initialize the size of the Compton profile CDF. This PR fixes the sizing of `profile_cdf_`.