### PR TITLE
Make sure FluxCollapseHelper loads missing nuclide data

### DIFF
--- a/openmc/deplete/helpers.py
+++ b/openmc/deplete/helpers.py
@@ -268,6 +268,11 @@ class FluxCollapseHelper(ReactionRateHelper):
         if self._reactions_direct and self._nuclides_direct is None:
             self._rate_tally.nuclides = nuclides
 
+        # Make sure nuclide data is loaded
+        for nuclide in self.nuclides:
+            if nuclide not in openmc.lib.nuclides:
+                openmc.lib.load_nuclide(nuclide)
+
     def generate_tallies(self, materials, scores):
         """Produce multigroup flux spectrum tally
 


### PR DESCRIPTION
# Description

As described in #2692, the flux reaction rate mode for depletion is currently broken due to the recent changes removing initial dilute nuclides. This PR should fix that.

Fixes #2692

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)