### PR TITLE
removing need for user to specify data_type arg when plotting xs

### DIFF
--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -58,7 +58,8 @@ ELEMENT_NAMES = list(openmc.data.ELEMENT_SYMBOL.values())[1:]
 
 def plot_xs(this, types, divisor_types=None, temperature=294., axis=None,
             sab_name=None, ce_cross_sections=None, mg_cross_sections=None,
-            enrichment=None, plot_CE=True, orders=None, divisor_orders=None):
+            enrichment=None, plot_CE=True, orders=None, divisor_orders=None,
+            **kwargs):
     """Creates a figure of continuous-energy cross sections for this item.
 
     Parameters
@@ -98,6 +99,9 @@ def plot_xs(this, types, divisor_types=None, temperature=294., axis=None,
         multi-group data.
     divisor_orders : Iterable of Integral, optional
         Same as orders, but for divisor_types
+    **kwargs :
+        All keyword arguments are passed to
+        :func:`matplotlib.pyplot.figure`.
 
     Returns
     -------
@@ -157,7 +161,7 @@ def plot_xs(this, types, divisor_types=None, temperature=294., axis=None,
 
     # Generate the plot
     if axis is None:
-        fig, ax = plt.subplots()
+        fig, ax = plt.subplots(**kwargs)
     else:
         fig = None
         ax = axis
@@ -270,15 +274,9 @@ def calculate_cexs(this, types, temperature=294., sab_name=None,
             data = np.zeros((len(types), len(energy_grid)))
             for line in range(len(types)):
                 data[line, :] = xs[line](energy_grid)
-
-    elif isinstance(this, openmc.Material):
+    else:
         energy_grid, data = _calculate_cexs_elem_mat(this, types, temperature,
                                                      cross_sections)
-    else:
-        msg = (
-            f"{this} is an invalid type, acceptable types are str, openmc.Material."
-        )
-        raise TypeError(msg)
 
     return energy_grid, data
 

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -63,8 +63,8 @@ def plot_xs(this, types, divisor_types=None, temperature=294., axis=None,
 
     Parameters
     ----------
-    this : {str, openmc.Material}
-        Object to source data from. Nuclides and Elements can be input as a str
+    this : str or openmc.Material
+        Object to source data from. Nuclides and elements can be input as a str
     types : Iterable of values of PLOT_TYPES
         The type of cross sections to include in the plot.
     divisor_types : Iterable of values of PLOT_TYPES, optional
@@ -217,8 +217,8 @@ def calculate_cexs(this, types, temperature=294., sab_name=None,
 
     Parameters
     ----------
-    this : {str, openmc.Material}
-        Object to source data from. Nuclides and Elements should be input as a
+    this : str or openmc.Material
+        Object to source data from. Nuclides and elements should be input as a
         str
     types : Iterable of values of PLOT_TYPES
         The type of cross sections to calculate
@@ -603,8 +603,8 @@ def calculate_mgxs(this, types, orders=None, temperature=294.,
 
     Parameters
     ----------
-    this : {str, openmc.Material}
-        Object to source data from. Nuclides and Elements can be input as a str
+    this : str or openmc.Material
+        Object to source data from. Nuclides and elements can be input as a str
     types : Iterable of values of PLOT_TYPES_MGXS
         The type of cross sections to calculate
     orders : Iterable of Integral, optional

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -32,7 +32,7 @@ def test_calculate_cexs_elem_mat_sab(test_mat):
     assert len(data[0]) == len(energy_grid)
 
 
-@pytest.mark.parametrize("this", ["Li", "Li6", openmc.Nuclide('Li6'), openmc.Element('Li')])
+@pytest.mark.parametrize("this", ["Li", "Li6"])
 def test_calculate_cexs_with_nuclide_and_element(this):
     # single type (reaction)
     energy_grid, data = openmc.plotter.calculate_cexs(
@@ -72,7 +72,7 @@ def test_calculate_cexs_with_materials(test_mat):
     assert len(data[0]) == len(energy_grid)
 
 
-@pytest.mark.parametrize("this", ["Be", "Be9", openmc.Nuclide('Be9'), openmc.Element('Be')])
+@pytest.mark.parametrize("this", ["Be", "Be9"])
 def test_plot_xs(this):
     assert isinstance(openmc.plotter.plot_xs(this, types=['total']), Figure)
 

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -4,14 +4,13 @@ import pytest
 from matplotlib.figure import Figure
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def test_mat():
     mat_1 = openmc.Material()
     mat_1.add_element("H", 4.0, "ao")
     mat_1.add_element("O", 4.0, "ao")
     mat_1.add_element("C", 4.0, "ao")
     return mat_1
-
 
 def test_calculate_cexs_elem_mat_sab(test_mat):
     """Checks that sab cross sections are included in the
