### PR TITLE
added from_cell_with_material

### DIFF
--- a/openmc/source.py
+++ b/openmc/source.py
@@ -329,6 +329,41 @@ class Source:
 
         return source
 
+    @classmethod
+    def from_cell_with_material(cls, cell):
+        """Generate an isotropic photon source from an openmc.Cell object.
+
+        Parameters
+        ----------
+        cell : openmc.Cell
+            OpenMC cell object to use for the source creation
+
+        Returns
+        -------
+        openmc.Source
+            Source generated from an openmc.Material
+
+        """
+
+        if cell.fill is None:
+            msg = ("The cell must be filled with an openmc.Material object "
+                   "as this method make use of the cells material and the " 
+                   "Material.decay_photon_energy method.")
+            raise ValueError(msg)
+        if cell.fill.volume is None:
+            msg = ("The openmc.Material object that the cell is filled with "
+                   "must have the volume property set")
+            raise ValueError(msg)
+
+        source = cls()
+        source.domain=cell
+        source.particle = 'photon'
+        source.energy=cell.fill.decay_photon_energy
+        source.space=openmc.stats.Box(*cell.bounding_box)
+        source.angle=openmc.stats.multivariate.Isotropic()
+        source.strength=cell.fill.decay_photon_energy.integral()
+
+        return source
 
 class ParticleType(Enum):
     NEUTRON = 0

--- a/tests/unit_tests/test_source.py
+++ b/tests/unit_tests/test_source.py
@@ -134,3 +134,21 @@ def test_rejection(run_in_tmpdir):
         assert p.r not in non_source_region
 
     openmc.lib.finalize()
+
+
+def test_from_cell_with_material():
+    mat=openmc.Material()
+    mat.add_element('U',1)
+    mat.volume=1
+    mat.set_density('g/cm3',1)
+
+    surf = openmc.Sphere(r=1)
+    cell=openmc.Cell(region=-surf)
+    cell.fill=mat
+
+    source=openmc.Source.from_cell_with_material(cell)
+    assert isinstance(source, openmc.Source())
+    assert source.space.lower_left == [-1, -1, -1]
+    assert source.space.upper_right == [1, 1, 1]
+    assert source.domain.region == -surf
+    assert source.particle == 'photon'


### PR DESCRIPTION
Following up on issue #2237 as I noticed this could be useful for the R2SModel class under developement by @eepeterson perhaps this class method for making a photon source from a cell containing activated material could shorten the code needed in the R2SModel