### PR TITLE
Use Discrete distribution for sampling a mesh source

### DIFF
--- a/include/openmc/distribution.h
+++ b/include/openmc/distribution.h
@@ -79,8 +79,8 @@ public:
 
   // Properties
   const vector<double>& x() const { return x_; }
-  const vector<double>& prob() const { return di_->prob(); }
-  const vector<size_t>& alias() const { return di_->alias(); }
+  const vector<double>& prob() const { return di_.prob(); }
+  const vector<size_t>& alias() const { return di_.alias(); }
 
 private:
   vector<double> x_; //!< Possible outcomes

--- a/include/openmc/distribution.h
+++ b/include/openmc/distribution.h
@@ -32,27 +32,24 @@ using UPtrDist = unique_ptr<Distribution>;
 UPtrDist distribution_from_xml(pugi::xml_node node);
 
 //==============================================================================
-//! A discrete distribution (probability mass function)
+//! A discrete distribution index (probability mass function)
 //==============================================================================
 
-class Discrete : public Distribution {
+class DiscreteIndex {
 public:
   explicit Discrete(pugi::xml_node node);
-  Discrete(const double* x, const double* p, int n);
   Discrete(const double* p, int n);
 
   //! Sample a value from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
-  double sample(uint64_t* seed) const override;
+  size_t sample(uint64_t* seed) const override;
 
   // Properties
-  const vector<double>& x() const { return x_; }
   const vector<double>& prob() const { return prob_; }
   const vector<size_t>& alias() const { return alias_; }
 
 private:
-  vector<double> x_;    //!< Possible outcomes
   vector<double> prob_; //!< Probability of accepting the uniformly sampled bin,
                         //!< mapped to alias method table
   vector<size_t> alias_; //!< Alias table
@@ -62,6 +59,31 @@ private:
 
   //! Initialize alias tables for distribution
   void init_alias();
+};
+
+//==============================================================================
+//! A discrete distribution (probability mass function)
+//==============================================================================
+
+class Discrete : public Distribution {
+public:
+  explicit Discrete(pugi::xml_node node);
+  Discrete(const double* x, const double* p, int n);
+
+  //! Sample a value from the distribution
+  //! \param seed Pseudorandom number seed pointer
+  //! \return Sampled value
+  double sample(uint64_t* seed) const override;
+
+  // Properties
+  const vector<double>& x() const { return x_; }
+  const vector<double>& prob() const { return di_->prob(); }
+  const vector<size_t>& alias() const { return di_->alias(); }
+
+private:
+  vector<double> x_;             //!< Possible outcomes
+  unique_ptr<DiscreteIndex> di_; //!< discrete probability distribution of
+                                 //!< outcome indices
 };
 
 //==============================================================================

--- a/include/openmc/distribution.h
+++ b/include/openmc/distribution.h
@@ -61,7 +61,7 @@ private:
   void normalize();
 
   //! Initialize alias tables for distribution
-  void init_alias(vector<double>& x, vector<double>& p);
+  void init_alias();
 };
 
 //==============================================================================

--- a/include/openmc/distribution.h
+++ b/include/openmc/distribution.h
@@ -37,7 +37,8 @@ UPtrDist distribution_from_xml(pugi::xml_node node);
 
 class DiscreteIndex {
 public:
-  explicit DiscreteIndex(pugi::xml_node node);
+  DiscreteIndex() {};
+  DiscreteIndex(pugi::xml_node node);
   DiscreteIndex(const double* p, int n);
 
   void assign(const double* p, int n);

--- a/include/openmc/distribution.h
+++ b/include/openmc/distribution.h
@@ -37,13 +37,15 @@ UPtrDist distribution_from_xml(pugi::xml_node node);
 
 class DiscreteIndex {
 public:
-  explicit Discrete(pugi::xml_node node);
-  Discrete(const double* p, int n);
+  explicit DiscreteIndex(pugi::xml_node node);
+  DiscreteIndex(const double* p, int n);
+
+  void assign(const double* p, int n);
 
   //! Sample a value from the distribution
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
-  size_t sample(uint64_t* seed) const override;
+  size_t sample(uint64_t* seed) const;
 
   // Properties
   const vector<double>& prob() const { return prob_; }
@@ -81,9 +83,9 @@ public:
   const vector<size_t>& alias() const { return di_->alias(); }
 
 private:
-  vector<double> x_;             //!< Possible outcomes
-  unique_ptr<DiscreteIndex> di_; //!< discrete probability distribution of
-                                 //!< outcome indices
+  vector<double> x_; //!< Possible outcomes
+  DiscreteIndex di_; //!< discrete probability distribution of
+                     //!< outcome indices
 };
 
 //==============================================================================

--- a/include/openmc/distribution.h
+++ b/include/openmc/distribution.h
@@ -39,6 +39,7 @@ class Discrete : public Distribution {
 public:
   explicit Discrete(pugi::xml_node node);
   Discrete(const double* x, const double* p, int n);
+  Discrete(const double* p, int n);
 
   //! Sample a value from the distribution
   //! \param seed Pseudorandom number seed pointer

--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -114,8 +114,8 @@ public:
 
 private:
   int32_t mesh_idx_ {C_NONE};
-  unique_ptr<DiscreteIndex> elem_idx_dist_; //!< Distribution of
-                                            //!< mesh element indices
+  DiscreteIndex elem_idx_dist_; //!< Distribution of
+                                //!< mesh element indices
 };
 
 //==============================================================================

--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -114,11 +114,7 @@ public:
 
 private:
   int32_t mesh_idx_ {C_NONE};
-  double total_strength_ {0.0};
-  // TODO: move to an independent class in the future that's similar
-  // to a discrete distribution without outcomes
-  std::vector<double> mesh_CDF_;
-  std::vector<double> mesh_strengths_;
+  UPtrDist elem_idx_; //!< Distribution of mesh element indices
 };
 
 //==============================================================================

