### PR TITLE
auto width and origin for edge cases

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -380,17 +380,21 @@ class Universe(UniverseBase):
             x, y = 0, 2
             xlabel, ylabel = 'x [cm]', 'z [cm]'
 
+        bb = self.bounding_box
         # checks to see if bounding box contains -inf or inf values
-        if True in np.isinf(self.bounding_box):
+        if True in np.isinf([bb[0][x], bb[1][x], bb[0][y], bb[1][y]]):
+            print('can not get origin or with')
             if origin is None:
                 origin = (0, 0, 0)
             if width is None:
                 width = (10, 10)
         else:
             if origin is None:
-                origin = self.bounding_box.center
+                # if nan values in the bb.center they get replaced with 0.0
+                # this happens when the bounding_box contains inf values
+                origin = np.nan_to_num(bb.center)
             if width is None:
-                bb_width = self.bounding_box.width
+                bb_width = bb.width
                 x_width = bb_width['xyz'.index(basis[0])]
                 y_width = bb_width['xyz'.index(basis[1])]
                 width = (x_width, y_width)

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -382,8 +382,7 @@ class Universe(UniverseBase):
 
         bb = self.bounding_box
         # checks to see if bounding box contains -inf or inf values
-        if True in np.isinf([bb[0][x], bb[1][x], bb[0][y], bb[1][y]]):
-            print('can not get origin or with')
+        if np.isinf([bb[0][x], bb[1][x], bb[0][y], bb[1][y]]).any():
             if origin is None:
                 origin = (0, 0, 0)
             if width is None:


### PR DESCRIPTION
as described in issue #2511 for geometry with inf values in the bounding box it is sometimes possible to still get the width and origin of the geometry in a specific basis.

I thought I wouldn't get time to do this today and that it would be tricker but I think this PR closes #2511 

I've not added tests yet as I could not figure out how to get the extent from a rretunred matplotlib axis object. I have been testing with this script

 ```python

import openmc
import matplotlib.pyplot as plt

# creates geometry with inf and -inf values in the bounding box
surf_1=openmc.ZCylinder(r=100.0)
cell_1 = openmc.Cell(region = -surf_1)
universe_1 = openmc.Universe(cells=[cell_1])

# width and origin default to None which attempts to find these values
# using the bounding box. The basis for this plot  
plot = universe_1.plot(
    basis='xy',
    width=None,
    origin=None
)

plt.show()
```

before this PR
![Screenshot from 2023-05-02 18-15-47](https://user-images.githubusercontent.com/8583900/235737942-f365710f-e8d1-42d5-946d-08be33025007.png)

after this PR
![Screenshot from 2023-05-02 18-16-15](https://user-images.githubusercontent.com/8583900/235737983-4589edff-c0cf-4a69-bc1e-2c7ad47d7bf1.png)


