### PR TITLE
F90_NONE Removal (MGMC tallying optimization)

### DIFF
--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -317,7 +317,6 @@ enum class GlobalTally { K_COLLISION, K_ABSORPTION, K_TRACKLENGTH, LEAKAGE };
 
 // Miscellaneous
 constexpr int C_NONE {-1};
-constexpr int F90_NONE {0}; // TODO: replace usage of this with C_NONE
 
 // Interpolation rules
 enum class Interpolation {

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -259,7 +259,7 @@ private:
   // Energy data
   double E_;      //!< post-collision energy in eV
   double E_last_; //!< pre-collision energy in eV
-  int g_ {0};     //!< post-collision energy group (MG only)
+  int g_ {C_NONE};//!< post-collision energy group (MG only)
   int g_last_;    //!< pre-collision energy group (MG only)
 
   // Other physical data

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -257,10 +257,10 @@ private:
   vector<int> cell_last_; //!< coordinates for all levels
 
   // Energy data
-  double E_;      //!< post-collision energy in eV
-  double E_last_; //!< pre-collision energy in eV
-  int g_ {C_NONE};//!< post-collision energy group (MG only)
-  int g_last_;    //!< pre-collision energy group (MG only)
+  double E_;       //!< post-collision energy in eV
+  double E_last_;  //!< pre-collision energy in eV
+  int g_ {C_NONE}; //!< post-collision energy group (MG only)
+  int g_last_;     //!< pre-collision energy group (MG only)
 
   // Other physical data
   double wgt_ {1.0};       //!< particle weight

--- a/src/tallies/filter_energy.cpp
+++ b/src/tallies/filter_energy.cpp
@@ -59,7 +59,7 @@ void EnergyFilter::set_bins(gsl::span<const double> bins)
 void EnergyFilter::get_all_bins(
   const Particle& p, TallyEstimator estimator, FilterMatch& match) const
 {
-  if (p.g() != F90_NONE && matches_transport_groups_) {
+  if (p.g() != C_NONE && matches_transport_groups_) {
     if (estimator == TallyEstimator::TRACKLENGTH) {
       match.bins_.push_back(data::mg.num_energy_groups_ - p.g() - 1);
     } else {
@@ -98,7 +98,7 @@ std::string EnergyFilter::text_label(int bin) const
 void EnergyoutFilter::get_all_bins(
   const Particle& p, TallyEstimator estimator, FilterMatch& match) const
 {
-  if (p.g() != F90_NONE && matches_transport_groups_) {
+  if (p.g() != C_NONE && matches_transport_groups_) {
     match.bins_.push_back(data::mg.num_energy_groups_ - p.g() - 1);
     match.weights_.push_back(1.0);
 


### PR DESCRIPTION
# Description

This PR fixes a small issue in multigroup mode when tallying with an energy filter. The code in question is:

```C++
void EnergyFilter::get_all_bins(
  const Particle& p, TallyEstimator estimator, FilterMatch& match) const
{
  if (p.g() != F90_NONE && matches_transport_groups_) {
    if (estimator == TallyEstimator::TRACKLENGTH) {
      match.bins_.push_back(data::mg.num_energy_groups_ - p.g() - 1);
    } else {
      match.bins_.push_back(data::mg.num_energy_groups_ - p.g_last() - 1);
    }
    match.weights_.push_back(1.0);

  } else {
    // Get the pre-collision energy of the particle.
    auto E = p.E_last();

    // Bin the energy.
    if (E >= bins_.front() && E <= bins_.back()) {
      auto bin = lower_bound_index(bins_.begin(), bins_.end(), E);
      match.bins_.push_back(bin);
      match.weights_.push_back(1.0);
    }
  }
}
```

If we are in multigroup mode and the bins match the XS group structure, then we should be taking the first branch. However, as the groups use 0 based indexing (and `F90_NONE` is defined as 0) if the particle is at group 0 then it doesn't follow the intended path. Instead, it takes the more expensive continuous energy branch. Thankfully in MG mode the energy gets set to the average of the bin when the particle begins life and when it changes energy, so the correct bin is found, but it would be faster to always take the first path if possible.

The fix is easy -- we can just change `F90_NONE` to `C_NONE` (defined as -1), and ensure the particle gets initialized with this value, so that the first branch is always taken in MG mode when the bins match the group structure. This has the added bonus of checking off a "TODO" item from the code comments. As this was the only place that `F90_NONE` was still being used, we were able to delete it.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
