### PR TITLE
Avoid out-of-bounds access in inelastic scatter sampling

### DIFF
--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -705,17 +705,10 @@ void scatter(Particle& p, int i_nuclide)
     // =======================================================================
     // INELASTIC SCATTERING
 
-    int j = 0;
+    int n = nuc->index_inelastic_scatter_.size();
     int i = 0;
-    while (prob < cutoff) {
+    for (int j = 0; j < n && prob < cutoff; ++j) {
       i = nuc->index_inelastic_scatter_[j];
-      ++j;
-
-      // Check to make sure inelastic scattering reaction sampled
-      if (i >= nuc->reactions_.size()) {
-        p.write_restart();
-        fatal_error("Did not sample any reaction for nuclide " + nuc->name_);
-      }
 
       // add to cumulative probability
       prob += nuc->reactions_[i]->xs(micro);


### PR DESCRIPTION
Several people have run into problems trying to use FENDL 3 data with OpenMC, usually encountering the following error:
```
ERROR: Did not sample any reaction for nuclide Fe58
```
After digging into this, I was able to determine the root cause, which is very subtle. When a neutron is in the unresolved resonance region, the inelastic scattering cross section is determined based on an "inelastic flag" that indicates what reaction should be used to evaluate inelastic scattering. Often this is MT=51, the first level inelastic scattering reaction, but sometimes the flag will indicate to use MT=4, which is the sum of MT=51 through 91 and is a redundant reaction. So in theory, summing up MT=51--91 should give the exact value on MT=4, but due to floating point roundoff sometimes they are ever so slightly different. The bug thus arises in the following situation:
- Neutron is in the URR 
- Inelastic flag indicates to use MT=4 for the inelastic cross section in the URR
- When sampling an inelastic scattering reaction, the cross section for each inelastic level is accounted for, but the condition for terminating the loop below is never met due to very small differences between the sum of the inelastic levels and the MT=4 data:
    https://github.com/openmc-dev/openmc/blob/6218becb1710780cc1e5ab82b896a0609375a2b6/src/physics.cpp#L710-L722

- Thus, another iteration of the loop is run and this time `index_inelastic_scatter_[j]` results in an out-of-bounds access, so the program reaches undefined behavior (depending on whatever random data is sitting in memory at this location).

The solution is pretty simple -- simply add another check for terminating this loop that guarantees we never access data beyond the end of the `index_inelastic_scatter_` vector. I've run simulations on several problems provided to me by @SteSeg where this problem was popping up and I've successfully gotten through 100 billion particles without encountering any issues.