### PR TITLE
Bug fix in `Region.from_expression` during tokenization

### DIFF
--- a/openmc/region.py
+++ b/openmc/region.py
@@ -105,16 +105,16 @@ class Region(ABC):
                 # If special character appears immediately after a non-operator,
                 # create a token with the appropriate half-space
                 if i_start >= 0:
-                    # When an opening parenthesis appears after a non-operator,
-                    # there's an implicit intersection operator between them
-                    if expression[i] == '(':
-                        tokens.append(' ')
-
                     j = int(expression[i_start:i])
                     if j < 0:
                         tokens.append(-surfaces[abs(j)])
                     else:
                         tokens.append(+surfaces[abs(j)])
+
+                    # When an opening parenthesis appears after a non-operator,
+                    # there's an implicit intersection operator between them
+                    if expression[i] == '(':
+                        tokens.append(' ')
 
                 if expression[i] in '()|~':
                     # For everything other than intersection, add the operator

--- a/tests/unit_tests/test_region.py
+++ b/tests/unit_tests/test_region.py
@@ -208,7 +208,8 @@ def test_from_expression(reset):
     # Opening parenthesis immediately after halfspace
     r = openmc.Region.from_expression('1(2|-3)', surfs)
     assert str(r) == '(1 (2 | -3))'
-
+    r = openmc.Region.from_expression('-1|(1 2(-3))', surfs)
+    assert str(r) == '(-1 | (1 2 -3))'
 
 def test_translate_inplace():
     sph = openmc.Sphere()


### PR DESCRIPTION
# Description

This fixes an issue that was observed by @yrrepy when converting an MCNP geometry using the [openmc_mcnp_adapter](https://github.com/openmc-dev/openmc_mcnp_adapter/issues/6). I was able to boil it down to the following region being interpreted incorrectly: `-1|(1 2(-3))`. Namely, when converting this expression to tokens, the implicit intersection operator between "2" and "(" got put in the wrong place. The test case we had for this before didn't catch this particular case.

Fixes openmc-dev/openmc_mcnp_adapter#6

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)