### PR TITLE
Introducing a functionality to reset the time for produced particles (neutrons)

### DIFF
--- a/docs/source/io_formats/settings.rst
+++ b/docs/source/io_formats/settings.rst
@@ -357,6 +357,16 @@ or sub-elements and can be set to either "false" or "true".
 
   .. note:: This element is not used in the multi-group :ref:`energy_mode`.
 
+---------------------
+``<reset_time_for_particle_production>`` Element
+---------------------
+
+The ``<reset_time_for_particle_production>`` element determines whether the time
+variable of the particle is reset or runs through for neutrons that are created
+during inelastic scattering or fission.
+
+  *Default*: false
+
 ----------------------------------
 ``<resonance_scattering>`` Element
 ----------------------------------

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -44,6 +44,8 @@ extern "C" bool photon_transport;  //!< photon transport turned on?
 extern "C" bool reduce_tallies;    //!< reduce tallies at end of batch?
 extern bool res_scat_on;           //!< use resonance upscattering method?
 extern "C" bool restart_run;       //!< restart run?
+extern bool reset_time_for_particle_production; //!< whether created particles
+                                                //!< start with time=0?
 extern "C" bool run_CE;            //!< run with continuous-energy data?
 extern bool source_latest;         //!< write latest source at each batch?
 extern bool source_separate;       //!< write source to separate file?

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -228,6 +228,10 @@ class Settings:
     create_delayed_neutrons : bool
         Whether delayed neutrons are created in fission.
 
+        .. versionadded:: 0.13
+    reset_time_for_particle_production : bool
+        Whether the time variable is reset for created neutrons.
+
         .. versionadded:: 0.13.3
     weight_windows_on : bool
         Whether weight windows are enabled
@@ -301,6 +305,7 @@ class Settings:
 
         self._create_fission_neutrons = None
         self._create_delayed_neutrons = None
+        self._reset_time_for_particle_production = None
         self._delayed_photon_scaling = None
         self._material_cell_offsets = None
         self._log_grid_bins = None
@@ -467,6 +472,10 @@ class Settings:
     @property
     def create_delayed_neutrons(self) -> bool:
         return self._create_delayed_neutrons
+
+    @property
+    def reset_time_for_particle_production(self) -> bool:
+        return self._reset_time_for_particle_production
 
     @property
     def delayed_photon_scaling(self) -> bool:
@@ -880,6 +889,12 @@ class Settings:
         cv.check_type('Whether create only prompt neutrons',
                       create_delayed_neutrons, bool)
         self._create_delayed_neutrons = create_delayed_neutrons
+
+    @reset_time_for_particle_production.setter
+    def reset_time_for_particle_production(self, reset_time_for_particle_production: bool):
+        cv.check_type('Whether created particles start with time=0',
+                      reset_time_for_particle_production, bool)
+        self._reset_time_for_particle_production = reset_time_for_particle_production
 
     @delayed_photon_scaling.setter
     def delayed_photon_scaling(self, value: bool):
@@ -1557,6 +1572,11 @@ class Settings:
         if text is not None:
             self.create_delayed_neutrons = text in ('true', '1')
 
+    def _reset_time_for_particle_production_from_xml_element(self, root):
+        text = get_text(root, 'reset_time_for_particle_production')
+        if text is not None:
+            self.reset_time_for_particle_production = text in ('true', '1')
+
     def _delayed_photon_scaling_from_xml_element(self, root):
         text = get_text(root, 'delayed_photon_scaling')
         if text is not None:
@@ -1656,6 +1676,7 @@ class Settings:
         self._create_volume_calcs_subelement(element)
         self._create_create_fission_neutrons_subelement(element)
         self._create_create_delayed_neutrons_subelement(element)
+        self._create_reset_time_for_particle_production(element)
         self._create_delayed_photon_scaling_subelement(element)
         self._create_event_based_subelement(element)
         self._create_max_particles_in_flight_subelement(element)
@@ -1685,6 +1706,7 @@ class Settings:
 
         # Check if path is a directory
         p = Path(path)
+
         if p.is_dir():
             p /= 'settings.xml'
 
@@ -1749,6 +1771,7 @@ class Settings:
         settings._resonance_scattering_from_xml_element(elem)
         settings._create_fission_neutrons_from_xml_element(elem)
         settings._create_delayed_neutrons_from_xml_element(elem)
+        settings._reset_time_for_particle_production_from_xml_element(elem)
         settings._delayed_photon_scaling_from_xml_element(elem)
         settings._event_based_from_xml_element(elem)
         settings._max_particles_in_flight_from_xml_element(elem)

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1242,6 +1242,11 @@ class Settings:
            elem = ET.SubElement(root, "create_delayed_neutrons")
            elem.text = str(self._create_delayed_neutrons).lower()
 
