### PR TITLE
Correct cylindrical/spherical centroids.

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -257,8 +257,8 @@ class StructuredMesh(MeshBase):
 
         """
         ndim = self.n_dimension
-        # this line ensures that the vertices aren't adjusted by the origin for
-        # cylindrical and spherical meshes
+        # this line ensures that the vertices aren't adjusted by the origin or
+        # converted to the Cartesian system for cylindrical and spherical meshes
         vertices = StructuredMesh.vertices.fget(self)
         s0 = (slice(None),) + (slice(0, -1),)*ndim
         s1 = (slice(None),) + (slice(1, None),)*ndim

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -257,7 +257,9 @@ class StructuredMesh(MeshBase):
 
         """
         ndim = self.n_dimension
-        vertices = self.vertices
+        # this line ensures that the vertices aren't adjusted by the origin for
+        # cylindrical and spherical meshes
+        vertices = StructuredMesh.vertices.fget(self)
         s0 = (slice(None),) + (slice(0, -1),)*ndim
         s1 = (slice(None),) + (slice(1, None),)*ndim
         return (vertices[s0] + vertices[s1]) / 2


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

The changeover from mesh coordinates to Cartesian coordinates as default for the `vertices` and `centroids` properties of our mesh classes in #2711 doesn't account for the `origin` property of the `CylindricalMesh` and `SphericalMesh` classes correctly and performs and the coordinate transformation twice in their `centroids` property. 

The coordinate conversion and origin is currently being applied too many times by nature of calling `self.vertices` inside the `StructuredMesh.centroids` implementation on the class instance for the cylindrical and spherical mesh types. This change ensures that the `StructuredMesh` version of `vertices` is always used in the `centroids` propety so that a) the `vertices` coordinates aren't converted to Cartesian and b) the mesh origin isn't applied as it would be in the `CylindricalMesh.vertices` or `SphericalMesh.vertices` implementations.

I added some spot check tests here to make sure this doesn't regress again.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
