### PR TITLE
Fix R < r torus intersection bug

### DIFF
--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -971,7 +971,11 @@ double torus_distance(double x1, double x2, double x3, double u1, double u2,
   for (int i = 0; i < 4; ++i) {
     if (roots[i].imag() == 0) {
       double root = roots[i].real();
-      if (root > cutoff && root < distance) {
+      double s1 = x1 + u1 * root;
+      double s2 = x2 + u2 * root;
+      double s3 = x3 + u3 * root;
+      double check = D * s3 * s3 + s1 * s1 + s2 * s2 + A * A - C * C;
+      if (root > cutoff && root < distance && check >= 0) {
         distance = root;
       }
     }

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -972,7 +972,7 @@ double torus_distance(double x1, double x2, double x3, double u1, double u2,
     if (roots[i].imag() == 0) {
       double root = roots[i].real();
       if (root > cutoff && root < distance) {
-        # Avoid roots corresponding to internal surfaces
+        // Avoid roots corresponding to internal surfaces
         double s1 = x1 + u1 * root;
         double s2 = x2 + u2 * root;
         double s3 = x3 + u3 * root;

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -971,12 +971,15 @@ double torus_distance(double x1, double x2, double x3, double u1, double u2,
   for (int i = 0; i < 4; ++i) {
     if (roots[i].imag() == 0) {
       double root = roots[i].real();
-      double s1 = x1 + u1 * root;
-      double s2 = x2 + u2 * root;
-      double s3 = x3 + u3 * root;
-      double check = D * s3 * s3 + s1 * s1 + s2 * s2 + A * A - C * C;
-      if (root > cutoff && root < distance && check >= 0) {
-        distance = root;
+      if (root > cutoff && root < distance) {
+        # Avoid roots corresponding to internal surfaces
+        double s1 = x1 + u1 * root;
+        double s2 = x2 + u2 * root;
+        double s3 = x3 + u3 * root;
+        double check = D * s3 * s3 + s1 * s1 + s2 * s2 + A * A - C * C;
+        if (check >= 0) {
+          distance = root;
+        }
       }
     }
   }


### PR DESCRIPTION
# Description
In the case when R < r the inner "imaginary" surfaces created an additional source of scattering close to the center of the torus. This error occurred due to the lack of a check in the solution of the torus equation. If we describe the equation in more detail, we obtain the following: 
![image](https://github.com/openmc-dev/openmc/assets/60288416/8d1263a9-2280-4188-9671-072fead4f726) 
We see that the left part should obviously be greater than or equal to zero. 
As a result of OpenMC with these geometry parameters ([torus_test_xml.tar.gz](https://github.com/openmc-dev/openmc/files/11958502/torus_test_xml.tar.gz)), there is an anomaly in the form of surfaces inside, which in fact should not be:
![bad_torus](https://github.com/openmc-dev/openmc/assets/60288416/ab2a8605-4657-48f1-9d53-ec7a229885f9)

This check was missing in the code of surface.cpp file and was added in lines 974-978. After fixing this error, the torus image looks correct:
![torus_good](https://github.com/openmc-dev/openmc/assets/60288416/16e7b720-e20b-4be5-bde2-d01351df4412)

This is probably not a common problem, but I encountered it when calculating heat in one of the projects, where there was an anomalous surface where it should not be.
Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
