### PR TITLE
Update the 2016 references to 2020

### DIFF
--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -207,8 +207,8 @@ _LOG_TWO = log(2.0)
 def atomic_mass(isotope):
     """Return atomic mass of isotope in atomic mass units.
 
-    Atomic mass data comes from the `Atomic Mass Evaluation 2016
-    <https://www-nds.iaea.org/amdc/ame2016/AME2016-a.pdf>`_.
+    Atomic mass data comes from the `Atomic Mass Evaluation 2020
+    <https://doi.org/10.1088/1674-1137/abddaf>`_.
 
     Parameters
     ----------


### PR DESCRIPTION
`openmc.data` now uses atomic mass data from the Atomic Mass Evaluation 2020. This docstring didn't get updated.