### PR TITLE
Add volume arguments on several methods in Material class

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1046,7 +1046,8 @@ class Material(IDManagerMixin):
             Specifies if the activity should be returned for the material as a
             whole or per nuclide. Default is False.
         volume : float, optional
-            Volume of the material if not assigned directly
+            Volume of the material. If not passed, defaults to using the
+            :attr:`Material.volume` attribute.
 
             .. versionadded:: 0.13.3
 
@@ -1092,7 +1093,8 @@ class Material(IDManagerMixin):
             Specifies if the decay heat should be returned for the material as a
             whole or per nuclide. Default is False.
         volume : float, optional
-            Volume of the material if not assigned directly
+            Volume of the material. If not passed, defaults to using the
+            :attr:`Material.volume` attribute.
 
             .. versionadded:: 0.13.3
 
@@ -1131,7 +1133,8 @@ class Material(IDManagerMixin):
         Parameters
         ----------
         volume : float, optional
-            Volume of the material if not assigned directly
+            Volume of the material. If not passed, defaults to using the
+            :attr:`Material.volume` attribute.
 
             .. versionadded:: 0.13.3
 
@@ -1185,7 +1188,8 @@ class Material(IDManagerMixin):
             Nuclide for which mass is desired. If not specified, the density
             for the entire material is given.
         volume : float, optional
-            Volume of the material if not assigned directly
+            Volume of the material. If not passed, defaults to using the
+            :attr:`Material.volume` attribute.
 
             .. versionadded:: 0.13.3
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1029,7 +1029,8 @@ class Material(IDManagerMixin):
 
         return nuclides
 
-    def get_activity(self, units: str = 'Bq/cm3', by_nuclide: bool = False):
+    def get_activity(self, units: str = 'Bq/cm3', by_nuclide: bool = False,
+                     volume: Optional[float] = None):
         """Returns the activity of the material or for each nuclide in the
         material in units of [Bq], [Bq/g] or [Bq/cm3].
 
@@ -1044,6 +1045,10 @@ class Material(IDManagerMixin):
         by_nuclide : bool
             Specifies if the activity should be returned for the material as a
             whole or per nuclide. Default is False.
+        volume : float, optional
+            Volume of the material if not assigned directly
+
+            .. versionadded:: 0.13.3
 
         Returns
         -------
@@ -1057,7 +1062,7 @@ class Material(IDManagerMixin):
         cv.check_type('by_nuclide', by_nuclide, bool)
 
         if units == 'Bq':
-            multiplier = self.volume
+            multiplier = volume if volume is not None else self.volume
         elif units == 'Bq/cm3':
             multiplier = 1
         elif units == 'Bq/g':
@@ -1070,7 +1075,8 @@ class Material(IDManagerMixin):
 
         return activity if by_nuclide else sum(activity.values())
 
-    def get_decay_heat(self, units: str = 'W', by_nuclide: bool = False):
+    def get_decay_heat(self, units: str = 'W', by_nuclide: bool = False,
+                       volume: Optional[float] = None):
         """Returns the decay heat of the material or for each nuclide in the
         material in units of [W], [W/g] or [W/cm3].
 
@@ -1085,6 +1091,10 @@ class Material(IDManagerMixin):
         by_nuclide : bool
             Specifies if the decay heat should be returned for the material as a
             whole or per nuclide. Default is False.
+        volume : float, optional
+            Volume of the material if not assigned directly
+
+            .. versionadded:: 0.13.3
 
         Returns
         -------
@@ -1098,7 +1108,7 @@ class Material(IDManagerMixin):
         cv.check_type('by_nuclide', by_nuclide, bool)
 
         if units == 'W':
-            multiplier = self.volume
+            multiplier = volume if volume is not None else self.volume
         elif units == 'W/cm3':
             multiplier = 1
         elif units == 'W/g':
@@ -1113,10 +1123,17 @@ class Material(IDManagerMixin):
 
         return decayheat if by_nuclide else sum(decayheat.values())
 
-    def get_nuclide_atoms(self):
+    def get_nuclide_atoms(self, volume: Optional[float] = None):
         """Return number of atoms of each nuclide in the material
 
         .. versionadded:: 0.13.1
+
+        Parameters
+        ----------
+        volume : float, optional
+            Volume of the material if not assigned directly
+
+            .. versionadded:: 0.13.3
 
         Returns
         -------
@@ -1125,11 +1142,13 @@ class Material(IDManagerMixin):
             atoms present in the material.
 
         """
