### PR TITLE
Fix photon transport when no atomic relaxation data is present

### DIFF
--- a/docs/source/devguide/tests.rst
+++ b/docs/source/devguide/tests.rst
@@ -31,9 +31,13 @@ Prerequisites
 
 - The test suite requires a specific set of cross section data in order for
   tests to pass. A download URL for the data that OpenMC expects can be found
-  within ``tools/ci/download-xs.sh``.
+  within ``tools/ci/download-xs.sh``. Once the tarball is downloaded and
+  unpacked, set the :envvar:`OPENMC_CROSS_SECTIONS` environment variable to the
+  path of the ``cross_sections.xml`` file within the unpacked data.
 - In addition to the HDF5 data, some tests rely on ENDF files. A download URL
-  for those can also be found in ``tools/ci/download-xs.sh``.
+  for those can also be found in ``tools/ci/download-xs.sh``. Once the tarball
+  is downloaded and unpacked, set the :envvar:`OPENMC_ENDF_DATA` environment
+  variable to the top-level directory of the unpacked tarball.
 - Some tests require `NJOY <https://www.njoy21.io/NJOY2016>`_ to preprocess
   cross section data. The test suite assumes that you have an ``njoy``
   executable available on your :envvar:`PATH`.

--- a/include/openmc/photon.h
+++ b/include/openmc/photon.h
@@ -100,6 +100,9 @@ public:
   // Bremsstrahlung scaled DCS
   xt::xtensor<double, 2> dcs_;
 
+  // Whether atomic relaxation data is present
+  bool has_atomic_relaxation_ {false};
+
   // Constant data
   static constexpr int MAX_STACK_SIZE =
     7; //!< maximum possible size of atomic relaxation stack

--- a/openmc/data/photon.py
+++ b/openmc/data/photon.py
@@ -13,7 +13,7 @@ from scipy.interpolate import CubicSpline
 
 import openmc.checkvalue as cv
 from openmc.mixin import EqualityMixin
-from . import HDF5_VERSION
+from . import HDF5_VERSION, HDF5_VERSION_MAJOR
 from .ace import Table, get_metadata, get_table
 from .data import ATOMIC_SYMBOL, EV_PER_MEV
 from .endf import Evaluation, get_head_record, get_tab1_record, get_list_record
@@ -143,6 +143,8 @@ class AtomicRelaxation(EqualityMixin):
         Dictionary indicating the number of electrons in a subshell when neutral
         (values) for given subshells (keys). The subshells should be given as
         strings, e.g., 'K', 'L1', 'L2', etc.
+    subshells : list
+        List of subshells as strings, e.g. ``['K', 'L1', ...]``
     transitions : pandas.DataFrame
         Dictionary indicating allowed transitions and their probabilities
         (values) for given subshells (keys). The subshells should be given as

--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -154,7 +154,6 @@ PhotonInteraction::PhotonInteraction(hid_t group)
 
     // TODO: Move to ElectronSubshell constructor
 
-    // Read binding energy and number of electrons
     hid_t tgroup = open_group(rgroup, designator.c_str());
 
     // Read binding energy energy and number of electrons if atomic relaxation

--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -156,8 +156,14 @@ PhotonInteraction::PhotonInteraction(hid_t group)
 
     // Read binding energy and number of electrons
     hid_t tgroup = open_group(rgroup, designator.c_str());
-    read_attribute(tgroup, "binding_energy", shell.binding_energy);
-    read_attribute(tgroup, "num_electrons", shell.n_electrons);
+
+    // Read binding energy energy and number of electrons if atomic relaxation
+    // data is present
+    if (attribute_exists(tgroup, "binding_energy")) {
+      has_atomic_relaxation_ = true;
+      read_attribute(tgroup, "binding_energy", shell.binding_energy);
+      read_attribute(tgroup, "num_electrons", shell.n_electrons);
+    }
 
     // Read subshell cross section
     xt::xtensor<double, 1> xs;
@@ -757,6 +763,10 @@ void PhotonInteraction::pair_production(double alpha, double* E_electron,
 
 void PhotonInteraction::atomic_relaxation(int i_shell, Particle& p) const
 {
+  // Return if no atomic relaxation data is present
+  if (!has_atomic_relaxation_)
+    return;
+
   // Stack for unprocessed holes left by transitioning electrons
   int n_holes = 0;
   array<int, MAX_STACK_SIZE> holes;

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -366,7 +366,14 @@ void sample_photon_reaction(Particle& p)
         xs_lower(i_shell) + f * (xs_upper(i_shell) - xs_lower(i_shell)));
 
       if (prob > cutoff) {
-        double E_electron = p.E() - shell.binding_energy;
+        // Determine binding energy based on whether atomic relaxation data is
+        // present (if not, use value from Compton profile data)
+        double binding_energy = element.has_atomic_relaxation_
+                                  ? shell.binding_energy
+                                  : element.binding_energy_[i_shell];
+
+        // Determine energy of secondary electron
+        double E_electron = p.E() - binding_energy;
 
         // Sample mu using non-relativistic Sauter distribution.
         // See Eqns 3.19 and 3.20 in "Implementing a photon physics


### PR DESCRIPTION
Right now there is an implicit assumption in the `PhotonInteraction` class that atomic relaxation data always exists. However, some nuclear data libraries only include photoatomic data with no corresponding atomic relaxation data (e.g., FENDL). In this case, we need some extra checks to ensure that we avoid trying to go through the atomic relaxation routines if no data is present. This PR fixes this situation by adding these checks.