### PR TITLE
Add missing override specifiers in C++ classes

### DIFF
--- a/include/openmc/distribution.h
+++ b/include/openmc/distribution.h
@@ -43,7 +43,7 @@ public:
   //! Sample a value from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
-  double sample(uint64_t* seed) const;
+  double sample(uint64_t* seed) const override;
 
   // Properties
   const vector<double>& x() const { return x_; }
@@ -75,7 +75,7 @@ public:
   //! Sample a value from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
-  double sample(uint64_t* seed) const;
+  double sample(uint64_t* seed) const override;
 
   double a() const { return a_; }
   double b() const { return b_; }
@@ -99,7 +99,7 @@ public:
   //! Sample a value from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
-  double sample(uint64_t* seed) const;
+  double sample(uint64_t* seed) const override;
 
   double a() const { return std::pow(offset_, ninv_); }
   double b() const { return std::pow(offset_ + span_, ninv_); }
@@ -124,7 +124,7 @@ public:
   //! Sample a value from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
-  double sample(uint64_t* seed) const;
+  double sample(uint64_t* seed) const override;
 
   double theta() const { return theta_; }
 
@@ -144,7 +144,7 @@ public:
   //! Sample a value from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
-  double sample(uint64_t* seed) const;
+  double sample(uint64_t* seed) const override;
 
   double a() const { return a_; }
   double b() const { return b_; }
@@ -168,7 +168,7 @@ public:
   //! Sample a value from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
-  double sample(uint64_t* seed) const;
+  double sample(uint64_t* seed) const override;
 
   double mean_value() const { return mean_value_; }
   double std_dev() const { return std_dev_; }
@@ -191,7 +191,7 @@ public:
   //! Sample a value from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
-  double sample(uint64_t* seed) const;
+  double sample(uint64_t* seed) const override;
 
   // x property
   vector<double>& x() { return x_; }
@@ -225,7 +225,7 @@ public:
   //! Sample a value from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
-  double sample(uint64_t* seed) const;
+  double sample(uint64_t* seed) const override;
 
   const vector<double>& x() const { return x_; }
 
@@ -244,7 +244,7 @@ public:
   //! Sample a value from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
-  double sample(uint64_t* seed) const;
+  double sample(uint64_t* seed) const override;
 
 private:
   // Storrage for probability + distribution

--- a/include/openmc/distribution_energy.h
+++ b/include/openmc/distribution_energy.h
@@ -37,7 +37,7 @@ public:
   //! \param[in] E Incident particle energy in [eV]
   //! \param[inout] seed Pseudorandom number seed pointer
   //! \return Sampled energy in [eV]
-  double sample(double E, uint64_t* seed) const;
+  double sample(double E, uint64_t* seed) const override;
 
 private:
   int primary_flag_; //!< Indicator of whether the photon is a primary or
@@ -58,7 +58,7 @@ public:
   //! \param[in] E Incident particle energy in [eV]
   //! \param[inout] seed Pseudorandom number seed pointer
   //! \return Sampled energy in [eV]
-  double sample(double E, uint64_t* seed) const;
+  double sample(double E, uint64_t* seed) const override;
 
 private:
   double threshold_;  //!< Energy threshold in lab, (A + 1)/A * |Q|
@@ -79,7 +79,7 @@ public:
   //! \param[in] E Incident particle energy in [eV]
   //! \param[inout] seed Pseudorandom number seed pointer
   //! \return Sampled energy in [eV]
-  double sample(double E, uint64_t* seed) const;
+  double sample(double E, uint64_t* seed) const override;
 
 private:
   //! Outgoing energy for a single incoming energy
@@ -110,7 +110,7 @@ public:
   //! \param[in] E Incident particle energy in [eV]
   //! \param[inout] seed Pseudorandom number seed pointer
   //! \return Sampled energy in [eV]
-  double sample(double E, uint64_t* seed) const;
+  double sample(double E, uint64_t* seed) const override;
 
 private:
   Tabulated1D theta_; //!< Incoming energy dependent parameter
