### PR TITLE
Add capability to unset cell temperatures

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -318,12 +318,12 @@ class Cell(IDManagerMixin):
     @temperature.setter
     def temperature(self, temperature):
         # Make sure temperatures are positive
-        cv.check_type('cell temperature', temperature, (Iterable, Real))
+        cv.check_type('cell temperature', temperature, (Iterable, Real), none_ok=True)
         if isinstance(temperature, Iterable):
             cv.check_type('cell temperature', temperature, Iterable, Real)
             for T in temperature:
                 cv.check_greater_than('cell temperature', T, 0.0, True)
-        else:
+        elif isinstance(temperature, Real):
             cv.check_greater_than('cell temperature', temperature, 0.0, True)
 
         # If this cell is filled with a universe or lattice, propagate

--- a/tests/unit_tests/test_cell.py
+++ b/tests/unit_tests/test_cell.py
@@ -92,6 +92,9 @@ def test_temperature(cell_with_lattice):
     assert c2.temperature == 400.0
     with pytest.raises(ValueError):
         c.temperature = -100.
+    c.temperature = None
+    assert c1.temperature == None
+    assert c2.temperature == None
 
     # distributed temperature
     cells, _, _, _ = cell_with_lattice


### PR DESCRIPTION
Adds "None" as an acceptable value for a cell's temperature. This serves as a method to unset a cell's temperature and to ensure that the unsetting propagates throughout everything filled inside of the cell.

Presently, once a cell's temperature is set, there is no method to unset the temperature without accessing the private _temperature attribute (which does not propagate the unsetting to the fills within this cell and is not desirable for users).