### PR TITLE
Allow transfer rates with nuclides.

### DIFF
--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -198,7 +198,7 @@ NEUTRON_MASS = 1.00866491595
 _ATOMIC_MASS = {}
 
 # Regex for GNDS nuclide names (used in zam function)
-_GNDS_NAME_RE = re.compile(r'([A-Zn][a-z]*)(\d+)((?:_[em]\d+)?)')
+GNDS_NAME_RE = re.compile(r'([A-Zn][a-z]*)(\d+)((?:_[em]\d+)?)')
 
 # Used in half_life function as a cache
 _HALF_LIFE = {}
@@ -514,7 +514,7 @@ def zam(name):
 
     """
     try:
-        symbol, A, state = _GNDS_NAME_RE.match(name).groups()
+        symbol, A, state = GNDS_NAME_RE.match(name).groups()
     except AttributeError:
         raise ValueError(f"'{name}' does not appear to be a nuclide name in "
                          "GNDS format")

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -726,6 +726,8 @@ class Chain:
                 material = materials
                 if element in transfer_rates.get_elements(material):
                     matrix[i, i] = transfer_rates.get_transfer_rate(material, element)
+                elif nuclide.name in transfer_rates.get_nuclides(material):
+                    matrix[i, i] = transfer_rates.get_transfer_rate(material, nuclide)
                 else:
                     matrix[i, i] = 0.0
             #Build transfer terms matrices
@@ -733,6 +735,8 @@ class Chain:
                 destination_material, material = materials
                 if transfer_rates.get_destination_material(material, element) == destination_material:
                     matrix[i, i] = transfer_rates.get_transfer_rate(material, element)
+                elif transfer_rates.get_destination_material(nuclide, element) == destination_material:
+                    matrix[i, i] = transfer_rates.get_transfer_rate(material, nuclide)
                 else:
                     matrix[i, i] = 0.0
             #Nothing else is allowed

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -724,10 +724,11 @@ class Chain:
             # Build transfer terms matrices
             if isinstance(materials, str):
                 material = materials
-                if element in transfer_rates.get_elements(material):
+                components = transfer_rates.get_components(material)
+                if element in components:
                     matrix[i, i] = transfer_rates.get_transfer_rate(material, element)
-                elif nuclide.name in transfer_rates.get_nuclides(material):
-                    matrix[i, i] = transfer_rates.get_transfer_rate(material, nuclide)
+                elif nuclide.name in components:
+                    matrix[i, i] = transfer_rates.get_transfer_rate(material, nuclide.name)
                 else:
                     matrix[i, i] = 0.0
             #Build transfer terms matrices

--- a/openmc/deplete/transfer_rates.py
+++ b/openmc/deplete/transfer_rates.py
@@ -1,8 +1,10 @@
 from numbers import Real
+import warnings
+import re
 
 from openmc.checkvalue import check_type, check_value
 from openmc import Material
-from openmc.data import ELEMENT_SYMBOL
+from openmc.data import ELEMENT_SYMBOL, zam, GNDS_NAME_RE
 
 
 class TransferRates:
@@ -91,7 +93,10 @@ class TransferRates:
 
         """
         material_id = self._get_material_id(material)
-        check_value('element', element, ELEMENT_SYMBOL.values())
+        try:
+            assert bool(re.match(GNDS_NAME_RE, element))
+        except:
+            check_value('element', element, ELEMENT_SYMBOL.values())
         return self.transfer_rates[material_id][element][0]
 
     def get_destination_material(self, material, element):