@@ -130,7 +130,7 @@ public:
   //! \param[in] E Incident particle energy in [eV]
   //! \param[inout] seed Pseudorandom number seed pointer
   //! \return Sampled energy in [eV]
-  double sample(double E, uint64_t* seed) const;
+  double sample(double E, uint64_t* seed) const override;
 
 private:
   Tabulated1D theta_; //!< Incoming energy dependent parameter
@@ -150,7 +150,7 @@ public:
   //! \param[in] E Incident particle energy in [eV]
   //! \param[inout] seed Pseudorandom number seed pointer
   //! \return Sampled energy in [eV]
-  double sample(double E, uint64_t* seed) const;
+  double sample(double E, uint64_t* seed) const override;
 
 private:
   Tabulated1D a_; //!< Energy-dependent 'a' parameter

--- a/include/openmc/distribution_multi.h
+++ b/include/openmc/distribution_multi.h
@@ -42,7 +42,7 @@ public:
   //! Sample a direction from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Direction sampled
-  Direction sample(uint64_t* seed) const;
+  Direction sample(uint64_t* seed) const override;
 
   // Observing pointers
   Distribution* mu() const { return mu_.get(); }
@@ -66,7 +66,7 @@ public:
   //! Sample a direction from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled direction
-  Direction sample(uint64_t* seed) const;
+  Direction sample(uint64_t* seed) const override;
 };
 
 //==============================================================================
@@ -82,7 +82,7 @@ public:
   //! Sample a direction from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled direction
-  Direction sample(uint64_t* seed) const;
+  Direction sample(uint64_t* seed) const override;
 };
 
 using UPtrAngle = unique_ptr<UnitSphereDistribution>;

--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -32,7 +32,7 @@ public:
   //! Sample a position from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled position
-  Position sample(uint64_t* seed) const;
+  Position sample(uint64_t* seed) const override;
 
   // Observer pointers
   Distribution* x() const { return x_.get(); }
@@ -56,7 +56,7 @@ public:
   //! Sample a position from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled position
-  Position sample(uint64_t* seed) const;
+  Position sample(uint64_t* seed) const override;
 
   Distribution* r() const { return r_.get(); }
   Distribution* phi() const { return phi_.get(); }
@@ -81,7 +81,7 @@ public:
   //! Sample a position from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled position
-  Position sample(uint64_t* seed) const;
+  Position sample(uint64_t* seed) const override;
 
   Distribution* r() const { return r_.get(); }
   Distribution* cos_theta() const { return cos_theta_.get(); }
@@ -106,7 +106,7 @@ public:
   //! Sample a position from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled position
-  Position sample(uint64_t* seed) const;
+  Position sample(uint64_t* seed) const override;
 
   const Mesh* mesh() const { return model::meshes.at(mesh_idx_).get(); }
 
@@ -132,7 +132,7 @@ public:
   //! Sample a position from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled position
-  Position sample(uint64_t* seed) const;
+  Position sample(uint64_t* seed) const override;
 
   // Properties
   bool only_fissionable() const { return only_fissionable_; }
@@ -158,7 +158,7 @@ public:
   //! Sample a position from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled position
-  Position sample(uint64_t* seed) const;
+  Position sample(uint64_t* seed) const override;
 
   Position r() const { return r_; }
 

--- a/include/openmc/lattice.h
+++ b/include/openmc/lattice.h
@@ -206,26 +206,28 @@ class RectLattice : public Lattice {
 public:
   explicit RectLattice(pugi::xml_node lat_node);
 
-  int32_t const& operator[](array<int, 3> const& i_xyz);
+  int32_t const& operator[](array<int, 3> const& i_xyz) override;
 
-  bool are_valid_indices(array<int, 3> const& i_xyz) const;
+  bool are_valid_indices(array<int, 3> const& i_xyz) const override;
 
   std::pair<double, array<int, 3>> distance(
-    Position r, Direction u, const array<int, 3>& i_xyz) const;
+    Position r, Direction u, const array<int, 3>& i_xyz) const override;
 
