### PR TITLE
added get_tabular method to energyfilters

### DIFF
--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1352,12 +1352,15 @@ class EnergyFilter(RealFilter):
             Tabular distribution with histogram interpolation
         """
 
-        probabilities = np.array(values) / sum(values)
+        probabilities = np.array(values, dtype=float)
+        probabilities /= probabilities.sum()
 
+        # Determine probability per eV, adding extra 0 at the end since it is a histogram
         probability_per_ev = probabilities / np.diff(self.values)
+        probability_per_ev = np.append(probability_per_ev, 0.0)
 
         kwargs.setdefault('interpolation', 'histogram')
-        return openmc.stats.Tabular(self.bins, probability_per_ev, **kwargs)
+        return openmc.stats.Tabular(self.values, probability_per_ev, **kwargs)
 
     @property
     def lethargy_bin_width(self):

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1352,8 +1352,7 @@ class EnergyFilter(RealFilter):
             Tabular distribution with histogram interpolation
         """
 
-        probabilities = np.array(values)
-        probabilities /= probabilities.sum()
+        probabilities = np.array(values) / sum(values)
 
         probability_per_ev = probabilities / np.diff(self.values)
 

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1332,6 +1332,35 @@ class EnergyFilter(RealFilter):
             cv.check_greater_than('filter value', v0, 0., equality=True)
             cv.check_greater_than('filter value', v1, 0., equality=True)
 
+    def get_tabular(self, values, interpolation='histogram'):
+        """Creates a openmc.stats.Tabular distribution using the EnergyFilter
+        bins and the provided values. Intended use is to help convert a
+        spectrum tally into a source energy.
+
+        Parameters
+        ----------
+        values : np.array
+            Array of numeric values, typically a tally.mean from a spectrum tally
+        interpolation : {'histogram', 'linear-linear', 'linear-log', 'log-linear', 'log-log'}
+            Indicate whether the density function is constant between tabulated
+            points or linearly-interpolated. Defaults to 'histogram'.         
+
+        Returns
+        -------
+        openmc.stats.Tabular
+            Tabular distribution with histogram interpolation
+        """
+
+        probabilities = values / sum(values)
+
+        probability_per_ev = probabilities / np.diff(self.bins).flatten()
+
+        return openmc.stats.Tabular(
+            x=self.bins,
+            p=probability_per_ev,
+            interpolation=interpolation
+        )
+
     @property
     def lethargy_bin_width(self):
         """Calculates the base 10 log width of energy bins which is useful when

--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -273,7 +273,7 @@ def test_energyfunc():
 
 def test_tabular_from_energyfilter():
     efilter = openmc.EnergyFilter([0.0, 10.0, 20.0, 25.0])
-    tab = efilter.get_tabular(values=np.array([5, 10, 10]))
+    tab = efilter.get_tabular(values=[5, 10, 10])
 
     assert tab.x.tolist() == [[0.0, 10.0], [10.0, 20.0], [20.0, 25.0]]
 

--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -279,7 +279,7 @@ def test_tabular_from_energyfilter():
 
     # combination of different values passed into get_tabular and different
     # width energy bins results in a doubling value for each p value
-    assert tab.p.tolist() == [0.02, 0.04, 0.08]
+    assert tab.p.tolist() == [0.02, 0.04, 0.08, 0.0]
 
     # distribution should integrate to unity
     assert tab.integral() == approx(1.0)

--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -275,11 +275,14 @@ def test_tabular_from_energyfilter():
     efilter = openmc.EnergyFilter([0.0, 10.0, 20.0, 25.0])
     tab = efilter.get_tabular(values=[5, 10, 10])
 
-    assert tab.x.tolist() == [[0.0, 10.0], [10.0, 20.0], [20.0, 25.0]]
+    assert tab.x.tolist() == [0.0, 10.0, 20.0, 25.0]
 
     # combination of different values passed into get_tabular and different
     # width energy bins results in a doubling value for each p value
     assert tab.p.tolist() == [0.02, 0.04, 0.08]
+
+    # distribution should integrate to unity
+    assert tab.integral() == approx(1.0)
 
     # 'histogram' is the default
     assert tab.interpolation == 'histogram'

--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -269,3 +269,20 @@ def test_energyfunc():
     np.testing.assert_allclose(f.energy, new_f.energy)
     np.testing.assert_allclose(f.y, new_f.y)
     assert f.interpolation == new_f.interpolation
+
+
+def test_tabular_from_energyfilter():
+    efilter = openmc.EnergyFilter([0.0, 10.0, 20.0, 25.0])
+    tab = efilter.get_tabular(values=np.array([5, 10, 10]))
+
+    assert tab.x.tolist() == [[0.0, 10.0], [10.0, 20.0], [20.0, 25.0]]
+
+    # combination of different values passed into get_tabular and different
+    # width energy bins results in a doubling value for each p value
+    assert tab.p.tolist() == [0.02, 0.04, 0.08]
+
+    # 'histogram' is the default
+    assert tab.interpolation == 'histogram'
+
+    tab = efilter.get_tabular(values=np.array([10, 10, 5]), interpolation='linear-linear')
+    assert tab.interpolation == 'linear-linear'


### PR DESCRIPTION
As discussed on [this thread of the openmc forum ](https://openmc.discourse.group/t/source-energy-distribution-for-neutron-of-different-energy-group/477/6) it is handy to be able to make tabular distributions from energy filters.

This PR attempts to add a method ```EnergyFilter.get_tabular``` to facilitate this.

Example usage

```python
cell_tally = results.get_tally(name='cell_spectra_tally')

tab = energy_filter.get_tabular(values=cell_tally.mean.flatten())

source = openmc.Source()
source.energy = tab
```

Many thanks to @Asureda who showed me the way forward for making this into a source energy distribution and the openmc forum thread and also talked me through the approach with a nice code example. 

Next step on the path to using this for activation is to find a way of setting the source strength