### PR TITLE
corrected pixel index for axis height

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -455,7 +455,7 @@ class Universe(UniverseBase):
                 axes.set_ylabel(ylabel)
                 params = fig.subplotpars
                 width = pixels[0]*px/(params.right - params.left)
-                height = pixels[0]*px/(params.top - params.bottom)
+                height = pixels[1]*px/(params.top - params.bottom)
                 fig.set_size_inches(width, height)
 
             if outline:


### PR DESCRIPTION
When plotting geometry and not passing in an axes we create an axis.

It is currently created with the wrong height but is then fixed by imshow so this doesn't get seen by the user.

However we could change this 0 to a 1 and then make the axis with the correct height.

Tiny change, no real consequences I just spotted it and felt it is worth proposing. 