### PR TITLE
Fix for muir std. dev.

### DIFF
--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -747,7 +747,7 @@ def muir(e0, m_rat, kt):
 
     """
     # https://permalink.lanl.gov/object/tr?what=info:lanl-repo/lareport/LA-05411-MS
-    std_dev = math.sqrt(4 * e0 * kt / m_rat)
+    std_dev = math.sqrt(2 * e0 * kt / m_rat)
     return Normal(e0, std_dev)
 
 


### PR DESCRIPTION
# Description
Contains a fix for the standard deviation of the Muir distribution provided in `openmc.stats`.

Fixes # (issue)

Resovles #2597.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
