### PR TITLE
Fix small typo in error message

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -636,7 +636,7 @@ class Model:
 
         if len(self.settings.volume_calculations) == 0:
             # Then there is no volume calculation specified
-            raise ValueError("The Settings.volume_calculation attribute must"
+            raise ValueError("The Settings.volume_calculations attribute must"
                              " be specified before executing this method!")
 
         with _change_directory(Path(cwd)):


### PR DESCRIPTION
The error message says to set `Settings.volume_calculation`. It needs an `s`. I spent a few minutes blankly staring at my computer to figure this out :-)