### PR TITLE
adding optional arg to matrix_func in Pool.py (for depletion)

### DIFF
--- a/openmc/deplete/pool.py
+++ b/openmc/deplete/pool.py
@@ -38,7 +38,7 @@ def deplete(func, chain, x, rates, dt, matrix_func=None, **func_args):
         Expected to return the depletion matrix required by
         ``func``
     func_args : dict
-        Remaining keyword arguments passed to the matrix_func
+        Remaining keyword arguments passed to matrix_func when used
 
     Returns
     -------

--- a/openmc/deplete/pool.py
+++ b/openmc/deplete/pool.py
@@ -15,7 +15,7 @@ USE_MULTIPROCESSING = True
 NUM_PROCESSES = None
 
 
-def deplete(func, chain, x, rates, dt, matrix_func=None):
+def deplete(func, chain, x, rates, dt, matrix_func=None, **func_args):
     """Deplete materials using given reaction rates for a specified time
 
     Parameters
@@ -37,6 +37,8 @@ def deplete(func, chain, x, rates, dt, matrix_func=None):
         ``fission_yields = {parent: {product: yield_frac}}``
         Expected to return the depletion matrix required by
         ``func``
+    func_args : dict
+        Remaining keyword arguments passed to the matrix_func
 
     Returns
     -------
@@ -57,7 +59,8 @@ def deplete(func, chain, x, rates, dt, matrix_func=None):
     if matrix_func is None:
         matrices = map(chain.form_matrix, rates, fission_yields)
     else:
-        matrices = map(matrix_func, repeat(chain), rates, fission_yields)
+        matrices = map(matrix_func, repeat(chain), rates, fission_yields,
+                       **func_args)
 
     inputs = zip(matrices, x, repeat(dt))
 


### PR DESCRIPTION
This should allow to pass additional args to pool.deplete when using user specified `matrix_func`

I figured this could be useful, if one need to use a user provided func to build the depletion matrix to allow additional argument to be provided. (And I kinda need it, it would allow me not to rewrite the `depletion/pool.py` file...)

I am un-aware of the exact development guide lines, feel free to point me in the right direction/documentation :)