### PR TITLE
Adding info on clang-format version used in CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Fixes # (issue)
 # Checklist
 
 - [ ] I have performed a self-review of my own code
-- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) on any C++ source files (if applicable)
+- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
 - [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
 - [ ] I have made corresponding changes to the documentation (if applicable)
 - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

--- a/docs/source/devguide/styleguide.rst
+++ b/docs/source/devguide/styleguide.rst
@@ -29,6 +29,10 @@ whenever a file is saved. For example, `Visual Studio Code
 <https://code.visualstudio.com/docs/cpp/cpp-ide#_code-formatting>`_ includes
 support for running clang-format.
 
+.. note::
+    OpenMC's CI uses `clang-format` version 15. A different version of `clang-format`
+    may produce different line changes and as a result fail the CI test.
+
 Miscellaneous
 -------------
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

As noted by @bam241 in #2746. Using different versions of `clang-format` than CI, which uses version 15, can result in failing C++ style tests without a clear path to fixing that issue. While this isn't what I would call a long-term fix, this PR at least adds a note that matching the version is important for getting the C++ style tests to pass in the developer's guide and the pull request template.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
