### PR TITLE
added acceptable keys to error message

### DIFF
--- a/openmc/config.py
+++ b/openmc/config.py
@@ -42,7 +42,9 @@ class _Config(MutableMapping):
             # Reset photon source data since it relies on chain file
             _DECAY_PHOTON_ENERGY.clear()
         else:
-            raise KeyError(f'Unrecognized config key: {key}')
+            raise KeyError(f'Unrecognized config key: {key}. Acceptable keys '
+                           'are "cross_sections", "mg_cross_sections" and '
+                           '"chain_file"')
 
     def __iter__(self):
         return iter(self._mapping)


### PR DESCRIPTION
Just a tiny change to the ```openmc.config``` keyError message. I think that returning the acceptable keys in the message could help users quickly correct their code. For example I keep forgetting if the key is cross_section or cross_sections and now it tells me what it should be