### PR TITLE
replaced ordereddict with {}

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -85,7 +85,7 @@ class Cell(IDManagerMixin):
         calculated in a stochastic volume calculation and added via the
         :meth:`Cell.add_volume_information` method. For 'distribmat' cells
         it is the total volume of all instances.
-    atoms : Dict
+    atoms : dict
         Mapping of nuclides to the total number of atoms for each nuclide
         present in the cell, or in all of its instances for a 'distribmat'
         fill. For example, {'U235': 1.0e22, 'U238': 5.0e22, ...}.
@@ -388,7 +388,7 @@ class Cell(IDManagerMixin):
 
         Returns
         -------
-        nuclides : Dict
+        nuclides : dict
             Dictionary whose keys are nuclide names and values are 2-tuples of
             (nuclide, density)
 
@@ -422,7 +422,7 @@ class Cell(IDManagerMixin):
 
         Returns
         -------
-        cells : Dict
+        cells : dict
             Dictionary whose keys are cell IDs and values are :class:`Cell`
             instances
 
@@ -446,7 +446,7 @@ class Cell(IDManagerMixin):
 
         Returns
         -------
-        materials : Dict
+        materials : dict
             Dictionary whose keys are material IDs and values are
             :class:`Material` instances
 
@@ -472,7 +472,7 @@ class Cell(IDManagerMixin):
 
         Returns
         -------
-        universes : Dict
+        universes : dict
             Dictionary whose keys are universe IDs and values are
             :class:`Universe` instances
 

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from collections.abc import Iterable
 from math import cos, sin, pi
 from numbers import Real
@@ -86,7 +85,7 @@ class Cell(IDManagerMixin):
         calculated in a stochastic volume calculation and added via the
         :meth:`Cell.add_volume_information` method. For 'distribmat' cells
         it is the total volume of all instances.
-    atoms : collections.OrderedDict
+    atoms : Dict
         Mapping of nuclides to the total number of atoms for each nuclide
         present in the cell, or in all of its instances for a 'distribmat'
         fill. For example, {'U235': 1.0e22, 'U238': 5.0e22, ...}.
@@ -316,7 +315,7 @@ class Cell(IDManagerMixin):
                 # Assumes that volume is total volume of all instances
                 # Also assumes that all instances have the same volume
                 partial_volume = self.volume / len(self.fill)
-                self._atoms = OrderedDict()
+                self._atoms = {}
                 for mat in self.fill:
                     for key, atom_per_bcm in mat.get_nuclide_atom_densities().items():
                         # To account for overlap of nuclides between distribmat
@@ -389,13 +388,13 @@ class Cell(IDManagerMixin):
 
         Returns
         -------
-        nuclides : collections.OrderedDict
+        nuclides : Dict
             Dictionary whose keys are nuclide names and values are 2-tuples of
             (nuclide, density)
 
         """
 
-        nuclides = OrderedDict()
+        nuclides = {}
 
         if self.fill_type == 'material':
             nuclides.update(self.fill.get_nuclide_densities())
@@ -423,13 +422,13 @@ class Cell(IDManagerMixin):
 
         Returns
         -------
-        cells : collections.orderedDict
+        cells : Dict
             Dictionary whose keys are cell IDs and values are :class:`Cell`
             instances
 
         """
 
-        cells = OrderedDict()
+        cells = {}
 
         if memo and self in memo:
             return cells
@@ -447,12 +446,12 @@ class Cell(IDManagerMixin):
 
         Returns
         -------
-        materials : collections.OrderedDict
+        materials : Dict
             Dictionary whose keys are material IDs and values are
             :class:`Material` instances
 
         """
-        materials = OrderedDict()
+        materials = {}
         if self.fill_type == 'material':
             materials[self.fill.id] = self.fill
         elif self.fill_type == 'distribmat':
@@ -473,13 +472,13 @@ class Cell(IDManagerMixin):
 
         Returns
         -------
-        universes : collections.OrderedDict
+        universes : Dict
             Dictionary whose keys are universe IDs and values are
             :class:`Universe` instances
 
         """
 
-        universes = OrderedDict()
+        universes = {}
 
         if self.fill_type == 'universe':
             universes[self.fill.id] = self.fill

