### PR TITLE
Ensure that property setters are used in CylindricalMesh and SphericalMesh

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1036,7 +1036,7 @@ class RectilinearMesh(StructuredMesh):
     @x_grid.setter
     def x_grid(self, grid):
         cv.check_type('mesh x_grid', grid, Iterable, Real)
-        self._x_grid = np.asarray(grid)
+        self._x_grid = np.asarray(grid, dtype=float)
 
     @property
     def y_grid(self):
@@ -1045,7 +1045,7 @@ class RectilinearMesh(StructuredMesh):
     @y_grid.setter
     def y_grid(self, grid):
         cv.check_type('mesh y_grid', grid, Iterable, Real)
-        self._y_grid = np.asarray(grid)
+        self._y_grid = np.asarray(grid, dtype=float)
 
     @property
     def z_grid(self):
@@ -1054,7 +1054,7 @@ class RectilinearMesh(StructuredMesh):
     @z_grid.setter
     def z_grid(self, grid):
         cv.check_type('mesh z_grid', grid, Iterable, Real)
-        self._z_grid = np.asarray(grid)
+        self._z_grid = np.asarray(grid, dtype=float)
 
     @property
     def _grids(self):
@@ -1249,9 +1249,9 @@ class CylindricalMesh(StructuredMesh):
     ):
         super().__init__(mesh_id, name)
 
-        self._r_grid = r_grid
-        self._phi_grid = phi_grid
-        self._z_grid = z_grid
+        self.r_grid = r_grid
+        self.phi_grid = phi_grid
+        self.z_grid = z_grid
         self.origin = origin
 
     @property
@@ -1281,7 +1281,7 @@ class CylindricalMesh(StructuredMesh):
     @r_grid.setter
     def r_grid(self, grid):
         cv.check_type('mesh r_grid', grid, Iterable, Real)
-        self._r_grid = np.asarray(grid)
+        self._r_grid = np.asarray(grid, dtype=float)
 
     @property
     def phi_grid(self):
@@ -1290,7 +1290,7 @@ class CylindricalMesh(StructuredMesh):
     @phi_grid.setter
     def phi_grid(self, grid):
         cv.check_type('mesh phi_grid', grid, Iterable, Real)
-        self._phi_grid = np.asarray(grid)
+        self._phi_grid = np.asarray(grid, dtype=float)
 
     @property
     def z_grid(self):
@@ -1299,7 +1299,7 @@ class CylindricalMesh(StructuredMesh):
     @z_grid.setter
     def z_grid(self, grid):
         cv.check_type('mesh z_grid', grid, Iterable, Real)
-        self._z_grid = np.asarray(grid)
+        self._z_grid = np.asarray(grid, dtype=float)
 
     @property
     def _grids(self):
@@ -1610,9 +1610,9 @@ class SphericalMesh(StructuredMesh):
     ):
         super().__init__(mesh_id, name)
 
-        self._r_grid = r_grid
-        self._theta_grid = theta_grid
-        self._phi_grid = phi_grid
+        self.r_grid = r_grid
+        self.theta_grid = theta_grid
+        self.phi_grid = phi_grid
         self.origin = origin
 
     @property
@@ -1633,7 +1633,7 @@ class SphericalMesh(StructuredMesh):
     def origin(self, coords):
         cv.check_type('mesh origin', coords, Iterable, Real)
         cv.check_length("mesh origin", coords, 3)
-        self._origin = np.asarray(coords)
+        self._origin = np.asarray(coords, dtype=float)
 
     @property
     def r_grid(self):
@@ -1642,7 +1642,7 @@ class SphericalMesh(StructuredMesh):
     @r_grid.setter
     def r_grid(self, grid):
         cv.check_type('mesh r_grid', grid, Iterable, Real)
-        self._r_grid = np.asarray(grid)
+        self._r_grid = np.asarray(grid, dtype=float)
 
     @property
     def theta_grid(self):
@@ -1651,7 +1651,7 @@ class SphericalMesh(StructuredMesh):
     @theta_grid.setter
     def theta_grid(self, grid):
         cv.check_type('mesh theta_grid', grid, Iterable, Real)
-        self._theta_grid = np.asarray(grid)
+        self._theta_grid = np.asarray(grid, dtype=float)
 
     @property
     def phi_grid(self):
@@ -1660,7 +1660,7 @@ class SphericalMesh(StructuredMesh):
     @phi_grid.setter
     def phi_grid(self, grid):
         cv.check_type('mesh phi_grid', grid, Iterable, Real)
-        self._phi_grid = np.asarray(grid)
+        self._phi_grid = np.asarray(grid, dtype=float)
 
     @property
     def _grids(self):

--- a/openmc/weight_windows.py
+++ b/openmc/weight_windows.py
@@ -908,7 +908,7 @@ class WeightWindowGenerator:
         wwg.on_the_fly = bool(get_text(elem, 'on_the_fly'))
         wwg.method = get_text(elem, 'method')
 
