### PR TITLE
allowing geometry to be fully made via constructor

### DIFF
--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -41,7 +41,7 @@ class Geometry:
 
     def __init__(
         self,
-        root : openmc.UniverseBase = None,
+        root: typing.Optional[openmc.UniverseBase] = None,
         merge_surfaces: bool = False,
         surface_precision: int = 10
     ):

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -39,7 +39,12 @@ class Geometry:
 
     """
 
-    def __init__(self, root : openmc.UniverseBase = None, merge_surfaces: bool = False, surface_precision: int = 10):
+    def __init__(
+        self,
+        root : openmc.UniverseBase = None,
+        merge_surfaces: bool = False,
+        surface_precision: int = 10
+    ):
         self._root_universe = None
         self._offsets = {}
         self.merge_surfaces = merge_surfaces

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -23,6 +23,8 @@ class Geometry:
     root : openmc.UniverseBase or Iterable of openmc.Cell, optional
         Root universe which contains all others, or an iterable of cells that
         should be used to create a root universe.
+    **kwargs : dict, optional
+        Any keyword arguments are used to set attributes on the instance.
 
     Attributes
     ----------
@@ -39,7 +41,7 @@ class Geometry:
 
     """
 
-    def __init__(self, root=None):
+    def __init__(self, root=None, **kwargs):
         self._root_universe = None
         self._offsets = {}
         self.merge_surfaces = False
@@ -52,6 +54,9 @@ class Geometry:
                 for cell in root:
                     univ.add_cell(cell)
                 self._root_universe = univ
+
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
     @property
     def root_universe(self) -> openmc.UniverseBase:

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -23,8 +23,6 @@ class Geometry:
     root : openmc.UniverseBase or Iterable of openmc.Cell, optional
         Root universe which contains all others, or an iterable of cells that
         should be used to create a root universe.
-    **kwargs : dict, optional
-        Any keyword arguments are used to set attributes on the instance.
 
     Attributes
     ----------
@@ -41,11 +39,11 @@ class Geometry:
 
     """
 
-    def __init__(self, root=None, **kwargs):
+    def __init__(self, root : openmc.UniverseBase = None, merge_surfaces: bool = False, surface_precision: int = 10):
         self._root_universe = None
         self._offsets = {}
-        self.merge_surfaces = False
-        self.surface_precision = 10
+        self.merge_surfaces = merge_surfaces
+        self.surface_precision = surface_precision
         if root is not None:
             if isinstance(root, openmc.UniverseBase):
                 self.root_universe = root
@@ -54,9 +52,6 @@ class Geometry:
                 for cell in root:
                     univ.add_cell(cell)
                 self._root_universe = univ
-
-        for key, value in kwargs.items():
-            setattr(self, key, value)
 
     @property
     def root_universe(self) -> openmc.UniverseBase:

--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -362,8 +362,13 @@ def test_remove_redundant_surfaces():
     clad = get_cyl_cell(r1, r2, z1, z2, m2)
     water = get_cyl_cell(r2, r3, z1, z2, m3)
     root = openmc.Universe(cells=[fuel, clad, water])
-    geom = openmc.Geometry(root)
-    geom.merge_surfaces=True
+    geom = openmc.Geometry(root=root, merge_surfaces=True, surface_precision=11)
+    assert geom.merge_surfaces is True
+    geom.merge_surfaces = False
+    assert geom.merge_surfaces is False
+    assert geom.surface_precision == 11
+    geom.surface_precision = 10
+    assert geom.surface_precision == 10
     model = openmc.model.Model(geometry=geom,
                                materials=openmc.Materials([m1, m2, m3]))
 


### PR DESCRIPTION
Hoping to contribute to @eepeterson mission of being able to entirely make the classes through the constructor. I thought I should have a go at allowing the geometry class to be specified through the constructor.

# Checklist

- [x] I have performed a self-review of my own code
<s> - [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable) </s> 
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

I have added tests and run pytest with the ```pytest tests/unit_tests/test_geometry.py``` as the openmc.Geometry is the class that has been changed.