### PR TITLE
added universe plot tests to catch color=None and axis values

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -370,8 +370,8 @@ class Universe(UniverseBase):
 
         Returns
         -------
-        matplotlib.image.AxesImage
-            Resulting image
+        matplotlib.axes.Axes
+            Axes containing resulting image
 
         """
         import matplotlib.image as mpimg

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -483,7 +483,7 @@ class Universe(UniverseBase):
             # add legend showing which colors represent which material
             # or cell if that was requested
             if legend:
-                if plot.colors is None:
+                if plot.colors == {}:
                     raise ValueError("Must pass 'colors' dictionary if you "
                                      "are adding a legend via legend=True.")
 
@@ -522,7 +522,8 @@ class Universe(UniverseBase):
                 axes.legend(handles=patches, **legend_kwargs)
 
             # Plot image and return the axes
-            return axes.imshow(img, extent=(x_min, x_max, y_min, y_max), **kwargs)
+            axes.imshow(img, extent=(x_min, x_max, y_min, y_max), **kwargs)
+            return axes
 
     def add_cell(self, cell):
         """Add a cell to the universe.

--- a/tests/unit_tests/test_universe.py
+++ b/tests/unit_tests/test_universe.py
@@ -61,14 +61,17 @@ def test_plot(run_in_tmpdir, sphere_model):
     }
 
     for basis in ('xy', 'yz', 'xz'):
-        pincell.geometry.root_universe.plot(
+        plot = pincell.geometry.root_universe.plot(
             colors=mat_colors,
             color_by="material",
             legend=True,
             pixels=(10, 10),
             basis=basis,
-            outline=True
+            outline=True,
+            axis_units='m'
         )
+        assert plot.xaxis.get_label().get_text() == f'{basis[0]} [m]'
+        assert plot.yaxis.get_label().get_text() == f'{basis[1]} [m]'
 
     # model with no inf values in bounding box
     m = sphere_model.materials[0]
@@ -77,13 +80,24 @@ def test_plot(run_in_tmpdir, sphere_model):
     colors = {m: 'limegreen'}
 
     for basis in ('xy', 'yz', 'xz'):
-        univ.plot(
+        plot = univ.plot(
             colors=colors,
             color_by="cell",
             legend=False,
             pixels=100,
             basis=basis,
             outline=False
+        )
+        assert plot.xaxis.get_label().get_text() == f'{basis[0]} [cm]'
+        assert plot.yaxis.get_label().get_text() == f'{basis[1]} [cm]'
+
+    msg = "Must pass 'colors' dictionary if you are adding a legend via legend=True."
+    # This plot call should fail as legend is True but colors is None
+    with pytest.raises(ValueError, match=msg):
+        univ.plot(
+            color_by="cell",
+            legend=True,
+            pixels=100,
         )
 
 


### PR DESCRIPTION
# Description

While plotting some geometry I kept getting an empty legend, I had set ```legend=True``` so I wasn't sure why it was blank  :confused: 

Looking through the universe.plot source code I noticed that when setting legend to True we also have to set the ```colours```. However the check for colors was not actually being triggered as ```plot.colors``` defaults to ```{}```

This PR fixes the logic so that passing in legend=True without setting colors now triggers a ValueError if colors is not set as well as originally intended.

I've added a test to safe guard this feature and while in the universe plot unit test I also added some asserts to check the axis labels are as expected :heavy_check_mark: 

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
<s>- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
<s>- [x] I have made corresponding changes to the documentation (if applicable)</s>
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
