### PR TITLE
making error message more helpful with material name

### DIFF
--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -223,8 +223,9 @@ class OpenMCOperator(TransportOperator):
             if mat.depletable:
                 burnable_mats.add(str(mat.id))
                 if mat.volume is None:
-                    raise RuntimeError("Volume not specified for depletable "
-                                       "material with ID={}.".format(mat.id))
+                    msh = ("Volume not specified for depletable material with "
+                           f"ID={mat.id}. Name={mat.name}")
+                    raise RuntimeError(msh)
                 volume[str(mat.id)] = mat.volume
                 self.heavy_metal += mat.fissionable_mass
 
@@ -242,7 +243,6 @@ class OpenMCOperator(TransportOperator):
         for nuc in model_nuclides:
             if nuc not in nuclides:
                 nuclides.append(nuc)
-
         return burnable_mats, volume, nuclides
 
     def _load_previous_results(self):

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -223,9 +223,11 @@ class OpenMCOperator(TransportOperator):
             if mat.depletable:
                 burnable_mats.add(str(mat.id))
                 if mat.volume is None:
-                    msh = ("Volume not specified for depletable material with "
-                           f"ID={mat.id} Name={mat.name}.")
-                    raise RuntimeError(msh)
+                    msg = ("Volume not specified for depletable material with "
+                           f"ID={mat.id}.")
+                    if mat.name is not None:
+                        msg = f"{msg[:-1]} Name={mat.name}."
+                    raise RuntimeError(msg)
                 volume[str(mat.id)] = mat.volume
                 self.heavy_metal += mat.fissionable_mass
 

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -224,7 +224,7 @@ class OpenMCOperator(TransportOperator):
                 burnable_mats.add(str(mat.id))
                 if mat.volume is None:
                     msh = ("Volume not specified for depletable material with "
-                           f"ID={mat.id}. Name={mat.name}")
+                           f"ID={mat.id} Name={mat.name}.")
                     raise RuntimeError(msh)
                 volume[str(mat.id)] = mat.volume
                 self.heavy_metal += mat.fissionable_mass

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -223,10 +223,12 @@ class OpenMCOperator(TransportOperator):
             if mat.depletable:
                 burnable_mats.add(str(mat.id))
                 if mat.volume is None:
-                    msg = ("Volume not specified for depletable material with "
-                           f"ID={mat.id}.")
-                    if mat.name is not None:
-                        msg = f"{msg[:-1]} Name={mat.name}."
+                    if mat.name is None:
+                        msg = ("Volume not specified for depletable material "
+                               f"with ID={mat.id}.")
+                    else:
+                        msg = ("Volume not specified for depletable material "
+                               f"with ID={mat.id} Name={mat.name}.")
                     raise RuntimeError(msg)
                 volume[str(mat.id)] = mat.volume
                 self.heavy_metal += mat.fissionable_mass


### PR DESCRIPTION
Tiny little PR

While running some depletion simulations it is necessary to set material volumes

I get a bit lost with large models and lots of IDs for cells, surface and materials so I thought it might be helpful to add the material name to the error message. I couldn't resists change the ```.format``` to an f string :smile: 

While it is totally possible to find the material from just the ID this makes it a tiny bit quicker and easier in the case where the user has named all their materials. I use a materials database which names materials automatically but perhaps that is just me.

Current error message
```bash
RuntimeError: Volume not specified for depletable material with ID=3.
```
Proposed error message
```bash
RuntimeError: Volume not specified for depletable material with ID=3 Name=Concrete.
```

Thanks for your consideration