### PR TITLE
Update copyright date and a few other small changes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2022 Massachusetts Institute of Technology, UChicago Argonne
+Copyright (c) 2011-2023 Massachusetts Institute of Technology, UChicago Argonne
 LLC, and OpenMC contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,7 +62,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'OpenMC'
-copyright = '2011-2022, Massachusetts Institute of Technology, UChicago Argonne LLC, and OpenMC contributors'
+copyright = '2011-2023, Massachusetts Institute of Technology, UChicago Argonne LLC, and OpenMC contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -4,7 +4,7 @@
 License Agreement
 =================
 
-Copyright © 2011-2022 Massachusetts Institute of Technology, UChicago Argonne
+Copyright © 2011-2023 Massachusetts Institute of Technology, UChicago Argonne
 LLC, and OpenMC contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -271,6 +271,16 @@ Prerequisites
 
           cmake -DOPENMC_USE_DAGMC=on -DCMAKE_PREFIX_PATH=/path/to/dagmc/installation ..
 
+    * MCPL_ library for reading and writing .mcpl files
+
+      This option allows OpenMC to read and write MCPL (Monte Carlo Particle
+      Lists) files instead of .h5 files for sources (external source
+      distribution, k-eigenvalue source distribution, and surface sources). To
+      turn this option on in the CMake configuration step, add the following
+      option:
+
+          cmake -DOPENMC_USE_MCPL=on ..
+
     * NCrystal_ library for defining materials with enhanced thermal neutron transport
 
       Adding this option allows the creation of materials from NCrystal, which
@@ -305,6 +315,7 @@ Prerequisites
 .. _MOAB: https://bitbucket.org/fathomteam/moab
 .. _libMesh: https://libmesh.github.io/
 .. _libpng: http://www.libpng.org/pub/png/libpng.html
+.. _MCPL: https://github.com/mctools/mcpl
 .. _NCrystal: https://github.com/mctools/ncrystal
 
 Obtaining the Source

--- a/man/man1/openmc.1
+++ b/man/man1/openmc.1
@@ -57,7 +57,7 @@ Indicates the default path to an HDF5 file that contains multi-group cross
 section libraries if the user has not specified the <cross_sections> tag in
 .I materials.xml\fP.
 .SH LICENSE
-Copyright \(co 2011-2022 Massachusetts Institute of Technology, UChicago
+Copyright \(co 2011-2023 Massachusetts Institute of Technology, UChicago
 Argonne LLC, and OpenMC contributors.
 .PP
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/openmc/executor.py
+++ b/openmc/executor.py
@@ -41,7 +41,7 @@ def _process_CLI_arguments(volume=False, geometry_debug=False, particles=None,
         Path to OpenMC executable. Defaults to 'openmc'.
     mpi_args : list of str, optional
         MPI execute command and any additional MPI arguments to pass,
-        e.g. ['mpiexec', '-n', '8'].
+        e.g., ['mpiexec', '-n', '8'].
     path_input : str or Pathlike
         Path to a single XML file or a directory containing XML files for the
         OpenMC executable to read.
@@ -139,6 +139,8 @@ def plot_geometry(output=True, openmc_exec='openmc', cwd='.', path_input=None):
         Path to a single XML file or a directory containing XML files for the
         OpenMC executable to read.
 
+        .. versionadded:: 0.13.3
+
     Raises
     ------
     RuntimeError
@@ -170,6 +172,8 @@ def plot_inline(plots, openmc_exec='openmc', cwd='.', path_input=None):
     path_input : str
         Path to a single XML file or a directory containing XML files for the
         OpenMC executable to read.
+
+        .. versionadded:: 0.13.3
 
     Raises
     ------
@@ -222,7 +226,7 @@ def calculate_volumes(threads=None, output=True, cwd='.',
         Path to OpenMC executable. Defaults to 'openmc'.
     mpi_args : list of str, optional
         MPI execute command and any additional MPI arguments to pass,
-        e.g. ['mpiexec', '-n', '8'].
+        e.g., ['mpiexec', '-n', '8'].
     cwd : str, optional
         Path to working directory to run in. Defaults to the current working
         directory.
@@ -280,7 +284,7 @@ def run(particles=None, threads=None, geometry_debug=False,
     openmc_exec : str, optional
         Path to OpenMC executable. Defaults to 'openmc'.
     mpi_args : list of str, optional
-        MPI execute command and any additional MPI arguments to pass, e.g.
+        MPI execute command and any additional MPI arguments to pass, e.g.,
         ['mpiexec', '-n', '8'].
     event_based : bool, optional
         Turns on event-based parallelism, instead of default history-based
@@ -290,6 +294,8 @@ def run(particles=None, threads=None, geometry_debug=False,
     path_input : str or Pathlike
         Path to a single XML file or a directory containing XML files for the
         OpenMC executable to read.
+
+        .. versionadded:: 0.13.3
 
     Raises
     ------

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -416,10 +416,10 @@ class Material(IDManagerMixin):
                 self._atoms = volume_calc.atoms[self.id]
             else:
                 raise ValueError('No volume information found for material ID={}.'
-                    .format(self.id))
+                                 .format(self.id))
         else:
             raise ValueError('No volume information found for material ID={}.'
-                .format(self.id))
+                             .format(self.id))
 
     def set_density(self, units: str, density: Optional[float] = None):
         """Set the density of the material
@@ -531,11 +531,10 @@ class Material(IDManagerMixin):
 
             params['percent_type'] = percent_type
 
-            ## check if nuclide
+            # check if nuclide
             if not component.isalpha():
                 self.add_nuclide(component, **params)
-            else: # is element
-                kwargs = params
+            else:
                 self.add_element(component, **params)
 
     def remove_nuclide(self, nuclide: str):
@@ -1582,7 +1581,6 @@ class Materials(cv.CheckedList):
         # at this level if needed
         if trailing_indent:
             file.write(indentation)
-
 
     def export_to_xml(self, path: PathLike = 'materials.xml'):
         """Export material collection to an XML file.

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -352,6 +352,8 @@ class Material(IDManagerMixin):
         on this string. The name and material_id parameters are simply passed on
         to the Material constructor.
 
+        .. versionadded:: 0.13.3
+
         Parameters
         ----------
         cfg : str

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -74,7 +74,7 @@ void title()
   // Write version information
   fmt::print(
     "                 | The OpenMC Monte Carlo Code\n"
-    "       Copyright | 2011-2022 MIT, UChicago Argonne LLC, and contributors\n"
+    "       Copyright | 2011-2023 MIT, UChicago Argonne LLC, and contributors\n"
     "         License | https://docs.openmc.org/en/latest/license.html\n"
     "         Version | {}.{}.{}{}\n",
     VERSION_MAJOR, VERSION_MINOR, VERSION_RELEASE, VERSION_DEV ? "-dev" : "");
@@ -340,7 +340,7 @@ void print_version()
 #ifdef GIT_SHA1
     fmt::print("Git SHA1: {}\n", GIT_SHA1);
 #endif
-    fmt::print("Copyright (c) 2011-2022 MIT, UChicago Argonne LLC, and "
+    fmt::print("Copyright (c) 2011-2023 MIT, UChicago Argonne LLC, and "
                "contributors\nMIT/X license at "
                "<https://docs.openmc.org/en/latest/license.html>\n");
   }


### PR DESCRIPTION
As the subject says, this PR updates the copyright date to 2023 and makes a few other small changes:

- Mention MCPL as an optional dependency in install instructions
- Style fixes in material.py
- Add a few missing `.. versionadded::` directives