--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -114,7 +114,7 @@ public:
 
 private:
   int32_t mesh_idx_ {C_NONE};
-  UPtrDist elem_idx_; //!< Distribution of mesh element indices
+  UPtrDist elem_idx_dist_; //!< Distribution of mesh element indices
 };
 
 //==============================================================================

--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -114,7 +114,8 @@ public:
 
 private:
   int32_t mesh_idx_ {C_NONE};
-  UPtrDist elem_idx_dist_; //!< Distribution of mesh element indices
+  unique_ptr<DiscreteIndex> elem_idx_dist_; //!< Distribution of
+                                            //!< mesh element indices
 };
 
 //==============================================================================

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -41,6 +41,19 @@ Discrete::Discrete(const double* x, const double* p, int n)
   this->init_alias(x_vec, p_vec);
 }
 
+Discrete::Discrete(const double* p, int n)
+{
+  std::vector<double> p_vec(p, p + n);
+  std::vector<double> x_vec(n);
+
+  for (int i=0; i<n; i++) 
+  {
+    x_vec[i] = i;
+  }
+
+  this->init_alias(x_vec, p_vec);
+}
+
 void Discrete::init_alias(vector<double>& x, vector<double>& p)
 {
   x_ = x;

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -26,7 +26,7 @@ Discrete::Discrete(pugi::xml_node node)
 {
   auto params = get_node_array<double>(node, "parameters");
 
-  std::size_t n = params.size()/2;
+  std::size_t n = params.size() / 2;
 
   x_.assign(params.begin(), params.begin() + n);
   prob_.assign(params.begin() + n, params.end());
@@ -36,7 +36,7 @@ Discrete::Discrete(pugi::xml_node node)
 
 Discrete::Discrete(const double* x, const double* p, int n)
 {
-  
+
   x_.assign(x, x + n);
   prob_.assign(p, p + n);
 
@@ -48,8 +48,7 @@ Discrete::Discrete(const double* p, int n)
   prob_.assign(p, p + n);
   x_.resize(n);
 
-  for (int i=0; i<n; i++) 
-  {
+  for (int i = 0; i < n; i++) {
     x_[i] = i;
   }
 

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -27,7 +27,7 @@ DiscreteIndex::DiscreteIndex(pugi::xml_node node)
   auto params = get_node_array<double>(node, "parameters");
   std::size_t n = params.size() / 2;
 
-  assign(params.begin(), n);
+  assign(&(*params.begin()), n);
 }
 
 DiscreteIndex::DiscreteIndex(const double* p, int n)

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -136,7 +136,7 @@ Discrete::Discrete(const double* x, const double* p, int n) : di_(p, n)
 
 double Discrete::sample(uint64_t* seed) const
 {
-  return x_[di_->sample(seed)];
+  return x_[di_.sample(seed)];
 }
 
 //==============================================================================

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -27,16 +27,12 @@ DiscreteIndex::DiscreteIndex(pugi::xml_node node)
   auto params = get_node_array<double>(node, "parameters");
   std::size_t n = params.size() / 2;
 
-  prob_.assign(params.begin() + n, params.end());
-
-  this->init_alias();
+  assign(params.begin(), n);
 }
 
 DiscreteIndex::DiscreteIndex(const double* p, int n)
 {
-  prob_.assign(p, p + n);
-
-  this->init_alias();
+  assign(p, n);
 }
 
 void DiscreteIndex::assign(const double* p, int n)

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -25,13 +25,21 @@ namespace openmc {
 DiscreteIndex::DiscreteIndex(pugi::xml_node node)
 {
   auto params = get_node_array<double>(node, "parameters");
+  std::size_t n = params.size() / 2;
 
-  prob_.assign(params.begin(), params.end());
+  prob_.assign(params.begin() + n, params.end());
 
   this->init_alias();
 }
 
 DiscreteIndex::DiscreteIndex(const double* p, int n)
+{
+  prob_.assign(p, p + n);
+
+  this->init_alias();
+}
+
+void DiscreteIndex::assign(const double* p, int n)
 {
   prob_.assign(p, p + n);
 
@@ -111,21 +119,19 @@ void DiscreteIndex::normalize()
 // Discrete implementation
 //==============================================================================
 
-Discrete::Discrete(pugi::xml_node node)
+Discrete::Discrete(pugi::xml_node node) : di_(node)
 {
   auto params = get_node_array<double>(node, "parameters");
 
   std::size_t n = params.size() / 2;
 
   x_.assign(params.begin(), params.begin() + n);
-  di_ = new DiscreteIndex(params.begin() + n, n)
 }
 
-Discrete::Discrete(const double* x, const double* p, int n)
+Discrete::Discrete(const double* x, const double* p, int n) : di_(p, n)
 {
 
   x_.assign(x, x + n);
-  di_ = new DiscreteIndex(params.begin() + n, n)
 }
 
 double Discrete::sample(uint64_t* seed) const

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -27,7 +27,7 @@ DiscreteIndex::DiscreteIndex(pugi::xml_node node)
   auto params = get_node_array<double>(node, "parameters");
   std::size_t n = params.size() / 2;
 
-  assign(&(*params.begin()), n);
+  assign(&(*params.begin()) + n, n);
 }
 
 DiscreteIndex::DiscreteIndex(const double* p, int n)

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -27,7 +27,7 @@ DiscreteIndex::DiscreteIndex(pugi::xml_node node)
   auto params = get_node_array<double>(node, "parameters");
   std::size_t n = params.size() / 2;
 
-  assign(&(*params.begin()) + n, n);
+  assign(params.data() + n, n);
 }
 
 DiscreteIndex::DiscreteIndex(const double* p, int n)

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -26,38 +26,38 @@ Discrete::Discrete(pugi::xml_node node)
 {
   auto params = get_node_array<double>(node, "parameters");
 
-  std::size_t n = params.size();
-  std::vector<double> x_vec(params.begin(), params.begin() + n / 2);
-  std::vector<double> p_vec(params.begin() + n / 2, params.end());
+  std::size_t n = params.size()/2;
 
-  this->init_alias(x_vec, p_vec);
+  x_.assign(params.begin(), params.begin() + n);
+  prob_.assign(params.begin() + n, params.end());
+
+  this->init_alias();
 }
 
 Discrete::Discrete(const double* x, const double* p, int n)
 {
-  std::vector<double> x_vec(x, x + n);
-  std::vector<double> p_vec(p, p + n);
+  
+  x_.assign(x, x + n);
+  prob_.assign(p, p + n);
 
-  this->init_alias(x_vec, p_vec);
+  this->init_alias();
 }
 
 Discrete::Discrete(const double* p, int n)
 {
-  std::vector<double> p_vec(p, p + n);
-  std::vector<double> x_vec(n);
+  prob_.assign(p, p + n);
+  x_.resize(n);
 
   for (int i=0; i<n; i++) 
   {
-    x_vec[i] = i;
+    x_[i] = i;
   }
 
-  this->init_alias(x_vec, p_vec);
+  this->init_alias();
 }
 
-void Discrete::init_alias(vector<double>& x, vector<double>& p)
+void Discrete::init_alias()
 {
-  x_ = x;
-  prob_ = p;
   normalize();
 
   // The initialization and sampling method is based on Vose

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -48,12 +48,14 @@ void DiscreteIndex::init_alias()
   vector<size_t> large;
   vector<size_t> small;
 
+  size_t n = prob_.size();
+
   // Set and allocate memory
-  alias_.assign(prob_.size(), 0);
+  alias_.assign(n, 0);
 
   // Fill large and small vectors based on 1/n
-  for (size_t i = 0; i < prob_.size(); i++) {
-    prob_[i] *= prob_.size();
+  for (size_t i = 0; i < n; i++) {
+    prob_[i] *= n;
     if (prob_[i] > 1.0) {
       large.push_back(i);
     } else {
@@ -83,9 +85,9 @@ void DiscreteIndex::init_alias()
 size_t DiscreteIndex::sample(uint64_t* seed) const
 {
   // Alias sampling of discrete distribution
-  int n = prob_.size();
+  size_t n = prob_.size();
   if (n > 1) {
-    int u = prn(seed) * n;
+    size_t u = prn(seed) * n;
     if (prn(seed) < prob_[u]) {
       return u;
     } else {

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -231,7 +231,7 @@ MeshSpatial::MeshSpatial(pugi::xml_node node)
     }
   }
 
-  elem_idx_dist_ = UPtrDist {new Discrete {strengths.data(), n_bins}};
+  elem_idx_dist_ = make_unique<DiscreteIndex>(strengths.data(), n_bins);
 }
 
 Position MeshSpatial::sample(uint64_t* seed) const

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -210,7 +210,7 @@ MeshSpatial::MeshSpatial(pugi::xml_node node)
   }
 
   int32_t n_bins = this->n_sources();
-  std::vector<double> strengths(n_bins, 0.0);
+  std::vector<double> strengths(n_bins, 1.0);
 
   // Create cdfs for sampling for an element over a mesh
   // Volume scheme is weighted by the volume of each tet

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -224,8 +224,15 @@ MeshSpatial::MeshSpatial(pugi::xml_node node)
                     "not match the number of entities in mesh {} ({}).",
           strengths.size(), mesh_id, n_bins));
     }
-    elem_idx_ = UPtrDist {new Discrete {strengths, n_bins}};
   }
+ 
+ if (get_node_value_bool(node, "volume_normalized")) {
+    for (int i = 0; i < n_bins; i++) {
+      strengths[i] *= mesh()->volume(i);
+    }
+  }
+
+  elem_idx_dist_ = UPtrDist {new Discrete {strengths, n_bins}};
 
 }
 
