### PR TITLE
Use huge_tree=True in lxml parsing

### DIFF
--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -293,8 +293,8 @@ class Geometry:
         if isinstance(materials, (str, os.PathLike)):
             materials = openmc.Materials.from_xml(materials)
 
-        p    = ET.XMLParser(huge_tree=True)
-        tree = ET.parse(path, parser=p)
+        parser = ET.XMLParser(huge_tree=True)
+        tree = ET.parse(path, parser=parser)
         root = tree.getroot()
 
         return cls.from_xml_element(root, materials)

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -293,7 +293,8 @@ class Geometry:
         if isinstance(materials, (str, os.PathLike)):
             materials = openmc.Materials.from_xml(materials)
 
-        tree = ET.parse(path)
+        p    = ET.XMLParser(huge_tree=True)
+        tree = ET.parse(path, parser=p)
         root = tree.getroot()
 
         return cls.from_xml_element(root, materials)

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1754,7 +1754,8 @@ class Materials(cv.CheckedList):
             Materials collection
 
         """
-        tree = ET.parse(path)
+        parser = ET.XMLParser(huge_tree=True)
+        tree = ET.parse(path, parser=parser)
         root = tree.getroot()
 
         return cls.from_xml_element(root)

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -253,7 +253,8 @@ class Model:
         path : str or PathLike
             Path to model.xml file
         """
-        tree = ET.parse(path)
+        parser = ET.XMLParser(huge_tree=True)
+        tree = ET.parse(path, parser=parser)
         root = tree.getroot()
 
         model = cls()

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -1508,6 +1508,7 @@ class Plots(cv.CheckedList):
             Plots collection
 
         """
-        tree = ET.parse(path)
+        parser = ET.XMLParser(huge_tree=True)
+        tree = ET.parse(path, parser=parser)
         root = tree.getroot()
         return cls.from_xml_element(root)

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1946,7 +1946,8 @@ class Settings:
             Settings object
 
         """
-        tree = ET.parse(path)
+        parser = ET.XMLParser(huge_tree=True)
+        tree = ET.parse(path, parser=parser)
         root = tree.getroot()
         meshes = _read_meshes(root)
         return cls.from_xml_element(root, meshes)

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3304,6 +3304,7 @@ class Tallies(cv.CheckedList):
             Tallies object
 
         """
-        tree = ET.parse(path)
+        parser = ET.XMLParser(huge_tree=True)
+        tree = ET.parse(path, parser=parser)
         root = tree.getroot()
         return cls.from_xml_element(root)


### PR DESCRIPTION
# Description
Enabled lxml support for very deep trees and very long text content in the geometry Python class. (huge_tree=true)

For large lattices with many elements (>~500,000 elements) the Python Universe plotter would fail due to the "huge text node". With this change I can successfully universe.py plot my highly detailed voxel lattice.

The change implemented follows that counselled here:
https://stackoverflow.com/questions/11850345/using-python-lxml-etree-for-huge-xml-files

Fixes:
The error appearing during universe.py plotting was:
```
Traceback (most recent call last):
  File "/home/abc/Projects/UniversePlotter.py", line 116, in <module>
    my_geometry=openmc.Geometry.from_xml();
  File "/home/abc/.local/lib/python3.10/site-packages/openmc/geometry.py", line 296, in from_xml
    tree = ET.parse(path)
  File "src/lxml/etree.pyx", line 3541, in lxml.etree.parse
  File "src/lxml/parser.pxi", line 1879, in lxml.etree._parseDocument
  File "src/lxml/parser.pxi", line 1905, in lxml.etree._parseDocumentFromURL
  File "src/lxml/parser.pxi", line 1808, in lxml.etree._parseDocFromFile
  File "src/lxml/parser.pxi", line 1180, in lxml.etree._BaseParser._parseDocFromFile
  File "src/lxml/parser.pxi", line 618, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 728, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 657, in lxml.etree._raiseParseError
  File "geometry.xml", line 435
lxml.etree.XMLSyntaxError: xmlSAX2Characters: huge text node, line 435, column 10000881
```


# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
~- [ ] I have made corresponding changes to the documentation (if applicable)~
~- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)~

