### PR TITLE
Reworking Tally::add_filter a bit

### DIFF
--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -67,7 +67,7 @@ public:
   //----------------------------------------------------------------------------
   // Other methods.
 
-  void add_filter(Filter* filter) { set_filters({&filter, 1}); }
+  void add_filter(Filter* filter);
 
   void init_triggers(pugi::xml_node node);
 

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -364,19 +364,23 @@ void Tally::set_filters(gsl::span<Filter*> filters)
   auto n = filters.size();
   filters_.reserve(n);
 
-  for (auto* filter : filters) { add_filter(filter); }
+  for (auto* filter : filters) {
+    add_filter(filter);
+  }
 }
 
-void Tally::add_filter(Filter* filter) {
+void Tally::add_filter(Filter* filter)
+{
   int32_t filter_idx = model::filter_map.at(filter->id());
   // if this filter is already present, do nothing and return
-  if (std::find(filters_.begin(), filters_.end(), filter_idx) != filters_.end()) return;
+  if (std::find(filters_.begin(), filters_.end(), filter_idx) != filters_.end())
+    return;
 
   // Keep track of indices for special filters
   if (dynamic_cast<const EnergyoutFilter*>(filter)) {
-      energyout_filter_ = filters_.size();
+    energyout_filter_ = filters_.size();
   } else if (dynamic_cast<const DelayedGroupFilter*>(filter)) {
-      delayedgroup_filter_ = filters_.size();
+    delayedgroup_filter_ = filters_.size();
   }
   filters_.push_back(filter_idx);
 }

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -364,18 +364,21 @@ void Tally::set_filters(gsl::span<Filter*> filters)
   auto n = filters.size();
   filters_.reserve(n);
 
-  for (int i = 0; i < n; ++i) {
-    // Add index to vector of filters
-    auto& f {filters[i]};
-    filters_.push_back(model::filter_map.at(f->id()));
+  for (auto* filter : filters) { add_filter(filter); }
+}
 
-    // Keep track of indices for special filters.
-    if (dynamic_cast<const EnergyoutFilter*>(f)) {
-      energyout_filter_ = i;
-    } else if (dynamic_cast<const DelayedGroupFilter*>(f)) {
-      delayedgroup_filter_ = i;
-    }
+void Tally::add_filter(Filter* filter) {
+  int32_t filter_idx = model::filter_map.at(filter->id());
+  // if this filter is already present, do nothing and return
+  if (std::find(filters_.begin(), filters_.end(), filter_idx) != filters_.end()) return;
+
+  // Keep track of indices for special filters
+  if (dynamic_cast<const EnergyoutFilter*>(filter)) {
+      energyout_filter_ = filters_.size();
+  } else if (dynamic_cast<const DelayedGroupFilter*>(filter)) {
+      delayedgroup_filter_ = filters_.size();
   }
+  filters_.push_back(filter_idx);
 }
 
 void Tally::set_strides()

--- a/tests/cpp_unit_tests/CMakeLists.txt
+++ b/tests/cpp_unit_tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_NAMES
   test_distribution
   test_file_utils
+  test_tally
   # Add additional unit test files here
 )
 

--- a/tests/cpp_unit_tests/test_tally.cpp
+++ b/tests/cpp_unit_tests/test_tally.cpp
@@ -37,4 +37,19 @@ TEST_CASE("Test add_filter")
 
   REQUIRE(tally->filters().size() == 1);
   REQUIRE(model::filter_map[cell_filter->id()] == tally->filters(0));
+
+  // set filters again using both filters
+  std::vector<Filter*> filters = {cell_filter, particle_filter};
+  tally->set_filters(filters);
+
+  REQUIRE(tally->filters().size() == 2);
+  REQUIRE(model::filter_map[cell_filter->id()] == tally->filters(0));
+  REQUIRE(model::filter_map[particle_filter->id()] == tally->filters(1));
+
+  // set filters with a duplicate filter, should only add the filter to the tally once
+  filters = {cell_filter, cell_filter};
+  tally->set_filters(filters);
+  REQUIRE(tally->filters().size() == 1);
+  REQUIRE(model::filter_map[cell_filter->id()] == tally->filters(0));
+
 }

--- a/tests/cpp_unit_tests/test_tally.cpp
+++ b/tests/cpp_unit_tests/test_tally.cpp
@@ -16,6 +16,7 @@ TEST_CASE("Test add_filter")
 
   // the filter should be added to the tally
   REQUIRE(tally->filters().size() == 1);
+  REQUIRE(model::filter_map[particle_filter->id()] == tally->filters(0));
 
   // add the particle filter to the tally again
   tally->add_filter(particle_filter);
@@ -28,10 +29,12 @@ TEST_CASE("Test add_filter")
 
   // now the size of the filters should have increased
   REQUIRE(tally->filters().size() == 2);
+  REQUIRE(model::filter_map[cell_filter->id()] == tally->filters(1));
 
   // if we set the filters explicitly there shouldn't be extra filters hanging
   // around
   tally->set_filters({&cell_filter, 1});
 
   REQUIRE(tally->filters().size() == 1);
+  REQUIRE(model::filter_map[cell_filter->id()] == tally->filters(0));
 }

--- a/tests/cpp_unit_tests/test_tally.cpp
+++ b/tests/cpp_unit_tests/test_tally.cpp
@@ -1,0 +1,37 @@
+#include "openmc/tallies/tally.h"
+#include <catch2/catch_test_macros.hpp>
+
+using namespace openmc;
+
+TEST_CASE("Test add_filter")
+{
+  // create a new tally object
+  Tally* tally = Tally::create();
+
+  // create a new particle filter
+  Filter* particle_filter = Filter::create("particle");
+
+  // add the particle filter to the tally
+  tally->add_filter(particle_filter);
+
+  // the filter should be added to the tally
+  REQUIRE(tally->filters().size() == 1);
+
+  // add the particle filter to the tally again
+  tally->add_filter(particle_filter);
+  // the tally should have the same number of filters
+  REQUIRE(tally->filters().size() == 1);
+
+  // create a cell filter
+  Filter* cell_filter = Filter::create("cell");
+  tally->add_filter(cell_filter);
+
+  // now the size of the filters should have increased
+  REQUIRE(tally->filters().size() == 2);
+
+  // if we set the filters explicitly there shouldn't be extra filters hanging
+  // around
+  tally->set_filters({&cell_filter, 1});
+
+  REQUIRE(tally->filters().size() == 1);
+}

--- a/tests/cpp_unit_tests/test_tally.cpp
+++ b/tests/cpp_unit_tests/test_tally.cpp
@@ -3,7 +3,7 @@
 
 using namespace openmc;
 
-TEST_CASE("Test add_filter")
+TEST_CASE("Test add/set_filter")
 {
   // create a new tally object
   Tally* tally = Tally::create();


### PR DESCRIPTION
I noticed that the `Tally::add_filter` of our C++ Tally class was really replacing the current set of filters with the filter passed into that method. This wasn't the behavior I was expecting from that method, so I decided to correct that and refactor the code a bit. 

I've added a few unit tests for this to ensure that `add_filter` appends to the set of filters on the Tally instance along with some other tests for the `set_filter` method.