### PR TITLE
Transfer rates multiple destination

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -686,16 +686,16 @@ class Chain:
         dict.update(matrix_dok, matrix)
         return matrix_dok.tocsr()
 
-    def form_rr_term(self, transfer_rates, materials):
+    def form_rr_term(self, tr_rates, mats):
         """Function to form the transfer rate term matrices.
 
         .. versionadded:: 0.13.4
 
         Parameters
         ----------
-        transfer_rates : openmc.deplete.TransferRates
+        tr_rates : openmc.deplete.TransferRates
             Instance of openmc.deplete.TransferRates
-        materials : string or two-tuple of strings
+        mats : string or two-tuple of strings
             Two cases are possible:
 
             1) Material ID as string:
@@ -719,27 +719,27 @@ class Chain:
         """
         matrix = defaultdict(float)
 
-        for i, nuclide in enumerate(self.nuclides):
-            element = re.split(r'\d+', nuclide.name)[0]
+        for i, nuc in enumerate(self.nuclides):
+            elm = re.split(r'\d+', nuc.name)[0]
             # Build transfer terms matrices
-            if isinstance(materials, str):
-                material = materials
-                components = transfer_rates.get_components(material)
-                if element in components:
-                    matrix[i, i] = sum(transfer_rates.get_transfer_rate(material, element))
-                elif nuclide.name in components:
-                    matrix[i, i] = sum(transfer_rates.get_transfer_rate(material, nuclide.name))
+            if isinstance(mats, str):
+                mat = mats
+                components = tr_rates.get_components(mat)
+                if elm in components:
+                    matrix[i, i] = sum(tr_rates.get_transfer_rate(mat, elm))
+                elif nuc.name in components:
+                    matrix[i, i] = sum(tr_rates.get_transfer_rate(mat, nuc.name))
                 else:
                     matrix[i, i] = 0.0
             #Build transfer terms matrices
-            elif isinstance(materials, tuple):
-                destination_material, material = materials
-                if destination_material in transfer_rates.get_destination_material(material, element):
-                    destination_material_index = transfer_rates.get_destination_material(material, element).index(destination_material)
-                    matrix[i, i] = transfer_rates.get_transfer_rate(material, element)[destination_material_index]
-                elif destination_material in transfer_rates.get_destination_material(material, nuclide.name):
-                    destination_material_index = transfer_rates.get_destination_material(material, nuclide.name).index(destination_material)
-                    matrix[i, i] = transfer_rates.get_transfer_rate(material, nuclide.name)[destination_material_index]
+            elif isinstance(mats, tuple):
+                dest_mat, mat = mats
+                if dest_mat in tr_rates.get_destination_material(mat, elm):
+                    dest_mat_idx = tr_rates.get_destination_material(mat, elm).index(dest_mat)
+                    matrix[i, i] = tr_rates.get_transfer_rate(mat, elm)[dest_mat_idx]
+                elif dest_mat in tr_rates.get_destination_material(mat, nuc.name):
+                    dest_mat_idx = tr_rates.get_destination_material(mat, nuc.name).index(dest_mat)
+                    matrix[i, i] = tr_rates.get_transfer_rate(mat, nuc.name)[dest_mat_idx]
                 else:
                     matrix[i, i] = 0.0
             #Nothing else is allowed

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -726,18 +726,20 @@ class Chain:
                 material = materials
                 components = transfer_rates.get_components(material)
                 if element in components:
-                    matrix[i, i] = transfer_rates.get_transfer_rate(material, element)
+                    matrix[i, i] = sum(transfer_rates.get_transfer_rate(material, element))
                 elif nuclide.name in components:
-                    matrix[i, i] = transfer_rates.get_transfer_rate(material, nuclide.name)
+                    matrix[i, i] = sum(transfer_rates.get_transfer_rate(material, nuclide.name))
                 else:
                     matrix[i, i] = 0.0
             #Build transfer terms matrices
             elif isinstance(materials, tuple):
                 destination_material, material = materials
