### PR TITLE
Improving documentation on the return array of openmc.lib.id_map

### DIFF
--- a/openmc/lib/plot.py
+++ b/openmc/lib/plot.py
@@ -229,7 +229,8 @@ def id_map(plot):
     -------
     id_map : numpy.ndarray
         A NumPy array with shape (vertical pixels, horizontal pixels, 3) of
-        OpenMC property ids with dtype int32
+        OpenMC property ids with dtype int32. The last dimension of the array
+        contains, in order, cell IDs, cell instances, and material IDs.
 
     """
     img_data = np.zeros((plot.v_res, plot.h_res, 3),


### PR DESCRIPTION
# Description

Improvement on the documentation of `openmc.lib.id_map`. I was using this function while doing some visualization of pincell power distributions with @JIWONC-CORE and had to go to the C++ source code to determine what information was stored in what index of the last dimension.
# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)