### PR TITLE
Avoid warning due to bounding box calculation in Universe.plot

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -7,7 +7,7 @@ from numbers import Integral, Real
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import lxml.etree as ET
-from warnings import warn
+import warnings
 
 import h5py
 import numpy as np
@@ -399,7 +399,9 @@ class Universe(UniverseBase):
             if origin is None:
                 # if nan values in the bb.center they get replaced with 0.0
                 # this happens when the bounding_box contains inf values
-                origin = np.nan_to_num(bb.center)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", RuntimeWarning)
+                    origin = np.nan_to_num(bb.center)
             if width is None:
                 bb_width = bb.width
                 x_width = bb_width['xyz'.index(basis[0])]

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -310,10 +310,9 @@ class Universe(UniverseBase):
         Parameters
         ----------
         origin : iterable of float
-            Coordinates at the origin of the plot, if left as None then the
-            universe.bounding_box.center will be used to attempt to
-            ascertain the origin. Defaults to (0, 0, 0) if the bounding_box
-            contains inf values
+            Coordinates at the origin of the plot. If left as None,
+            universe.bounding_box.center will be used to attempt to ascertain
+            the origin with infinite values being replaced by 0.
         width : iterable of float
             Width of the plot in each basis direction. If left as none then the
             universe.bounding_box.width() will be used to attempt to


### PR DESCRIPTION
# Description

Some of you may have noticed that running `universe.plot()` produces a warning message about an invalid value (for an example, see the screenshot in #2648). This is due to a bounding box calculation where the bounding box has some infinity values in it (that result in a `nan` value in the `center` property). This PR simply silences the warning since the invalid values are being handled appropriately.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)