### PR TITLE
reproducibility: sort surf source bank before write

### DIFF
--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -428,6 +428,18 @@ void finalize_batch()
     auto filename = settings::path_output + "surface_source";
     auto surf_work_index =
       mpi::calculate_parallel_index_vector(simulation::surf_source_bank.size());
+
+    // Sort, because the file ordering will differ based on the order that
+    // threads finish work in. We want to produce the same output every time
+    // given the same random seed. We probably don't need to sort globally over
+    // MPI ranks to ensure reproducible output.
+    std::sort(simulation::surf_source_bank.begin(),
+      simulation::surf_source_bank.end(),
+      [](const SourceSite& l, const SourceSite& r) {
+        return std::tie(l.parent_id, l.progeny_id) <
+               std::tie(r.parent_id, r.progeny_id);
+      });
+
     gsl::span<SourceSite> surfbankspan(simulation::surf_source_bank.begin(),
       simulation::surf_source_bank.size());
     if (settings::surf_mcpl_write) {


### PR DESCRIPTION
If you look at the code where we load particles into the surface source bank (`Particle::cross_surface`), you'll see that we probably should be sorting this bank before writing in order to ensure the same output file is produced each time without regard to the order threads run in. It appears that this race condition caused unlucky CI failure for @cfichtlscherer, so if he can rebase on this and pass CI, we should definitely merge this tiny change.