--- a/openmc/data/ace.py
+++ b/openmc/data/ace.py
@@ -15,7 +15,6 @@ generates ACE-format cross sections.
 
 """
 
-from collections import OrderedDict
 import enum
 from pathlib import Path
 import struct
@@ -544,7 +543,7 @@ def get_libraries_from_xsdir(path):
 
     # Create list of ACE libraries -- we use an ordered dictionary while
     # building to get O(1) membership checks while retaining insertion order
-    libraries = OrderedDict()
+    libraries = {}
     for line in lines:
         words = line.split()
         if len(words) < 3:
@@ -576,7 +575,7 @@ def get_libraries_from_xsdata(path):
     with open(xsdata, 'r') as xsdata_file:
         # As in get_libraries_from_xsdir, we use a dict for O(1) membership
         # check while retaining insertion order
-        libraries = OrderedDict()
+        libraries = {}
         for line in xsdata_file:
             words = line.split()
             if len(words) >= 9:

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -75,7 +75,7 @@ class IncidentNeutron(EqualityMixin):
         state.
     name : str
         Name of the nuclide using the GNDS naming convention
-    reactions : Dict
+    reactions : dict
         Contains the cross sections, secondary angle and energy distributions,
         and other associated data for each reaction. The keys are the MT values
         and the values are Reaction objects.

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from collections.abc import Mapping, MutableMapping
 from io import StringIO
 from math import log10
@@ -76,7 +75,7 @@ class IncidentNeutron(EqualityMixin):
         state.
     name : str
         Name of the nuclide using the GNDS naming convention
-    reactions : collections.OrderedDict
+    reactions : Dict
         Contains the cross sections, secondary angle and energy distributions,
         and other associated data for each reaction. The keys are the MT values
         and the values are Reaction objects.
@@ -107,7 +106,7 @@ class IncidentNeutron(EqualityMixin):
         self.kTs = kTs
         self.energy = {}
         self._fission_energy = None
-        self.reactions = OrderedDict()
+        self.reactions = {}
         self._urr = {}
         self._resonances = None
 

--- a/openmc/data/photon.py
+++ b/openmc/data/photon.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from collections.abc import Mapping, Callable
 from copy import deepcopy
 from io import StringIO
@@ -432,7 +431,7 @@ class IncidentPhoton(EqualityMixin):
         the projection of the electron momentum on the scattering vector,
         :math:`p_z` for each subshell). Note that subshell occupancies may not
         match the atomic relaxation data.
-    reactions : collections.OrderedDict
+    reactions : Dict
         Contains the cross sections for each photon reaction. The keys are MT
         values and the values are instances of :class:`PhotonReaction`.
 
@@ -441,7 +440,7 @@ class IncidentPhoton(EqualityMixin):
     def __init__(self, atomic_number):
         self.atomic_number = atomic_number
         self._atomic_relaxation = None
-        self.reactions = OrderedDict()
+        self.reactions = {}
         self.compton_profiles = {}
         self.bremsstrahlung = {}
 

--- a/openmc/data/photon.py
+++ b/openmc/data/photon.py
@@ -431,7 +431,7 @@ class IncidentPhoton(EqualityMixin):
         the projection of the electron momentum on the scattering vector,
         :math:`p_z` for each subshell). Note that subshell occupancies may not
         match the atomic relaxation data.
-    reactions : Dict
+    reactions : dict
         Contains the cross sections for each photon reaction. The keys are MT
         values and the values are instances of :class:`PhotonReaction`.
 

--- a/openmc/deplete/atom_number.py
+++ b/openmc/deplete/atom_number.py
@@ -45,8 +45,8 @@ class AtomNumber:
 
     """
     def __init__(self, local_mats, nuclides, volume, n_nuc_burn):
-        self.index_mat = {(mat, i) for i, mat in enumerate(local_mats)}
-        self.index_nuc = {(nuc, i) for i, nuc in enumerate(nuclides)}
+        self.index_mat = {mat: i for i, mat in enumerate(local_mats)}
+        self.index_nuc = {nuc: i for i, nuc in enumerate(nuclides)}
 
         self.volume = np.ones(len(local_mats))
         for mat, val in volume.items():

--- a/openmc/deplete/atom_number.py
+++ b/openmc/deplete/atom_number.py
@@ -2,8 +2,6 @@
 
 An ndarray to store atom densities with string, integer, or slice indexing.
 """
-from collections import OrderedDict
-
 import numpy as np
 
 from openmc import Material
@@ -47,8 +45,8 @@ class AtomNumber:
 
     """
     def __init__(self, local_mats, nuclides, volume, n_nuc_burn):
-        self.index_mat = OrderedDict((mat, i) for i, mat in enumerate(local_mats))
-        self.index_nuc = OrderedDict((nuc, i) for i, nuc in enumerate(nuclides))
+        self.index_mat = {(mat, i) for i, mat in enumerate(local_mats)}
+        self.index_nuc = {(nuc, i) for i, nuc in enumerate(nuclides)}
 
         self.volume = np.ones(len(local_mats))
         for mat, val in volume.items():

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -9,7 +9,7 @@ from itertools import chain
 import math
 import os
 import re
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import defaultdict, namedtuple
 from collections.abc import Mapping, Iterable
 from numbers import Real, Integral
 from warnings import warn
@@ -248,7 +248,7 @@ class Chain:
         Nuclides present in the chain.
     reactions : list of str
         Reactions that are tracked in the depletion chain
-    nuclide_dict : OrderedDict of str to int
+    nuclide_dict : Dict of str to int
         Maps a nuclide name to an index in nuclides.
     fission_yields : None or iterable of dict
         List of effective fission yields for materials. Each dictionary
@@ -264,7 +264,7 @@ class Chain:
     def __init__(self):
         self.nuclides = []
         self.reactions = []
-        self.nuclide_dict = OrderedDict()
+        self.nuclide_dict = {}
         self._fission_yields = None
 
     def __contains__(self, nuclide):

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -248,7 +248,7 @@ class Chain:
         Nuclides present in the chain.
     reactions : list of str
         Reactions that are tracked in the depletion chain
-    nuclide_dict : Dict of str to int
+    nuclide_dict : dict of str to int
         Maps a nuclide name to an index in nuclides.
     fission_yields : None or iterable of dict
         List of effective fission yields for materials. Each dictionary

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -171,7 +171,7 @@ class OpenMCOperator(TransportOperator):
         -------
         burnable_mats : list of str
             List of burnable material IDs
-        volume : Dict of str to float
+        volume : dict of str to float
             Volume of each material in [cm^3]
         nuclides : list of str
             Nuclides in order of how they'll appear in the simulation.
@@ -245,7 +245,7 @@ class OpenMCOperator(TransportOperator):
         ----------
         local_mats : list of str
             Material IDs to be managed by this process
