### PR TITLE
Adding ability to set additional ww attrs from openmc.lib

### DIFF
--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -191,6 +191,14 @@ int openmc_weight_windows_get_bounds(int32_t index, const double** lower_bounds,
   const double** upper_bounds, size_t* size);
 int openmc_weight_windows_set_bounds(int32_t index, const double* lower_bounds,
   const double* upper_bounds, size_t size);
+int openmc_weight_windows_get_survival_ratio( int32_t index, double* ratio);
+int openmc_weight_windows_set_survival_ratio(int32_t index, double ratio);
+int openmc_weight_windows_get_max_lower_bound_ratio( int32_t index, double* lb_ratio);
+int openmc_weight_windows_set_max_lower_bound_ratio(int32_t index, double lb_ratio);
+int openmc_weight_windows_get_weight_cutoff( int32_t index, double* cutoff);
+int openmc_weight_windows_set_weight_cutoff(int32_t index, double cutoff);
+int openmc_weight_windows_get_max_split( int32_t index, int* max_split);
+int openmc_weight_windows_set_max_split(int32_t index, int max_split);
 size_t openmc_weight_windows_size();
 int openmc_weight_windows_export(const char* filename = nullptr);
 int openmc_weight_windows_import(const char* filename = nullptr);

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -191,13 +191,15 @@ int openmc_weight_windows_get_bounds(int32_t index, const double** lower_bounds,
   const double** upper_bounds, size_t* size);
 int openmc_weight_windows_set_bounds(int32_t index, const double* lower_bounds,
   const double* upper_bounds, size_t size);
-int openmc_weight_windows_get_survival_ratio( int32_t index, double* ratio);
+int openmc_weight_windows_get_survival_ratio(int32_t index, double* ratio);
 int openmc_weight_windows_set_survival_ratio(int32_t index, double ratio);
-int openmc_weight_windows_get_max_lower_bound_ratio( int32_t index, double* lb_ratio);
-int openmc_weight_windows_set_max_lower_bound_ratio(int32_t index, double lb_ratio);
-int openmc_weight_windows_get_weight_cutoff( int32_t index, double* cutoff);
+int openmc_weight_windows_get_max_lower_bound_ratio(
+  int32_t index, double* lb_ratio);
+int openmc_weight_windows_set_max_lower_bound_ratio(
+  int32_t index, double lb_ratio);
+int openmc_weight_windows_get_weight_cutoff(int32_t index, double* cutoff);
 int openmc_weight_windows_set_weight_cutoff(int32_t index, double cutoff);
-int openmc_weight_windows_get_max_split( int32_t index, int* max_split);
+int openmc_weight_windows_get_max_split(int32_t index, int* max_split);
 int openmc_weight_windows_set_max_split(int32_t index, int max_split);
 size_t openmc_weight_windows_size();
 int openmc_weight_windows_export(const char* filename = nullptr);

--- a/include/openmc/weight_windows.h
+++ b/include/openmc/weight_windows.h
@@ -155,6 +155,22 @@ public:
 
   void set_particle_type(ParticleType p_type);
 
+  double survival_ratio() const { return survival_ratio_; }
+
+  double& survival_ratio() { return survival_ratio_; }
+
+  double max_lower_bound_ratio() const { return max_lb_ratio_; }
+
+  double& max_lower_bound_ratio() { return max_lb_ratio_; }
+
+  int max_split() const { return max_split_; }
+
+  int& max_split() { return max_split_; }
+
+  double weight_cutoff() const { return weight_cutoff_; }
+
+  double& weight_cutoff() { return weight_cutoff_; }
+
   //----------------------------------------------------------------------------
   // Accessors
   int32_t id() const { return id_; }

