### PR TITLE
Correct typo in how score is indexed for trigger console. 

### DIFF
--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -101,7 +101,7 @@ void check_tally_triggers(double& ratio, int& tally_id, int& score)
           // If this is the most uncertain value, set the output variables.
           if (this_ratio > ratio) {
             ratio = this_ratio;
-            score = t.scores_[trigger.score_index];
+            score = t.scores_[score_index];
             tally_id = t.id_;
           }
         }


### PR DESCRIPTION
As described in #2338, I'm fairly certain there is minor typo in how the limiting score is determined. This fix proposed here does give me the expected behavior, but could use a double-check.

Closes #2338