### PR TITLE
Add get_activity() function to deplete.Results class

### DIFF
--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -2,7 +2,7 @@ import numbers
 import bisect
 import math
 import typing  # required to prevent typing.Union namespace overwriting Union
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, Optional, Tuple, List
 from warnings import warn
 
 import h5py
@@ -101,7 +101,7 @@ class Results(list):
         units: str = "Bq/cm3",
         by_nuclide: bool = False, 
         volume: Optional[float] = None
-    ) -> Tuple[np.ndarray, typing.Union[np.ndarray, list[dict]]]:
+    ) -> Tuple[np.ndarray, typing.Union[np.ndarray, List[dict]]]:
         """Get activity of material over time.
 
         Parameters

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -101,7 +101,7 @@ class Results(list):
         units: str = "Bq/cm3",
         by_nuclide: bool = False, 
         volume: Optional[float] = None
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> Tuple[np.ndarray, typing.Union[np.ndarray, list[dict]]]:
         """Get activity of material over time.
 
         Parameters
@@ -138,7 +138,7 @@ class Results(list):
         
         times = np.empty_like(self, dtype=float)
         if by_nuclide:
-            activities = np.empty_like(self, dtype=dict)
+            activities = [None] * len(self)
         else:
             activities = np.empty_like(self, dtype=float)
 

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -111,7 +111,6 @@ class Results(list):
         units : {'Bq', 'Bq/g', 'Bq/cm3'}
             Specifies the type of activity to return, options include total
             activity [Bq], specific [Bq/g] or volumetric activity [Bq/cm3].
-            Default is volumetric activity [Bq/cm3].
         by_nuclide : bool
             Specifies if the activity should be returned for the material as a
             whole or per nuclide. Default is False.

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -95,6 +95,60 @@ class Results(list):
         )
         return cls(filename)
 
+    def get_activity(
+        self,
+        mat: typing.Union[Material, str],
+        units: str = "Bq/cm3",
+        by_nuclide: bool = False, 
+        volume: Optional[float] = None
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Get activity of material over time.
+
+        Parameters
+        ----------
+        mat : openmc.Material, str
+            Material object or material id to evaluate
+        units : {'Bq', 'Bq/g', 'Bq/cm3'}
+            Specifies the type of activity to return, options include total
+            activity [Bq], specific [Bq/g] or volumetric activity [Bq/cm3].
+            Default is volumetric activity [Bq/cm3].
+        by_nuclide : bool
+            Specifies if the activity should be returned for the material as a
+            whole or per nuclide. Default is False.
+        volume : float, optional
+            Volume of the material. If not passed, defaults to using the
+            :attr:`Material.volume` attribute.
+
+        Returns
+        -------
+        times : numpy.ndarray
+            Array of times in [s]
+        activities : numpy.ndarray
+            Array of total activities if by_nuclide = False (default)
+            or array of dictionaries of activities by nuclide if
+            by_nuclide = True.
+            
+        """
+        if isinstance(mat, Material):
+            mat_id = str(mat.id)
+        elif isinstance(mat, str):
+            mat_id = mat
+        else:
+            raise TypeError('mat should be of type openmc.Material or str')
+        
+        times = np.empty_like(self, dtype=float)
+        if by_nuclide:
+            activities = np.empty_like(self, dtype=dict)
+        else:
+            activities = np.empty_like(self, dtype=float)
+
+        # Evaluate activity for each depletion time
+        for i, result in enumerate(self):
+            times[i] = result.time[0]
+            activities[i] = result.get_material(mat_id).get_activity(units, by_nuclide, volume)
+        
+        return times, activities
+
     def get_atoms(
         self,
         mat: typing.Union[Material, str],

--- a/tests/unit_tests/test_deplete_resultslist.py
+++ b/tests/unit_tests/test_deplete_resultslist.py
@@ -31,9 +31,7 @@ def test_get_activity(res):
         [2.106574218e+05, 1.227519888e+11, 1.177491828e+11, 1.031986176e+11])
     t_nuc, a_nuc = res.get_activity("1", by_nuclide=True)
     
-    a_xe135 = np.empty_like(a_nuc, dtype=float)
-    for idx in range(0, len(a_nuc)):
-        a_xe135[idx] = a_nuc[idx]["Xe135"]
+    a_xe135 = np.array([a_nuc_i["Xe135"] for a_nuc_i in a_nuc])
 
     np.testing.assert_allclose(t_nuc, t_ref)
     np.testing.assert_allclose(a_xe135, a_xe135_ref)

--- a/tests/unit_tests/test_deplete_resultslist.py
+++ b/tests/unit_tests/test_deplete_resultslist.py
@@ -15,6 +15,29 @@ def res():
                 / 'test_reference.h5')
     return openmc.deplete.Results(filename)
 
+def test_get_activity(res):
+    """Tests evaluating activity"""
+    t, a = res.get_activity("1")
+
+    t_ref = np.array([0.0, 1296000.0, 2592000.0, 3888000.0])
+    a_ref = np.array(
+        [1.25167956e+06, 3.71938527e+11, 4.43264300e+11, 3.55547176e+11])
+
+    np.testing.assert_allclose(t, t_ref)
+    np.testing.assert_allclose(a, a_ref)
+
+    # Check by_nuclide
+    a_xe135_ref = np.array(
+        [2.106574218e+05, 1.227519888e+11, 1.177491828e+11, 1.031986176e+11])
+    t_nuc, a_nuc = res.get_activity("1", by_nuclide=True)
+    
+    a_xe135 = np.empty_like(a_nuc, dtype=float)
+    for idx in range(0, len(a_nuc)):
+        a_xe135[idx] = a_nuc[idx]["Xe135"]
+
+    np.testing.assert_allclose(t_nuc, t_ref)
+    np.testing.assert_allclose(a_xe135, a_xe135_ref)
+
 
 def test_get_atoms(res):
     """Tests evaluating single nuclide concentration."""


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Hello, this PR is to add a function get_activity() to the deplete.Results class to get the activity of a depletable material at the different time steps of a depletion run. It follows a similar format to some of the other functions in the deplete.Results class, such as get_atoms() and get_mass(). It works by calling the Material.get_activity() function for the specified material at the different time steps. 

I found this capability useful, so I thought I would share it. Please let me know what you think! I am happy to hear feedback and make changes as needed.

Thank you!

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
