### PR TITLE
Update include/openmc/nuclide.h

### DIFF
--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -20,6 +20,7 @@
 #include "openmc/urr.h"
 #include "openmc/vector.h"
 #include "openmc/wmp.h"
+#include "openmc/material.h"
 
 namespace openmc {
 


### PR DESCRIPTION
The Intel LLVM compiler fails to compile 'nuclide.cpp' with error

  error: use of undeclared identifier 'model'

This patch adds the missing include to 'nuclide.h'.