### PR TITLE
added cell name to vol calc print out

### DIFF
--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -532,7 +532,7 @@ int openmc_calculate_volumes()
         domain_type = "  Universe ";
       }
 
-      // Display domain volumes
+      // Display domain volumes in terminal
       for (int j = 0; j < vol_calc.domain_ids_.size(); j++) {
         std::string region_name {""};
         if (vol_calc.domain_type_ == VolumeCalculation::TallyDomain::CELL) {

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -534,16 +534,19 @@ int openmc_calculate_volumes()
 
       // Display domain volumes
       for (int j = 0; j < vol_calc.domain_ids_.size(); j++) {
-        std::string cell_name {""};
+        std::string region_name {""};
         if (vol_calc.domain_type_ == VolumeCalculation::TallyDomain::CELL) {
           int cell_idx = model::cell_map[vol_calc.domain_ids_[j]];
-          cell_name = model::cells[cell_idx]->name();
-          if (cell_name.size())
-            cell_name.insert(0, " "); // prepend space for formatting
+          region_name = model::cells[cell_idx]->name();
+        } else if (vol_calc.domain_type_ == VolumeCalculation::TallyDomain::MATERIAL) {
+          int mat_idx = model::material_map[vol_calc.domain_ids_[j]];
+          region_name = model::materials[mat_idx]->name();
         }
+        if (region_name.size())
+          region_name.insert(0, " "); // prepend space for formatting
 
         write_message(4, "{}{}{}: {} +/- {} cm^3", domain_type,
-          vol_calc.domain_ids_[j], cell_name, results[j].volume[0],
+          vol_calc.domain_ids_[j], region_name, results[j].volume[0],
           results[j].volume[1]);
       }
 

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -538,7 +538,8 @@ int openmc_calculate_volumes()
         if (vol_calc.domain_type_ == VolumeCalculation::TallyDomain::CELL) {
           int cell_idx = model::cell_map[vol_calc.domain_ids_[j]];
           region_name = model::cells[cell_idx]->name();
-        } else if (vol_calc.domain_type_ == VolumeCalculation::TallyDomain::MATERIAL) {
+        } else if (vol_calc.domain_type_ ==
+                   VolumeCalculation::TallyDomain::MATERIAL) {
           int mat_idx = model::material_map[vol_calc.domain_ids_[j]];
           region_name = model::materials[mat_idx]->name();
         }

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -532,7 +532,7 @@ int openmc_calculate_volumes()
         domain_type = "  Universe ";
       }
 
-      // Display domain volumes in terminal
+      // Display domain volumes
       for (int j = 0; j < vol_calc.domain_ids_.size(); j++) {
         std::string region_name {""};
         if (vol_calc.domain_type_ == VolumeCalculation::TallyDomain::CELL) {


### PR DESCRIPTION
# Description

Following up on @bam241 inspirational PR (#2652) where material names were added to the volume calculation terminal std out.

I had a go at adding cell names to the volume calculation to match the material names that we now print out

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
<s> - [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable) 
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)</s>