### PR TITLE
Add inline to openmc::interpolate

### DIFF
--- a/include/openmc/interpolate.h
+++ b/include/openmc/interpolate.h
@@ -56,8 +56,9 @@ inline double interpolate_lagrangian(gsl::span<const double> xs,
   return output;
 }
 
-double interpolate(gsl::span<const double> xs, gsl::span<const double> ys,
-  double x, Interpolation i = Interpolation::lin_lin)
+inline double interpolate(gsl::span<const double> xs,
+  gsl::span<const double> ys, double x,
+  Interpolation i = Interpolation::lin_lin)
 {
   int idx = lower_bound_index(xs.begin(), xs.end(), x);
 


### PR DESCRIPTION
# Description

The `interpolate` function in interpolate.h was being defined in a header without being `inline`. This PR simply adds the `inline` specifier so that we don't end up with multiple definitions of the same function.

Fixes #2788

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>