### PR TITLE
Rename `divide_by_adens` to `divide_by_atoms`

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -265,8 +265,8 @@ class ReactionRateHelper(ABC):
             Ordering of reactions
         """
 
-    def divide_by_adens(self, number):
-        """Normalize reaction rates by number of nuclides
+    def divide_by_atoms(self, number):
+        """Normalize reaction rates by number of atoms
 
         Acts on the current material examined by :meth:`get_material_rates`
 

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -541,10 +541,10 @@ class OpenMCOperator(TransportOperator):
                 self._normalization_helper.update(
                     tally_rates[:, fission_ind])
 
-            # Divide by total number and store
-            rates[i] = self._rate_helper.divide_by_adens(number)
+            # Divide by total number of atoms and store
+            rates[i] = self._rate_helper.divide_by_atoms(number)
 
-        # Scale reaction rates to obtain units of reactions/sec
+        # Scale reaction rates to obtain units of reactions/sec/atom
         rates *= self._normalization_helper.factor(source_rate)
 
         # Store new fission yields on the chain

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -544,7 +544,7 @@ class OpenMCOperator(TransportOperator):
             # Divide by total number of atoms and store
             rates[i] = self._rate_helper.divide_by_atoms(number)
 
-        # Scale reaction rates to obtain units of reactions/sec/atom
+        # Scale reaction rates to obtain units of (reactions/sec)/atom
         rates *= self._normalization_helper.factor(source_rate)
 
         # Store new fission yields on the chain


### PR DESCRIPTION
In honor of @yardasol's visit to Chicago today, I've decided to open this mini PR renaming the `ReactionRateHelper.divide_by_adens` method to `divide_by_atoms`, which accurately describes what the method is actually doing. We had talked about this over the summer but then forgotten to actually include it on any PRs.