### PR TITLE
moved diff_burnable_mat to model

### DIFF
--- a/openmc/deplete/coupled_operator.py
+++ b/openmc/deplete/coupled_operator.py
@@ -278,41 +278,8 @@ class CoupledOperator(OpenMCOperator):
     def _differentiate_burnable_mats(self):
         """Assign distribmats for each burnable material"""
 
-        # Count the number of instances for each cell and material
-        self.geometry.determine_paths(instances_only=True)
-
-        # Extract all burnable materials which have multiple instances
-        distribmats = set(
-            [mat for mat in self.materials
-             if mat.depletable and mat.num_instances > 1])
-
-        if self.diff_volume_method == 'divide equally':
-            for mat in distribmats:
-                if mat.volume is None:
-                    raise RuntimeError("Volume not specified for depletable "
-                                       f"material with ID={mat.id}.")
-                mat.volume /= mat.num_instances
-
-        if distribmats:
-            # Assign distribmats to cells
-            for cell in self.geometry.get_all_material_cells().values():
-                if cell.fill in distribmats:
-                    mat = cell.fill
-                    if self.diff_volume_method == 'divide equally':
-                        cell.fill = [mat.clone() for _ in range(cell.num_instances)]
-                    elif self.diff_volume_method == 'match cell':
-                        for _ in range(cell.num_instances):
-                            cell.fill = mat.clone()
-                            if not cell.volume:
-                                raise ValueError(
-                                    f"Volume of cell ID={cell.id} not specified. "
-                                    "Set volumes of cells prior to using "
-                                    "diff_volume_method='match cell'."
-                                )
-                            cell.fill.volume = cell.volume
-
-        self.materials = openmc.Materials(
-            self.model.geometry.get_all_materials().values()
+        self.model.differentiate_burnable_mats(
+            diff_volume_method=self.diff_volume_method
         )
 
     def _load_previous_results(self):

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1015,3 +1015,53 @@ class Model:
         """
 
         self._change_py_lib_attribs(names_or_ids, volume, 'material', 'volume')
+
+    def differentiate_burnable_mats(self, diff_volume_method: str):
+        """Assign distribmats for each burnable material
+
+        .. versionadded:: 0.13.4
+
+        Parameters
+        ----------
+        diff_volume_method : str
+            Specifies how the volumes of the new materials should be found.
+            Default is to 'divide equally' which divides the original material
+            volume equally between the new materials, 'match cell' sets the
+            volume of the material to volume of the cell they fill.
+        """
+        # Count the number of instances for each cell and material
+        self.geometry.determine_paths(instances_only=True)
+
+        # Extract all burnable materials which have multiple instances
+        distribmats = set(
+            [mat for mat in self.materials
+                if mat.depletable and mat.num_instances > 1])
+
+        if diff_volume_method == 'divide equally':
+            for mat in distribmats:
+                if mat.volume is None:
+                    raise RuntimeError("Volume not specified for depletable "
+                                        f"material with ID={mat.id}.")
+                mat.volume /= mat.num_instances
+
+        if distribmats:
+            # Assign distribmats to cells
+            for cell in self.geometry.get_all_material_cells().values():
+                if cell.fill in distribmats:
+                    mat = cell.fill
+                    if diff_volume_method == 'divide equally':
+                        cell.fill = [mat.clone() for _ in range(cell.num_instances)]
+                    elif diff_volume_method == 'match cell':
+                        for _ in range(cell.num_instances):
+                            cell.fill = mat.clone()
+                            if not cell.volume:
+                                raise ValueError(
+                                    f"Volume of cell ID={cell.id} not specified. "
+                                    "Set volumes of cells prior to using "
+                                    "diff_volume_method='match cell'."
+                                )
+                            cell.fill.volume = cell.volume
+
+        self.materials = openmc.Materials(
+            self.geometry.get_all_materials().values()
+        )


### PR DESCRIPTION
# Description

It would be useful to be able to call ```diff_burnable_mats``` on the ```Model``` class. Then I can call ```model.diff_burnable_mats``` before calling a volume calculation. I tend to carry out a volume calculation to get the cell/material volumes needed for depletion simulations. Full motivation in #2714 

Would it be acceptable to move the function to the model.py? We do have a few other methods that operate on materials there like ```update_material_volumes```.

This would not change or break behavior for users that want to diff_burnablemats when calling the deplete method

Fixes # (issue)
#2714 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
