### PR TITLE
Fix compilation with gcc 5

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -412,7 +412,7 @@ private:
 
   bool full_phi_ {false};
 
-  constexpr inline int sanitize_angular_index(int idx, bool full, int N) const
+  inline int sanitize_angular_index(int idx, bool full, int N) const
   {
     if ((idx > 0) and (idx <= N)) {
       return idx;
@@ -467,7 +467,7 @@ private:
   bool full_theta_ {false};
   bool full_phi_ {false};
 
-  constexpr inline int sanitize_angular_index(int idx, bool full, int N) const
+  inline int sanitize_angular_index(int idx, bool full, int N) const
   {
     if ((idx > 0) and (idx <= N)) {
       return idx;

--- a/include/openmc/position.h
+++ b/include/openmc/position.h
@@ -216,14 +216,18 @@ using Direction = Position;
 
 } // namespace openmc
 
+namespace fmt {
+
 template<>
-struct fmt::formatter<openmc::Position> : formatter<std::string> {
+struct formatter<openmc::Position> : formatter<std::string> {
   template<typename FormatContext>
   auto format(const openmc::Position& pos, FormatContext& ctx)
   {
-    return fmt::formatter<std::string>::format(
+    return formatter<std::string>::format(
       fmt::format("({}, {}, {})", pos.x, pos.y, pos.z), ctx);
   }
 };
+
+} // namespace fmt
 
 #endif // OPENMC_POSITION_H


### PR DESCRIPTION
It was recently pointed out (#2474) that compiling OpenMC is broken on gcc 5. Although gcc 5 is pretty old at this point and I wouldn't necessarily propose we keep maintaining support for it, in this case the changes were simple enough, so I figured why not incorporate them.