### PR TITLE
OpenMPMutex "Copying"

### DIFF
--- a/include/openmc/openmp_interface.h
+++ b/include/openmc/openmp_interface.h
@@ -41,12 +41,11 @@ public:
   // rather, it produces two different mutexes.
 
   // Copy constructor
-  OpenMPMutex(const OpenMPMutex& other) {
-    OpenMPMutex();
-  }
+  OpenMPMutex(const OpenMPMutex& other) { OpenMPMutex(); }
 
   // Copy assignment operator
-  OpenMPMutex& operator=(const OpenMPMutex& other) {
+  OpenMPMutex& operator=(const OpenMPMutex& other)
+  {
     OpenMPMutex();
     return *this;
   }

--- a/include/openmc/openmp_interface.h
+++ b/include/openmc/openmp_interface.h
@@ -29,11 +29,27 @@ public:
 #endif
   }
 
-  // Mutexes cannot be copied.  We need to explicitly delete the copy
-  // constructor and copy assignment operator to ensure the compiler doesn't
-  // "help" us by implicitly trying to copy the underlying mutexes.
-  OpenMPMutex(const OpenMPMutex&) = delete;
-  OpenMPMutex& operator=(const OpenMPMutex&) = delete;
+  // omp_lock_t objects cannot be deep copied, they can only be shallow
+  // copied. Thus, while shallow copying of an omp_lock_t object is
+  // completely valid (provided no race conditions exist), true copying
+  // of an OpenMPMutex object is not valid due to the action of the
+  // destructor. However, since locks are fungible, we can simply replace
+  // copying operations with default construction. This allows storage of
+  // OpenMPMutex objects within containers that may need to move/copy them
+  // (e.g., std::vector). It is left to the caller to understand that
+  // copying of OpenMPMutex does not produce two handles to the same mutex,
+  // rather, it produces two different mutexes.
+
+  // Copy constructor
+  OpenMPMutex(const OpenMPMutex& other) {
+    OpenMPMutex();
+  }
+
+  // Copy assignment operator
+  OpenMPMutex& operator=(const OpenMPMutex& other) {
+    OpenMPMutex();
+    return *this;
+  }
 
   //! Lock the mutex.
   //


### PR DESCRIPTION
# Description

The original `OpenMPMutex` class definition deletes the copy operator and copy assignment operators. This was a reasonable strategy, as if we copy this object then only a shallow copy is performed (i.e., destroying the original object will uninitialize the `omp_lock_t` within the new copied object). While deletion of these operators works, it also precludes the class from being stored in various STL containers that might need to copy or move the objects (e.g., `std::vector`).

Given that `omp_lock_t` objects are inherently fungible, we can just define the copy operators with default construction. I.e., copying just creates a new object, it does not copy anything from the original object. This allows for usage of the object in STL containers like vectors.

For performance, we might also want to implement move operators, but I'm hesitant to introduce even more code that may not be used and likely isn't going to be covered by testing. Additionally, as movement of locks would only ever be done during program initialization, there is no tangible benefit to the move semantics, so probably not worth the extra code.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
