### PR TITLE
Release of version 0.13.3

### DIFF
--- a/docs/source/releasenotes/0.13.2.rst
+++ b/docs/source/releasenotes/0.13.2.rst
@@ -14,7 +14,7 @@ Notably, a capability has been added to compute the photon spectra from decay of
 unstable nuclides. Alongside that, a new :data:`openmc.config` configuration
 variable has been introduced that allows easier configuration of data sources.
 Additionally, users can now perform cell or material rejection when sampling
-external source distributions. Finally,
+external source distributions.
 
 ------------------------------------
 Compatibility Notes and Deprecations

--- a/docs/source/releasenotes/0.13.3.rst
+++ b/docs/source/releasenotes/0.13.3.rst
@@ -1,0 +1,134 @@
+====================
+What's New in 0.13.3
+====================
+
+.. currentmodule:: openmc
+
+-------
+Summary
+-------
+
+This release of OpenMC includes many bug fixes, performance improvements, and
+several notable new features. Some of the highlights include support for MCPL
+source files, NCrystal thermal scattering materials, and a new
+:class:`openmc.stats.MeshSpatial` class that allows a source distribution to be
+specified over a mesh. Additionally, OpenMC now allows you to export your model
+as a single XML file rather than separate XML files for geometry, materials,
+settings, and tallies.
+
+------------------------------------
+Compatibility Notes and Deprecations
+------------------------------------
+
+- Atomic mass data used in :func:`openmc.data.atomic_mass` has been updated to
+  AME 2020, which results in slightly different masses.
+
+------------
+New Features
+------------
+
+- Support was added for `MCPL <https://mctools.github.io/mcpl/>`_ files to be
+  used as external sources. Additionally, source points and surfaces sources can
+  be written as MCPL files instead of HDF5 files. (`#2116
+  <https://github.com/openmc-dev/openmc/pull/2116>`_)
+- Support was added for `NCrystal <https://github.com/mctools/ncrystal>`_
+  thermal scattering materials. (`#2222
+  <https://github.com/openmc-dev/openmc/pull/2222>`_)
+- The :class:`~openmc.CylindricalMesh` and :class:`~openmc.SphericalMesh`
+  classes now have an ``origin`` attribute that changes the center of the mesh.
+  (`#2256 <https://github.com/openmc-dev/openmc/pull/2256>`_)
+- A new :class:`openmc.model.Polygon` class allows defining generalized 2D
+  polygons. (`#2266 <https://github.com/openmc-dev/openmc/pull/2266>`_)
+- A new :func:`openmc.data.decay_energy` function and
+  :meth:`openmc.Material.get_decay_heat` method enable determination of decay
+  heat from a single nuclide or material. (`#2287
+  <https://github.com/openmc-dev/openmc/pull/2287>`_)
+- Full models can now be written as a single XML file rather than separate
+  geometry, materials, settings, and tallies XML files. (`#2291
+  <https://github.com/openmc-dev/openmc/pull/2291>`_)
+- Discrete distributions are now sampled using alias sampling, which is O(1) in
+  time. (`#2329 <https://github.com/openmc-dev/openmc/pull/2329>`_)
+- The new :class:`openmc.stats.MeshSpatial` allows a spatial source distribution
+  to be specified with source strengths for each mesh element. (`#2334
+  <https://github.com/openmc-dev/openmc/pull/2334>`_)
+- The new :meth:`openmc.Geometry.get_surfaces_by_name` method returns a list of
+  matching surfaces in a geometry. (`#2347
+  <https://github.com/openmc-dev/openmc/pull/2347>`_)
+- A new :attr:`openmc.Settings.create_delayed_neutrons` attribute controls
+  whether delayed neutrons are created during a simulation. (`#2348
+  <https://github.com/openmc-dev/openmc/pull/2348>`_)
+- The :meth:`openmc.deplete.Results.export_to_materials` method now takes a
+  ``path`` argument. (`#2364 <https://github.com/openmc-dev/openmc/pull/2364>`_)
+- A new :meth:`openmc.EnergyFilter.get_tabular` method allows one to create a
+  tabular distribution based on tally results using an energy filter. (`#2371
+  <https://github.com/openmc-dev/openmc/pull/2371>`_)
+- Several methods in the :class:`openmc.Material` class that require a volume to
+  be set (e.g., :meth:`~openmc.Material.get_mass`) now accept a ``volume``
+  argument. (`#2412 <https://github.com/openmc-dev/openmc/pull/2412>`_)
+
+---------
+Bug Fixes
+---------
+
+- Fix for finding redundant surfaces (`#2263 <https://github.com/openmc-dev/openmc/pull/2263>`_)
+- Adds tolerance for temperatures slightly out of bounds (`#2265 <https://github.com/openmc-dev/openmc/pull/2265>`_)
+- Fix getter/setter for weight window bounds (`#2275 <https://github.com/openmc-dev/openmc/pull/2275>`_)
+- Make sure Chain.reduce preserves decay source (`#2283 <https://github.com/openmc-dev/openmc/pull/2283>`_)
+- Fix array shape for weight window bounds (`#2284 <https://github.com/openmc-dev/openmc/pull/2284>`_)
+- Fix for non-zero CDF start points in TSL data (`#2290 <https://github.com/openmc-dev/openmc/pull/2290>`_)
+- Fix a case where inelastic scattering yield is zero (`#2295 <https://github.com/openmc-dev/openmc/pull/2295>`_)
+- Prevent Compton profile out-of-bounds memory access (`#2297 <https://github.com/openmc-dev/openmc/pull/2297>`_)
+- Produce light particles from decay (`#2301 <https://github.com/openmc-dev/openmc/pull/2301>`_)
+- Fix zero runtime attributes in depletion statepoints (`#2302 <https://github.com/openmc-dev/openmc/pull/2302>`_)
+- Fix bug in openmc.Universe.get_nuclide_densities (`#2310 <https://github.com/openmc-dev/openmc/pull/2310>`_)
+- Only show print output from depletion on rank 0 (`#2311 <https://github.com/openmc-dev/openmc/pull/2311>`_)
+- Fix photon transport with no atomic relaxation data (`#2312 <https://github.com/openmc-dev/openmc/pull/2312>`_)
+- Fix for precedence in region expressions (`#2318 <https://github.com/openmc-dev/openmc/pull/2318>`_)
+- Allow source particles with energy below cutoff (`#2319 <https://github.com/openmc-dev/openmc/pull/2319>`_)
+- Fix IncidentNeutron.from_njoy for high temperatures (`#2320 <https://github.com/openmc-dev/openmc/pull/2320>`_)
+- Add capability to unset cell temperatures (`#2323 <https://github.com/openmc-dev/openmc/pull/2323>`_)
+- Fix in plot_xs when S(a,b) tables are present (`#2335 <https://github.com/openmc-dev/openmc/pull/2335>`_)
+- Various fixes for tally triggers (`#2344 <https://github.com/openmc-dev/openmc/pull/2344>`_)
+- Raise error when mesh is flat (`#2363 <https://github.com/openmc-dev/openmc/pull/2363>`_)
+- Don't call normalize inside Tabular.mean (`#2375 <https://github.com/openmc-dev/openmc/pull/2375>`_)
+- Avoid out-of-bounds access in inelastic scatter sampling (`#2378 <https://github.com/openmc-dev/openmc/pull/2378>`_)
+- Use correct direction for anisotropic fission (`#2381 <https://github.com/openmc-dev/openmc/pull/2381>`_)
+- Fix several thermal scattering nuclide assignments (`#2382 <https://github.com/openmc-dev/openmc/pull/2382>`_)
+- Fix _materials_by_id attribute in Model (`#2385 <https://github.com/openmc-dev/openmc/pull/2385>`_)
+- Updates to batch checks for simulation restarts (`#2390 <https://github.com/openmc-dev/openmc/pull/2390>`_)
+- write_data_to_vtk volume normalization correction (`#2397 <https://github.com/openmc-dev/openmc/pull/2397>`_)
+- Enable generation of JEFF 3.3 depletion chain (`#2410 <https://github.com/openmc-dev/openmc/pull/2410>`_)
+- Fix spherical to Cartesian coordinate conversion (`#2417 <https://github.com/openmc-dev/openmc/pull/2417>`_)
+- Handle zero photon cross sections in IncidentPhoton.from_ace (`#2433 <https://github.com/openmc-dev/openmc/pull/2433>`_)
+- Fix hybrid depletion when nuclides are not present (`#2436 <https://github.com/openmc-dev/openmc/pull/2436>`_)
+- Fix bug in cylindrical and spherical meshes (`#2439 <https://github.com/openmc-dev/openmc/pull/2439>`_)
+- Improvements to mesh radial boundary coincidence (`#2443 <https://github.com/openmc-dev/openmc/pull/2443>`_)
+
+------------
+Contributors
+------------
+
+- `Hunter Belanger <https://github.com/HunterBelanger>`_
+- `Rémi Delaporte-Mathurin <https://github.com/RemDelaporteMathurin>`_
+- `Christopher Fichtlscherer <https://github.com/cfichtlscherer>`_
+- `Valerio Giusti <https://github.com/valeriogiusti>`_
+- `Chris Keckler <https://github.com/keckler>`_
+- `Kalin Kiesling <https://github.com/kkiesling>`_
+- `Thomas Kittelmann <https://github.com/tkittel>`_
+- `Erik Knudsen <https://github.com/ebknudsen>`_
+- `Colin Larmier <https://github.com/colinelarmier>`_
+- `Amanda Lund <https://github.com/amandalund>`_
+- `Jose Ignacio Marquez Damien <https://github.com/marquezj>`_
+- `Josh May <https://github.com/joshmay1>`_
+- `Patrick Myers <https://github.com/myerspat>`_
+- `Baptiste Mouginot <https://github.com/bam241>`_
+- `April Novak <https://github.com/aprilnovak>`_
+- `Matthew Nyberg <https://github.com/NybergWISC>`_
+- `Ethan Peterson <https://github.com/eepeterson>`_
+- `Gavin Ridley <https://github.com/gridley>`_
+- `Paul Romano <https://github.com/paulromano>`_
+- `Patrick Shriwise <https://github.com/pshriwise>`_
+- `Jonathan Shimwell <https://github.com/Shimwell>`_
+- `Paul Wilson <https://github.com/gonuke>`_
+- `Olek Yardas <https://github.com/yardasol>`_
+- `Jiankai Yu <https://github.com/rockfool>`_

