### PR TITLE
change mesh source CDF definition to eliminate round-off

### DIFF
--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -114,7 +114,6 @@ public:
 
 private:
   int32_t mesh_idx_ {C_NONE};
-  double total_strength_ {0.0};
   // TODO: move to an independent class in the future that's similar
   // to a discrete distribution without outcomes
   std::vector<double> mesh_CDF_;

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -214,7 +214,6 @@ MeshSpatial::MeshSpatial(pugi::xml_node node)
 
   mesh_CDF_.resize(n_bins + 1);
   mesh_CDF_[0] = {0.0};
-  total_strength_ = 0.0;
 
   // Create cdfs for sampling for an element over a mesh
   // Volume scheme is weighted by the volume of each tet
@@ -237,11 +236,14 @@ MeshSpatial::MeshSpatial(pugi::xml_node node)
     }
   }
 
-  total_strength_ =
-    std::accumulate(mesh_strengths_.begin(), mesh_strengths_.end(), 0.0);
+  for (int i = 0; i < n_bins; i++) {
+    mesh_CDF_[i + 1] = mesh_CDF_[i] + mesh_strengths_[i];
+  }
+
+  double normalization = 1.0/mesh_CDF_.back();
 
   for (int i = 0; i < n_bins; i++) {
-    mesh_CDF_[i + 1] = mesh_CDF_[i] + mesh_strengths_[i] / total_strength_;
+    mesh_CDF_[i] *= normalization;
   }
 
   if (fabs(mesh_CDF_.back() - 1.0) > FP_COINCIDENT) {


### PR DESCRIPTION
The current approach to forming the CDF for a mesh source is prone to a round-off error when used with very large meshes.  It then tests against that round off error and halts when detected.  This takes a different approach which may be less prone to round off error and is guaranteed to avoid failing the test.

This algorithm is probably very slow and there is a lot of motivation to transition to using a DiscreteDistribution to take advantage of the recently implemented alias sampling (#2329)

Fixes #2406 