### PR TITLE
Make BoundingBox a mutable type and add convenience methods.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,10 +134,13 @@ jobs:
             ~/nndc_hdf5
             ~/endf-b-vii.1
           key: ${{ runner.os }}-build-xs-cache
-      
+
       - name: before
         shell: bash
         run: $GITHUB_WORKSPACE/tools/ci/gha-before-script.sh
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
       - name: test
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Setup tmate session
         if: ${{ failure() }}
-          uses: mxschmitt/action-tmate@v3
+        uses: mxschmitt/action-tmate@v3
 
       - name: after_success
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,16 +139,11 @@ jobs:
         shell: bash
         run: $GITHUB_WORKSPACE/tools/ci/gha-before-script.sh
 
-
       - name: test
         shell: bash
         run: |
           CTEST_OUTPUT_ON_FAILURE=1 make test -C $GITHUB_WORKSPACE/build/
           $GITHUB_WORKSPACE/tools/ci/gha-script.sh
-
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
 
       - name: after_success
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,14 +139,16 @@ jobs:
         shell: bash
         run: $GITHUB_WORKSPACE/tools/ci/gha-before-script.sh
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
 
       - name: test
         shell: bash
         run: |
           CTEST_OUTPUT_ON_FAILURE=1 make test -C $GITHUB_WORKSPACE/build/
           $GITHUB_WORKSPACE/tools/ci/gha-script.sh
+
+      - name: Setup tmate session
+        if: ${{ failure() }}
+          uses: mxschmitt/action-tmate@v3
 
       - name: after_success
         shell: bash

--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -44,12 +44,11 @@ class BoundingBox:
         return "BoundingBox(lower_left={}, upper_right={})".format(
             tuple(self.lower_left), tuple(self.upper_right))
 
-    def __iter__(self):
-        yield self[0]
-        yield self[1]
-
     def __getitem__(self, key) -> np.ndarray:
         return self._bounds[key]
+
+    def __len__(self):
+        return 2
 
     def __setitem__(self, key, val):
         self._bounds[key] = val
@@ -62,9 +61,19 @@ class BoundingBox:
     def lower_left(self) -> np.ndarray:
         return self[0]
 
+    @lower_left.setter
+    def lower_left(self, llc):
+        check_length('lower_left', llc, 3, 3)
+        self[0] = llc
+
     @property
     def upper_right(self) -> np.ndarray:
         return self[1]
+
+    @upper_right.setter
+    def upper_right(self, urc):
+        check_length('upper_right', urc, 3, 3)
+        self[1] = urc
 
     @property
     def volume(self) -> float:
@@ -128,9 +137,14 @@ class BoundingBox:
         -------
         An expanded bounding box
         """
-        self[0] = np.minimum(self.lower_left, other_box.lower_left)
-        self[1] = np.maximum(self.upper_right, other_box.upper_right)
-        return self if inplace else BoundingBox(*self)
+        llc = np.minimum(self.lower_left, other_box.lower_left)
+        urc = np.maximum(self.upper_right, other_box.upper_right)
+        if inplace:
+            self.lower_left = llc
+            self.upper_right = urc
+            return self
+        else:
+            return BoundingBox(llc, urc)
 
     def reduce(self, other_box: BoundingBox, inplace: bool = False) -> BoundingBox:
         """Reduce the box to match the dimensions of the input bounding box
@@ -147,9 +161,14 @@ class BoundingBox:
         -------
         A reduced bounding box
         """
-        self[0][:] = np.maximum(self.lower_left, other_box.lower_left)
-        self[1][:] = np.minimum(self.upper_right, other_box.upper_right)
-        return self if inplace else BoundingBox(*self)
+        llc = np.maximum(self.lower_left, other_box.lower_left)
+        urc = np.minimum(self.upper_right, other_box.upper_right)
+        if inplace:
+            self.lower_left = llc
+            self.upper_right = urc
+            return self
+        else:
+            return BoundingBox(llc, urc)
 
     @classmethod
     def infinite(cls):

--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -48,7 +48,7 @@ class BoundingBox:
         return self._bounds[key]
 
     def __setitem__(self, key, val):
-        self._bounds[key]
+        self._bounds[key] = val
 
     def __hash__(self) -> int:
         return hash(self._bounds.data)

--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -145,6 +145,18 @@ class BoundingBox:
         return self
 
     @classmethod
+    def inverted_box(cls):
+        """Create an infinite, inverted box. Useful as a starting point for determining
+           geometry bounds for union operations.
+
+        Returns
+        -------
+        An infinitely large bounding box.
+        """
+        infs = np.full((3,), np.inf)
+        return cls(infs, -infs)
+
+    @classmethod
     def unbounded_box(cls):
         """Create an infinite box. Useful as a starting point for determining
            geometry bounds.

--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -177,7 +177,7 @@ class BoundingBox:
             return BoundingBox(llc, urc)
 
     @classmethod