--- a/docs/source/releasenotes/index.rst
+++ b/docs/source/releasenotes/index.rst
@@ -7,6 +7,7 @@ Release Notes
 .. toctree::
   :maxdepth: 1
 
+  0.13.3
   0.13.2
   0.13.1
   0.13.0

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -277,7 +277,7 @@ Prerequisites
       Lists) files instead of .h5 files for sources (external source
       distribution, k-eigenvalue source distribution, and surface sources). To
       turn this option on in the CMake configuration step, add the following
-      option:
+      option::
 
           cmake -DOPENMC_USE_MCPL=on ..
 
@@ -288,7 +288,7 @@ Prerequisites
       on-the-fly approach. To use it `install
       <https://github.com/mctools/ncrystal/wiki/Get-NCrystal>`_ and `initialize
       <https://github.com/mctools/ncrystal/wiki/Using-NCrystal#setting-up>`_
-      NCrystal and turn on the option in the CMake configuration step:
+      NCrystal and turn on the option in the CMake configuration step::
 
           cmake -DOPENMC_USE_NCRYSTAL=on ..
 
@@ -299,7 +299,7 @@ Prerequisites
       be used, but the implementation is currently restricted to collision
       estimators. In addition to turning this option on, the path to the libMesh
       installation should be specified as part of the ``CMAKE_PREFIX_PATH``
