### PR TITLE
added get_surfaces_by_name method to geometry

### DIFF
--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -525,6 +525,27 @@ class Geometry:
         """
         return self._get_domains_by_name(name, case_sensitive, matching, 'cell')
 
+    def get_surfaces_by_name(self, name, case_sensitive=False, matching=False):
+        """Return a list of surfaces with matching names.
+
+        Parameters
+        ----------
+        name : str
+            The name to search match
+        case_sensitive : bool
+            Whether to distinguish upper and lower case letters in each
+            surface's name (default is False)
+        matching : bool
+            Whether the names must match completely (default is False)
+
+        Returns
+        -------
+        list of openmc.Surface
+            Surfaces matching the queried name
+
+        """
+        return self._get_domains_by_name(name, case_sensitive, matching, 'surface')
+
     def get_cells_by_fill_name(self, name, case_sensitive=False, matching=False):
         """Return a list of cells with fills with matching names.
 

--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -159,12 +159,13 @@ def test_get_by_name():
     m2 = openmc.Material(name='Zirconium')
     m2.add_element('Zr', 1.0)
 
-    c1 = openmc.Cell(fill=m1, name='cell1')
+    s1 = openmc.Sphere(name='surface1')
+    c1 = openmc.Cell(fill=m1, region=-s1, name='cell1')
     u1 = openmc.Universe(name='Zircaloy universe', cells=[c1])
 
-    cyl = openmc.ZCylinder()
-    c2 = openmc.Cell(fill=u1, region=-cyl, name='cell2')
-    c3 = openmc.Cell(fill=m2, region=+cyl, name='Cell3')
+    s2 = openmc.ZCylinder(name='surface2')
+    c2 = openmc.Cell(fill=u1, region=-s2, name='cell2')
+    c3 = openmc.Cell(fill=m2, region=+s2, name='Cell3')
     root = openmc.Universe(name='root Universe', cells=[c2, c3])
     geom = openmc.Geometry(root)
 
@@ -176,6 +177,13 @@ def test_get_by_name():
     assert not mats ^ {m2}
     mats = geom.get_materials_by_name('zirconium', True, True)
     assert not mats
+
+    surfaces = set(geom.get_surfaces_by_name('surface'))
+    assert not surfaces ^ {s1, s2}
+    surfaces = set(geom.get_surfaces_by_name('Surface2', False, True))
+    assert not surfaces ^ {s2}
+    surfaces = geom.get_surfaces_by_name('Surface2', True, True)
+    assert not surfaces
 
     cells = set(geom.get_cells_by_name('cell'))
     assert not cells ^ {c1, c2, c3}


### PR DESCRIPTION
This PR attemps to add a ```get_surfaces_by_name``` To match the existing ```get_materials_by_name``` and ```get_cells_by_name``` in the ```openmc.Geoemtry()``` class

I have added tests in the same style as the existing tests.
