### PR TITLE
added padding arg to bounding_region

### DIFF
--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -950,7 +950,13 @@ class DAGMCUniverse(UniverseBase):
         dagmc_element.set('filename', str(self.filename))
         xml_element.append(dagmc_element)
 
-    def bounding_region(self, bounded_type='box', boundary_type='vacuum', starting_id=10000):
+    def bounding_region(
+            self,
+            bounded_type: str = 'box',
+            boundary_type: str = 'vacuum',
+            starting_id: int = 10000,
+            padding: float = 0.
+        ):
         """Creates a either a spherical or box shaped bounding region around
         the DAGMC geometry.
 
@@ -970,6 +976,10 @@ class DAGMCUniverse(UniverseBase):
             Starting ID of the surface(s) used in the region. For bounded_type
             'box', the next 5 IDs will also be used. Defaults to 10000 to reduce
             the chance of an overlap of surface IDs with the DAGMC geometry.
+        padding : float
+            Distance between the bounding region surfaces and the minimal
+            bounding box. Allows for the region to be larger than the DAGMC
+            geometry.
 
         Returns
         -------
@@ -994,19 +1004,19 @@ class DAGMCUniverse(UniverseBase):
                 y0=bbox_center[1],
                 z0=bbox_center[2],
                 boundary_type=boundary_type,
-                r=radius,
+                r=radius + padding,
             )
 
             return -bounding_surface
 
         if bounded_type == 'box':
             # defines plane surfaces for all six faces of the bounding box
-            lower_x = openmc.XPlane(bbox[0][0], surface_id=starting_id)
-            upper_x = openmc.XPlane(bbox[1][0], surface_id=starting_id+1)
-            lower_y = openmc.YPlane(bbox[0][1], surface_id=starting_id+2)
-            upper_y = openmc.YPlane(bbox[1][1], surface_id=starting_id+3)
-            lower_z = openmc.ZPlane(bbox[0][2], surface_id=starting_id+4)
-            upper_z = openmc.ZPlane(bbox[1][2], surface_id=starting_id+5)
+            lower_x = openmc.XPlane(bbox[0][0]-padding, surface_id=starting_id)
+            upper_x = openmc.XPlane(bbox[1][0]+padding, surface_id=starting_id+1)
+            lower_y = openmc.YPlane(bbox[0][1]-padding, surface_id=starting_id+2)
+            upper_y = openmc.YPlane(bbox[1][1]+padding, surface_id=starting_id+3)
+            lower_z = openmc.ZPlane(bbox[0][2]-padding, surface_id=starting_id+4)
+            upper_z = openmc.ZPlane(bbox[1][2]+padding, surface_id=starting_id+5)
 
             region = +lower_x & -upper_x & +lower_y & -upper_y & +lower_z & -upper_z
 

--- a/tests/unit_tests/dagmc/test_bounds.py
+++ b/tests/unit_tests/dagmc/test_bounds.py
@@ -23,23 +23,38 @@ def test_bounding_region(request):
     assert isinstance(region, openmc.Region)
     assert len(region) == 6
     assert region[0].surface.type == "x-plane"
+    assert region[0].surface.x0 == -25.
     assert region[1].surface.type == "x-plane"
+    assert region[1].surface.x0 == 25.
     assert region[2].surface.type == "y-plane"
+    assert region[2].surface.y0 == -25.
     assert region[3].surface.type == "y-plane"
+    assert region[3].surface.y0 == 25.
     assert region[4].surface.type == "z-plane"
+    assert region[4].surface.z0 == -25.
     assert region[5].surface.type == "z-plane"
+    assert region[5].surface.z0 == 25.
     assert region[0].surface.boundary_type == "vacuum"
     assert region[1].surface.boundary_type == "vacuum"
     assert region[2].surface.boundary_type == "vacuum"
     assert region[3].surface.boundary_type == "vacuum"
     assert region[4].surface.boundary_type == "vacuum"
     assert region[5].surface.boundary_type == "vacuum"
+    region = u.bounding_region(padding=5)
+    assert region[0].surface.x0 == -30.
+    assert region[1].surface.x0 == 30.
+    assert region[2].surface.y0 == -30.
+    assert region[3].surface.y0 == 30.
+    assert region[4].surface.z0 == -30.
+    assert region[5].surface.z0 == 30.
 
     region = u.bounding_region(bounded_type="sphere", boundary_type="reflective")
     assert isinstance(region, openmc.Region)
     assert isinstance(region, openmc.Halfspace)
     assert region.surface.type == "sphere"
     assert region.surface.boundary_type == "reflective"
+    larger_region = u.bounding_region(bounded_type="sphere", padding=10)
+    assert larger_region.surface.r == region.surface.r +10
 
 
 def test_bounded_universe(request):


### PR DESCRIPTION
# Description

Every so often a user makes a DAGMC geometry and puts the source outside of the bounding CSG cell. This has come up a few times on the forum, most recently

https://openmc.discourse.group/t/error-more-than-95-of-external-source-sites-sampled-were-rejected-please-check-your-external-source-s-spatial-definition/3343

I'm wondering if this proposed ```padding``` argument might help as it allows the newly formed bounding region to be larger and thus include the source term.

```python
u = openmc.DAGMCUniverse('dagmc.h5m').bounded_universe(padding=1000)  
# makes the containing cell bigger than the dagmc universe by 1000 in each direction
```

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