-      variable.::
+      variable::
 
           cmake -DOPENMC_USE_LIBMESH=on -DOPENMC_USE_MPI=on -DCMAKE_PREFIX_PATH=/path/to/libmesh/installation ..
 
@@ -371,6 +371,10 @@ CMakeLists.txt Options
 
 The following options are available in the CMakeLists.txt file:
 
+OPENMC_ENABLE_COVERAGE
+  Compile and link code instrumented for coverage analysis. This is typically
+  used in conjunction with gcov_. (Default: off)
+
 OPENMC_ENABLE_PROFILE
   Enables profiling using the GNU profiler, gprof. (Default: off)
 
@@ -385,22 +389,23 @@ OPENMC_USE_DAGMC
   should also be defined as `DAGMC_ROOT` in the CMake configuration command.
   (Default: off)
 
+OPENMC_USE_MCPL
+  Turns on support for reading MCPL_ source files and writing MCPL source points
+  and surface sources. (Default: off)
+
 OPENMC_USE_NCRYSTAL
-  Turns on support for NCrystal materials. NCrystal must be
-  `installed <https://github.com/mctools/ncrystal/wiki/Get-NCrystal>`_ and
-  `initialized <https://github.com/mctools/ncrystal/wiki/Using-NCrystal#setting-up>`_.
+  Turns on support for NCrystal materials. NCrystal must be `installed
+  <https://github.com/mctools/ncrystal/wiki/Get-NCrystal>`_ and `initialized
+  <https://github.com/mctools/ncrystal/wiki/Using-NCrystal#setting-up>`_.
   (Default: off)
 
 OPENMC_USE_LIBMESH
   Enables the use of unstructured mesh tallies with libMesh_. (Default: off)
 
