### PR TITLE
add auto legend to universe.plot

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -296,7 +296,6 @@ class Universe(UniverseBase):
         return []
 
     # default kwargs that are passed to plt.legend in the plot method below.
-    # If you change this, be sure to change it in the docstring for plot below.
     _default_legend_kwargs = {'bbox_to_anchor': (
         1.05, 1), 'loc': 2, 'borderaxespad': 0.0}
 

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -330,11 +330,12 @@ class Universe(UniverseBase):
             Axes to draw to
 
             .. versionadded:: 0.13.1
-        legend : bool
-            whether a legend showing material or cell names should be drawn
         **kwargs
             Keyword arguments passed to :func:`matplotlib.pyplot.imshow`
 
+            .. versionadded:: 0.13.4
+        legend : bool
+            Whether a legend showing material or cell names should be drawn
         Returns
         -------
         matplotlib.image.AxesImage

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -342,9 +342,6 @@ class Universe(UniverseBase):
             .. versionadded:: 0.13.4
         legend_kwargs : dict
             Keyword arguments passed to :func:`matplotlib.pyplot.legend`.
-            The default is:
-
-            {'bbox_to_anchor': (1.05, 1), 'loc':2, 'borderaxespad': 0.0}
 
             .. versionadded:: 0.13.4
         **kwargs

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -424,7 +424,8 @@ class Universe(UniverseBase):
                             "Color dict key type does not match color_by")
 
                     # this works whether we're doing cells or materials
-                    key_patch = mpatches.Patch(color=color, label=key.name)
+                    label = key.name if key.name != '' else key.id
+                    key_patch = mpatches.Patch(color=color, label=label)
                     patches.append(key_patch)
 
                 axes.legend(handles=patches, bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.0)

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -404,8 +404,8 @@ class Universe(UniverseBase):
             # or cell if that was requested
             if legend:
                 if plot.colors is None:
-                    raise Exception("Must set plot color dictionary if you would"
-                                    " like to have an automatic legend.")
+                    raise Exception("Must set plot color dictionary if you "
+                                    "would like to have an automatic legend.")
 
                 if color_by == "cell":
                     expected_key_type = openmc.Cell

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -409,10 +409,8 @@ class Universe(UniverseBase):
 
                 if color_by == "cell":
                     expected_key_type = openmc.Cell
-                elif color_by == "material":
-                    expected_key_type = openmc.Material
                 else:
-                    raise Exception("wtf?")
+                    expected_key_type = openmc.Material
 
                 patches = []
                 for key, color in plot.colors.items():

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -428,7 +428,7 @@ class Universe(UniverseBase):
                     key_patch = mpatches.Patch(color=color, label=key.name)
                     patches.append(key_patch)
 
-                axes.legend(handles=patches)
+                axes.legend(handles=patches, bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.0)
 
             # Plot image and return the axes
             return axes.imshow(img, extent=(x_min, x_max, y_min, y_max), **kwargs)


### PR DESCRIPTION
Pastes @prshriwise's code from [here](https://openmc.discourse.group/t/print-out-the-corresponding-cell-in-the-geometry-plot/1974/2) into the python library. Also pep8'd universe.py.

This was specifically requested in the OpenMC workshop at the student conference today. It's a nice feature to have!

Use example:

```python
import openmc
from matplotlib import pyplot as plt
import matplotlib.patches as mpatches


pincell = openmc.examples.pwr_pin_cell()
materials = pincell.materials
mat_colors = {materials[0] : 'green',
              materials[1] : 'gray',
              materials[2] : 'blue'}
a = pincell.geometry.root_universe.plot(colors=mat_colors,
                                        color_by='material',
                                       legend=True)

plt.show()
```

![image](https://user-images.githubusercontent.com/18088906/231872299-3e490d1b-ecd8-487f-96b7-9afd63a546bb.png)
