### PR TITLE
Fix parsing xml files when running openmc-plotter in regions with comma decimal separator

### DIFF
--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -1,5 +1,6 @@
 #include "openmc/initialize.h"
 
+#include <clocale>
 #include <cstddef>
 #include <cstdlib> // for getenv
 #include <cstring>
@@ -42,14 +43,6 @@
 int openmc_init(int argc, char* argv[], const void* intracomm)
 {
   using namespace openmc;
-
-  // This fixes parsing the xml files when running openmc-plotter in regions
-  // where the decimal separator is , insted of .
-  // This is an issue of the upstream xml parser pugixml.
-  // See https://github.com/zeux/pugixml/issues/469
-  if (std::setlocale(LC_ALL, "C") == NULL) {
-    fatal_error("Cannot set local to C.");
-  }
 
 #ifdef OPENMC_MPI
   // Check if intracomm was passed
@@ -114,9 +107,24 @@ int openmc_init(int argc, char* argv[], const void* intracomm)
   // will be re-initialized later
   openmc::openmc_set_seed(DEFAULT_SEED);
 
+  // Copy previous locale and set locale to C. This is a workaround for an issue
+  // whereby when openmc_init is called from the plotter, the Qt application
+  // framework first calls std::setlocale, which affects how pugixml reads
+  // floating point numbers due to a bug:
+  // https://github.com/zeux/pugixml/issues/469
+  std::string prev_locale = std::setlocale(LC_ALL, nullptr);
+  if (std::setlocale(LC_ALL, "C") == NULL) {
+    fatal_error("Cannot set locale to C.");
+  }
+
   // Read XML input files
   if (!read_model_xml())
     read_separate_xml_files();
+
+  // Reset locale to previous state
+  if (std::setlocale(LC_ALL, prev_locale.c_str()) == NULL) {
+    fatal_error("Cannot reset locale.");
+  }
 
   // Write some initial output under the header if needed
   initial_output();

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -43,6 +43,14 @@ int openmc_init(int argc, char* argv[], const void* intracomm)
 {
   using namespace openmc;
 
+  // This fixes parsing the xml files when running openmc-plotter in regions
+  // where the decimal separator is , insted of .
+  // This is an issue of the upstream xml parser pugixml.
+  // See https://github.com/zeux/pugixml/issues/469
+  if (std::setlocale(LC_ALL, "C") == NULL) {
+    fatal_error("Cannot set local to C.");
+  }
+
 #ifdef OPENMC_MPI
   // Check if intracomm was passed
   MPI_Comm comm;


### PR DESCRIPTION


<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

OpenMC was failing to read xml files when it was run by openmc-plotter in systems where the decimal separator is "," instead of ".". When OpenMC was run standarlone, it worked well.

It is related to this issue in the pugixml parser: https://github.com/zeux/pugixml/issues/469.

The QT libraries used to create the GUI of openmc-plotter forced the code to use the default decimal separator of the system, which was different from the standard "." used in programming languages like C or C++. This change forces using "." as decimal separator.

I left a comment just in case it is some day fixed upstream by the pugixml developers.

Fixes https://github.com/openmc-dev/plotter/issues/124

# Checklist

- [X] I have performed a self-review of my own code
- [X] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [X] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works (if applicable)

Items 3 and 4 do not apply. For item 5 I am not sure how to create an adequate test since this is platform dependant.

<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
