### PR TITLE
Raise error when mesh is flat

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -447,7 +447,7 @@ class RegularMesh(StructuredMesh):
             warnings.warn("Unsetting width attribute.")
         
         if self.lower_left is not None and any(np.isclose(self.lower_left, upper_right)):
-            raise ValueError("mesh cannot have zero thickness is any dimension")
+            raise ValueError("Mesh cannot have zero thickness in any dimension")
 
     @width.setter
     def width(self, width):

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -795,7 +795,7 @@ class RegularMesh(StructuredMesh):
     def is_flat(self):
         """Returns True if the mesh is flat
         """
-        if None in [self.lower_left, self.upper_right]:
+        if self.lower_left is None or self.upper_right is None:
             return False
 
         for val1, val2 in zip(self.lower_left, self.upper_right):

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -434,7 +434,7 @@ class RegularMesh(StructuredMesh):
         self._lower_left = lower_left
 
         if self.upper_right is not None and any(np.isclose(self.upper_right, lower_left)):
-            raise ValueError("mesh cannot have zero thickness is any dimension")
+            raise ValueError("Mesh cannot have zero thickness in any dimension")
 
     @upper_right.setter
     def upper_right(self, upper_right):

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -433,6 +433,9 @@ class RegularMesh(StructuredMesh):
         cv.check_length('mesh lower_left', lower_left, 1, 3)
         self._lower_left = lower_left
 
+        if self.is_flat():
+            raise ValueError("mesh cannot be flat")
+
     @upper_right.setter
     def upper_right(self, upper_right):
         cv.check_type('mesh upper_right', upper_right, Iterable, Real)
@@ -442,6 +445,9 @@ class RegularMesh(StructuredMesh):
         if self._width is not None:
             self._width = None
             warnings.warn("Unsetting width attribute.")
+        
+        if self.is_flat():
+            raise ValueError("mesh cannot be flat")
 
     @width.setter
     def width(self, width):
@@ -785,6 +791,16 @@ class RegularMesh(StructuredMesh):
             datasets=datasets,
             volume_normalization=volume_normalization
         )
+
+    def is_flat(self):
+        """Returns True if the mesh is flat
+        """
+        if None in [self.lower_left, self.upper_right]:
+            return False
+
+        for val1, val2 in zip(self.lower_left, self.upper_right):
+            if val1 == val2:
+                return True
 
 def Mesh(*args, **kwargs):
     warnings.warn("Mesh has been renamed RegularMesh. Future versions of "

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -433,8 +433,8 @@ class RegularMesh(StructuredMesh):
         cv.check_length('mesh lower_left', lower_left, 1, 3)
         self._lower_left = lower_left
 
-        if self.is_flat():
-            raise ValueError("mesh cannot be flat")
+        if self.upper_right is not None and any(np.isclose(self.upper_right, lower_left)):
+            raise ValueError("mesh cannot have zero thickness is any dimension")
 
     @upper_right.setter
     def upper_right(self, upper_right):
@@ -446,8 +446,8 @@ class RegularMesh(StructuredMesh):
             self._width = None
             warnings.warn("Unsetting width attribute.")
         
-        if self.is_flat():
-            raise ValueError("mesh cannot be flat")
+        if self.lower_left is not None and any(np.isclose(self.lower_left, upper_right)):
+            raise ValueError("mesh cannot have zero thickness is any dimension")
 
     @width.setter
     def width(self, width):
@@ -791,16 +791,6 @@ class RegularMesh(StructuredMesh):
             datasets=datasets,
             volume_normalization=volume_normalization
         )
