### PR TITLE
Clip low-importance points from discrete distributions

### DIFF
--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -599,7 +599,7 @@ def decay_photon_energy(nuclide: str) -> Optional[Univariate]:
     openmc.stats.Univariate or None
         Distribution of energies in [eV] of photons emitted from decay, or None
         if no photon source exists. Note that the probabilities represent
-        intensities, given as [decay/sec].
+        intensities, given as [Bq].
     """
     if not _DECAY_PHOTON_ENERGY:
         chain_file = openmc.config.get('chain_file')

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -764,8 +764,9 @@ class Geometry:
             Assigns colors to specific materials or cells. Keys are instances of
             :class:`Cell` or :class:`Material` and values are RGB 3-tuples, RGBA
             4-tuples, or strings indicating SVG color names. Red, green, blue,
-            and alpha should all be floats in the range [0.0, 1.0], for example:
-            .. code-block:: python
+            and alpha should all be floats in the range [0.0, 1.0], for
+            example::
+
                # Make water blue
                water = openmc.Cell(fill=h2o)
                universe.plot(..., colors={water: (0., 0., 1.))

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -308,14 +308,10 @@ class Material(IDManagerMixin):
         if not dists:
             return None
 
-        # Clip low-intensity values in discrete spectra
+        # Get combined distribution, clip low-intensity values in discrete spectra
         combined = openmc.data.combine_distributions(dists, probs)
-        if isinstance(combined, Discrete):
+        if isinstance(combined, (Discrete, Mixture)):
             combined.clip(clip_tolerance, inplace=True)
-        elif isinstance(combined, Mixture):
-            for dist in combined.distribution:
-                if isinstance(dist, Discrete):
-                    dist.clip(clip_tolerance, inplace=True)
 
         return combined
 

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -311,6 +311,8 @@ class Material(IDManagerMixin):
         cv.check_value('units', units, {'Bq', 'Bq/g', 'Bq/cm3'})
         if units == 'Bq':
             multiplier = volume if volume is not None else self.volume
+            if multiplier is None:
+                raise ValueError("volume must be specified if units='Bq'")
         elif units == 'Bq/cm3':
             multiplier = 1
         elif units == 'Bq/g':

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -281,25 +281,24 @@ class Material(IDManagerMixin):
             "version.", FutureWarning)
         return self.get_decay_photon_energy(0.0)
 
-    def get_decay_photon_energy(self, clip_threshold: float = 1e-6) -> Optional[Univariate]:
+    def get_decay_photon_energy(self, clip_tolerance: float = 1e-6) -> Optional[Univariate]:
         """Return energy distribution of decay photons from unstable nuclides.
 
         Parameters
         ----------
-        clip_threshold : float
+        clip_tolerance : float
             Maximum fraction of integral of the product of `x` and `p` for
             discrete distributions that will be discarded.
 
         Returns
         -------
         Decay photon energy distribution. The integral of this distribution is
-        the total intensity of the photon source in [decay/sec].
+        the total intensity of the photon source in [Bq].
 
         """
-        atoms = self.get_nuclide_atoms()
         dists = []
         probs = []
-        for nuc, num_atoms in atoms.items():
+        for nuc, num_atoms in self.get_nuclide_atoms().items():
             source_per_atom = openmc.data.decay_photon_energy(nuc)
             if source_per_atom is not None:
                 dists.append(source_per_atom)
@@ -312,11 +311,11 @@ class Material(IDManagerMixin):
         # Clip low-intensity values in discrete spectra
         combined = openmc.data.combine_distributions(dists, probs)
         if isinstance(combined, Discrete):
-            combined.clip(clip_threshold, inplace=True)
+            combined.clip(clip_tolerance, inplace=True)
         elif isinstance(combined, Mixture):
             for dist in combined.distribution:
                 if isinstance(dist, Discrete):
-                    dist.clip(clip_threshold, inplace=True)
+                    dist.clip(clip_tolerance, inplace=True)
 
         return combined
 

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -609,6 +609,7 @@ class Model:
         this method creates the XML files and runs OpenMC via a system call. In
         both cases this method returns the path to the last statepoint file
         generated.
+
         .. versionchanged:: 0.12
             Instead of returning the final k-effective value, this function now
             returns the path to the final statepoint written.

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -271,8 +271,7 @@ class Discrete(Univariate):
         Parameters
         ----------
         tolerance : float
-            Maximum fraction of integral of the product of `x` and `p` that will
-            be discarded.
+            Maximum fraction of :math:`\sum_i x_i p_i` that will be discarded.
         inplace : bool
             Whether to modify the current object in-place or return a new one.
 

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -257,7 +257,7 @@ class Discrete(Univariate):
         """
         return np.sum(self.p)
 