-        volume : Dict of str to float
+        volume : dict of str to float
             Volumes for the above materials in [cm^3]
         all_nuclides : list of str
             Nuclides to be used in the simulation.

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -6,7 +6,6 @@ transport-independent transport operators.
 """
 
 from abc import abstractmethod
-from collections import OrderedDict
 
 import numpy as np
 
@@ -172,7 +171,7 @@ class OpenMCOperator(TransportOperator):
         -------
         burnable_mats : list of str
             List of burnable material IDs
-        volume : OrderedDict of str to float
+        volume : Dict of str to float
             Volume of each material in [cm^3]
         nuclides : list of str
             Nuclides in order of how they'll appear in the simulation.
@@ -181,7 +180,7 @@ class OpenMCOperator(TransportOperator):
 
         burnable_mats = set()
         model_nuclides = set()
-        volume = OrderedDict()
+        volume = {}
 
         self.heavy_metal = 0.0
 
@@ -246,7 +245,7 @@ class OpenMCOperator(TransportOperator):
         ----------
         local_mats : list of str
             Material IDs to be managed by this process
-        volume : OrderedDict of str to float
+        volume : Dict of str to float
             Volumes for the above materials in [cm^3]
         all_nuclides : list of str
             Nuclides to be used in the simulation.

--- a/openmc/deplete/reaction_rates.py
+++ b/openmc/deplete/reaction_rates.py
@@ -29,11 +29,11 @@ class ReactionRates(np.ndarray):
 
     Attributes
     ----------
-    index_mat : OrderedDict of str to int
+    index_mat : Dict of str to int
         A dictionary mapping material ID as string to index.
-    index_nuc : OrderedDict of str to int
+    index_nuc : Dict of str to int
         A dictionary mapping nuclide name as string to index.
-    index_rx : OrderedDict of str to int
+    index_rx : Dict of str to int
         A dictionary mapping reaction name as string to index.
     n_mat : int
         Number of materials.

--- a/openmc/deplete/reaction_rates.py
+++ b/openmc/deplete/reaction_rates.py
@@ -29,11 +29,11 @@ class ReactionRates(np.ndarray):
 
     Attributes
     ----------
-    index_mat : Dict of str to int
+    index_mat : dict of str to int
         A dictionary mapping material ID as string to index.
-    index_nuc : Dict of str to int
+    index_nuc : dict of str to int
         A dictionary mapping nuclide name as string to index.
-    index_rx : Dict of str to int
+    index_rx : dict of str to int
         A dictionary mapping reaction name as string to index.
     n_mat : int
         Number of materials.

--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -6,7 +6,6 @@ timestep.
 
 import copy
 import warnings
-from collections import OrderedDict
 from pathlib import Path
 
 import h5py
@@ -43,13 +42,13 @@ class StepResult:
         Number of nuclides.
     rates : list of ReactionRates
         The reaction rates for each substep.
-    volume : OrderedDict of str to float
+    volume : Dict of str to float
         Dictionary mapping mat id to volume.
-    index_mat : OrderedDict of str to int
+    index_mat : Dict of str to int
         A dictionary mapping mat ID as string to index.
-    index_nuc : OrderedDict of str to int
+    index_nuc : Dict of str to int
         A dictionary mapping nuclide name as string to index.
-    mat_to_hdf5_ind : OrderedDict of str to int
+    mat_to_hdf5_ind : Dict of str to int
         A dictionary mapping mat ID as string to global index.
     n_hdf5_mats : int
         Number of materials in entire geometry.
@@ -462,11 +461,11 @@ class StepResult:
             results.proc_time = np.array([np.nan])
 
         # Reconstruct dictionaries
-        results.volume = OrderedDict()
-        results.index_mat = OrderedDict()
-        results.index_nuc = OrderedDict()
-        rxn_nuc_to_ind = OrderedDict()
-        rxn_to_ind = OrderedDict()
+        results.volume = {}
+        results.index_mat = {}
+        results.index_nuc = {}
+        rxn_nuc_to_ind = {}
+        rxn_to_ind = {}
 
         for mat, mat_handle in handle["/materials"].items():
             vol = mat_handle.attrs["volume"]

--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -42,13 +42,13 @@ class StepResult:
         Number of nuclides.
     rates : list of ReactionRates
         The reaction rates for each substep.
-    volume : Dict of str to float
+    volume : dict of str to float
         Dictionary mapping mat id to volume.
-    index_mat : Dict of str to int
+    index_mat : dict of str to int
         A dictionary mapping mat ID as string to index.
-    index_nuc : Dict of str to int
+    index_nuc : dict of str to int
         A dictionary mapping nuclide name as string to index.
-    mat_to_hdf5_ind : Dict of str to int
+    mat_to_hdf5_ind : dict of str to int
         A dictionary mapping mat ID as string to global index.
     n_hdf5_mats : int
         Number of materials in entire geometry.

--- a/openmc/element.py
+++ b/openmc/element.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import re
 import lxml.etree as ET
 
@@ -124,7 +123,7 @@ class Element(str):
         natural_nuclides = {name for name, abundance in natural_isotopes(self)}
 
         # Create dict to store the expanded nuclides and abundances
-        abundances = OrderedDict()
+        abundances = {}
 
         # If cross_sections is None, get the cross sections from the global
         # configuration

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1,5 +1,4 @@
 from abc import ABCMeta
-from collections import OrderedDict
 from collections.abc import Iterable
 import hashlib
 from itertools import product
@@ -1677,7 +1676,7 @@ class DistribcellFilter(Filter):
                 level_key = f'level {i_level + 1}'
 
                 # Create a dictionary for this level for Pandas Multi-index
-                level_dict = OrderedDict()
+                level_dict = {}
 
                 # Use the first distribcell path to determine if level
                 # is a universe/cell or lattice level

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -367,7 +367,7 @@ class Geometry:
 
         Returns
         -------
-        Dict
+        dict
             Dictionary mapping cell IDs to :class:`openmc.Cell` instances
 
         """
@@ -381,7 +381,7 @@ class Geometry:
 
         Returns
         -------
-        Dict
+        dict
             Dictionary mapping universe IDs to :class:`openmc.Universe`
             instances
 
@@ -396,7 +396,7 @@ class Geometry:
 
         Returns
         -------
-        Dict
+        dict
             Dictionary mapping material IDs to :class:`openmc.Material`
             instances
 
@@ -411,7 +411,7 @@ class Geometry:
 
         Returns
         -------
-        Dict
+        dict
             Dictionary mapping cell IDs to :class:`openmc.Cell` instances that
             are filled with materials or distributed materials.
 
@@ -433,7 +433,7 @@ class Geometry:
 
         Returns
         -------
-        Dict
+        dict
             Dictionary mapping universe IDs to :class:`openmc.Universe`
             instances with at least one material-filled cell
 
@@ -453,7 +453,7 @@ class Geometry:
 
         Returns
         -------
