### PR TITLE
`write_data_to_vtk` volume normalization correction

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -266,7 +266,7 @@ class StructuredMesh(MeshBase):
             datasets_out.append(dataset)
 
             if volume_normalization:
-                dataset /= self.volumes.flatten()
+                dataset /= self.volumes.T.flatten()
 
             dataset_array = vtk.vtkDoubleArray()
             dataset_array.SetName(label)
@@ -1012,7 +1012,7 @@ class RectilinearMesh(StructuredMesh):
             the VTK object
         """
         # create points
-        pts_cartesian = np.array([[x, y, z] for z in self.z_grid for y in self.y_grid for x in self.x_grid])
+        pts_cartesian = self.vertices.T.reshape(-1, 3)
 
         return super().write_data_to_vtk(
             points=pts_cartesian,
@@ -1303,14 +1303,8 @@ class CylindricalMesh(StructuredMesh):
             the VTK object
         """
         # create points
-        pts_cylindrical = np.array(
-            [
-                [r, phi, z]
-                for z in self.z_grid
-                for phi in self.phi_grid
-                for r in self.r_grid
-            ]
-        )
+        pts_cylindrical = self.vertices.T.reshape(-1, 3)
+
         pts_cartesian = np.copy(pts_cylindrical)
         r, phi = pts_cylindrical[:, 0], pts_cylindrical[:, 1]
         pts_cartesian[:, 0] = r * np.cos(phi)
@@ -1534,16 +1528,9 @@ class SphericalMesh(StructuredMesh):
         vtk.vtkStructuredGrid
             the VTK object
         """
-
         # create points
-        pts_spherical = np.array(
-            [
-                [r, theta, phi]
-                for phi in self.phi_grid
-                for theta in self.theta_grid
-                for r in self.r_grid
-            ]
-        )
+        pts_spherical = self.vertices.T.reshape(-1, 3)
+
         pts_cartesian = np.copy(pts_spherical)
         r, theta, phi = pts_spherical[:, 0], pts_spherical[:, 1], pts_spherical[:, 2]
         pts_cartesian[:, 0] = r * np.sin(phi) * np.cos(theta)

--- a/tests/unit_tests/test_mesh_to_vtk.py
+++ b/tests/unit_tests/test_mesh_to_vtk.py
@@ -91,3 +91,61 @@ def test_write_data_to_vtk_size_mismatch(mesh):
     )
     with pytest.raises(ValueError, match=expected_error_msg):
         mesh.write_data_to_vtk(filename="out.vtk", datasets={"label": data})
+
+def test_write_data_to_vtk_round_trip(run_in_tmpdir):
+    cmesh = openmc.CylindricalMesh()
+    cmesh.r_grid = (0.0, 1.0, 2.0)
+    cmesh.z_grid = (0.0, 2.0, 4.0, 5.0)
+    cmesh.phi_grid = (0.0, 3.0, 6.0)
+
+    smesh = openmc.SphericalMesh()
+    smesh.r_grid = (0.0, 1.0, 2.0)
+    smesh.theta_grid = (0.0, 2.0, 4.0, 5.0)
+    smesh.phi_grid = (0.0, 3.0, 6.0)
+
+    rmesh = openmc.RegularMesh()
+    rmesh.lower_left = (0.0, 0.0, 0.0)
+    rmesh.upper_right = (1.0, 3.0, 5.0)
+    rmesh.dimension = (2, 1, 6)
+
+    for mesh in [smesh, cmesh, rmesh]:
+
+        filename = "mesh.vtk"
+        data = np.array([1.0] * 12)  # there are 12 voxels in each mesh
+        mesh.write_data_to_vtk(
+            filename=filename,
+            datasets={"normalized": data},
+            volume_normalization=True
+        )
+
+        reader = vtk.vtkStructuredGridReader()
+        reader.SetFileName(filename)
+        reader.ReadAllFieldsOn()
+        reader.Update()
+
+        cell_data = reader.GetOutput().GetCellData()
+        uniform_array = cell_data.GetArray("normalized")
+        num_tuples = uniform_array.GetNumberOfTuples()
+        vtk_values = [uniform_array.GetValue(i) for i in range(num_tuples)]
+
+        # checks that the vtk cell values are equal to the data / mesh volumes
+        assert np.allclose(vtk_values, data / mesh.volumes.T.flatten())
+
+        mesh.write_data_to_vtk(
+            filename=filename,
+            datasets={"not_normalized": data},
+            volume_normalization=False,
+        )
+
+        reader = vtk.vtkStructuredGridReader()
+        reader.SetFileName(filename)
+        reader.ReadAllFieldsOn()
+        reader.Update()
+
+        cell_data = reader.GetOutput().GetCellData()
+        uniform_array = cell_data.GetArray("not_normalized")
+        num_tuples = uniform_array.GetNumberOfTuples()
+        vtk_values = [uniform_array.GetValue(i) for i in range(num_tuples)]
+
+        # checks that the vtk cell values are equal to the data
+        assert np.array_equal(vtk_values, data)


### PR DESCRIPTION
I recently noticed that the volume normalization for structured mesh types (other than regular mesh) was producing strange results while working on #2359. This turned out to be because the method expects data in `kji` ordering for the elements (with `i` changing fastest), but when normalizing these results by the element volumes the `MeshBase.volumes` property returns them in `ijk` ordering. This PR fixes that by transposing the volumes array in this method.

I also noticed that vertices were being created manually, so I've updated the vertices arrays to leverage the `MeshBase.vertices` property instead.