### PR TITLE
adding get_sum_of_source_strengths property

### DIFF
--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -936,6 +936,17 @@ class Settings:
         cv.check_greater_than('maximum particle tracks', value, 0, True)
         self._max_tracks = value
 
+    @property
+    def get_sum_of_source_strengths(self):
+        """Gets the total source strength of all sources. Useful when
+        normalizing the tally result from model with sources that comprise of
+        multiple openmc.Source objects"""
+
+        total_strength = 0
+        for source in self.source:
+            total_strength += source.strength
+        return total_strength
+
     def _create_run_mode_subelement(self, root):
         elem = ET.SubElement(root, "run_mode")
         elem.text = self._run_mode.value

--- a/tests/unit_tests/test_settings.py
+++ b/tests/unit_tests/test_settings.py
@@ -120,3 +120,13 @@ def test_export_to_xml(run_in_tmpdir):
     assert vol.samples == 1000
     assert vol.lower_left == (-10., -10., -10.)
     assert vol.upper_right == (10., 10., 10.)
+
+
+def test_get_sum_of_source_strengths(run_in_tmpdir):
+    settings = openmc.Settings()
+    source_1 = openmc.Source(space=openmc.stats.Point(), strength=10)
+    source_2 = openmc.Source(space=openmc.stats.Point(), strength=5.5)
+    settings.source = source_1
+    assert settings.get_sum_of_source_strengths == 10
+    settings.source = [source_1, source_2]
+    assert settings.get_sum_of_source_strengths == 15.5


### PR DESCRIPTION
I'm a bit unsure about this PR. I think perhaps we should have a ```openmc.Sources``` object to collect individual ```openmc.Source``` objects as I think there is a need to do operations on a collection of sources. But seeing as we don't currently have that class here is my proposal for an operation that might be useful to run on multiple source objects. It lives in the ```openmc.Settings``` class as that has access to the information.

Also just to mention this is perhaps easy for users to perform themselves, but I'm sure there will be a need for operations on a collection of openmc.Source objects in the future

When running R2S simulations we make a lot of sources and each source as a source strength. One could set the source strength using the ```source.energy.integral()``` which effectively makes it a source in units of Becquerels. Anyway the simulation results need to be scaled by the source strength of all the sources simulated to get useful results. Therefore I propose we have a tiny method that allows on to get the source strength of all the sources assigned to the settings.source object.

This is currently a property that lives in the ```openmc.Settings``` class as that has access to all the sources.

Happy to discuss making an ```openmc.Sources``` class for these sorts of operations instead. Might be a bit like the ```openmc.Materials``` container we have for indivdual ```openmc.Material``` objects.

Tagging @eepeterson for guidance