@@ -33,12 +32,11 @@ def test_calculate_cexs_elem_mat_sab(test_mat):
     assert len(data[0]) == len(energy_grid)
 
 
-@pytest.mark.parametrize("this,data_type", [("Li", "element"), ("Li6", "nuclide")])
-def test_calculate_cexs_with_element(this, data_type):
-
+@pytest.mark.parametrize("this", ["Li", "Li6", openmc.Nuclide('Li6'), openmc.Element('Li')])
+def test_calculate_cexs_with_nuclide_and_element(this):
     # single type (reaction)
     energy_grid, data = openmc.plotter.calculate_cexs(
-        this=this, data_type=data_type, types=[205]
+        this=this, types=[205]
     )
 
     assert isinstance(energy_grid, np.ndarray)
@@ -47,9 +45,9 @@ def test_calculate_cexs_with_element(this, data_type):
     assert len(data) == 1
     assert len(data[0]) == len(energy_grid)
 
-    # two types (reaction)
+    # two types (reactions)
     energy_grid, data = openmc.plotter.calculate_cexs(
-        this=this, data_type=data_type, types=[2, "elastic"]
+        this=this, types=[2, "elastic"]
     )
 
     assert isinstance(energy_grid, np.ndarray)
@@ -64,7 +62,7 @@ def test_calculate_cexs_with_element(this, data_type):
 
 def test_calculate_cexs_with_materials(test_mat):
     energy_grid, data = openmc.plotter.calculate_cexs(
-        this=test_mat, types=[205], data_type="material"
+        this=test_mat, types=[205]
     )
 
     assert isinstance(energy_grid, np.ndarray)
@@ -74,14 +72,10 @@ def test_calculate_cexs_with_materials(test_mat):
     assert len(data[0]) == len(energy_grid)
 
 
-@pytest.mark.parametrize(("this,data_type"), [("Be", "element"), ("Be9", "nuclide")])
-def test_plot_xs(this, data_type):
-    assert isinstance(
-        openmc.plotter.plot_xs(this, data_type=data_type, types=["total"]), Figure
-    )
+@pytest.mark.parametrize("this", ["Be", "Be9", openmc.Nuclide('Be9'), openmc.Element('Be')])
+def test_plot_xs(this):
+    assert isinstance(openmc.plotter.plot_xs(this, types=['total']), Figure)
 
 
 def test_plot_xs_mat(test_mat):
-    assert isinstance(
-        openmc.plotter.plot_xs(test_mat, data_type="material", types=["total"]), Figure
-    )
+    assert isinstance(openmc.plotter.plot_xs(test_mat, types=['total']), Figure)


### PR DESCRIPTION
I took a look at removing the ```data_type``` argument in the plotter.py file.

```data_type``` is used to identity if the ```this``` argument is a nuclide, element, macroscopic or a material. This is a bit more complex that a simple type check as strings are also accepted for element and nuclide.

I think we can automatically determine the type of plotting (element, nuclide, macroscopic or material) needed . If ```this``` is a string we can check if the string appears in the list of elements and if it does then it is an element and if it does not then it is a nuclide. Materials and Macroscopic appear to just be supported if they are openmc.Material and openmc.Macroscopic classes respectively (so no need to check if a string is used in those cases)

I believe this keeps the same functionality as before however I think the plot_xs didn't previously worked with a openmc.Macroscopic type.