### PR TITLE
skip test that fails if VTK is missing

### DIFF
--- a/tests/unit_tests/test_plots.py
+++ b/tests/unit_tests/test_plots.py
@@ -70,6 +70,8 @@ def myprojectionplot():
 
 
 def test_voxel_plot(run_in_tmpdir):
+    # attempt to preload VTK and skip this test if unavailable
+    vtk = pytest.importorskip('vtk')
     surf1 = openmc.Sphere(r=500, boundary_type='vacuum')
     cell1 = openmc.Cell(region=-surf1)
     geometry = openmc.Geometry([cell1])


### PR DESCRIPTION
This small change fixes a test failure when VTK is not available.

Some tests (`unit_tests/test_tracks.py`) use `pytest.importorskip('vtk')` to skip the tests if VTK is absent.

This test (`unit_test/test_plots.py`) doesn't explicitly import VTK, but calls a method that has delayed importing of VTK only when the method is called.  Since it doesn't make sense to invoke pytest in that method, this adds an attempt to "preload" VTK before that method is called and skip the test is VTK is absent.

This may not affect CI or other testing if VTK is generally available for that testing.

h/t @lewisgross1296 