### PR TITLE
Minor revisions to support Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy<1.22", "cython"]
+requires = ["setuptools", "wheel", "numpy<1.24", "cython"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy<1.24", "cython"]
+requires = ["setuptools", "wheel", "numpy", "cython"]

--- a/setup.py
+++ b/setup.py
@@ -54,10 +54,10 @@ kwargs = {
         'Programming Language :: C++',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 
     # Dependencies

--- a/tests/regression_tests/cmfd_feed/test.py
+++ b/tests/regression_tests/cmfd_feed/test.py
@@ -111,7 +111,7 @@ def test_cmfd_write_matrices():
     # Load flux vector from numpy output file
     flux_np = np.load('fluxvec.npy')
     # Load flux from data file
-    flux_dat = np.loadtxt("fluxvec.dat", delimiter='\n')
+    flux_dat = np.loadtxt("fluxvec.dat")
 
     # Compare flux from numpy file, .dat file, and from simulation
     assert(np.all(np.isclose(flux_np, cmfd_run._phi)))


### PR DESCRIPTION
Getting openmc working on Python 3.11 requires a version upgrade to numpy, which differs in behavior for the project only in the use of `np.loadtxt()` which now explicitly disallows specifying newlines as the delimiter character. This change updates the package version restrictions and fixes the one test with an explicit dependency on the former delimiter behavior.