### PR TITLE
map does not accept keyword argument, fixing PR #2356

### DIFF
--- a/openmc/deplete/pool.py
+++ b/openmc/deplete/pool.py
@@ -15,7 +15,7 @@ USE_MULTIPROCESSING = True
 NUM_PROCESSES = None
 
 
-def deplete(func, chain, x, rates, dt, matrix_func=None, **func_args):
+def deplete(func, chain, x, rates, dt, matrix_func=None, *func_args):
     """Deplete materials using given reaction rates for a specified time
 
     Parameters
@@ -60,7 +60,7 @@ def deplete(func, chain, x, rates, dt, matrix_func=None, **func_args):
         matrices = map(chain.form_matrix, rates, fission_yields)
     else:
         matrices = map(matrix_func, repeat(chain), rates, fission_yields,
-                       **func_args)
+                       *func_args)
 
     inputs = zip(matrices, x, repeat(dt))
 

--- a/openmc/deplete/pool.py
+++ b/openmc/deplete/pool.py
@@ -15,7 +15,7 @@ USE_MULTIPROCESSING = True
 NUM_PROCESSES = None
 
 
-def deplete(func, chain, x, rates, dt, matrix_func=None, *func_args):
+def deplete(func, chain, x, rates, dt, matrix_func=None, *matrix_args):
     """Deplete materials using given reaction rates for a specified time
 
     Parameters
@@ -37,8 +37,8 @@ def deplete(func, chain, x, rates, dt, matrix_func=None, *func_args):
         ``fission_yields = {parent: {product: yield_frac}}``
         Expected to return the depletion matrix required by
         ``func``
-    func_args : dict
-        Remaining keyword arguments passed to matrix_func when used
+    matrix_args : Any, optional
+        Additional arguments passed to matrix_func
 
     Returns
     -------
@@ -60,7 +60,7 @@ def deplete(func, chain, x, rates, dt, matrix_func=None, *func_args):
         matrices = map(chain.form_matrix, rates, fission_yields)
     else:
         matrices = map(matrix_func, repeat(chain), rates, fission_yields,
-                       *func_args)
+                       *matrix_args)
 
     inputs = zip(matrices, x, repeat(dt))
 


### PR DESCRIPTION
In a recent merged PR #2356 , I was issuing, I implemented modification to allow additional argument to be passed to the `matrix_function` when a customized `matrix_func` was passed to the `pool.deplete` method.

While waiting to the previous PR to be reviewed and merged, I had overloaded the `pool.deplete` function to allow to continue my work. I just realized that I therefore had not tested it...

Sadly, my addition to the `pool.deplete` function was not working as: `TypeError: map() takes no keyword arguments` ...

This should fix my mistake, I tested it locally.

I am sorry for the inconvenience. 
I was not able to find a proper location to implement unit test to ensure this would not happen again (there is no `test_deplete_pool.py` file), if you wish me to create it and implement a test for this please let me know.