### PR TITLE
Install vectfit in CI without build isolation

### DIFF
--- a/tools/ci/gha-install-vectfit.sh
+++ b/tools/ci/gha-install-vectfit.sh
@@ -39,6 +39,9 @@ cd $HOME
 git clone -b $XTENSOR_BLAS_BRANCH $XTENSOR_BLAS_REPO
 cd xtensor-blas && mkdir build && cd build && cmake .. && sudo make install
 
+# Install wheel (remove when vectfit supports installation with build isolation)
+pip install wheel
+
 # Install vectfit
 cd $HOME
 git clone https://github.com/liangjg/vectfit.git

--- a/tools/ci/gha-install-vectfit.sh
+++ b/tools/ci/gha-install-vectfit.sh
@@ -42,4 +42,4 @@ cd xtensor-blas && mkdir build && cd build && cmake .. && sudo make install
 # Install vectfit
 cd $HOME
 git clone https://github.com/liangjg/vectfit.git
-pip install ./vectfit
+pip install --no-build-isolation ./vectfit


### PR DESCRIPTION
It looks like recent CI runs are [failing](https://github.com/openmc-dev/openmc/actions/runs/4709602358?pr=2471) due to a [new release of pip](https://pip.pypa.io/en/stable/news/#v23-1) that removes a `setup.py install` fallback. This PR attempts to fix this by turning off build isolation when installing vectfit.