### PR TITLE
Fix mention of cmake flag in troubleshooting guide

### DIFF
--- a/docs/source/usersguide/troubleshoot.rst
+++ b/docs/source/usersguide/troubleshoot.rst
@@ -28,7 +28,7 @@ commands:
 .. code-block:: sh
 
     mkdir build-debug && cd build-debug
-    cmake -Ddebug=on /path/to/openmc
+    cmake -DCMAKE_BUILD_TYPE=Debug /path/to/openmc
     make
 
 Now when you re-run your problem, it should report exactly where the program


### PR DESCRIPTION
# Description

There was an outdated mention of `-Ddebug=on` in the troubleshooting guide. This PR fixes it (fixes #2615).

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>
