### PR TITLE
fixed typo in CF4Integrator docstring

### DIFF
--- a/openmc/deplete/integrators.py
+++ b/openmc/deplete/integrators.py
@@ -137,7 +137,7 @@ class CF4Integrator(Integrator):
         \mathbf{n}_{i+1} &= \exp \left ( \frac{\mathbf{A}_1}{4} + \frac{\mathbf{A}_2}{6}
             + \frac{\mathbf{A}_3}{6} - \frac{\mathbf{A}_4}{12} \right )
         \exp \left ( -\frac{\mathbf{A}_1}{12} + \frac{\mathbf{A}_2}{6} +
-            \frac{\mathbf{A}_3}{6} - \frac{\mathbf{A}_4}{4} \right ) \mathbf{n}_i.
+            \frac{\mathbf{A}_3}{6} + \frac{\mathbf{A}_4}{4} \right ) \mathbf{n}_i.
         \end{aligned}
     """
     _num_stages = 4


### PR DESCRIPTION
# Description

The `CF4Integrator` docstring has a minus sign where it should be a plus sign in one of the matrix exponential terms. The underlying algorithm implemented in `_matrix_funcs.py` is correct so this PR is just reflecting that.


# Checklist

- [x] I have performed a self-review of my own code
~~- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
~~- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
