### PR TITLE
Use `multiply_density` in depletion reaction rate helper classes

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -274,8 +274,7 @@ class ReactionRateHelper(ABC):
         Parameters
         ----------
         number : iterable of float
-            Number density [atoms/b-cm] of each nuclide tracked in the
-            calculation.
+            Number of each nuclide in [atom] tracked in the calculation.
 
         Returns
         -------

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -392,7 +392,6 @@ class FluxCollapseHelper(ReactionRateHelper):
                     rate_per_nuc = nuc.collapse_rate(
                         mt, mat.temperature, self._energies, flux)
 
-                    # Multiply by density to get absolute reaction rate
                     self._results_cache[i_nuc, i_rx] = rate_per_nuc
 
         return self._results_cache

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -305,6 +305,7 @@ class FluxCollapseHelper(ReactionRateHelper):
             self._rate_tally.writable = False
             self._rate_tally.scores = self._reactions_direct
             self._rate_tally.filters = [MaterialFilter(materials)]
+            self._rate_tally.multiply_density = False
             self._rate_tally_means_cache = None
             if self._nuclides_direct is not None:
                 # check if any direct tally nuclides are requested that are not
@@ -376,13 +377,7 @@ class FluxCollapseHelper(ReactionRateHelper):
 
         mat = self._materials[mat_index]
 
-        # Build nucname: density mapping to enable O(1) lookup in loop below
-        densities = dict(zip(mat.nuclides, mat.densities))
-
         for name, i_nuc in zip(self.nuclides, nuc_index):
-            # Determine density of nuclide
-            density = densities[name]
-
             for mt, score, i_rx in zip(self._mts, self._scores, react_index):
                 if score in self._reactions_direct and name in nuclides_direct:
                     # Determine index in rx_rates
@@ -398,7 +393,7 @@ class FluxCollapseHelper(ReactionRateHelper):
                         mt, mat.temperature, self._energies, flux)
 
                     # Multiply by density to get absolute reaction rate
-                    self._results_cache[i_nuc, i_rx] = rate_per_nuc * density
+                    self._results_cache[i_nuc, i_rx] = rate_per_nuc
 
         return self._results_cache
 

--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -26,6 +26,7 @@ __all__ = (
     "ConstantFissionYieldHelper", "FissionYieldCutoffHelper",
     "AveragedFissionYieldHelper", "FluxCollapseHelper")
 
+
 class TalliedFissionYieldHelper(FissionYieldHelper):
     """Abstract class for computing fission yields with tallies
 
@@ -159,22 +160,23 @@ class DirectReactionRateHelper(ReactionRateHelper):
     def generate_tallies(self, materials, scores):
         """Produce one-group reaction rate tally
 
-        Uses the :mod:`openmc.lib` to generate a tally
-        of relevant reactions across all burnable materials.
+        Uses the :mod:`openmc.lib` to generate a tally of relevant reactions
+        across all burnable materials.
 
         Parameters
         ----------
-        materials : iterable of :class:`openmc.Material`
-            Burnable materials in the problem. Used to
-            construct a :class:`openmc.MaterialFilter`
+        materials : iterable of :class:`openmc.lib.Material`
+            Burnable materials in the problem. Used to construct a
+            :class:`openmc.lib.MaterialFilter`
         scores : iterable of str
-            Reaction identifiers, e.g. ``"(n, fission)"``,
-            ``"(n, gamma)"``, needed for the reaction rate tally.
+            Reaction identifiers, e.g. ``"(n, fission)"``, ``"(n, gamma)"``,
+            needed for the reaction rate tally.
         """
         self._rate_tally = Tally()
         self._rate_tally.writable = False
         self._rate_tally.scores = scores
         self._rate_tally.filters = [MaterialFilter(materials)]
+        self._rate_tally.multiply_density = False
         self._rate_tally_means_cache = None
 
     @property
@@ -194,7 +196,7 @@ class DirectReactionRateHelper(ReactionRateHelper):
         """
         self._rate_tally_means_cache = None
 
-    def get_material_rates(self, mat_id, nuc_index, react_index):
+    def get_material_rates(self, mat_id, nuc_index, rx_index):
         """Return an array of reaction rates for a material
 
         Parameters
@@ -204,7 +206,7 @@ class DirectReactionRateHelper(ReactionRateHelper):
         nuc_index : iterable of int
             Index for each nuclide in :attr:`nuclides` in the
             desired reaction rate matrix
-        react_index : iterable of int
+        rx_index : iterable of int
             Index for each reaction scored in the tally
 
         Returns
@@ -215,9 +217,8 @@ class DirectReactionRateHelper(ReactionRateHelper):
         """
         self._results_cache.fill(0.0)
         full_tally_res = self.rate_tally_means[mat_id]