-        if self.volume is None:
+        if volume is None:
+            volume = self.volume
+        if volume is None:
             raise ValueError("Volume must be set in order to determine atoms.")
         atoms = {}
         for nuclide, atom_per_bcm in self.get_nuclide_atom_densities().items():
-            atoms[nuclide] = 1.0e24 * atom_per_bcm * self.volume
+            atoms[nuclide] = 1.0e24 * atom_per_bcm * volume
         return atoms
 
     def get_mass_density(self, nuclide: Optional[str] = None):
@@ -1154,7 +1173,7 @@ class Material(IDManagerMixin):
             mass_density += density_i
         return mass_density
 
-    def get_mass(self, nuclide: Optional[str] = None):
+    def get_mass(self, nuclide: Optional[str] = None, volume: Optional[float] = None):
         """Return mass of one or all nuclides.
 
         Note that this method requires that the :attr:`Material.volume` has
@@ -1165,6 +1184,11 @@ class Material(IDManagerMixin):
         nuclides : str, optional
             Nuclide for which mass is desired. If not specified, the density
             for the entire material is given.
+        volume : float, optional
+            Volume of the material if not assigned directly
+
+            .. versionadded:: 0.13.3
+
 
         Returns
         -------
@@ -1172,9 +1196,11 @@ class Material(IDManagerMixin):
             Mass of the nuclide/material in [g]
 
         """
-        if self.volume is None:
+        if volume is None:
+            volume = self.volume
+        if volume is None:
             raise ValueError("Volume must be set in order to determine mass.")
-        return self.volume*self.get_mass_density(nuclide)
+        return volume*self.get_mass_density(nuclide)
 
     def clone(self, memo: Optional[dict] = None):
         """Create a copy of this material with a new unique ID.

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -244,7 +244,7 @@ class Model:
     def from_model_xml(cls, path='model.xml'):
         """Create model from single XML file
 
-        .. vesionadded:: 0.13.3
+        .. versionadded:: 0.13.3
 
         Parameters
         ----------

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -377,6 +377,9 @@ def test_get_nuclide_atoms():
     atoms = mat.get_nuclide_atoms()
     assert atoms['Li6'] == pytest.approx(mat.density * mat.volume)
 
+    atoms = mat.get_nuclide_atoms(volume=10.0)
+    assert atoms['Li6'] == pytest.approx(mat.density * 10.0)
+
 
 def test_mass():
     m = openmc.Material()
@@ -393,6 +396,9 @@ def test_mass():
     assert m.get_mass('U235') == pytest.approx(10.0)
     assert m.get_mass() == pytest.approx(20.0)
     assert m.fissionable_mass == pytest.approx(10.0)
+
+    # Test with volume specified as argument
+    assert m.get_mass('Zr90', volume=1.0) == pytest.approx(1.0)
 
 
 def test_materials(run_in_tmpdir):
@@ -544,11 +550,14 @@ def test_get_activity():
     m4.volume = 10.
     assert pytest.approx(m4.get_activity(units='Bq')) == 355978108155965.94*3/2*10 # [Bq]
 
+    # Test with volume specified as argument
+    assert pytest.approx(m4.get_activity(units='Bq', volume=1.0)) == 355978108155965.94*3/2
+
 
 def test_get_decay_heat():
     # Set chain file for testing
     openmc.config['chain_file'] = Path(__file__).parents[1] / 'chain_simple.xml'
-    
+
     """Tests the decay heat of stable, metastable and active materials"""
     m1 = openmc.Material()
     m1.add_nuclide("U235", 0.2)
@@ -589,7 +598,10 @@ def test_get_decay_heat():
     # volume is required to calculate total decay heat
     m4.volume = 10.
     assert pytest.approx(m4.get_decay_heat(units='W')) == 40175.15720273193*3/2*10 # [W]
- 
+
+    # Test with volume specified as argument
+    assert pytest.approx(m4.get_decay_heat(units='W', volume=1.0)) == 40175.15720273193*3/2
+
 
 def test_decay_photon_energy():
     # Set chain file for testing


### PR DESCRIPTION
This PR adds a `volume` argument to several methods in the `Material` class, namely:
- `get_activity`
- `get_decay_heat`
- `get_nuclide_atoms`
- `get_mass`

The purpose of this change is to allow one to query these properties for a material that is present in multiple cells which may have different volumes (i.e., you can't just assign a single volume to the `Material` object itself). The specific case I ran into this was when setting up a cell-based R2S workflow.