### PR TITLE
allows Geometry.from_xml() to accept path for materials file

### DIFF
--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
 import numpy as np
 import openmc
@@ -274,7 +275,18 @@ def test_from_xml(run_in_tmpdir, mixed_lattice_model):
     # Export model
     mixed_lattice_model.export_to_xml()
 
-    # Import geometry
+    mats_from_xml = openmc.Materials.from_xml('materials.xml')
+    # checking string a Path are both acceptable
+    for path in ['geometry.xml', Path('geometry.xml')]:
+        for materials in [mats_from_xml, 'matreials.xml']:
+            # Import geometry from file
+            geom = openmc.Geometry.from_xml(path=path)
+            assert isinstance(geom, openmc.Geometry)
+            ll, ur = geom.bounding_box
+            assert ll == pytest.approx((-6.0, -6.0, -np.inf))
+            assert ur == pytest.approx((6.0, 6.0, np.inf))
+        
+    # checking that the default args also work
     geom = openmc.Geometry.from_xml()
     assert isinstance(geom, openmc.Geometry)
     ll, ur = geom.bounding_box

--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -278,9 +278,9 @@ def test_from_xml(run_in_tmpdir, mixed_lattice_model):
     mats_from_xml = openmc.Materials.from_xml('materials.xml')
     # checking string a Path are both acceptable
     for path in ['geometry.xml', Path('geometry.xml')]:
-        for materials in [mats_from_xml, 'matreials.xml']:
+        for materials in [mats_from_xml, 'materials.xml']:
             # Import geometry from file
-            geom = openmc.Geometry.from_xml(path=path)
+            geom = openmc.Geometry.from_xml(path=path, materials=materials)
             assert isinstance(geom, openmc.Geometry)
             ll, ur = geom.bounding_box
             assert ll == pytest.approx((-6.0, -6.0, -np.inf))


### PR DESCRIPTION
This PR attempts to allow the materials.xml filename / filepath to be specified when creating a geometry from a xml file. Perhaps this is slightly more flexible that the hard coded use of 'materials.xml' which we have currently.

I have added to the existing test to check the geometry is still loaded for a few different combinations of arguments.

Also it opens up the potential use of materials=None to pass in no materials. In the longer term I would be keen to propose the option of no materials when loading the geometry.