### PR TITLE
Correct `openmc.lib` wrapper for `evaluate_legendre`.

### DIFF
--- a/openmc/lib/math.py
+++ b/openmc/lib/math.py
@@ -103,7 +103,7 @@ def evaluate_legendre(data, x):
     """
 
     data_arr = np.array(data, dtype=np.float64)
-    return _dll.evaluate_legendre(len(data),
+    return _dll.evaluate_legendre(len(data)-1,
                                   data_arr.ctypes.data_as(POINTER(c_double)), x)
 
 


### PR DESCRIPTION
This PR is related to recent `test_evaluate_legendre` failures in CI due to a bug in the `openmc.lib.math.evaluate_legendre` wrapper. That wrapper passes the length of the Legendre coefficients array as the first argument to `openmc::evaulate_legendre` C++ function, which expects that argument to be the order of the polynomial not the size of the coefficients.

The outcome of this is that the `openmc::evaluate_legendre` accesses memory past the end of the `data` array when `l == n` in the for loop below, resulting in undefined behavior. 

https://github.com/openmc-dev/openmc/blob/ca49d8167fb14417313a04223eaeaeb0e299fa19/src/math_functions.cpp#L111-L121

My only theory as to why this started triggering a failure is that the majority of the time the value at `data[n]` comes back as zero and the contribution to `val` when `l == n` is in turn zero and some recent change either in the CI (environment, compiler, etc.) or the codebase itself may have made this failing behavior more likely. Just my working theory today -- if others have thoughts I'd be interested in hearing them!

The simple fix for this is to correct the value of the first argument passed to `openmc::evaluate_legendre`.

In discussing this with @paulromano, he aptly noted that the only apparent purpose of this wrapper is for testing and that we can likely remove it if and place those tests in the new C++ test suite. Issue to track that task separately from this fix: #2728 