### PR TITLE
Manually instantiate cloned cells rather than deepcopying

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 from collections.abc import Iterable
-from copy import deepcopy
 from math import cos, sin, pi
 from numbers import Real
 from xml.etree import ElementTree as ET
@@ -519,8 +518,14 @@ class Cell(IDManagerMixin):
             paths = self._paths
             self._paths = None
 
-            clone = deepcopy(self)
-            clone.id = None
+            clone = openmc.Cell()
+            clone.name = self.name
+            clone.temperature = self.temperature
+            clone.volume = self.volume
+            if self.translation is not None:
+                clone.translation = self.translation
+            if self.rotation is not None:
+                clone.rotation = self.rotation
             clone._num_instances = None
 
             # Restore paths on original instance

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -520,8 +520,9 @@ class Cell(IDManagerMixin):
 
             clone = openmc.Cell()
             clone.name = self.name
-            clone.temperature = self.temperature
             clone.volume = self.volume
+            if self.temperature is not None:
+                clone.temperature = self.temperature
             if self.translation is not None:
                 clone.translation = self.translation
             if self.rotation is not None:

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -518,8 +518,7 @@ class Cell(IDManagerMixin):
             paths = self._paths
             self._paths = None
 
-            clone = openmc.Cell()
-            clone.name = self.name
+            clone = openmc.Cell(name=self.name)
             clone.volume = self.volume
             if self.temperature is not None:
                 clone.temperature = self.temperature

--- a/tests/unit_tests/test_cell.py
+++ b/tests/unit_tests/test_cell.py
@@ -58,24 +58,54 @@ def test_clone():
     cyl = openmc.ZCylinder()
     c = openmc.Cell(fill=m, region=-cyl)
     c.temperature = 650.
+    c.translation = (1,2,3)
+    c.rotation = (4,5,6)
+    c.volume = 100
 
     c2 = c.clone()
     assert c2.id != c.id
     assert c2.fill != c.fill
     assert c2.region != c.region
     assert c2.temperature == c.temperature
+    assert all(c2.translation == c.translation)
+    assert all(c2.rotation == c.rotation)
+    assert c2.volume == c.volume
 
     c3 = c.clone(clone_materials=False)
     assert c3.id != c.id
     assert c3.fill == c.fill
     assert c3.region != c.region
     assert c3.temperature == c.temperature
+    assert all(c2.translation == c.translation)
+    assert all(c2.rotation == c.rotation)
 
     c4 = c.clone(clone_regions=False)
     assert c4.id != c.id
     assert c4.fill != c.fill
     assert c4.region == c.region
     assert c4.temperature == c.temperature
+    assert all(c2.translation == c.translation)
+    assert all(c2.rotation == c.rotation)
+
+    c5 = c.clone(clone_materials=False, clone_regions=False)
+    assert c5.id != c.id
+    assert c5.fill == c.fill
+    assert c5.region == c.region
+    assert c5.temperature == c.temperature
+    assert all(c2.translation == c.translation)
+    assert all(c2.rotation == c.rotation)
+
+    # Mutate the original to ensure the changes are not seen in the clones
+    c.fill = openmc.Material()
+    c.region = +openmc.ZCylinder()
+    c.translation = [-1,-2,-3]
+    c.rotation = [-4,-5,-6]
+    c.temperature = 1
+    assert c5.fill != c.fill
+    assert c5.region != c.region
+    assert c5.temperature != c.temperature
+    assert all(c2.translation != c.translation)
+    assert all(c2.rotation != c.rotation)
 
 
 def test_temperature(cell_with_lattice):

--- a/tests/unit_tests/test_cell.py
+++ b/tests/unit_tests/test_cell.py
@@ -57,43 +57,37 @@ def test_clone():
     m = openmc.Material()
     cyl = openmc.ZCylinder()
     c = openmc.Cell(fill=m, region=-cyl)
