### PR TITLE
Small fix in `plot_xs` when S(a,b) tables are present

### DIFF
--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -563,7 +563,7 @@ def _calculate_cexs_elem_mat(this, types, temperature=294.,
     for nuclide in nuclides.items():
         sabs[nuclide[0]] = None
     if isinstance(this, openmc.Material):
-        for sab_name in this._sab:
+        for sab_name, _ in this._sab:
             sab = openmc.data.ThermalScattering.from_hdf5(
                 library.get_by_material(sab_name, data_type='thermal')['path'])
             for nuc in sab.nuclides:

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -1,0 +1,27 @@
+import openmc
+import numpy as np
+
+
+def test_calculate_cexs_elem_mat_sab():
+    """Checks that sab cross sections are included in the
+    _calculate_cexs_elem_mat method and have the correct shape"""
+
+    mat_1 = openmc.Material()
+    mat_1.add_element("H", 4.0, "ao")
+    mat_1.add_element("O", 4.0, "ao")
+    mat_1.add_element("C", 4.0, "ao")
+
+    mat_1.add_s_alpha_beta("c_C6H6")
+    mat_1.set_density("g/cm3", 0.865)
+
+    energy_grid, data = openmc.plotter._calculate_cexs_elem_mat(
+        mat_1,
+        ["inelastic"],
+        sab_name="c_C6H6",
+    )
+
+    assert isinstance(energy_grid, np.ndarray)
+    assert isinstance(data, np.ndarray)
+    assert len(energy_grid) > 1
+    assert len(data) == 1
+    assert len(data[0]) == len(energy_grid)


### PR DESCRIPTION
A user [noted](https://openmc.discourse.group/t/plot-elastic-scattering-cross-section-for-mesitylene-at-20k-including-s-a-b/2563/4) an error when trying to plot a cross section using `openmc.plot_xs` for a material that included an S(a,b) table. It turned out to be a simple one-line fix.

@nelsonag Hope you wouldn't mind taking a quick look at this when you have a moment!