### PR TITLE
added check for group name

### DIFF
--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1400,6 +1400,7 @@ class EnergyFilter(RealFilter):
 
         """
 
+        cv.check_value('group_structure', group_structure, openmc.mgxs.GROUP_STRUCTURES.keys())
         return cls(openmc.mgxs.GROUP_STRUCTURES[group_structure.upper()])
 
 


### PR DESCRIPTION
# Description

Any chance we can sneak in this check_value for the group structure name. Currently a mistyped name returns a key error which is not much help.

This PR changes it so that we get a more informative error
```
ValueError: Unable to set "group_structure" to "VITAMINJ-175" since it is not in "dict_keys(['CASMO-2', 'CASMO-4', 'CASMO-8', 'CASMO-16', 'CASMO-25', 'CASMO-40', 'VITAMIN-J-42', 'SCALE-44', 'MPACT-51', 'MPACT-60', 'MPACT-69', 'CASMO-70', 'XMAS-172', 'VITAMIN-J-175', 'SCALE-252', 'TRIPOLI-315', 'SHEM-361', 'CCFE-709', 'UKAEA-1102', 'ECCO-1968'])"
```

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)

