### PR TITLE
Set cross_sections for element expansion in Material.add_element()

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -641,7 +641,8 @@ class Material(IDManagerMixin):
     def add_element(self, element: str, percent: float, percent_type: str = 'ao',
                     enrichment: Optional[float] = None,
                     enrichment_target: Optional[str] = None,
-                    enrichment_type: Optional[str] = None):
+                    enrichment_type: Optional[str] = None,
+                    cross_sections: str = None):
         """Add a natural element to the material
 
         Parameters
@@ -668,6 +669,8 @@ class Material(IDManagerMixin):
             Default is: 'ao' for two-isotope enrichment; 'wo' for U enrichment
 
             .. versionadded:: 0.12
+        cross_sections : str, optional
+            Location of cross_sections.xml file. Default is None.
 
         Notes
         -----
@@ -746,7 +749,8 @@ class Material(IDManagerMixin):
                                       percent_type,
                                       enrichment,
                                       enrichment_target,
-                                      enrichment_type):
+                                      enrichment_type,
+                                      cross_sections):
             self.add_nuclide(*nuclide)
 
     def add_elements_from_formula(self, formula: str, percent_type: str = 'ao',

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -642,7 +642,7 @@ class Material(IDManagerMixin):
                     enrichment: Optional[float] = None,
                     enrichment_target: Optional[str] = None,
                     enrichment_type: Optional[str] = None,
-                    cross_sections: str = None):
+                    cross_sections: Optional[str] = None):
         """Add a natural element to the material
 
         Parameters
@@ -670,7 +670,7 @@ class Material(IDManagerMixin):
 
             .. versionadded:: 0.12
         cross_sections : str, optional
-            Location of cross_sections.xml file. Default is None.
+            Location of cross_sections.xml file.
 
         Notes
         -----
@@ -1460,7 +1460,7 @@ class Material(IDManagerMixin):
         if "cfg" in elem.attrib:
             cfg = elem.get("cfg")
             return Material.from_ncrystal(cfg, material_id=mat_id)
-     
+
         mat = cls(mat_id)
         mat.name = elem.get('name')
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Allows for the cross_sections to be specified while adding elements to a material. Previously, the only way to do this was to set the OPENMC_CROSS_SECTIONS env variable or by setting the openmc.config.

# Checklist

- ~[ ] I have performed a self-review of my own code~
- ~[ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)~
- ~[ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~
- ~[ ] I have made corresponding changes to the documentation (if applicable)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
