### PR TITLE
Produce light particles from decay

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -630,14 +630,26 @@ class Chain:
 
             # Gain from radioactive decay
             if nuc.n_decay_modes != 0:
-                for _, target, branching_ratio in nuc.decay_modes:
-                    # Allow for total annihilation for debug purposes
-                    if target is not None:
-                        branch_val = branching_ratio * decay_constant
+                for decay_type, target, branching_ratio in nuc.decay_modes:
+                    branch_val = branching_ratio * decay_constant
 
-                        if branch_val != 0.0:
+                    # Allow for total annihilation for debug purposes
+                    if branch_val != 0.0:
+                        if target is not None:
                             k = self.nuclide_dict[target]
                             matrix[k, i] += branch_val
+
+                        # Produce alphas and protons from decay
+                        if 'alpha' in decay_type:
+                            k = self.nuclide_dict.get('He4')
+                            if k is not None:
+                                count = decay_type.count('alpha')
+                                matrix[k, i] += count * branch_val
+                        elif 'p' in decay_type:
+                            k = self.nuclide_dict.get('H1')
+                            if k is not None:
+                                count = decay_type.count('p')
+                                matrix[k, i] += count * branch_val
 
             if nuc.name in rates.index_nuc:
                 # Extract all reactions for this nuclide in this cell

