### PR TITLE
Auto pixel calc for universe plot

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -320,11 +320,11 @@ class Universe(UniverseBase):
             ascertain the plot width.  Defaults to (10, 10) if the bounding_box
             contains inf values
         pixels : Iterable of int or int
-            If iterable of int then provide then this sets the number of pixels
-            to use in each basis direction. If int provided then this sets the
-            total number of pixels in the plot and the number of pixels in each
-            basis direction is calculated from this total and the image aspect
-            ratio.
+            If iterable of ints provided then this directly sets the number of
+            pixels to use in each basis direction. If int provided then this
+            sets the total number of pixels in the plot and the number of
+            pixels in each basis direction is calculated from this total and
+            the image aspect ratio.
         basis : {'xy', 'xz', 'yz'}
             The basis directions for the plot
         color_by : {'cell', 'material'}

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -398,8 +398,11 @@ class Universe(UniverseBase):
                 y_width = bb_width['xyz'.index(basis[1])]
                 width = (x_width, y_width)
 
-        if pixels is None:
-            total_pixels = 40000
+        if pixels is None or isinstance(pixels, int):
+            if pixels is None:
+                total_pixels = 40000
+            elif isinstance(pixels, int):
+                total_pixels = pixels
             aspect_ratio = width[0] / width[1]
             pixels_y = np.sqrt(total_pixels / aspect_ratio)
             pixels = (int(total_pixels / pixels_y), int(pixels_y))

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -401,7 +401,7 @@ class Universe(UniverseBase):
 
         if isinstance(pixels, int):
             aspect_ratio = width[0] / width[1]
-            pixels_y = np.sqrt(pixels / aspect_ratio)
+            pixels_y = math.sqrt(pixels / aspect_ratio)
             pixels = (int(pixels / pixels_y), int(pixels_y))
 
         x_min = origin[x] - 0.5*width[0]

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -300,7 +300,7 @@ class Universe(UniverseBase):
     _default_legend_kwargs = {'bbox_to_anchor': (
         1.05, 1), 'loc': 2, 'borderaxespad': 0.0}
 
-    def plot(self, origin=None, width=None, pixels=(200, 200),
+    def plot(self, origin=None, width=None, pixels=None,
              basis='xy', color_by='cell', colors=None, seed=None,
              openmc_exec='openmc', axes=None, legend=False,
              legend_kwargs=_default_legend_kwargs, outline=False,
@@ -320,7 +320,10 @@ class Universe(UniverseBase):
             ascertain the plot width.  Defaults to (10, 10) if the bounding_box
             contains inf values
         pixels : Iterable of int
-            Number of pixels to use in each basis direction
+            Number of pixels to use in each basis direction, if left as None
+            then the pixels in each basis direction is assigned a number
+            of pixels proportionally to it's relative width while also keeping
+            the total number of pixels in the plot equals to 40000.
         basis : {'xy', 'xz', 'yz'}
             The basis directions for the plot
         color_by : {'cell', 'material'}
@@ -394,6 +397,12 @@ class Universe(UniverseBase):
                 x_width = bb_width['xyz'.index(basis[0])]
                 y_width = bb_width['xyz'.index(basis[1])]
                 width = (x_width, y_width)
+
+        if pixels is None:
+            total_pixels = 40000
+            aspect_ratio = width[0] / width[1]
+            pixels_y = np.sqrt(total_pixels / aspect_ratio)
+            pixels = (int(total_pixels / pixels_y), int(pixels_y))
 
         x_min = origin[x] - 0.5*width[0]
         x_max = origin[x] + 0.5*width[0]

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -300,7 +300,7 @@ class Universe(UniverseBase):
     _default_legend_kwargs = {'bbox_to_anchor': (
         1.05, 1), 'loc': 2, 'borderaxespad': 0.0}
 
-    def plot(self, origin=None, width=None, pixels=None,
+    def plot(self, origin=None, width=None, pixels=40000,
              basis='xy', color_by='cell', colors=None, seed=None,
              openmc_exec='openmc', axes=None, legend=False,
              legend_kwargs=_default_legend_kwargs, outline=False,
@@ -319,11 +319,12 @@ class Universe(UniverseBase):
             universe.bounding_box.width() will be used to attempt to
             ascertain the plot width.  Defaults to (10, 10) if the bounding_box
             contains inf values
-        pixels : Iterable of int
-            Number of pixels to use in each basis direction, if left as None
-            then the pixels in each basis direction is assigned a number
-            of pixels proportionally to it's relative width while also keeping
-            the total number of pixels in the plot equals to 40000.
+        pixels : Iterable of int or int
+            If iterable of int then provide then this sets the number of pixels
+            to use in each basis direction. If int provided then this sets the
+            total number of pixels in the plot and the number of pixels in each
+            basis direction is calculated from this total and the image aspect
+            ratio.
         basis : {'xy', 'xz', 'yz'}
             The basis directions for the plot
         color_by : {'cell', 'material'}
@@ -398,14 +399,10 @@ class Universe(UniverseBase):
                 y_width = bb_width['xyz'.index(basis[1])]
                 width = (x_width, y_width)
 
-        if pixels is None or isinstance(pixels, int):
-            if pixels is None:
-                total_pixels = 40000
-            elif isinstance(pixels, int):
-                total_pixels = pixels
+        if isinstance(pixels, int):
             aspect_ratio = width[0] / width[1]
-            pixels_y = np.sqrt(total_pixels / aspect_ratio)
-            pixels = (int(total_pixels / pixels_y), int(pixels_y))
+            pixels_y = np.sqrt(pixels / aspect_ratio)
+            pixels = (int(pixels / pixels_y), int(pixels_y))
 
         x_min = origin[x] - 0.5*width[0]
         x_max = origin[x] + 0.5*width[0]

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -1,3 +1,4 @@
+import math
 import typing
 from abc import ABC, abstractmethod
 from collections import OrderedDict

--- a/tests/unit_tests/test_universe.py
+++ b/tests/unit_tests/test_universe.py
@@ -81,7 +81,7 @@ def test_plot(run_in_tmpdir, sphere_model):
             colors=colors,
             color_by="cell",
             legend=False,
-            pixels=(10, 10),
+            pixels=100,
             basis=basis,
             outline=False
         )


### PR DESCRIPTION
I've just been using the recently upgraded universe.plot and really liking all the automation.

I am thinking it could be even more convenient if we calculate the pixels in each basis direction for the user.

For  long thin plots with a high aspect ratio I found myself manually calculating the aspect ratio and change the default pixels from (200, 200) to something that shared the pixels more evenly across the plot.

I thought it might be worth allowing the user to put in a single int and in this case treating this input as a total number of pixels sharing the pixels across the axis proportionally to their width. This allow easier scaling of resolution without the user having to know the aspect ratio of their geometry.