### PR TITLE
added particle option to material.get_activity

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1105,7 +1105,7 @@ class Material(IDManagerMixin):
         volume : float, optional
             Volume of the material. If not passed, defaults to using the
             :attr:`Material.volume` attribute.
-        particle : {'beta-', 'alpha', 'p', 'n', 'beta+', 'gamma', 'sf'}
+        particle : {'beta', 'alpha', 'p', 'n' 'gamma', 'sf'}
             Specifies if the activity of an individual particle should be
             returned. If left as None then any particles is used. If setting
             particle then it is also necessary to specify the chain file to use
@@ -1143,9 +1143,9 @@ class Material(IDManagerMixin):
                         for dt in nuc.decay_modes:
                             if particle in dt[0]:
                                 # multiplied by dt[2] which is the branching ratio
-                                decay_const_dict[nuc.name] = (
-                                    log(2.0) / nuc.half_life * dt[2]
-                                )
+                                decay_const_dict[nuc.name] = decay_const_dict[
+                                    nuc.name
+                                ] + (log(2.0) / nuc.half_life * dt[2])
                     else:
                         if nuc.n_decay_modes == 0:
                             decay_const_dict[nuc.name] = 0.0

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -565,6 +565,66 @@ def test_get_activity():
     # Test with volume specified as argument
     assert pytest.approx(m4.get_activity(units='Bq', volume=1.0)) == 355978108155965.94*3/2
 
+    # Test activity when a chain file is used and nuclide has no decay
+    m5 = openmc.Material()
+    m5.add_nuclide("U235", 1)
+    m5.set_density("g/cm3", 1)
+    assert pytest.approx(m5.get_activity(units="Bq/g")) == 79960.38150492319
+    assert (
+        pytest.approx(
+            m5.get_activity(
+                units="Bq/g", chain_file=Path(__file__).parents[1] / "chain_simple.xml"
+            )
+        )
+        == 0.0
+    )  # U23 has no decay path in chain_simple.xml
+
+    # Test activity when a chain file is used and nuclide has decay
+    m6 = openmc.Material()
+    m6.add_nuclide("I135", 1)
+    m6.set_density("g/cm3", 1)
+    assert pytest.approx(m6.get_activity(units="Bq/g")) == 1.3081699229530213e17
+    assert (
+        pytest.approx(
+            m6.get_activity(
+                units="Bq/g",
+                chain_file=Path(__file__).parents[1] / "chain_simple.xml",
+                particle="beta",
+            )
+        )
+        == 1.3081699229530213e17
+    )
+    # neutron is not a decay type of I135 so this should return 0.
+    assert (
+        pytest.approx(
+            m6.get_activity(
+                units="Bq/g",
+                chain_file=Path(__file__).parents[1] / "chain_simple.xml",
+                particle="neutron",
+            )
+        )
+        == 0.0
+    )
+    assert (
+        pytest.approx(
+            m6.get_activity(
+                units="Bq/g", chain_file=Path(__file__).parents[1] / "chain_simple.xml"
+            )
+        )
+        == 1.3081699229530213e17
+    )
+    assert (
+        pytest.approx(
+            m6.get_activity(
+                units="Bq/g",
+                by_nuclide=True,
+                particle="beta",
+                chain_file=Path(__file__).parents[1] / "chain_simple.xml",
+            )["I135"]
+        )
+        == 1.3081699229530213e17
+    )
+
 
 def test_get_decay_heat():
     # Set chain file for testing


### PR DESCRIPTION
# Description

This PR attempts to modify the material.get_activity so that one can specify a particle and get just the activity for that particle as discussed in #2527 
Many thanks to @jbae11 for the coding logic behind this PR

There are two part I'm not  sure about hence the draft PR (I've also canceled the CI)

- should a check_value be added for the particle name. I've stopped short of added this check_value on the particle inputs as I've seen different words for the same particle used in different chain files e.g. electron or beta-
- Currently this checks the nuclide.decay_types for presence of a particle and adds it to the activity if it is present, however should I also check the nuclide.source for the particle. This chain file snippet has beta-,n decay with gamma emission so this gamma is not caught by the PR currently but the two difference beta decays are.
```
  <nuclide name="He8" half_life="0.1191" decay_modes="2" decay_energy="5185336.0" reactions="0">
    <decay type="beta-" target="Li8" branching_ratio="0.84"/>
    <decay type="beta-,n" target="Li7" branching_ratio="0.16"/>
    <source type="discrete" particle="photon">
      <parameters>980000.0 4.888695480019765</parameters>
    </source>
```

Fixes # (issue)
#2527 


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

I've run [darker](https://github.com/akaihola/darker) on the lines of code changed in this PR which lets on run black on only the edited lines of coe