### PR TITLE
Remove misleading warn message from deplete.chain.py 

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -734,9 +734,6 @@ class Chain:
                 if transfer_rates.get_destination_material(material, element) == destination_material:
                     matrix[i, i] = transfer_rates.get_transfer_rate(material, element)
                 else:
-                    warn(f'Material {destination_material} is not defined '
-                         f'as a destination material for Material {material}. '
-                         'Setting transfer rate to 0.0')
                     matrix[i, i] = 0.0
             #Nothing else is allowed
         n = len(self)


### PR DESCRIPTION
Remove misleading warn message from deplete.chain.py as discussed [here](https://openmc.discourse.group/t/transfer-rates-warning-for-destination-material/3054).