### PR TITLE
Updates to mesh vertices and centroids

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1519,6 +1519,7 @@ class CylindricalMesh(StructuredMesh):
 
     @property
     def vertices(self):
+        warnings.warn('Cartesian coordinates are returned from this property as of version 0.13.4')
         return self._convert_to_cartesian(self.cylindrical_vertices, self.origin)
 
     @property
@@ -1529,6 +1530,7 @@ class CylindricalMesh(StructuredMesh):
 
     @property
     def centroids(self):
+        warnings.warn('Cartesian coordinates are returned from this property as of version 0.13.4')
         return self._convert_to_cartesian(self.cylindrical_centroids, self.origin)
 
     @property
@@ -1812,6 +1814,7 @@ class SphericalMesh(StructuredMesh):
 
     @property
     def vertices(self):
+        warnings.warn('Cartesian coordinates are returned from this property as of version 0.13.4')
         return self._convert_to_cartesian(self.spherical_vertices, self.origin)
 
     @property
@@ -1822,6 +1825,7 @@ class SphericalMesh(StructuredMesh):
 
     @property
     def centroids(self):
+        warnings.warn('Cartesian coordinates are returned from this property as of version 0.13.4')
         return self._convert_to_cartesian(self.spherical_centroids, self.origin)
 
     @property

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -260,12 +260,7 @@ class StructuredMesh(MeshBase):
         vertices = self.vertices
         s0 = (slice(None),) + (slice(0, -1),)*ndim
         s1 = (slice(None),) + (slice(1, None),)*ndim
-        centroids = (vertices[s0] + vertices[s1]) / 2
-
-        if isinstance(self, (CylindricalMesh, SphericalMesh)):
-            centroids = self._convert_to_cartesian(centroids, self.origin)
-
-        return centroids
+        return (vertices[s0] + vertices[s1]) / 2
 
     @property
     def num_mesh_cells(self):

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -2047,8 +2047,8 @@ class UnstructuredMesh(MeshBase):
         conn = self.connectivity[:, bin]
         # remove invalid connectivity values
         conn = conn[conn >= 0]
-        coords = self.vertices[conn]
-        return coords.mean(axis=0)
+        coords = self.vertices[:, conn]
+        return coords.mean(axis=1)
 
     def write_vtk_mesh(self, **kwargs):
         """Map data to unstructured VTK mesh elements.

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -172,9 +172,8 @@ class StructuredMesh(MeshBase):
     def vertices(self):
         """Return coordinates of mesh vertices in Cartesian coordinates. Also
            see :meth:`CylindricalMesh.cylindrical_vertices` and
-           :meth:`SphericalMesh.spherical_vertices` for coordinates in the mesh
-           coordinate system.
-
+           :meth:`SphericalMesh.spherical_vertices` for coordinates in other coordinate
+           systems.
 
         Returns
         -------

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1888,14 +1888,14 @@ class UnstructuredMesh(MeshBase):
     volumes : Iterable of float
         Volumes of the unstructured mesh elements
     centroids : numpy.ndarray
-        Centroids of the mesh elements with array shape (n_elements, 3)
+        Centroids of the mesh elements with array shape (3, n_elements)
 
     vertices : numpy.ndarray
-        Coordinates of the mesh vertices with array shape (n_elements, 3)
+        Coordinates of the mesh vertices with array shape (3, n_elements)
 
         .. versionadded:: 0.13.1
     connectivity : numpy.ndarray
-        Connectivity of the elements with array shape (n_elements, 8)
+        Connectivity of the elements with array shape (8, n_elements)
 
         .. versionadded:: 0.13.1
     element_types : Iterable of integers
@@ -1986,7 +1986,7 @@ class UnstructuredMesh(MeshBase):
 
     @property
     def connectivity(self):
-        return self._connectivity
+        return self._connectivity.T
 
     @property
     def element_types(self):
@@ -2050,7 +2050,7 @@ class UnstructuredMesh(MeshBase):
             x, y, z values of the element centroid
 
         """
-        conn = self.connectivity[bin]
+        conn = self.connectivity[:, bin]
         # remove invalid connectivity values
         conn = conn[conn >= 0]
         coords = self.vertices[conn]
@@ -2122,7 +2122,7 @@ class UnstructuredMesh(MeshBase):
 
         n_skipped = 0
         elems = []
-        for elem_type, conn in zip(self.element_types, self.connectivity):
+        for elem_type, conn in zip(self.element_types, self.connectivity.T):
             if elem_type == self._LINEAR_TET:
                 elem = vtk.vtkTetra()
             elif elem_type == self._LINEAR_HEX:

--- a/tests/regression_tests/unstructured_mesh/test.py
+++ b/tests/regression_tests/unstructured_mesh/test.py
@@ -54,7 +54,7 @@ class UnstructuredMeshTest(PyAPITestHarness):
                 exp_vertex = (-10.0, -10.0, 10.0)
                 exp_centroid = (-9.0, -9.0, 9.0)
 
-            np.testing.assert_array_equal(umesh.verticess[:, 0], exp_vertex)
+            np.testing.assert_array_equal(umesh.vertices[:, 0], exp_vertex)
             np.testing.assert_array_equal(umesh.centroid(0), exp_centroid)
 
             # loop over the tallies and get data

--- a/tests/regression_tests/unstructured_mesh/test.py
+++ b/tests/regression_tests/unstructured_mesh/test.py
@@ -54,7 +54,7 @@ class UnstructuredMeshTest(PyAPITestHarness):
                 exp_vertex = (-10.0, -10.0, 10.0)
                 exp_centroid = (-9.0, -9.0, 9.0)
 
-            np.testing.assert_array_equal(umesh.vertices[0], exp_vertex)
+            np.testing.assert_array_equal(umesh.verticess[:, 0], exp_vertex)
             np.testing.assert_array_equal(umesh.centroid(0), exp_centroid)
 
             # loop over the tallies and get data
@@ -322,4 +322,3 @@ def test_unstructured_mesh_hexes(model):
     harness.ELEM_PER_VOXEL = 1
 
     harness.main()
-


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR adjusts the `vertices` and `centroid` properties on the Python API mesh classes s.t. they always return Cartesian coordinates for any mesh type. Methods for getting `vertices` and `centroid` coordinates in other systems have been added for `CylindricalMesh` and `SphericalMesh`.

I've also updated the `UnstructuredMesh` `vertices`, `centroids`, and `connectivity` properties to return the same structure as the other classes with a shape (3, ...) so that they can be unpacked as `x, y, z = mesh.centroids` when needed.

# Checklist

- [x] I have performed a self-review of my own code
~- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
~- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
