### PR TITLE
clarify track-length flux estimator

### DIFF
--- a/docs/source/methods/tallies.rst
+++ b/docs/source/methods/tallies.rst
@@ -179,12 +179,12 @@ n(\mathbf{r}, \mathbf{\hat{\Omega}}, E, t)` and :math:`d\ell = v \, dt` where
 
 Equation :eq:`track-length-integral` indicates that we can use the length of a
 particle's trajectory as an estimate for the flux, i.e. the track-length
-estimator of the flux would be
+estimator of the volume-integrated flux would be
 
 .. math::
     :label: track-length-flux
 
-    \phi = \frac{1}{W} \sum_{i \in T} w_i \ell_i
+    V \phi = \frac{1}{W} \sum_{i \in T} w_i \ell_i
 
 where :math:`T` is the set of all the particle's trajectories within the desired
 volume and :math:`\ell_i` is the length of the :math:`i`-th trajectory. In the


### PR DESCRIPTION
I was attempting to explain to someone how to properly normalize tallies for fixed source problems and came across what I think is a bit unclear in the theory section of the docs.