+    def _create_reset_time_for_particle_production(self, root):
+       if self._reset_time_for_particle_production is not None:
+           elem = ET.SubElement(root, "reset_time_for_particle_production")
+           elem.text = str(self._reset_time_for_particle_production).lower()
+
     def _create_delayed_photon_scaling_subelement(self, root):
         if self._delayed_photon_scaling is not None:
             elem = ET.SubElement(root, "delayed_photon_scaling")

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -75,6 +75,7 @@ int openmc_finalize()
   settings::confidence_intervals = false;
   settings::create_fission_neutrons = true;
   settings::create_delayed_neutrons = true;
+  settings::reset_time_for_particle_production = false;
   settings::electron_treatment = ElectronTreatment::LED;
   settings::delayed_photon_scaling = true;
   settings::energy_cutoff = {0.0, 1000.0, 0.0, 0.0};

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -78,6 +78,7 @@ void Particle::create_secondary(
   bank.u = u;
   bank.E = settings::run_CE ? E : g();
   bank.time = time();
+  std::cout << "time in the bank  " << bank.time << std::endl;
 
   n_bank_second() += 1;
 }

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -77,9 +77,11 @@ void Particle::create_secondary(
   bank.r = r();
   bank.u = u;
   bank.E = settings::run_CE ? E : g();
-  bank.time = time();
-  std::cout << "time in the bank  " << bank.time << std::endl;
-
+  if (settings::reset_time_for_particle_production == true) {
+    bank.time = 0.0;
+  } else {
+    bank.time = time();
+  }
   n_bank_second() += 1;
 }
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -77,7 +77,7 @@ void Particle::create_secondary(
   bank.r = r();
   bank.u = u;
   bank.E = settings::run_CE ? E : g();
-  if (settings::reset_time_for_particle_production == true) {
+  if (settings::reset_time_for_particle_production) {
     bank.time = 0.0;
   } else {
     bank.time = time();

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -205,7 +205,11 @@ void create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx)
     SourceSite site;
     site.r = p.r();
     site.particle = ParticleType::neutron;
-    site.time = p.time();
+    if (settings::reset_time_for_particle_production == true) {
+      site.time = 0.0;
+    } else {
+      site.time = p.time();
+    }
     site.wgt = 1. / weight;
     site.parent_id = p.id();
     site.progeny_id = p.n_progeny()++;

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -205,7 +205,7 @@ void create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx)
     SourceSite site;
     site.r = p.r();
     site.particle = ParticleType::neutron;
-    if (settings::reset_time_for_particle_production == true) {
+    if (settings::reset_time_for_particle_production) {
       site.time = 0.0;
     } else {
       site.time = p.time();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -56,6 +56,7 @@ bool output_tallies {true};
 bool particle_restart_run {false};
 bool photon_transport {false};
 bool reduce_tallies {true};
+bool reset_time_for_particle_production {false};
 bool res_scat_on {false};
 bool restart_run {false};
 bool run_CE {true};
@@ -897,6 +898,12 @@ void read_settings_xml(pugi::xml_node root)
   // Check whether to use event-based parallelism
   if (check_for_node(root, "event_based")) {
     event_based = get_node_value_bool(root, "event_based");
+  }
+
+  // Check whether created particles start with time=0
+  if (check_for_node(root, "reset_time_for_particle_production")) {
+    reset_time_for_particle_production =
+      get_node_value_bool(root, "reset_time_for_particle_production");
   }
 
   // Check whether material cell offsets should be generated

--- a/tests/unit_tests/test_settings.py
+++ b/tests/unit_tests/test_settings.py
@@ -50,6 +50,7 @@ def test_export_to_xml(run_in_tmpdir):
         upper_right = (10., 10., 10.))
     s.create_fission_neutrons = True
     s.create_delayed_neutrons = False
+    s.reset_time_for_particle_production = True
     s.log_grid_bins = 2000
     s.photon_transport = False
     s.electron_treatment = 'led'
@@ -109,6 +110,7 @@ def test_export_to_xml(run_in_tmpdir):
                                       'nuclides': ['U235', 'U238', 'Pu239']}
     assert s.create_fission_neutrons
     assert not s.create_delayed_neutrons 
+    assert s.reset_time_for_particle_production
     assert s.log_grid_bins == 2000
     assert not s.photon_transport
     assert s.electron_treatment == 'led'


### PR DESCRIPTION
Neutrons are produced either by (n,xn)-reactions or fission. At the moment, the time variable p.time() is not reset for the produced neutrons. This is now possible:

`settings.reset_time_for_particle_production = True`

Using this setting in combination with 

`settings.create_delayed_neutrons = False`

OpenMC should now be capable to determine the [prompt neutron lifetime](https://www.nuclear-power.com/nuclear-power/fission/prompt-neutrons/prompt-generation-time-mean-generation-time/) by using a tally with the corresponding scores in combination with a TimeFilter.

See also the following discussions:
https://openmc.discourse.group/t/kinetic-parameter-evaluation-update/302
https://openmc.discourse.group/t/kinetic-parameter-calculation/596

I am looking forward to your feedback.