### PR TITLE
Add volume calc standard deviation as a retrievable property

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -85,6 +85,9 @@ class Cell(IDManagerMixin):
         calculated in a stochastic volume calculation and added via the
         :meth:`Cell.add_volume_information` method. For 'distribmat' cells
         it is the total volume of all instances.
+    volume_std : float
+        Standard deviation in cm^3 of the stochastic volume calculation, added
+        via :meth:`Cell.add_volume_information` method.
     atoms : collections.OrderedDict
         Mapping of nuclides to the total number of atoms for each nuclide
         present in the cell, or in all of its instances for a 'distribmat'
@@ -110,6 +113,7 @@ class Cell(IDManagerMixin):
         self._paths = None
         self._num_instances = None
         self._volume = None
+        self._volume_std = None
         self._atoms = None
 
     def __contains__(self, point):
@@ -187,6 +191,10 @@ class Cell(IDManagerMixin):
     @property
     def volume(self):
         return self._volume
+
+    @property
+    def volume_std(self):
+        return self._volume_std
 
     @property
     def atoms(self):
@@ -364,6 +372,7 @@ class Cell(IDManagerMixin):
         if volume_calc.domain_type == 'cell':
             if self.id in volume_calc.volumes:
                 self._volume = volume_calc.volumes[self.id].n
+                self._volume_std = volume_calc.volumes[self.id].s
                 self._atoms = volume_calc.atoms[self.id]
             else:
                 raise ValueError('No volume information found for this cell.')
@@ -520,6 +529,7 @@ class Cell(IDManagerMixin):
 
             clone = openmc.Cell(name=self.name)
             clone.volume = self.volume
+            clone.volume_std = self.volume_std
             if self.temperature is not None:
                 clone.temperature = self.temperature
             if self.translation is not None:

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -529,7 +529,7 @@ class Cell(IDManagerMixin):
 
             clone = openmc.Cell(name=self.name)
             clone.volume = self.volume
-            clone.volume_std = self.volume_std
+            clone._volume_std = self.volume_std
             if self.temperature is not None:
                 clone.temperature = self.temperature
             if self.translation is not None:

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -144,9 +144,9 @@ class Cell(IDManagerMixin):
                                                   self.temperature)
         string += '{: <16}=\t{}\n'.format('\tTranslation', self.translation)
         if self._volume_std is not None:
-            string += '{: <16}=\t{} +/- {}\n'.format('\tVolume', self.volume, self.volume_std)
+            string += '{: <16}=\t{} +/- {} [cm^3]\n'.format('\tVolume', self.volume, self.volume_std)
         else:
-            string += '{: <16}=\t{}\n'.format('\tVolume', self.volume)
+            string += '{: <16}=\t{} [cm^3]\n'.format('\tVolume', self.volume)
 
         return string
 

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -143,7 +143,10 @@ class Cell(IDManagerMixin):
             string += '\t{0: <15}=\t{1}\n'.format('Temperature',
                                                   self.temperature)
         string += '{: <16}=\t{}\n'.format('\tTranslation', self.translation)
-        string += '{: <16}=\t{}\n'.format('\tVolume', self.volume)
+        if self._volume_std is not None:
+            string += '{: <16}=\t{} +/- {}\n'.format('\tVolume', self.volume, self.volume_std)
+        else:
+            string += '{: <16}=\t{}\n'.format('\tVolume', self.volume)
 
         return string
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -81,6 +81,9 @@ class Material(IDManagerMixin):
         Volume of the material in cm^3. This can either be set manually or
         calculated in a stochastic volume calculation and added via the
         :meth:`Material.add_volume_information` method.
+    volume_std : float
+        Standard deviation in cm^3 of the stochastic volume calculation, added
+        via :meth:`Material.add_volume_information` method.
     paths : list of str
         The paths traversed through the CSG tree to reach each material
         instance. This property is initialized by calling the
@@ -120,6 +123,7 @@ class Material(IDManagerMixin):
         self._paths = None
         self._num_instances = None
         self._volume = None
+        self._volume_std = None
         self._atoms = {}
         self._isotropic = []
         self._ncrystal_cfg = None
@@ -226,6 +230,11 @@ class Material(IDManagerMixin):
     @property
     def volume(self):
         return self._volume
+
+    @property
+    def volume_std(self):
+        return self._volume_std
+
 
     @property
     def ncrystal_cfg(self):
@@ -415,6 +424,7 @@ class Material(IDManagerMixin):
         if volume_calc.domain_type == 'material':
             if self.id in volume_calc.volumes:
                 self._volume = volume_calc.volumes[self.id].n