-                if transfer_rates.get_destination_material(material, element) == destination_material:
-                    matrix[i, i] = transfer_rates.get_transfer_rate(material, element)
-                elif transfer_rates.get_destination_material(material, nuclide.name) == destination_material:
-                    matrix[i, i] = transfer_rates.get_transfer_rate(material, nuclide.name)
+                if destination_material in transfer_rates.get_destination_material(material, element):
+                    destination_material_index = transfer_rates.get_destination_material(material, element).index(destination_material)
+                    matrix[i, i] = transfer_rates.get_transfer_rate(material, element)[destination_material_index]
+                elif destination_material in transfer_rates.get_destination_material(material, nuclide.name):
+                    destination_material_index = transfer_rates.get_destination_material(material, nuclide.name).index(destination_material)
+                    matrix[i, i] = transfer_rates.get_transfer_rate(material, nuclide.name)[destination_material_index]
                 else:
                     matrix[i, i] = 0.0
             #Nothing else is allowed

--- a/openmc/deplete/transfer_rates.py
+++ b/openmc/deplete/transfer_rates.py
@@ -112,7 +112,7 @@ class TransferRates:
 
         Returns
         -------
-        destination_material_id : List of str
+        destination_material_id : list of str
             Depletable material ID to where the element or nuclide gets
             transferred
 
@@ -220,10 +220,10 @@ class TransferRates:
                                          'a transfer rate.')
 
             if component in self.transfer_rates[material_id]:
