### PR TITLE
Enable generation of JEFF 3.3 depletion chain

### DIFF
--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -558,9 +558,9 @@ class Decay(EqualityMixin):
                     raise NotImplementedError("Multiple interpolation regions: {name}, {particle}")
                 interpolation = INTERPOLATION_SCHEME[f.interpolation[0]]
                 if interpolation not in ('histogram', 'linear-linear'):
-                    raise NotImplementedError(
+                    warn(
                         f"Continuous spectra with {interpolation} interpolation "
-                        f"({name}, {particle}) not supported")
+                        f"({name}, {particle}) encountered.")
 
                 intensity = spectra['continuous_normalization'].n
                 rates = decay_constant * intensity * f.y

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -834,10 +834,6 @@ class Tabular(Univariate):
         self._interpolation = interpolation
 
     def cdf(self):
-        if not self.interpolation in ('histogram', 'linear-linear'):
-            raise NotImplementedError('Can only generate CDFs for tabular '
-                                      'distributions using histogram or '
-                                      'linear-linear interpolation')
         c = np.zeros_like(self.x)
         x = self.x
         p = self.p
@@ -846,15 +842,16 @@ class Tabular(Univariate):
             c[1:] = p[:-1] * np.diff(x)
         elif self.interpolation == 'linear-linear':
             c[1:] = 0.5 * (p[:-1] + p[1:]) * np.diff(x)
+        else:
+            raise NotImplementedError('Can only generate CDFs for tabular '
+                                      'distributions using histogram or '
+                                      'linear-linear interpolation')
+
 
         return np.cumsum(c)
 
     def mean(self):
         """Compute the mean of the tabular distribution"""
-        if not self.interpolation in ('histogram', 'linear-linear'):
-            raise NotImplementedError('Can only compute mean for tabular '
-                                      'distributions using histogram '
-                                      'or linear-linear interpolation.')
         if self.interpolation == 'linear-linear':
             mean = 0.0
             for i in range(1, len(self.x)):
@@ -875,6 +872,10 @@ class Tabular(Univariate):
             x_r = self.x[1:]
             p_l = self.p[:-1]
             mean = (0.5 * (x_l + x_r) * (x_r - x_l) * p_l).sum()
+        else:
+            raise NotImplementedError('Can only compute mean for tabular '
+                                      'distributions using histogram '
+                                      'or linear-linear interpolation.')
 
         # Normalize for when integral of distribution is not 1
         mean /= self.integral()
@@ -886,10 +887,6 @@ class Tabular(Univariate):
         self.p /= self.cdf().max()
 
     def sample(self, n_samples=1, seed=None):
-        if not self.interpolation in ('histogram', 'linear-linear'):
-            raise NotImplementedError('Can only sample tabular distributions '
-                                      'using histogram or '
-                                      'linear-linear interpolation')
         np.random.seed(seed)
         xi = np.random.rand(n_samples)
 
@@ -941,6 +938,11 @@ class Tabular(Univariate):
             quad[quad < 0.0] = 0.0
             m[non_zero] = x_i[non_zero] + (np.sqrt(quad) - p_i[non_zero]) / m[non_zero]
             samples_out = m
+
+        else:
+            raise NotImplementedError('Can only sample tabular distributions '
+                                      'using histogram or '
+                                      'linear-linear interpolation')
 
         assert all(samples_out < self.x[-1])
         return samples_out


### PR DESCRIPTION
Right now, if you try to generate a depletion chain based on JEFF 3.3, you run into exceptions that are related to #2409. Namely, the decay data for many actinides in JEFF 3.3 includes neutron spectra that are represented as tabulated distributions with log-linear interpolation. In `Chain.from_endf`, the log-linear interpolation causes an exception; in this PR, I've changed that to a warning so that processing of the chain can continue. Longer term if #2409 is addressed, we can get rid of the warning altogether.