### PR TITLE
allowing xml file for materials

### DIFF
--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -267,7 +267,7 @@ class Geometry:
         ----------
         path : PathLike, optional
             Path to geometry XML file
-        materials : openmc.Materials or or PathLike
+        materials : openmc.Materials or PathLike
             Materials used to assign to cells. If PathLike, an attempt is made
             to generate materials from the provided xml file.
 

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -1,3 +1,5 @@
+import os
+import typing
 from collections import OrderedDict, defaultdict
 from collections.abc import Iterable
 from copy import deepcopy
@@ -7,7 +9,7 @@ import warnings
 
 import openmc
 import openmc._xml as xml
-from .checkvalue import check_type, check_less_than, check_greater_than
+from .checkvalue import check_type, check_less_than, check_greater_than, PathLike
 
 
 class Geometry:
@@ -254,16 +256,20 @@ class Geometry:
             raise ValueError('Error determining root universe.')
 
     @classmethod
-    def from_xml(cls, path='geometry.xml', materials=None):
+    def from_xml(
+        cls,
+        path: PathLike = 'geometry.xml',
+        materials: typing.Optional[typing.Union[PathLike, 'openmc.Materials']] = 'materials.xml'
+    ):
         """Generate geometry from XML file
 
         Parameters
         ----------
-        path : str, optional
+        path : PathLike, optional
             Path to geometry XML file
-        materials : openmc.Materials or None
-            Materials used to assign to cells. If None, an attempt is made to
-            generate it from the materials.xml file.
+        materials : openmc.Materials or or PathLike
+            Materials used to assign to cells. If PathLike, an attempt is made
+            to generate materials from the provided xml file.
 
         Returns
         -------
@@ -271,10 +277,13 @@ class Geometry:
             Geometry object
 
         """
-        # Create dictionary to easily look up materials
-        if materials is None:
-            filename = Path(path).parent / 'materials.xml'
-            materials = openmc.Materials.from_xml(str(filename))
+
+        # Using str and os.Pathlike here to avoid error when using just the imported PathLike
+        # TypeError: Subscripted generics cannot be used with class and instance checks
+        check_type('materials', materials, (str, os.PathLike, openmc.Materials))
+
+        if isinstance(materials, (str, os.PathLike)):
+            materials = openmc.Materials.from_xml(materials)
 
         tree = ET.parse(path)
         root = tree.getroot()

--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -290,7 +290,6 @@ def test_from_xml(run_in_tmpdir, mixed_lattice_model):
         geom = openmc.Geometry.from_xml(path='geometry.xml', materials=None)
     assert 'Unable to set "materials" to "None"' in str(excinfo.value)
 
-
     # checking that the default args also work
     geom = openmc.Geometry.from_xml()
     assert isinstance(geom, openmc.Geometry)


### PR DESCRIPTION
This PR replaces #2326 which got a bit conflicted with the develop branch after #2291 was merged in.

This PR attempts to allow the materials.xml filename / filepath to be specified when creating a geometry from a xml file. Perhaps this is slightly more flexible that the hard coded use of 'materials.xml' which we have currently.

I have added to the existing test to check the geometry is still loaded for a few different combinations of arguments.

Also it opens up the potential use of materials=None to pass in no materials. In the longer term I would be keen to propose the option of no materials when loading the geometry.