-        Dict
+        dict
             Dictionary mapping lattice IDs to :class:`openmc.Lattice` instances
 
         """
@@ -472,7 +472,7 @@ class Geometry:
 
         Returns
         -------
-        Dict
+        dict
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import os
 import typing
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from copy import deepcopy
 from collections.abc import Iterable
 from pathlib import Path
@@ -362,41 +362,41 @@ class Geometry:
 
         return indices if return_list else indices[0]
 
-    def get_all_cells(self) -> typing.OrderedDict[int, openmc.Cell]:
+    def get_all_cells(self) -> typing.Dict[int, openmc.Cell]:
         """Return all cells in the geometry.
 
         Returns
         -------
-        collections.OrderedDict
+        Dict
             Dictionary mapping cell IDs to :class:`openmc.Cell` instances
 
         """
         if self.root_universe is not None:
             return self.root_universe.get_all_cells(memo=set())
         else:
-            return OrderedDict()
+            return {}
 
-    def get_all_universes(self) -> typing.OrderedDict[int, openmc.Universe]:
+    def get_all_universes(self) -> typing.Dict[int, openmc.Universe]:
         """Return all universes in the geometry.
 
         Returns
         -------
-        collections.OrderedDict
+        Dict
             Dictionary mapping universe IDs to :class:`openmc.Universe`
             instances
 
         """
-        universes = OrderedDict()
+        universes = {}
         universes[self.root_universe.id] = self.root_universe
         universes.update(self.root_universe.get_all_universes())
         return universes
 
-    def get_all_materials(self) -> typing.OrderedDict[int, openmc.Material]:
+    def get_all_materials(self) -> typing.Dict[int, openmc.Material]:
         """Return all materials within the geometry.
 
         Returns
         -------
-        collections.OrderedDict
+        Dict
             Dictionary mapping material IDs to :class:`openmc.Material`
             instances
 
@@ -404,19 +404,19 @@ class Geometry:
         if self.root_universe is not None:
             return self.root_universe.get_all_materials(memo=set())
         else:
-            return OrderedDict()
+            return {}
 
-    def get_all_material_cells(self) -> typing.OrderedDict[int, openmc.Cell]:
+    def get_all_material_cells(self) -> typing.Dict[int, openmc.Cell]:
         """Return all cells filled by a material
 
         Returns
         -------
-        collections.OrderedDict
+        Dict
             Dictionary mapping cell IDs to :class:`openmc.Cell` instances that
             are filled with materials or distributed materials.
 
         """
-        material_cells = OrderedDict()
+        material_cells = {}
 
         for cell in self.get_all_cells().values():
             if cell.fill_type in ('material', 'distribmat'):
@@ -425,7 +425,7 @@ class Geometry:
 
         return material_cells
 
-    def get_all_material_universes(self) -> typing.OrderedDict[int, openmc.Universe]:
+    def get_all_material_universes(self) -> typing.Dict[int, openmc.Universe]:
         """Return all universes having at least one material-filled cell.
 
         This method can be used to find universes that have at least one cell
@@ -433,12 +433,12 @@ class Geometry:
 
         Returns
         -------
-        collections.OrderedDict
+        Dict
             Dictionary mapping universe IDs to :class:`openmc.Universe`
             instances with at least one material-filled cell
 
         """
-        material_universes = OrderedDict()
+        material_universes = {}
 
         for universe in self.get_all_universes().values():
             for cell in universe.cells.values():
@@ -448,16 +448,16 @@ class Geometry:
 
         return material_universes
 
-    def get_all_lattices(self) -> typing.OrderedDict[int, openmc.Lattice]:
+    def get_all_lattices(self) -> typing.Dict[int, openmc.Lattice]:
         """Return all lattices defined
 
         Returns
         -------
-        collections.OrderedDict
+        Dict
             Dictionary mapping lattice IDs to :class:`openmc.Lattice` instances
 
         """
-        lattices = OrderedDict()
+        lattices = {}
 
         for cell in self.get_all_cells().values():
             if cell.fill_type == 'lattice':
@@ -466,17 +466,17 @@ class Geometry:
 
         return lattices
 
-    def get_all_surfaces(self) -> typing.OrderedDict[int, openmc.Surface]:
+    def get_all_surfaces(self) -> typing.Dict[int, openmc.Surface]:
         """
         Return all surfaces used in the geometry
 
         Returns
         -------
-        collections.OrderedDict
+        Dict
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """
-        surfaces = OrderedDict()
+        surfaces = {}
 
         for cell in self.get_all_cells().values():
             if cell.region is not None:

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -112,7 +112,7 @@ class Lattice(IDManagerMixin, ABC):
 
         Returns
         -------
-        universes : Dict
+        universes : dict
             Dictionary whose keys are universe IDs and values are
             :class:`openmc.UniverseBase` instances
 
@@ -163,7 +163,7 @@ class Lattice(IDManagerMixin, ABC):
 
         Returns
         -------
-        cells : Dict
+        cells : dict
             Dictionary whose keys are cell IDs and values are :class:`Cell`
             instances
 
@@ -188,7 +188,7 @@ class Lattice(IDManagerMixin, ABC):
 
         Returns
         -------
-        materials : Dict
+        materials : dict
             Dictionary whose keys are material IDs and values are
             :class:`Material` instances
 
@@ -208,7 +208,7 @@ class Lattice(IDManagerMixin, ABC):
 
         Returns
         -------
-        universes : Dict
+        universes : dict
             Dictionary whose keys are universe IDs and values are
             :class:`Universe` instances
 
@@ -1126,7 +1126,7 @@ class HexLattice(Lattice):
     @property
     def orientation(self):
         return self._orientation
-    
+
     @orientation.setter
     def orientation(self, orientation):
         cv.check_value('orientation', orientation.lower(), ('x', 'y'))

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from collections import OrderedDict
 from collections.abc import Iterable
 from copy import deepcopy
 from math import sqrt, floor
@@ -113,13 +112,13 @@ class Lattice(IDManagerMixin, ABC):
 
         Returns
         -------