-        if elem.find('update_parameters'):
+        if elem.find('update_parameters') is not None:
             update_parameters = {}
             params_elem = elem.find('update_parameters')
             for entry in params_elem:

--- a/tests/regression_tests/time_cutoff/test.py
+++ b/tests/regression_tests/time_cutoff/test.py
@@ -21,8 +21,8 @@ def time_model():
     settings_file.batches = 10
     settings_file.particles = 100
     settings_file.cutoff = {'time_neutron': time_cutoff}
-    settings_file.source = openmc.source.Source(space=openmc.stats.Point(),
-                                                energy=openmc.stats.Discrete([1e4], [1]))
+    settings_file.source = openmc.IndependentSource(
+        space=openmc.stats.Point(), energy=openmc.stats.Discrete([1e4], [1]))
     model.settings = settings_file
 
     # Tally flux under time cutoff

--- a/tests/unit_tests/test_deplete_transfer_rates.py
+++ b/tests/unit_tests/test_deplete_transfer_rates.py
@@ -91,8 +91,8 @@ def test_get_set(model, case_name, transfer_rates):
                                                    transfer_rate)
             elif case_name == 'rates_invalid_2':
                 with pytest.raises(ValueError, match='Cannot add transfer '
-                                    f'rate for element Gd to material 1 with '
-                                   'transfer rate\(s\) for nuclide\(s\) '
+                                   f'rate for element Gd to material 1 with '
+                                   r'transfer rate\(s\) for nuclide\(s\) '
                                    'Gd156, Gd157.'):
                     for component, transfer_rate in transfer_rates.items():
                         transfer.set_transfer_rate(material_input,

--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -101,7 +101,7 @@ def test_SphericalMesh_initiation():
     # test defaults
     mesh = openmc.SphericalMesh(r_grid=(0, 10))
     assert (mesh.origin == np.array([0, 0, 0])).all()
-    assert mesh.r_grid == (0, 10)
+    assert (mesh.r_grid == np.array([0, 10])).all()
     assert (mesh.theta_grid == np.array([0, pi])).all()
     assert (mesh.phi_grid == np.array([0, 2*pi])).all()
 
@@ -113,22 +113,26 @@ def test_SphericalMesh_initiation():
         phi_grid=(2, 4)
     )
     assert (mesh.origin == np.array([1, 2, 3])).all()
-    assert mesh.r_grid == (0., 2.)
-    assert mesh.theta_grid == (1, 3)
-    assert mesh.phi_grid == (2, 4)
+    assert (mesh.r_grid == np.array([0., 2.])).all()
+    assert (mesh.theta_grid == np.array([1, 3])).all()
+    assert (mesh.phi_grid == np.array([2, 4])).all()
 
     # test attribute changing
     mesh.r_grid = (0, 11)
     assert (mesh.r_grid == np.array([0., 11.])).all()
+
+    # waffles and pancakes are unfortunately not valid radii
+    with pytest.raises(TypeError):
+        openmc.SphericalMesh(('🧇', '🥞'))
 
 
 def test_CylindricalMesh_initiation():
     # test defaults
     mesh = openmc.CylindricalMesh(r_grid=(0, 10), z_grid=(0, 10))
     assert (mesh.origin == np.array([0, 0, 0])).all()
-    assert mesh.r_grid == (0, 10)
-    assert mesh.phi_grid == (0, 2*pi)
-    assert mesh.z_grid == (0, 10)
+    assert (mesh.r_grid == np.array([0, 10])).all()
+    assert (mesh.phi_grid == np.array([0, 2*pi])).all()
+    assert (mesh.z_grid == np.array([0, 10])).all()
 
     # test setting on creation
     mesh = openmc.CylindricalMesh(
@@ -139,7 +143,7 @@ def test_CylindricalMesh_initiation():
     )
     assert (mesh.origin == np.array([1, 2, 3])).all()
     assert (mesh.r_grid == np.array([0., 2.])).all()
-    assert mesh.z_grid == (1, 3)
+    assert (mesh.z_grid == np.array([1, 3])).all()
     assert (mesh.phi_grid == np.array([2, 4])).all()
 
     # test attribute changing
@@ -147,3 +151,7 @@ def test_CylindricalMesh_initiation():
     assert (mesh.r_grid == np.array([0, 10.])).all()
     mesh.z_grid = (0., 4.)
     assert (mesh.z_grid == np.array([0, 4.])).all()
+
+    # waffles and pancakes are unfortunately not valid radii
+    with pytest.raises(TypeError):
+        openmc.SphericalMesh(('🧇', '🥞'))


### PR DESCRIPTION
# Description

I noticed that the constructors for `CylindricalMesh` and `SphericalMesh` were directly setting `_r_grid`, `_phi_grid`, etc. instead of going through the properties, which perform checks on the values. This PR fixes and makes corresponding changes in the tests.

I've also included a few small fixes for warnings that were being raised during tests.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)