### PR TITLE
Check for zero fission cross section before sampling fission reaction

### DIFF
--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -106,7 +106,7 @@ void sample_neutron_reaction(Particle& p)
 
   const auto& nuc {data::nuclides[i_nuclide]};
 
-  if (nuc->fissionable_) {
+  if (nuc->fissionable_ && p.neutron_xs(i_nuclide).fission > 0.0) {
     auto& rx = sample_fission(i_nuclide, p);
     if (settings::run_mode == RunMode::EIGENVALUE) {
       create_fission_sites(p, i_nuclide, rx);


### PR DESCRIPTION
# Description

As described in #2599, OpenMC runs into problems when a threshold fission reaction is present. Specifically, in the following lines:
https://github.com/openmc-dev/openmc/blob/3f9cd0d7cb982428295cff25963f4ee2726d34a9/src/physics.cpp#L109-L110
we assume that if a nuclide is fissionable, we can sample a fission reaction. Normally there is just a single fission reaction so the sampling step is trivial, but when you have first-chance, second-chance, etc. fission, it's necessary to pick one of them for the sake of producing fission neutrons. This happens with Pu244 in JEFF 3.3 which both has threshold fission where the fission cross section is 0 below a cutoff and has multiple fission reactions. In this case, for energies below the cutoff, OpenMC will abort with:
```
terminate called after throwing an instance of 'std::runtime_error'
what(): No fission reaction was sampled for Pu244
```

The fix here is to simply check if the total fission cross section is non-zero before calling `sample_fission`.

Fixes #2599

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>

Note that none of the data in the cross section library we use for testing has this condition, so I couldn't really add a test for it.
