### PR TITLE
material.__repr__ no longer prints 0 percent nucs

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -158,8 +158,9 @@ class Material(IDManagerMixin):
         string += '{: <16}\n'.format('\tNuclides')
 
         for nuclide, percent, percent_type in self._nuclides:
-            string += '{: <16}'.format('\t{}'.format(nuclide))
-            string += '=\t{: <12} [{}]\n'.format(percent, percent_type)
+            if percent != 0.:
+                string += '{: <16}'.format('\t{}'.format(nuclide))
+                string += '=\t{: <12} [{}]\n'.format(percent, percent_type)
 
         if self._macroscopic is not None:
             string += '{: <16}\n'.format('\tMacroscopic Data')


### PR DESCRIPTION
# Description

I was running some depletion simulations and kept seeing materials reported with 0.0 values by the  material.__repr__

This PR puts in a check in the material.__repr__ so that if the percent is == to 0. then it won't be printed.

This would help keep the material output minimal and in some cases I have tens of 0.0 value nuclides

Minimal reproducable example
```python
import openmc
import openmc.deplete
openmc.config['chain_file'] = '/home/jshimwell/ENDF-B-VIII.0-NNDC/chain-nndc-b8.0.xml'
chain_file = openmc.config['chain_file']

my_material = openmc.Material(material_id=5) 
my_material.add_element(element="C", percent=1, percent_type="wo")
my_material.set_density(units="g/cm3", density=1)
my_material.volume = 1
my_material.depletable = True
materials = openmc.Materials([my_material])

sph1 = openmc.Sphere(r=1, boundary_type='vacuum')
shield_cell = openmc.Cell(region=-sph1)
shield_cell.fill = my_material

geometry = openmc.Geometry([shield_cell])

source = openmc.Source()
source.space = openmc.stats.Point((0, 0, 0))
source.angle = openmc.stats.Isotropic()
source.energy = openmc.stats.Discrete([2e6], [1])
source.particles = 'neutron'

settings = openmc.Settings()
settings.batches = 2
settings.inactive = 0
settings.particles = 100
settings.source = source
settings.run_mode = 'fixed source'
model = openmc.model.Model(geometry, materials, settings)
model.deplete(
    [24,24],
    source_rates=[1e20,0],
    method="predictor",
    final_step=False,
    operator_kwargs={
        "normalization_mode": "source-rate",
        "chain_file": chain_file,
        "reduce_chain_level": 5,
        "reduce_chain": True      
    },
)
results = openmc.deplete.Results('depletion_results.h5')
for i, step in enumerate(results):
    mat = step.get_material(str(5))
    print(mat)
```
This example currently prints ...
```python
Material
        ID             =        5
        Name           =
        Temperature    =        None
        Density        =        None [sum]
        Volume         =        1.0 [cm^3]
        Depletable     =        False
        S(a,b) Tables  
        Nuclides       
        H1             =        7.428286734653292e-27 [ao]
        H2             =        1.6834508944996423e-34 [ao]
        H3             =        6.451582248424866e-43 [ao]
        He3            =        3.22045384433583e-50 [ao]
        He4            =        2.0157546152145823e-26 [ao]
        He6            =        0.0          [ao]
        Li6            =        0.0          [ao]
        Li7            =        0.0          [ao]
        Li8            =        0.0          [ao]
        Li9            =        0.0          [ao]
        Be9            =        0.0          [ao]
        Be10           =        0.0          [ao]
        Be11           =        0.0          [ao]
        B10            =        0.0          [ao]
        B11            =        2.015754614064492e-26 [ao]
        C12            =        0.049582630041349364 [ao]
        C13            =        0.0005554352076668191 [ao]
        C14            =        1.2530575928706076e-11 [ao]
        C15            =        0.0          [ao]
        N13            =        0.0          [ao]
        N14            =        1.738256247339412e-21 [ao]
        N15            =        1.8297591360953484e-29 [ao]
        N16            =        1.4960545608286922e-38 [ao]
        O16            =        2.158557547223951e-37 [ao]
```

After this PR the example prints
```python
Material
        ID             =        5
        Name           =
        Temperature    =        None
        Density        =        None [sum]
        Volume         =        1.0 [cm^3]
        Depletable     =        False
        S(a,b) Tables  
        Nuclides       
        H1             =        7.428286734653298e-27 [ao]
        H2             =        1.6834508944996423e-34 [ao]
        H3             =        6.451582248424866e-43 [ao]
        He3            =        3.22045384433583e-50 [ao]
        He4            =        2.0157546152145823e-26 [ao]
        B11            =        2.015754614064492e-26 [ao]
        C12            =        0.049582630041349364 [ao]
        C13            =        0.0005554352076668191 [ao]
        C14            =        1.2530575928706076e-11 [ao]
        N14            =        1.738256247339412e-21 [ao]
        N15            =        1.8297591360953484e-29 [ao]
        N16            =        1.4960545608286922e-38 [ao]
        O16            =        2.158557547223951e-37 [ao]
```

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)