### PR TITLE
Build h5py against Cython < 3.0 in CI

### DIFF
--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -40,7 +40,7 @@ if [[ $MPI == 'y' ]]; then
     export CC=mpicc
     export HDF5_MPI=ON
     export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich
-    pip install wheel cython
+    pip install wheel "cython<3.0"
     pip install --no-binary=h5py --no-build-isolation h5py
 fi
 


### PR DESCRIPTION
# Description

Some of you may have noticed that recent CI jobs are failing. It looks like this is due to a new release of Cython (3.0), which appears to be incompatible with the most recent release of h5py (see h5py/h5py#2268). This PR restricts the Cython version used to build h5py to get around that.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>