### PR TITLE
Fix hybrid depletion direct tally error if nuclides are not present in material

### DIFF
--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -308,8 +308,8 @@ class FluxCollapseHelper(ReactionRateHelper):
             if self._nuclides_direct is not None:
                 # check if any direct tally nuclides are requested that are not
                 # already loaded with the materials. Load separately if so.
-                mat_nuclides = [n for mat in materials for n in mat.nuclides]
-                extra_nuclides = set(self._nuclides_direct) - set(mat_nuclides)
+                mat_nuclides = {n for mat in materials for n in mat.nuclides}
+                extra_nuclides = set(self._nuclides_direct) - mat_nuclides
                 for nuc in extra_nuclides:
                     load_nuclide(nuc)
                 self._rate_tally.nuclides = self._nuclides_direct

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -15,7 +15,7 @@ from openmc.mpi import comm
 from openmc.checkvalue import check_type, check_greater_than
 from openmc.data import JOULE_PER_EV, REACTION_MT
 from openmc.lib import (
-    Tally, MaterialFilter, EnergyFilter, EnergyFunctionFilter)
+    Tally, MaterialFilter, EnergyFilter, EnergyFunctionFilter, load_nuclide)
 import openmc.lib
 from .abc import (
     ReactionRateHelper, NormalizationHelper, FissionYieldHelper)
@@ -189,7 +189,7 @@ class DirectReactionRateHelper(ReactionRateHelper):
     def reset_tally_means(self):
         """Reset the cached mean rate tallies.
         .. note::
-            
+
                 This step must be performed after each transport cycle
         """
         self._rate_tally_means_cache = None
@@ -306,6 +306,12 @@ class FluxCollapseHelper(ReactionRateHelper):
             self._rate_tally.filters = [MaterialFilter(materials)]
             self._rate_tally_means_cache = None
             if self._nuclides_direct is not None:
+                # check if any direct tally nuclides are requested that are not
+                # already loaded with the materials. Load separately if so.
+                mat_nuclides = [n for mat in materials for n in mat.nuclides]
+                extra_nuclides = set(self._nuclides_direct) - set(mat_nuclides)
+                for nuc in extra_nuclides:
+                    load_nuclide(nuc)
                 self._rate_tally.nuclides = self._nuclides_direct
 
     @property
@@ -327,7 +333,7 @@ class FluxCollapseHelper(ReactionRateHelper):
     def reset_tally_means(self):
         """Reset the cached mean rate and flux tallies.
         .. note::
-            
+
                 This step must be performed after each transport cycle
         """
         self._flux_tally_means_cache = None

--- a/tests/unit_tests/test_deplete_activation.py
+++ b/tests/unit_tests/test_deplete_activation.py
@@ -47,7 +47,7 @@ ENERGIES = np.logspace(log10(1e-5), log10(2e7), 100)
     ("direct", {}, 1e-5),
     ("flux", {'energies': ENERGIES}, 0.01),
     ("flux", {'energies': ENERGIES, 'reactions': ['(n,gamma)']}, 1e-5),
-    ("flux", {'energies': ENERGIES, 'reactions': ['(n,gamma)'], 'nuclides': ['W186', 'H3']}, 1e-5),
+    ("flux", {'energies': ENERGIES, 'reactions': ['(n,gamma)'], 'nuclides': ['W186', 'H3']}, 1e-2),
 ])
 def test_activation(run_in_tmpdir, model, reaction_rate_mode, reaction_rate_opts, tolerance):
     # Determine (n.gamma) reaction rate using initial run

--- a/tests/unit_tests/test_deplete_activation.py
+++ b/tests/unit_tests/test_deplete_activation.py
@@ -47,7 +47,7 @@ ENERGIES = np.logspace(log10(1e-5), log10(2e7), 100)
     ("direct", {}, 1e-5),
     ("flux", {'energies': ENERGIES}, 0.01),
     ("flux", {'energies': ENERGIES, 'reactions': ['(n,gamma)']}, 1e-5),
-    ("flux", {'energies': ENERGIES, 'reactions': ['(n,gamma)'], 'nuclides': ['W186']}, 1e-5),
+    ("flux", {'energies': ENERGIES, 'reactions': ['(n,gamma)'], 'nuclides': ['W186', 'H3']}, 1e-5),
 ])
 def test_activation(run_in_tmpdir, model, reaction_rate_mode, reaction_rate_opts, tolerance):
     # Determine (n.gamma) reaction rate using initial run


### PR DESCRIPTION
This fixes an issue discovered when using the hybrid method for depletion when a set of nuclides is passed to be direct tallied. If the nuclide to be direct tallied is not present in the initial materials, the nuclide has not yet been loaded and therefore is not available for the tally construction (error appears that "[nuclide] has not been loaded yet."). To fix this, we can determine the set of nuclides requested that are not present in the initial materials and load them before the tally initialization.

Also, the capability to pass a set of nuclides like this must not be covered in tests since this error appears. It's not clear to me where such a test should live, so if you have advice on that, I will add the test where appropriate.