### PR TITLE
XML read fixes in Plot classes

### DIFF
--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -11,7 +11,7 @@ import openmc
 import openmc.checkvalue as cv
 from openmc.checkvalue import PathLike
 
-from ._xml import clean_indentation, get_elem_tuple, reorder_attributes
+from ._xml import clean_indentation, get_elem_tuple, reorder_attributes, get_text
 from .mixin import IDManagerMixin
 
 _BASES = ['xy', 'xz', 'yz']
@@ -482,6 +482,9 @@ class PlotBase(IDManagerMixin):
         """
 
         element = ET.Element("plot")
+        element.set("id", str(self._id))
+        if len(self._name) > 0:
+            element.set("name", str(self.name))
         if self._filename is not None:
             element.set("filename", self._filename)
         element.set("color_by", self._color_by)
@@ -782,7 +785,6 @@ class Plot(PlotBase):
         """
 
         element = super().to_xml_element()
-        element.set("id", str(self._id))
         element.set("type", self._type)
 
         if self._type == 'slice':
@@ -843,12 +845,14 @@ class Plot(PlotBase):
 
         """
         plot_id = int(elem.get("id"))
-        plot = cls(plot_id)
+        name = get_text(elem, 'name')
+        plot = cls(plot_id, name)
         if "filename" in elem.keys():
             plot.filename = elem.get("filename")
         plot.color_by = elem.get("color_by")
         plot.type = elem.get("type")
-        plot.basis = elem.get("basis")
+        if plot.type == 'slice':
+            plot.basis = elem.get("basis")
 
         plot.origin = get_elem_tuple(elem, "origin", float)
         plot.width = get_elem_tuple(elem, "width", float)
@@ -1176,7 +1180,6 @@ class ProjectionPlot(PlotBase):
         """
 
         element = super().to_xml_element()
-        element.set("id", str(self._id))
         element.set("type", "projection")
 
         subelement = ET.SubElement(element, "camera_position")
@@ -1276,7 +1279,7 @@ class ProjectionPlot(PlotBase):
 
         tmp = elem.find("orthographic_width")
         if tmp is not None:
-            self.orthographic_width = float(tmp)
+            plot.orthographic_width = float(tmp)
 
         plot.pixels = get_elem_tuple(elem, "pixels")
         plot.camera_position = get_elem_tuple(elem, "camera_position", float)

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -845,7 +845,7 @@ class Plot(PlotBase):
 
         """
         plot_id = int(elem.get("id"))
-        name = get_text(elem, 'name')
+        name = get_text(elem, 'name', '')
         plot = cls(plot_id, name)
         if "filename" in elem.keys():
             plot.filename = elem.get("filename")

--- a/tests/unit_tests/test_plots.py
+++ b/tests/unit_tests/test_plots.py
@@ -199,3 +199,25 @@ def test_plots(run_in_tmpdir):
     assert new_plots[0].colors == p1.colors
     assert new_plots[0].mask_components == p1.mask_components
     assert new_plots[1].origin == p2.origin
+
+
+def test_voxel_plot_roundtrip():
+    # Define a voxel plot and create XML element
+    plot = openmc.Plot(name='my voxel plot')
+    plot.type = 'voxel'
+    plot.filename = 'voxel1'
+    plot.pixels = (50, 50, 50)
+    plot.origin = (0., 0., 0.)
+    plot.width = (75., 75., 75.)
+    plot.color_by = 'material'
+    elem = plot.to_xml_element()
+
+    # Read back from XML and make sure it hasn't changed
+    new_plot = plot.from_xml_element(elem)
+    assert new_plot.name == plot.name
+    assert new_plot.filename == plot.filename
+    assert new_plot.type == plot.type
+    assert new_plot.pixels == plot.pixels
+    assert new_plot.origin == plot.origin
+    assert new_plot.width == plot.width
+    assert new_plot.color_by == plot.color_by


### PR DESCRIPTION
# Description

I noticed recently while generating a voxel plot that when I tried to read back a model with `Model.from_xml` that included a voxel plot, it raised an exception because it was expecting the "basis" to be set (which isn't written for a voxel plot). This PR fixes that and several other small bugs I noticed in XML read/write for Plots.

Cue @gridley telling us how much this manual XML reading/writing sucks!

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)