-                self.transfer_rates[material_id][component].append( \
+                self.transfer_rates[material_id][component].append(
                     (transfer_rate / unit_conv, destination_material_id))
             else:
-                self.transfer_rates[material_id][component] =  \
-                    [(transfer_rate / unit_conv, destination_material_id)]
+                self.transfer_rates[material_id][component] = [
+                    (transfer_rate / unit_conv, destination_material_id)]
             if destination_material_id is not None:
                 self.index_transfer.add((destination_material_id, material_id))

--- a/openmc/deplete/transfer_rates.py
+++ b/openmc/deplete/transfer_rates.py
@@ -91,13 +91,13 @@ class TransferRates:
 
         Returns
         -------
-        transfer_rate : float
-            Transfer rate value
+        transfer_rate : list of floats
+            Transfer rate values
 
         """
         material_id = self._get_material_id(material)
         check_type('component', component, str)
-        return self.transfer_rates[material_id][component][0]
+        return [i[0] for i in self.transfer_rates[material_id][component]]
 
     def get_destination_material(self, material, component):
         """Return destination material for given material and
@@ -112,7 +112,7 @@ class TransferRates:
 
         Returns
         -------
-        destination_material_id : str
+        destination_material_id : List of str
             Depletable material ID to where the element or nuclide gets
             transferred
 
@@ -120,7 +120,9 @@ class TransferRates:
         material_id = self._get_material_id(material)
         check_type('component', component, str)
         if component in self.transfer_rates[material_id]:
-            return self.transfer_rates[material_id][component][1]
+            return [i[1] for i in self.transfer_rates[material_id][component]]
+        else:
+            return []
 
     def get_components(self, material):
         """Extract removing elements and/or nuclides for a given material
@@ -217,7 +219,11 @@ class TransferRates:
                                          f'where element {element} already has '
                                          'a transfer rate.')
 
-            self.transfer_rates[material_id][component] = \
-                transfer_rate / unit_conv, destination_material_id
+            if component in self.transfer_rates[material_id]:
+                self.transfer_rates[material_id][component].append( \
+                    (transfer_rate / unit_conv, destination_material_id))
+            else:
+                self.transfer_rates[material_id][component] =  \
+                    [(transfer_rate / unit_conv, destination_material_id)]
             if destination_material_id is not None:
                 self.index_transfer.add((destination_material_id, material_id))

--- a/tests/regression_tests/deplete_with_transfer_rates/test.py
+++ b/tests/regression_tests/deplete_with_transfer_rates/test.py
@@ -82,5 +82,5 @@ def test_transfer_rates(run_in_tmpdir, model, rate, dest_mat, power, ref_result)
     res_ref = openmc.deplete.Results(path_reference)
     res_test = openmc.deplete.Results(path_test)
 
-    assert_atoms_equal(res_ref, res_test)
+    assert_atoms_equal(res_ref, res_test, 1e-4)
     assert_reaction_rates_equal(res_ref, res_test)

--- a/tests/unit_tests/test_deplete_transfer_rates.py
+++ b/tests/unit_tests/test_deplete_transfer_rates.py
@@ -107,9 +107,9 @@ def test_get_set(model, case_name, transfer_rates):
                                                destination_material=\
                                                dest_material_input)
                     assert transfer.get_transfer_rate(
-                        material_input, component) == transfer_rate
+                        material_input, component)[0] == transfer_rate
                     assert transfer.get_destination_material(
-                        material_input, component) == str(dest_material.id)
+                        material_input, component)[0] == str(dest_material.id)
                 assert transfer.get_components(material_input) == \
                     transfer_rates.keys()
 
@@ -138,7 +138,7 @@ def test_units(transfer_rate_units, unit_conv, model):
     for component in components:
         transfer.set_transfer_rate('f', [component], transfer_rate * unit_conv,
                                    transfer_rate_units=transfer_rate_units)
-        assert transfer.get_transfer_rate('f', component) == transfer_rate
+        assert transfer.get_transfer_rate('f', component)[0] == transfer_rate
 
 
 def test_transfer(run_in_tmpdir, model):

--- a/tests/unit_tests/test_deplete_transfer_rates.py
+++ b/tests/unit_tests/test_deplete_transfer_rates.py
@@ -27,16 +27,25 @@ def model():
     w.set_density("g/cc", 1.0)
     w.depletable = True
 
+    # material just to test multiple destination material
+    h = openmc.Material(name="h")
+    h.add_element("He", 1)
+    h.set_density("g/cc", 1.78e-4)
+    h.depletable = True
+
     radii = [0.42, 0.45]
     f.volume = np.pi * radii[0] ** 2
     w.volume = np.pi * (radii[1]**2 - radii[0]**2)
-    materials = openmc.Materials([f, w])
+    h.volume = 1
+    materials = openmc.Materials([f, w, h])
 
     surf_f = openmc.Sphere(r=radii[0])
     surf_w = openmc.Sphere(r=radii[1], boundary_type='vacuum')
+    surf_h = openmc.Sphere(x0=10, r=1, boundary_type='vacuum')
     cell_f = openmc.Cell(fill=f, region=-surf_f)
     cell_w = openmc.Cell(fill=w, region=+surf_f & -surf_w)
-    geometry = openmc.Geometry([cell_f, cell_w])
+    cell_h = openmc.Cell(fill=h, region=-surf_h)
+    geometry = openmc.Geometry([cell_f, cell_w, cell_h])
 
     settings = openmc.Settings()
     settings.particles = 1000
@@ -52,6 +61,8 @@ def model():
                            'Xe': 0.1}),
     ('elements_nuclides', {'U': 0.01, 'Xe': 0.1, 'I135': 0.01, 'Gd156': 0.1,
                            'Gd157': 0.01}),
+    ('multiple_transfer', {'U': 0.01, 'Xe': 0.1, 'I135': 0.01, 'Gd156': 0.1,
+                           'Gd157': 0.01}),
     ('rates_invalid_1', {'Gd': 0.01, 'Gd157': 0.01, 'Gd156': 0.01}),
     ('rates_invalid_2', {'Gd156': 0.01, 'Gd157': 0.01, 'Gd': 0.01}),
     ('rates_invalid_3', {'Gb156': 0.01}),
@@ -64,7 +75,8 @@ def test_get_set(model, case_name, transfer_rates):
     transfer = TransferRates(op, model)
 
     # Test by Openmc material, material name and material id
-    material, dest_material = [m for m in model.materials if m.depletable]
+    material, dest_material, dest_material2 = [m for m in model.materials
+                                               if m.depletable]
     for material_input in [material, material.name, material.id]:
         for dest_material_input in [dest_material, dest_material.name,
                                     dest_material.id]:
@@ -113,6 +125,19 @@ def test_get_set(model, case_name, transfer_rates):
                 assert transfer.get_components(material_input) == \
                     transfer_rates.keys()
 
+            if case_name == 'multiple_transfer':
+                for dest2_material_input in [dest_material2, dest_material2.name,
+                                    dest_material2.id]:
+                    for component, transfer_rate in transfer_rates.items():
+                        transfer.set_transfer_rate(material_input, [component],
+                                               transfer_rate,
+                                               destination_material=\
+                                               dest2_material_input)
+                        for id, dest_mat in zip([0,1],[dest_material,dest_material2]):
+                            assert transfer.get_transfer_rate(
+                                material_input, component)[id] == transfer_rate
+                            assert transfer.get_destination_material(
+                                material_input, component)[id] == str(dest_mat.id)
 
 @pytest.mark.parametrize("transfer_rate_units, unit_conv", [
     ('1/s', 1),


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description
Allows to set transfer rates of a component (element or nuclide) from one material to multiple ones. The need was discussed [here](https://openmc.discourse.group/t/transfer-rates-with-multiple-destinations/3207/2).

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
