### PR TITLE
Change GND to GNDS

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -247,7 +247,7 @@ napoleon_use_ivar = True
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
-    'matplotlib': ('https://matplotlib.org/', None)
+    'matplotlib': ('https://matplotlib.org/stable/', None)
 }

--- a/docs/source/pythonapi/data.rst
+++ b/docs/source/pythonapi/data.rst
@@ -66,7 +66,7 @@ Core Functions
     decay_energy
     decay_photon_energy
     dose_coefficients
-    gnd_name
+    gnds_name
     half_life
     isotopes
     kalbach_slope

--- a/docs/source/usersguide/scripts.rst
+++ b/docs/source/usersguide/scripts.rst
@@ -157,9 +157,9 @@ geometry.xml
   added. Any 'surfaces' attributes/elements on a cell will be renamed 'region'.
 
 materials.xml
-  Nuclide names will be changed from ACE aliases (e.g., Am-242m) to HDF5/GND
+  Nuclide names will be changed from ACE aliases (e.g., Am-242m) to HDF5/GNDS
   names (e.g., Am242_m1). Thermal scattering table names will be changed from
-  ACE aliases (e.g., HH2O) to HDF5/GND names (e.g., c_H_in_H2O).
+  ACE aliases (e.g., HH2O) to HDF5/GNDS names (e.g., c_H_in_H2O).
 
 ----------------------
 ``openmc-update-mgxs``

--- a/openmc/data/ace.py
+++ b/openmc/data/ace.py
@@ -24,7 +24,7 @@ import numpy as np
 
 import openmc.checkvalue as cv
 from openmc.mixin import EqualityMixin
-from .data import ATOMIC_SYMBOL, gnd_name, EV_PER_MEV, K_BOLTZMANN
+from .data import ATOMIC_SYMBOL, gnds_name, EV_PER_MEV, K_BOLTZMANN
 from .endf import ENDF_FLOAT_RE
 
 
@@ -88,7 +88,7 @@ def get_metadata(zaid, metastable_scheme='nndc'):
 
     # Determine name
     element = ATOMIC_SYMBOL[Z]
-    name = gnd_name(Z, mass_number, metastable)
+    name = gnds_name(Z, mass_number, metastable)
 
     return (name, element, Z, mass_number, metastable)
 

--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -197,8 +197,8 @@ NEUTRON_MASS = 1.00866491595
 # Used in atomic_mass function as a cache
 _ATOMIC_MASS = {}
 
-# Regex for GND nuclide names (used in zam function)
-_GND_NAME_RE = re.compile(r'([A-Zn][a-z]*)(\d+)((?:_[em]\d+)?)')
+# Regex for GNDS nuclide names (used in zam function)
+_GNDS_NAME_RE = re.compile(r'([A-Zn][a-z]*)(\d+)((?:_[em]\d+)?)')
 
 # Used in half_life function as a cache
 _HALF_LIFE = {}
@@ -436,8 +436,11 @@ def water_density(temperature, pressure=0.1013):
     return coeff / pi / gamma1_pi
 
 
-def gnd_name(Z, A, m=0):
-    """Return nuclide name using GND convention
+def gnds_name(Z, A, m=0):
+    """Return nuclide name using GNDS convention
+
+    .. versionchanged:: 0.14.0
+        Function name changed from ``gnd_name`` to ``gnds_name``
 
     Parameters
     ----------
@@ -451,7 +454,7 @@ def gnd_name(Z, A, m=0):
     Returns
     -------
     str
-        Nuclide name in GND convention, e.g., 'Am242_m1'
+        Nuclide name in GNDS convention, e.g., 'Am242_m1'
 
     """
     if m > 0:
@@ -502,7 +505,7 @@ def zam(name):
     Parameters
     ----------
     name : str
-        Name of nuclide using GND convention, e.g., 'Am242_m1'
+        Name of nuclide using GNDS convention, e.g., 'Am242_m1'
 
     Returns
     -------
@@ -511,10 +514,10 @@ def zam(name):
 
     """
     try:
