### PR TITLE
In volume calculation mode, only load atomic weight ratio from data files

### DIFF
--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -62,6 +62,10 @@ Nuclide::Nuclide(hid_t group, const vector<double>& temperature)
   read_attribute(group, "metastable", metastable_);
   read_attribute(group, "atomic_weight_ratio", awr_);
 
+  if (settings::run_mode == RunMode::VOLUME) {
+    return;
+  }
+
   // Determine temperatures available
   hid_t kT_group = open_group(group, "kTs");
   auto dset_names = dataset_names(kT_group);


### PR DESCRIPTION
# Description

This PR is <s>an alternative</s> complementary to #2725.

@bam241 This is what I was thinking -- for volume calculation mode (which is used by openmc-plotter), we still open the .h5 files but only load the atomic weight ratio since this is all that is needed for the sake of computing densities. This won't yet allow users to run the plotter without having cross sections specified, but it at least does speed up the loading time significantly since all the cross section data itself is not loaded.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>
