### PR TITLE
Adding missing origin to CylindricalMesh.from_domain

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1314,7 +1314,6 @@ class CylindricalMesh(StructuredMesh):
                 for p in range(1, np + 1)
                 for r in range(1, nr + 1))
 
-
     @property
     def lower_left(self):
         return np.array((
@@ -1413,7 +1412,6 @@ class CylindricalMesh(StructuredMesh):
             (openmc.Cell, openmc.Region, openmc.Universe, openmc.Geometry),
         )
 
-
         # loaded once to avoid reading h5m file repeatedly
         cached_bb = domain.bounding_box
         max_bounding_box_radius = max(
@@ -1439,8 +1437,14 @@ class CylindricalMesh(StructuredMesh):
             cached_bb[1][2],
             num=dimension[2]+1
         )
+        origin = cached_bb.center
         mesh = cls(
-            r_grid=r_grid, z_grid=z_grid, phi_grid=phi_grid, mesh_id=mesh_id, name=name
+            r_grid=r_grid,
+            z_grid=z_grid,
+            phi_grid=phi_grid,
+            mesh_id=mesh_id,
+            name=name,
+            origin=origin
         )
 
         return mesh

--- a/tests/unit_tests/test_mesh_from_domain.py
+++ b/tests/unit_tests/test_mesh_from_domain.py
@@ -30,6 +30,7 @@ def test_cylindrical_mesh_from_cell():
     assert np.array_equal(mesh.r_grid, [0., 25., 50.])
     assert np.array_equal(mesh.phi_grid, [0., 0.5*np.pi, np.pi, 1.5*np.pi, 2.*np.pi])
     assert np.array_equal(mesh.z_grid, [0., 10., 20., 30.])
+    assert np.array_equal(mesh.origin, [0., 0., 15.])
 
 
 def test_reg_mesh_from_region():


### PR DESCRIPTION
# Description

While making cylindrical meshes from a domain I noticed the mesh was not fitting the geometry correctly in the Z direction. After digging into the code I noticed that the origin was not set and therefore defaulting to 0,0,0. My geometry starts on the zplane=0 and goes upwards. Anyway this PR now sets the origin to the center of the bounding box.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
