### PR TITLE
testing get_all_universes is in DAGMCUniverse

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -91,6 +91,23 @@ class UniverseBase(ABC, IDManagerMixin):
         else:
             raise ValueError('No volume information found for this universe.')
 
+    def get_all_universes(self):
+        """Return all universes that are contained within this one.
+
+        Returns
+        -------
+        universes : collections.OrderedDict
+            Dictionary whose keys are universe IDs and values are
+            :class:`Universe` instances
+
+        """
+        # Append all Universes within each Cell to the dictionary
+        universes = OrderedDict()
+        for cell in self.get_all_cells().values():
+            universes.update(cell.get_all_universes())
+
+        return universes
+
     @abstractmethod
     def create_xml_subelement(self, xml_element, memo=None):
         """Add the universe xml representation to an incoming xml element
@@ -537,23 +554,6 @@ class Universe(UniverseBase):
             materials.update(cell.get_all_materials(memo))
 
         return materials
-
-    def get_all_universes(self):
-        """Return all universes that are contained within this one.
-
-        Returns
-        -------
-        universes : collections.OrderedDict
-            Dictionary whose keys are universe IDs and values are
-            :class:`Universe` instances
-
-        """
-        # Append all Universes within each Cell to the dictionary
-        universes = OrderedDict()
-        for cell in self.get_all_cells().values():
-            universes.update(cell.get_all_universes())
-
-        return universes
 
     def create_xml_subelement(self, xml_element, memo=None):
         # Iterate over all Cells

--- a/tests/unit_tests/test_universe.py
+++ b/tests/unit_tests/test_universe.py
@@ -93,10 +93,12 @@ def test_get_all_universes():
     u2 = openmc.Universe(cells=[c2])
     c3 = openmc.Cell(fill=u1)
     c4 = openmc.Cell(fill=u2)
-    u3 = openmc.Universe(cells=[c3, c4])
+    u3 = openmc.DAGMCUniverse(filename="")
+    c5 = openmc.Cell(fill=u3)
+    u4 = openmc.Universe(cells=[c3, c4, c5])
 
-    univs = set(u3.get_all_universes().values())
-    assert not (univs ^ {u1, u2})
+    univs = set(u4.get_all_universes().values())
+    assert not (univs ^ {u1, u2, u3})
 
 
 def test_clone():


### PR DESCRIPTION
PR to move the Universe.get_all_universes to UniverseBase.get_all_universes so that DAGMCUniverse (which inherits UniverseBase) can make use of this nice method.

No changes to the method were needed

I've adapted a test to make use of this method which should fail

The 2nd commit should pass the test

Closes #2387

