### PR TITLE
Expose universe plotting for the cell class

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -563,24 +563,24 @@ class Cell(IDManagerMixin):
     def plot(self, *args, **kwargs):
         """Display a slice plot of the cell.
 
+        .. versionadded:: 0.13.4
+
         Parameters
         ----------
         origin : iterable of float
-            Coordinates at the origin of the plot, if left as None then the
-            universe.bounding_box.center will be used to attempt to
-            ascertain the origin. Defaults to (0, 0, 0) if the bounding_box
-            contains inf values
+            Coordinates at the origin of the plot. If left as None then the
+            bounding box center will be used to attempt to ascertain the origin.
+            Defaults to (0, 0, 0) if the bounding box is not finite
         width : iterable of float
             Width of the plot in each basis direction. If left as none then the
-            universe.bounding_box.width() will be used to attempt to
-            ascertain the plot width.  Defaults to (10, 10) if the bounding_box
-            contains inf values
+            bounding box width will be used to attempt to ascertain the plot
+            width. Defaults to (10, 10) if the bounding box is not finite
         pixels : Iterable of int or int
-            If iterable of ints provided then this directly sets the number of
-            pixels to use in each basis direction. If int provided then this
-            sets the total number of pixels in the plot and the number of
-            pixels in each basis direction is calculated from this total and
-            the image aspect ratio.
+            If iterable of ints provided, then this directly sets the number of
+            pixels to use in each basis direction. If int provided, then this
+            sets the total number of pixels in the plot and the number of pixels
+            in each basis direction is calculated from this total and the image
+            aspect ratio.
         basis : {'xy', 'xz', 'yz'}
             The basis directions for the plot
         color_by : {'cell', 'material'}
@@ -602,31 +602,21 @@ class Cell(IDManagerMixin):
             Path to OpenMC executable.
         axes : matplotlib.Axes
             Axes to draw to
-
-            .. versionadded:: 0.13.1
         legend : bool
             Whether a legend showing material or cell names should be drawn
-
-            .. versionadded:: 0.13.4
         legend_kwargs : dict
             Keyword arguments passed to :func:`matplotlib.pyplot.legend`.
-
-            .. versionadded:: 0.13.4
         outline : bool
             Whether outlines between color boundaries should be drawn
-
-            .. versionadded:: 0.13.4
         axis_units : {'km', 'm', 'cm', 'mm'}
             Units used on the plot axis
-
-            .. versionadded:: 0.13.4
         **kwargs
             Keyword arguments passed to :func:`matplotlib.pyplot.imshow`
 
         Returns
         -------
-        matplotlib.image.AxesImage
-            Resulting image
+        matplotlib.axes.Axes
+            Axes containing resulting image
 
         """
         return openmc.Universe(cells=[self]).plot(*args, **kwargs)

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -560,6 +560,77 @@ class Cell(IDManagerMixin):
 
         return memo[self]
 
+    def plot(self, *args, **kwargs):
+        """Display a slice plot of the cell.
+
+        Parameters
+        ----------
+        origin : iterable of float
+            Coordinates at the origin of the plot, if left as None then the
+            universe.bounding_box.center will be used to attempt to
+            ascertain the origin. Defaults to (0, 0, 0) if the bounding_box
+            contains inf values
+        width : iterable of float
+            Width of the plot in each basis direction. If left as none then the
+            universe.bounding_box.width() will be used to attempt to
+            ascertain the plot width.  Defaults to (10, 10) if the bounding_box
+            contains inf values
+        pixels : Iterable of int or int
+            If iterable of ints provided then this directly sets the number of
+            pixels to use in each basis direction. If int provided then this
+            sets the total number of pixels in the plot and the number of
+            pixels in each basis direction is calculated from this total and
+            the image aspect ratio.
+        basis : {'xy', 'xz', 'yz'}
+            The basis directions for the plot
+        color_by : {'cell', 'material'}
+            Indicate whether the plot should be colored by cell or by material
+        colors : dict
+            Assigns colors to specific materials or cells. Keys are instances of
+            :class:`Cell` or :class:`Material` and values are RGB 3-tuples, RGBA
+            4-tuples, or strings indicating SVG color names. Red, green, blue,
+            and alpha should all be floats in the range [0.0, 1.0], for example:
+
+            .. code-block:: python
+
+               # Make water blue
+               water = openmc.Cell(fill=h2o)
+               universe.plot(..., colors={water: (0., 0., 1.))
+        seed : int
+            Seed for the random number generator
+        openmc_exec : str
+            Path to OpenMC executable.
+        axes : matplotlib.Axes
+            Axes to draw to
+
+            .. versionadded:: 0.13.1
+        legend : bool
+            Whether a legend showing material or cell names should be drawn
+
+            .. versionadded:: 0.13.4
+        legend_kwargs : dict
+            Keyword arguments passed to :func:`matplotlib.pyplot.legend`.
+
+            .. versionadded:: 0.13.4
+        outline : bool
+            Whether outlines between color boundaries should be drawn
+
+            .. versionadded:: 0.13.4
+        axis_units : {'km', 'm', 'cm', 'mm'}
+            Units used on the plot axis
+
+            .. versionadded:: 0.13.4
+        **kwargs
+            Keyword arguments passed to :func:`matplotlib.pyplot.imshow`
+
+        Returns
+        -------
+        matplotlib.image.AxesImage
+            Resulting image
+
+        """
+        return openmc.Universe(cells=[self]).plot(*args, **kwargs)
+
     def create_xml_subelement(self, xml_element, memo=None):
         """Add the cell's xml representation to an incoming xml element
 


### PR DESCRIPTION
# Description

Quality of life PR here allowing us to access the `openmc.Universe.plot` functionality from the `Cell` class. This PR provides the same functionality to the `Cell` class by creating a single-cell universe in the method and forwarding arguments to `Universe.plot`.

<img width="1098" alt="Screenshot 2023-08-13 at 3 16 16 PM" src="https://github.com/openmc-dev/openmc/assets/4563941/61e05dc0-ec3b-4c56-ba40-d3734e20da50">


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
