### PR TITLE
Add C++ format check to GitHub Actions

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -22,4 +22,4 @@ jobs:
 
       - name: Failure Check
         if: steps.linter.outputs.checks-failed > 0
-        run: echo "Some files failed the linting checks! See job summary and file annotations for more info"
+        run: echo "Some files failed the formatting check! See job summary and file annotations for more info" && exit 1

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,25 @@
+name: C++ Format Check
+
+on: pull_request
+
+jobs:
+  cpp-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cpp-linter/cpp-linter-action@v2
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: file
+          files-changed-only: true
+          tidy-checks: '-*'
+          version: '15' # clang-format version
+          file-annotations: true
+          step-summary: true
+          extensions: 'cpp,h'
+
+      - name: Failure Check
+        if: steps.linter.outputs.checks-failed > 0
+        run: echo "Some files failed the linting checks! See job summary and file annotations for more info"

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -29,6 +29,11 @@ openmc::vector<unique_ptr<WeightWindows>> weight_windows;
 // Non-member functions
 //==============================================================================
 
+void empty_function(){
+  bool bad_format=true;
+  if(bad_format){std::cout<<"this is bad"<< std::endl;}
+};
+
 void apply_weight_windows(Particle& p)
 {
   // skip dead or no energy

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -29,11 +29,6 @@ openmc::vector<unique_ptr<WeightWindows>> weight_windows;
 // Non-member functions
 //==============================================================================
 
-void empty_function(){
-  bool bad_format=true;
-  if(bad_format){std::cout<<"this is bad"<< std::endl;}
-};
-
 void apply_weight_windows(Particle& p)
 {
   // skip dead or no energy


### PR DESCRIPTION
As perhaps the most frequent perpetrator in attempting to violate our C++ format guidelines these days, I thought I'd invest a little of my time to save a lot of others' by adding an automated formatting check in our actions for pull requests. Using a consistent environment and `clang-format` version also allows us to ensure that the code formatting check is consistent.

This PR adds a workflow using the https://github.com/cpp-linter/cpp-linter-action to check any of the changed `.cpp`/`.h` files in the PR for proper formatting. The action provides file annotations in the code changes highlighting the offending lines as well as a summary of the format check in the job summary. It can also provide a summary of the violating files in the PR thread. I think this would be the fastest and most visible way for submitters/reviewers to check the formatting result, but I found that after fixing the formatting the thread comment doesn't always update correctly. For a technical explanation of why this is, see [here](https://github.com/cpp-linter/cpp-linter-action/issues/154). At the same time, it might be preferable to keep the PR thread comments to discussion of design/code only without extra clutter. 🤷🏻 

FWIW, there are many tools out there that perform this kind of operation but this tool I found to be well-supported and actively maintained (as evidenced by the fast response to the issue I raised) with all of the features I was looking for (formatting chcek only changed files, file annotations, optional failure if formatting is needed).

On that last note, I currently have this action setup to pass but add file annotations if the format is violated. It's would be very easy to report failure from the job and still add file annotations to block a PR merge with format violations.