### PR TITLE
remove meaningless const qualifiers from plot.h

### DIFF
--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -99,8 +99,8 @@ public:
   virtual void print_info() const = 0;
 
   const std::string& path_plot() const { return path_plot_; }
-  const int id() const { return id_; }
-  const int level() const { return level_; }
+  int id() const { return id_; }
+  int level() const { return level_; }
 
   // Public color-related data
   PlottableInterface(pugi::xml_node plot_node);


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

As pointed out in #2683, the intel compiler issues some warnings about meaningless const qualifiers when returning some ints from a plotting class. This PR just removes that to fix the warnings; it has nothing to do with the issues observed on intel compilers.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- x ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
