### PR TITLE
Order nuclides deterministically when adding from elements

### DIFF
--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -489,7 +489,7 @@ def isotopes(element):
 
     # Get the nuclides present in nature
     result = []
-    for kv in sorted(NATURAL_ABUNDANCE.items()):
+    for kv in NATURAL_ABUNDANCE.items():
         if re.match(r'{}\d+'.format(element), kv[0]):
             result.append(kv)
 

--- a/openmc/element.py
+++ b/openmc/element.py
@@ -195,7 +195,7 @@ class Element(str):
         # If a cross_section library is not present, expand the element into
         # its natural nuclides
         else:
-            for nuclide in natural_nuclides:
+            for nuclide in sorted(list(natural_nuclides)):
                 abundances[nuclide] = NATURAL_ABUNDANCE[nuclide]
 
         # Modify mole fractions if enrichment provided

--- a/openmc/element.py
+++ b/openmc/element.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree as ET
 
 import openmc.checkvalue as cv
 import openmc
-from openmc.data import NATURAL_ABUNDANCE, atomic_mass, \
+from openmc.data import NATURAL_ABUNDANCE, atomic_mass, zam, \
     isotopes as natural_isotopes
 
 
@@ -147,8 +147,8 @@ class Element(str):
             # and sort to avoid different ordering between Python 2 and 3.
             mutual_nuclides = natural_nuclides.intersection(library_nuclides)
             absent_nuclides = natural_nuclides.difference(mutual_nuclides)
-            mutual_nuclides = sorted(list(mutual_nuclides))
-            absent_nuclides = sorted(list(absent_nuclides))
+            mutual_nuclides = sorted(mutual_nuclides, key=zam)
+            absent_nuclides = sorted(absent_nuclides, key=zam)
 
             # If all naturally occurring isotopes are present in the library,
             # add them based on their abundance
@@ -195,7 +195,7 @@ class Element(str):
         # If a cross_section library is not present, expand the element into
         # its natural nuclides
         else:
-            for nuclide in sorted(list(natural_nuclides)):
+            for nuclide in sorted(natural_nuclides, key=zam):
                 abundances[nuclide] = NATURAL_ABUNDANCE[nuclide]
 
         # Modify mole fractions if enrichment provided


### PR DESCRIPTION
I had noticed that the order to the nuclides returned from the `openmc.Material.add_element()` method were non-deterministically ordered. This change sorts those nuclides numerically so that they are always returned in the same order.