### PR TITLE
added energy cut for decay photons

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -291,12 +291,13 @@ class Material(IDManagerMixin):
                 dists.append(source_per_atom)
                 probs.append(num_atoms)
 
-        if min_energy_cutoff and dists:
-            not_cut_energies = dists.x > min_energy_cutoff
-            dists.x = dists.x[not_cut_energies]
-            probs.p = probs.p[not_cut_energies]
+        combo_dist = openmc.data.combine_distributions(dists, probs) if dists else None
 
-        return openmc.data.combine_distributions(dists, probs) if dists else None
+        if min_energy_cutoff and dists:
+            not_cut_energies = combo_dist.x > min_energy_cutoff
+            combo_dist.x = combo_dist.x[not_cut_energies]
+            combo_dist.p = combo_dist.p[not_cut_energies]
+        return combo_dist
 
     @classmethod
     def from_hdf5(cls, group: h5py.Group):

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -558,6 +558,12 @@ def test_decay_photon_energy():
     # Get decay photon source and make sure it's the right type
     src = m.decay_photon_energy()
     assert isinstance(src, openmc.stats.Discrete)
+    assert len(src.x) == 98
+    assert len(src.p) == 98
+    src = m.decay_photon_energy(min_energy_cutoff=4000.)
+    # just one less entry as the cutoff removes a single photon energy
+    assert len(src.x) == 97
+    assert len(src.p) == 97
 
     # If we add Xe135 (which has a tabular distribution), the photon source
     # should be a mixture distribution

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -556,13 +556,13 @@ def test_decay_photon_energy():
     m.volume = 1.0
 
     # Get decay photon source and make sure it's the right type
-    src = m.decay_photon_energy
+    src = m.decay_photon_energy()
     assert isinstance(src, openmc.stats.Discrete)
 
     # If we add Xe135 (which has a tabular distribution), the photon source
     # should be a mixture distribution
     m.add_nuclide('Xe135', 1.0e-24)
-    src = m.decay_photon_energy
+    src = m.decay_photon_energy()
     assert isinstance(src, openmc.stats.Mixture)
 
     # With a single atom of each, the intensity of the photon source should be
@@ -578,4 +578,4 @@ def test_decay_photon_energy():
     stable = openmc.Material()
     stable.add_nuclide('Gd156', 1.0)
     stable.volume = 1.0
-    assert stable.decay_photon_energy is None
+    assert stable.decay_photon_energy() is None


### PR DESCRIPTION
This topic has come up on discourse before on [discourse](https://openmc.discourse.group/t/shutdown-dose-rate-calculations/2289/6) and also on @eepeterson R2Smodel branch.

Perhaps it is worth adding some low energy cut to ```material.decay_photon_energy``` to allow users to conveniently remove low energy photons from the simulation. These low energy photons cause issues during transport so we could even have a default set to remove them automatically but perhaps that is a step to far.

I'm sure there are more efficient ways of doing this, perhaps in the C++ layer we could automatically not transport these photons. However this approach allow users to be aware that they are getting removed from the source.

So I've thrown together this PR for your consideration it is based on @paulromano comment on discourse and @eepeterson R2sModel branch. If people think this is worth considering then I would be keen to add some tests