### PR TITLE
allowing materials.xml to be specified

### DIFF
--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -396,7 +396,7 @@ class Results(list):
             materials.xml will be used. If that element is not present,
             nuclides from openmc.config['cross_sections'] will be used.
         path : PathLike
-            Path to file to write. Defaults to 'materials.xml'.
+            Path to materials XML file to read. Defaults to 'materials.xml'.
 
         Returns
         -------

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -375,7 +375,8 @@ class Results(list):
     def export_to_materials(
         self,
         burnup_index: int,
-        nuc_with_data: Optional[Iterable[str]] = None
+        nuc_with_data: Optional[Iterable[str]] = None,
+        path: PathLike = 'materials.xml'
     ) -> Materials:
         """Return openmc.Materials object based on results at a given step
 
@@ -394,6 +395,8 @@ class Results(list):
             If not provided, nuclides from the cross_sections element of
             materials.xml will be used. If that element is not present,
             nuclides from openmc.config['cross_sections'] will be used.
+        path : PathLike
+            Path to file to write. Defaults to 'materials.xml'.
 
         Returns
         -------
@@ -407,7 +410,7 @@ class Results(list):
         # updated. If for some reason you have modified OpenMC to produce
         # new materials as depletion takes place, this method will not
         # work as expected and leave out that material.
-        mat_file = Materials.from_xml("materials.xml")
+        mat_file = Materials.from_xml(path)
 
         # Only nuclides with valid transport data will be written to
         # the new materials XML file. The precedence of nuclides to select


### PR DESCRIPTION
The ```Results.export_to_materials``` method in ```openmc.deplete``` is super useful.

This PR is an attempt to make it a tiny bit more flexible by allowing the path to the materials.xml to be specified.

This is useful when running multiple depletion steps and wanting to get the materials for a seperate folder or elsewhere.

It is useful to have the different stages stored in separate file locations so that the materials at each time step can be investigated.

Would you be able to review @eepeterson as this is similar to changes you had in your R2SModel branch but I've tried to use the path argument with PathLike the same way it is used elsewhere in openmc (e.g. [here](https://github.com/openmc-dev/openmc/blob/3f5b90042c378f4182ef196ac075dd8cd8cec686/openmc/material.py#L1587))