### PR TITLE
added check to length of input args for IndependantOperator

### DIFF
--- a/openmc/deplete/independent_operator.py
+++ b/openmc/deplete/independent_operator.py
@@ -132,10 +132,10 @@ class IndependentOperator(OpenMCOperator):
         check_type('micros', micros, Iterable, MicroXS)
         check_type('fluxes', fluxes, Iterable, float)
 
-        if len(set([len(fluxes), len(micros), len(materials)])) != 1:
-            msg = (f'The length of fluxes {len(fluxes)} should be equal to ' 
-                   f'the length of micros {len(micros)} and the length of '
-                   f'materials {len(materials)}.')
+        if not (len(fluxes) == len(micros) == len(materials)):
+            msg = (f'The length of fluxes ({len(fluxes)}) should be equal to '
+                   f'the length of micros ({len(micros)}) and the length of '
+                   f'materials ({len(materials)}).')
             raise ValueError(msg)
 
         if keff is not None:

--- a/openmc/deplete/independent_operator.py
+++ b/openmc/deplete/independent_operator.py
@@ -130,6 +130,14 @@ class IndependentOperator(OpenMCOperator):
         # Validate micro-xs parameters
         check_type('materials', materials, openmc.Materials)
         check_type('micros', micros, Iterable, MicroXS)
+        check_type('fluxes', fluxes, Iterable, float)
+
+        if len(set([len(fluxes), len(micros), len(materials)])) != 1:
+            msg = (f'The length of fluxes {len(fluxes)} should be equal to ' 
+                   f'the length of micros {len(micros)} and the length of '
+                   f'materials {len(materials)}.')
+            raise ValueError(msg)
+
         if keff is not None:
             check_type('keff', keff, tuple, float)
             keff = ufloat(*keff)

--- a/tests/unit_tests/test_deplete_independent_operator.py
+++ b/tests/unit_tests/test_deplete_independent_operator.py
@@ -4,8 +4,10 @@
 
 from pathlib import Path
 
-from openmc.deplete import IndependentOperator, MicroXS
+import pytest
+
 from openmc import Material, Materials
+from openmc.deplete import IndependentOperator, MicroXS
 
 CHAIN_PATH = Path(__file__).parents[1] / "chain_simple.xml"
 ONE_GROUP_XS = Path(__file__).parents[1] / "micro_xs_simple.csv"
@@ -36,3 +38,18 @@ def test_operator_init():
     fluxes = [1.0]
     micros = [micro_xs]
     IndependentOperator(materials, fluxes, micros, CHAIN_PATH)
+
+
+def test_error_handeling():
+    micro_xs = MicroXS.from_csv(ONE_GROUP_XS)
+    fuel = Material(name="oxygen")
+    fuel.add_element("O", 2)
+    fuel.set_density("g/cc", 1)
+    fuel.depletable = True
+    fuel.volume = 1
+    materials = Materials([fuel])
+    fluxes = [1.0, 2.0]
+    micros = [micro_xs]
+    with pytest.raises(ValueError) as excinfo:
+        IndependentOperator(materials, fluxes, micros, CHAIN_PATH)
+    assert "The length of fluxes 2" in str(excinfo.value)

--- a/tests/unit_tests/test_deplete_independent_operator.py
+++ b/tests/unit_tests/test_deplete_independent_operator.py
@@ -40,7 +40,7 @@ def test_operator_init():
     IndependentOperator(materials, fluxes, micros, CHAIN_PATH)
 
 
-def test_error_handeling():
+def test_error_handling():
     micro_xs = MicroXS.from_csv(ONE_GROUP_XS)
     fuel = Material(name="oxygen")
     fuel.add_element("O", 2)
@@ -50,6 +50,5 @@ def test_error_handeling():
     materials = Materials([fuel])
     fluxes = [1.0, 2.0]
     micros = [micro_xs]
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match=r"The length of fluxes \(2\)"):
         IndependentOperator(materials, fluxes, micros, CHAIN_PATH)
-    assert "The length of fluxes 2" in str(excinfo.value)


### PR DESCRIPTION
# Description

I noticed it is easy to pass incorrect length arguments to Independent Operator and found myself passing in flux groups instead of single flux values.

After reading the docs string more carefully I now realise that the length of fluxes, micros and materials should all be the same.

Passing in a longer flux with extra values does not actually cause an error in the code, it just continues without a crash.

So it is a bit too easy to add in a flux spectra here without noticing. I added in a check that will catch the input error and a test to test the error handling.

Many thanks to @jbae11

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