@@ -234,7 +241,7 @@ Position MeshSpatial::sample(uint64_t* seed) const
   // Create random variable for sampling element from mesh
   double eta = prn(seed);
   // Sample over the CDF defined in initialization above
-  int32_t elem_idx = elem_idx_->sample(eta);
+  int32_t elem_idx = elem_idx_dist_->sample(eta);
   return mesh()->sample(seed, elem_idx);
 }
 

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -237,7 +237,7 @@ MeshSpatial::MeshSpatial(pugi::xml_node node)
 Position MeshSpatial::sample(uint64_t* seed) const
 {
   // Sample over the CDF defined in initialization above
-  int32_t elem_idx = elem_idx_dist_->sample(seed);
+  int32_t elem_idx = elem_idx_dist_.sample(seed);
   return mesh()->sample(seed, elem_idx);
 }
 

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -215,7 +215,6 @@ MeshSpatial::MeshSpatial(pugi::xml_node node)
   // Create cdfs for sampling for an element over a mesh
   // Volume scheme is weighted by the volume of each tet
   // File scheme is weighted by an array given in the xml file
-  mesh_strengths_ = std::vector<double>(n_bins, 1.0);
   if (check_for_node(node, "strengths")) {
     strengths = get_node_array<double>(node, "strengths");
     if (strengths.size() != n_bins) {
@@ -232,16 +231,14 @@ MeshSpatial::MeshSpatial(pugi::xml_node node)
     }
   }
 
