### PR TITLE
fix unit conversion in openmc.deplete.Results.get_mass

### DIFF
--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -318,7 +318,7 @@ class Results(list):
             # Divide by volume to get density
             mass /= self[0].volume[mat_id]
         elif mass_units == "kg":
-            mass *= 1e3
+            mass /= 1e3
 
         return times, mass
 

--- a/tests/unit_tests/test_deplete_resultslist.py
+++ b/tests/unit_tests/test_deplete_resultslist.py
@@ -111,7 +111,7 @@ def test_get_mass(res):
     assert n_cm3 == pytest.approx(n_ref / volume)
 
     t_min, n_bcm = res.get_mass("1", "Xe135", mass_units="kg", time_units="min")
-    assert n_bcm == pytest.approx(n_ref * 1e3)
+    assert n_bcm == pytest.approx(n_ref / 1e3)
     assert t_min == pytest.approx(t_ref / 60)
 
     t_hour, _n = res.get_mass("1", "Xe135", time_units="h")


### PR DESCRIPTION
# Description

The openmc.deplete.Results class provides a get_mass method that can provides mass values in g (default), g/cm3, and kg.
 To convert from g to kg, the mass is multiplied by 1_000, which convert to mg instead.

Fixes # (issue)

I changed to * operator to the / operator for correct conversion.

# Checklist

- [x ] I have performed a self-review of my own code
- [] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
