### PR TITLE
multipole documentation typo fix

### DIFF
--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -1154,8 +1154,8 @@ class WindowedMultipole(EqualityMixin):
         Returns
         -------
         3-tuple of Real
-            Total, absorption, and fission microscopic cross sections at the
-            given energy and temperature.
+            Scattering, absorption, and fission microscopic cross sections 
+            at the given energy and temperature.
 
         """
 
@@ -1248,8 +1248,8 @@ class WindowedMultipole(EqualityMixin):
         Returns
         -------
         3-tuple of Real or 3-tuple of numpy.ndarray
-            Total, absorption, and fission microscopic cross sections at the
-            given energy and temperature.
+            Scattering, absorption, and fission microscopic cross sections
+            at the given energy and temperature.
 
         """
 


### PR DESCRIPTION
`multipole.py` documentation incorrectly claims that the total micro XS is returned as the first tuple element on evaluation, but it's actually the scattering cross section.