### PR TITLE
Fix `IncidentNeutron.from_njoy` for high temperatures

### DIFF
--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -868,9 +868,8 @@ class IncidentNeutron(EqualityMixin):
 
             heatr_evals = get_evaluations(kwargs["heatr"])
             heatr_local_evals = get_evaluations(kwargs["heatr"] + "_local")
-            for ev, ev_local in zip(heatr_evals, heatr_local_evals):
-                temp = "{}K".format(round(ev.target["temperature"]))
 
+            for ev, ev_local, temp in zip(heatr_evals, heatr_local_evals, data.temperatures):
                 # Get total KERMA (originally from ACE file) and energy grid
                 kerma = data.reactions[301].xs[temp]
                 E = kerma.x

--- a/tests/unit_tests/test_data_neutron.py
+++ b/tests/unit_tests/test_data_neutron.py
@@ -531,3 +531,12 @@ def test_ace_table_types():
     assert TT.from_suffix('20t') == TT.THERMAL_SCATTERING
     with pytest.raises(ValueError):
         TT.from_suffix('z')
+
+
+@needs_njoy
+def test_high_temperature():
+    endf_data = os.environ['OPENMC_ENDF_DATA']
+    endf_file = os.path.join(endf_data, 'neutrons', 'n-001_H_001.endf')
+
+    # Ensure that from_njoy works when given a high temperature
+    openmc.data.IncidentNeutron.from_njoy(endf_file, temperatures=[123_456.0])


### PR DESCRIPTION
This PR closes #2317. The issue at hand is described very thoroughly in the issue, so I won't bother to repeat it here. I'll just note that I've also added a small test to cover this case.