### PR TITLE
Fix algorithm for adding parentheses to enforce precedence in region expressions

### DIFF
--- a/tests/regression_tests/complex_cell/geometry.xml
+++ b/tests/regression_tests/complex_cell/geometry.xml
@@ -19,7 +19,7 @@
 
   <cell id="1" material="1" region="3 -4 13 -14" />
   <cell id="2" material="2" region="2 -5 12 -15 ~(3 -4 13 -14)" />
-  <cell id="3" material="3" region="((1 -7 17 -16) | (7 -6 11 -17)) (-2 | 5 | -12 | 15)" />
+  <cell id="3" material="3" region="(1 -7 17 -16 | 7 -6 11 -17) (-2 | 5 | -12 | 15)" />
   <cell id="4" material="4" region="((1 -7 11 -17) | (7 -6 17 -16)) ~(2 -5 12 -15)" />
 
 </geometry>


### PR DESCRIPTION
I was recently working with a model that was generated by [csg2csg](https://github.com/makeclean/csg2csg) that included a region expression with something like the following `(1 -2 | 3)`. In this expression, there is both an intersection operator (implicit, between 1 and -2) and a union operator (between -2 and 3). This expression was causing OpenMC to crash on initialization due to the recent refactoring/optimization done by @myerspat in #2178. After digging into it, I discovered two issues:
1. The `add_parentheses` method occasionally returned an iterator that pointed to memory outside of the vector it's supposed to be referencing.
2. For this particular case (union after intersection), parentheses were not being added in the correct place. Specifically, we would end up with the expression `(1 -2 | ( ) 3)` instead of `((1 -2) | 3)`.

This PR fixes both these issues, the first of which is handled by changes in `add_parentheses` and the second of which handled by changes in `add_precedence`. I've also updated the `complex_cell` regression test to cover this case.

As a final note, XML files generated by OpenMC's Python API already have precedence enforced so these bugs wouldn't affect models that were generated from the Python API. This was only discovered because `csg2csg` directly writes geometry.xml files without going through OpenMC's Python API.