### PR TITLE
Fix docstring for MicroXS class

### DIFF
--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -37,8 +37,9 @@ class MicroXS(DataFrame):
                    dilute_initial=1.0e3,
                    energy_bounds=(0, 20e6),
                    run_kwargs=None):
-        """Generate a one-group cross-section dataframe using
-        OpenMC. Note that the ``openmc`` executable must be compiled.
+        """Generate a one-group cross-section dataframe using OpenMC.
+
+        Note that the ``openmc`` executable must be compiled.
 
         Parameters
         ----------
@@ -55,8 +56,6 @@ class MicroXS(DataFrame):
             Initial atom density [atoms/cm^3] to add for nuclides that
             are zero in initial condition to ensure they exist in the cross
             section data. Only done for nuclides with reaction rates.
-        reactions : list of str, optional
-            Reaction names to tally
         energy_bound : 2-tuple of float, optional
             Bounds for the energy group.
         run_kwargs : dict, optional


### PR DESCRIPTION
Closes #2537. For now, this PR just removes the documentation mentioning `reactions` since it is not actually an argument. Longer term we should allow for the user to specify what reactions they want -- I can take care of that as part of refactoring the `MicroXS` class overall to not add in dilute nuclides (once #2539 is merged).