### PR TITLE
Releasing ID after creating dummy universe for cell plotting

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -618,7 +618,10 @@ class Cell(IDManagerMixin):
             Axes containing resulting image
 
         """
-        return openmc.Universe(cells=[self]).plot(*args, **kwargs)
+        u = openmc.Universe(cells=[self])
+        ax = u.plot(*args, **kwargs)
+        openmc.release_ids([u.id], openmc.Universe)
+        return ax
 
     def create_xml_subelement(self, xml_element, memo=None):
         """Add the cell's xml representation to an incoming xml element

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -618,10 +618,10 @@ class Cell(IDManagerMixin):
             Axes containing resulting image
 
         """
-        u = openmc.Universe(cells=[self])
-        ax = u.plot(*args, **kwargs)
-        openmc.release_ids([u.id], openmc.Universe)
-        return ax
+        # Create dummy universe but preserve used_ids
+        u = openmc.Universe(cells=[self], universe_id=openmc.Universe.next_id + 1)
+        openmc.Universe.used_ids.remove(u.id)
+        return u.plot(*args, **kwargs)
 
     def create_xml_subelement(self, xml_element, memo=None):
         """Add the cell's xml representation to an incoming xml element

--- a/openmc/mixin.py
+++ b/openmc/mixin.py
@@ -73,6 +73,7 @@ class IDManagerMixin:
             self._id = uid
 
 
+
 def reset_auto_ids():
     """Reset counters for all auto-generated IDs"""
     for cls in IDManagerMixin.__subclasses__():
@@ -97,6 +98,19 @@ def reserve_ids(ids, cls=None):
             cls.used_ids |= set(ids)
     else:
         cls.used_ids |= set(ids)
+
+
+def release_ids(ids, cls):
+    """Release IDs from the set of used IDs
+
+    Parameters
+    ----------
+    ids : iterable of int
+
+    """
+    for uid in ids:
+        cls.used_ids.remove(uid)
+    cls.next_id = max(cls.used_ids) + 1
 
 
 def set_auto_id(next_id):

--- a/openmc/mixin.py
+++ b/openmc/mixin.py
@@ -100,7 +100,7 @@ def reserve_ids(ids, cls=None):
         cls.used_ids |= set(ids)
 
 
-def release_ids(ids, cls):
+def release_ids(ids, cls=None):
     """Release IDs from the set of used IDs
 
     Parameters
@@ -108,12 +108,18 @@ def release_ids(ids, cls):
     ids : iterable of int
         IDs to release
     cls : type
-       Class for which IDs should be released (e.g., :class:`openmc.Cell`).
+       Class for which IDs should be released (e.g., :class:`openmc.Cell`). If
+       None, all classes that have auto-generated IDs will be used.
+
 
     """
-    for uid in ids:
-        cls.used_ids.remove(uid)
-    cls.next_id = max(cls.used_ids) + 1
+    if cls is None:
+        for cls in IDManagerMixin.__subclasses__():
+            release_ids(ids, cls)
+    else:
+        for uid in ids:
+            cls.used_ids.remove(uid)
+        cls.next_id = max(cls.used_ids) + 1
 
 
 def set_auto_id(next_id):

--- a/openmc/mixin.py
+++ b/openmc/mixin.py
@@ -73,7 +73,6 @@ class IDManagerMixin:
             self._id = uid
 
 
-
 def reset_auto_ids():
     """Reset counters for all auto-generated IDs"""
     for cls in IDManagerMixin.__subclasses__():
@@ -98,27 +97,6 @@ def reserve_ids(ids, cls=None):
             cls.used_ids |= set(ids)
     else:
         cls.used_ids |= set(ids)
-
-
-def release_ids(ids, cls=None):
-    """Release IDs from the set of used IDs
-
-    Parameters
-    ----------
-    ids : iterable of int
-        IDs to release
-    cls : type
-       Class for which IDs should be released (e.g., :class:`openmc.Cell`). If
-       None, all classes that have auto-generated IDs will be used.
-
-
-    """
-    if cls is None:
-        for cls in IDManagerMixin.__subclasses__():
-            release_ids(ids, cls)
-    else:
-        cls.used_ids -= set(ids)
-        cls.next_id = max(cls.used_ids) + 1
 
 
 def set_auto_id(next_id):

--- a/openmc/mixin.py
+++ b/openmc/mixin.py
@@ -106,6 +106,9 @@ def release_ids(ids, cls):
     Parameters
     ----------
     ids : iterable of int
+        IDs to release
+    cls : type
+       Class for which IDs should be released (e.g., :class:`openmc.Cell`).
 
     """
     for uid in ids:

--- a/openmc/mixin.py
+++ b/openmc/mixin.py
@@ -117,8 +117,7 @@ def release_ids(ids, cls=None):
         for cls in IDManagerMixin.__subclasses__():
             release_ids(ids, cls)
     else:
-        for uid in ids:
-            cls.used_ids.remove(uid)
+        cls.used_ids -= set(ids)
         cls.next_id = max(cls.used_ids) + 1
 
 

--- a/tests/unit_tests/test_cell.py
+++ b/tests/unit_tests/test_cell.py
@@ -345,3 +345,19 @@ def test_rotation_from_xml(rotation):
         elem, {s.id: s}, {'void': None}, openmc.Universe
     )
     np.testing.assert_allclose(new_cell.rotation, cell.rotation)
+
+
+def test_plot(run_in_tmpdir):
+    zcyl = openmc.ZCylinder()
+    c = openmc.Cell(region=-zcyl)
+
+    # create a universe before the plot
+    u_before = openmc.Universe()
+
+    # create a plot of the cell
+    c.plot()
+
+    # create a universe after the plot
+    u_after = openmc.Universe()
+
+    assert u_before.id + 1 == u_after.id

--- a/tests/unit_tests/test_cell.py
+++ b/tests/unit_tests/test_cell.py
@@ -360,4 +360,6 @@ def test_plot(run_in_tmpdir):
     # create a universe after the plot
     u_after = openmc.Universe()
 
+    # ensure that calling the plot method doesn't
+    # affect the universe ID space
     assert u_before.id + 1 == u_after.id


### PR DESCRIPTION
# Description

This might be overkill, but while reviewing @shimwell's PR providing the `Geometry.plot` option I realized that creating a `Universe` object in the `Cell.plot` method might reserve a bunch of IDs under the hood and potentially confuse users later on during model generation. 

Here I've added a function to the mixin module that allows us to release IDs for a given type. This way the next `Universe` object created after a `Cell.plot` call will have the same ID as it would have in the absence of the plot call.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