-OPENMC_ENABLE_COVERAGE
-  Compile and link code instrumented for coverage analysis. This is typically
-  used in conjunction with gcov_. (Default: off)
-
 OPENMC_USE_MPI
-  Turns on compiling with MPI (default: off). For further information on MPI options,
-  please see the `FindMPI.cmake documentation <https://cmake.org/cmake/help/latest/module/FindMPI.html>`_.
+  Turns on compiling with MPI (Default: off). For further information on MPI
+  options, please see the `FindMPI.cmake documentation
+  <https://cmake.org/cmake/help/latest/module/FindMPI.html>`_.
 
 To set any of these options (e.g., turning on profiling), the following form
 should be used:

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -105,9 +105,9 @@ other information use:
 
 .. note::
 
-    It should be noted that by default OpenMC builds with ``-O2 -g`` flags which
-    are equivalent to a CMake build type of `RelwithDebInfo`. In addition, MPI
-    is OFF while OpenMP is ON.
+    It should be noted that by default OpenMC is built with
+    `-DCMAKE_BUILD_TYPE=RelwithDebInfo`. In addition, MPI is OFF while OpenMP is
+    ON.
 
 It is recommended to install OpenMC with the Python API. Information about this
 Spack recipe can be found with the following command:
@@ -133,17 +133,18 @@ following command:
     configured defaults unless otherwise specfied in the specification on the
     command line. In the above example, assuming the default options weren't
     changed in Spack's package configuration, py-openmc will link against a
-    non-optimized non-MPI openmc. Even if an optimized openmc was built
-    separately, it will rebuild openmc with optimization OFF. Thus, if you are
-    trying to link against dependencies that were configured different than
-    defaults, ``^openmc[variants]`` will have to be present in the command.
+    non-MPI non-release build of openmc. Even if a release build of openmc was
+    built separately, it will rebuild openmc with the default build type. Thus,
+    if you are trying to link against dependencies that were configured
+    different than defaults, ``^openmc[variants]`` will have to be present in
+    the command.
 
-For a more performant build of OpenMC with optimization turned ON and MPI
-provided by OpenMPI, the following command can be used:
+For a release build of OpenMC with MPI support on (provided by OpenMPI), the
+following command can be used:
 
 .. code-block:: sh
 
-    spack install py-openmc+mpi ^openmc+optimize ^openmpi
+    spack install py-openmc +mpi ^openmpi ^openmc build_type=Release
 
 .. note::
 
@@ -163,7 +164,7 @@ This can be observed using Spack's ``spec`` tool:
 
 .. code-block::
 
-    spack spec py-openmc+mpi ^openmc+optimize
+    spack spec py-openmc +mpi ^openmc build_type=Release
 
 Once installed, environment/lmod modules can be generated or Spack's ``load``
 feature can be used to access the installed packages.
@@ -526,13 +527,7 @@ distribution/repository, run:
 pip will first check that all :ref:`required third-party packages
 <usersguide_python_prereqs>` have been installed, and if they are not present,
 they will be installed by downloading the appropriate packages from the Python
-Package Index (`PyPI <https://pypi.org/>`_). However, do note that since pip
-runs the ``setup.py`` script which requires NumPy, you will have to first
-install NumPy:
-
-.. code-block:: sh
-
-    pip install numpy
+Package Index (`PyPI <https://pypi.org/>`_).
 
 Installing in "Development" Mode
 --------------------------------

