### PR TITLE
creating parent dirs for output_dir

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -69,7 +69,7 @@ def change_directory(output_dir):
     """
     orig_dir  = os.getcwd()
     try:
-        output_dir.mkdir(exist_ok=True)
+        output_dir.mkdir(parents=True, exist_ok=True)
         os.chdir(output_dir)
         yield
     finally:


### PR DESCRIPTION
Currently when setting the ```openmc.deplete.CoupledOperator().output_dir``` to a directory with a subfolder the subfolder does not get created and the python script crashes with an error.

For example, this would reproduce the bug
```python
operator = openmc.deplete.CoupledOperator(
    model=model,
    normalization_mode="source-rate"
)
operator.output_dir = 'outputfolder/anotherfolder'  # this path contains a sub folder
```

This PR attempts to fix the error by adding ```parents=True``` to the folder creation command in ```openmc.deplete.abc.py```