### PR TITLE
Improved get step where value error msg

### DIFF
--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -511,11 +511,11 @@ class Results(list):
 
         if math.isclose(time, times[ix], rel_tol=rtol, abs_tol=atol):
             return ix
-
+        closest = min(times, key=lambda t: abs(time - t))
         raise ValueError(
-            "A value of {} {} was not found given absolute and "
-            "relative tolerances {} and {}.".format(
-                time, time_units, atol, rtol)
+            f"A value of {time} {time_units} was not found given absolute and "
+            f"relative tolerances {atol} and {rtol}. Closest time is {closest}"
+            f"{time_units}."
         )
 
     def export_to_materials(

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -515,7 +515,7 @@ class Results(list):
         closest = min(times, key=lambda t: abs(time - t))
         raise ValueError(
             f"A value of {time} {time_units} was not found given absolute and "
-            f"relative tolerances {atol} and {rtol}. Closest time is {closest}"
+            f"relative tolerances {atol} and {rtol}. Closest time is {closest} "
             f"{time_units}."
         )
 

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -511,6 +511,7 @@ class Results(list):
 
         if math.isclose(time, times[ix], rel_tol=rtol, abs_tol=atol):
             return ix
+
         closest = min(times, key=lambda t: abs(time - t))
         raise ValueError(
             f"A value of {time} {time_units} was not found given absolute and "


### PR DESCRIPTION
# Description

While using the ```deplete.Results.get_step_where``` I kept putting in the wrong time and would find it handy if the error message provided a little more information. Then I can get the right time easily with my next try.

This PR simply updates the message printed when the time requested is not found. The new message contains the value of the closest matching time.

Before PR

```A value of 67 d was not found given absolute and relative tolerances 1e-06 and 0.001```

After PR

```A value of 67 d was not found given absolute and relative tolerances 1e-06 and 0.001. Closest time is 6.000011574074074 d.```

# Checklist

- [x] I have performed a self-review of my own code
<s> - [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
<s> - [ ] I have made corresponding changes to the documentation (if applicable)</s> 
<s> - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)</s> 

