### PR TITLE
added get_cells_by_depletable method

### DIFF
--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -659,6 +659,22 @@ class Geometry:
         """
         return self._get_domains_by_name(name, case_sensitive, matching, 'lattice')
 
+    def get_cells_by_depletable(self) -> typing.List[openmc.Cell]:
+        """Return all cells that are filled with depletable materials.
+
+        Returns
+        -------
+        list of openmc.Cell
+            Cells filled with depletable material
+
+        """
+        depleted_cells = []
+        for cell in self.get_all_cells().values():
+            if cell.fill:
+                if cell.fill.depletable is True:
+                    depleted_cells.append(cell)
+        return depleted_cells
+
     def remove_redundant_surfaces(self) -> typing.Dict[int, openmc.Surface]:
         """Remove and return all of the redundant surfaces.
 

--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -326,6 +326,7 @@ def test_rotation_matrix():
     assert geom.find((0.0, -0.5, 0.0))[-1] == c1
     assert geom.find((0.0, -1.5, 0.0))[-1] == c2
 
+
 def test_remove_redundant_surfaces():
     """Test ability to remove redundant surfaces"""
 
@@ -373,3 +374,21 @@ def test_remove_redundant_surfaces():
     # There should be 0 remaining redundant surfaces
     n_redundant_surfs = len(geom.remove_redundant_surfaces().keys())
     assert n_redundant_surfs == 0
+
+
+def test_get_cells_by_depletable():
+    """Test ability to find cells with materials that are depletable"""
+
+    m1 = openmc.Material()
+    m1.add_nuclide('H1', 1.0)
+    m1.depletable = True
+    m2 = openmc.Material()
+    m2.add_nuclide('H1', 1.0)
+
+    s1 = openmc.Sphere(r=1)
+    c1 = openmc.Cell(fill=m1, region=-s1)
+    s2 = openmc.Sphere(r=2)
+    c2 = openmc.Cell(fill=m2, region=-s2 & +s1)
+
+    geom = openmc.Geometry([c1, c2])
+    assert geom.get_cells_by_depletable() == [c1]


### PR DESCRIPTION
I keep writing code to get the cells within a geometry where the material has been set to ```depletable=True``` for shut down dose rate calculations. So I thought it might be handy to include this in the geometry class.