### PR TITLE
simplifying LEQI docstring math and removing unnecessary operations

### DIFF
--- a/openmc/deplete/_matrix_funcs.py
+++ b/openmc/deplete/_matrix_funcs.py
@@ -77,4 +77,4 @@ def leqi_f4(chain, inputs, fission_yields=None):
     return (-dt ** 2 / (12 * dt_l * (dt + dt_l)) * f1
             + (dt ** 2 + 2 * dt * dt_l + dt_l ** 2)
             / (12 * dt_l * (dt + dt_l)) * f2
-            + (4 * dt * dt_l + 5 * dt_l ** 2) / (12 * dt_l * (dt + dt_l)) * f3)
+            + (4 * dt + 5 * dt_l) / (12 * (dt + dt_l)) * f3)

--- a/openmc/deplete/integrators.py
+++ b/openmc/deplete/integrators.py
@@ -360,8 +360,7 @@ class LEQIIntegrator(Integrator):
               h_i)} \mathbf{A}_0 + \frac{h_{i-1}}{12 (h_{i-1} + h_i)} \mathbf{A}_1 \\
         \mathbf{F}_4 &= \frac{-h_i^2}{12 h_{i-1} (h_{i-1} + h_i)} \mathbf{A}_{-1} +
               \frac{h_{i-1}^2 + 2 h_i h_{i-1} + h_i^2}{12 h_{i-1} (h_{i-1} + h_i)}
-              \mathbf{A}_0 + \frac{5 h_{i-1}^2 + 4 h_i h_{i-1}}{12 h_{i-1}
-              (h_{i-1} + h_i)} \mathbf{A}_1 \\
+              \mathbf{A}_0 + \frac{5 h_{i-1} + 4 h_i}{12 (h_{i-1} + h_i)} \mathbf{A}_1 \\
         \mathbf{n}_{i+1} &= \exp(h_i \mathbf{F}_4) \exp(h_i \mathbf{F}_3) \mathbf{n}_i
         \end{aligned}
 


### PR DESCRIPTION
# Description

I have been going through all the integrators to make sure that if $\mathbf{A}$ is constant over the whole time step $h_i$ (as it is for many fusion relevant calculations) that all the multistep integrators reduce to $`\mathbf{n}_{i+1} = \exp(h_i \mathbf{A}) \mathbf{n}_{i}`$. In going through the `LEQIIntegrator` method I noticed there are a couple unnecessary multiplications in the $`\mathbf{F}_4`$ term and thought it would be good to remove those and make the last term in $`\mathbf{F}_4`$ look more like the last term in $`\mathbf{F}_3`$. 

Here is what the docs look like now:

$`
\begin{aligned}
       \mathbf{F}_3 &= \frac{-h_i^2}{12 h_{i-1} (h_{i-1} + h_i)} \mathbf{A}_{-1} +
              \frac{5 h_{i-1}^2 + 6 h_i h_{i-1} + h_i^2}{12 h_{i-1} (h_{i-1} +
              h_i)} \mathbf{A}_0 + \frac{h_{i-1}}{12 (h_{i-1} + h_i)} \mathbf{A}_1 \\
        \mathbf{F}_4 &= \frac{-h_i^2}{12 h_{i-1} (h_{i-1} + h_i)} \mathbf{A}_{-1} +
              \frac{h_{i-1}^2 + 2 h_i h_{i-1} + h_i^2}{12 h_{i-1} (h_{i-1} + h_i)}
              \mathbf{A}_0 + \frac{5 h_{i-1}^2 + 4 h_i h_{i-1}}{12 h_{i-1}
              (h_{i-1} + h_i)} \mathbf{A}_1 \\
\end{aligned}
`$




And here is the small change with this patch:

$`
\begin{aligned}
\mathbf{F}_3 &= \frac{-h_i^2}{12 h_{i-1} (h_{i-1} + h_i)} \mathbf{A}_{-1} +
              \frac{5 h_{i-1}^2 + 6 h_i h_{i-1} + h_i^2}{12 h_{i-1} (h_{i-1} +
              h_i)} \mathbf{A}_0 + \frac{h_{i-1}}{12 (h_{i-1} + h_i)} \mathbf{A}_1 \\
\mathbf{F}_4 &= \frac{-h_i^2}{12 h_{i-1} (h_{i-1} + h_i)} \mathbf{A}_{-1} +
              \frac{h_{i-1}^2 + 2 h_i h_{i-1} + h_i^2}{12 h_{i-1} (h_{i-1} + h_i)}
              \mathbf{A}_0 + \frac{5 h_{i-1} + 4 h_i}{12 (h_{i-1} + h_i)} \mathbf{A}_1 \\
\end{aligned}
`$

I also removed these terms from the corresponding matrix function in `_matrix_funcs.py` 

If you work through the math for constant $\mathbf{A}$ you see that $`\mathbf{F}_3 = \mathbf{F}_4 = \frac{1}{2}\mathbf{A}`$ so that $`\mathbf{n}_{i+1} = \exp(h_i \mathbf{F}_4) \exp(h_i \mathbf{F}_3) \mathbf{n}_i = \exp(h_i \mathbf{A}) \mathbf{n}_{i}`$.

Some of this is a bit unnecessary since for the `IndependentOperator` you really only should use the `PredictorIntegrator` and perhaps it's even worth constraining that for performance (and accuracy) reasons.

# Checklist

- [x] I have performed a self-review of my own code
~~- [] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
~~- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