-    def infinite(cls):
+    def infinite(cls) -> BoundingBox:
         """Create an infinite box. Useful as a starting point for determining
            geometry bounds.
 

--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -54,6 +54,17 @@ class BoundingBox:
         self._bounds[key] = val
 
     def __iand__(self, other: BoundingBox) -> BoundingBox:
+        """Updates the box be the intersection of itself and another box
+
+        Parameters
+        ----------
+        other : BoundingBox
+            The box used to resize this box
+
+        Returns
+        -------
+        An updated bounding box
+        """
         self.lower_left = np.maximum(self.lower_left, other.lower_left)
         self.upper_right = np.minimum(self.upper_right, other.upper_right)
         return self
@@ -64,6 +75,17 @@ class BoundingBox:
         return new
 
     def __ior__(self, other: BoundingBox) -> BoundingBox:
+        """Updates the box be the union of itself and another box
+
+        Parameters
+        ----------
+        other : BoundingBox
+            The box used to resize this box
+
+        Returns
+        -------
+        An updated bounding box
+        """
         self.lower_left = np.minimum(self.lower_left, other.lower_left)
         self.upper_right = np.maximum(self.upper_right, other.upper_right)
         return self
@@ -126,8 +148,8 @@ class BoundingBox:
     def width(self):
         return self.upper_right - self.lower_left
 
-    def extend(self, padding_distance: float, inplace: bool = False) -> BoundingBox:
-        """Returns an extended bounding box
+    def expand(self, padding_distance: float, inplace: bool = False) -> BoundingBox:
+        """Returns an expanded bounding box
 
         Parameters
         ----------
@@ -139,7 +161,7 @@ class BoundingBox:
 
         Returns
         -------
-        An extended bounding box
+        An expanded bounding box
         """
         if inplace:
             self[0] -= padding_distance
@@ -147,48 +169,6 @@ class BoundingBox:
             return self
         else:
             return BoundingBox(self[0] - padding_distance, self[1] + padding_distance)
-
-    def expand(self, other_box: BoundingBox, inplace: bool = False) -> BoundingBox:
-        """Expand the box to contain another box
-
-        Parameters
-        ----------
-        other_box : BoundingBox
-            The box used to resize this box
-        inplace : bool
-            Whether or not to return a new BoundingBox instance or to modify the
-            current BoundingBox object.
-
-        Returns
-        -------
-        An expanded bounding box
-        """
-        if inplace:
-            self |= other_box
-            return self
-        else:
-            return self | other_box
-
-    def reduce(self, other_box: BoundingBox, inplace: bool = False) -> BoundingBox:
-        """Reduce the box to match the dimensions of the input bounding box
-
-        Parameters
-        ----------
-        other_box : BoundingBox
-            The box used to resize this box
-        inplace : bool
-            Whether or not to return a new BoundingBox instance or to modify the
-            current BoundingBox object.
-
-        Returns
-        -------
-        A reduced bounding box
-        """
-        if inplace:
-            self &= other_box
-            return self
-        else:
-            return self & other_box
 
     @classmethod
     def infinite(cls) -> BoundingBox:

--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -106,21 +106,27 @@ class BoundingBox:
     def width(self):
         return self.upper_right - self.lower_left
 
-    def extend(self, padding_distance: float) -> BoundingBox:
+    def extend(self, padding_distance: float, inplace: bool = False) -> BoundingBox:
         """Returns an extended bounding box
 
         Parameters
         ----------
         padding_distance : float
             The distance to enlarge the bounding box by
+        inplace : bool
+            Whether or not to return a new BoundingBox instance or to modify the
+            current BoundingBox object.
 
         Returns
         -------
-        An expanded bounding box
+        An extended bounding box
         """
-        self[0] -= padding_distance
-        self[1] += padding_distance
-        return self
+        if inplace:
+            self[0] -= padding_distance
+            self[1] += padding_distance
+            return self
+        else:
+            return BoundingBox(self[0] - padding_distance, self[1] + padding_distance)
 
     def expand(self, other_box: BoundingBox, inplace: bool = False) -> BoundingBox:
         """Expand the box to contain another box
@@ -131,7 +137,7 @@ class BoundingBox:
             The box used to resize this box
         inplace : bool
             Whether or not to return a new BoundingBox instance or to modify the
-            coefficients of this plane.
+            current BoundingBox object.
 
         Returns
         -------
@@ -155,7 +161,7 @@ class BoundingBox:
             The box used to resize this box
         inplace : bool
             Whether or not to return a new BoundingBox instance or to modify the
-            coefficients of this plane.
+            current BoundingBox object.
 
         Returns
         -------

--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -128,8 +128,8 @@ class BoundingBox:
         -------
         An expanded bounding box
         """
-        self[0][:] = np.minimum(self.lower_left, other_box.lower_left)
-        self[1][:] = np.maximum(self.upper_right, other_box.upper_right)
+        self[0] = np.minimum(self.lower_left, other_box.lower_left)
+        self[1] = np.maximum(self.upper_right, other_box.upper_right)
         return self if inplace else BoundingBox(*self)
 
     def reduce(self, other_box: BoundingBox, inplace: bool = False) -> BoundingBox:

--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -112,7 +112,7 @@ class BoundingBox:
         self[1] += padding_distance
         return self
 
-    def update(self, other_box: BoundingBox) -> BoundingBox:
+    def expand(self, other_box: BoundingBox) -> BoundingBox:
         """Expand the box to contain another box
 
         Parameters
@@ -145,7 +145,7 @@ class BoundingBox:
         return self
 
     @classmethod
-    def inverted_box(cls):
+    def inf_inverted_box(cls):
         """Create an infinite, inverted box. Useful as a starting point for determining
            geometry bounds for union operations.
 
