### PR TITLE
Adding independent operator to model.deplete

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -352,7 +352,7 @@ class Model:
             method: str = 'cecm',
             operator_class: str = 'CoupledOperator',
             final_step: bool = True,
-            operator_kwargs: Optional[Dict]=None,
+            operator_kwargs: Optional[Dict] = None,
             directory: PathLike = '.',
             output:bool = True,
             **integrator_kwargs

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -369,14 +369,14 @@ class Model:
             Array of timesteps in units of [s]. Note that values are not
             cumulative.
         method : str, optional
-             Integration method used for depletion (e.g., 'cecm', 'predictor').
-             Defaults to 'cecm'.
+            Integration method used for depletion (e.g., 'cecm', 'predictor').
+            Defaults to 'cecm'.
         operator_class : str, optional
-             Operator class used for depletion (e.g., 'CoupledOperator' or
-             'IndependentOperator'). Defaults to 'CoupledOperator'. If
-             IndependentOperator is selected then all depletable materials
-             in the model will be used and fluxes and micros will need passing
-             in via the operator_kwargs.
+            Operator class used for depletion (e.g., 'CoupledOperator' or
+            'IndependentOperator'). Defaults to 'CoupledOperator'. If
+            IndependentOperator is selected then all depletable materials
+            in the model will be used and fluxes and micros will need passing
+            in via the operator_kwargs.
         final_step : bool, optional
             Indicate whether or not a transport solve should be run at the end
             of the last timestep. Defaults to running this transport solve.


### PR DESCRIPTION
# Description

I noticed a [TODO](https://github.com/openmc-dev/openmc/blob/a3695c784eaddd74549f50b79567bc3d12254e79/openmc/model/model.py#L399) in the code so thought I would have a go at allowing the IndependentOperator to be used in model.deplete. Currently model.deplete makes use of the CoupleOperator.

I've been testing by comparing [this](https://github.com/fusion-energy/neutronics-workshop/blob/testing_model.deplete/tasks/task_10_activation_transmutation_depletion/3_full_pulse_schedule.py) script output with [this](https://github.com/fusion-energy/neutronics-workshop/blob/testing_model.deplete/tasks/task_10_activation_transmutation_depletion/4_full_pulse_schedule.py) script output 

I still need to add some tests to this PR, so this is just a draft PR for now

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