-  elem_idx_dist_ = UPtrDist {new Discrete {strengths, n_bins}};
+  elem_idx_dist_ = UPtrDist {new Discrete {strengths.data(), n_bins}};
 
 }
 
 Position MeshSpatial::sample(uint64_t* seed) const
 {
-  // Create random variable for sampling element from mesh
-  double eta = prn(seed);
   // Sample over the CDF defined in initialization above
-  int32_t elem_idx = elem_idx_dist_->sample(eta);
+  int32_t elem_idx = elem_idx_dist_->sample(seed);
   return mesh()->sample(seed, elem_idx);
 }
 

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -224,15 +224,14 @@ MeshSpatial::MeshSpatial(pugi::xml_node node)
           strengths.size(), mesh_id, n_bins));
     }
   }
- 
- if (get_node_value_bool(node, "volume_normalized")) {
+
+  if (get_node_value_bool(node, "volume_normalized")) {
     for (int i = 0; i < n_bins; i++) {
       strengths[i] *= mesh()->volume(i);
     }
   }
 
   elem_idx_dist_ = UPtrDist {new Discrete {strengths.data(), n_bins}};
-
 }
 
 Position MeshSpatial::sample(uint64_t* seed) const

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -231,7 +231,7 @@ MeshSpatial::MeshSpatial(pugi::xml_node node)
     }
   }
 
-  elem_idx_dist_ = make_unique<DiscreteIndex>(strengths.data(), n_bins);
+  elem_idx_dist_.assign(strengths.data(), n_bins);
 }
 
 Position MeshSpatial::sample(uint64_t* seed) const


### PR DESCRIPTION
The current mesh source builds a large CDF and linearly searches it for sampling.  This change uses the `Discrete` distribution that is already available, with its built-in alias sampling.

For mesh sampling, the independent variable is an integer element index, and the `Discrete` distribution only supports doubles for independent variables.  This implementation takes advantage of automatic conversion between doubles and integers.