-
-    def is_flat(self):
-        """Returns True if the mesh is flat
-        """
-        if self.lower_left is None or self.upper_right is None:
-            return False
-
-        for val1, val2 in zip(self.lower_left, self.upper_right):
-            if val1 == val2:
-                return True
 
 def Mesh(*args, **kwargs):
     warnings.warn("Mesh has been renamed RegularMesh. Future versions of "

--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -1,5 +1,6 @@
 import openmc
 import pytest
+import numpy as np
 
 @pytest.mark.parametrize("val_left,val_right", [(0, 0), (-1., -1.), (2.0, 2)])
 def test_raises_error_when_flat(val_left, val_right):
@@ -32,3 +33,25 @@ def test_raises_error_when_flat(val_left, val_right):
     with pytest.raises(ValueError):
         mesh.upper_right = [25, 25, val_right]
         mesh.lower_left = [-25, -25, val_left]
+
+
+def test_corner_none_returns_false():
+    """Checks mesh is not considered flat when one
+    corner is None
+    """
+    mesh = openmc.RegularMesh()
+    mesh.lower_left = [-25, -25, -25]
+    assert not mesh.is_flat()
+
+    mesh = openmc.RegularMesh()
+    mesh.upper_right = [-25, -25, -25]
+    assert not mesh.is_flat()
+
+    # test with np array
+    mesh = openmc.RegularMesh()
+    mesh.lower_left = np.array([-25, -25, -25])
+    assert not mesh.is_flat()
+
+    mesh = openmc.RegularMesh()
+    mesh.upper_right = np.array([-25, -25, -25])
+    assert not mesh.is_flat()

--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -1,9 +1,34 @@
 import openmc
 import pytest
 
-def test_raises_error_when_flat():
+@pytest.mark.parametrize("val_left,val_right", [(0, 0), (-1., -1.), (2.0, 2)])
+def test_raises_error_when_flat(val_left, val_right):
+    """Checks that an error is raised when a mesh is flat"""
+    mesh = openmc.RegularMesh()
+
+    # Same X
     with pytest.raises(ValueError):
-        mesh = openmc.RegularMesh()
-        mesh.dimension = [50, 50, 1]
-        mesh.lower_left = [-25, -25, 0]
-        mesh.upper_right = [25, 25, 0]
+        mesh.lower_left = [val_left, -25, -25]
+        mesh.upper_right = [val_right, 25, 25]
+
+    with pytest.raises(ValueError):
+        mesh.upper_right = [val_right, 25, 25]
+        mesh.lower_left = [val_left, -25, -25]
+
+    # Same Y
+    with pytest.raises(ValueError):
+        mesh.lower_left = [-25, val_left, -25]
+        mesh.upper_right = [25, val_right, 25]
+
+    with pytest.raises(ValueError):
+        mesh.upper_right = [25, val_right, 25]
+        mesh.lower_left = [-25, val_left, -25]
+
+    # Same Z
+    with pytest.raises(ValueError):
+        mesh.lower_left = [-25, -25, val_left]
+        mesh.upper_right = [25, 25, val_right]
+
+    with pytest.raises(ValueError):
+        mesh.upper_right = [25, 25, val_right]
+        mesh.lower_left = [-25, -25, val_left]

--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -33,25 +33,3 @@ def test_raises_error_when_flat(val_left, val_right):
     with pytest.raises(ValueError):
         mesh.upper_right = [25, 25, val_right]
         mesh.lower_left = [-25, -25, val_left]
-
-
-def test_corner_none_returns_false():
-    """Checks mesh is not considered flat when one
-    corner is None
-    """
-    mesh = openmc.RegularMesh()
-    mesh.lower_left = [-25, -25, -25]
-    assert not mesh.is_flat()
-
-    mesh = openmc.RegularMesh()
-    mesh.upper_right = [-25, -25, -25]
-    assert not mesh.is_flat()
-
-    # test with np array
-    mesh = openmc.RegularMesh()
-    mesh.lower_left = np.array([-25, -25, -25])
-    assert not mesh.is_flat()
-
-    mesh = openmc.RegularMesh()
-    mesh.upper_right = np.array([-25, -25, -25])
-    assert not mesh.is_flat()

--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -1,0 +1,9 @@
+import openmc
+import pytest
+
+def test_raises_error_when_flat():
+    with pytest.raises(ValueError):
+        mesh = openmc.RegularMesh()
+        mesh.dimension = [50, 50, 1]
+        mesh.lower_left = [-25, -25, 0]
+        mesh.upper_right = [25, 25, 0]


### PR DESCRIPTION
One of our students ran into an weird hanging behaviour. We realised it is a case of #2070.
We also realised I offered to work on a fix for this exact same issue....... but never did. So here it is!

This PR adds a test for the `RegularMesh` corners to check if the mesh is flat (infinitely thin). If so, a `ValueError` is raised.