### PR TITLE
cy mesh origin from start of z_grid and _r_grid

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1413,7 +1413,7 @@ class CylindricalMesh(StructuredMesh):
             (openmc.Cell, openmc.Region, openmc.Universe, openmc.Geometry),
         )
 
-        # loaded once to avoid reading h5m file repeatedly
+        # loaded once to avoid recalculating bounding box
         cached_bb = domain.bounding_box
         max_bounding_box_radius = max(
             [

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1438,7 +1438,7 @@ class CylindricalMesh(StructuredMesh):
             cached_bb[1][2],
             num=dimension[2]+1
         )
-        origin = (r_grid[0], r_grid[0], z_grid[0])
+        origin = (cached_bb.center[0], cached_bb.center[1], z_grid[0])
         mesh = cls(
             r_grid=r_grid,
             z_grid=z_grid,

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1438,7 +1438,7 @@ class CylindricalMesh(StructuredMesh):
             cached_bb[1][2],
             num=dimension[2]+1
         )
-        origin = cached_bb.center
+        origin = (r_grid[0], r_grid[0], z_grid[0])
         mesh = cls(
             r_grid=r_grid,
             z_grid=z_grid,

--- a/tests/unit_tests/test_mesh_from_domain.py
+++ b/tests/unit_tests/test_mesh_from_domain.py
@@ -18,10 +18,11 @@ def test_reg_mesh_from_cell():
 
 def test_cylindrical_mesh_from_cell():
     """Tests a CylindricalMesh can be made from a Cell and the specified
-    dimensions are propagated through. Cell is not centralized"""
+    dimensions are propagated through."""
+    # Cell is not centralized on Z axis
     cy_surface = openmc.ZCylinder(r=50)
-    z_surface_1 = openmc.ZPlane(z0=30)
-    z_surface_2 = openmc.ZPlane(z0=0)
+    z_surface_1 = openmc.ZPlane(z0=40)
+    z_surface_2 = openmc.ZPlane(z0=10)
     cell = openmc.Cell(region=-cy_surface & -z_surface_1 & +z_surface_2)
     mesh = openmc.CylindricalMesh.from_domain(domain=cell, dimension=[2, 4, 3])
 
@@ -29,8 +30,27 @@ def test_cylindrical_mesh_from_cell():
     assert np.array_equal(mesh.dimension, (2, 4, 3))
     assert np.array_equal(mesh.r_grid, [0., 25., 50.])
     assert np.array_equal(mesh.phi_grid, [0., 0.5*np.pi, np.pi, 1.5*np.pi, 2.*np.pi])
-    assert np.array_equal(mesh.z_grid, [0., 10., 20., 30.])
-    assert np.array_equal(mesh.origin, [0., 0., 0.])
+    assert np.array_equal(mesh.z_grid, [10., 20., 30., 40.])
+    assert np.array_equal(mesh.origin, [0., 0., 10.])
+
+    # Cell is not centralized on Z or X axis
+    cy_surface = openmc.ZCylinder(r=50, x0=100)
+    cell = openmc.Cell(region=-cy_surface & -z_surface_1 & +z_surface_2)
+    mesh = openmc.CylindricalMesh.from_domain(domain=cell, dimension=[1, 1, 1])
+
+    assert isinstance(mesh, openmc.CylindricalMesh)
+    assert np.array_equal(mesh.dimension, (1, 1, 1))
+    assert np.array_equal(mesh.r_grid, [0., 150.])
+    assert np.array_equal(mesh.origin, [100., 0., 10.])
+
+    # Cell is not centralized on Z, X or Y axis
+    cy_surface = openmc.ZCylinder(r=50, x0=100, y0=170)
+    cell = openmc.Cell(region=-cy_surface & -z_surface_1 & +z_surface_2)
+    mesh = openmc.CylindricalMesh.from_domain(domain=cell, dimension=[1, 1, 1])
+
+    assert isinstance(mesh, openmc.CylindricalMesh)
+    assert np.array_equal(mesh.r_grid, [0., 220.])
+    assert np.array_equal(mesh.origin, [100., 170., 10.])
 
 
 def test_reg_mesh_from_region():

--- a/tests/unit_tests/test_mesh_from_domain.py
+++ b/tests/unit_tests/test_mesh_from_domain.py
@@ -30,7 +30,7 @@ def test_cylindrical_mesh_from_cell():
     assert np.array_equal(mesh.r_grid, [0., 25., 50.])
     assert np.array_equal(mesh.phi_grid, [0., 0.5*np.pi, np.pi, 1.5*np.pi, 2.*np.pi])
     assert np.array_equal(mesh.z_grid, [0., 10., 20., 30.])
-    assert np.array_equal(mesh.origin, [0., 0., 15.])
+    assert np.array_equal(mesh.origin, [0., 0., 0.])
 
 
 def test_reg_mesh_from_region():


### PR DESCRIPTION
# Description

This PR attempts to fix the cylindrical mesh origin again :blush: 

PR #2676 put the origin at the center of the mesh when it should have been at the start of the mesh.

Totally my fault, hopefully this fix is actually right this time. I added more tests to check off axis behavior 

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
