### PR TITLE
updated checkout action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       LIBMESH: ${{ matrix.libmesh }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/dockerhub-publish-release-dagmc-libmesh.yml
+++ b/.github/workflows/dockerhub-publish-release-dagmc-libmesh.yml
@@ -8,7 +8,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       -

--- a/.github/workflows/dockerhub-publish-release-dagmc.yml
+++ b/.github/workflows/dockerhub-publish-release-dagmc.yml
@@ -8,7 +8,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       -

--- a/.github/workflows/dockerhub-publish-release-libmesh.yml
+++ b/.github/workflows/dockerhub-publish-release-libmesh.yml
@@ -8,7 +8,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       -

--- a/.github/workflows/dockerhub-publish-release.yml
+++ b/.github/workflows/dockerhub-publish-release.yml
@@ -8,7 +8,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       -


### PR DESCRIPTION
I noticed the CI was failing with this error message

```bash
Python 3.10 (omp=n, mpi=n, dagmc=n, ncrystal=n, libmesh=n, event=n vectfit=n)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

This PR updates the checkout action to use v3 instead of v2