### PR TITLE
Adding helpful info to keyerror for StepResults.get_material

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -618,7 +618,10 @@ class Cell(IDManagerMixin):
             Axes containing resulting image
 
         """
-        return openmc.Universe(cells=[self]).plot(*args, **kwargs)
+        # Create dummy universe but preserve used_ids
+        u = openmc.Universe(cells=[self], universe_id=openmc.Universe.next_id + 1)
+        openmc.Universe.used_ids.remove(u.id)
+        return u.plot(*args, **kwargs)
 
     def create_xml_subelement(self, xml_element, memo=None):
         """Add the cell's xml representation to an incoming xml element

--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -210,27 +210,27 @@ class StepResult:
         mat_id : str
             Material ID as a string
 
-        Raises
-        ------
-        KeyError
-            If mat_id specified is not found in the StepResult
-
         Returns
         -------
         openmc.Material
             Equivalent material
+
+        Raises
+        ------
+        KeyError
+            If specified material ID is not found in the StepResult
+
         """
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', openmc.IDWarning)
             material = openmc.Material(material_id=int(mat_id))
         try:
             vol = self.volume[mat_id]
-        except KeyError:
-            msg = (
+        except KeyError as e:
+            raise KeyError(
                 f'mat_id {mat_id} not found in StepResult. Available mat_id '
                 f'values are {list(self.volume.keys())}'
-            )
-            raise KeyError(msg)
+            ) from e
         for nuc, _ in sorted(self.index_nuc.items(), key=lambda x: x[1]):
             atoms = self[0, mat_id, nuc]
             if atoms < 0.0:

--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -218,7 +218,14 @@ class StepResult:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', openmc.IDWarning)
             material = openmc.Material(material_id=int(mat_id))
-        vol = self.volume[mat_id]
+        try:
+            vol = self.volume[mat_id]
+        except KeyError:
+            msg = (
+                'mat_id not found in StepResult. Available mat_id values are'
+                f'{list(self.volume.keys())}'
+            )
+            raise KeyError(msg)
         for nuc, _ in sorted(self.index_nuc.items(), key=lambda x: x[1]):
             atoms = self[0, mat_id, nuc]
             if atoms < 0.0:

--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -210,6 +210,11 @@ class StepResult:
         mat_id : str
             Material ID as a string
 
+        Raises
+        ------
+        KeyError
+            If mat_id specified is not found in the StepResult
+
         Returns
         -------
         openmc.Material
@@ -222,8 +227,8 @@ class StepResult:
             vol = self.volume[mat_id]
         except KeyError:
             msg = (
-                'mat_id not found in StepResult. Available mat_id values are'
-                f'{list(self.volume.keys())}'
+                f'mat_id {mat_id} not found in StepResult. Available mat_id '
+                f'values are {list(self.volume.keys())}'
             )
             raise KeyError(msg)
         for nuc, _ in sorted(self.index_nuc.items(), key=lambda x: x[1]):


### PR DESCRIPTION
# Description

Inspired by [this user story](https://openmc.discourse.group/t/issues-fetching-nuclide-concentration-from-depleted-results/3367)

This PR proposes adding to the error message that a user gets when trying to access a material id in the StepResult.get_material() that is not present.


```python
import openmc
import openmc.deplete
results = openmc.deplete.Results.from_hdf5('depletion_results.h5')
step=results[0]
step.get_material('42')
```

current behaviour
```
>>> KeyError: '42'
```
proposed behaviour
```
KeyError: "mat_id '42' not found in StepResult. Available mat_id values are ['1', '2', '3']"
```

# Checklist

- [x] I have performed a self-review of my own code
<s> - [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)</s>
<s>- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)<\s>