-  void get_indices(Position r, Direction u, array<int, 3>& result) const;
+  void get_indices(
+    Position r, Direction u, array<int, 3>& result) const override;
 
-  int get_flat_index(const array<int, 3>& i_xyz) const;
+  int get_flat_index(const array<int, 3>& i_xyz) const override;
 
-  Position get_local_position(Position r, const array<int, 3>& i_xyz) const;
+  Position get_local_position(
+    Position r, const array<int, 3>& i_xyz) const override;
 
-  int32_t& offset(int map, array<int, 3> const& i_xyz);
+  int32_t& offset(int map, array<int, 3> const& i_xyz) override;
 
-  int32_t offset(int map, int indx) const;
+  int32_t offset(int map, int indx) const override;
 
-  std::string index_to_string(int indx) const;
+  std::string index_to_string(int indx) const override;
 
-  void to_hdf5_inner(hid_t group_id) const;
+  void to_hdf5_inner(hid_t group_id) const override;
 
 private:
   array<int, 3> n_cells_; //!< Number of cells along each axis
@@ -239,32 +241,34 @@ class HexLattice : public Lattice {
 public:
   explicit HexLattice(pugi::xml_node lat_node);
 
-  int32_t const& operator[](array<int, 3> const& i_xyz);
+  int32_t const& operator[](array<int, 3> const& i_xyz) override;
 
-  LatticeIter begin();
+  LatticeIter begin() override;
 
-  ReverseLatticeIter rbegin();
+  ReverseLatticeIter rbegin() override;
 
-  bool are_valid_indices(array<int, 3> const& i_xyz) const;
+  bool are_valid_indices(array<int, 3> const& i_xyz) const override;
 
   std::pair<double, array<int, 3>> distance(
-    Position r, Direction u, const array<int, 3>& i_xyz) const;
+    Position r, Direction u, const array<int, 3>& i_xyz) const override;
 
-  void get_indices(Position r, Direction u, array<int, 3>& result) const;
+  void get_indices(
+    Position r, Direction u, array<int, 3>& result) const override;
 
-  int get_flat_index(const array<int, 3>& i_xyz) const;
+  int get_flat_index(const array<int, 3>& i_xyz) const override;
 
-  Position get_local_position(Position r, const array<int, 3>& i_xyz) const;
+  Position get_local_position(
+    Position r, const array<int, 3>& i_xyz) const override;
 
-  bool is_valid_index(int indx) const;
+  bool is_valid_index(int indx) const override;
 
-  int32_t& offset(int map, array<int, 3> const& i_xyz);
+  int32_t& offset(int map, array<int, 3> const& i_xyz) override;
 
-  int32_t offset(int map, int indx) const;
+  int32_t offset(int map, int indx) const override;
 
-  std::string index_to_string(int indx) const;
+  std::string index_to_string(int indx) const override;
 
-  void to_hdf5_inner(hid_t group_id) const;
+  void to_hdf5_inner(hid_t group_id) const override;
 
 private:
   enum class Orientation {

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -527,8 +527,6 @@ public:
   //! \return element connectivity as IDs of the vertices
   virtual std::vector<int> connectivity(int id) const = 0;
 
-  virtual double volume(int bin) const = 0;
-
   //! Get the library used for this unstructured mesh
   virtual std::string library() const = 0;
 

--- a/include/openmc/scattdata.h
+++ b/include/openmc/scattdata.h
@@ -137,22 +137,23 @@ protected:
 public:
   void init(const xt::xtensor<int, 1>& in_gmin,
     const xt::xtensor<int, 1>& in_gmax, const double_2dvec& in_mult,
-    const double_3dvec& coeffs);
+    const double_3dvec& coeffs) override;
 
-  void combine(
-    const vector<ScattData*>& those_scatts, const vector<double>& scalars);
+  void combine(const vector<ScattData*>& those_scatts,
+    const vector<double>& scalars) override;
 
   //! \brief Find the maximal value of the angular distribution to use as a
   // bounding box with rejection sampling.
   void update_max_val();
 
