### PR TITLE
Updating source definitions in examples

### DIFF
--- a/examples/custom_source/build_xml.py
+++ b/examples/custom_source/build_xml.py
@@ -18,7 +18,7 @@ settings = openmc.Settings()
 settings.run_mode = 'fixed source'
 settings.batches = 10
 settings.particles = 1000
-source = openmc.IndependentSource()
+source = openmc.CompiledSource()
 source.library = 'build/libsource.so'
 settings.source = source
 settings.export_to_xml()

--- a/examples/lattice/hexagonal/build_xml.py
+++ b/examples/lattice/hexagonal/build_xml.py
@@ -115,7 +115,7 @@ settings_file.particles = particles
 # Create an initial uniform spatial source distribution over fissionable zones
 bounds = [-1, -1, -1, 1, 1, 1]
 uniform_dist = openmc.stats.Box(bounds[:3], bounds[3:], only_fissionable=True)
-settings_file.source = openmc.source.Source(space=uniform_dist)
+settings_file.source = openmc.IndependentSource(space=uniform_dist)
 
 settings_file.keff_trigger = {'type' : 'std_dev', 'threshold' : 5E-4}
 settings_file.trigger_active = True

--- a/examples/lattice/nested/build_xml.py
+++ b/examples/lattice/nested/build_xml.py
@@ -125,7 +125,7 @@ settings_file.particles = particles
 # Create an initial uniform spatial source distribution over fissionable zones
 bounds = [-1, -1, -1, 1, 1, 1]
 uniform_dist = openmc.stats.Box(bounds[:3], bounds[3:], only_fissionable=True)
-settings_file.source = openmc.source.Source(space=uniform_dist)
+settings_file.source = openmc.IndependentSource(space=uniform_dist)
 
 settings_file.export_to_xml()
 

--- a/examples/lattice/simple/build_xml.py
+++ b/examples/lattice/simple/build_xml.py
@@ -116,7 +116,7 @@ settings_file.particles = particles
 # Create an initial uniform spatial source distribution over fissionable zones
 bounds = [-1, -1, -1, 1, 1, 1]
 uniform_dist = openmc.stats.Box(bounds[:3], bounds[3:], only_fissionable=True)
-settings_file.source = openmc.source.Source(space=uniform_dist)
+settings_file.source = openmc.IndependentSource(space=uniform_dist)
 
 settings_file.trigger_active = True
 settings_file.trigger_max_batches = 100

--- a/examples/parameterized_custom_source/build_xml.py
+++ b/examples/parameterized_custom_source/build_xml.py
@@ -18,7 +18,7 @@ settings = openmc.Settings()
 settings.run_mode = 'fixed source'
 settings.batches = 10
 settings.particles = 1000
-source = openmc.IndependentSource()
+source = openmc.CompiledSource()
 source.library = 'build/libparameterized_source.so'
 source.parameters = 'radius=3.0, energy=14.08e6'
 settings.source = source

--- a/examples/pincell/build_xml.py
+++ b/examples/pincell/build_xml.py
@@ -68,7 +68,7 @@ settings.particles = 1000
 lower_left = (-pitch/2, -pitch/2, -1)
 upper_right = (pitch/2, pitch/2, 1)
 uniform_dist = openmc.stats.Box(lower_left, upper_right, only_fissionable=True)
-settings.source = openmc.source.Source(space=uniform_dist)
+settings.source = openmc.IndependentSource(space=uniform_dist)
 
 # For source convergence checks, add a mesh that can be used to calculate the
 # Shannon entropy

--- a/examples/pincell_depletion/restart_depletion.py
+++ b/examples/pincell_depletion/restart_depletion.py
@@ -27,7 +27,7 @@ settings.particles = 10000
 # Create an initial uniform spatial source distribution over fissionable zones
 bounds = [-0.62992, -0.62992, -1, 0.62992, 0.62992, 1]
 uniform_dist = openmc.stats.Box(bounds[:3], bounds[3:], only_fissionable=True)
-settings.source = openmc.source.Source(space=uniform_dist)
+settings.source = openmc.IndependentSource(space=uniform_dist)
 
 entropy_mesh = openmc.RegularMesh()
 entropy_mesh.lower_left = [-0.39218, -0.39218, -1.e50]

--- a/examples/pincell_depletion/run_depletion.py
+++ b/examples/pincell_depletion/run_depletion.py
@@ -72,7 +72,7 @@ settings.particles = 1000
 # Create an initial uniform spatial source distribution over fissionable zones
 bounds = [-0.62992, -0.62992, -1, 0.62992, 0.62992, 1]
 uniform_dist = openmc.stats.Box(bounds[:3], bounds[3:], only_fissionable=True)
-settings.source = openmc.source.Source(space=uniform_dist)
+settings.source = openmc.IndependentSource(space=uniform_dist)
 
 entropy_mesh = openmc.RegularMesh()
 entropy_mesh.lower_left = [-0.39218, -0.39218, -1.e50]

--- a/examples/pincell_multigroup/build_xml.py
+++ b/examples/pincell_multigroup/build_xml.py
@@ -114,7 +114,7 @@ settings.particles = 1000
 lower_left = (-pitch/2, -pitch/2, -1)
 upper_right = (pitch/2, pitch/2, 1)
 uniform_dist = openmc.stats.Box(lower_left, upper_right, only_fissionable=True)
-settings.source = openmc.source.Source(space=uniform_dist)
+settings.source = openmc.IndependentSource(space=uniform_dist)
 settings.export_to_xml()
 
 ###############################################################################

--- a/tests/unit_tests/weightwindows/test_ww_gen.py
+++ b/tests/unit_tests/weightwindows/test_ww_gen.py
@@ -62,7 +62,7 @@ def model():
     # 10 keV neutron point source at the origin
     space = openmc.stats.Point()
     energy = openmc.stats.Discrete(x=[1e4], p=[1.0])
-    settings.source = openmc.Source(space=space, energy=energy)
+    settings.source = openmc.IndependentSource(space=space, energy=energy)
 
     return openmc.Model(geometry=geometry, settings=settings)
 


### PR DESCRIPTION

# Description

This PR updates the source definitions based on #2524 in our `examples/` directory to a) remove warnings from the use of the deprecated `Source` class and use `IndependentSource` instead and b) update from `Source` to `CompiledSource` in the case of the custom source routine examples. 

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
~- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)~ N/A
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
~- [ ] I have made corresponding changes to the documentation (if applicable)~ N/A
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

I'll claim that the examples themselves are the tests in this case.