-        universes : collections.OrderedDict
+        universes : Dict
             Dictionary whose keys are universe IDs and values are
             :class:`openmc.UniverseBase` instances
 
         """
 
-        univs = OrderedDict()
+        univs = {}
         for k in range(len(self._universes)):
             for j in range(len(self._universes[k])):
                 if isinstance(self._universes[k][j], openmc.UniverseBase):
@@ -164,12 +163,12 @@ class Lattice(IDManagerMixin, ABC):
 
         Returns
         -------
-        cells : collections.OrderedDict
+        cells : Dict
             Dictionary whose keys are cell IDs and values are :class:`Cell`
             instances
 
         """
-        cells = OrderedDict()
+        cells = {}
 
         if memo and self in memo:
             return cells
@@ -189,13 +188,13 @@ class Lattice(IDManagerMixin, ABC):
 
         Returns
         -------
-        materials : collections.OrderedDict
+        materials : Dict
             Dictionary whose keys are material IDs and values are
             :class:`Material` instances
 
         """
 
-        materials = OrderedDict()
+        materials = {}
 
         # Append all Cells in each Cell in the Universe to the dictionary
         cells = self.get_all_cells(memo)
@@ -209,7 +208,7 @@ class Lattice(IDManagerMixin, ABC):
 
         Returns
         -------
-        universes : collections.OrderedDict
+        universes : Dict
             Dictionary whose keys are universe IDs and values are
             :class:`Universe` instances
 
@@ -217,7 +216,7 @@ class Lattice(IDManagerMixin, ABC):
 
         # Initialize a dictionary of all Universes contained by the Lattice
         # in each nested Universe level
-        all_universes = OrderedDict()
+        all_universes = {}
 
         # Get all unique Universes contained in each of the lattice cells
         unique_universes = self.get_unique_universes()

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from collections import OrderedDict, defaultdict, namedtuple, Counter
+from collections import defaultdict, namedtuple, Counter
 from collections.abc import Iterable
 from copy import deepcopy
 from numbers import Real
@@ -937,8 +937,7 @@ class Material(IDManagerMixin):
 
         """
 
-        # keep ordered dictionary for testing purposes
-        nuclides = OrderedDict()
+        nuclides = {}
 
         for nuclide in self._nuclides:
             nuclides[nuclide.name] = nuclide
@@ -1023,7 +1022,7 @@ class Material(IDManagerMixin):
 
         nuc_densities = density * nuc_densities
 
-        nuclides = OrderedDict()
+        nuclides = {}
         for n, nuc in enumerate(nucs):
             if nuclide is None or nuclide == nuc:
                 nuclides[nuc] = nuc_densities[n]

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from collections.abc import Iterable
 import copy
 from numbers import Integral
@@ -83,7 +82,7 @@ class Library:
     tally_trigger : openmc.Trigger
         An (optional) tally precision trigger given to each tally used to
         compute the cross section
-    all_mgxs : collections.OrderedDict
+    all_mgxs : Dict
         MGXS objects keyed by domain ID and cross section type
     sp_filename : str
         The filename of the statepoint with tally data used to the
@@ -119,7 +118,7 @@ class Library:
         self._legendre_order = 0
         self._histogram_bins = 16
         self._tally_trigger = None
-        self._all_mgxs = OrderedDict()
+        self._all_mgxs = {}
         self._sp_filename = None
         self._keff = None
         self._sparse = False
@@ -159,9 +158,9 @@ class Library:
             clone._keff = self._keff
             clone._sparse = self.sparse
 
-            clone._all_mgxs = OrderedDict()
+            clone._all_mgxs = {}
             for domain in self.domains:
-                clone.all_mgxs[domain.id] = OrderedDict()
+                clone.all_mgxs[domain.id] = {}
                 for mgxs_type in self.mgxs_types:
                     mgxs = copy.deepcopy(self.all_mgxs[domain.id][mgxs_type])
                     clone.all_mgxs[domain.id][mgxs_type] = mgxs
@@ -503,7 +502,7 @@ class Library:
 
         # Initialize MGXS for each domain and mgxs type and store in dictionary
         for domain in self.domains:
