### PR TITLE
Check for invalid domain IDs in volume calculations

### DIFF
--- a/tests/unit_tests/test_volume.py
+++ b/tests/unit_tests/test_volume.py
@@ -13,3 +13,19 @@ def test_infinity_handling():
 
     with pytest.raises(ValueError, match="must be finite"):
         openmc.VolumeCalculation([cell1], 100, lower_left, upper_right)
+
+
+@pytest.mark.parametrize('cls', [openmc.Cell, openmc.Material, openmc.Universe])
+def test_invalid_id(run_in_tmpdir, cls):
+    m = openmc.Material()
+    m.add_nuclide('U235', 0.02)
+    sph = openmc.Sphere(boundary_type='vacuum')
+    cell = openmc.Cell(fill=m, region=-sph)
+    model = openmc.Model(geometry=openmc.Geometry([cell]))
+
+    # Apply volume calculation with unused domains
+    model.settings.volume_calculations = openmc.VolumeCalculation(
+        [cls()], 10000, *model.geometry.bounding_box)
+
+    with pytest.raises(RuntimeError):
+        model.calculate_volumes()


### PR DESCRIPTION
# Description

As described in #2726, if you run a volume calculation with a domain that doesn't actually exist in the geometry, it will still run erroneously. This PR adds a check to ensure that the domain IDs specified actually exist in the geometry.

Fixes #2726

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)