### PR TITLE
Call simulation_finalize if needed when finalizing OpenMC

### DIFF
--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -63,6 +63,8 @@ using namespace openmc;
 
 int openmc_finalize()
 {
+  if (simulation::initialized) openmc_simulation_finalize();
+
   // Clear results
   openmc_reset();
 

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -63,7 +63,8 @@ using namespace openmc;
 
 int openmc_finalize()
 {
-  if (simulation::initialized) openmc_simulation_finalize();
+  if (simulation::initialized)
+    openmc_simulation_finalize();
 
   // Clear results
   openmc_reset();


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Small change here to automatically call `openmc_simulation_finalize` inside `openmc_finalize` if it hasn't been called already.

Fixes # (issue)

N/A

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
~- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~ N/A
~- [ ] I have made corresponding changes to the documentation (if applicable)~ N/A
~- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)~ N/A
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
