### PR TITLE
Skip BC check for volume calculations

### DIFF
--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -81,7 +81,8 @@ void read_geometry_xml(pugi::xml_node root)
     }
   }
 
-  if (settings::run_mode != RunMode::PLOTTING && settings::run_mode != RunMode::VOLUME && !boundary_exists) {
+  if (settings::run_mode != RunMode::PLOTTING &&
+      settings::run_mode != RunMode::VOLUME && !boundary_exists) {
     fatal_error("No boundary conditions were applied to any surfaces!");
   }
 

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -81,7 +81,7 @@ void read_geometry_xml(pugi::xml_node root)
     }
   }
 
-  if (settings::run_mode != RunMode::PLOTTING && !boundary_exists) {
+  if (settings::run_mode != RunMode::PLOTTING && settings::run_mode != RunMode::VOLUME && !boundary_exists) {
     fatal_error("No boundary conditions were applied to any surfaces!");
   }
 

--- a/tests/unit_tests/test_volume.py
+++ b/tests/unit_tests/test_volume.py
@@ -29,3 +29,17 @@ def test_invalid_id(run_in_tmpdir, cls):
 
     with pytest.raises(RuntimeError):
         model.calculate_volumes()
+
+
+def test_no_bcs(run_in_tmpdir):
+    """Ensure that a model without boundary conditions can be used in a volume calculation"""
+    model = openmc.examples.pwr_pin_cell()
+    for surface in model.geometry.get_all_surfaces().values():
+        surface.boundary_type = 'transmission'
+
+    bbox = openmc.BoundingBox([-1.]*3, [1.]*3)
+    cells = list(model.geometry.get_all_cells().values())
+    vc = openmc.VolumeCalculation(cells, samples=10, lower_left=bbox[0], upper_right=bbox[1])
+
+    model.settings.volume_calculations = [vc]
+    model.calculate_volumes()


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This is a simple change that, similar to running OpenMC in plotting mode, allows initialization to complete for a geometry without non-transmission boundary conditions when running in volume calculation mode. 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)

<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