-        symbol, A, state = _GND_NAME_RE.match(name).groups()
+        symbol, A, state = _GNDS_NAME_RE.match(name).groups()
     except AttributeError:
         raise ValueError(f"'{name}' does not appear to be a nuclide name in "
-                         "GND format")
+                         "GNDS format")
 
     if symbol not in ATOMIC_NUMBER:
         raise ValueError(f"'{symbol}' is not a recognized element symbol")

--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -144,7 +144,7 @@ class FissionProductYields(EqualityMixin):
 
         # Assign basic nuclide properties
         self.nuclide = {
-            'name': ev.gnd_name,
+            'name': ev.gnds_name,
             'atomic_number': ev.target['atomic_number'],
             'mass_number': ev.target['mass_number'],
             'isomeric_state': ev.target['isomeric_state']

--- a/openmc/data/endf.py
+++ b/openmc/data/endf.py
@@ -12,7 +12,7 @@ import re
 
 import numpy as np
 
-from .data import gnd_name
+from .data import gnds_name
 from .function import Tabulated1D
 try:
     from ._endf import float_endf
@@ -520,10 +520,10 @@ class Evaluation:
             self.reaction_list.append((mf, mt, nc, mod))
 
     @property
-    def gnd_name(self):
-        return gnd_name(self.target['atomic_number'],
-                        self.target['mass_number'],
-                        self.target['isomeric_state'])
+    def gnds_name(self):
+        return gnds_name(self.target['atomic_number'],
+                         self.target['mass_number'],
+                         self.target['isomeric_state'])
 
 
 class Tabulated2D:
@@ -531,7 +531,7 @@ class Tabulated2D:
 
     This is a dummy class that is not really used other than to store the
     interpolation information for a two-dimensional function. Once we refactor
-    to adopt GND-like data containers, this will probably be removed or
+    to adopt GNDS-like data containers, this will probably be removed or
     extended.
 
     Parameters

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -748,12 +748,12 @@ class WindowedMultipole(EqualityMixin):
     Parameters
     ----------
     name : str
-        Name of the nuclide using the GND naming convention
+        Name of the nuclide using the GNDS naming convention
 
     Attributes
     ----------
     name : str
-        Name of the nuclide using the GND naming convention
+        Name of the nuclide using the GNDS naming convention
     spacing : float
         The width of each window in sqrt(E)-space.  For example, the frst window
         will end at (sqrt(E_min) + spacing)**2 and the second window at

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -44,7 +44,7 @@ class IncidentNeutron(EqualityMixin):
     Parameters
     ----------
     name : str
-        Name of the nuclide using the GND naming convention
+        Name of the nuclide using the GNDS naming convention
     atomic_number : int
         Number of protons in the target nucleus
     mass_number : int
@@ -75,7 +75,7 @@ class IncidentNeutron(EqualityMixin):
         Metastable state of the target nucleus. A value of zero indicates ground
         state.
     name : str
-        Name of the nuclide using the GND naming convention
+        Name of the nuclide using the GNDS naming convention
     reactions : collections.OrderedDict
         Contains the cross sections, secondary angle and energy distributions,
         and other associated data for each reaction. The keys are the MT values

--- a/openmc/data/reaction.py
+++ b/openmc/data/reaction.py
@@ -555,7 +555,7 @@ def _get_activation_products(ev, rx):
             Z, A = divmod(items[2], 1000)
             excited_state = items[3]
 
-            # Get GND name for product
+            # Get GNDS name for product
             symbol = ATOMIC_SYMBOL[Z]
             if excited_state > 0:
                 name = '{}{}_e{}'.format(symbol, A, excited_state)

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -104,7 +104,7 @@ def get_thermal_name(name):
     Returns
     -------
     str
-        GND-format thermal scattering name
+        GNDS-format thermal scattering name
 
     """
     if name in _THERMAL_NAMES:
@@ -396,7 +396,7 @@ class ThermalScattering(EqualityMixin):
     Parameters
     ----------
     name : str
-        Name of the material using GND convention, e.g. c_H_in_H2O
+        Name of the material using GNDS convention, e.g. c_H_in_H2O
     atomic_weight_ratio : float
         Atomic mass ratio of the target nuclide.
     kTs : Iterable of float
@@ -415,7 +415,7 @@ class ThermalScattering(EqualityMixin):
         Inelastic scattering cross section derived in the incoherent
         approximation
     name : str
-        Name of the material using GND convention, e.g. c_H_in_H2O
+        Name of the material using GNDS convention, e.g. c_H_in_H2O
     temperatures : Iterable of str
         List of string representations the temperatures of the target nuclide
         in the data set.  The temperatures are strings of the temperature,
@@ -491,7 +491,7 @@ class ThermalScattering(EqualityMixin):
             ACE table to read from. If given as a string, it is assumed to be
             the filename for the ACE file.
         name : str
-            GND-conforming name of the material, e.g. c_H_in_H2O. If none is
+            GNDS-conforming name of the material, e.g. c_H_in_H2O. If none is
             passed, the appropriate name is guessed based on the name of the ACE
             table.
 
@@ -596,7 +596,7 @@ class ThermalScattering(EqualityMixin):
             ACE table to read from. If given as a string, it is assumed to be
             the filename for the ACE file.
         name : str
-            GND-conforming name of the material, e.g. c_H_in_H2O. If none is
+            GNDS-conforming name of the material, e.g. c_H_in_H2O. If none is
             passed, the appropriate name is guessed based on the name of the ACE
             table.
 

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -15,7 +15,7 @@ from numbers import Real, Integral
 from warnings import warn
 
 from openmc.checkvalue import check_type, check_greater_than
-from openmc.data import gnd_name, zam, DataLibrary
+from openmc.data import gnds_name, zam, DataLibrary
 from openmc.exceptions import DataError
 from .nuclide import FissionYieldDistribution
 
@@ -135,14 +135,14 @@ def replace_missing(product, decay_data):
     Parameters
     ----------
     product : str
-        Name of product in GND format, e.g. 'Y86_m1'.
+        Name of product in GNDS format, e.g. 'Y86_m1'.
     decay_data : dict
         Dictionary of decay data
 
     Returns
     -------
     product : str
-        Replacement for missing product in GND format.
+        Replacement for missing product in GNDS format.
 
     """
     # Determine atomic number, mass number, and metastable state
@@ -213,7 +213,7 @@ def replace_missing_fpy(actinide, fpy_data, decay_data):
     # Check if metastable state has data (e.g., Am242m)
     Z, A, m = zam(actinide)
     if m == 0:
-        metastable = gnd_name(Z, A, 1)
+        metastable = gnds_name(Z, A, 1)
         if metastable in fpy_data:
             return metastable
 
@@ -222,7 +222,7 @@ def replace_missing_fpy(actinide, fpy_data, decay_data):
     while isotone in decay_data:
         Z += 1
         A += 1
-        isotone = gnd_name(Z, A, 0)
+        isotone = gnds_name(Z, A, 0)
         if isotone in fpy_data:
             return isotone
 
@@ -231,7 +231,7 @@ def replace_missing_fpy(actinide, fpy_data, decay_data):
     while isotone in decay_data:
         Z -= 1
         A -= 1
-        isotone = gnd_name(Z, A, 0)
+        isotone = gnds_name(Z, A, 0)
         if isotone in fpy_data:
             return isotone
 
@@ -357,7 +357,7 @@ class Chain:
         reactions = {}
         for f in neutron_files:
             evaluation = openmc.data.endf.Evaluation(f)
-            name = evaluation.gnd_name
+            name = evaluation.gnds_name
             reactions[name] = {}
             for mf, mt, nc, mod in evaluation.reaction_list:
                 if mf == 3:
@@ -904,7 +904,7 @@ class Chain:
                 ground_target = grounds.get(parent_name)
                 if ground_target is None:
                     pz, pa, pm = zam(parent_name)
-                    ground_target = gnd_name(pz, pa + 1, 0)
+                    ground_target = gnds_name(pz, pa + 1, 0)
                 new_ratios[ground_target] = ground_br
                 parent.add_reaction(reaction, ground_target, rxn_Q, ground_br)
 

--- a/openmc/deplete/nuclide.py
+++ b/openmc/deplete/nuclide.py
@@ -82,7 +82,7 @@ class Nuclide:
     Parameters
     ----------
     name : str, optional
-        GND name of this nuclide, e.g. ``"He4"``, ``"Am242_m1"``
+        GNDS name of this nuclide, e.g. ``"He4"``, ``"Am242_m1"``
 
     Attributes
     ----------

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -925,7 +925,7 @@ class MGXS:
         # Tabulate the atomic number densities for all nuclides
         elif nuclides == 'all':
             nuclides = self.get_nuclides()
-            densities = np.zeros(self.num_nuclides, dtype=np.float)
+            densities = np.zeros(self.num_nuclides, dtype=float)
             for i, nuclide in enumerate(nuclides):
                 densities[i] += self.get_nuclide_density(nuclide)
 
@@ -3019,7 +3019,7 @@ class DiffusionCoefficient(TransportXS):
                 new_filt = openmc.EnergyFilter(old_filt.values)
                 p1_tally.filters[-2] = new_filt
 
-                p1_tally = p1_tally.get_slice(filters=[openmc.LegendreFilter], 
+                p1_tally = p1_tally.get_slice(filters=[openmc.LegendreFilter],
                     filter_bins=[('P1',)],squeeze=True)
                 p1_tally._scores = ['scatter-1']
                 total_xs = self.tallies['total'] / self.tallies['flux (tracklength)']

--- a/openmc/nuclide.py
+++ b/openmc/nuclide.py
@@ -26,7 +26,7 @@ class Nuclide(str):
             if name.endswith('m'):
                 name = name[:-1] + '_m1'
 
-            msg = ('OpenMC nuclides follow the GND naming convention. '
+            msg = ('OpenMC nuclides follow the GNDS naming convention. '
                    f'Nuclide "{orig_name}" is being renamed as "{name}".')
             warnings.warn(msg)
 

--- a/scripts/openmc-update-inputs
+++ b/scripts/openmc-update-inputs
@@ -4,7 +4,6 @@
 """
 
 import argparse
-from difflib import get_close_matches
 from itertools import chain
 from random import randint
 from shutil import move
@@ -27,8 +26,8 @@ geometry.xml: Lattices containing 'outside' attributes/tags will be replaced
   will be renamed 'region'.
 
 materials.xml: Nuclide names will be changed from ACE aliases (e.g., Am-242m) to
-  HDF5/GND names (e.g., Am242_m1). Thermal scattering table names will be
-  changed from ACE aliases (e.g., HH2O) to HDF5/GND names (e.g., c_H_in_H2O).
+  HDF5/GNDS names (e.g., Am242_m1). Thermal scattering table names will be
+  changed from ACE aliases (e.g., HH2O) to HDF5/GNDS names (e.g., c_H_in_H2O).
 
 """
 

--- a/tests/regression_tests/diff_tally/test.py
+++ b/tests/regression_tests/diff_tally/test.py
@@ -103,9 +103,8 @@ class DiffTallyTestHarness(PyAPITestHarness):
         sp = openmc.StatePoint(statepoint)
 
         # Extract the tally data as a Pandas DataFrame.
-        df = pd.DataFrame()
-        for t in sp.tallies.values():
-            df = df.append(t.get_pandas_dataframe(), ignore_index=True)
+        tally_dfs = [t.get_pandas_dataframe() for t in sp.tallies.values()]
+        df = pd.concat(tally_dfs, ignore_index=True)
 
         # Extract the relevant data as a CSV string.
         cols = ('d_material', 'd_nuclide', 'd_variable', 'score', 'mean',

--- a/tests/regression_tests/surface_tally/test.py
+++ b/tests/regression_tests/surface_tally/test.py
@@ -164,9 +164,8 @@ class SurfaceTallyTestHarness(PyAPITestHarness):
         sp = openmc.StatePoint(self._sp_name)
 
         # Extract the tally data as a Pandas DataFrame.
-        df = pd.DataFrame()
-        for t in sp.tallies.values():
-            df = df.append(t.get_pandas_dataframe(), ignore_index=True)
+        tally_dfs = [t.get_pandas_dataframe() for t in sp.tallies.values()]
+        df = pd.concat(tally_dfs, ignore_index=True)
 
         # Extract the relevant data as a CSV string.
         cols = ('mean', 'std. dev.')

--- a/tests/unit_tests/test_data_misc.py
+++ b/tests/unit_tests/test_data_misc.py
@@ -101,12 +101,12 @@ def test_water_density():
     assert dens(500.0, 3.0) == pytest.approx(1e-3/0.120241800e-2, 1e-6)
 
 
-def test_gnd_name():
-    assert openmc.data.gnd_name(1, 1) == 'H1'
-    assert openmc.data.gnd_name(40, 90) == ('Zr90')
-    assert openmc.data.gnd_name(95, 242, 0) == ('Am242')
-    assert openmc.data.gnd_name(95, 242, 1) == ('Am242_m1')
-    assert openmc.data.gnd_name(95, 242, 10) == ('Am242_m10')
+def test_gnds_name():
+    assert openmc.data.gnds_name(1, 1) == 'H1'
+    assert openmc.data.gnds_name(40, 90) == ('Zr90')
+    assert openmc.data.gnds_name(95, 242, 0) == ('Am242')
+    assert openmc.data.gnds_name(95, 242, 1) == ('Am242_m1')
+    assert openmc.data.gnds_name(95, 242, 10) == ('Am242_m10')
 
 
 def test_isotopes():

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -77,8 +77,8 @@ def test_write_data_to_vtk_size_mismatch(mesh):
     # by regex. These are needed to make the test string match the error message
     # string when using the match argument as that uses regular expression
     expected_error_msg = (
-        f"The size of the dataset 'label' \({len(data)}\) should be equal to "
-        f"the number of mesh cells \({mesh.num_mesh_cells}\)"
+        f"The size of the dataset 'label' ({len(data)}) should be equal to "
+        f"the number of mesh cells ({mesh.num_mesh_cells})"
     )
     with pytest.raises(ValueError, match=expected_error_msg):
         mesh.write_data_to_vtk(filename="out.vtk", datasets={"label": data})

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -77,8 +77,8 @@ def test_write_data_to_vtk_size_mismatch(mesh):
     # by regex. These are needed to make the test string match the error message
     # string when using the match argument as that uses regular expression
     expected_error_msg = (
-        f"The size of the dataset 'label' ({len(data)}) should be equal to "
-        f"the number of mesh cells ({mesh.num_mesh_cells})"
+        fr"The size of the dataset 'label' \({len(data)}\) should be equal to "
+        fr"the number of mesh cells \({mesh.num_mesh_cells}\)"
     )
     with pytest.raises(ValueError, match=expected_error_msg):
         mesh.write_data_to_vtk(filename="out.vtk", datasets={"label": data})


### PR DESCRIPTION
A few places in the Python API mention "GND", which was the name that preceded [GNDS](https://www.oecd-nea.org/jcms/pl_39689/specifications-for-the-generalised-nuclear-database-structure-gnds) (Generalized Nuclear Database Structure). This PR simply updates the naming to use GNDS. I've also fixed a few small issues:

- Addressed several warnings that would pop up when running tests (deprecated method from pandas, invalid escape sequence, improper use of numpy.float)
- Updated intersphinx URLs