### PR TITLE
Allow source particles with energy below cutoff

### DIFF
--- a/docs/source/usersguide/tallies.rst
+++ b/docs/source/usersguide/tallies.rst
@@ -269,9 +269,8 @@ The following tables show all valid scores:
     |heating               |Total nuclear heating in units of eV per source    |
     |                      |particle. For neutrons, this corresponds to MT=301 |
     |                      |produced by NJOY's HEATR module while for photons, |
-    |                      |this is tallied from either direct photon energy   |
-    |                      |deposition (analog estimator) or pre-generated     |
-    |                      |photon heating number. See :ref:`methods_heating`  |
+    |                      |this is tallied from direct photon energy          |
+    |                      |deposition. See :ref:`methods_heating`.            |
     +----------------------+---------------------------------------------------+
     |heating-local         |Total nuclear heating in units of eV per source    |
     |                      |particle assuming energy from secondary photons is |

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -256,9 +256,6 @@ SourceSite IndependentSource::sample(uint64_t* seed) const
     if (xt::any(energies > data::energy_max[p])) {
       fatal_error("Source energy above range of energies of at least "
                   "one cross section table");
-    } else if (xt::any(energies < data::energy_min[p])) {
-      fatal_error("Source energy below range of energies of at least "
-                  "one cross section table");
     }
   }
 
@@ -266,8 +263,8 @@ SourceSite IndependentSource::sample(uint64_t* seed) const
     // Sample energy spectrum
     site.E = energy_->sample(seed);
 
-    // Resample if energy falls outside minimum or maximum particle energy
-    if (site.E < data::energy_max[p] && site.E > data::energy_min[p])
+    // Resample if energy falls above maximum particle energy
+    if (site.E < data::energy_max[p])
       break;
 
     n_reject++;


### PR DESCRIPTION
This PR allows a source energy distribution to include particles below the user-defined cutoff (default 1 keV for photons). Right now, if you have a discrete distribution and some of the points are below the cutoff, you will get an error about the source energies. However, a more desirable behavior would be to allow source particles of these energies and just have them immediately deposit their energy. We already have an early check to kill off photons below the cutoff before any collision processing:
https://github.com/openmc-dev/openmc/blob/d7fc8e59a27fd9581450b7ea25d89a7637c6cb03/src/physics.cpp#L269-L277
So with that, the fix is as simple as allowing the source particles to be born in the first place.

This has come up in the context of fusion dose rate calculations where a decay photon source is generated from an activated material. The new `decay_photon_energy` function/method often results in a distribution that includes low-energy photons that will trigger the aforementioned error.