### PR TITLE
Add type checks on Intersection, Union, Complement

### DIFF
--- a/openmc/region.py
+++ b/openmc/region.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 
 import numpy as np
 
-from .checkvalue import check_type
 from .bounding_box import BoundingBox
 
 
@@ -362,6 +361,9 @@ class Intersection(Region, MutableSequence):
 
     def __init__(self, nodes):
         self._nodes = list(nodes)
+        for node in nodes:
+            if not isinstance(node, Region):
+                raise ValueError('Intersection operands must be of type Region')
 
     def __and__(self, other):
         new = Intersection(self)
@@ -450,6 +452,9 @@ class Union(Region, MutableSequence):
 
     def __init__(self, nodes):
         self._nodes = list(nodes)
+        for node in nodes:
+            if not isinstance(node, Region):
+                raise ValueError('Union operands must be of type Region')
 
     def __or__(self, other):
         new = Union(self)
@@ -566,7 +571,8 @@ class Complement(Region):
 
     @node.setter
     def node(self, node):
-        check_type('node', node, Region)
+        if not isinstance(node, Region):
+            raise ValueError('Complement operand must be of type Region')
         self._node = node
 
     @property

--- a/tests/unit_tests/test_region.py
+++ b/tests/unit_tests/test_region.py
@@ -222,3 +222,21 @@ def test_translate_inplace():
     # Translating a region in-place should *not* produce new surfaces
     region3 = region.translate((0.5, -6.7, 3.9), inplace=True)
     assert str(region) == str(region3)
+
+
+def test_invalid_operands():
+    s = openmc.Sphere()
+    z = 3
+
+    # Intersection with invalid operand
+    with pytest.raises(ValueError, match='must be of type Region'):
+        -s & +z
+
+    # Union with invalid operand
+    with pytest.raises(ValueError, match='must be of type Region'):
+        -s | +z
+
+    # Complement with invalid operand
+    with pytest.raises(ValueError, match='must be of type Region'):
+        openmc.Complement(z)
+


### PR DESCRIPTION
# Description

This PR performs type checks on operands to the `Intersection`, `Union`, and `Complement` classes. I decided not to use our standard `check_type` function because there was a noticeable overhead on very large CSG models (e.g., calling `Model.from_xml()`).

Closes #2563

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)