### PR TITLE
Ignoring nuclides with no xs data when writing material xml files

### DIFF
--- a/openmc/deplete/coupled_operator.py
+++ b/openmc/deplete/coupled_operator.py
@@ -56,32 +56,6 @@ def _find_cross_sections(model):
     return cross_sections
 
 
-def _get_nuclides_with_data(cross_sections):
-    """Loads cross_sections.xml file to find nuclides with neutron data
-
-    Parameters
-    ----------
-    cross_sections : str
-        Path to cross_sections.xml file
-
-    Returns
-    -------
-    nuclides : set of str
-        Set of nuclide names that have cross secton data
-
-    """
-    nuclides = set()
-    data_lib = DataLibrary.from_xml(cross_sections)
-    for library in data_lib.libraries:
-        if library['type'] != 'neutron':
-            continue
-        for name in library['materials']:
-            if name not in nuclides:
-                nuclides.add(name)
-
-    return nuclides
-
-
 class CoupledOperator(OpenMCOperator):
     """Transport-coupled transport operator.
 
@@ -298,22 +272,6 @@ class CoupledOperator(OpenMCOperator):
                 new_res = res_obj.distribute(self.local_mats, mat_indexes)
                 self.prev_res.append(new_res)
 
-    def _get_nuclides_with_data(self, cross_sections):
-        """Loads cross_sections.xml file to find nuclides with neutron data
-
-        Parameters
-        ----------
-        cross_sections : str
-            Path to cross_sections.xml file
-
-        Returns
-        -------
-        nuclides : set of str
-            Set of nuclide names that have cross secton data
-
-        """
-        return _get_nuclides_with_data(cross_sections)
-
     def _get_helper_classes(self, helper_kwargs):
         """Create the ``_rate_helper``, ``_normalization_helper``, and
         ``_yield_helper`` objects.
@@ -402,7 +360,7 @@ class CoupledOperator(OpenMCOperator):
         for mat in self.materials:
             mat._nuclides.sort(key=lambda x: nuclides.index(x[0]))
 
-        self.materials.export_to_xml(nuclides_to_ignore=self._decay_nucs)
+        self.materials.export_to_xml(ignore_phantom_nuclides=True)
 
     def __call__(self, vec, source_rate):
         """Runs a simulation.

--- a/openmc/deplete/independent_operator.py
+++ b/openmc/deplete/independent_operator.py
@@ -275,10 +275,6 @@ class IndependentOperator(OpenMCOperator):
                 self.prev_res.append(new_res)
 
 
-    def _get_nuclides_with_data(self, cross_sections: List[MicroXS]) -> Set[str]:
-        """Finds nuclides with cross section data"""
-        return set(cross_sections[0].nuclides)
-
     class _IndependentRateHelper(ReactionRateHelper):
         """Class for generating one-group reaction rates with flux and
         one-group cross sections.

--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -13,10 +13,10 @@ import numpy as np
 
 from openmc.checkvalue import check_type, check_value, check_iterable_type, PathLike
 from openmc.exceptions import DataError
-from openmc import StatePoint
+from openmc import StatePoint, get_nuclides_with_data
 import openmc
 from .chain import Chain, REACTIONS
-from .coupled_operator import _find_cross_sections, _get_nuclides_with_data
+from .coupled_operator import _find_cross_sections
 
 _valid_rxns = list(REACTIONS)
 _valid_rxns.append('fission')
