### PR TITLE
A few improvements related to the Model class

### DIFF
--- a/man/man1/openmc.1
+++ b/man/man1/openmc.1
@@ -8,7 +8,10 @@ sections are available.
 .SH SYNOPSIS
 \fBopenmc\fR [\fIoptions\fR] [\fIpath\fR]
 .PP
-It is assumed that if no
+.I path
+specifies either the path to a single model XML file containing the full model
+or a directory containing either a model.xml file or a set of individual XML
+files (settings.xml, materials.xml, geometry.xml). It is assumed that if no
 .I path
 is specified, the XML input files are present in the current directory.
 .SH OPTIONS
@@ -45,6 +48,9 @@ Show help message.
 The behavior of
 .B openmc
 is affected by the following environment variables.
+.TP
+.B OPENMC_CHAIN_FILE
+Indicates the path to a depletion chain XML file.
 .TP
 .B OPENMC_CROSS_SECTIONS
 Indicates the default path to the cross_sections.xml summary file that is used

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -597,11 +597,13 @@ class Model:
     def run(self, particles=None, threads=None, geometry_debug=False,
             restart_file=None, tracks=False, output=True, cwd='.',
             openmc_exec='openmc', mpi_args=None, event_based=None,
-            export_model_xml=True):
-        """Runs OpenMC. If the C API has been initialized, then the C API is
-        used, otherwise, this method creates the XML files and runs OpenMC via
-        a system call. In both cases this method returns the path to the last
-        statepoint file generated.
+            export_model_xml=True, **export_kwargs):
+        """Run OpenMC
+
+        If the C API has been initialized, then the C API is used, otherwise,
+        this method creates the XML files and runs OpenMC via a system call. In
+        both cases this method returns the path to the last statepoint file
+        generated.
 
         .. versionchanged:: 0.12
             Instead of returning the final k-effective value, this function now
@@ -630,27 +632,30 @@ class Model:
         output : bool, optional
             Capture OpenMC output from standard out
         cwd : str, optional
-            Path to working directory to run in. Defaults to the current
-            working directory.
+            Path to working directory to run in. Defaults to the current working
+            directory.
         openmc_exec : str, optional
             Path to OpenMC executable. Defaults to 'openmc'.
         mpi_args : list of str, optional
-            MPI execute command and any additional MPI arguments to pass,
-            e.g. ['mpiexec', '-n', '8'].
+            MPI execute command and any additional MPI arguments to pass, e.g.
+            ['mpiexec', '-n', '8'].
         event_based : None or bool, optional
-            Turns on event-based parallelism if True. If None, the value in
-            the Settings will be used.
+            Turns on event-based parallelism if True. If None, the value in the
+            Settings will be used.
         export_model_xml : bool, optional
-            Exports a single model.xml file rather than separate files.
-            Defaults to True.
+            Exports a single model.xml file rather than separate files. Defaults
+            to True.
 
             .. versionadded:: 0.13.3
+        **export_kwargs
+            Keyword arguments passed to either :meth:`Model.export_to_model_xml`
+            or :meth:`Model.export_to_xml`.
 
         Returns
         -------
         Path
-            Path to the last statepoint written by this run
-            (None if no statepoint was written)
+            Path to the last statepoint written by this run (None if no
+            statepoint was written)
 
         """
 
@@ -695,9 +700,9 @@ class Model:
             else:
                 # Then run via the command line
                 if export_model_xml:
-                    self.export_to_model_xml()
+                    self.export_to_model_xml(**export_kwargs)
                 else:
-                    self.export_to_xml()
+                    self.export_to_xml(**export_kwargs)
                 openmc.run(particles, threads, geometry_debug, restart_file,
                            tracks, output, Path('.'), openmc_exec, mpi_args,
                            event_based)

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -358,7 +358,7 @@ bool read_model_xml()
   for (const auto& input : other_inputs) {
     if (file_exists(settings::path_input + input)) {
       warning((fmt::format("Other XML file input(s) are present. These files "
-                           "will be ignored in favor of the {} file.",
+                           "may be ignored in favor of the {} file.",
         model_filename)));
       break;
     }
@@ -392,8 +392,16 @@ bool read_model_xml()
   // Initialize distribcell_filters
   prepare_distribcell();
 
-  if (check_for_node(root, "plots"))
+  if (check_for_node(root, "plots")) {
     read_plots_xml(root.child("plots"));
+  } else {
+    // When no <plots> element is present in the model.xml file, check for a
+    // regular plots.xml file
+    std::string filename = settings::path_input + "plots.xml";
+    if (file_exists(filename)) {
+      read_plots_xml();
+    }
+  }
 
   return true;
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -268,7 +268,7 @@ void print_usage()
 {
   if (mpi::master) {
     fmt::print(
-      "Usage: openmc [options] [directory]\n\n"
+      "Usage: openmc [options] [path]\n\n"
       "Options:\n"
       "  -c, --volume           Run in stochastic volume calculation mode\n"
       "  -g, --geometry-debug   Run with geometry debugging on\n"

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -223,16 +223,11 @@ void read_settings_xml()
   std::string filename = settings::path_input + "settings.xml";
   if (!file_exists(filename)) {
     if (run_mode != RunMode::PLOTTING) {
-      fatal_error(
-        fmt::format("Settings XML file '{}' does not exist! In order "
-                    "to run OpenMC, you first need a set of input files; at a "
-                    "minimum, this "
-                    "includes settings.xml, geometry.xml, and materials.xml "
-                    "or a single XML file containing all of these files. "
-                    "Please consult "
-                    "the user's guide at https://docs.openmc.org for further "
-                    "information.",
-          filename));
+      fatal_error("Could not find any XML input files! In order to run OpenMC, "
+                  "you first need a set of input files; at a minimum, this "
+                  "includes settings.xml, geometry.xml, and materials.xml or a "
+                  "single model XML file. Please consult the user's guide at "
+                  "https://docs.openmc.org for further information.");
     } else {
       // The settings.xml file is optional if we just want to make a plot.
       return;


### PR DESCRIPTION
This PR makes a few small improvements related to the `openmc.Model` class:

- When calling `mode.run`, you can now pass keyword arguments on to `export_to_xml` or `export_to_model_xml`, which importantly allows you to call `model.run(remove_surfs=True)`, which was not possible before.
- When no `<plots>` are present in a model.xml file, OpenMC will now look for a plots.xml file. This closes #2446.
- Updated an error message regarding missing settings.xml which might be a little confusing (if you are using model.xml, it doesn't matter that you're missing settings.xml)