### PR TITLE
added path arg to integrator.integrate

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -18,7 +18,7 @@ from warnings import warn
 from numpy import nonzero, empty, asarray
 from uncertainties import ufloat
 
-from openmc.checkvalue import check_type, check_greater_than
+from openmc.checkvalue import check_type, check_greater_than, PathLike
 from openmc.mpi import comm
 from .stepresult import StepResult
 from .chain import Chain
@@ -762,7 +762,12 @@ class Integrator(ABC):
         return (self.operator.prev_res[-1].time[-1],
                 len(self.operator.prev_res) - 1)
 
-    def integrate(self, final_step=True, output=True):
+    def integrate(
+            self,
+            final_step: bool = True,
+            output: bool = True,
+            path: PathLike = 'depletion_results.h5'
+        ):
         """Perform the entire depletion process across all steps
 
         Parameters
@@ -776,6 +781,10 @@ class Integrator(ABC):
             Indicate whether to display information about progress
 
             .. versionadded:: 0.13.1
+        path : PathLike
+            Path to file to write. Defaults to 'depletion_results.h5'.
+
+            .. versionadded:: 0.14.1
         """
         with change_directory(self.operator.output_dir):
             n = self.operator.initial_condition()
@@ -802,7 +811,7 @@ class Integrator(ABC):
                 n = n_list.pop()
 
                 StepResult.save(self.operator, n_list, res_list, [t, t + dt],
-                                source_rate, self._i_res + i, proc_time)
+                                source_rate, self._i_res + i, proc_time, path)
 
                 t += dt
 
@@ -954,15 +963,21 @@ class SIIntegrator(Integrator):
             self.operator.settings.particles //= self.n_steps
         return inherited
 
-    def integrate(self, output=True):
+    def integrate(
+            self,
+            output: bool = True,
+            path: PathLike = "depletion_results.h5"
+        ):
         """Perform the entire depletion process across all steps
 
         Parameters
         ----------
         output : bool, optional
             Indicate whether to display information about progress
+        path : PathLike
+            Path to file to write. Defaults to 'depletion_results.h5'.
 
-            .. versionadded:: 0.13.1
+            .. versionadded:: 0.14.1
         """
         with change_directory(self.operator.output_dir):
             n = self.operator.initial_condition()
@@ -992,13 +1007,13 @@ class SIIntegrator(Integrator):
                 n = n_list.pop()
 
                 StepResult.save(self.operator, n_list, res_list, [t, t + dt],
-                             p, self._i_res + i, proc_time)
+                             p, self._i_res + i, proc_time, path)
 
                 t += dt
 
             # No final simulation for SIE, use last iteration results
             StepResult.save(self.operator, [n], [res_list[-1]], [t, t],
-                         p, self._i_res + len(self), proc_time)
+                         p, self._i_res + len(self), proc_time, path)
             self.operator.write_bos_data(self._i_res + len(self))
 
         self.operator.finalize()


### PR DESCRIPTION
# Description

This PR attempts to add a ```path``` argument to the ```Integrator.integrate```. This new argument defaults to the normal 
```"depletion_results.h5"``` value so does not change the behavior for users. For users who what to then this gives them the ability to write the depletion results to a specified path.

This is handy for R2S workflows where one might want to use the integrator and write the depletes to a specified location and avoid things like [this](https://github.com/fusion-energy/neutronics-workshop/blob/89a076b58a200c8787ef7e3f67b0af81db97a1e0/tasks/task_11_CSG_shut_down_dose_tallies/2_faster_mulitiple_puse_shut_down_dose_rate_example.py#L148-L149) where the file needs moving by the user.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
