### PR TITLE
Fix close surfaces bug

### DIFF
--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -203,6 +203,7 @@ void Particle::event_advance()
   double distance = std::min(boundary().distance, collision_distance());
 
   // Advance particle in space and time
+  distance = std::max(distance, 1.e-12);
   for (int j = 0; j < n_coord(); ++j) {
     coord(j).r += distance * coord(j).u;
   }


### PR DESCRIPTION
The problem manifests itself when two surfaces overlap, such as two spheres at the origin with the same radius. If you put the source in the center of the spheres, OpenMC will take a very long time to calculate the intersection of these surfaces by a particle, which significantly reduces performance. In the same conditions between MCNP and OpenMC there will be about 200 times difference in simulation time. 
If we use a debugger, it becomes clear that the function that determines the distance traveled by the particle determines the value of the distance traveled between the spheres as ~1e-16, which is less than the computational error. 
I am not sure that my solution to the problem in this case is universal, but I was able to achieve a significant performance improvement for the tasks I need. The point is that in the src/particle.cpp file in line 206 we can set the distance parameter so that a result less than 1e-12 is not considered further. Since 1e-12 meters is less than the size of an atom, it is unlikely that a distance less than an atom will be encountered. 
I'm sure we can come up with a more universal solution to this problem, for example, by removing repeating surfaces beforehand, but at the moment I can only see such a solution to the problem.


Before:
 =======================>     TIMING STATISTICS     <=======================
 Total time for initialization     = 1.4792e-02 seconds
   Reading cross sections          = 1.1796e-04 seconds
 Total time in simulation          = 1.0215e+02 seconds
   Time in transport only          = 1.0215e+02 seconds
   Time in active batches          = 1.0215e+02 seconds
   Time accumulating tallies       = 2.4692e-05 seconds
   Time writing statepoints        = 1.8115e-03 seconds
 Total time for finalization       = 3.5190e-06 seconds
 Total time elapsed                = 1.0216e+02 seconds
 Calculation Rate (active)         = 97896.6 particles/second
 ============================>     RESULTS     <============================

After:
 =======================>     TIMING STATISTICS     <=======================
 Total time for initialization     = 1.3530e-02 seconds
   Reading cross sections          = 1.2147e-04 seconds
 Total time in simulation          = 8.5538e+01 seconds
   Time in transport only          = 8.5536e+01 seconds
   Time in active batches          = 8.5538e+01 seconds
   Time accumulating tallies       = 1.7564e-05 seconds
   Time writing statepoints        = 1.8315e-03 seconds
 Total time for finalization       = 2.6580e-06 seconds
 Total time elapsed                = 8.5552e+01 seconds
 Calculation Rate (active)         = 116907 particles/second
 ============================>     RESULTS     <============================