@@ -157,7 +157,7 @@ class BoundingBox:
         return cls(infs, -infs)
 
     @classmethod
-    def unbounded_box(cls):
+    def inf_box(cls):
         """Create an infinite box. Useful as a starting point for determining
            geometry bounds.
 

--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -53,6 +53,26 @@ class BoundingBox:
     def __setitem__(self, key, val):
         self._bounds[key] = val
 
+    def __iand__(self, other: BoundingBox) -> BoundingBox:
+        self.lower_left = np.maximum(self.lower_left, other.lower_left)
+        self.upper_right = np.minimum(self.upper_right, other.upper_right)
+        return self
+
+    def __and__(self, other: BoundingBox) -> BoundingBox:
+        new = BoundingBox(*self)
+        new &= other
+        return new
+
+    def __ior__(self, other: BoundingBox) -> BoundingBox:
+        self.lower_left = np.minimum(self.lower_left, other.lower_left)
+        self.upper_right = np.maximum(self.upper_right, other.upper_right)
+        return self
+
+    def __or__(self, other: BoundingBox) -> BoundingBox:
+        new = BoundingBox(*self)
+        new |= other
+        return new
+
     @property
     def center(self) -> np.ndarray:
         return (self[0] + self[1]) / 2
@@ -143,14 +163,11 @@ class BoundingBox:
         -------
         An expanded bounding box
         """
-        llc = np.minimum(self.lower_left, other_box.lower_left)
-        urc = np.maximum(self.upper_right, other_box.upper_right)
         if inplace:
-            self.lower_left = llc
-            self.upper_right = urc
+            self |= other_box
             return self
         else:
-            return BoundingBox(llc, urc)
+            return self | other_box
 
     def reduce(self, other_box: BoundingBox, inplace: bool = False) -> BoundingBox:
         """Reduce the box to match the dimensions of the input bounding box
@@ -167,14 +184,11 @@ class BoundingBox:
         -------
         A reduced bounding box
         """
-        llc = np.maximum(self.lower_left, other_box.lower_left)
-        urc = np.minimum(self.upper_right, other_box.upper_right)
         if inplace:
-            self.lower_left = llc
-            self.upper_right = urc
+            self &= other_box
             return self
         else:
-            return BoundingBox(llc, urc)
+            return self & other_box
 
     @classmethod
     def infinite(cls) -> BoundingBox:

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -414,13 +414,10 @@ class Intersection(Region, MutableSequence):
 
     @property
     def bounding_box(self):
-        lower_left = np.array([-np.inf, -np.inf, -np.inf])
-        upper_right = np.array([np.inf, np.inf, np.inf])
+        box = BoundingBox.unbounded_box()
         for n in self:
-            lower_left_n, upper_right_n = n.bounding_box
-            lower_left[:] = np.maximum(lower_left, lower_left_n)
-            upper_right[:] = np.minimum(upper_right, upper_right_n)
-        return BoundingBox(lower_left, upper_right)
+            box.reduce(n.bounding_box)
+        return box
 
 
 class Union(Region, MutableSequence):

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -416,7 +416,7 @@ class Intersection(Region, MutableSequence):
     def bounding_box(self):
         box = BoundingBox.infinite()
         for n in self:
-            box.reduce(n.bounding_box)
+            box.reduce(n.bounding_box, True)
         return box
 
 
@@ -505,7 +505,7 @@ class Union(Region, MutableSequence):
         bbox = BoundingBox(np.array([np.inf]*3),
                            np.array([-np.inf]*3))
         for n in self:
-            bbox.expand(n.bounding_box)
+            bbox.expand(n.bounding_box, True)
         return bbox
 
 

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -414,7 +414,7 @@ class Intersection(Region, MutableSequence):
 
     @property
     def bounding_box(self):
-        box = BoundingBox.inf_box()
+        box = BoundingBox.infinite()
         for n in self:
             box.reduce(n.bounding_box)
         return box
@@ -502,7 +502,8 @@ class Union(Region, MutableSequence):
 
     @property
     def bounding_box(self):
-        bbox = BoundingBox.inf_inverted_box()
+        bbox = BoundingBox(np.array([np.inf]*3),
+                           np.array([-np.inf]*3))
         for n in self:
             bbox.expand(n.bounding_box)
         return bbox

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -502,13 +502,10 @@ class Union(Region, MutableSequence):
 
     @property
     def bounding_box(self):
-        lower_left = np.array([np.inf, np.inf, np.inf])
-        upper_right = np.array([-np.inf, -np.inf, -np.inf])
+        bbox = BoundingBox.inverted_box()
         for n in self:
-            lower_left_n, upper_right_n = n.bounding_box
-            lower_left[:] = np.minimum(lower_left, lower_left_n)
-            upper_right[:] = np.maximum(upper_right, upper_right_n)
-        return BoundingBox(lower_left, upper_right)
+            bbox.update(n.bounding_box)
+        return bbox
 
 
 class Complement(Region):

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -414,7 +414,7 @@ class Intersection(Region, MutableSequence):
 
     @property
     def bounding_box(self):
-        box = BoundingBox.unbounded_box()
+        box = BoundingBox.inf_box()
         for n in self:
             box.reduce(n.bounding_box)
         return box
@@ -502,9 +502,9 @@ class Union(Region, MutableSequence):
 
     @property
     def bounding_box(self):
