### PR TITLE
Making z-grid relative to the mesh origin in from_domain.

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1439,6 +1439,10 @@ class CylindricalMesh(StructuredMesh):
             num=dimension[2]+1
         )
         origin = (cached_bb.center[0], cached_bb.center[1], z_grid[0])
+
+        # make z-grid relative to the origin
+        z_grid -= origin[2]
+
         mesh = cls(
             r_grid=r_grid,
             z_grid=z_grid,

--- a/tests/unit_tests/test_mesh_from_domain.py
+++ b/tests/unit_tests/test_mesh_from_domain.py
@@ -30,7 +30,7 @@ def test_cylindrical_mesh_from_cell():
     assert np.array_equal(mesh.dimension, (2, 4, 3))
     assert np.array_equal(mesh.r_grid, [0., 25., 50.])
     assert np.array_equal(mesh.phi_grid, [0., 0.5*np.pi, np.pi, 1.5*np.pi, 2.*np.pi])
-    assert np.array_equal(mesh.z_grid, [10., 20., 30., 40.])
+    assert np.array_equal(mesh.z_grid, [0., 10., 20., 30.])
     assert np.array_equal(mesh.origin, [0., 0., 10.])
 
     # Cell is not centralized on Z or X axis
@@ -83,7 +83,7 @@ def test_cylindrical_mesh_from_region():
     assert np.array_equal(mesh.dimension, (6, 2, 3))
     assert np.array_equal(mesh.r_grid, [0., 1., 2., 3., 4., 5., 6.])
     assert np.array_equal(mesh.phi_grid, [0., 0.5*np.pi, np.pi])
-    assert np.array_equal(mesh.z_grid, [-30., -10., 10., 30.])
+    assert np.array_equal(mesh.z_grid, [0.0, 20., 40., 60])
 
 
 def test_reg_mesh_from_universe():

--- a/tests/unit_tests/test_mesh_from_domain.py
+++ b/tests/unit_tests/test_mesh_from_domain.py
@@ -84,6 +84,7 @@ def test_cylindrical_mesh_from_region():
     assert np.array_equal(mesh.r_grid, [0., 1., 2., 3., 4., 5., 6.])
     assert np.array_equal(mesh.phi_grid, [0., 0.5*np.pi, np.pi])
     assert np.array_equal(mesh.z_grid, [0.0, 20., 40., 60])
+    assert np.array_equal(mesh.origin, (0.0, 0.0, -30.))
 
 
 def test_reg_mesh_from_universe():


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

I noticed a bug in `CylindricalMesh.from_domain` today. The z-grid was being set with the lowest value equal to that of the mesh origin, but it is intended to be treated relative to the origin as described in the class docstrings.

Some updates to expected test values ensure this new behavior.

# Checklist

- [x] I have performed a self-review of my own code
~- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
~- [ ] I have made corresponding changes to the documentation (if applicable)~
~- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
