### PR TITLE
Refactor of translation from mesh handle to index for DAGMC geometry.

### DIFF
--- a/include/openmc/dagmc.h
+++ b/include/openmc/dagmc.h
@@ -37,6 +37,8 @@ class DAGSurface : public Surface {
 public:
   DAGSurface(std::shared_ptr<moab::DagMC> dag_ptr, int32_t dag_idx);
 
+  moab::EntityHandle mesh_handle() const;
+
   double evaluate(Position r) const override;
   double distance(Position r, Direction u, bool coincident) const override;
   Direction normal(Position r) const override;
@@ -56,6 +58,8 @@ private:
 class DAGCell : public Cell {
 public:
   DAGCell(std::shared_ptr<moab::DagMC> dag_ptr, int32_t dag_idx);
+
+  moab::EntityHandle mesh_handle() const;
 
   bool contains(Position r, Direction u, int32_t on_surface) const override;
 
@@ -122,6 +126,16 @@ public:
   void legacy_assign_material(
     std::string mat_string, std::unique_ptr<DAGCell>& c) const;
 
+  //! Return the index into the model cells vector for a given DAGMC volume
+  //! handle in the universe
+  //! \param[in] vol MOAB handle to the DAGMC volume set
+  int32_t cell_index(moab::EntityHandle vol) const;
+
+  //! Return the index into the model surfaces vector for a given DAGMC surface
+  //! handle in the universe
+  //! \param[in] surf MOAB handle to the DAGMC surface set
+  int32_t surface_index(moab::EntityHandle surf) const;
+
   //! Generate a string representing the ranges of IDs present in the DAGMC
   //! model. Contiguous chunks of IDs are represented as a range (i.e. 1-10). If
   //! there is a single ID a chunk, it will be represented as a single number
@@ -142,6 +156,7 @@ public:
                             //!< universe in OpenMC's surface vector
 
   // Accessors
+  std::shared_ptr<moab::DagMC> dagmc_ptr() const { return dagmc_instance_; }
   bool has_graveyard() const { return has_graveyard_; }
 
 private:

--- a/include/openmc/dagmc.h
+++ b/include/openmc/dagmc.h
@@ -47,7 +47,7 @@ public:
   inline void to_hdf5_inner(hid_t group_id) const override {};
 
   // Accessor methods
-  const std::shared_ptr<moab::DagMC>& dagmc_ptr() const { return dagmc_ptr_; }
+  moab::DagMC* dagmc_ptr() const { return dagmc_ptr_.get(); }
   int32_t dag_index() const { return dag_index_; }
 
 private:
@@ -71,7 +71,7 @@ public:
   void to_hdf5_inner(hid_t group_id) const override;
 
   // Accessor methods
-  const std::shared_ptr<moab::DagMC>& dagmc_ptr() const { return dagmc_ptr_; }
+  moab::DagMC* dagmc_ptr() const { return dagmc_ptr_.get(); }
   int32_t dag_index() const { return dag_index_; }
 
 private:
@@ -156,7 +156,7 @@ public:
                             //!< universe in OpenMC's surface vector
 
   // Accessors
-  std::shared_ptr<moab::DagMC> dagmc_ptr() const { return dagmc_instance_; }
+  moab::DagMC* dagmc_ptr() const { return dagmc_instance_.get(); }
   bool has_graveyard() const { return has_graveyard_; }
 
 private:

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -329,13 +329,15 @@ void DAGUniverse::init_geometry()
   } // end surface loop
 }
 
