### PR TITLE
Fix loop over particle coordinate levels for source domain rejection

### DIFF
--- a/src/source.cpp
+++ b/src/source.cpp
@@ -222,10 +222,10 @@ SourceSite IndependentSource::sample(uint64_t* seed) const
             found = contains(domain_ids_, model::materials[mat_index]->id());
           }
         } else {
-          for (const auto& coord : p.coord()) {
+          for (int i = 0; i < p.n_coord(); i++) {
             auto id = (domain_type_ == DomainType::CELL)
-                        ? model::cells[coord.cell]->id_
-                        : model::universes[coord.universe]->id_;
+                        ? model::cells[p.coord(i).cell]->id_
+                        : model::universes[p.coord(i).universe]->id_;
             if ((found = contains(domain_ids_, id)))
               break;
           }


### PR DESCRIPTION
# Description

I ran into this bug while trying to use domain rejection on a problem with multiple universe levels. The loop over particle coordinate levels should have been checking `n_coord()` rather than blindly iterating over the `coord()` vector.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)