### PR TITLE
Defer import of matplotlib in multipole.py

### DIFF
--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -1,14 +1,12 @@
 from numbers import Real
 from math import exp, erf, pi, sqrt
 from copy import deepcopy
-import warnings
 
 import os
 import h5py
 import pickle
 import numpy as np
 from scipy.signal import find_peaks
-import matplotlib.pyplot as plt
 
 import openmc.checkvalue as cv
 from ..exceptions import DataError
@@ -364,6 +362,7 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
         for i, mt in enumerate(mts):
             if not test_xs_ref[i].any():
                 continue
+            import matplotlib.pyplot as plt
             fig, ax1 = plt.subplots()
             lns1 = ax1.loglog(test_energy, test_xs_ref[i], 'g', label="ACE xs")
             lns2 = ax1.loglog(test_energy, best_test_xs[i], 'b', label="VF xs")
@@ -1154,7 +1153,7 @@ class WindowedMultipole(EqualityMixin):
         Returns
         -------
         3-tuple of Real
-            Scattering, absorption, and fission microscopic cross sections 
+            Scattering, absorption, and fission microscopic cross sections
             at the given energy and temperature.
 
         """

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -6,7 +6,6 @@ import operator
 
 import numpy as np
 from scipy.spatial import ConvexHull, Delaunay
-from matplotlib.path import Path
 
 import openmc
 from openmc.checkvalue import (check_greater_than, check_value,
@@ -1021,6 +1020,7 @@ class Polygon(CompositeSurface):
         -------
         surfsets : a list of lists of surface, operator pairs
         """
+        from matplotlib.path import Path
 
         # Get centroids of all the simplices and determine if they are inside
         # the polygon defined by input vertices or not.

--- a/tests/regression_tests/python_import/test.py
+++ b/tests/regression_tests/python_import/test.py
@@ -1,7 +1,0 @@
-import sys
-import openmc
-
-
-def test_matplotlib_presence():
-    """Checks that remains a deferred import"""
-    assert 'matplotlib.pyplot' not in sys.modules

--- a/tests/regression_tests/python_import/test.py
+++ b/tests/regression_tests/python_import/test.py
@@ -1,0 +1,7 @@
+import sys
+import openmc
+
+
+def test_matplotlib_presence():
+    """Checks that remains a deferred import"""
+    assert 'matplotlib.pyplot' not in sys.modules

--- a/tests/test_matplotlib_import.py
+++ b/tests/test_matplotlib_import.py
@@ -1,0 +1,6 @@
+import sys
+import openmc
+
+def test_matplotlib_presence():
+    """Checks that matplotlib remains a deferred import"""
+    assert 'matplotlib' not in sys.modules

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -1,7 +1,6 @@
 import numpy as np
 import openmc
 import pytest
-from matplotlib.figure import Figure
 
 
 @pytest.fixture(scope='module')
@@ -74,8 +73,10 @@ def test_calculate_cexs_with_materials(test_mat):
 
 @pytest.mark.parametrize("this", ["Be", "Be9"])
 def test_plot_xs(this):
-    assert isinstance(openmc.plotter.plot_xs(this, types=['total']), Figure)
+    from matplotlib.figure import Figure
+    assert isinstance(openmc.plot_xs(this, types=['total']), Figure)
 
 
 def test_plot_xs_mat(test_mat):
-    assert isinstance(openmc.plotter.plot_xs(test_mat, types=['total']), Figure)
+    from matplotlib.figure import Figure
+    assert isinstance(openmc.plot_xs(test_mat, types=['total']), Figure)


### PR DESCRIPTION
In most places in our Python API, the import of `matplotlib` is "deferred" (happens within the scope of a function rather than at module-level). However, I noticed one import that was still happening at module-level. Deferring that one import has the effect of reducing the time to `import openmc` by about a factor of 2 (YMMV):
- Before change:
```
$ time python -c 'import openmc'

real	0m1.353s
user	0m1.977s
sys	0m2.246s
```
- After change:
```
$ time python -c 'import openmc'

real	0m0.717s
user	0m1.528s
sys	0m2.407s
```