+                self._volume_std = volume_calc.volumes[self.id].s
                 self._atoms = volume_calc.atoms[self.id]
             else:
                 raise ValueError('No volume information found for material ID={}.'

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -144,6 +144,11 @@ class Material(IDManagerMixin):
         string += '{: <16}=\t{}\n'.format('\tName', self._name)
         string += '{: <16}=\t{}\n'.format('\tTemperature', self._temperature)
 
+        if self._volume_std is not None:
+            string += '{: <16}=\t{} +/- {} [cm]\n'.format('\tVolume', self.volume, self.volume_std)
+        else:
+            string += '{: <16}=\t{} [cm]\n'.format('\tVolume', self.volume)
+            
         string += '{: <16}=\t{}'.format('\tDensity', self._density)
         string += f' [{self._density_units}]\n'
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -145,9 +145,9 @@ class Material(IDManagerMixin):
         string += '{: <16}=\t{}\n'.format('\tTemperature', self._temperature)
 
         if self._volume_std is not None:
-            string += '{: <16}=\t{} +/- {} [cm]\n'.format('\tVolume', self.volume, self.volume_std)
+            string += '{: <16}=\t{} +/- {} [cm^3]\n'.format('\tVolume', self.volume, self.volume_std)
         else:
-            string += '{: <16}=\t{} [cm]\n'.format('\tVolume', self.volume)
+            string += '{: <16}=\t{} [cm^3]\n'.format('\tVolume', self.volume)
             
         string += '{: <16}=\t{}'.format('\tDensity', self._density)
         string += f' [{self._density_units}]\n'

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -59,6 +59,10 @@ class UniverseBase(ABC, IDManagerMixin):
     def volume(self):
         return self._volume
 
+    @property
+    def volume_std(self):
+        return self._volume_std
+
     @name.setter
     def name(self, name):
         if name is not None:
@@ -85,6 +89,7 @@ class UniverseBase(ABC, IDManagerMixin):
         if volume_calc.domain_type == 'universe':
             if self.id in volume_calc.volumes:
                 self._volume = volume_calc.volumes[self.id].n
+                self._volume_std = volume_calc.volumes[self.id].s
                 self._atoms = volume_calc.atoms[self.id]
             else:
                 raise ValueError('No volume information found for this universe.')
@@ -179,6 +184,9 @@ class Universe(UniverseBase):
         Volume of the universe in cm^3. This can either be set manually or
         calculated in a stochastic volume calculation and added via the
         :meth:`Universe.add_volume_information` method.
+    volume_std : float
+        Standard deviation in cm^3 of the stochastic volume calculation, added
+        via :meth:`Universe.add_volume_information` method.
     bounding_box : 2-tuple of numpy.array
         Lower-left and upper-right coordinates of an axis-aligned bounding box
         of the universe.

--- a/tests/regression_tests/distribmat/results_true.dat
+++ b/tests/regression_tests/distribmat/results_true.dat
@@ -7,4 +7,4 @@ Cell
 	Region         =	-9
 	Rotation       =	None
 	Translation    =	None
-	Volume         =	None
+	Volume         =	None [cm^3]

--- a/tests/regression_tests/multipole/results_true.dat
+++ b/tests/regression_tests/multipole/results_true.dat
@@ -39,4 +39,4 @@ Cell
 	Rotation       =	None
 	Temperature    =	[500. 700.   0. 800.]
 	Translation    =	None
-	Volume         =	None
+	Volume         =	None [cm^3]

--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -2,6 +2,7 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import numpy as np
+from uncertainties import UFloat
 import openmc
 import pytest
 
@@ -44,7 +45,7 @@ def test_volume(run_in_tmpdir, uo2):
         assert not nucs ^ {'U235', 'O16'}
 
         # make sure standard deviation is also set from the calculation
-        assert isinstance(domain.volume_std, float)
+        assert isinstance(domain.volume, UFloat)
 
 
 def test_export_xml(run_in_tmpdir, uo2):

--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -43,6 +43,9 @@ def test_volume(run_in_tmpdir, uo2):
         nucs = set(domain.get_nuclide_densities())
         assert not nucs ^ {'U235', 'O16'}
 
+        # make sure standard deviation is also set from the calculation
+        assert domain.volume_std is not None
+
 
 def test_export_xml(run_in_tmpdir, uo2):
     s1 = openmc.Sphere(r=1.)

--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -44,7 +44,7 @@ def test_volume(run_in_tmpdir, uo2):
         assert not nucs ^ {'U235', 'O16'}
 
         # make sure standard deviation is also set from the calculation
-        assert domain.volume_std is not None
+        assert isinstance(domain.volume_std, float)
 
 
 def test_export_xml(run_in_tmpdir, uo2):


### PR DESCRIPTION
resolves #2221

I added a property to `Cell`, `Material`, and `Universe` that sets the volume standard deviation property (`volume_std`) if results are loaded from a stochastic volume calc. I intentionally did not add it as something that can be set manually because there wouldn't be a standard deviation if it wasn't from loading the results of a volume calc, but I can easily change that if people would prefer it to be able to be set manually as well. I also added the standard deviation to the string representation for Cell if the information is present (Material and Universe already don't print that info).

This update to just add another property is the easy fix as well. A more involved update would be to change the `.volume` property to be an `uncertainties` variable instead of type `float` and report it in the same property. But that could break backward compatibility. Still, I am open to trying to do it that way if it's preferred. Also, I didn't set anything downstream to propagate this in calculations (eg calculation of nuclide densities).