### PR TITLE
Fixing `Universe.plot` seed.

### DIFF
--- a/docs/source/io_formats/settings.rst
+++ b/docs/source/io_formats/settings.rst
@@ -345,12 +345,12 @@ either "false" or "true".
 
   *Default*: false
 
-------------------
+-----------------------
 ``<plot_seed>`` Element
-------------------
+-----------------------
 
-The ``plot_seed`` element is used to set the seed used for the linear congruential
-pseudo-random number generator during generation of colors in plots.
+The ``<plot_seed>`` element is used to set the seed for the pseudorandom number
+generator during generation of colors in plots.
 
   *Default*: 1
 

--- a/docs/source/io_formats/settings.rst
+++ b/docs/source/io_formats/settings.rst
@@ -345,6 +345,15 @@ either "false" or "true".
 
   *Default*: false
 
+------------------
+``<plot_seed>`` Element
+------------------
+
+The ``plot_seed`` element is used to set the seed used for the linear congruential
+pseudo-random number generator during generation of colors in plots.
+
+  *Default*: 1
+
 ---------------------
 ``<ptables>`` Element
 ---------------------
@@ -1175,4 +1184,3 @@ mesh-based weight windows.
 
   The ``weight_windows_file`` element has no attributes and contains the path to
   a weight windows HDF5 file to load during simulation initialization.
-

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -133,6 +133,8 @@ class Settings:
         Number of particles per generation
     photon_transport : bool
         Whether to use photon transport.
+    plot_seed : bool
+       Initial seed for randomly generated plot colors.
     ptables : bool
         Determine whether probability tables are used.
     resonance_scattering : dict
@@ -270,6 +272,7 @@ class Settings:
         self._confidence_intervals = None
         self._electron_treatment = None
         self._photon_transport = None
+        self._plot_seed = None
         self._ptables = None
         self._seed = None
         self._survival_biasing = None
@@ -503,6 +506,16 @@ class Settings:
     def photon_transport(self, photon_transport: bool):
         cv.check_type('photon transport', photon_transport, bool)
         self._photon_transport = photon_transport
+
+    @property
+    def plot_seed(self):
+        return self._plot_seed
+
+    @plot_seed.setter
+    def plot_seed(self, seed):
+        cv.check_type('random plot color seed', seed, Integral)
+        cv.check_greater_than('random plot color seed', seed, 0)
+        self._plot_seed = seed
 
     @property
     def seed(self) -> int:
@@ -1118,6 +1131,11 @@ class Settings:
             element = ET.SubElement(root, "photon_transport")
             element.text = str(self._photon_transport).lower()
 
+    def _create_plot_seed_subelement(self, root):
+        if self._plot_seed is not None:
+            element = ET.SubElement(root, "plot_seed")
+            element.text = str(self._plot_seed)
+
     def _create_ptables_subelement(self, root):
         if self._ptables is not None:
             element = ET.SubElement(root, "ptables")
@@ -1491,6 +1509,11 @@ class Settings:
         if text is not None:
             self.photon_transport = text in ('true', '1')
 
+    def _plot_seed_from_xml_element(self, root):
+        text = get_text(root, 'plot_seed')
+        if text is not None:
+            self.plot_seed = int(text)
+
     def _ptables_from_xml_element(self, root):
         text = get_text(root, 'ptables')
         if text is not None:
@@ -1706,6 +1729,7 @@ class Settings:
         self._create_energy_mode_subelement(element)
         self._create_max_order_subelement(element)
         self._create_photon_transport_subelement(element)
+        self._create_plot_seed_subelement(element)
         self._create_ptables_subelement(element)
         self._create_seed_subelement(element)
         self._create_survival_biasing_subelement(element)
@@ -1802,6 +1826,7 @@ class Settings:
         settings._energy_mode_from_xml_element(elem)
         settings._max_order_from_xml_element(elem)
         settings._photon_transport_from_xml_element(elem)
+        settings._plot_seed_from_xml_element(elem)
         settings._ptables_from_xml_element(elem)
         settings._seed_from_xml_element(elem)
         settings._survival_biasing_from_xml_element(elem)

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -133,7 +133,7 @@ class Settings:
         Number of particles per generation
     photon_transport : bool
         Whether to use photon transport.
-    plot_seed : bool
+    plot_seed : int
        Initial seed for randomly generated plot colors.
     ptables : bool
         Determine whether probability tables are used.

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -423,7 +423,7 @@ class Universe(UniverseBase):
             model = openmc.Model()
             model.geometry = openmc.Geometry(self)
             if seed is not None:
-                model.settings.seed = seed
+                model.settings.plot_seed = seed
 
             # Determine whether any materials contains macroscopic data and if
             # so, set energy mode accordingly

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -22,6 +22,7 @@
 #include "openmc/mesh.h"
 #include "openmc/message_passing.h"
 #include "openmc/output.h"
+#include "openmc/plot.h"
 #include "openmc/random_lcg.h"
 #include "openmc/simulation.h"
 #include "openmc/source.h"
@@ -388,6 +389,12 @@ void read_settings_xml(pugi::xml_node root)
     } else if (rel_max_lost_particles <= 0.0 || rel_max_lost_particles >= 1.0) {
       fatal_error("Relative max lost particles must be between zero and one.");
     }
+  }
+
+  // Copy plotting random number seed if specified
+  if (check_for_node(root, "plot_seed")) {
+    auto seed = std::stoll(get_node_value(root, "plot_seed"));
+    model::plotter_seed = seed;
   }
 
   // Copy random number seed if specified

--- a/tests/unit_tests/test_settings.py
+++ b/tests/unit_tests/test_settings.py
@@ -23,6 +23,7 @@ def test_export_to_xml(run_in_tmpdir):
     s.surf_source_write = {'surface_ids': [2], 'max_particles': 200}
     s.confidence_intervals = True
     s.ptables = True
+    s.plot_seed = 100
     s.survival_biasing = True
     s.cutoff = {'weight': 0.25, 'weight_avg': 0.5, 'energy_neutron': 1.0e-5,
                 'energy_photon': 1000.0, 'energy_electron': 1.0e-5,
@@ -82,6 +83,7 @@ def test_export_to_xml(run_in_tmpdir):
     assert s.surf_source_write == {'surface_ids': [2], 'max_particles': 200}
     assert s.confidence_intervals
     assert s.ptables
+    assert s.plot_seed == 100
     assert s.seed == 17
     assert s.survival_biasing
     assert s.cutoff == {'weight': 0.25, 'weight_avg': 0.5,
@@ -108,7 +110,7 @@ def test_export_to_xml(run_in_tmpdir):
                                       'energy_min': 1.0, 'energy_max': 1000.0,
                                       'nuclides': ['U235', 'U238', 'Pu239']}
     assert s.create_fission_neutrons
-    assert not s.create_delayed_neutrons 
+    assert not s.create_delayed_neutrons
     assert s.log_grid_bins == 2000
     assert not s.photon_transport
     assert s.electron_treatment == 'led'


### PR DESCRIPTION
# Description

Adds an `openmc.Settings.plot_seed` attribute on the Python side and ingests it during a load of `settings.xml` to set the `model::plotter_seed` value.

<img width="1067" alt="Screenshot 2023-08-13 at 3 07 05 PM" src="https://github.com/openmc-dev/openmc/assets/4563941/af40f156-b334-4d87-9556-d9c2baec946c">

Fixes #2646

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