@@ -112,7 +117,10 @@ class TransferRates:
 
         """
         material_id = self._get_material_id(material)
-        check_value('element', element, ELEMENT_SYMBOL.values())
+        try:
+            assert bool(re.match(GNDS_NAME_RE, element))
+        except:
+            check_value('element', element, ELEMENT_SYMBOL.values())
         if element in self.transfer_rates[material_id]:
             return self.transfer_rates[material_id][element][1]
 
@@ -143,7 +151,7 @@ class TransferRates:
         material : openmc.Material or str or int
             Depletable material
         elements : list of str
-            List of strings of elements that share transfer rate
+            List of strings of elements or nuclides that share transfer rate
         transfer_rate : float
             Rate at which elements are transferred. A positive or negative values
             set removal of feed rates, respectively.
@@ -182,7 +190,14 @@ class TransferRates:
             raise ValueError("Invalid transfer rate unit '{}'".format(transfer_rate_units))
 
         for element in elements:
-            check_value('element', element, ELEMENT_SYMBOL.values())
+            try:
+                assert bool(re.match(GNDS_NAME_RE, element))
+            except:
+                check_value('element', element, ELEMENT_SYMBOL.values())
+
+            ############################
+            ## ADD BLOCK TO DISALLOW AN ELEMENT AND NUCLIDE OF THE SAME ELEMENT ##
+            ############################
             self.transfer_rates[material_id][element] = transfer_rate / unit_conv, destination_material_id
             if destination_material_id is not None:
                 self.index_transfer.add((destination_material_id, material_id))

--- a/tests/unit_tests/test_deplete_transfer_rates.py
+++ b/tests/unit_tests/test_deplete_transfer_rates.py
@@ -45,29 +45,52 @@ def model():
 
     return openmc.Model(geometry, materials, settings)
 
+@pytest.mark.parametrize("case_name, transfer_rates", [
+    ('elements', {'U': 0.01, 'Xe': 0.1}),
+    ('nuclides', {'I135': 0.01, 'Gd156': 0.1, 'Gd157': 0.01}),
+    ('nuclides_elements', {'I135': 0.01, 'Gd156': 0.1, 'Gd157': 0.01, 'U': 0.01, 'Xe': 0.1}),
+    ('elements_nuclides', {'U': 0.01, 'Xe': 0.1, 'I135': 0.01, 'Gd156': 0.1, 'Gd157': 0.01}),
+    ('rates_invalid_1', {'Gd': 0.01, 'Gd157': 0.01, 'Gd156': 0.01}),
+    ('rates_invalid_2', {'Gd156': 0.01, 'Gd157': 0.01, 'Gd': 0.01})
+    ])
 
-def test_get_set(model):
+def test_get_set(model, case_name, transfer_rates):
     """Tests the get/set methods"""
 
-    # create transfer rates for U and Xe
-    transfer_rates = {'U': 0.01, 'Xe': 0.1, 'Gd157': 0.2, 'I135': -0.2}
     op = CoupledOperator(model, CHAIN_PATH)
     transfer = TransferRates(op, model)
 
     # Test by Openmc material, material name and material id
     material, dest_material = [m for m in model.materials if m.depletable]
-
     for material_input in [material, material.name, material.id]:
         for dest_material_input in [dest_material, dest_material.name,
                                     dest_material.id]:
-            for component, transfer_rate in transfer_rates.items():
-                transfer.set_transfer_rate(material_input, [element], transfer_rate,
-                                 destination_material=dest_material_input)
-                assert transfer.get_transfer_rate(material_input,
-                                            component) == transfer_rate
-                assert transfer.get_destination_material(material_input,
-                                                    component) == str(dest_material.id)
-            assert transfer.get_elements(material_input) == transfer_rates.keys()
+            if case_name == 'rates_invalid_1':
+                with pytest.raises(ValueError, match='Cannot add transfer '
+                                    'rate for nuclide Gd157 to material 1 '
+                                    'where element Gd already has a '
+                                    'transfer rate.'):
+                    for component, transfer_rate in transfer_rates.items():
+                        transfer.set_transfer_rate(material_input,
+                                                   [component],
+                                                   transfer_rate)
+            elif case_name == 'rates_invalid_2':
+                with pytest.raises(ValueError, match='Cannot add transfer '
+                                    f'rate for element Gd to material 1 with '
+                                    'transfer rate\(s\) for nuclide\(s\) Gd156, Gd157.'):
+                    for component, transfer_rate in transfer_rates.items():
+                        transfer.set_transfer_rate(material_input,
+                                                   [component],
+                                                   transfer_rate)
+            else:
+                for component, transfer_rate in transfer_rates.items():
+                    transfer.set_transfer_rate(material_input, [component], transfer_rate,
+                                     destination_material=dest_material_input)
+                    assert transfer.get_transfer_rate(material_input,
+                                                component) == transfer_rate
+                    assert transfer.get_destination_material(material_input,
+                                                        component) == str(dest_material.id)
+                assert transfer.get_components(material_input) == transfer_rates.keys()
 
 
 @pytest.mark.parametrize("transfer_rate_units, unit_conv", [

--- a/tests/unit_tests/test_deplete_transfer_rates.py
+++ b/tests/unit_tests/test_deplete_transfer_rates.py
@@ -50,7 +50,7 @@ def test_get_set(model):
     """Tests the get/set methods"""
 
     # create transfer rates for U and Xe
-    transfer_rates = {'U': 0.01, 'Xe': 0.1}
+    transfer_rates = {'U': 0.01, 'Xe': 0.1, 'Gd157': 0.2, 'I135': -0.2}
     op = CoupledOperator(model, CHAIN_PATH)
     transfer = TransferRates(op, model)
 
@@ -60,13 +60,13 @@ def test_get_set(model):
     for material_input in [material, material.name, material.id]:
         for dest_material_input in [dest_material, dest_material.name,
                                     dest_material.id]:
-            for element, transfer_rate in transfer_rates.items():
+            for component, transfer_rate in transfer_rates.items():
                 transfer.set_transfer_rate(material_input, [element], transfer_rate,
                                  destination_material=dest_material_input)
                 assert transfer.get_transfer_rate(material_input,
-                                            element) == transfer_rate
+                                            component) == transfer_rate
                 assert transfer.get_destination_material(material_input,
-                                                    element) == str(dest_material.id)
+                                                    component) == str(dest_material.id)
             assert transfer.get_elements(material_input) == transfer_rates.keys()
 
 
@@ -86,14 +86,15 @@ def test_get_set(model):
 def test_units(transfer_rate_units, unit_conv, model):
     """ Units testing"""
     # create transfer rate Xe
-    element = 'Xe'
+    components = ['Xe', 'U235']
     transfer_rate = 1e-5
     op = CoupledOperator(model, CHAIN_PATH)
     transfer = TransferRates(op, model)
 
-    transfer.set_transfer_rate('f', [element], transfer_rate * unit_conv,
-                         transfer_rate_units=transfer_rate_units)
-    assert transfer.get_transfer_rate('f', element) == transfer_rate
+    for component in components:
+        transfer.set_transfer_rate('f', [component], transfer_rate * unit_conv,
+                             transfer_rate_units=transfer_rate_units)
+        assert transfer.get_transfer_rate('f', component) == transfer_rate
 
 
 def test_transfer(run_in_tmpdir, model):


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description
This PR adds capabilities to enable `TransferRates` to work with specific nuclides. While transferring specific nuclides would most likely not occur in a real fuel processing system, it is a useful feature to have for comparison with other codes (i.e. [Serpent2's `repr` card](https://serpent.vtt.fi/mediawiki/index.php/Input_syntax_manual#rep_.28reprocessor_definition.29)).

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
