### PR TITLE
added volume information to material repr

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -143,8 +143,7 @@ class Material(IDManagerMixin):
         string += '{: <16}=\t{}'.format('\tDensity', self._density)
         string += f' [{self._density_units}]\n'
 
-        string += '{: <16}=\t{}'.format('\tVolume', self._volume)
-        string += ' [cm^3]\n'
+        string += '{: <16}=\t{} [cm^3]\n'.format('\tVolume', self._volume)
 
         string += '{: <16}\n'.format('\tS(a,b) Tables')
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -143,6 +143,9 @@ class Material(IDManagerMixin):
         string += '{: <16}=\t{}'.format('\tDensity', self._density)
         string += f' [{self._density_units}]\n'
 
+        string += '{: <16}=\t{}'.format('\tVolume', self._volume)
+        string += ' [cm3]\n'
+
         string += '{: <16}\n'.format('\tS(a,b) Tables')
 
         if self._ncrystal_cfg:

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -144,7 +144,7 @@ class Material(IDManagerMixin):
         string += f' [{self._density_units}]\n'
 
         string += '{: <16}=\t{}'.format('\tVolume', self._volume)
-        string += ' [cm3]\n'
+        string += ' [cm^3]\n'
 
         string += '{: <16}\n'.format('\tS(a,b) Tables')
 


### PR DESCRIPTION
Hi all, another tiny PR for your consideration

I'm doing a few depletion simulations and this requires adding volume information to each material.

It would be useful for me at least if the ```material.__repr__``` included the volume information.

Then when a material is printed it will display volume along with other handy things like name, density, temperature etc and I can easily see which of my materials still need volume adding

before this PR
```
 Material
	ID             =	8
	Name           =	mat_suspended_floor
	Temperature    =	None
	Density        =	7.82 [g/cm3]
	S(a,b) Tables  
	Nuclides       
	Fe54           =	0.057115528049999996 [ao]
```


after this PR
```
 Material
	ID             =	8
	Name           =	mat_suspended_floor
	Temperature    =	None
	Density        =	7.82 [g/cm3]
	Volume         =	1.2709345346346374e+26 [cm3]
	S(a,b) Tables  
	Nuclides       
	Fe54           =	0.057115528049999996 [ao]
```