--- a/openmc/lib/weight_windows.py
+++ b/openmc/lib/weight_windows.py
@@ -69,6 +69,38 @@ _dll.openmc_weight_windows_get_bounds.argtypes = [c_int32, POINTER(POINTER(c_dou
 _dll.openmc_weight_windows_get_bounds.restype = c_int
 _dll.openmc_weight_windows_get_bounds.errcheck = _error_handler
 
+_dll.openmc_weight_windows_get_survival_ratio.argtypes = [c_int32, POINTER(c_double)]
+_dll.openmc_weight_windows_get_survival_ratio.restype = c_int
+_dll.openmc_weight_windows_get_survival_ratio.errcheck = _error_handler
+
+_dll.openmc_weight_windows_set_survival_ratio.argtypes = [c_int32, c_double]
+_dll.openmc_weight_windows_set_survival_ratio.restype = c_int
+_dll.openmc_weight_windows_set_survival_ratio.errcheck = _error_handler
+
+_dll.openmc_weight_windows_get_max_lower_bound_ratio.argtypes = [c_int32, POINTER(c_double)]
+_dll.openmc_weight_windows_get_max_lower_bound_ratio.restype = c_int
+_dll.openmc_weight_windows_get_max_lower_bound_ratio.errcheck = _error_handler
+
+_dll.openmc_weight_windows_set_max_lower_bound_ratio.argtypes = [c_int32, c_double]
+_dll.openmc_weight_windows_set_max_lower_bound_ratio.restype = c_int
+_dll.openmc_weight_windows_set_max_lower_bound_ratio.errcheck = _error_handler
+
+_dll.openmc_weight_windows_get_weight_cutoff.argtypes = [c_int32, POINTER(c_double)]
+_dll.openmc_weight_windows_get_weight_cutoff.restype = c_int
+_dll.openmc_weight_windows_get_weight_cutoff.errcheck = _error_handler
+
+_dll.openmc_weight_windows_set_weight_cutoff.argtypes = [c_int32, c_double]
+_dll.openmc_weight_windows_set_weight_cutoff.restype = c_int
+_dll.openmc_weight_windows_set_weight_cutoff.errcheck = _error_handler
+
+_dll.openmc_weight_windows_get_max_split.argtypes = [c_int32, POINTER(c_int)]
+_dll.openmc_weight_windows_get_max_split.restype = c_int
+_dll.openmc_weight_windows_get_max_split.errcheck = _error_handler
+
+_dll.openmc_weight_windows_set_max_split.argtypes = [c_int32, c_int]
+_dll.openmc_weight_windows_set_max_split.restype = c_int
+_dll.openmc_weight_windows_set_max_split.errcheck = _error_handler
+
 
 class WeightWindows(_FortranObjectWithID):
     """WeightWindows stored internally.
@@ -200,6 +232,46 @@ class WeightWindows(_FortranObjectWithID):
         upper_p = upper.ctypes.data_as(POINTER(c_double))
 
         _dll.openmc_weight_windows_set_bounds(self._index, lower_p, upper_p, lower.size)
+
+    @property
+    def survival_ratio(self):
+        ratio = c_double()
+        _dll.openmc_weight_windows_get_survival_ratio(self._index, ratio)
+        return ratio.value
+
+    @survival_ratio.setter
+    def survival_ratio(self, ratio):
+        _dll.openmc_weight_windows_set_survival_ratio(self._index, ratio)
+
+    @property
+    def max_lower_bound_ratio(self):
+        lb_ratio = c_double()
+        _dll.openmc_weight_windows_get_max_lower_bound_ratio(self._index, lb_ratio)
+        return lb_ratio.value
+
+    @max_lower_bound_ratio.setter
+    def max_lower_bound_ratio(self, lb_ratio):
+        _dll.openmc_weight_windows_set_max_lower_bound_ratio(self._index, lb_ratio)
+
+    @property
+    def weight_cutoff(self):
+        cutoff = c_double()
+        _dll.openmc_weight_windows_get_weight_cutoff(self._index, cutoff)
+        return cutoff.value
+
+    @weight_cutoff.setter
+    def weight_cutoff(self, cutoff):
+        _dll.openmc_weight_windows_set_weight_cutoff(self._index, cutoff)
+
+    @property
+    def max_split(self):
+        max_split = c_int()
+        _dll.openmc_weight_windows_get_max_split(self._index, max_split)
+        return max_split.value
+
+    @max_split.setter
+    def max_split(self, max_split):
+        _dll.openmc_weight_windows_set_max_split(self._index, max_split)
 
     def update_magic(self, tally, value='mean', threshold=1.0, ratio=5.0):
         """Update weight window values using the MAGIC method

--- a/openmc/weight_windows.py
+++ b/openmc/weight_windows.py
@@ -166,6 +166,7 @@ class WeightWindows(IDManagerMixin):
         string += '{: <16}=\t{}\n'.format('\tMesh', self.mesh)
         string += '{: <16}=\t{}\n'.format('\tParticle Type', self._particle_type)
         string += '{: <16}=\t{}\n'.format('\tEnergy Bounds', self._energy_bounds)
+        string += '{: <16}=\t{}\n'.format('\tMax lower bound ratio', self.max_lower_bound_ratio)
         string += '{: <16}=\t{}\n'.format('\tLower WW Bounds', self._lower_ww_bounds)
         string += '{: <16}=\t{}\n'.format('\tUpper WW Bounds', self._upper_ww_bounds)
         string += '{: <16}=\t{}\n'.format('\tSurvival Ratio', self._survival_ratio)

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -1095,8 +1095,7 @@ extern "C" int openmc_weight_windows_get_max_split(
   return 0;
 }
 
-extern "C" int openmc_weight_windows_set_max_split(
-  int32_t index, int max_split)
+extern "C" int openmc_weight_windows_set_max_split(int32_t index, int max_split)
 {
   if (int err = verify_ww_index(index))
     return err;

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -1024,6 +1024,87 @@ extern "C" int openmc_weight_windows_set_bounds(int32_t index,
   return 0;
 }
 
+extern "C" int openmc_weight_windows_get_survival_ratio(
+  int32_t index, double* ratio)
+{
+  if (int err = verify_ww_index(index))
+    return err;
+  const auto& wws = variance_reduction::weight_windows[index];
+  *ratio = wws->survival_ratio();
+  return 0;
+}
+
+extern "C" int openmc_weight_windows_set_survival_ratio(
+  int32_t index, double ratio)
+{
+  if (int err = verify_ww_index(index))
+    return err;
+  const auto& wws = variance_reduction::weight_windows[index];
+  wws->survival_ratio() = ratio;
+  std::cout << "Survival ratio: " << wws->survival_ratio() << std::endl;
+  return 0;
+}
+
+extern "C" int openmc_weight_windows_get_max_lower_bound_ratio(
+  int32_t index, double* lb_ratio)
+{
+  if (int err = verify_ww_index(index))
+    return err;
+  const auto& wws = variance_reduction::weight_windows[index];
+  *lb_ratio = wws->max_lower_bound_ratio();
+  return 0;
+}
+
+extern "C" int openmc_weight_windows_set_max_lower_bound_ratio(
+  int32_t index, double lb_ratio)
+{
+  if (int err = verify_ww_index(index))
+    return err;
+  const auto& wws = variance_reduction::weight_windows[index];
+  wws->max_lower_bound_ratio() = lb_ratio;
+  return 0;
+}
+
+extern "C" int openmc_weight_windows_get_weight_cutoff(
+  int32_t index, double* cutoff)
+{
+  if (int err = verify_ww_index(index))
+    return err;
+  const auto& wws = variance_reduction::weight_windows[index];
+  *cutoff = wws->weight_cutoff();
+  return 0;
+}
+
+extern "C" int openmc_weight_windows_set_weight_cutoff(
+  int32_t index, double cutoff)
+{
+  if (int err = verify_ww_index(index))
+    return err;
+  const auto& wws = variance_reduction::weight_windows[index];
+  wws->weight_cutoff() = cutoff;
+  return 0;
+}
+
+extern "C" int openmc_weight_windows_get_max_split(
+  int32_t index, int* max_split)
+{
+  if (int err = verify_ww_index(index))
+    return err;
+  const auto& wws = variance_reduction::weight_windows[index];
+  *max_split = wws->max_split();
+  return 0;
+}
+
+extern "C" int openmc_weight_windows_set_max_split(
+  int32_t index, int max_split)
+{
+  if (int err = verify_ww_index(index))
+    return err;
+  const auto& wws = variance_reduction::weight_windows[index];
+  wws->max_split() = max_split;
+  return 0;
+}
+
 extern "C" int openmc_extend_weight_windows(
   int32_t n, int32_t* index_start, int32_t* index_end)
 {

--- a/tests/unit_tests/weightwindows/test_ww_gen.py
+++ b/tests/unit_tests/weightwindows/test_ww_gen.py
@@ -206,18 +206,36 @@ def test_ww_import_export(run_in_tmpdir, model):
 
     lb_before, up_before = ww.bounds
 
+    # set some additional weight windows properties after transport
+    ww.survival_ratio = 0.7
+    assert ww.survival_ratio == 0.7
+
+    ww.weight_cutoff = 1e-10
+    assert ww.weight_cutoff == 1e-10
+
+    ww.max_lower_bound_ratio = 200.0
+    assert ww.max_lower_bound_ratio == 200.0
+
+    ww.max_split = 26000
+    assert ww.max_split == 26000
+
     openmc.lib.export_weight_windows()
 
     assert Path('weight_windows.h5').exists()
 
     openmc.lib.import_weight_windows('weight_windows.h5')
 
-    ww = openmc.lib.weight_windows[2]
+    imported_ww = openmc.lib.weight_windows[2]
 
-    lb_after, up_after = ww.bounds
+    lb_after, up_after = imported_ww.bounds
 
     assert np.allclose(lb_before, lb_after)
     assert np.allclose(up_before, up_after)
+
+    assert ww.survival_ratio == imported_ww.survival_ratio
+    assert ww.max_lower_bound_ratio == imported_ww.max_lower_bound_ratio
+    assert ww.weight_cutoff == imported_ww.weight_cutoff
+    assert ww.max_split == imported_ww.max_split
 
     openmc.lib.finalize()
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This adds the ability to set additional attributes of `WeightWindows` objects:

  - `survival_ratio`
  - `max_lower_bound_ratio`
  - `weight_cutoff`
  - `max_splits`

Fixes # (issue)

#2607 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