-    c.temperature = 650.
-    c.translation = (1,2,3)
-    c.rotation = (4,5,6)
-    c.volume = 100
 
+    # Check cloning with all optional params as the defaults
     c2 = c.clone()
     assert c2.id != c.id
     assert c2.fill != c.fill
     assert c2.region != c.region
-    assert c2.temperature == c.temperature
-    assert all(c2.translation == c.translation)
-    assert all(c2.rotation == c.rotation)
-    assert c2.volume == c.volume
 
     c3 = c.clone(clone_materials=False)
     assert c3.id != c.id
     assert c3.fill == c.fill
     assert c3.region != c.region
-    assert c3.temperature == c.temperature
-    assert all(c2.translation == c.translation)
-    assert all(c2.rotation == c.rotation)
 
     c4 = c.clone(clone_regions=False)
     assert c4.id != c.id
     assert c4.fill != c.fill
     assert c4.region == c.region
-    assert c4.temperature == c.temperature
-    assert all(c2.translation == c.translation)
-    assert all(c2.rotation == c.rotation)
+
+    # Add optional properties to the original cell to ensure they're cloned successfully
+    c.temperature = 650.
+    c.translation = [1,2,3]
+    c.rotation = [4,5,6]
+    c.volume = 100
 
     c5 = c.clone(clone_materials=False, clone_regions=False)
     assert c5.id != c.id
     assert c5.fill == c.fill
     assert c5.region == c.region
     assert c5.temperature == c.temperature
-    assert all(c2.translation == c.translation)
-    assert all(c2.rotation == c.rotation)
+    assert c5.volume == c.volume
+    assert all(c5.translation == c.translation)
+    assert all(c5.rotation == c.rotation)
 
     # Mutate the original to ensure the changes are not seen in the clones
     c.fill = openmc.Material()
@@ -101,11 +95,13 @@ def test_clone():
     c.translation = [-1,-2,-3]
     c.rotation = [-4,-5,-6]
     c.temperature = 1
+    c.volume = 1
     assert c5.fill != c.fill
     assert c5.region != c.region
     assert c5.temperature != c.temperature
-    assert all(c2.translation != c.translation)
-    assert all(c2.rotation != c.rotation)
+    assert c5.volume != c.volume
+    assert all(c5.translation != c.translation)
+    assert all(c5.rotation != c.rotation)
 
 
 def test_temperature(cell_with_lattice):

--- a/tests/unit_tests/test_cell.py
+++ b/tests/unit_tests/test_cell.py
@@ -76,8 +76,8 @@ def test_clone():
 
     # Add optional properties to the original cell to ensure they're cloned successfully
     c.temperature = 650.
-    c.translation = [1,2,3]
-    c.rotation = [4,5,6]
+    c.translation = (1., 2., 3.)
+    c.rotation = (4., 5., 6.)
     c.volume = 100
 
     c5 = c.clone(clone_materials=False, clone_regions=False)
@@ -92,8 +92,8 @@ def test_clone():
     # Mutate the original to ensure the changes are not seen in the clones
     c.fill = openmc.Material()
     c.region = +openmc.ZCylinder()
-    c.translation = [-1,-2,-3]
-    c.rotation = [-4,-5,-6]
+    c.translation = (-1., -2., -3.)
+    c.rotation = (-4., -5., -6.)
     c.temperature = 1
     c.volume = 1
     assert c5.fill != c.fill


### PR DESCRIPTION
These proposed changes replace the deepcopying of cloned cells with a manual new instantiation. Any present optional cell properties are applied to the clone. Depending on cloning settings, the fill and region properties are set accordingly as before.

This provides a noticeable and significant performance improvement, particularly when cloning complicated cells, because it removes the potential for extra steps. With the deepcopy method, the original cell's fill and region attributes were deepcopied and immediately overwritten.

I've added some more testing to check this implementation, please let me know if anything looks like it might be off!