### PR TITLE
Always set html_theme in readthedocs configuration

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -120,10 +120,9 @@ pygments_style = 'tango'
 # -- Options for HTML output ---------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages
-if not on_rtd:
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+import sphinx_rtd_theme
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_logo = '_images/openmc_logo.png'
 


### PR DESCRIPTION
# Description

Looks like our CI is currently failing on all PRs due to a readthedocs build failure, which in turn is due to an [internal change in RTD](https://github.com/readthedocs/readthedocs.org/issues/10662). This PR should fix this by always setting `html_theme`.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>