### PR TITLE
Weight window surface

### DIFF
--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -30,6 +30,7 @@
 #include "openmc/tallies/tally.h"
 #include "openmc/tallies/tally_scoring.h"
 #include "openmc/track_output.h"
+#include "openmc/weight_windows.h"
 
 #ifdef DAGMC
 #include "DagMC.hpp"
@@ -272,6 +273,16 @@ void Particle::event_cross_surface()
   } else {
     // Particle crosses surface
     cross_surface();
+    switch(this->type()) {
+      case ParticleType::neutron:
+        if(settings::weight_windows_on && this->alive()) {
+          apply_weight_windows(*this);
+        }
+      case ParticleType::photon:
+        if(settings::weight_windows_on && this->alive()) {
+          apply_weight_windows(*this);
+        }
+    }
     event() = TallyEvent::SURFACE;
   }
   // Score cell to cell partial currents

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -273,15 +273,17 @@ void Particle::event_cross_surface()
   } else {
     // Particle crosses surface
     cross_surface();
-    switch(this->type()) {
+    switch (this->type()) {
       case ParticleType::neutron:
         if(settings::weight_windows_on && this->alive()) {
           apply_weight_windows(*this);
         }
+        break;
       case ParticleType::photon:
         if(settings::weight_windows_on && this->alive()) {
           apply_weight_windows(*this);
         }
+        break;
     }
     event() = TallyEvent::SURFACE;
   }


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Performing weight window upon surface crossing.
Note: 1) Not supporting cross_lattice yet. 2) only supporting neutron and photon.

Fixes # (issue)

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
