### PR TITLE
try to constrain triangulation

### DIFF
--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -773,13 +773,16 @@ class Polygon(CompositeSurface):
             points = points[:-1, :]
         check_length('points', points, 3)
 
+        if len(points) != len(np.unique(points, axis=0)):
+            raise ValueError('Duplicate points were detected in the Polygon input')
+
         # Check if polygon is self-intersecting by comparing edges pairwise
         n = len(points)
         is_self_intersecting = False
         for i in range(n):
             p1x, p1y = points[i, :]
             p2x, p2y = points[(i + 1) % n, :]
-            for j in range(i, n):
+            for j in range(i + 1, n):
                 p3x, p3y = points[j, :]
                 p4x, p4y = points[(j + 1) % n, :]
 

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -776,26 +776,87 @@ class Polygon(CompositeSurface):
         if len(points) != len(np.unique(points, axis=0)):
             raise ValueError('Duplicate points were detected in the Polygon input')
 
-        # Check if polygon is self-intersecting by comparing edges pairwise
-        n = len(points)
-        is_self_intersecting = False
-        for i in range(n):
-            p1x, p1y = points[i, :]
-            p2x, p2y = points[(i + 1) % n, :]
-            for j in range(i + 1, n):
-                p3x, p3y = points[j, :]
-                p4x, p4y = points[(j + 1) % n, :]
-
-
         # Order the points counter-clockwise (necessary for offset method)
         # Calculates twice the signed area of the polygon using the "Shoelace
         # Formula" https://en.wikipedia.org/wiki/Shoelace_formula
-        # If signed area is positive the curve is oriented counter-clockwise
+        # If signed area is positive the curve is oriented counter-clockwise.
+        # If the signed area is negative the curve is oriented clockwise.
         xpts, ypts = points.T
-        if np.sum(ypts*(np.roll(xpts, 1) - np.roll(xpts, -1))) > 0:
-            return points
+        if np.sum(ypts*(np.roll(xpts, 1) - np.roll(xpts, -1))) < 0:
+            points = points[::-1, :]
 
