### PR TITLE
Fix bug in `openmc.Universe.get_nuclide_densities()`

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -469,7 +469,7 @@ class Universe(UniverseBase):
         """
         nuclides = OrderedDict()
 
-        if self._atoms is not None:
+        if len(self._atoms) > 0:
             volume = self.volume
             for name, atoms in self._atoms.items():
                 nuclide = openmc.Nuclide(name)

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -469,7 +469,7 @@ class Universe(UniverseBase):
         """
         nuclides = OrderedDict()
 
-        if len(self._atoms) > 0:
+        if self._atoms:
             volume = self.volume
             for name, atoms in self._atoms.items():
                 nuclide = openmc.Nuclide(name)

--- a/tests/unit_tests/test_universe.py
+++ b/tests/unit_tests/test_universe.py
@@ -132,3 +132,14 @@ def test_create_xml(cell_with_lattice):
     assert all(c.get('universe') == str(u.id) for c in cell_elems)
     assert not (set(c.get('id') for c in cell_elems) ^
                 set(str(c.id) for c in cells))
+
+
+def test_get_nuclide_densities():
+    surf = openmc.Sphere()
+    material = openmc.Material()
+    material.add_elements_from_formula("H2O")
+    material.set_density("g/cm3", 1)
+    cell = openmc.Cell(region=-surf,fill=material)
+    universe = openmc.Universe(cells=[cell])
+    with pytest.raises(RuntimeError):
+        universe.get_nuclide_densities()

--- a/tests/unit_tests/test_universe.py
+++ b/tests/unit_tests/test_universe.py
@@ -139,7 +139,7 @@ def test_get_nuclide_densities():
     material = openmc.Material()
     material.add_elements_from_formula("H2O")
     material.set_density("g/cm3", 1)
-    cell = openmc.Cell(region=-surf,fill=material)
+    cell = openmc.Cell(region=-surf, fill=material)
     universe = openmc.Universe(cells=[cell])
     with pytest.raises(RuntimeError):
         universe.get_nuclide_densities()


### PR DESCRIPTION
In the Universe object, the `_atoms` attribute is initialized to an empty dictionary. This attribute is only set once volumes are added to the universe. When the `get_nuclide_densities()` method is called, a check is present to ensure volumes have been set before returning the nuclide densities. The check was invalid, meaning the Exception was not raised and an empty nuclide dictionary was instead returned. This PR corrects this bug by ensuring the Exception is properly raised.