### PR TITLE
Change "update_params" to "update_parameters" in test suite: test_ww_gen.py

### DIFF
--- a/tests/unit_tests/weightwindows/test_ww_gen.py
+++ b/tests/unit_tests/weightwindows/test_ww_gen.py
@@ -230,8 +230,8 @@ def test_ww_gen_roundtrip(run_in_tmpdir, model):
 
     wwg = openmc.WeightWindowGenerator(mesh, energy_bounds, particle_type)
     wwg.update_parameters = {'ratio' : 5.0,
-                            'threshold': 0.8,
-                            'value' : 'mean'}
+                             'threshold': 0.8,
+                             'value' : 'mean'}
 
     model.settings.weight_window_generators = wwg
     model.export_to_xml()

--- a/tests/unit_tests/weightwindows/test_ww_gen.py
+++ b/tests/unit_tests/weightwindows/test_ww_gen.py
@@ -230,8 +230,8 @@ def test_ww_gen_roundtrip(run_in_tmpdir, model):
 
     wwg = openmc.WeightWindowGenerator(mesh, energy_bounds, particle_type)
     wwg.update_parameters = {'ratio' : 5.0,
-                         'threshold': 0.8,
-                         'value' : 'mean'}
+                            'threshold': 0.8,
+                            'value' : 'mean'}
 
     model.settings.weight_window_generators = wwg
     model.export_to_xml()

--- a/tests/unit_tests/weightwindows/test_ww_gen.py
+++ b/tests/unit_tests/weightwindows/test_ww_gen.py
@@ -229,7 +229,7 @@ def test_ww_gen_roundtrip(run_in_tmpdir, model):
     particle_type = 'neutron'
 
     wwg = openmc.WeightWindowGenerator(mesh, energy_bounds, particle_type)
-    wwg.update_params = {'ratio' : 5.0,
+    wwg.update_parameters = {'ratio' : 5.0,
                          'threshold': 0.8,
                          'value' : 'mean'}
 


### PR DESCRIPTION
On line 232 of test_ww_gen.py, an "update_params" variable associated with the weight window generator is set, whereas an "update_parameters" variable is expected according to the openmc.WeightWindowGenerator documentation. In this branch I have corrected the variable name such that the ratio, threshold, and value may be specified.

# Checklist

- [x] I have performed a self-review of my own code
