### PR TITLE
added mkdir to cwd argument in run

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -16,7 +16,7 @@ import openmc
 import openmc._xml as xml
 from openmc.dummy_comm import DummyCommunicator
 from openmc.executor import _process_CLI_arguments
-from openmc.checkvalue import check_type, check_value
+from openmc.checkvalue import check_type, check_value, PathLike
 from openmc.exceptions import InvalidIDError
 
 
@@ -632,7 +632,7 @@ class Model:
             Settings.max_tracks is set. Defaults to False.
         output : bool, optional
             Capture OpenMC output from standard out
-        cwd : str, optional
+        cwd : PathLike, optional
             Path to working directory to run in. Defaults to the current working
             directory.
         openmc_exec : str, optional
@@ -669,7 +669,10 @@ class Model:
         last_statepoint = None
 
         # Operate in the provided working directory
-        with _change_directory(Path(cwd)):
+        if not isinstance(cwd, Path):
+            cwd = Path(cwd)
+        cwd.mkdir(parents=True, exist_ok=True)
+        with _change_directory(cwd):
             if self.is_initialized:
                 # Handle the run options as applicable
                 # First dont allow ones that must be set via init

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -24,7 +24,7 @@ from openmc.exceptions import InvalidIDError
 def _change_directory(working_dir):
     """A context manager for executing in a provided working directory"""
     start_dir = Path.cwd()
-    Path.mkdir(working_dir, exist_ok=True)
+    Path.mkdir(working_dir, parents=True, exist_ok=True)
     os.chdir(working_dir)
     try:
         yield
@@ -669,10 +669,7 @@ class Model:
         last_statepoint = None
 
         # Operate in the provided working directory
-        if not isinstance(cwd, Path):
-            cwd = Path(cwd)
-        cwd.mkdir(parents=True, exist_ok=True)
-        with _change_directory(cwd):
+        with _change_directory(Path(cwd)):
             if self.is_initialized:
                 # Handle the run options as applicable
                 # First dont allow ones that must be set via init


### PR DESCRIPTION
When passing a path into ```model.run(cwd='my_path')```  it appears that we can't currently accept a path with a sub-directory. So this currently fails

```model.run(cwd='my_path/subfolder')```

This PR adds a ```pathlib.Path.mkdir``` command to create the folder and subfolders if it doesn't exist