### PR TITLE
Faster indexing in `MicroXS` object

### DIFF
--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -187,6 +187,8 @@ class MicroXS:
         self.data = data
         self.nuclides = nuclides
         self.reactions = reactions
+        self._nuc_idx = {nuc: i for i, nuc in enumerate(nuclides)}
+        self._rx_idx = {rx: i for i, rx in enumerate(reactions)}
 
     # TODO: Add a classmethod for generating MicroXS directly from cross section
     # data using a known flux spectrum
@@ -222,8 +224,8 @@ class MicroXS:
 
     def __getitem__(self, index):
         nuc, rx = index
-        i_nuc = self.nuclides.index(nuc)
-        i_rx = self.reactions.index(rx)
+        i_nuc = self._nuc_idx[nuc]
+        i_rx = self._rx_idx[rx]
         return self.data[i_nuc, i_rx]
 
     def to_csv(self, *args, **kwargs):

--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -187,8 +187,8 @@ class MicroXS:
         self.data = data
         self.nuclides = nuclides
         self.reactions = reactions
-        self._nuc_idx = {nuc: i for i, nuc in enumerate(nuclides)}
-        self._rx_idx = {rx: i for i, rx in enumerate(reactions)}
+        self._index_nuc = {nuc: i for i, nuc in enumerate(nuclides)}
+        self._index_rx = {rx: i for i, rx in enumerate(reactions)}
 
     # TODO: Add a classmethod for generating MicroXS directly from cross section
     # data using a known flux spectrum
@@ -224,8 +224,8 @@ class MicroXS:
 
     def __getitem__(self, index):
         nuc, rx = index
-        i_nuc = self._nuc_idx[nuc]
-        i_rx = self._rx_idx[rx]
+        i_nuc = self._index_nuc[nuc]
+        i_rx = self._index_rx[rx]
         return self.data[i_nuc, i_rx]
 
     def to_csv(self, *args, **kwargs):


### PR DESCRIPTION
# Description

I noticed the majority of the time spent in a depletion calculation using the `IndependentOperator` was being spent in various calls to the `index` method of the Python builtin list class inside `MicroXS.__get_item__`. Adding private maps for these indices speeds up the `MicroXS._get_item__` by a factor of 30 and the whole depletion calculation by a factor of 2 on my machine. 

Some profiling output for before the change:
![image](https://github.com/openmc-dev/openmc/assets/18011007/539e6a88-7956-47be-b68d-bdc455b2234e)

and after the change:
![image](https://github.com/openmc-dev/openmc/assets/18011007/8fec6b6d-9de3-4507-95f4-1d815f36c56e)


# Checklist

- [x] I have performed a self-review of my own code
~~- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
~~- [ ] I have made corresponding changes to the documentation (if applicable)~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