-  double calc_f(int gin, int gout, double mu);
+  double calc_f(int gin, int gout, double mu) override;
 
-  void sample(int gin, int& gout, double& mu, double& wgt, uint64_t* seed);
+  void sample(
+    int gin, int& gout, double& mu, double& wgt, uint64_t* seed) override;
 
-  size_t get_order() { return dist[0][0].size() - 1; };
+  size_t get_order() override { return dist[0][0].size() - 1; };
 
-  xt::xtensor<double, 3> get_matrix(size_t max_order);
+  xt::xtensor<double, 3> get_matrix(size_t max_order) override;
 };
 
 //==============================================================================
@@ -170,18 +171,19 @@ protected:
 public:
   void init(const xt::xtensor<int, 1>& in_gmin,
     const xt::xtensor<int, 1>& in_gmax, const double_2dvec& in_mult,
-    const double_3dvec& coeffs);
+    const double_3dvec& coeffs) override;
 
-  void combine(
-    const vector<ScattData*>& those_scatts, const vector<double>& scalars);
+  void combine(const vector<ScattData*>& those_scatts,
+    const vector<double>& scalars) override;
 
-  double calc_f(int gin, int gout, double mu);
+  double calc_f(int gin, int gout, double mu) override;
 
-  void sample(int gin, int& gout, double& mu, double& wgt, uint64_t* seed);
+  void sample(
+    int gin, int& gout, double& mu, double& wgt, uint64_t* seed) override;
 
-  size_t get_order() { return dist[0][0].size(); };
+  size_t get_order() override { return dist[0][0].size(); };
 
-  xt::xtensor<double, 3> get_matrix(size_t max_order);
+  xt::xtensor<double, 3> get_matrix(size_t max_order) override;
 };
 
 //==============================================================================
@@ -204,18 +206,19 @@ protected:
 public:
   void init(const xt::xtensor<int, 1>& in_gmin,
     const xt::xtensor<int, 1>& in_gmax, const double_2dvec& in_mult,
-    const double_3dvec& coeffs);
+    const double_3dvec& coeffs) override;
 
-  void combine(
-    const vector<ScattData*>& those_scatts, const vector<double>& scalars);
+  void combine(const vector<ScattData*>& those_scatts,
+    const vector<double>& scalars) override;
 
-  double calc_f(int gin, int gout, double mu);
+  double calc_f(int gin, int gout, double mu) override;
 
-  void sample(int gin, int& gout, double& mu, double& wgt, uint64_t* seed);
+  void sample(
+    int gin, int& gout, double& mu, double& wgt, uint64_t* seed) override;
 
-  size_t get_order() { return dist[0][0].size(); };
+  size_t get_order() override { return dist[0][0].size(); };
 
-  xt::xtensor<double, 3> get_matrix(size_t max_order);
+  xt::xtensor<double, 3> get_matrix(size_t max_order) override;
 };
 
 //==============================================================================

--- a/include/openmc/surface.h
+++ b/include/openmc/surface.h
@@ -146,9 +146,6 @@ class CSGSurface : public Surface {
 public:
   explicit CSGSurface(pugi::xml_node surf_node);
   CSGSurface();
-
-protected:
-  virtual void to_hdf5_inner(hid_t group_id) const = 0;
 };
 
 //==============================================================================