@@ -81,7 +81,7 @@ def get_microxs_and_flux(
         reactions = chain.reactions
     if not nuclides:
         cross_sections = _find_cross_sections(model)
-        nuclides_with_data = _get_nuclides_with_data(cross_sections)
+        nuclides_with_data = get_nuclides_with_data(cross_sections)
         nuclides = [nuc.name for nuc in chain.nuclides
                     if nuc.name in nuclides_with_data]
 

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -15,6 +15,7 @@ import openmc
 from openmc.checkvalue import check_value
 from openmc.exceptions import DataError
 from openmc.mpi import comm
+from openmc import get_nuclides_with_data
 from .abc import TransportOperator, OperatorResult
 from .atom_number import AtomNumber
 from .reaction_rates import ReactionRates
@@ -148,16 +149,12 @@ class OpenMCOperator(TransportOperator):
         # for which there is an entry in the micro_xs parameter
         openmc.reset_auto_ids()
 
-        self.nuclides_with_data = self._get_nuclides_with_data(
-            self.cross_sections)
+        self.nuclides_with_data = get_nuclides_with_data(self.cross_sections)
 
         # Select nuclides with data that are also in the chain
         self._burnable_nucs = [nuc.name for nuc in self.chain.nuclides
                                if nuc.name in self.nuclides_with_data]
 
-        # Select nuclides without data that are also in the chain
-        self._decay_nucs = [nuc.name for nuc in self.chain.nuclides
-                            if nuc.name not in self.nuclides_with_data]
 
         self.burnable_mats, volumes, all_nuclides = self._get_burnable_mats()
         self.local_mats = _distribute(self.burnable_mats)
@@ -207,10 +204,10 @@ class OpenMCOperator(TransportOperator):
         # Iterate once through the geometry to get dictionaries
         for mat in self.materials:
             for nuclide in mat.get_nuclides():
-                if nuclide in self.nuclides_with_data or self._decay_nucs:
+                if nuclide in self.nuclides_with_data or self.chain.nuclides:
                     model_nuclides.add(nuclide)
                 else:
-                    msg = (f"Nuclilde {nuclide} in material {mat.id} is not "
+                    msg = (f"Nuclide {nuclide} in material {mat.id} is not "
                            "present in the depletion chain and has no cross "
                            "section data.")
                     raise warn(msg)
@@ -246,23 +243,6 @@ class OpenMCOperator(TransportOperator):
     def _load_previous_results(self):
         """Load results from a previous depletion simulation"""
         pass
-
-    @abstractmethod
-    def _get_nuclides_with_data(self, cross_sections):
-        """Find nuclides with cross section data
-
-        Parameters
-        ----------
-        cross_sections : str or pandas.DataFrame
-            Path to continuous energy cross section library, or object
-            containing one-group cross-sections.
-
-        Returns
-        -------
-        nuclides : set of str
-            Set of nuclide names that have cross secton data
-
-        """
 
     def _extract_number(self, local_mats, volume, all_nuclides, prev_res=None):
         """Construct AtomNumber using geometry

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1315,7 +1315,7 @@ class Material(IDManagerMixin):
 
     def _get_nuclides_xml(
             self, nuclides: typing.Iterable[NuclideTuple],
-            nuclides_to_ignore: Optional[typing.Iterable[str]] = None)-> List[ET.Element]:
+            nuclides_to_ignore: Optional[typing.Iterable[str]] = None) -> List[ET.Element]:
         xml_elements = []
 
         # Remove any nuclides to ignore from the XML export
@@ -1734,8 +1734,8 @@ class Materials(cv.CheckedList):
         # one go.
         with open(str(p), 'w', encoding='utf-8',
                   errors='xmlcharrefreplace') as fh:
-            self._write_xml(fh, 
-                            ignore_phantom_nuclides=ignore_phantom_nuclides, 
+            self._write_xml(fh,
+                            ignore_phantom_nuclides=ignore_phantom_nuclides,
                             nuclides_to_ignore=nuclides_to_ignore)
 
     @classmethod
@@ -1801,7 +1801,7 @@ def get_nuclides_with_data(cross_sections):
         Set of nuclide names that have cross secton data
 
     """
-    if isinstance(cross_sections, Path):
+    if isinstance(cross_sections, cv.PathLike):
         nuclides = set()
         data_lib = DataLibrary.from_xml(cross_sections)
         for library in data_lib.libraries:

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -431,7 +431,7 @@ class Model:
                 depletion_operator.cleanup_when_done = True
                 depletion_operator.finalize()
 
-    def export_to_xml(self, directory='.', remove_surfs=False):
+    def export_to_xml(self, directory='.', remove_surfs=False, ignore_phantom_nuclides=False):
         """Export model to separate XML files.
 
         Parameters
@@ -457,18 +457,18 @@ class Model:
         # for all materials in the geometry and use that to automatically build
         # a collection.
         if self.materials:
-            self.materials.export_to_xml(d)
+            self.materials.export_to_xml(d, ignore_phantom_nuclides=ignore_phantom_nuclides)
         else:
             materials = openmc.Materials(self.geometry.get_all_materials()
                                          .values())
-            materials.export_to_xml(d)
+            materials.export_to_xml(d, ignore_phantom_nuclides=ignore_phantom_nuclides)
 
         if self.tallies:
             self.tallies.export_to_xml(d)
         if self.plots:
             self.plots.export_to_xml(d)
 
-    def export_to_model_xml(self, path='model.xml', remove_surfs=False):
+    def export_to_model_xml(self, path='model.xml', remove_surfs=False, ignore_phantom_nuclides=False):
         """Export model to a single XML file.
 
         .. versionadded:: 0.13.3
@@ -523,7 +523,7 @@ class Model:
             fh.write("<model>\n")
             # Write the materials collection to the open XML file first.
             # This will write the XML header also
-            materials._write_xml(fh, False, level=1)
+            materials._write_xml(fh, False, level=1, ignore_phantom_nuclides=ignore_phantom_nuclides)
             # Write remaining elements as a tree
             fh.write(ET.tostring(geometry_element, encoding="unicode"))
             fh.write(ET.tostring(settings_element, encoding="unicode"))


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Adding an `ignore_phantom_nuclides` argument to `Materials.export_to_xml`, `Model.export_to_xml` and `Model.export_to_model_xml` (and `Model.run`). This allows a user to automatically ignore nuclides that have no cross-sections when writing xml files. A typical usecase is running an eigenvalue calculation on a depleted material. This new argument is set to `False` by default.

A first implementation of this was available when using `OpenMCOperator` to start depletion from existing depleted materials, this PR refactors it to allow static calculations as well. In particular the `_get_nuclides_with_data` function was moved from the `OpenMCOperator` subclasses to the material.py file.

A warning message was also added to inform the user about the percentage of mass density lost when ignoring these nuclides, a high number would be problematic for the calculation's accuracy but this should not be the case for most practical uses.

This feature was discussed with @pshriwise during the last OpenMC community call. This is my first non trivial PR, so any feedback is of course much appreciated.

# Example script

Here is a minimal working script showcasing the feature:

```python
import openmc
import openmc.deplete
from openmc import Geometry, Material, Materials, Settings, Universe, Cell, Sphere

mat = Material()
mat.add_nuclide("U235", 0.06, "ao")
mat.add_nuclide("U238", 0.94, "ao")
mat.add_nuclide("C14", 1, "ao")
mat.set_density("g/cm3", 10)
mat.temperature = 700
mat.volume = 1000
materials = Materials(materials=[mat])

sphere = -Sphere(r=10, boundary_type="vacuum")
cell = Cell(fill=mat, region=sphere)
geometry = Geometry(root=Universe(cells=[cell]))

settings = Settings()
settings.particles = 1000
settings.batches = 100
settings.inactive = 10
settings.temperature = {"method": "interpolation"}
settings.source = openmc.IndependentSource(space=openmc.stats.Point())

# Using individual exports:
materials.export_to_xml(ignore_phantom_nuclides=True)
geometry.export_to_xml()
settings.export_to_xml()
openmc.run()

# Using model export_to_xml:
# model = openmc.Model(geometry=geometry, settings=settings, materials=materials)
# model.export_to_xml(ignore_phantom_nuclides=True)
# openmc.run()

# Using model export_to_model_xml:
# model = openmc.Model(geometry=geometry, settings=settings, materials=materials)
# model.export_to_model_xml(ignore_phantom_nuclides=True)
# openmc.run()

# Using model.run() directly
# model = openmc.Model(geometry=geometry, settings=settings, materials=materials)
# model.run(export_model_xml=True, ignore_phantom_nuclides=True)

# Restarting a depletion calculation:
# model = openmc.Model(geometry=geometry, settings=settings, materials=materials)
# operator = openmc.deplete.CoupledOperator(model)
# integrator = openmc.deplete.PredictorIntegrator(operator, [10, 10, 10], [80, 80, 80], timestep_units='d')
# integrator.integrate()
```

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
