### PR TITLE
allowing stepresult to save to a path

### DIFF
--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -520,11 +520,10 @@ class StepResult:
             be process-dependent and will be reduced across MPI
             processes.
 
-        .. versionadded:: 0.13.4
-
         path : PathLike
             Path to file to write. Defaults to 'depletion_results.h5'.
 
+            .. versionadded:: 0.13.4
         """
         # Get indexing terms
         vol_dict, nuc_list, burn_list, full_burn_list = op.get_results_info()
@@ -556,7 +555,7 @@ class StepResult:
             results.proc_time = comm.reduce(proc_time, op=MPI.SUM)
 
         if not Path(path).is_file():
-            Path(path).parents[0].mkdir(parents=True, exist_ok=True)
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
         results.export_to_hdf5(path, step_ind)
 
     def transfer_volumes(self, model):

--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -4,15 +4,17 @@ Contains capabilities for generating and saving results of a single depletion
 timestep.
 """
 
-from collections import OrderedDict
 import copy
 import warnings
+from collections import OrderedDict
+from pathlib import Path
 
 import h5py
 import numpy as np
 
 import openmc
 from openmc.mpi import comm, MPI
+from openmc.checkvalue import PathLike
 from .reaction_rates import ReactionRates
 
 VERSION_RESULTS = (1, 1)
@@ -495,7 +497,8 @@ class StepResult:
         return results
 
     @staticmethod
-    def save(op, x, op_results, t, source_rate, step_ind, proc_time=None):
+    def save(op, x, op_results, t, source_rate, step_ind, proc_time=None,
+             path: PathLike = "depletion_results.h5"):
         """Creates and writes depletion results to disk
 
         Parameters
@@ -516,6 +519,8 @@ class StepResult:
             Total process time spent depleting materials. This may
             be process-dependent and will be reduced across MPI
             processes.
+        path : PathLike
+            Path to file to write. Defaults to 'depletion_results.h5'.
 
         """
         # Get indexing terms
@@ -547,7 +552,9 @@ class StepResult:
         if results.proc_time is not None:
             results.proc_time = comm.reduce(proc_time, op=MPI.SUM)
 
-        results.export_to_hdf5("depletion_results.h5", step_ind)
+        if not Path(path).is_file():
+            Path(path).parents[0].mkdir(parents=True, exist_ok=True)
+        results.export_to_hdf5(path, step_ind)
 
     def transfer_volumes(self, model):
         """Transfers volumes from depletion results to geometry

--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -519,6 +519,9 @@ class StepResult:
             Total process time spent depleting materials. This may
             be process-dependent and will be reduced across MPI
             processes.
+
+        .. versionadded:: 0.13.4
+
         path : PathLike
             Path to file to write. Defaults to 'depletion_results.h5'.
 

--- a/tests/unit_tests/test_deplete_integrator.py
+++ b/tests/unit_tests/test_deplete_integrator.py
@@ -99,6 +99,12 @@ def test_results_save(run_in_tmpdir):
                   for k, rates in zip(eigvl1, rate1)]
     op_result2 = [OperatorResult(ufloat(*k), rates)
                   for k, rates in zip(eigvl2, rate2)]
+
+    # saves within a subdirectory
+    StepResult.save(op, x1, op_result1, t1, 0, 0, path='out/put/depletion.h5')
+    res = Results('out/put/depletion.h5')
+
+    # saves with default filename
     StepResult.save(op, x1, op_result1, t1, 0, 0)
     StepResult.save(op, x2, op_result2, t2, 0, 1)
 


### PR DESCRIPTION

# Description

This PR adds a path argument to the StepResult.save() method which allows the user to specify a path of the depltion result. The default is still depletion_result.h5.

Fixes # (issue)
Partly fixes user request https://openmc.discourse.group/t/output-folder-path-for-integrator-integrate/3089/2

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