-        bbox = BoundingBox.inverted_box()
+        bbox = BoundingBox.inf_inverted_box()
         for n in self:
-            bbox.update(n.bounding_box)
+            bbox.expand(n.bounding_box)
         return bbox
 
 

--- a/openmc/region.py
+++ b/openmc/region.py
@@ -416,7 +416,7 @@ class Intersection(Region, MutableSequence):
     def bounding_box(self):
         box = BoundingBox.infinite()
         for n in self:
-            box.reduce(n.bounding_box, True)
+            box &= n.bounding_box
         return box
 
 
@@ -505,7 +505,7 @@ class Union(Region, MutableSequence):
         bbox = BoundingBox(np.array([np.inf]*3),
                            np.array([-np.inf]*3))
         for n in self:
-            bbox.expand(n.bounding_box, True)
+            bbox |= n.bounding_box
         return bbox
 
 

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -233,7 +233,7 @@ class Surface(IDManagerMixin, ABC):
             desired half-space
 
         """
-        return BoundingBox.inf_box()
+        return BoundingBox.infinite()
 
     def clone(self, memo=None):
         """Create a copy of this surface with a new unique ID.
@@ -1203,7 +1203,7 @@ class Cylinder(QuadricMixin, Surface):
                   else np.inf for xi, dxi in zip(self._origin, self._axis)]
             return BoundingBox(np.array(ll), np.array(ur))
         elif side == '+':
-            return BoundingBox.inf_box()
+            return BoundingBox.infinite()
 
     def _get_base_coeffs(self):
         # Get x, y, z coordinates of two points
@@ -1370,7 +1370,7 @@ class XCylinder(QuadricMixin, Surface):
                 np.array([np.inf, self.y0 + self.r, self.z0 + self.r])
             )
         elif side == '+':
-            return BoundingBox.inf_box()
+            return BoundingBox.infinite()
 
     def evaluate(self, point):
         y = point[1] - self.y0
@@ -1462,7 +1462,7 @@ class YCylinder(QuadricMixin, Surface):
                 np.array([self.x0 + self.r, np.inf, self.z0 + self.r])
             )
         elif side == '+':
-            return BoundingBox.inf_box()
+            return BoundingBox.infinite()
 
     def evaluate(self, point):
         x = point[0] - self.x0
@@ -1554,7 +1554,7 @@ class ZCylinder(QuadricMixin, Surface):
                 np.array([self.x0 + self.r, self.y0 + self.r, np.inf])
             )
         elif side == '+':
-            return BoundingBox.inf_box()
+            return BoundingBox.infinite()
 
     def evaluate(self, point):
         x = point[0] - self.x0
@@ -1645,7 +1645,7 @@ class Sphere(QuadricMixin, Surface):
                 np.array([self.x0 + self.r, self.y0 + self.r, self.z0 + self.r])
             )
         elif side == '+':
-            return BoundingBox.inf_box()
+            return BoundingBox.infinite()
 
     def evaluate(self, point):
         x = point[0] - self.x0
@@ -2266,7 +2266,7 @@ class XTorus(TorusMixin, Surface):
                 np.array([x0 + b, y0 + a + c, z0 + a + c])
             )
         elif side == '+':
-            return BoundingBox.inf_box()
+            return BoundingBox.infinite()
 class YTorus(TorusMixin, Surface):
     r"""A torus of the form :math:`(y - y_0)^2/B^2 + (\sqrt{(x - x_0)^2 + (z -
     z_0)^2} - A)^2/C^2 - 1 = 0`.
@@ -2337,7 +2337,7 @@ class YTorus(TorusMixin, Surface):
                 np.array([x0 + a + c, y0 + b, z0 + a + c])
             )
         elif side == '+':
-            return BoundingBox.inf_box()
+            return BoundingBox.infinite()
 
 
 class ZTorus(TorusMixin, Surface):
@@ -2410,7 +2410,7 @@ class ZTorus(TorusMixin, Surface):
                 np.array([x0 + a + c, y0 + a + c, z0 + b])
             )
         elif side == '+':
-            return BoundingBox.inf_box()
+            return BoundingBox.infinite()
 
 
 class Halfspace(Region):

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -233,7 +233,7 @@ class Surface(IDManagerMixin, ABC):
             desired half-space
 
         """
