### PR TITLE
Adding bounding box to spherical mesh

### DIFF
--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -45,7 +45,7 @@ def test_mesh_regular_mesh_bounding_box():
 
 
 def test_mesh_spherical_mesh_bounding_box():
-    # test with mesh at 0,0,0 origin
+    # test with mesh at origin at 0,0,0
     mesh = openmc.SphericalMesh()
     mesh.r_grid = np.array([0.1, 0.2, 0.5, 1.])
     mesh.origin = (0, 0, 0)

--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -44,3 +44,12 @@ def test_mesh_bounding_box():
     np.testing.assert_array_equal(bb.lower_left, np.array([-2, -3 ,-5]))
     np.testing.assert_array_equal(bb.upper_right, np.array([2, 3, 5]))
 
+def test_mesh_spherical_upper_right():
+    mesh = openmc.SphericalMesh()
+    mesh.r_grid = np.array([1.0])
+    mesh.origin = (0,0,0)
+    assert mesh.upper_right == (1.,1.,1.)
+    assert mesh.lower_left == (-1.,-1.,-1.)
+    mesh.origin = (3, 5, 7)
+    assert mesh.upper_right == (4,6,8)
+    assert mesh.lower_left == (2,4,6)


### PR DESCRIPTION


# Description
Adapted computation of lower_left and upper_right coordinates for spherical mesh objects. Tested against BoundingBox class

Fixes # 2550

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
