### PR TITLE
fix docker image building for openmc+dagmc combination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ RUN cd $HOME \
 RUN if [ "$build_dagmc" = "on" ]; then \
         # Install addition packages required for DAGMC
         apt-get -y install libeigen3-dev libnetcdf-dev libtbb-dev libglfw3-dev \
-        && pip install --upgrade numpy cython \
+        && pip install --upgrade numpy "cython<3.0" \
         # Clone and install EMBREE
         && mkdir -p $HOME/EMBREE && cd $HOME/EMBREE \
         && git clone --single-branch -b ${EMBREE_TAG} --depth 1 ${EMBREE_REPO} \


### PR DESCRIPTION
# Description

I just noticed a red badge on our readme, it looks like the docker image for openmc with dagmc has been failing for a little while
https://github.com/openmc-dev/openmc/actions?query=workflow%3Adockerhub-publish-develop-dagmc

This PR attempts to fix the failing dockerfile build by pinning the version of cython.

I've built the image locally and this appears to fix the build problem.

A similar PR has already been merged into DAGMC
https://github.com/svalinn/DAGMC/pull/893


Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code

I've not added a test but the Ci test for building this dockerfile already exists