-    def clip(self, threshold: float = 1e-6, inplace: bool = False) -> Discrete:
+    def clip(self, tolerance: float = 1e-6, inplace: bool = False) -> Discrete:
         r"""Remove low-importance points from discrete distribution.
 
         Given a probability mass function :math:`p(x)` with :math:`\{x_1, x_2,
@@ -270,7 +270,7 @@ class Discrete(Univariate):
 
         Parameters
         ----------
-        threshold : float
+        tolerance : float
             Maximum fraction of integral of the product of `x` and `p` that will
             be discarded.
         inplace : bool
@@ -293,7 +293,7 @@ class Discrete(Univariate):
         cumsum /= cumsum[-1]
 
         # Find index which satisfies cutoff
-        index_cutoff = np.searchsorted(cumsum, 1.0 - threshold)
+        index_cutoff = np.searchsorted(cumsum, 1.0 - tolerance)
 
         # Now get indices up to cutoff
         new_indices = index_sort[:index_cutoff + 1]

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -629,6 +629,12 @@ def test_decay_photon_energy():
     src = m.get_decay_photon_energy()
     assert isinstance(src, openmc.stats.Discrete)
 
+    # Make sure units/volume work as expected
+    src_v2 = m.get_decay_photon_energy(volume=2.0)
+    assert src.p * 2.0 == pytest.approx(src_v2.p)
+    src_per_cm3 = m.get_decay_photon_energy(units='Bq/cm3', volume=100.0)
+    assert (src.p == src_per_cm3.p).all()
+
     # If we add Xe135 (which has a tabular distribution), the photon source
     # should be a mixture distribution
     m.add_nuclide('Xe135', 1.0e-24)

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -626,13 +626,13 @@ def test_decay_photon_energy():
     m.volume = 1.0
 
     # Get decay photon source and make sure it's the right type
-    src = m.decay_photon_energy
+    src = m.get_decay_photon_energy()
     assert isinstance(src, openmc.stats.Discrete)
 
     # If we add Xe135 (which has a tabular distribution), the photon source
     # should be a mixture distribution
     m.add_nuclide('Xe135', 1.0e-24)
-    src = m.decay_photon_energy
+    src = m.get_decay_photon_energy()
     assert isinstance(src, openmc.stats.Mixture)
 
     # With a single atom of each, the intensity of the photon source should be
@@ -642,10 +642,16 @@ def test_decay_photon_energy():
 
     assert src.integral() == pytest.approx(sum(
         intensity(decay_photon_energy(nuc)) for nuc in m.get_nuclides()
+    ), rel=1e-3)
+
+    # When the clipping threshold is zero, the intensities should match exactly
+    src = m.get_decay_photon_energy(0.0)
+    assert src.integral() == pytest.approx(sum(
+        intensity(decay_photon_energy(nuc)) for nuc in m.get_nuclides()
     ))
 
     # A material with no unstable nuclides should have no decay photon source
     stable = openmc.Material()
     stable.add_nuclide('Gd156', 1.0)
     stable.volume = 1.0
-    assert stable.decay_photon_energy is None
+    assert stable.get_decay_photon_energy() is None

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -248,6 +248,24 @@ def test_mixture():
     assert len(d) == 4
 
 
+def test_mixture_clip():
+    # Create mixture distribution containing a discrete distribution with two
+    # points that are not important, one because the x value is very small, and
+    # one because the p value is very small
+    d1 = openmc.stats.Discrete([1e-8, 1.0, 2.0, 1000.0], [3.0, 2.0, 5.0, 1e-12])
+    d2 = openmc.stats.Uniform(0, 5)
+    mix = openmc.stats.Mixture([0.5, 0.5], [d1, d2])
+
+    # Clipping should reduce the contained discrete distribution to 2 points
+    mix_clip = mix.clip(1e-6)
+    assert mix_clip.distribution[0].x.size == 2
+    assert mix_clip.distribution[0].p.size == 2
+
+    # Make sure inplace returns same object
+    mix_same = mix.clip(1e-6, inplace=True)
+    assert mix_same is mix
+
+
 def test_polar_azimuthal():
     # default polar-azimuthal should be uniform in mu and phi
     d = openmc.stats.PolarAzimuthal()

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -74,6 +74,22 @@ def test_merge_discrete():
     assert triple.integral() == pytest.approx(6.0)
 
 
+def test_clip_discrete():
+    # Create discrete distribution with two points that are not important, one
+    # because the x value is very small, and one because the p value is very
+    # small
+    d = openmc.stats.Discrete([1e-8, 1.0, 2.0, 1000.0], [3.0, 2.0, 5.0, 1e-12])
+
+    # Clipping the distribution should result in two points
+    d_clip = d.clip(1e-6)
+    assert d_clip.x.size == 2
+    assert d_clip.p.size == 2
+
+    # Make sure inplace returns same object
+    d_same = d.clip(1e-6, inplace=True)
+    assert d_same is d
+
+
 def test_uniform():
     a, b = 10.0, 20.0
     d = openmc.stats.Uniform(a, b)


### PR DESCRIPTION
# Description

While working on the R2S workflow for fusion shutdown dose rate calculations, one thing I noticed is that when generating a decay photon source from an activated material, often the photon energy distribution will have 100s of discrete lines of extremely low importance (usually from a nuclide that is present in the composition at a very low concentration). This PR implements a new `clip()` method on the `Discrete` class that allows one to simplify the distribution, getting rid of low-importance points while still closely preserving the mean of the distribution. It then builds on that by using the `clip` method for `Material.decay_photon_energy` which is now present as a method (`get_decay_photon_energy`) rather than a property to give the user a way to control the threshold used for clipping.

By the way, if anyone has a better name than `clip`, I'm all ears!

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)