### PR TITLE
Option units for geometry plot

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -303,7 +303,7 @@ class Universe(UniverseBase):
 
     def plot(self, origin=None, width=None, pixels=40000,
              basis='xy', color_by='cell', colors=None, seed=None,
-             openmc_exec='openmc', axes=None, legend=False,
+             openmc_exec='openmc', axes=None, legend=False, axis_units='cm',
              legend_kwargs=_default_legend_kwargs, outline=False,
              **kwargs):
         """Display a slice plot of the universe.
@@ -377,13 +377,13 @@ class Universe(UniverseBase):
         # Determine extents of plot
         if basis == 'xy':
             x, y = 0, 1
-            xlabel, ylabel = 'x [cm]', 'y [cm]'
+            xlabel, ylabel = f'x [{axis_units}]', f'y [{axis_units}]'
         elif basis == 'yz':
             x, y = 1, 2
-            xlabel, ylabel = 'y [cm]', 'z [cm]'
+            xlabel, ylabel = f'y [{axis_units}]', f'z [{axis_units}]'
         elif basis == 'xz':
             x, y = 0, 2
-            xlabel, ylabel = 'x [cm]', 'z [cm]'
+            xlabel, ylabel = f'x [{axis_units}]', f'z [{axis_units}]'
 
         bb = self.bounding_box
         # checks to see if bounding box contains -inf or inf values
@@ -408,10 +408,12 @@ class Universe(UniverseBase):
             pixels_y = math.sqrt(pixels / aspect_ratio)
             pixels = (int(pixels / pixels_y), int(pixels_y))
 
-        x_min = origin[x] - 0.5*width[0]
-        x_max = origin[x] + 0.5*width[0]
-        y_min = origin[y] - 0.5*width[1]
-        y_max = origin[y] + 0.5*width[1]
+        axis_scaling_factor = {'km': 0.00001, 'm': 0.01, 'cm': 1, 'mm': 10}
+
+        x_min = (origin[x] - 0.5*width[0]) * axis_scaling_factor[axis_units]
+        x_max = (origin[x] + 0.5*width[0]) * axis_scaling_factor[axis_units]
+        y_min = (origin[y] - 0.5*width[1]) * axis_scaling_factor[axis_units]
+        y_max = (origin[y] + 0.5*width[1]) * axis_scaling_factor[axis_units]
 
         with TemporaryDirectory() as tmpdir:
             model = openmc.Model()

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -361,6 +361,10 @@ class Universe(UniverseBase):
             Whether outlines between color boundaries should be drawn
 
             .. versionadded:: 0.13.4
+        axis_units : {'km', 'm', 'cm', 'mm'}
+            Units used on the plot axis, the default is cm
+
+            .. versionadded:: 0.13.4
         **kwargs
             Keyword arguments passed to :func:`matplotlib.pyplot.imshow`
 

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -362,7 +362,7 @@ class Universe(UniverseBase):
 
             .. versionadded:: 0.13.4
         axis_units : {'km', 'm', 'cm', 'mm'}
-            Units used on the plot axis, the default is cm
+            Units used on the plot axis
 
             .. versionadded:: 0.13.4
         **kwargs


### PR DESCRIPTION
# Description

It would be handy for people with large models to be able to plot geometry with different units. The default is still cm so this won't break anything for existing scripts. I have a few models where meters would be ideal so I would just add ```axis_units='m'``` to the arguments. Is there any chance we can allow axis units on the ```universe.plot```?

Fixes # (issue)
No issue sorry

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