--- a/openmc/deplete/independent_operator.py
+++ b/openmc/deplete/independent_operator.py
@@ -150,7 +150,7 @@ class IndependentOperator(OpenMCOperator):
     @classmethod
     def from_nuclides(cls, volume, nuclides,
                       micro_xs,
-                      chain_file,
+                      chain_file=None,
                       nuc_units='atom/b-cm',
                       keff=None,
                       normalization_mode='fission-q',
@@ -170,9 +170,9 @@ class IndependentOperator(OpenMCOperator):
             values.
         micro_xs : MicroXS
             One-group microscopic cross sections.
-        chain_file : str
+        chain_file : str, optional
             Path to the depletion chain XML file.
-        nuc_units : {'atom/cm3', 'atom/b-cm'}
+        nuc_units : {'atom/cm3', 'atom/b-cm'}, optional
             Units for nuclide concentration.
         keff : 2-tuple of float, optional
            keff eigenvalue and uncertainty from transport calculation.

--- a/openmc/deplete/independent_operator.py
+++ b/openmc/deplete/independent_operator.py
@@ -31,6 +31,9 @@ class IndependentOperator(OpenMCOperator):
     passed to an integrator class, such as
     :class:`openmc.deplete.CECMIntegrator`.
 
+    Note that passing an empty :class:`~openmc.deplete.MicroXS` instance to the
+    ``micro_xs`` argument allows a decay-only calculation to be run.
+
     .. versionadded:: 0.13.1
 
     Parameters
@@ -38,9 +41,11 @@ class IndependentOperator(OpenMCOperator):
     materials : openmc.Materials
         Materials to deplete.
     micro_xs : MicroXS
-        One-group microscopic cross sections in [b] .
+        One-group microscopic cross sections in [b]. If the
+        :class:`~openmc.deplete.MicroXS` is empty, a decay-only calculation will
+        be run.
     chain_file : str
-        Path to the depletion chain XML file.  Defaults to
+        Path to the depletion chain XML file. Defaults to
         ``openmc.config['chain_file']``.
     keff : 2-tuple of float, optional
        keff eigenvalue and uncertainty from transport calculation.
@@ -169,9 +174,12 @@ class IndependentOperator(OpenMCOperator):
             Dictionary with nuclide names as keys and nuclide concentrations as
             values.
         micro_xs : MicroXS
-            One-group microscopic cross sections.
+            One-group microscopic cross sections in [b]. If the
+            :class:`~openmc.deplete.MicroXS` is empty, a decay-only calculation
+            will be run.
         chain_file : str, optional
-            Path to the depletion chain XML file.
+            Path to the depletion chain XML file. Defaults to
+            ``openmc.config['chain_file']``.
         nuc_units : {'atom/cm3', 'atom/b-cm'}, optional
             Units for nuclide concentration.
         keff : 2-tuple of float, optional

--- a/openmc/deplete/independent_operator.py
+++ b/openmc/deplete/independent_operator.py
@@ -42,7 +42,7 @@ class IndependentOperator(OpenMCOperator):
         Materials to deplete.
     micro_xs : MicroXS
         One-group microscopic cross sections in [b]. If the
-        :class:`~openmc.deplete.MicroXS` is empty, a decay-only calculation will
+        :class:`~openmc.deplete.MicroXS` object is empty, a decay-only calculation will
         be run.
     chain_file : str
         Path to the depletion chain XML file. Defaults to
@@ -175,7 +175,7 @@ class IndependentOperator(OpenMCOperator):
             values.
         micro_xs : MicroXS
             One-group microscopic cross sections in [b]. If the
-            :class:`~openmc.deplete.MicroXS` is empty, a decay-only calculation
+            :class:`~openmc.deplete.MicroXS` object is empty, a decay-only calculation
             will be run.
         chain_file : str, optional
             Path to the depletion chain XML file. Defaults to

--- a/tests/unit_tests/test_deplete_decay_products.py
+++ b/tests/unit_tests/test_deplete_decay_products.py
@@ -1,0 +1,43 @@
+import openmc.deplete
+import pytest
+
+
+def test_deplete_decay_products(run_in_tmpdir):
+    # Create chain file with H1, He4, and Li5
+    with open('test_chain.xml', 'w') as chain_file:
+        chain_file.write("""
+<depletion_chain>
+  <nuclide name="H1" reactions="0">
+  </nuclide>
+  <nuclide name="He4" reactions="0"/>
+  <nuclide name="Li5" half_life="3.06868e-22" decay_modes="1" decay_energy="1965000.0" reactions="0">
+    <decay type="alpha" target="H1" branching_ratio="1.0"/>
+  </nuclide>
+</depletion_chain>
+        """)
+
+    # Create depletion operator with no reactions
+    micro_xs = openmc.deplete.MicroXS()
+    op = openmc.deplete.IndependentOperator.from_nuclides(
+        volume=1.0,
+        nuclides={'Li5': 1.0},
+        micro_xs=micro_xs,
+        chain_file='test_chain.xml',
+        normalization_mode='source-rate'
+    )
+
+    # Create time-integrator and integrate
+    integrator = openmc.deplete.PredictorIntegrator(
+        op, timesteps=[1.0], source_rates=[0.0], timestep_units='d'
+    )
+    integrator.integrate(final_step=False)
+
+    # Get concentration of H1 and He4
+    results = openmc.deplete.Results('depletion_results.h5')
+    _, h1 = results.get_atoms("1", "H1")
+    _, he4 = results.get_atoms("1", "He4")
+
+    # Since we started with 1e24 atoms of Li5, we should have 1e24 atoms of both
+    # H1 and He4
+    assert h1[1] == pytest.approx(1e24)
+    assert he4[1] == pytest.approx(1e24)


### PR DESCRIPTION
A user [recently noted](https://openmc.discourse.group/t/he-4-production-from-alpha-decay-and-n-alpha-reactions/2473) that decay calculations do not account for the production of light particles. For example, if you were to look at the depletion chain data for <sup>5</sup>Li:
```xml
<nuclide name="Li5" half_life="3.06868e-22" decay_modes="1" decay_energy="1965000.0" reactions="0">
  <decay type="alpha" target="H1" branching_ratio="1.0"/>
</nuclide>
```
running a decay calculation would produce H1 because it's explicitly listed as a "target", but the alpha particle itself would not be produced. This PR fixes this so that alphas and/or protons are produced when the decay mode indicates it.

I've also made some changes to allow `IndependentOperator` to work with an empty `MicroXS` object (useful for doing a decay-only calculation). @yardasol would you be able to review the changes here?