### PR TITLE
Update documentation around use of source classes

### DIFF
--- a/docs/source/io_formats/settings.rst
+++ b/docs/source/io_formats/settings.rst
@@ -508,14 +508,15 @@ attributes/sub-elements:
       as a unique pointer. This function can be used to pass parameters through to
       the source from the XML, if needed.
 
-    More documentation on how to build sources can be found in :ref:`custom_source`.
+    More documentation on how to build sources can be found in
+    :ref:`compiled_source`.
 
   :parameters:
     If this attribute is given, it indicated that the source type is
     ``compiled``. Its value provides the parameters to pass through to the class
     generated using the ``library`` parameter. More documentation on how to
     build parametrized sources can be found in
-    :ref:`parameterized_custom_source`.
+    :ref:`parameterized_compiled_source`.
 
   :space:
     An element specifying the spatial distribution of source sites. This element

--- a/docs/source/pythonapi/base.rst
+++ b/docs/source/pythonapi/base.rst
@@ -21,7 +21,10 @@ Simulation Settings
    :nosignatures:
    :template: myclass.rst
 
-   openmc.Source
+   openmc.SourceBase
+   openmc.IndependentSource
+   openmc.FileSource
+   openmc.CompiledSource
    openmc.SourceParticle
    openmc.VolumeCalculation
    openmc.Settings
@@ -42,9 +45,6 @@ Material Specification
    :nosignatures:
    :template: myclass.rst
 
-   openmc.Nuclide
-   openmc.Element
-   openmc.Macroscopic
    openmc.Material
    openmc.Materials
 

--- a/docs/source/usersguide/tallies.rst
+++ b/docs/source/usersguide/tallies.rst
@@ -318,9 +318,9 @@ The following tables show all valid scores:
     |                      |NJOY's HEATR module.                               |
     +----------------------+---------------------------------------------------+
     |pulse-height          |The energy deposited by an entire photon's history |
-    |                      |(including its progeny). Units are eV per source   | 
+    |                      |(including its progeny). Units are eV per source   |
     |                      |particle. Note that this score can only be combined|
-    |                      |with a cell filter and an energy filter.           |   
+    |                      |with a cell filter and an energy filter.           |
     +----------------------+---------------------------------------------------+
 
 .. _usersguide_tally_normalization:
@@ -337,7 +337,7 @@ it is usually straightforward to convert units if the source rate is known. For
 example, if the system being modeled includes a source that is emitting 10\
 :sup:`4` neutrons per second, the tally results just need to be multipled by 10\
 :sup:`4`. This can either be done manually or using the
-:attr:`openmc.Source.strength` attribute.
+:attr:`openmc.SourceBase.strength` attribute.
 
 For a :math:`k`\ -eigenvalue calculation, normalizing tally results is not as
 simple because the source rate is not actually known. Instead, we typically know


### PR DESCRIPTION
# Description

I noticed that our documentation still mentions `openmc.Source` in quite a few places which needs to be updated to `openmc.IndependentSource` after #2524. There were also some mentions of `CustomSource`, which generally we prefer to be called `CompiledSource` now.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>
