### PR TITLE
Streamlined URR PRNG stream selection to avoid unneeded store/load ops

### DIFF
--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -857,9 +857,7 @@ void Nuclide::calculate_urr_xs(int i_temp, Particle& p) const
   // This guarantees the randomness and, at the same time, makes sure we
   // reuse random numbers for the same nuclide at different temperatures,
   // therefore preserving correlation of temperature in probability tables.
-  p.stream() = STREAM_URR_PTABLE;
-  double r = future_prn(static_cast<int64_t>(index_), *p.current_seed());
-  p.stream() = STREAM_TRACKING;
+  double r = future_prn(static_cast<int64_t>(index_), p.seeds(STREAM_URR_PTABLE));
 
   // Warning: this assumes row-major order of cdf_values_
   int i_low = upper_bound_index(&urr.cdf_values_(i_energy, 0),

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -857,7 +857,8 @@ void Nuclide::calculate_urr_xs(int i_temp, Particle& p) const
   // This guarantees the randomness and, at the same time, makes sure we
   // reuse random numbers for the same nuclide at different temperatures,
   // therefore preserving correlation of temperature in probability tables.
-  double r = future_prn(static_cast<int64_t>(index_), p.seeds(STREAM_URR_PTABLE));
+  double r =
+    future_prn(static_cast<int64_t>(index_), p.seeds(STREAM_URR_PTABLE));
 
   // Warning: this assumes row-major order of cdf_values_
   int i_low = upper_bound_index(&urr.cdf_values_(i_energy, 0),

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -150,9 +150,7 @@ void sample_neutron_reaction(Particle& p)
 
   // Advance URR seed stream 'N' times after energy changes
   if (p.E() != p.E_last()) {
-    p.stream() = STREAM_URR_PTABLE;
-    advance_prn_seed(data::nuclides.size(), p.current_seed());
-    p.stream() = STREAM_TRACKING;
+    advance_prn_seed(data::nuclides.size(), p.seeds(STREAM_URR_PTABLE));
   }
 
   // Play russian roulette if survival biasing is turned on

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -150,7 +150,7 @@ void sample_neutron_reaction(Particle& p)
 
   // Advance URR seed stream 'N' times after energy changes
   if (p.E() != p.E_last()) {
-    advance_prn_seed(data::nuclides.size(), p.seeds(STREAM_URR_PTABLE));
+    advance_prn_seed(data::nuclides.size(), &p.seeds(STREAM_URR_PTABLE));
   }
 
   // Play russian roulette if survival biasing is turned on


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Very slight optimization (and reduction in lines of code) when changing streams to sample/forward the URR PRNG stream. In the affected cases, we were switching quickly to the URR stream to do something, then switching back to the standard tracking stream. This required writing to the particle field `stream_`, calling the PRNG function (which would read from `stream_`), then setting `stream_` back to the original tracking stream. Now, we directly pull the needed seed from the particle based on the stream we know we are accessing, which eliminates touching the `stream_` variable altogether.

It's unlikely this makes any measurable difference on CPU, but in any event, the instance in `nuclide.cpp` is part of the inner loop of the cross section lookup event, so optimizations here are a good idea, however small. Additionally, it reduces LOC while being (perhaps) slightly more readable.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
