### PR TITLE
Fix potential out-of-bounds access in TimeFilter

### DIFF
--- a/src/tallies/filter_time.cpp
+++ b/src/tallies/filter_time.cpp
@@ -80,15 +80,14 @@ void TimeFilter::get_all_bins(
       if (t_end < bins_[i_bin + 1])
         break;
     }
-  } else {
+  } else if (t_end < bins_.back()) {
     // -------------------------------------------------------------------------
     // For collision estimator or surface tallies, find a match based on the
     // exact time of the particle
-    if (t_end < bins_.back()) {
-      const auto i_bin = lower_bound_index(bins_.begin(), bins_.end(), t_end);
-      match.bins_.push_back(i_bin);
-      match.weights_.push_back(1.0);
-    }
+
+    const auto i_bin = lower_bound_index(bins_.begin(), bins_.end(), t_end);
+    match.bins_.push_back(i_bin);
+    match.weights_.push_back(1.0);
   }
 }
 

--- a/src/tallies/filter_time.cpp
+++ b/src/tallies/filter_time.cpp
@@ -84,9 +84,11 @@ void TimeFilter::get_all_bins(
     // -------------------------------------------------------------------------
     // For collision estimator or surface tallies, find a match based on the
     // exact time of the particle
-    const auto i_bin = lower_bound_index(bins_.begin(), bins_.end(), t_end);
-    match.bins_.push_back(i_bin);
-    match.weights_.push_back(1.0);
+    if (t_end < bins_.back()) {
+      const auto i_bin = lower_bound_index(bins_.begin(), bins_.end(), t_end);
+      match.bins_.push_back(i_bin);
+      match.weights_.push_back(1.0);
+    }
   }
 }
 


### PR DESCRIPTION
@HunterBelanger pointed out to me that there is a potential for an out-of-bounds error due to the lack of a check in `TimeFilter::get_all_bins`. Namely, for collision estimator/surface tallies, we don't check that the ending time of a particle's track is within the time bin range. This PR simply adds that check.