### PR TITLE
docs: typo fix

### DIFF
--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -163,7 +163,7 @@ class Settings:
     statepoint : dict
         Options for writing state points. Acceptable keys are:
 
-        :batches: list of batches at which to write source
+        :batches: list of batches at which to write state
     surf_source_read : dict
         Options for reading surface source points. Acceptable keys are:
 

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -163,7 +163,7 @@ class Settings:
     statepoint : dict
         Options for writing state points. Acceptable keys are:
 
-        :batches: list of batches at which to write state
+        :batches: list of batches at which to write statepoint files
     surf_source_read : dict
         Options for reading surface source points. Acceptable keys are:
 


### PR DESCRIPTION
the description of `statepoint.batches` is the same as `sourcepoint.batches`, which confuses me a bit