-        return BoundingBox.unbounded_box()
+        return BoundingBox.inf_box()
 
     def clone(self, memo=None):
         """Create a copy of this surface with a new unique ID.
@@ -1203,7 +1203,7 @@ class Cylinder(QuadricMixin, Surface):
                   else np.inf for xi, dxi in zip(self._origin, self._axis)]
             return BoundingBox(np.array(ll), np.array(ur))
         elif side == '+':
-            return BoundingBox.unbounded_box()
+            return BoundingBox.inf_box()
 
     def _get_base_coeffs(self):
         # Get x, y, z coordinates of two points
@@ -1370,7 +1370,7 @@ class XCylinder(QuadricMixin, Surface):
                 np.array([np.inf, self.y0 + self.r, self.z0 + self.r])
             )
         elif side == '+':
-            return BoundingBox.unbounded_box()
+            return BoundingBox.inf_box()
 
     def evaluate(self, point):
         y = point[1] - self.y0
@@ -1462,7 +1462,7 @@ class YCylinder(QuadricMixin, Surface):
                 np.array([self.x0 + self.r, np.inf, self.z0 + self.r])
             )
         elif side == '+':
-            return BoundingBox.unbounded_box()
+            return BoundingBox.inf_box()
 
     def evaluate(self, point):
         x = point[0] - self.x0
@@ -1554,7 +1554,7 @@ class ZCylinder(QuadricMixin, Surface):
                 np.array([self.x0 + self.r, self.y0 + self.r, np.inf])
             )
         elif side == '+':
-            return BoundingBox.unbounded_box()
+            return BoundingBox.inf_box()
 
     def evaluate(self, point):
         x = point[0] - self.x0
@@ -1645,7 +1645,7 @@ class Sphere(QuadricMixin, Surface):
                 np.array([self.x0 + self.r, self.y0 + self.r, self.z0 + self.r])
             )
         elif side == '+':
-            return BoundingBox.unbounded_box()
+            return BoundingBox.inf_box()
 
     def evaluate(self, point):
         x = point[0] - self.x0
@@ -2266,7 +2266,7 @@ class XTorus(TorusMixin, Surface):
                 np.array([x0 + b, y0 + a + c, z0 + a + c])
             )
         elif side == '+':
-            return BoundingBox.unbounded_box()
+            return BoundingBox.inf_box()
 class YTorus(TorusMixin, Surface):
     r"""A torus of the form :math:`(y - y_0)^2/B^2 + (\sqrt{(x - x_0)^2 + (z -
     z_0)^2} - A)^2/C^2 - 1 = 0`.
@@ -2337,7 +2337,7 @@ class YTorus(TorusMixin, Surface):
                 np.array([x0 + a + c, y0 + b, z0 + a + c])
             )
         elif side == '+':
-            return BoundingBox.unbounded_box()
+            return BoundingBox.inf_box()
 
 
 class ZTorus(TorusMixin, Surface):
@@ -2410,7 +2410,7 @@ class ZTorus(TorusMixin, Surface):
                 np.array([x0 + a + c, y0 + a + c, z0 + b])
             )
         elif side == '+':
-            return BoundingBox.unbounded_box()
+            return BoundingBox.inf_box()
 
 
 class Halfspace(Region):

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -2267,6 +2267,8 @@ class XTorus(TorusMixin, Surface):
             )
         elif side == '+':
             return BoundingBox.infinite()
+
+
 class YTorus(TorusMixin, Surface):
     r"""A torus of the form :math:`(y - y_0)^2/B^2 + (\sqrt{(x - x_0)^2 + (z -
     z_0)^2} - A)^2/C^2 - 1 = 0`.

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -233,10 +233,7 @@ class Surface(IDManagerMixin, ABC):
             desired half-space
 
         """
-        return BoundingBox(
-            np.array([-np.inf, -np.inf, -np.inf]),
-            np.array([np.inf, np.inf, np.inf])
-        )
+        return BoundingBox.unbounded_box()
 
     def clone(self, memo=None):
         """Create a copy of this surface with a new unique ID.
@@ -1205,12 +1202,8 @@ class Cylinder(QuadricMixin, Surface):
             ur = [xi + r if np.isclose(dxi, 0., rtol=0., atol=self._atol)
                   else np.inf for xi, dxi in zip(self._origin, self._axis)]
             return BoundingBox(np.array(ll), np.array(ur))
-
         elif side == '+':
-            return BoundingBox(
-                np.array([-np.inf, -np.inf, -np.inf]),
-                np.array([np.inf, np.inf, np.inf])
-            )
+            return BoundingBox.unbounded_box()
 
     def _get_base_coeffs(self):
         # Get x, y, z coordinates of two points
@@ -1377,10 +1370,7 @@ class XCylinder(QuadricMixin, Surface):
                 np.array([np.inf, self.y0 + self.r, self.z0 + self.r])
             )
         elif side == '+':
-            return BoundingBox(
-                np.array([-np.inf, -np.inf, -np.inf]),
-                np.array([np.inf, np.inf, np.inf])
-            )
+            return BoundingBox.unbounded_box()
 
     def evaluate(self, point):
         y = point[1] - self.y0
@@ -1472,10 +1462,7 @@ class YCylinder(QuadricMixin, Surface):
                 np.array([self.x0 + self.r, np.inf, self.z0 + self.r])
             )
         elif side == '+':
-            return BoundingBox(
-                np.array([-np.inf, -np.inf, -np.inf]),
-                np.array([np.inf, np.inf, np.inf])
-            )
+            return BoundingBox.unbounded_box()
 
     def evaluate(self, point):
         x = point[0] - self.x0
@@ -1567,10 +1554,7 @@ class ZCylinder(QuadricMixin, Surface):
                 np.array([self.x0 + self.r, self.y0 + self.r, np.inf])
             )
         elif side == '+':
-            return BoundingBox(
-                np.array([-np.inf, -np.inf, -np.inf]),
-                np.array([np.inf, np.inf, np.inf])
-            )
+            return BoundingBox.unbounded_box()
 
     def evaluate(self, point):
         x = point[0] - self.x0
@@ -1661,10 +1645,7 @@ class Sphere(QuadricMixin, Surface):
                 np.array([self.x0 + self.r, self.y0 + self.r, self.z0 + self.r])
             )
         elif side == '+':
-            return BoundingBox(
-                np.array([-np.inf, -np.inf, -np.inf]),
-                np.array([np.inf, np.inf, np.inf])
-            )
+            return BoundingBox.unbounded_box()
 
     def evaluate(self, point):
         x = point[0] - self.x0
@@ -2285,11 +2266,7 @@ class XTorus(TorusMixin, Surface):
                 np.array([x0 + b, y0 + a + c, z0 + a + c])
             )
         elif side == '+':
-            return BoundingBox(
-                np.array([-np.inf, -np.inf, -np.inf]),
-                np.array([np.inf, np.inf, np.inf])
-            )
-
+            return BoundingBox.unbounded_box()
 class YTorus(TorusMixin, Surface):
     r"""A torus of the form :math:`(y - y_0)^2/B^2 + (\sqrt{(x - x_0)^2 + (z -
     z_0)^2} - A)^2/C^2 - 1 = 0`.
