### PR TITLE
Improvements to spherical/cylindrical mesh radial boundary coincidence with geometry

### DIFF
--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -51,6 +51,10 @@ constexpr double FP_PRECISION {1e-14};
 constexpr double FP_REL_PRECISION {1e-5};
 constexpr double FP_COINCIDENT {1e-12};
 
+// Coincidence tolerances
+constexpr double TORUS_TOL {1e-10};
+constexpr double RADIAL_MESH_TOL {1e-10};
+
 // Maximum number of random samples per history
 constexpr int MAX_SAMPLE {100000};
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1088,7 +1088,7 @@ double CylindricalMesh::find_r_crossing(
   D = std::sqrt(D);
 
   // the solution -p - D is always smaller as -p + D : Check this one first
-  if (std::abs(c) <= 1e-10)
+  if (std::abs(c) <= RADIAL_MESH_TOL)
     return INFTY;
 
   if (-p - D > l)
@@ -1316,7 +1316,7 @@ double SphericalMesh::find_r_crossing(
   double c = r.dot(r) - r0 * r0;
   double D = p * p - c;
 
-  if (std::abs(c) <= 1e-10)
+  if (std::abs(c) <= RADIAL_MESH_TOL)
     return INFTY;
 
   if (D >= 0.0) {

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1091,7 +1091,7 @@ double CylindricalMesh::find_r_crossing(
   if (std::abs(c) <= 1e-10)
     return INFTY;
 
-  if (-p - D > l && std::abs(c) > 1e-10)
+  if (-p - D > l)
     return -p - D;
   if (-p + D > l)
     return -p + D;

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1066,6 +1066,9 @@ double CylindricalMesh::find_r_crossing(
   // s^2 * (u^2 + v^2) + 2*s*(u*x+v*y) + x^2+y^2-r0^2 = 0
 
   const double r0 = grid_[0][shell];
+  if (r0 == 0.0)
+    return INFTY;
+
   const double denominator = u.x * u.x + u.y * u.y;
 
   // Direction of flight is in z-direction. Will never intersect r.
@@ -1085,6 +1088,9 @@ double CylindricalMesh::find_r_crossing(
   D = std::sqrt(D);
 
   // the solution -p - D is always smaller as -p + D : Check this one first
+  if (std::abs(c) <= 1e-10)
+    return INFTY;
+
   if (-p - D > l && std::abs(c) > 1e-10)
     return -p - D;
   if (-p + D > l)
@@ -1304,14 +1310,19 @@ double SphericalMesh::find_r_crossing(
   // solve |r+s*u| = r0
   // |r+s*u| = |r| + 2*s*r*u + s^2 (|u|==1 !)
   const double r0 = grid_[0][shell];
+  if (r0 == 0.0)
+    return INFTY;
   const double p = r.dot(u);
   double c = r.dot(r) - r0 * r0;
   double D = p * p - c;
 
+  if (std::abs(c) <= 1e-10)
+    return INFTY;
+
   if (D >= 0.0) {
     D = std::sqrt(D);
     // the solution -p - D is always smaller as -p + D : Check this one first
-    if (-p - D > l && std::abs(c) > 1e-10)
+    if (-p - D > l)
       return -p - D;
     if (-p + D > l)
       return -p + D;

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -1044,7 +1044,7 @@ double torus_distance(double x1, double x2, double x3, double u1, double u2,
   // zero but possibly small and positive. A tolerance is set to discard that
   // zero.
   double distance = INFTY;
-  double cutoff = coincident ? 1e-10 : 0.0;
+  double cutoff = coincident ? TORUS_TOL : 0.0;
   for (int i = 0; i < 4; ++i) {
     if (roots[i].imag() == 0) {
       double root = roots[i].real();

--- a/tests/unit_tests/test_cylindrical_mesh.py
+++ b/tests/unit_tests/test_cylindrical_mesh.py
@@ -75,7 +75,7 @@ def label(p):
         return f'estimator:{p}'
 
 @pytest.mark.parametrize('estimator,origin', test_cases, ids=label)
-def test_offset_mesh(model, estimator, origin):
+def test_offset_mesh(run_in_tmpdir, model, estimator, origin):
     """Tests that the mesh has been moved based on tally results
     """
     mesh = model.tallies[0].filters[0].mesh

--- a/tests/unit_tests/test_cylindrical_mesh.py
+++ b/tests/unit_tests/test_cylindrical_mesh.py
@@ -113,7 +113,7 @@ def void_coincident_geom_model():
 
     model.materials = openmc.Materials()
     radii = [0.1,1, 5, 50, 100, 150, 250]
-    cylinders = [openmc.Sphere(r=ri) for ri in radii]
+    cylinders = [openmc.ZCylinder(r=ri) for ri in radii]
     cylinders[-1].boundary_type = 'vacuum'
 
     regions = openmc.model.subdivide(cylinders)[:-1]

--- a/tests/unit_tests/test_cylindrical_mesh.py
+++ b/tests/unit_tests/test_cylindrical_mesh.py
@@ -113,10 +113,10 @@ def void_coincident_geom_model():
 
     model.materials = openmc.Materials()
     radii = [0.1,1, 5, 50, 100, 150, 250]
-    spheres = [openmc.Sphere(r=ri) for ri in radii]
-    spheres[-1].boundary_type = 'vacuum'
+    cylinders = [openmc.Sphere(r=ri) for ri in radii]
+    cylinders[-1].boundary_type = 'vacuum'
 
-    regions = openmc.model.subdivide(spheres)[:-1]
+    regions = openmc.model.subdivide(cylinders)[:-1]
     cells = [openmc.Cell(region=r, fill=None) for r in regions]
     geom = openmc.Geometry(cells)
 

--- a/tests/unit_tests/test_cylindrical_mesh.py
+++ b/tests/unit_tests/test_cylindrical_mesh.py
@@ -98,7 +98,6 @@ def test_offset_mesh(model, estimator, origin):
         centroids = mesh.centroids
         for ijk in mesh.indices:
             i, j, k = np.array(ijk) - 1
-            print(centroids[:, i, j, k])
             if model.geometry.find(centroids[:, i, j, k]):
                 mean[i, j, k] == 0.0
             else:
@@ -152,7 +151,6 @@ def _check_void_cylindrical_tally(statepoint_filename):
         neutron_flux = flux_tally.get_reshaped_data().squeeze()
         # we expect the tally results to be the same as the mesh grid width
         # for these cases
-        print(neutron_flux)
         d_r = mesh.r_grid[1] - mesh.r_grid[0]
         assert neutron_flux == pytest.approx(d_r)
 

--- a/tests/unit_tests/test_spherical_mesh.py
+++ b/tests/unit_tests/test_spherical_mesh.py
@@ -107,3 +107,103 @@ def test_offset_mesh(model, estimator, origin):
                 mean[i, j, k] == 0.0
             else:
                 mean[i, j, k] != 0.0
+
+# Some void geometry tests to check our radial intersection methods on
+# spherical and cylindrical meshes
+
+@pytest.fixture()
+def void_coincident_geom_model():
+    """A model with many geometric boundaries coincident with mesh boundaries
+    across many scales
+    """
+    openmc.reset_auto_ids()
+
+    model = openmc.Model()
+
+    model.materials = openmc.Materials()
+    radii = [0.1, 1, 5, 50, 100, 150, 250]
+    spheres = [openmc.Sphere(r=ri) for ri in radii]
+    spheres[-1].boundary_type = 'vacuum'
+
+    regions = openmc.model.subdivide(spheres)[:-1]
+    cells = [openmc.Cell(region=r, fill=None) for r in regions]
+    geom = openmc.Geometry(cells)
+
+    model.geometry = geom
+
+    settings = openmc.Settings(run_mode='fixed source')
+    settings.batches = 2
+    settings.particles = 5000
+    model.settings = settings
+
+    mesh = openmc.SphericalMesh()
+    mesh.r_grid = np.linspace(0, 250, 501)
+    mesh_filter = openmc.MeshFilter(mesh)
+
+    tally = openmc.Tally()
+    tally.scores = ['flux']
+    tally.filters = [mesh_filter]
+
+    model.tallies = openmc.Tallies([tally])
+
+    return model
+
+
+# convenience function for checking tally results
+# in the following tests
+def _check_void_spherical_tally(statepoint_filename):
+    with openmc.StatePoint(statepoint_filename) as sp:
+        flux_tally = sp.tallies[1]
+        mesh = flux_tally.find_filter(openmc.MeshFilter).mesh
+        neutron_flux = flux_tally.get_reshaped_data().squeeze() / mesh.volumes.flatten()
+        flux_diff = np.diff(neutron_flux)
+        # ensure flux values are monotonically decreasing due to
+        # geometric attenuation
+        assert (flux_diff < 0.0).all()
+
+
+def test_void_geom_pnt_src(run_in_tmpdir, void_coincident_geom_model):
+    # add isotropic point source
+    src = openmc.Source()
+    src.space = openmc.stats.Point()
+    src.energy = openmc.stats.Discrete([14.06e6], [1])
+    void_coincident_geom_model.settings.source = src
+
+    sp_filename = void_coincident_geom_model.run()
+
+    _check_void_spherical_tally(sp_filename)
+
+
+def test_void_geom_boundary_src(run_in_tmpdir, void_coincident_geom_model):
+    # update source to a number of points on the outside of the sphere
+    # with directions pointing toward the origin
+
+    # sources
+    phi_vals = np.linspace(0, np.pi, 20)
+    theta_vals = np.linspace(0, 2.0*np.pi, 20)
+
+    bbox = void_coincident_geom_model.geometry.bounding_box
+    # can't source particles directly on the geometry boundary
+    outer_r = bbox[1][0] - 0.00001
+
+    sources = []
+
+    energy = openmc.stats.Discrete([14.06e6], [1])
+
+    for phi, theta in zip(phi_vals, theta_vals):
+
+        src = openmc.Source()
+        src.energy = energy
+
+        pnt = np.array([np.sin(phi)*np.cos(theta), np.sin(phi)*np.sin(theta), np.cos(phi)])
+        u = -pnt
+        src.space = openmc.stats.Point(outer_r*pnt)
+        src.angle = openmc.stats.Monodirectional(u)
+
+        sources.append(src)
+
+    void_coincident_geom_model.settings.source = sources
+
+    sp_filename = void_coincident_geom_model.run()
+
+    _check_void_spherical_tally(sp_filename)

--- a/tests/unit_tests/test_spherical_mesh.py
+++ b/tests/unit_tests/test_spherical_mesh.py
@@ -79,7 +79,7 @@ def label(p):
         return f'estimator:{p}'
 
 @pytest.mark.parametrize('estimator,origin', test_cases, ids=label)
-def test_offset_mesh(model, estimator, origin):
+def test_offset_mesh(run_in_tmpdir, model, estimator, origin):
     """Tests that the mesh has been moved based on tally results
     """
     mesh = model.tallies[0].filters[0].mesh

--- a/tests/unit_tests/test_spherical_mesh.py
+++ b/tests/unit_tests/test_spherical_mesh.py
@@ -102,7 +102,6 @@ def test_offset_mesh(model, estimator, origin):
         centroids = mesh.centroids
         for ijk in mesh.indices:
             i, j, k = np.array(ijk) - 1
-            print(centroids[:, i, j, k])
             if model.geometry.find(centroids[:, i, j, k]):
                 mean[i, j, k] == 0.0
             else:


### PR DESCRIPTION
This is a follow-on to #2439 and resolves #2369.

@eepeterson presented a test case in #2369 with a geometry that has multiple geometric boundaries coincident with spherical mesh boundaries. The artifacts shown there were traced back to coincident surface intersections for on the spherical mesh returning very small positive distances to the coincident surface. This caused the logic of the raytracing routine behind tracklength mesh tallies to attribute the entire particle track to the wrong mesh bin. 

I originally thought that the best solution would be to check the particle's direction against the normal of the radial surface to determine which mesh surface intersection to use, but this falls apart when the particle is traveling through the innermost radial bin or intersects the same radial boundary twice (the normals might be very different at the entrance and exit location). In the end, I settled on two changes that address the outer boundary coincidence from #2439 as well as cases where inner geometry and mesh boundaries are coincident. **1.** we always return `INFTY` if the particle is coincident with a mesh surface at the beginning of the track. **2.** I've also added a check for intersections with a mesh surface where `r = 0.0`. `find_r_crossing` will return `INFTY` in this case as well -- crossing this boundary will indicate that the particle is outside of the mesh and that isn't accurate for the case of a spherical/cylindrical mesh.

These changes were made in both the `SphericalMesh` and `CylindricalMesh` classes. A set of void geometry tests are included for each class as well -- one with an isotropic point source in the center and another with a set of sources located on the outer boundary of the geometry pointing toward the model origin.