### PR TITLE
adding cell name to volume calculation when possible

### DIFF
--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -534,8 +534,20 @@ int openmc_calculate_volumes()
 
       // Display domain volumes
       for (int j = 0; j < vol_calc.domain_ids_.size(); j++) {
-        write_message(4, "{}{}: {} +/- {} cm^3", domain_type,
-          vol_calc.domain_ids_[j], results[j].volume[0], results[j].volume[1]);
+        std::string cell_name = "";
+        if (domain_type == "  Cell ") {
+          int cell_pos = model::cell_map[vol_calc.domain_ids_[j]];
+          cell_name = model::cells[cell_pos]->name();
+        }
+        if (cell_name != "") {
+          write_message(4, "{}{} {}: {} +/- {} cm^3", domain_type,
+                        vol_calc.domain_ids_[j], cell_name,
+                        results[j].volume[0], results[j].volume[1]);
+        } else {
+          write_message(4, "{}{}: {} +/- {} cm^3", domain_type,
+                        vol_calc.domain_ids_[j], results[j].volume[0],
+                        results[j].volume[1]);
+        }
       }
 
       // Write volumes to HDF5 file

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -541,12 +541,12 @@ int openmc_calculate_volumes()
         }
         if (cell_name != "") {
           write_message(4, "{}{} {}: {} +/- {} cm^3", domain_type,
-                        vol_calc.domain_ids_[j], cell_name,
-                        results[j].volume[0], results[j].volume[1]);
+            vol_calc.domain_ids_[j], cell_name, results[j].volume[0],
+            results[j].volume[1]);
         } else {
           write_message(4, "{}{}: {} +/- {} cm^3", domain_type,
-                        vol_calc.domain_ids_[j], results[j].volume[0],
-                        results[j].volume[1]);
+            vol_calc.domain_ids_[j], results[j].volume[0],
+            results[j].volume[1]);
         }
       }
 

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -534,20 +534,17 @@ int openmc_calculate_volumes()
 
       // Display domain volumes
       for (int j = 0; j < vol_calc.domain_ids_.size(); j++) {
-        std::string cell_name = "";
-        if (domain_type == "  Cell ") {
-          int cell_pos = model::cell_map[vol_calc.domain_ids_[j]];
-          cell_name = model::cells[cell_pos]->name();
+        std::string cell_name {""};
+        if (vol_calc.domain_type_ == VolumeCalculation::TallyDomain::CELL) {
+          int cell_idx = model::cell_map[vol_calc.domain_ids_[j]];
+          cell_name = model::cells[cell_idx]->name();
+          if (cell_name.size())
+            cell_name.insert(0, " "); // prepend space for formatting
         }
-        if (cell_name != "") {
-          write_message(4, "{}{} {}: {} +/- {} cm^3", domain_type,
-            vol_calc.domain_ids_[j], cell_name, results[j].volume[0],
-            results[j].volume[1]);
-        } else {
-          write_message(4, "{}{}: {} +/- {} cm^3", domain_type,
-            vol_calc.domain_ids_[j], results[j].volume[0],
-            results[j].volume[1]);
-        }
+
+        write_message(4, "{}{}{}: {} +/- {} cm^3", domain_type,
+          vol_calc.domain_ids_[j], cell_name, results[j].volume[0],
+          results[j].volume[1]);
       }
 
       // Write volumes to HDF5 file


### PR DESCRIPTION
This aims to answer issue #2638.

```
import openmc

surf_1 = openmc.Sphere(r=10, boundary_type='vacuum')
cell_1 = openmc.Cell(region=-surf_1, name='user-friendly-name')
geometry = openmc.Geometry([cell_1])
model = openmc.Model(geometry)

vol_calc = openmc.VolumeCalculation([cell_1], 10_000)
model.settings.volume_calculations = [vol_calc]
model.calculate_volumes()
```
now returns:
`Cell 1user-friendly-name: 4179.2 +/- 39.95983903871486 cm^3` instead of 
`Cell 1: 4179.2 +/- 39.95983903871486 cm^3`

while other domain types and cell without names still have the usual return.



I can't quite figure how to run the test:
I tried running `pytest tests` from openMC home folder (and unsetting `OPENMC_CROSS_SECTIONS` first), but test start and fail before completion, I get:
```
pytest -vv tests                                                                                                                                                                                                                             develop 
=========================================================================================================================== test session starts ============================================================================================================================
platform darwin -- Python 3.9.11, pytest-7.3.2, pluggy-1.0.0 -- /Users/mouginot/.pyenv/versions/3.9.11/bin/python3.9
cachedir: .pytest_cache
rootdir: /Users/mouginot/work/app/openmc
configfile: pytest.ini
plugins: typeguard-3.0.2, cov-4.1.0, anyio-3.7.1
collected 898 items                                                                                                                                                                                                                                                        

tests/test_matplotlib_import.py::test_matplotlib_presence PASSED                                                                                                                                                                                                     [  0%]
tests/regression_tests/adj_cell_rotation/test.py::test_rotation FAILED                                                                                                                                                                                               [  0%]
tests/regression_tests/asymmetric_lattice/test.py::test_asymmetric_lattice FAILED                                                                                                                                                                                    [  0%]
tests/regression_tests/cmfd_feed/test.py::test_cmfd_physical_adjoint %                                                                                                                                                                                                                                                                                                                                                                                                        
```
from my branch or the `openmc::develop`