@@ -2360,10 +2337,7 @@ class YTorus(TorusMixin, Surface):
                 np.array([x0 + a + c, y0 + b, z0 + a + c])
             )
         elif side == '+':
-            return BoundingBox(
-                np.array([-np.inf, -np.inf, -np.inf]),
-                np.array([np.inf, np.inf, np.inf])
-            )
+            return BoundingBox.unbounded_box()
 
 
 class ZTorus(TorusMixin, Surface):
@@ -2436,10 +2410,7 @@ class ZTorus(TorusMixin, Surface):
                 np.array([x0 + a + c, y0 + a + c, z0 + b])
             )
         elif side == '+':
-            return BoundingBox(
-                np.array([-np.inf, -np.inf, -np.inf]),
-                np.array([np.inf, np.inf, np.inf])
-            )
+            return BoundingBox.unbounded_box()
 
 
 class Halfspace(Region):

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1204,7 +1204,7 @@ class Cylinder(QuadricMixin, Surface):
                   else -np.inf for xi, dxi in zip(self._origin, self._axis)]
             ur = [xi + r if np.isclose(dxi, 0., rtol=0., atol=self._atol)
                   else np.inf for xi, dxi in zip(self._origin, self._axis)]
-            return (np.array(ll), np.array(ur))
+            return BoundingBox(np.array(ll), np.array(ur))
 
         elif side == '+':
             return BoundingBox(

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -234,8 +234,7 @@ class Universe(UniverseBase):
         if regions:
             return openmc.Union(regions).bounding_box
         else:
-            # Infinite bounding box
-            return openmc.Intersection([]).bounding_box
+            return openmc.BoundingBox.infinite()
 
     @classmethod
     def from_hdf5(cls, group, cells):
@@ -993,7 +992,7 @@ class DAGMCUniverse(UniverseBase):
         check_type('bounded type', bounded_type, str)
         check_value('bounded type', bounded_type, ('box', 'sphere'))
 
-        bbox = self.bounding_box.extend(padding_distance, True)
+        bbox = self.bounding_box.expand(padding_distance, True)
 
         if bounded_type == 'sphere':
             radius = np.linalg.norm(bbox.upper_right - bbox.center)

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -993,7 +993,7 @@ class DAGMCUniverse(UniverseBase):
         check_type('bounded type', bounded_type, str)
         check_value('bounded type', bounded_type, ('box', 'sphere'))
 
-        bbox = self.bounding_box.extend(padding_distance)
+        bbox = self.bounding_box.extend(padding_distance, True)
 
         if bounded_type == 'sphere':
             radius = np.linalg.norm(bbox.upper_right - bbox.center)

--- a/tests/unit_tests/test_bounding_box.py
+++ b/tests/unit_tests/test_bounding_box.py
@@ -102,7 +102,7 @@ def test_bounding_box_methods():
     # test expand/reduce methods
     other_bb = openmc.BoundingBox([-5, -5, -50], [5, 50, 5])
 
-    reduced_bb = test_bb.reduce(other_bb)
+    reduced_bb = test_bb & other_bb
 
     # inplace was False by default. BoundingBox.reduce should return a new object
     assert test_bb is not reduced_bb
@@ -114,17 +114,14 @@ def test_bounding_box_methods():
     assert all(reduced_bb[0] == [-5, -5, -12])
     assert all(reduced_bb[1] == [5, 14, 5])
 
-    reduced_bb = test_bb.reduce(other_bb, True)
-
-    # inplace was set to true. BoundingBox.reduce should return the same object
-    assert test_bb is reduced_bb
+    test_bb &= other_bb
 
     assert all(test_bb[0] == [-5, -5, -12])
     assert all(test_bb[1] == [5, 14, 5])
 
     other_bb = openmc.BoundingBox([-50, -50, -1], [50, 1, 50])
 
-    expanded_bb = test_bb.expand(other_bb)
+    expanded_bb = test_bb | other_bb
 
     # inplace was False by default. BoundingBox.expand should return a new object
     assert test_bb is not expanded_bb
@@ -136,15 +133,12 @@ def test_bounding_box_methods():
     assert all(expanded_bb[0] == [-50, -50, -12])
     assert all(expanded_bb[1] == [50, 14, 50])
 
-    expanded_bb = test_bb.expand(other_bb, True)
-
-    # inplace was set to True. BoundingBox.reduce should return the same object
-    assert test_bb is expanded_bb
+    test_bb |= other_bb
 
     assert all(test_bb[0] == [-50, -50, -12])
     assert all(test_bb[1] == [50, 14, 50])
 
-    extended_bbox = test_bb.extend(0.1)
+    extended_bbox = test_bb.expand(0.1)
 
     assert extended_bbox is not test_bb
 
@@ -155,7 +149,7 @@ def test_bounding_box_methods():
     assert all(extended_bbox[0] == [-50.1, -50.1, -12.1])
     assert all(extended_bbox[1] == [50.1, 14.1, 50.1])
 
-    extended_bbox = test_bb.extend(0.1, True)
+    extended_bbox = test_bb.expand(0.1, True)
 
     # inplace was set to True. BoundingBox.reduce should return the same object
     assert extended_bbox is test_bb

--- a/tests/unit_tests/test_bounding_box.py
+++ b/tests/unit_tests/test_bounding_box.py
@@ -132,8 +132,28 @@ def test_bounding_box_methods():
 
     expanded_bb = test_bb.expand(other_bb, True)
 
-    # inplace was set to true. BoundingBox.reduce should return the same object
+    # inplace was set to True. BoundingBox.reduce should return the same object
     assert test_bb is expanded_bb
 
     assert all(test_bb[0] == [-50, -50, -12])
     assert all(test_bb[1] == [50, 14, 50])
+
+    extended_bbox = test_bb.extend(0.1)
+
+    assert extended_bbox is not test_bb
+
+    # the original bounding box should not be changed with inplace as False
+    assert all(test_bb[0] == [-50, -50, -12])
+    assert all(test_bb[1] == [50, 14, 50])
+
+    assert all(extended_bbox[0] == [-50.1, -50.1, -12.1])
+    assert all(extended_bbox[1] == [50.1, 14.1, 50.1])
+
+    extended_bbox = test_bb.extend(0.1, True)
+
+    # inplace was set to True. BoundingBox.reduce should return the same object
+    assert extended_bbox is test_bb
+
+    assert all(test_bb[0] == [-50.1, -50.1, -12.1])
+    assert all(test_bb[1] == [50.1, 14.1, 50.1])
+

--- a/tests/unit_tests/test_bounding_box.py
+++ b/tests/unit_tests/test_bounding_box.py
@@ -82,8 +82,8 @@ def test_bounding_box_extents():
     assert test_bb_1.extent['xz'] == (-10., 1., -30., 3.)
     assert test_bb_1.extent['yz'] == (-20., 2., -30., 3.)
 
-def test_bounding_box_methods():
 
+def test_bounding_box_methods():
     test_bb = openmc.BoundingBox.infinite()
 
     # check assignment operator
@@ -92,6 +92,12 @@ def test_bounding_box_methods():
 
     assert all(test_bb[0] == [-10, -11, -12])
     assert all(test_bb[1] == [13, 14, 15])
+
+    # check length and iteration
+    assert len(test_bb) == 2
+    ll, ur = test_bb
+    assert all(ll == [-10, -11, -12])
+    assert all(ur == [13, 14, 15])
 
     # test expand/reduce methods
     other_bb = openmc.BoundingBox([-5, -5, -50], [5, 50, 5])
@@ -156,4 +162,3 @@ def test_bounding_box_methods():
 
     assert all(test_bb[0] == [-50.1, -50.1, -12.1])
     assert all(test_bb[1] == [50.1, 14.1, 50.1])
-

--- a/tests/unit_tests/test_bounding_box.py
+++ b/tests/unit_tests/test_bounding_box.py
@@ -101,6 +101,10 @@ def test_bounding_box_methods():
     # inplace was False by default. BoundingBox.reduce should return a new object
     assert test_bb is not reduced_bb
 
+    # the original bounding box should be unchanged
+    assert all(test_bb[0] == [-10, -11, -12])
+    assert all(test_bb[1] == [13, 14, 15])
+
     assert all(reduced_bb[0] == [-5, -5, -12])
     assert all(reduced_bb[1] == [5, 14, 5])
 
@@ -118,6 +122,10 @@ def test_bounding_box_methods():
 
     # inplace was False by default. BoundingBox.expand should return a new object
     assert test_bb is not expanded_bb
+
+    # the original bounding box should be unchanged
+    assert all(test_bb[0] == [-5, -5, -12])
+    assert all(test_bb[1] == [5, 14, 5])
 
     assert all(expanded_bb[0] == [-50, -50, -12])
     assert all(expanded_bb[1] == [50, 14, 50])

--- a/tests/unit_tests/test_bounding_box.py
+++ b/tests/unit_tests/test_bounding_box.py
@@ -81,3 +81,51 @@ def test_bounding_box_extents():
     assert test_bb_1.extent['xy'] == (-10., 1., -20., 2.)
     assert test_bb_1.extent['xz'] == (-10., 1., -30., 3.)
     assert test_bb_1.extent['yz'] == (-20., 2., -30., 3.)
+
+def test_bounding_box_methods():
+
+    test_bb = openmc.BoundingBox.infinite()
+
+    # check assignment operator
+    test_bb[0] = [-10, -11, -12]
+    test_bb[1] = [13, 14, 15]
+
+    assert all(test_bb[0] == [-10, -11, -12])
+    assert all(test_bb[1] == [13, 14, 15])
+
+    # test expand/reduce methods
+    other_bb = openmc.BoundingBox([-5, -5, -50], [5, 50, 5])
+
+    reduced_bb = test_bb.reduce(other_bb)
+
+    # inplace was False by default. BoundingBox.reduce should return a new object
+    assert test_bb is not reduced_bb
+
+    assert all(reduced_bb[0] == [-5, -5, -12])
+    assert all(reduced_bb[1] == [5, 14, 5])
+
+    reduced_bb = test_bb.reduce(other_bb, True)
+
+    # inplace was set to true. BoundingBox.reduce should return the same object
+    assert test_bb is reduced_bb
+
+    assert all(test_bb[0] == [-5, -5, -12])
+    assert all(test_bb[1] == [5, 14, 5])
+
+    other_bb = openmc.BoundingBox([-50, -50, -1], [50, 1, 50])
+
+    expanded_bb = test_bb.expand(other_bb)
+
+    # inplace was False by default. BoundingBox.expand should return a new object
+    assert test_bb is not expanded_bb
+
+    assert all(expanded_bb[0] == [-50, -50, -12])
+    assert all(expanded_bb[1] == [50, 14, 50])
+
+    expanded_bb = test_bb.expand(other_bb, True)
+
+    # inplace was set to true. BoundingBox.reduce should return the same object
+    assert test_bb is expanded_bb
+
+    assert all(test_bb[0] == [-50, -50, -12])
+    assert all(test_bb[1] == [50, 14, 50])

--- a/tests/unit_tests/test_source_mesh.py
+++ b/tests/unit_tests/test_source_mesh.py
@@ -97,48 +97,49 @@ def test_unstructured_mesh_sampling(model, request, test_cases):
     source = openmc.IndependentSource(space=space, energy=energy)
     model.settings.source = source
 
-    model.export_to_xml()
+    with cdtemp([mesh_filename]):
+        model.export_to_xml()
 
-    n_measurements = 100
-    n_samples = 1000
+        n_measurements = 100
+        n_samples = 1000
 
-    cell_counts = np.zeros((n_cells, n_measurements))
+        cell_counts = np.zeros((n_cells, n_measurements))
 
-    # This model contains 1000 geometry cells. Each cell is a hex
-    # corresponding to 12 of the tets. This test runs 1000 samples. This
-    #  results in the following average for each cell
-    openmc.lib.init([])
+        # This model contains 1000 geometry cells. Each cell is a hex
+        # corresponding to 12 of the tets. This test runs 1000 samples. This
+        #  results in the following average for each cell
+        openmc.lib.init([])
 
-    # perform many sets of samples and track counts for each cell
-    for m in range(n_measurements):
-        sites = openmc.lib.sample_external_source(n_samples)
-        cells = [openmc.lib.find_cell(s.r) for s in sites]
+        # perform many sets of samples and track counts for each cell
+        for m in range(n_measurements):
+            sites = openmc.lib.sample_external_source(n_samples)
+            cells = [openmc.lib.find_cell(s.r) for s in sites]
 
-        for c in cells:
-            # subtract one from index to account for root cell
-            cell_counts[c[0]._index - 1, m] += 1
+            for c in cells:
+                # subtract one from index to account for root cell
+                cell_counts[c[0]._index - 1, m] += 1
 
-    # make sure particle transport is successful
-    openmc.lib.run()
-    openmc.lib.finalize()
+        # make sure particle transport is successful
+        openmc.lib.run()
+        openmc.lib.finalize()
 
-    # normalize cell counts to get sampling frequency per particle
-    cell_counts /= n_samples
+        # normalize cell counts to get sampling frequency per particle
+        cell_counts /= n_samples
 
-    # get the mean and std. dev. of the cell counts
-    mean = cell_counts.mean(axis=1)
-    std_dev = cell_counts.std(axis=1)
+        # get the mean and std. dev. of the cell counts
+        mean = cell_counts.mean(axis=1)
+        std_dev = cell_counts.std(axis=1)
 
-    if test_cases['source_strengths'] == 'uniform':
-        exp_vals = np.ones(n_cells) / n_cells
-    else:
-        # sum up the source strengths for each tet, these are the expected true mean
-        # of the sampling frequency for that cell
-        exp_vals = strengths.reshape(-1, 12).sum(axis=1) / sum(strengths)
+        if test_cases['source_strengths'] == 'uniform':
+            exp_vals = np.ones(n_cells) / n_cells
+        else:
+            # sum up the source strengths for each tet, these are the expected true mean
+            # of the sampling frequency for that cell
+            exp_vals = strengths.reshape(-1, 12).sum(axis=1) / sum(strengths)
 
-    diff = np.abs(mean - exp_vals)
-    assert((diff < 2*std_dev).sum() / diff.size >= 0.95)
-    assert((diff < 6*std_dev).sum() / diff.size >= 0.997)
+        diff = np.abs(mean - exp_vals)
+        assert((diff < 2*std_dev).sum() / diff.size >= 0.95)
+        assert((diff < 6*std_dev).sum() / diff.size >= 0.997)
 
 
 def test_strengths_size_failure(request, model):


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

As discussed [here](https://github.com/openmc-dev/openmc/pull/2701#discussion_r1340761816) in #2701, this makes `openmc.BoundingBox` a mutable type. I've added some methods for convenience that update the bounding box using other bounding boxes as well as a couple of class methods for bounding box creation.

# Checklist

- [x] I have performed a self-review of my own code
~- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
~- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)~ (refactor)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
