### PR TITLE
Mesh dimension doc string to include order details

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -395,7 +395,7 @@ class StructuredMesh(MeshBase):
 
         ### Add all points to the unstructured grid, maintaining a flat list of IDs as we go ###
 
-        # flat array storind point IDs for a given vertex
+        # flat array storing point IDs for a given vertex
         # in the grid
         point_ids = []
 

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -493,7 +493,7 @@ class RegularMesh(StructuredMesh):
     name : str
         Name of the mesh
     dimension : Iterable of int
-        The number of mesh cells in each direction.
+        The number of mesh cells in each direction (x, y, z).
     n_dimension : int
         Number of mesh dimensions.
     lower_left : Iterable of float
@@ -742,7 +742,7 @@ class RegularMesh(StructuredMesh):
             bounding box of the property of the object passed will be used to
             set the lower_left and upper_right of the mesh instance
         dimension : Iterable of int
-            The number of mesh cells in each direction.
+            The number of mesh cells in each direction (x, y, z).
         mesh_id : int
             Unique identifier for the mesh
         name : str
@@ -984,7 +984,7 @@ class RectilinearMesh(StructuredMesh):
     name : str
         Name of the mesh
     dimension : Iterable of int
-        The number of mesh cells in each direction.
+        The number of mesh cells in each direction (x, y, z).
     n_dimension : int
         Number of mesh dimensions (always 3 for a RectilinearMesh).
     x_grid : numpy.ndarray
@@ -1183,7 +1183,8 @@ class CylindricalMesh(StructuredMesh):
     name : str
         Name of the mesh
     dimension : Iterable of int
-        The number of mesh cells in each direction.
+        The number of mesh cells in each direction (r_grid,
+        phi_grid, z_grid).
     n_dimension : int
         Number of mesh dimensions (always 3 for a CylindricalMesh).
     r_grid : numpy.ndarray
@@ -1482,7 +1483,8 @@ class SphericalMesh(StructuredMesh):
     name : str
         Name of the mesh
     dimension : Iterable of int
-        The number of mesh cells in each direction.
+        The number of mesh cells in each direction (r_grid,
+        phi_grid, phi_grid).
     n_dimension : int
         Number of mesh dimensions (always 3 for a SphericalMesh).
     r_grid : numpy.ndarray

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1484,7 +1484,7 @@ class SphericalMesh(StructuredMesh):
         Name of the mesh
     dimension : Iterable of int
         The number of mesh cells in each direction (r_grid,
-        phi_grid, phi_grid).
+        theta_grid, phi_grid).
     n_dimension : int
         Number of mesh dimensions (always 3 for a SphericalMesh).
     r_grid : numpy.ndarray


### PR DESCRIPTION
# Description
While working through a mesh tally simulation with @rlbarker we thought it might be nice to include more details of the mesh.dimension in the doc string. We had to pop into the source code to check occasionally and it might be handy to have the mesh.dimension order in the doc string for cylindrical and spherical mesh 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