-            self.all_mgxs[domain.id] = OrderedDict()
+            self.all_mgxs[domain.id] = {}
             for mgxs_type in self.mgxs_types:
                 if mgxs_type in openmc.mgxs.MDGXS_TYPES:
                     mgxs = openmc.mgxs.MDGXS.get_mgxs(

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -82,7 +82,7 @@ class Library:
     tally_trigger : openmc.Trigger
         An (optional) tally precision trigger given to each tally used to
         compute the cross section
-    all_mgxs : Dict
+    all_mgxs : dict
         MGXS objects keyed by domain ID and cross section type
     sp_filename : str
         The filename of the statepoint with tally data used to the
@@ -190,7 +190,7 @@ class Library:
     def name(self, name):
         cv.check_type('name', name, str)
         self._name = name
-    
+
     @property
     def mgxs_types(self):
         return self._mgxs_types
@@ -305,7 +305,7 @@ class Library:
     @property
     def energy_groups(self):
         return self._energy_groups
-    
+
     @energy_groups.setter
     def energy_groups(self, energy_groups):
         cv.check_type('energy groups', energy_groups, openmc.mgxs.EnergyGroups)
@@ -323,7 +323,7 @@ class Library:
         cv.check_greater_than('num delayed groups', num_delayed_groups, 0,
                               equality=True)
         self._num_delayed_groups = num_delayed_groups
-    
+
     @property
     def num_polar(self):
         return self._num_polar
@@ -381,7 +381,7 @@ class Library:
             self.correction = None
 
         self._scatter_format = scatter_format
-    
+
     @property
     def legendre_order(self):
         return self._legendre_order

--- a/openmc/mgxs/mdgxs.py
+++ b/openmc/mgxs/mdgxs.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import copy
 import itertools
 from numbers import Integral
@@ -90,7 +89,7 @@ class MDGXS(MGXS):
         the multi-group cross section
     estimator : {'tracklength', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section
     rxn_rate_tally : openmc.Tally
         Derived tally for the reaction rate tally used in the numerator to
@@ -161,7 +160,7 @@ class MDGXS(MGXS):
             clone._sparse = self.sparse
             clone._derived = self.derived
 
-            clone._tallies = OrderedDict()
+            clone._tallies = {}
             for tally_type, tally in self.tallies.items():
                 clone.tallies[tally_type] = copy.deepcopy(tally, memo)
 
@@ -972,7 +971,7 @@ class ChiDelayed(MDGXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`ChiDelayed.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -1491,7 +1490,7 @@ class DelayedNuFissionXS(MDGXS):
         the multi-group cross section
     estimator : {'tracklength', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`DelayedNuFissionXS.tally_keys` property
         and values are instances of :class:`openmc.Tally`.
@@ -1630,7 +1629,7 @@ class Beta(MDGXS):
         the multi-group cross section
     estimator : {'tracklength', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`Beta.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -1823,7 +1822,7 @@ class DecayRate(MDGXS):
         the multi-group cross section
     estimator : {'tracklength', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`DecayRate.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -2137,7 +2136,7 @@ class MatrixMDGXS(MDGXS):
         the multi-group cross section
     estimator : {'tracklength', 'collision', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section
     rxn_rate_tally : openmc.Tally
         Derived tally for the reaction rate tally used in the numerator to
@@ -2735,7 +2734,7 @@ class DelayedNuFissionMatrixXS(MatrixMDGXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`DelayedNuFissionXS.tally_keys` property
         and values are instances of :class:`openmc.Tally`.

--- a/openmc/mgxs/mdgxs.py
+++ b/openmc/mgxs/mdgxs.py
@@ -89,7 +89,7 @@ class MDGXS(MGXS):
         the multi-group cross section
     estimator : {'tracklength', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section
     rxn_rate_tally : openmc.Tally
         Derived tally for the reaction rate tally used in the numerator to
@@ -971,7 +971,7 @@ class ChiDelayed(MDGXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`ChiDelayed.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -1490,7 +1490,7 @@ class DelayedNuFissionXS(MDGXS):
         the multi-group cross section
     estimator : {'tracklength', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`DelayedNuFissionXS.tally_keys` property
         and values are instances of :class:`openmc.Tally`.
@@ -1629,7 +1629,7 @@ class Beta(MDGXS):
         the multi-group cross section
     estimator : {'tracklength', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`Beta.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -1822,7 +1822,7 @@ class DecayRate(MDGXS):
         the multi-group cross section
     estimator : {'tracklength', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`DecayRate.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -2136,7 +2136,7 @@ class MatrixMDGXS(MDGXS):
         the multi-group cross section
     estimator : {'tracklength', 'collision', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section
     rxn_rate_tally : openmc.Tally
         Derived tally for the reaction rate tally used in the numerator to
@@ -2734,7 +2734,7 @@ class DelayedNuFissionMatrixXS(MatrixMDGXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`DelayedNuFissionXS.tally_keys` property
         and values are instances of :class:`openmc.Tally`.

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import copy
 from numbers import Integral
 import os
@@ -216,7 +215,7 @@ class MGXS:
         the multi-group cross section
     estimator : {'tracklength', 'collision', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section
     rxn_rate_tally : openmc.Tally
         Derived tally for the reaction rate tally used in the numerator to
@@ -319,7 +318,7 @@ class MGXS:
         clone._derived = self.derived
         clone._mgxs_type = self._mgxs_type
 
-        clone._tallies = OrderedDict()
+        clone._tallies = {}
         for tally_type, tally in self.tallies.items():
             clone.tallies[tally_type] = copy.deepcopy(tally, memo)
 
@@ -576,7 +575,7 @@ class MGXS:
         if self._tallies is None:
 
             # Initialize a collection of Tallies
-            self._tallies = OrderedDict()
+            self._tallies ={}
 
             # Create a domain Filter object
             filter_type = _DOMAIN_TO_FILTER[self.domain_type]
@@ -1690,7 +1689,7 @@ class MGXS:
             merged_mgxs.nuclides = self.nuclides + other.nuclides
 
         # Null base tallies but merge reaction rate and cross section tallies
-        merged_mgxs._tallies = OrderedDict()
+        merged_mgxs._tallies ={}
         merged_mgxs._rxn_rate_tally = self.rxn_rate_tally.merge(other.rxn_rate_tally)
         merged_mgxs._xs_tally = self.xs_tally.merge(other.xs_tally)
 
@@ -2690,7 +2689,7 @@ class TransportXS(MGXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`TransportXS.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -2931,7 +2930,7 @@ class DiffusionCoefficient(TransportXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`TransportXS.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -3078,7 +3077,7 @@ class DiffusionCoefficient(TransportXS):
             diff_coef = transport**(-1) / 3.0
             diff_coef *= self.tallies['flux (tracklength)']
             flux_tally = condensed_xs.tallies['flux (tracklength)']
-            condensed_xs._tallies = OrderedDict()
+            condensed_xs._tallies ={}
             condensed_xs._tallies[self._rxn_type] = diff_coef
             condensed_xs._tallies['flux (tracklength)'] = flux_tally
             condensed_xs._rxn_rate_tally = diff_coef
@@ -3394,7 +3393,7 @@ class FissionXS(MGXS):
         the multi-group cross section
     estimator : {'tracklength', 'collision', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`FissionXS.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -3613,7 +3612,7 @@ class ScatterXS(MGXS):
         the multi-group cross section
     estimator : {'tracklength', 'collision', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`ScatterXS.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -3923,7 +3922,7 @@ class ScatterMatrixXS(MatrixMGXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`ScatterMatrixXS.tally_keys` property
         and values are instances of :class:`openmc.Tally`.
@@ -5193,7 +5192,7 @@ class NuFissionMatrixXS(MatrixMGXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`NuFissionMatrixXS.tally_keys`
         property and values are instances of :class:`openmc.Tally`.
@@ -5354,7 +5353,7 @@ class Chi(MGXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`Chi.tally_keys` property and values are
         instances of :class:`openmc.Tally`.
@@ -5922,7 +5921,7 @@ class MeshSurfaceMGXS(MGXS):
         the multi-group cross section
     estimator : {'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section
     rxn_rate_tally : openmc.Tally
         Derived tally for the reaction rate tally used in the numerator to
@@ -6309,7 +6308,7 @@ class Current(MeshSurfaceMGXS):
         the multi-group cross section
     estimator : {'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : collections.OrderedDict
+    tallies : Dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`TotalXS.tally_keys` property and values
         are instances of :class:`openmc.Tally`.

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -215,7 +215,7 @@ class MGXS:
         the multi-group cross section
     estimator : {'tracklength', 'collision', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section
     rxn_rate_tally : openmc.Tally
         Derived tally for the reaction rate tally used in the numerator to
@@ -2689,7 +2689,7 @@ class TransportXS(MGXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`TransportXS.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -2930,7 +2930,7 @@ class DiffusionCoefficient(TransportXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`TransportXS.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -3077,7 +3077,7 @@ class DiffusionCoefficient(TransportXS):
             diff_coef = transport**(-1) / 3.0
             diff_coef *= self.tallies['flux (tracklength)']
             flux_tally = condensed_xs.tallies['flux (tracklength)']
-            condensed_xs._tallies ={}
+            condensed_xs._tallies = {}
             condensed_xs._tallies[self._rxn_type] = diff_coef
             condensed_xs._tallies['flux (tracklength)'] = flux_tally
             condensed_xs._rxn_rate_tally = diff_coef
@@ -3393,7 +3393,7 @@ class FissionXS(MGXS):
         the multi-group cross section
     estimator : {'tracklength', 'collision', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`FissionXS.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -3612,7 +3612,7 @@ class ScatterXS(MGXS):
         the multi-group cross section
     estimator : {'tracklength', 'collision', 'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`ScatterXS.tally_keys` property and
         values are instances of :class:`openmc.Tally`.
@@ -3922,7 +3922,7 @@ class ScatterMatrixXS(MatrixMGXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`ScatterMatrixXS.tally_keys` property
         and values are instances of :class:`openmc.Tally`.
@@ -5192,7 +5192,7 @@ class NuFissionMatrixXS(MatrixMGXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`NuFissionMatrixXS.tally_keys`
         property and values are instances of :class:`openmc.Tally`.
@@ -5353,7 +5353,7 @@ class Chi(MGXS):
         the multi-group cross section
     estimator : 'analog'
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`Chi.tally_keys` property and values are
         instances of :class:`openmc.Tally`.
@@ -5921,7 +5921,7 @@ class MeshSurfaceMGXS(MGXS):
         the multi-group cross section
     estimator : {'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section
     rxn_rate_tally : openmc.Tally
         Derived tally for the reaction rate tally used in the numerator to
@@ -6308,7 +6308,7 @@ class Current(MeshSurfaceMGXS):
         the multi-group cross section
     estimator : {'analog'}
         The tally estimator used to compute the multi-group cross section
-    tallies : Dict
+    tallies : dict
         OpenMC tallies needed to compute the multi-group cross section. The keys
         are strings listed in the :attr:`TotalXS.tally_keys` property and values
         are instances of :class:`openmc.Tally`.

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from collections import OrderedDict
 from collections.abc import MutableSequence
 from copy import deepcopy
 
@@ -47,17 +46,17 @@ class Region(ABC):
 
         Parameters
         ----------
-        surfaces: collections.OrderedDict, optional
+        surfaces: Dict, optional
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         Returns
         -------
-        surfaces: collections.OrderedDict
+        surfaces: Dict
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """
         if surfaces is None:
-            surfaces = OrderedDict()
+            surfaces = {}
         for region in self:
             surfaces = region.get_surfaces(surfaces)
         return surfaces
@@ -590,17 +589,17 @@ class Complement(Region):
 
         Parameters
         ----------
-        surfaces: collections.OrderedDict, optional
+        surfaces: Dict, optional
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         Returns
         -------
-        surfaces: collections.OrderedDict
+        surfaces: Dict
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """
         if surfaces is None:
-            surfaces = OrderedDict()
+            surfaces = {}
         for region in self.node:
             surfaces = region.get_surfaces(surfaces)
         return surfaces

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -46,12 +46,12 @@ class Region(ABC):
 
         Parameters
         ----------
-        surfaces: Dict, optional
+        surfaces : dict, optional
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         Returns
         -------
-        surfaces: Dict
+        surfaces : dict
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """
@@ -589,12 +589,12 @@ class Complement(Region):
 
         Parameters
         ----------
-        surfaces: Dict, optional
+        surfaces : dict, optional
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         Returns
         -------
-        surfaces: Dict
+        surfaces : dict
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from collections import OrderedDict
 from collections.abc import Iterable
 from copy import deepcopy
 import math
@@ -2549,17 +2548,17 @@ class Halfspace(Region):
 
         Parameters
         ----------
-        surfaces: collections.OrderedDict, optional
+        surfaces: Dict, optional
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         Returns
         -------
-        surfaces: collections.OrderedDict
+        surfaces: Dict
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """
         if surfaces is None:
-            surfaces = OrderedDict()
+            surfaces = {}
 
         surfaces[self.surface.id] = self.surface
         return surfaces

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -2548,12 +2548,12 @@ class Halfspace(Region):
 
         Parameters
         ----------
-        surfaces: Dict, optional
+        surfaces : dict, optional
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         Returns
         -------
-        surfaces: Dict
+        surfaces : dict
             Dictionary mapping surface IDs to :class:`openmc.Surface` instances
 
         """

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -99,7 +99,7 @@ class UniverseBase(ABC, IDManagerMixin):
 
         Returns
         -------
-        universes : Dict
+        universes : dict
             Dictionary whose keys are universe IDs and values are
             :class:`Universe` instances
 
@@ -198,7 +198,7 @@ class Universe(UniverseBase):
         Unique identifier of the universe
     name : str
         Name of the universe
-    cells : Dict
+    cells : dict
         Dictionary whose keys are cell IDs and values are :class:`Cell`
         instances
     volume : float
@@ -609,7 +609,7 @@ class Universe(UniverseBase):
 
         Returns
         -------
-        nuclides : Dict
+        nuclides : dict
             Dictionary whose keys are nuclide names and values are 2-tuples of
             (nuclide, density)
 
@@ -636,7 +636,7 @@ class Universe(UniverseBase):
 
         Returns
         -------
-        cells : Dict
+        cells : dict
             Dictionary whose keys are cell IDs and values are :class:`Cell`
             instances
 
@@ -664,7 +664,7 @@ class Universe(UniverseBase):
 
         Returns
         -------
-        materials : Dict
+        materials : dict
             Dictionary whose keys are material IDs and values are
             :class:`Material` instances
 

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -1,7 +1,6 @@
 import math
 import typing
 from abc import ABC, abstractmethod
-from collections import OrderedDict
 from collections.abc import Iterable
 from copy import deepcopy
 from numbers import Integral, Real
@@ -46,7 +45,7 @@ class UniverseBase(ABC, IDManagerMixin):
 
         # Keys   - Cell IDs
         # Values - Cells
-        self._cells = OrderedDict()
+        self._cells = {}
 
     def __repr__(self):
         string = 'Universe\n'
@@ -100,13 +99,13 @@ class UniverseBase(ABC, IDManagerMixin):
 
         Returns
         -------
-        universes : collections.OrderedDict
+        universes : Dict
             Dictionary whose keys are universe IDs and values are
             :class:`Universe` instances
 
         """
         # Append all Universes within each Cell to the dictionary
-        universes = OrderedDict()
+        universes = {}
         for cell in self.get_all_cells().values():
             universes.update(cell.get_all_universes())
 
@@ -169,7 +168,7 @@ class UniverseBase(ABC, IDManagerMixin):
             clone = self._partial_deepcopy()
 
             # Clone all cells for the universe clone
-            clone._cells = OrderedDict()
+            clone._cells = {}
             for cell in self._cells.values():
                 clone.add_cell(cell.clone(clone_materials, clone_regions,
                                           memo))
@@ -199,7 +198,7 @@ class Universe(UniverseBase):
         Unique identifier of the universe
     name : str
         Name of the universe
-    cells : collections.OrderedDict
+    cells : Dict
         Dictionary whose keys are cell IDs and values are :class:`Cell`
         instances
     volume : float
@@ -610,12 +609,12 @@ class Universe(UniverseBase):
 
         Returns
         -------
-        nuclides : collections.OrderedDict
+        nuclides : Dict
             Dictionary whose keys are nuclide names and values are 2-tuples of
             (nuclide, density)
 
         """
-        nuclides = OrderedDict()
+        nuclides = {}
 
         if self._atoms:
             volume = self.volume
@@ -637,13 +636,13 @@ class Universe(UniverseBase):
 
         Returns
         -------
-        cells : collections.OrderedDict
+        cells : Dict
             Dictionary whose keys are cell IDs and values are :class:`Cell`
             instances
 
         """
 
-        cells = OrderedDict()
+        cells = {}
 
         if memo and self in memo:
             return cells
@@ -665,13 +664,13 @@ class Universe(UniverseBase):
 
         Returns
         -------
-        materials : collections.OrderedDict
+        materials : Dict
             Dictionary whose keys are material IDs and values are
             :class:`Material` instances
 
         """
 
-        materials = OrderedDict()
+        materials = {}
 
         # Append all Cells in each Cell in the Universe to the dictionary
         cells = self.get_all_cells(memo)
@@ -882,10 +881,10 @@ class DAGMCUniverse(UniverseBase):
         return sorted(set(material_tags_ascii))
 
     def get_all_cells(self, memo=None):
-        return OrderedDict()
+        return {}
 
     def get_all_materials(self, memo=None):
-        return OrderedDict()
+        return {}
 
     def _n_geom_elements(self, geom_type):
         """

--- a/openmc/volume.py
+++ b/openmc/volume.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from collections.abc import Iterable, Mapping
 from numbers import Real, Integral
 import lxml.etree as ET
@@ -281,7 +280,7 @@ class VolumeCalculation:
                     volumes[domain_id] = volume
                     nucnames = group['nuclides'][()]
                     atoms_ = group['atoms'][()]
-                    atom_dict = OrderedDict()
+                    atom_dict = {}
                     for name_i, atoms_i in zip(nucnames, atoms_):
                         atom_dict[name_i.decode()] = ufloat(*atoms_i)
                     atoms[domain_id] = atom_dict

--- a/tests/unit_tests/test_lattice_discretization.py
+++ b/tests/unit_tests/test_lattice_discretization.py
@@ -34,8 +34,8 @@ def test_discretization_clone_only_some_materials(rlat2):
     fuel1 = next(iter(rlat_clone.get_universe((0, 0)).cells.values())).fill
     rlat_clone.discretize(materials_to_clone=[fuel1])
 
-    assert next(reversed(rlat_clone.get_universe((0, 0)).cells.values())).fill\
-         == next(reversed(rlat_clone.get_universe((1, 0)).cells.values())).fill
+    assert next(reversed(list(rlat_clone.get_universe((0, 0)).cells.values()))).fill\
+         == next(reversed(list(rlat_clone.get_universe((1, 0)).cells.values()))).fill
     assert next(iter(rlat_clone.get_universe((0, 0)).cells.values())).fill\
          != next(iter(rlat_clone.get_universe((1, 0)).cells.values())).fill
 


### PR DESCRIPTION
# Description

As discussed on Slack we are able to remove collections.OrderedDict and replace it with a native python dictionary. OrderedDict was once necessary as dictionaries were not ordered in python. Howver native python dictionaries are now ordered in python 3.6 and above :tada: and the minimal version of python openmc supports is 3.7

Fixes # (issue) - no issue raised

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
<s>- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
</s>
