### PR TITLE
Add Python 3.11 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.10"]
         mpi: [n, y]
         omp: [n, y]
         dagmc: [n]
@@ -44,31 +44,31 @@ jobs:
           - python-version: 3.9
             omp: n
             mpi: n
-          - python-version: 3.10
+          - python-version: "3.11"
             omp: n
             mpi: n
           - dagmc: y
-            python-version: "3.11"
+            python-version: "3.10"
             mpi: y
             omp: y
           - ncrystal: y
-            python-version: "3.11"
+            python-version: "3.10"
             mpi: n
             omp: n
           - libmesh: y
-            python-version: "3.11"
+            python-version: "3.10"
             mpi: y
             omp: y
           - libmesh: y
-            python-version: "3.11"
+            python-version: "3.10"
             mpi: n
             omp: y
           - event: y
-            python-version: "3.11"
+            python-version: "3.10"
             omp: y
             mpi: n
           - vectfit: y
-            python-version: "3.11"
+            python-version: "3.10"
             omp: n
             mpi: y
     name: "Python ${{ matrix.python-version }} (omp=${{ matrix.omp }},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
         vectfit: [n]
 
         include:
-          - python-version: 3.7
+          - python-version: "3.7"
             omp: n
             mpi: n
-          - python-version: 3.8
+          - python-version: "3.8"
             omp: n
             mpi: n
-          - python-version: 3.9
+          - python-version: "3.9"
             omp: n
             mpi: n
           - python-version: "3.11"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         mpi: [n, y]
         omp: [n, y]
         dagmc: [n]
@@ -44,28 +44,31 @@ jobs:
           - python-version: 3.9
             omp: n
             mpi: n
+          - python-version: 3.10
+            omp: n
+            mpi: n
           - dagmc: y
-            python-version: "3.10"
+            python-version: "3.11"
             mpi: y
             omp: y
           - ncrystal: y
-            python-version: "3.10"
+            python-version: "3.11"
             mpi: n
             omp: n
           - libmesh: y
-            python-version: "3.10"
+            python-version: "3.11"
             mpi: y
             omp: y
           - libmesh: y
-            python-version: "3.10"
+            python-version: "3.11"
             mpi: n
             omp: y
           - event: y
-            python-version: "3.10"
+            python-version: "3.11"
             omp: y
             mpi: n
           - vectfit: y
-            python-version: "3.10"
+            python-version: "3.11"
             omp: n
             mpi: y
     name: "Python ${{ matrix.python-version }} (omp=${{ matrix.omp }},

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ kwargs = {
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 
     # Dependencies


### PR DESCRIPTION
This PR is meant to supersede #2324 and adds Python 3.11 into the CI testing matrix.