### PR TITLE
Fix type hint in Materials class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ if(OPENMC_USE_DAGMC)
     message(FATAL_ERROR "Discovered DAGMC Version: ${DAGMC_VERSION}. \
     Please update DAGMC to version 3.2.0 or greater.")
   endif()
+  message(STATUS "Found DAGMC: ${DAGMC_DIR} (version ${DAGMC_VERSION})")
 endif()
 
 #===============================================================================

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1713,7 +1713,7 @@ class Materials(cv.CheckedList):
             self._write_xml(fh, nuclides_to_ignore=nuclides_to_ignore)
 
     @classmethod
-    def from_xml_element(cls, elem) -> Material:
+    def from_xml_element(cls, elem) -> Materials:
         """Generate materials collection from XML file
 
         Parameters
@@ -1740,7 +1740,7 @@ class Materials(cv.CheckedList):
         return materials
 
     @classmethod
-    def from_xml(cls, path: PathLike = 'materials.xml') -> Material:
+    def from_xml(cls, path: PathLike = 'materials.xml') -> Materials:
         """Generate materials collection from XML file
 
         Parameters


### PR DESCRIPTION
# Description

Quick PR fixing a type hint that I noticed was not correct on `Materials.from_xml`. There's also one unrelated change in CMakeLists.txt where I've added a status line indicating where a DAGMC installation is found if building against DAGMC (noticed we were missing this).

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>