### PR TITLE
Account for integral of underlying distributions when sampling Mixture

### DIFF
--- a/include/openmc/distribution.h
+++ b/include/openmc/distribution.h
@@ -22,6 +22,10 @@ class Distribution {
 public:
   virtual ~Distribution() = default;
   virtual double sample(uint64_t* seed) const = 0;
+
+  //! Return integral of distribution
+  //! \return Integral of distribution
+  virtual double integral() const { return 1.0; };
 };
 
 using UPtrDist = unique_ptr<Distribution>;
@@ -51,11 +55,13 @@ public:
   // Properties
   const vector<double>& prob() const { return prob_; }
   const vector<size_t>& alias() const { return alias_; }
+  double integral() const { return integral_; }
 
 private:
   vector<double> prob_; //!< Probability of accepting the uniformly sampled bin,
                         //!< mapped to alias method table
   vector<size_t> alias_; //!< Alias table
+  double integral_;      //!< Integral of distribution
 
   //! Normalize distribution so that probabilities sum to unity
   void normalize();
@@ -77,6 +83,8 @@ public:
   //! \param seed Pseudorandom number seed pointer
   //! \return Sampled value
   double sample(uint64_t* seed) const override;
+
+  double integral() const override { return di_.integral(); };
 
   // Properties
   const vector<double>& x() const { return x_; }
@@ -219,17 +227,19 @@ public:
   //! \return Sampled value
   double sample(uint64_t* seed) const override;
 
-  // x property
+  // properties
   vector<double>& x() { return x_; }
   const vector<double>& x() const { return x_; }
   const vector<double>& p() const { return p_; }
   Interpolation interp() const { return interp_; }
+  double integral() const override { return integral_; };
 
 private:
   vector<double> x_;     //!< tabulated independent variable
   vector<double> p_;     //!< tabulated probability density
   vector<double> c_;     //!< cumulative distribution at tabulated values
   Interpolation interp_; //!< interpolation rule
+  double integral_;      //!< Integral of distribution
 
   //! Initialize tabulated probability density function
   //! \param x Array of values for independent variable
@@ -272,12 +282,15 @@ public:
   //! \return Sampled value
   double sample(uint64_t* seed) const override;
 
+  double integral() const override { return integral_; }
+
 private:
   // Storrage for probability + distribution
   using DistPair = std::pair<double, UPtrDist>;
 
   vector<DistPair>
-    distribution_; //!< sub-distributions + cummulative probabilities
+    distribution_;  //!< sub-distributions + cummulative probabilities
+  double integral_; //!< integral of distribution
 };
 
 } // namespace openmc

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -105,9 +105,9 @@ size_t DiscreteIndex::sample(uint64_t* seed) const
 void DiscreteIndex::normalize()
 {
   // Renormalize density function so that it sums to unity
-  double norm = std::accumulate(prob_.begin(), prob_.end(), 0.0);
+  integral_ = std::accumulate(prob_.begin(), prob_.end(), 0.0);
   for (auto& p_i : prob_) {
-    p_i /= norm;
+    p_i /= integral_;
   }
 }
 
@@ -301,9 +301,10 @@ void Tabular::init(
   }
 
   // Normalize density and distribution functions
+  integral_ = c_[n - 1];
   for (int i = 0; i < n; ++i) {
-    p_[i] = p_[i] / c_[n - 1];
-    c_[i] = c_[i] / c_[n - 1];
+    p_[i] = p_[i] / integral_;
+    c_[i] = c_[i] / integral_;
   }
 }
 
@@ -379,12 +380,14 @@ Mixture::Mixture(pugi::xml_node node)
     if (!pair.child("dist"))
       fatal_error("Mixture pair element does not have a distribution.");
 
-    // cummulative sum of probybilities
-    cumsum += std::stod(pair.attribute("probability").value());
+    // cummulative sum of probabilities
+    double p = std::stod(pair.attribute("probability").value());
 
     // Save cummulative probybility and distrubution
-    distribution_.push_back(
-      std::make_pair(cumsum, distribution_from_xml(pair.child("dist"))));
+    auto dist = distribution_from_xml(pair.child("dist"));
+    cumsum += p * dist->integral();
+
+    distribution_.push_back(std::make_pair(cumsum, std::move(dist)));
   }
 
   // Normalize cummulative probabilities to 1

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -383,7 +383,7 @@ Mixture::Mixture(pugi::xml_node node)
     // cummulative sum of probabilities
     double p = std::stod(pair.attribute("probability").value());
 
-    // Save cummulative probybility and distrubution
+    // Save cummulative probability and distribution
     auto dist = distribution_from_xml(pair.child("dist"));
     cumsum += p * dist->integral();
 

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -104,7 +104,9 @@ size_t DiscreteIndex::sample(uint64_t* seed) const
 
 void DiscreteIndex::normalize()
 {
-  // Renormalize density function so that it sums to unity
+  // Renormalize density function so that it sums to unity. Note that we save
+  // the integral of the distribution so that if it is used as part of another
+  // distribution (e.g., Mixture), we know its relative strength.
   integral_ = std::accumulate(prob_.begin(), prob_.end(), 0.0);
   for (auto& p_i : prob_) {
     p_i /= integral_;
@@ -300,7 +302,9 @@ void Tabular::init(
     }
   }
 
-  // Normalize density and distribution functions
+  // Normalize density and distribution functions. Note that we save the
+  // integral of the distribution so that if it is used as part of another
+  // distribution (e.g., Mixture), we know its relative strength.
   integral_ = c_[n - 1];
   for (int i = 0; i < n; ++i) {
     p_[i] = p_[i] / integral_;


### PR DESCRIPTION
# Description

The `Mixture` distribution type allows you to sample a mixture of multiple distributions at specified probabilities. We used to assume that the underlying distributions always integrated to one, but now we have distributions which are allowed to integrate to non-unity values to represent intensities (e.g., line spectra from a decay photon source). On the Python side, when sampling the `Mixture` distribution, the probabilities are weighted by the integrals of the underlying distributions, but we missed this on the C++ side. This PR fixes this so that the integrals of the distributions are accounted for when choosing which distribution to sampling from.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- <s>[ ] I have made corresponding changes to the documentation (if applicable)</s>
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)