### PR TITLE
cylindrical mesh lower left Z value corrected

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1320,7 +1320,7 @@ class CylindricalMesh(StructuredMesh):
         return np.array((
             self.origin[0] - self.r_grid[-1],
             self.origin[1] - self.r_grid[-1],
-            self.origin[2] - self.z_grid[-1]
+            self.origin[2] + self.z_grid[0]
         ))
 
     @property

--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -56,20 +56,25 @@ def test_cylindrical_mesh_bounding_box():
         origin=(0, 0, 0)
     )
     np.testing.assert_array_equal(mesh.upper_right, (1, 1, 1))
-    np.testing.assert_array_equal(mesh.lower_left, (-1, -1, -1))
+    np.testing.assert_array_equal(mesh.lower_left, (-1, -1, 0.1))
     bb = mesh.bounding_box
     assert isinstance(bb, openmc.BoundingBox)
-    np.testing.assert_array_equal(bb.lower_left, (-1, -1, -1))
+    np.testing.assert_array_equal(bb.lower_left, (-1, -1, 0.1))
     np.testing.assert_array_equal(bb.upper_right, (1, 1, 1))
 
     # test with mesh at origin (3, 5, 7)
     mesh.origin = (3, 5, 7)
     np.testing.assert_array_equal(mesh.upper_right, (4, 6, 8))
-    np.testing.assert_array_equal(mesh.lower_left, (2, 4, 6))
+    np.testing.assert_array_equal(mesh.lower_left, (2, 4, 7.1))
     bb = mesh.bounding_box
     assert isinstance(bb, openmc.BoundingBox)
-    np.testing.assert_array_equal(bb.lower_left, (2, 4, 6))
+    np.testing.assert_array_equal(bb.lower_left, (2, 4, 7.1))
     np.testing.assert_array_equal(bb.upper_right, (4, 6, 8))
+
+    # changing z grid to contain negative numbers
+    mesh.z_grid = [-10, 0, 10]
+    np.testing.assert_array_equal(mesh.lower_left, (2, 4, -3))
+    np.testing.assert_array_equal(mesh.upper_right, (4, 6, 17))
 
 
 def test_spherical_mesh_bounding_box():


### PR DESCRIPTION
# Description

I think the ```CylindricalMesh.bounding_box.lower_left``` Z value might not be correct. 

Steps to reproduce
```python
import oenmc
mesh = openmc.CylindricalMesh(
    r_grid=[1,2,3],
    z_grid=[0,10,20,30]
)
print(mesh.bounding_box)
BoundingBox(lower_left=(-3.0, -3.0, -30.0), upper_right=(3.0, 3.0, 30.0))
```

I was expecting the result to be 
```BoundingBox(lower_left=(-3.0, -3.0, 0.0), upper_right=(3.0, 3.0, 30.0))``` but it currently returns -30 instead of 0 for the lower left z value. As the mesh.origin is 0,0,0 and the z_grid goes from the origin upwards in steps of 0,10,20,30. There is no negative value in the z grid so I think the lower left value is not calculated correctly at the moment


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

