### PR TITLE
Auto origin and width for plots

### DIFF
--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -27,6 +27,8 @@ class BoundingBox(tuple):
         The x, y, z coordinates of the upper right corner of the bounding box in [cm]
     volume : float
         The volume of the bounding box in [cm^3]
+    width : {'x', 'y', 'z'}
+        The width of the specified axis
     """
 
     def __new__(cls, lower_left: Iterable[float], upper_right: Iterable[float]):
@@ -55,3 +57,19 @@ class BoundingBox(tuple):
     @property
     def volume(self) -> float:
         return np.abs(np.prod(self[1] - self[0]))
+
+    def width(self, axis: str):
+        """The width of the specified axis
+
+        Parameters
+        ----------
+        width : {'x', 'y', 'z'}
+            The width of the specified axis
+
+        Returns
+        -------
+        width : float
+            width of axis
+        """
+        index = {'x': 0, 'y': 1, 'z': 2}[axis]
+        return abs((self.lower_left - self.upper_right)[index])

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -300,7 +300,7 @@ class Universe(UniverseBase):
     _default_legend_kwargs = {'bbox_to_anchor': (
         1.05, 1), 'loc': 2, 'borderaxespad': 0.0}
 
-    def plot(self, origin=(0., 0., 0.), width=(1., 1.), pixels=(200, 200),
+    def plot(self, origin=None, width=None, pixels=(200, 200),
              basis='xy', color_by='cell', colors=None, seed=None,
              openmc_exec='openmc', axes=None, legend=False,
              legend_kwargs=_default_legend_kwargs, outline=False,
@@ -309,10 +309,13 @@ class Universe(UniverseBase):
 
         Parameters
         ----------
-        origin : Iterable of float
-            Coordinates at the origin of the plot
-        width : Iterable of float
-            Width of the plot in each basis direction
+        origin : Optional Iterable of float
+            Coordinates at the origin of the plot, if left as None then the
+            universe.bounding_box.center will be used to ascertain the origin
+        width : Optional Iterable of float
+            Width of the plot in each basis direction. If left as none then the
+            universe.bounding_box.width() will be used to ascertain the plot
+            axis widths
         pixels : Iterable of int
             Number of pixels to use in each basis direction
         basis : {'xy', 'xz', 'yz'}
@@ -367,12 +370,23 @@ class Universe(UniverseBase):
         if basis == 'xy':
             x, y = 0, 1
             xlabel, ylabel = 'x [cm]', 'y [cm]'
+                
         elif basis == 'yz':
             x, y = 1, 2
             xlabel, ylabel = 'y [cm]', 'z [cm]'
+
         elif basis == 'xz':
             x, y = 0, 2
             xlabel, ylabel = 'x [cm]', 'z [cm]'
+
+        if width is None:
+            x_width = self.bounding_box.width(basis[0])
+            y_width = self.bounding_box.width(basis[1])
+            width = (x_width, y_width)
+
+        if origin is None:
+            origin = self.bounding_box.center
+
         x_min = origin[x] - 0.5*width[0]
         x_max = origin[x] + 0.5*width[0]
         y_min = origin[y] - 0.5*width[1]


### PR DESCRIPTION
This PR attempts to automate two arguments in the ```universe.plot``` method.

Currently the ```origin``` defaults to ```(0,0,0)``` which is often the center of the geometry. However this PR attempts to find the center of the geometry using the new bounding box class

Currently the ```width``` is set to ```(1,1)``` which is occasionally the size of the geometry. However this PR attempts to find the axis width for the user using the new bounding box class.

I think these new defaults will help users produce plots quicker and with less knowledge of the geometry being plotted.

However they might slow down the plotting for very large geometry where the bounding box takes time to calculate. In that case the user might want to specify the width and origin manually.