--- a/include/openmc/version.h.in
+++ b/include/openmc/version.h.in
@@ -10,7 +10,7 @@ namespace openmc {
 constexpr int VERSION_MAJOR {@OPENMC_VERSION_MAJOR@};
 constexpr int VERSION_MINOR {@OPENMC_VERSION_MINOR@};
 constexpr int VERSION_RELEASE {@OPENMC_VERSION_RELEASE@};
-constexpr bool VERSION_DEV {true};
+constexpr bool VERSION_DEV {false};
 constexpr std::array<int, 3> VERSION {VERSION_MAJOR, VERSION_MINOR, VERSION_RELEASE};
 // clang-format on
 

--- a/openmc/__init__.py
+++ b/openmc/__init__.py
@@ -38,4 +38,4 @@ from .config import *
 from openmc.model import rectangular_prism, hexagonal_prism, Model
 
 
-__version__ = '0.13.3-dev'
+__version__ = '0.13.3'

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -398,6 +398,8 @@ class Results(list):
         path : PathLike
             Path to materials XML file to read. Defaults to 'materials.xml'.
 
+            .. versionadded:: 0.13.3
+
         Returns
         -------
         mat_file : Materials

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1349,6 +1349,8 @@ class EnergyFilter(RealFilter):
         (e.g., a source spectrum) based on tally results that were obtained from
         using an :class:`~openmc.EnergyFilter`.
 
+        .. versionadded:: 0.13.3
+
         Parameters
         ----------
         values : iterable of float

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -537,6 +537,8 @@ class Geometry:
     def get_surfaces_by_name(self, name, case_sensitive=False, matching=False):
         """Return a list of surfaces with matching names.
 
+        .. versionadded:: 0.13.3
+
         Parameters
         ----------
         name : str

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -644,6 +644,8 @@ class Model:
             Exports a single model.xml file rather than separate files.
             Defaults to True.
 
+            .. versionadded:: 0.13.3
+
         Returns
         -------
         Path

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -632,6 +632,8 @@ class ZConeOneSided(CompositeSurface):
 class Polygon(CompositeSurface):
     """Create a polygon composite surface from a path of closed points.
 
+    .. versionadded:: 0.13.3
+
     Parameters
     ----------
     points : np.ndarray
@@ -927,7 +929,7 @@ class Polygon(CompositeSurface):
         if group is None:
             sidx = next(iter(neighbor_map))
             return self._group_simplices(neighbor_map, group=[sidx])
-        # Otherwise use the last simplex in the group 
+        # Otherwise use the last simplex in the group
         else:
             sidx = group[-1]
             # Remove current simplex from dictionary since it is in a group

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -1436,6 +1436,8 @@ class Tally(IDManagerMixin):
             dimensions. This will result in more than one dimension per filter
             for the returned data array.
 
+            .. versionadded:: 0.13.3
+
         Returns
         -------
         numpy.ndarray

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -360,6 +360,8 @@ void print_build_info()
   std::string png(n);
   std::string profiling(n);
   std::string coverage(n);
+  std::string mcpl(n);
+  std::string ncrystal(n);
 
 #ifdef PHDF5
   phdf5 = y;
@@ -372,6 +374,12 @@ void print_build_info()
 #endif
 #ifdef LIBMESH
   libmesh = y;
+#endif
+#ifdef OPENMC_MCPL
+  mcpl = y;
+#endif
+#ifdef NCRYSTAL
+  ncrystal = y;
 #endif
 #ifdef USE_LIBPNG
   png = y;
@@ -396,6 +404,8 @@ void print_build_info()
     fmt::print("PNG support:           {}\n", png);
     fmt::print("DAGMC support:         {}\n", dagmc);
     fmt::print("libMesh support:       {}\n", libmesh);
+    fmt::print("MCPL support:          {}\n", mcpl);
+    fmt::print("NCrystal support:      {}\n", ncrystal);
     fmt::print("Coverage testing:      {}\n", coverage);
     fmt::print("Profiling flags:       {}\n", profiling);
   }


### PR DESCRIPTION
To support the OpenMC course next week, I'd like to put out a new release with the latest and greatest features and bug fixes. This PR:

- Updates version numbers to remove "-dev"
- Adds release notes for 0.13.3
- Adds missing `.. versionadded::` directives
- Minor updates to installation instructions