-        return points[::-1, :]
+
+        # Check if polygon is self-intersecting by comparing edges pairwise
+        n = len(points)
+        for i in range(n):
+            p0 = points[i, :]
+            p1 = points[(i + 1) % n, :]
+            for j in range(i + 1, n):
+                p2 = points[j, :]
+                p3 = points[(j + 1) % n, :]
+                # Compute orientation of p0 wrt p2->p3 line segment
+                cp0 = np.cross(p3-p0, p2-p0)
+                # Compute orientation of p1 wrt p2->p3 line segment
+                cp1 = np.cross(p3-p1, p2-p1)
+                # Compute orientation of p2 wrt p0->p1 line segment
+                cp2 = np.cross(p1-p2, p0-p2)
+                # Compute orientation of p3 wrt p0->p1 line segment
+                cp3 = np.cross(p1-p3, p0-p3)
+
+                # Group cross products in an array and find out how many are 0
+                cross_products = np.array([[cp0, cp1], [cp2, cp3]])
+                cps_near_zero = np.isclose(cross_products, 0).astype(int)
+                num_zeros = np.sum(cps_near_zero)
+
+                # Topologies of 2 finite line segments categorized by the number
+                # of zero-valued cross products:
+                #
+                # 0: No 3 points lie on the same line
+                # 1: 1 point lies on the same line defined by the other line
+                # segment, but is not coincident with either of the points
+                # 2: 2 points are coincident, but the line segments are not
+                # collinear which guarantees no intersection
+                # 3: not possible
+                # 4: Both line segments are collinear, simply need to check if
+                # they overlap or not
+
+                if num_zeros == 0:
+                    # If the orientations of p0 and p1 have opposite signs
+                    # and the orientations of p2 and p3 have opposite signs
+                    # then there is an intersection.
+                    if all(np.prod(cross_products, axis=-1) < 0):
+                        raise ValueError('Polygon cannot be self-intersecting')
+                    continue
+
+                elif num_zeros == 1:
+                    # determine which line segment has 2 out of the 3 collinear
+                    # points
+                    idx = np.argwhere(np.sum(cps_near_zero, axis=-1) == 0)
+                    if np.prod(cross_products[idx, :]) < 0:
+                        raise ValueError('Polygon cannot be self-intersecting')
+                    continue
+
+                elif num_zeros == 2:
+                    continue
+
+                elif num_zeros == 4:
+                    # Determine number of unique points, x span and y span for
+                    # both line segments
+                    #unique_pts = np.unique(np.vstack((p0, p1, p2, p3)), axis=0)
+                    xmin1, xmax1 = min(p0[0], p1[0]), max(p0[0], p1[0])
+                    ymin1, ymax1 = min(p0[1], p1[1]), max(p0[1], p1[1])
+                    xmin2, xmax2 = min(p2[0], p3[0]), max(p2[0], p3[0])
+                    ymin2, ymax2 = min(p2[1], p3[1]), max(p2[1], p3[1])
+                    xlap = xmin1 < xmax2 and xmin2 < xmax1
+                    ylap = ymin1 < ymax2 and ymin2 < ymax1
+                    if xlap or ylap:
+                        raise ValueError('Polygon cannot be self-intersecting')
+                    continue
+
+                else:
+                    warnings.warn('Unclear if Polygon is self-intersecting')
+
+        return points
 
     def _constrain_triangulation(self, points, depth=0):
         """Generate a constrained triangulation by ensuring all edges of the

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -785,7 +785,6 @@ class Polygon(CompositeSurface):
         if np.sum(ypts*(np.roll(xpts, 1) - np.roll(xpts, -1))) < 0:
             points = points[::-1, :]
 
-
         # Check if polygon is self-intersecting by comparing edges pairwise
         n = len(points)
         for i in range(n):

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -851,7 +851,6 @@ class Polygon(CompositeSurface):
                     # All 4 cross products are zero
                     # Determine number of unique points, x span and y span for
                     # both line segments
-                    #unique_pts = np.unique(np.vstack((p0, p1, p2, p3)), axis=0)
                     xmin1, xmax1 = min(p0[0], p1[0]), max(p0[0], p1[0])
                     ymin1, ymax1 = min(p0[1], p1[1]), max(p0[1], p1[1])
                     xmin2, xmax2 = min(p2[0], p3[0]), max(p2[0], p3[0])

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -816,9 +816,14 @@ class Polygon(CompositeSurface):
                 # segment, but is not coincident with either of the points
                 # 2: 2 points are coincident, but the line segments are not
                 # collinear which guarantees no intersection
-                # 3: not possible
+                # 3: not possible, except maybe floating point issues?
                 # 4: Both line segments are collinear, simply need to check if
                 # they overlap or not
+                # adapted from algorithm linked below and modified to only
+                # consider intersections on the interior of line segments as
+                # proper intersections: i.e. segments sharing end points do not
+                # count as intersections.
+                # https://www.geeksforgeeks.org/check-if-two-given-line-segments-intersect/
 
                 if num_zeros == 0:
                     # If the orientations of p0 and p1 have opposite signs
@@ -839,7 +844,12 @@ class Polygon(CompositeSurface):
                 elif num_zeros == 2:
                     continue
 
-                elif num_zeros == 4:
+                elif num_zeros == 3:
+                    warnings.warn('Unclear if Polygon is self-intersecting')
+                    continue
+
+                else:
+                    # All 4 cross products are zero
                     # Determine number of unique points, x span and y span for
                     # both line segments
                     #unique_pts = np.unique(np.vstack((p0, p1, p2, p3)), axis=0)
@@ -852,9 +862,6 @@ class Polygon(CompositeSurface):
                     if xlap or ylap:
                         raise ValueError('Polygon cannot be self-intersecting')
                     continue
-
-                else:
-                    warnings.warn('Unclear if Polygon is self-intersecting')
 
         return points
 

--- a/tests/unit_tests/test_surface_composite.py
+++ b/tests/unit_tests/test_surface_composite.py
@@ -339,3 +339,57 @@ def test_polygon():
             offset_star = star_poly.offset(.6)
             assert (0, 0, 0) in -offset_star
             assert any([(0, 0, 0) in reg for reg in offset_star.regions])
+
+    # check invalid Polygon input points
+    # duplicate points not just at start and end
+    rz_points = np.array([[6.88, 3.02],
+                          [6.88, 2.72],
+                          [6.88, 3.02],
+                          [7.63, 0.0],
+                          [5.75, 0.0],
+                          [5.75, 1.22],
+                          [7.63, 0.0],
+                          [6.30, 1.22],
+                          [6.30, 3.02],
+                          [6.88, 3.02]])
+    with pytest.raises(ValueError):
+        openmc.model.Polygon(rz_points)
+
+    # segment traces back on previous segment
+    rz_points = np.array([[6.88, 3.02],
+                          [6.88, 2.72],
+                          [6.88, 2.32],
+                          [6.88, 2.52],
+                          [7.63, 0.0],
+                          [5.75, 0.0],
+                          [6.75, 0.0],
+                          [5.75, 1.22],
+                          [6.30, 1.22],
+                          [6.30, 3.02],
+                          [6.88, 3.02]])
+    with pytest.raises(ValueError):
+        openmc.model.Polygon(rz_points)
+
+    # segments intersect (line-line)
+    rz_points = np.array([[6.88, 3.02],
+                          [5.88, 2.32],
+                          [7.63, 0.0],
+                          [5.75, 0.0],
+                          [5.75, 1.22],
+                          [6.30, 1.22],
+                          [6.30, 3.02],
+                          [6.88, 3.02]])
+    with pytest.raises(ValueError):
+        openmc.model.Polygon(rz_points)
+
+    # segments intersect (line-point)
+    rz_points = np.array([[6.88, 3.02],
+                          [6.3, 2.32],
+                          [7.63, 0.0],
+                          [5.75, 0.0],
+                          [5.75, 1.22],
+                          [6.30, 1.22],
+                          [6.30, 3.02],
+                          [6.88, 3.02]])
+    with pytest.raises(ValueError):
+        openmc.model.Polygon(rz_points)


### PR DESCRIPTION
This PR attempts to fix an issue reported in #2357 when a triangulation in the `Polygon` `CompositeSurface` class doesn't generate a facet on one or more of the polygon edges. The `scipy.spatial.Delaunay` object does not support constrained triangulation so without pulling in additional mesh libraries as dependencies, one way to work around this is to find the offending edges if a triangulation "fails" and to break those edges into multiple edges. 

The figure below shows the resulting triangulation from #2357 with this fix implemented. I can't guarantee this will always work, but it certainly should be more robust. Curious to see if this solves your use case @hassec 

![Figure_1](https://user-images.githubusercontent.com/18011007/214478196-9543b670-2b51-4ccf-a087-c2aec54d8a86.png)

This results in the domain decomposition into 3 regions shown below:
![Figure_2](https://user-images.githubusercontent.com/18011007/214478947-c11ec6a1-1d0b-472c-a51c-8c7514d24bac.png)

