### PR TITLE
added missing Depletable to __repr__

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -145,6 +145,7 @@ class Material(IDManagerMixin):
         string += f' [{self._density_units}]\n'
 
         string += '{: <16}=\t{} [cm^3]\n'.format('\tVolume', self._volume)
+        string += '{: <16}=\t{}\n'.format('\tDepletable', self._depletable)
 
         string += '{: <16}\n'.format('\tS(a,b) Tables')
 


### PR DESCRIPTION

# Description
Tiny PR to see if it would it be allowed to add another line for the Depletable status of a material in the __repr__
```
import openmc
openmc.Material()

Material
	ID             =	1
	Name           =	
	Temperature    =	None
	Density        =	None [sum]
	Volume         =	None [cm^3]
	Depletable     =	False                       <------- this PR adds this line
	S(a,b) Tables  
	Nuclides     
```
Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
<s>- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
-</s>

