### PR TITLE
adding get_all_nuclides method to geometry class

### DIFF
--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -391,6 +391,23 @@ class Geometry:
         universes.update(self.root_universe.get_all_universes())
         return universes
 
+    def get_all_nuclides(self) -> typing.List[str]:
+        """Return all nuclides within the geometry.
+
+        Returns
+        -------
+        list
+            sorted list of all the nuclides in the geometry materials
+
+        """
+        all_nuclides = []
+        for material in self.get_all_materials().values():
+            for nuclide in material.get_nuclides():
+                if nuclide not in all_nuclides:
+                    all_nuclides.append(nuclide)
+        return sorted(all_nuclides)
+
+
     def get_all_materials(self) -> typing.Dict[int, openmc.Material]:
         """Return all materials within the geometry.
 

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -397,16 +397,13 @@ class Geometry:
         Returns
         -------
         list
-            sorted list of all the nuclides in the geometry materials
+            Sorted list of all nuclides in materials appearing in the geometry
 
         """
-        all_nuclides = []
+        all_nuclides = set()
         for material in self.get_all_materials().values():
-            for nuclide in material.get_nuclides():
-                if nuclide not in all_nuclides:
-                    all_nuclides.append(nuclide)
+            all_nuclides |= set(material.get_nuclides())
         return sorted(all_nuclides)
-
 
     def get_all_materials(self) -> typing.Dict[int, openmc.Material]:
         """Return all materials within the geometry.

--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -378,3 +378,15 @@ def test_remove_redundant_surfaces():
     # There should be 0 remaining redundant surfaces
     n_redundant_surfs = len(geom.remove_redundant_surfaces().keys())
     assert n_redundant_surfs == 0
+
+def test_get_all_nuclides():
+    m1 = openmc.Material()
+    m1.add_nuclide('Fe56', 1)
+    m1.add_nuclide('Be9', 1)
+    m2 = openmc.Material()
+    m2.add_nuclide('Be9', 1)
+    s = openmc.Sphere()
+    c1 = openmc.Cell(fill=m1, region=-s)
+    c2 = openmc.Cell(fill=m2, region=+s)
+    geom = openmc.Geometry([c1, c2])
+    assert geom.get_all_nuclides() == ['Be9', 'Fe56']


### PR DESCRIPTION
# Description

I've been using ```openmc.deplete.get_microxs_and_flux(nuclides =...)``` and wanting to pass in the nuclides present in the geometry. Having the proposed simple ```get_all_nuclides``` method on the geometry class would save me some user script inconvenience. Getting a mutable flat sequenceof all the nuclides without duplicates can certainly be done on the user script it is just a mild inconvenience.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
