### PR TITLE
Fix zero-valued `runtime` attribute in depletion statepoints.

### DIFF
--- a/openmc/deplete/coupled_operator.py
+++ b/openmc/deplete/coupled_operator.py
@@ -460,7 +460,6 @@ class CoupledOperator(OpenMCOperator):
 
         # Run OpenMC
         openmc.lib.run()
-        openmc.lib.reset_timers()
 
         # Extract results
         rates = self._calculate_reaction_rates(source_rate)
@@ -528,6 +527,8 @@ class CoupledOperator(OpenMCOperator):
         openmc.lib.statepoint_write(
             "openmc_simulation_n{}.h5".format(step),
             write_source=False)
+
+        openmc.lib.reset_timers()
 
     def finalize(self):
         """Finalize a depletion simulation and release resources."""


### PR DESCRIPTION
This PR addressed the problem described in issue #2289.

Specifically, this PR:
- Moves `openmc.lib.reset_timers()` from `CoupledOperator.__call__()` to `CoupledOperator.write_bos_data()`
- Adds some lines to the `depletion_with_transport` regression test to check the `runtime` attributes.

Closes #2289.
