### PR TITLE
Added inf check in VolumeCalculation.

### DIFF
--- a/openmc/volume.py
+++ b/openmc/volume.py
@@ -121,10 +121,10 @@ class VolumeCalculation:
             else:
                 raise ValueError('Could not automatically determine bounding box '
                                  'for stochastic volume calculation.')
-        
+
         if np.isinf(self.lower_left).any() or np.isinf(self.upper_right).any():
-            raise ValueError('Infinite value found in lower_left or '
-                             'upper_right. Could not compute volume.')
+            raise ValueError('Lower-left and upper-right bounding box '
+                             'coordinates must be finite.')
 
     @property
     def ids(self):

--- a/openmc/volume.py
+++ b/openmc/volume.py
@@ -121,6 +121,10 @@ class VolumeCalculation:
             else:
                 raise ValueError('Could not automatically determine bounding box '
                                  'for stochastic volume calculation.')
+        
+        if np.isinf(self.lower_left).any() or np.isinf(self.upper_right).any():
+            raise ValueError('Infinite value found in lower_left or '
+                             'upper_right. Could not compute volume.')
 
     @property
     def ids(self):

--- a/tests/unit_tests/test_volume.py
+++ b/tests/unit_tests/test_volume.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pytest
+
+import openmc
+
+
+def test_infinity_handling():
+    surf1 = openmc.Sphere(boundary_type="vacuum")
+    reg1 = -surf1
+    cell1 = openmc.Cell(region=reg1)
+
+    lower_left = [-2, -np.inf, -2]
+    upper_right = [np.inf, 2, 2]
+
+    msg = "Infinite value found in lower_left or upper_right. Could not compute volume."
+
+    with pytest.raises(ValueError, match=msg):
+        openmc.VolumeCalculation([cell1], 100, lower_left, upper_right)

--- a/tests/unit_tests/test_volume.py
+++ b/tests/unit_tests/test_volume.py
@@ -6,13 +6,10 @@ import openmc
 
 def test_infinity_handling():
     surf1 = openmc.Sphere(boundary_type="vacuum")
-    reg1 = -surf1
-    cell1 = openmc.Cell(region=reg1)
+    cell1 = openmc.Cell(region=-surf1)
 
-    lower_left = [-2, -np.inf, -2]
-    upper_right = [np.inf, 2, 2]
+    lower_left = (-2, -np.inf, -2)
+    upper_right = (np.inf, 2, 2)
 
-    msg = "Infinite value found in lower_left or upper_right. Could not compute volume."
-
-    with pytest.raises(ValueError, match=msg):
+    with pytest.raises(ValueError, match="must be finite"):
         openmc.VolumeCalculation([cell1], 100, lower_left, upper_right)


### PR DESCRIPTION
# Description

As reported on discord [link](https://openmc.discourse.group/t/volume-calculation-of-polygon-region/3277) it would be useful if the lower_left and upper_right were checked for infinity values when performing a volume calculation.  This raises an error if upper_right or lower_left contain an infinite value.  I have also written a test to check that this error is triggered correctly.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