-int32_t DAGUniverse::cell_index(moab::EntityHandle vol) const {
+int32_t DAGUniverse::cell_index(moab::EntityHandle vol) const
+{
   // return the index of the volume in the DAGMC instance and then
   // adjust by the offset into the model cells for this DAGMC universe
   return dagmc_ptr()->index_by_handle(vol) + cell_idx_offset_;
 }
 
-int32_t DAGUniverse::surface_index(moab::EntityHandle surf) const {
+int32_t DAGUniverse::surface_index(moab::EntityHandle surf) const
+{
   // return the index of the surface in the DAGMC instance and then
   // adjust by the offset into the model cells for this DAGMC universe
   return dagmc_ptr()->index_by_handle(surf) + surf_idx_offset_;
@@ -655,7 +657,8 @@ bool DAGCell::contains(Position r, Direction u, int32_t on_surface) const
   return result;
 }
 
-moab::EntityHandle DAGCell::mesh_handle() const {
+moab::EntityHandle DAGCell::mesh_handle() const
+{
   return dagmc_ptr()->entity_by_index(3, dag_index());
 }
 
@@ -684,7 +687,8 @@ DAGSurface::DAGSurface(std::shared_ptr<moab::DagMC> dag_ptr, int32_t dag_idx)
   geom_type_ = GeometryType::DAG;
 } // empty constructor
 
-moab::EntityHandle DAGSurface::mesh_handle() const {
+moab::EntityHandle DAGSurface::mesh_handle() const
+{
   return dagmc_ptr()->entity_by_index(2, dag_index());
 }
 

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -329,6 +329,18 @@ void DAGUniverse::init_geometry()
   } // end surface loop
 }
 
+int32_t DAGUniverse::cell_index(moab::EntityHandle vol) const {
+  // return the index of the volume in the DAGMC instance and then
+  // adjust by the offset into the model cells for this DAGMC universe
+  return dagmc_ptr()->index_by_handle(vol) + cell_idx_offset_;
+}
+
+int32_t DAGUniverse::surface_index(moab::EntityHandle surf) const {
+  // return the index of the surface in the DAGMC instance and then
+  // adjust by the offset into the model cells for this DAGMC universe
+  return dagmc_ptr()->index_by_handle(surf) + surf_idx_offset_;
+}
+
 std::string DAGUniverse::dagmc_ids_for_dim(int dim) const
 {
   // generate a vector of ids
@@ -643,6 +655,10 @@ bool DAGCell::contains(Position r, Direction u, int32_t on_surface) const
   return result;
 }
 
+moab::EntityHandle DAGCell::mesh_handle() const {
+  return dagmc_ptr()->entity_by_index(3, dag_index());
+}
+
 void DAGCell::to_hdf5_inner(hid_t group_id) const
 {
   write_string(group_id, "geom_type", "dagmc", false);
@@ -667,6 +683,10 @@ DAGSurface::DAGSurface(std::shared_ptr<moab::DagMC> dag_ptr, int32_t dag_idx)
 {
   geom_type_ = GeometryType::DAG;
 } // empty constructor
+
+moab::EntityHandle DAGSurface::mesh_handle() const {
+  return dagmc_ptr()->entity_by_index(2, dag_index());
+}
 
 double DAGSurface::evaluate(Position r) const
 {
@@ -747,10 +767,8 @@ int32_t next_cell(int32_t surf, int32_t curr_cell, int32_t univ)
   auto cellp = dynamic_cast<DAGCell*>(model::cells[curr_cell].get());
   auto univp = static_cast<DAGUniverse*>(model::universes[univ].get());
 
-  moab::EntityHandle surf_handle =
-    surfp->dagmc_ptr()->entity_by_index(2, surfp->dag_index());
-  moab::EntityHandle curr_vol =
-    cellp->dagmc_ptr()->entity_by_index(3, cellp->dag_index());
+  moab::EntityHandle surf_handle = surfp->mesh_handle();
+  moab::EntityHandle curr_vol = cellp->mesh_handle();
 
   moab::EntityHandle new_vol;
   moab::ErrorCode rval =
@@ -758,7 +776,7 @@ int32_t next_cell(int32_t surf, int32_t curr_cell, int32_t univ)
   if (rval != moab::MB_SUCCESS)
     return -1;
 
-  return cellp->dagmc_ptr()->index_by_handle(new_vol) + univp->cell_idx_offset_;
+  return univp->cell_index(new_vol);
 }
 
 } // namespace openmc


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

As I was reviewing #2655, I noticed that we have some convoluted calls in `next_cell` for getting the index of DAGMC volumes and surfaces into `model::cells`/`model::surfaces`. This PR adds a few methods to clean that up a bit and avoid someone getting lost in logic they shouldn't have to worry about outside of the `DAGUniverse` class. Just a refactor, so no additional tests here.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