-        for i_tally, (i_nuc, i_react) in enumerate(
-                product(nuc_index, react_index)):
-            self._results_cache[i_nuc, i_react] = full_tally_res[i_tally]
+        for i_tally, (i_nuc, i_rx) in enumerate(product(nuc_index, rx_index)):
+            self._results_cache[i_nuc, i_rx] = full_tally_res[i_tally]
 
         return self._results_cache
 

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -543,14 +543,14 @@ class OpenMCOperator(TransportOperator):
             fission_yields.append(self._yield_helper.weighted_yields(i))
 
             # Accumulate energy from fission
-            barn_cm = 1e24 * self.number.get_mat_volume(mat)
+            volume_b_cm = 1e24 * self.number.get_mat_volume(mat)
             if fission_ind is not None:
-                atom_per_bcm = number / barn_cm
+                atom_per_bcm = number / volume_b_cm
                 fission_rates = tally_rates[:, fission_ind] * atom_per_bcm
                 self._normalization_helper.update(fission_rates)
 
             # Divide by [b-cm] to get [(reactions/src)/atom]
-            rates[i] = tally_rates / barn_cm
+            rates[i] = tally_rates / volume_b_cm
 
         # Scale reaction rates to obtain units of [(reactions/sec)/atom]
         rates *= self._normalization_helper.factor(source_rate)

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -371,8 +371,8 @@ class OpenMCOperator(TransportOperator):
 
         Parameters
         ----------
-        materials : list of str
-            list of material IDs
+        materials : list of openmc.lib.Material
+            list of materials
 
         Returns
         -------
@@ -503,7 +503,7 @@ class OpenMCOperator(TransportOperator):
 
         # Form fast map
         nuc_ind = [rates.index_nuc[nuc] for nuc in rxn_nuclides]
-        react_ind = [rates.index_rx[react] for react in self.chain.reactions]
+        rx_ind = [rates.index_rx[react] for react in self.chain.reactions]
 
         # Keep track of energy produced from all reactions in eV per source
         # particle
@@ -534,21 +534,25 @@ class OpenMCOperator(TransportOperator):
             for nuc, i_nuc_results in zip(rxn_nuclides, nuc_ind):
                 number[i_nuc_results] = self.number[mat, nuc]
 
+            # Get microscopic reaction rates in [(reactions/src)*b-cm/atom]. 2D
+            # array with shape (nuclides, reactions).
             tally_rates = self._rate_helper.get_material_rates(
-                mat_index, nuc_ind, react_ind)
+                mat_index, nuc_ind, rx_ind)
 
             # Compute fission yields for this material
             fission_yields.append(self._yield_helper.weighted_yields(i))
 
             # Accumulate energy from fission
+            barn_cm = 1e24 * self.number.get_mat_volume(mat)
             if fission_ind is not None:
-                self._normalization_helper.update(
-                    tally_rates[:, fission_ind])
+                atom_per_bcm = number / barn_cm
+                fission_rates = tally_rates[:, fission_ind] * atom_per_bcm
+                self._normalization_helper.update(fission_rates)
 
-            # Divide by total number of atoms and store
-            rates[i] = self._rate_helper.divide_by_atoms(number)
+            # Divide by [b-cm] to get [(reactions/src)/atom]
+            rates[i] = tally_rates / barn_cm
 
-        # Scale reaction rates to obtain units of (reactions/sec)/atom
+        # Scale reaction rates to obtain units of [(reactions/sec)/atom]
         rates *= self._normalization_helper.factor(source_rate)
 
         # Store new fission yields on the chain


### PR DESCRIPTION
This PR is a follow on to #2539 and updates the depletion system in OpenMC to utilize the new `multiply_density` option. Since depletion only requires microscopic reaction rates, there's no need to have the tally system multiply by atom density only to divide it out later. With changes here, we now avoid that.

These changes will allow us to get rid of `dilute_initial` altogether. In fact, I already have that working on a branch but will save it for a separate PR because it does result in test changes. The changes in this PR require no updates to test results.