@@ -160,11 +157,11 @@ protected:
 class SurfaceXPlane : public CSGSurface {
 public:
   explicit SurfaceXPlane(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
-  BoundingBox bounding_box(bool pos_side) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
+  BoundingBox bounding_box(bool pos_side) const override;
 
   double x0_;
 };
@@ -178,11 +175,11 @@ public:
 class SurfaceYPlane : public CSGSurface {
 public:
   explicit SurfaceYPlane(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
-  BoundingBox bounding_box(bool pos_side) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
+  BoundingBox bounding_box(bool pos_side) const override;
 
   double y0_;
 };
@@ -196,11 +193,11 @@ public:
 class SurfaceZPlane : public CSGSurface {
 public:
   explicit SurfaceZPlane(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
-  BoundingBox bounding_box(bool pos_side) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
+  BoundingBox bounding_box(bool pos_side) const override;
 
   double z0_;
 };
@@ -214,10 +211,10 @@ public:
 class SurfacePlane : public CSGSurface {
 public:
   explicit SurfacePlane(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
 
   double A_, B_, C_, D_;
 };
@@ -232,11 +229,11 @@ public:
 class SurfaceXCylinder : public CSGSurface {
 public:
   explicit SurfaceXCylinder(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
-  BoundingBox bounding_box(bool pos_side) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
+  BoundingBox bounding_box(bool pos_side) const override;
 
   double y0_, z0_, radius_;
 };
@@ -251,11 +248,11 @@ public:
 class SurfaceYCylinder : public CSGSurface {
 public:
   explicit SurfaceYCylinder(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
-  BoundingBox bounding_box(bool pos_side) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
+  BoundingBox bounding_box(bool pos_side) const override;
 
   double x0_, z0_, radius_;
 };
@@ -270,11 +267,11 @@ public:
 class SurfaceZCylinder : public CSGSurface {
 public:
   explicit SurfaceZCylinder(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
-  BoundingBox bounding_box(bool pos_side) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
+  BoundingBox bounding_box(bool pos_side) const override;
 
   double x0_, y0_, radius_;
 };
@@ -289,11 +286,11 @@ public:
 class SurfaceSphere : public CSGSurface {
 public:
   explicit SurfaceSphere(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
-  BoundingBox bounding_box(bool pos_side) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
+  BoundingBox bounding_box(bool pos_side) const override;
 
   double x0_, y0_, z0_, radius_;
 };
@@ -308,10 +305,10 @@ public:
 class SurfaceXCone : public CSGSurface {
 public:
   explicit SurfaceXCone(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
 
   double x0_, y0_, z0_, radius_sq_;
 };
@@ -326,10 +323,10 @@ public:
 class SurfaceYCone : public CSGSurface {
 public:
   explicit SurfaceYCone(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
 
   double x0_, y0_, z0_, radius_sq_;
 };
@@ -344,10 +341,10 @@ public:
 class SurfaceZCone : public CSGSurface {
 public:
   explicit SurfaceZCone(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
 
   double x0_, y0_, z0_, radius_sq_;
 };
@@ -362,10 +359,10 @@ public:
 class SurfaceQuadric : public CSGSurface {
 public:
   explicit SurfaceQuadric(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
 
   // Ax^2 + By^2 + Cz^2 + Dxy + Eyz + Fxz + Gx + Hy + Jz + K = 0
   double A_, B_, C_, D_, E_, F_, G_, H_, J_, K_;
@@ -380,10 +377,10 @@ public:
 class SurfaceXTorus : public CSGSurface {
 public:
   explicit SurfaceXTorus(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
 
   double x0_, y0_, z0_, A_, B_, C_;
 };
@@ -397,10 +394,10 @@ public:
 class SurfaceYTorus : public CSGSurface {
 public:
   explicit SurfaceYTorus(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
 
   double x0_, y0_, z0_, A_, B_, C_;
 };
@@ -414,10 +411,10 @@ public:
 class SurfaceZTorus : public CSGSurface {
 public:
   explicit SurfaceZTorus(pugi::xml_node surf_node);
-  double evaluate(Position r) const;
-  double distance(Position r, Direction u, bool coincident) const;
-  Direction normal(Position r) const;
-  void to_hdf5_inner(hid_t group_id) const;
+  double evaluate(Position r) const override;
+  double distance(Position r, Direction u, bool coincident) const override;
+  Direction normal(Position r) const override;
+  void to_hdf5_inner(hid_t group_id) const override;
 
   double x0_, y0_, z0_, A_, B_, C_;
 };


### PR DESCRIPTION
This PR adds many missing `override` specifiers, which will cause warnings with some compilers either by default or when flags request it (e.g., gcc with `-Wsuggest-override`).