### PR TITLE
avoid python C API segfault on intel mac

### DIFF
--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -68,7 +68,12 @@ extern std::string path_input;  //!< directory where main .xml files resides
 extern std::string path_output; //!< directory where output files are written
 extern std::string path_particle_restart; //!< path to a particle restart file
 extern std::string path_sourcepoint;      //!< path to a source file
-extern "C" std::string path_statepoint;   //!< path to a statepoint file
+extern std::string path_statepoint;       //!< path to a statepoint file
+
+// This is required because the c_str() may not be the first thing in
+// std::string. Sometimes it is, but it seems libc++ may not be like that
+// on some computers, like the intel Mac.
+extern "C" char const* path_statepoint_c; //!< C pointer to statepoint file name
 
 extern "C" int32_t n_inactive;         //!< number of inactive batches
 extern "C" int32_t max_lost_particles; //!< maximum number of lost particles

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -193,6 +193,7 @@ int parse_command_line(int argc, char* argv[])
         // Set path and flag for type of run
         if (filetype == "statepoint") {
           settings::path_statepoint = argv[i];
+          settings::path_statepoint_c = settings::path_statepoint.c_str();
           settings::restart_run = true;
         } else if (filetype == "particle restart") {
           settings::path_particle_restart = argv[i];

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -82,6 +82,8 @@ std::string path_output;
 std::string path_particle_restart;
 std::string path_sourcepoint;
 std::string path_statepoint;
+std::string empty_string = "";
+char const* path_statepoint_c {empty_string.c_str()};
 
 int32_t n_inactive {0};
 int32_t max_lost_particles {10};


### PR DESCRIPTION
You can't reliably use extern "C" std::strings. The python C API ends up basically reinterpret casting path_statepoint, which is an std::string to char*. Depending on the libc++ implementation, this may segfault, as it does on my intel Mac. This failure can be seen in the cmfd_restart test, with this output below.

```
test.py Fatal Python error: Segmentation fault

Current thread 0x00007ff85fd97340 (most recent call first):
  File "/Users/sebastiantchakerian/Codes/openmc/openmc/lib/settings.py", line 59 in path_statepoint
  File "/Users/sebastiantchakerian/Codes/openmc/openmc/cmfd.py", line 1036 in _configure_cmfd
  File "/Users/sebastiantchakerian/Codes/openmc/openmc/cmfd.py", line 837 in init
  File "/Users/sebastiantchakerian/Codes/openmc/openmc/cmfd.py", line 812 in run_in_memory
  File "/usr/local/Cellar/python@3.9/3.9.16/Frameworks/Python.framework/Versions/3.9/lib/python3.9/contextlib.py", line 119 in __enter__
  File "/Users/sebastiantchakerian/Codes/openmc/openmc/cmfd.py", line 778 in run
  File "/Users/sebastiantchakerian/Codes/openmc/tests/regression_tests/cmfd_restart/test.py", line 29 in execute_test
  File "/Users/sebastiantchakerian/Codes/openmc/tests/testing_harness.py", line 42 in main
  File "/Users/sebastiantchakerian/Codes/openmc/tests/regression_tests/cmfd_restart/test.py", line 72 in test_cmfd_restart
  File "/usr/local/lib/python3.9/site-packages/_pytest/python.py", line 195 in pytest_pyfunc_call
  File "/usr/local/lib/python3.9/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/usr/local/lib/python3.9/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/usr/local/lib/python3.9/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/usr/local/lib/python3.9/site-packages/_pytest/python.py", line 1789 in runtest
  File "/usr/local/lib/python3.9/site-packages/_pytest/runner.py", line 167 in pytest_runtest_call
  File "/usr/local/lib/python3.9/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/usr/local/lib/python3.9/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/usr/local/lib/python3.9/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/usr/local/lib/python3.9/site-packages/_pytest/runner.py", line 260 in <lambda>
  File "/usr/local/lib/python3.9/site-packages/_pytest/runner.py", line 339 in from_call
  File "/usr/local/lib/python3.9/site-packages/_pytest/runner.py", line 259 in call_runtest_hook
  File "/usr/local/lib/python3.9/site-packages/_pytest/runner.py", line 220 in call_and_report
  File "/usr/local/lib/python3.9/site-packages/_pytest/runner.py", line 131 in runtestprotocol
  File "/usr/local/lib/python3.9/site-packages/_pytest/runner.py", line 112 in pytest_runtest_protocol
  File "/usr/local/lib/python3.9/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/usr/local/lib/python3.9/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/usr/local/lib/python3.9/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/usr/local/lib/python3.9/site-packages/_pytest/main.py", line 349 in pytest_runtestloop
  File "/usr/local/lib/python3.9/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/usr/local/lib/python3.9/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/usr/local/lib/python3.9/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/usr/local/lib/python3.9/site-packages/_pytest/main.py", line 324 in _main
  File "/usr/local/lib/python3.9/site-packages/_pytest/main.py", line 270 in wrap_session
  File "/usr/local/lib/python3.9/site-packages/_pytest/main.py", line 317 in pytest_cmdline_main
  File "/usr/local/lib/python3.9/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/usr/local/lib/python3.9/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/usr/local/lib/python3.9/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/usr/local/lib/python3.9/site-packages/_pytest/config/__init__.py", line 167 in main
  File "/usr/local/lib/python3.9/site-packages/_pytest/config/__init__.py", line 190 in console_main
  File "/usr/local/bin/pytest", line 8 in <module>
[1]    14769 segmentation fault  pytest
```