### PR TITLE
allowing different volume methods for diff mat

### DIFF
--- a/openmc/deplete/independent_operator.py
+++ b/openmc/deplete/independent_operator.py
@@ -148,10 +148,10 @@ class IndependentOperator(OpenMCOperator):
 
         self.fluxes = fluxes
         super().__init__(
-            materials,
-            micros,
-            chain_file,
-            prev_results,
+            materials=materials,
+            cross_sections=micros,
+            chain_file=chain_file,
+            prev_results=prev_results,
             fission_q=fission_q,
             helper_kwargs=helper_kwargs,
             reduce_chain=reduce_chain,

--- a/tests/unit_tests/test_deplete_coupled_operator.py
+++ b/tests/unit_tests/test_deplete_coupled_operator.py
@@ -48,8 +48,73 @@ def model():
 
     return openmc.Model(geometry, materials, settings)
 
+@pytest.fixture()
+def model_with_volumes():
+    mat1 = openmc.Material()
+    mat1.add_element("Ag", 1, percent_type="ao")
+    mat1.set_density("g/cm3", 10.49)
+    mat1.depletable = True
+    mat1.volume = 102
+
+    mat2 = openmc.Material()
+    mat2.add_element("Ag", 1, percent_type="ao")
+    mat2.set_density("g/cm3", 10.49)
+    materials = openmc.Materials([mat1, mat2])
+
+    sph1 = openmc.Sphere(r=1.0)
+    sph2 = openmc.Sphere(r=2.0, x0=3)
+    sph3 = openmc.Sphere(r=5.0, boundary_type="vacuum")
+
+    cell1 = openmc.Cell(region=-sph1, cell_id=1)
+    cell1.volume = 4.19
+    cell2 = openmc.Cell(region=-sph2, cell_id=2)
+    cell2.volume = 33.51
+    cell3 = openmc.Cell(region=-sph3 & +sph1 & +sph2, cell_id=3)
+    cell3.volume = 485.9
+
+    cell1.fill = mat1
+    cell2.fill = mat1
+    cell3.fill = mat2
+
+    geometry = openmc.Geometry([cell1, cell2, cell3])
+
+    return openmc.model.Model(geometry, materials)
+
 def test_operator_init(model):
     """The test uses a temporary dummy chain. This file will be removed
     at the end of the test, and only contains a depletion_chain node."""
 
     CoupledOperator(model, CHAIN_PATH)
+
+def test_diff_volume_method_match_cell(model_with_volumes):
+    """Tests the volumes assigned to the materials match the cell volumes"""
+
+    operator = openmc.deplete.CoupledOperator(
+        model=model_with_volumes,
+        diff_burnable_mats=True,
+        diff_volume_method='match cell',
+        chain_file=CHAIN_PATH
+    )
+
+    all_cells = operator.geometry.get_all_cells()
+    assert all_cells[1].fill.volume == 4.19
+    assert all_cells[2].fill.volume == 33.51
+    # mat2 is not depletable
+    assert all_cells[3].fill.volume is None
+
+def test_diff_volume_method_divide_equally(model_with_volumes):
+    """Tests the volumes assigned to the materials are divided equally"""
+
+    operator = openmc.deplete.CoupledOperator(
+        model=model_with_volumes,
+        diff_burnable_mats=True,
+        diff_volume_method='divide equally',
+        chain_file=CHAIN_PATH
+    )
+
+    all_cells = operator.geometry.get_all_cells()
+    assert all_cells[1].fill[0].volume == 51
+    assert all_cells[2].fill[0].volume == 51
+    # mat2 is not depletable
+    assert all_cells[3].fill.volume is None
+


### PR DESCRIPTION
# Description

A while back I tried PR #2653 but this changed the behaviour of the diff_burnable_mat too much for it's main use case.

```diff_burnable_mat``` appears to be doing two things when set to True, it changes the materials volumes and makes extra materials. This PR attempts to separate out both of these things and allow the user to specify each one

This PR is an attempt to add another argument to CoupledOperator so that the manner in which the volume is found can be user specified. This maintains current behavior as default when diff_burnable_mat is set to True but also allows users to split up the materials so that their volumes are assigned to the cell volume instead of always being divided equally.

Another argument called ```diff_volume_method```  which can be set to "divide equally" (default) or "match cell" (useful for fusion r2s and burn up)

Fig 6 in [this ](https://www.sciencedirect.com/science/article/pii/S0920379615002471) fantastic paper 😄 suggests we get about 20% burn up at the front of DEMO reactor solid breeder blankets. Hence I'm keen to see the CoupledOperator working in this slightly different way for fusion simulations.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)