### PR TITLE
Move 'import lxml' to third-party block of imports

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -1,8 +1,8 @@
 from collections.abc import Iterable
 from math import cos, sin, pi
 from numbers import Real
-import lxml.etree as ET
 
+import lxml.etree as ET
 import numpy as np
 from uncertainties import UFloat
 

--- a/openmc/data/library.py
+++ b/openmc/data/library.py
@@ -1,8 +1,8 @@
 import os
-import lxml.etree as ET
 import pathlib
 
 import h5py
+import lxml.etree as ET
 
 import openmc
 from openmc._xml import clean_indentation, reorder_attributes

--- a/openmc/deplete/nuclide.py
+++ b/openmc/deplete/nuclide.py
@@ -8,8 +8,8 @@ from collections.abc import Mapping
 from collections import namedtuple, defaultdict
 from warnings import warn
 from numbers import Real
-import lxml.etree as ET
 
+import lxml.etree as ET
 import numpy as np
 
 from openmc.checkvalue import check_type

--- a/openmc/element.py
+++ b/openmc/element.py
@@ -1,4 +1,5 @@
 import re
+
 import lxml.etree as ET
 
 import openmc.checkvalue as cv

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -3,9 +3,9 @@ from collections.abc import Iterable
 import hashlib
 from itertools import product
 from numbers import Real, Integral
-import lxml.etree as ET
 import warnings
 
+import lxml.etree as ET
 import numpy as np
 import pandas as pd
 

--- a/openmc/filter_expansion.py
+++ b/openmc/filter_expansion.py
@@ -1,4 +1,5 @@
 from numbers import Integral, Real
+
 import lxml.etree as ET
 
 import openmc.checkvalue as cv

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -4,8 +4,8 @@ from copy import deepcopy
 from math import sqrt, floor
 from numbers import Real
 import types
-import lxml.etree as ET
 
+import lxml.etree as ET
 import numpy as np
 
 import openmc

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -8,8 +8,8 @@ import re
 import typing  # imported separately as py3.8 requires typing.Iterable
 import warnings
 from typing import Optional, List, Union, Dict
-import lxml.etree as ET
 
+import lxml.etree as ET
 import numpy as np
 import h5py
 

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -7,10 +7,10 @@ from pathlib import Path
 from numbers import Integral
 from tempfile import NamedTemporaryFile
 import warnings
-import lxml.etree as ET
 from typing import Optional, Dict
 
 import h5py
+import lxml.etree as ET
 
 import openmc
 import openmc._xml as xml

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -1,10 +1,10 @@
 from collections.abc import Iterable, Mapping
 from numbers import Integral, Real
 from pathlib import Path
-import lxml.etree as ET
 from typing import Optional
 
 import h5py
+import lxml.etree as ET
 import numpy as np
 
 import openmc

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1,4 +1,3 @@
-import os
 from collections.abc import Iterable, Mapping, MutableSequence
 from enum import Enum
 import itertools
@@ -7,11 +6,11 @@ from numbers import Integral, Real
 from pathlib import Path
 import typing  # required to prevent typing.Union namespace overwriting Union
 from typing import Optional
+
 import lxml.etree as ET
 
 import openmc.checkvalue as cv
 from openmc.stats.multivariate import MeshSpatial
-
 from . import (RegularMesh, SourceBase, MeshSource, IndependentSource,
                VolumeCalculation, WeightWindows, WeightWindowGenerator)
 from ._xml import clean_indentation, get_text, reorder_attributes

--- a/openmc/source.py
+++ b/openmc/source.py
@@ -7,8 +7,8 @@ import warnings
 import typing  # imported separately as py3.8 requires typing.Iterable
 # also required to prevent typing.Union namespace overwriting Union
 from typing import Optional, Sequence
-import lxml.etree as ET
 
+import lxml.etree as ET
 import numpy as np
 import h5py
 

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -3,9 +3,9 @@ from collections.abc import Iterable
 from copy import deepcopy
 import math
 from numbers import Real
-import lxml.etree as ET
 from warnings import warn, catch_warnings, simplefilter
 
+import lxml.etree as ET
 import numpy as np
 
 from .checkvalue import check_type, check_value, check_length, check_greater_than

--- a/openmc/tally_derivative.py
+++ b/openmc/tally_derivative.py
@@ -1,4 +1,5 @@
 from numbers import Integral
+
 import lxml.etree as ET
 
 import openmc.checkvalue as cv

--- a/openmc/trigger.py
+++ b/openmc/trigger.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable
 from numbers import Real
+
 import lxml.etree as ET
 
 import openmc.checkvalue as cv

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -1,24 +1,20 @@
 import math
-import typing
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from copy import deepcopy
 from numbers import Integral, Real
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import lxml.etree as ET
 import warnings
 
 import h5py
+import lxml.etree as ET
 import numpy as np
 
 import openmc
 import openmc.checkvalue as cv
-
 from ._xml import get_text
 from .checkvalue import check_type, check_value
 from .mixin import IDManagerMixin
-from .plots import _SVG_COLORS
 from .surface import _BOUNDARY_TYPES
 
 

--- a/openmc/volume.py
+++ b/openmc/volume.py
@@ -1,11 +1,11 @@
 from collections.abc import Iterable, Mapping
 from numbers import Real, Integral
-import lxml.etree as ET
 import warnings
 
+import h5py
+import lxml.etree as ET
 import numpy as np
 import pandas as pd
-import h5py
 from uncertainties import ufloat
 
 import openmc

--- a/openmc/weight_windows.py
+++ b/openmc/weight_windows.py
@@ -12,7 +12,6 @@ from openmc.filter import _PARTICLES
 from openmc.mesh import MeshBase, RectilinearMesh, CylindricalMesh, SphericalMesh, UnstructuredMesh
 import openmc.checkvalue as cv
 from openmc.checkvalue import PathLike
-
 from ._xml import get_text, clean_indentation
 from .mixin import IDManagerMixin
 

--- a/tests/unit_tests/test_cell.py
+++ b/tests/unit_tests/test_cell.py
@@ -1,10 +1,8 @@
 import lxml.etree as ET
-
 import numpy as np
 from uncertainties import ufloat
 import openmc
 import pytest
-
 
 from tests.unit_tests import assert_unbounded
 from openmc.data import atomic_mass, AVOGADRO

--- a/tests/unit_tests/test_deplete_nuclide.py
+++ b/tests/unit_tests/test_deplete_nuclide.py
@@ -1,7 +1,8 @@
 """Tests for the openmc.deplete.Nuclide class."""
 
-import lxml.etree as ET
 import copy
+
+import lxml.etree as ET
 import numpy as np
 import pytest
 from openmc.deplete import nuclide

--- a/tests/unit_tests/test_lattice.py
+++ b/tests/unit_tests/test_lattice.py
@@ -1,6 +1,6 @@
 from math import sqrt
-import lxml.etree as ET
 
+import lxml.etree as ET
 import openmc
 import pytest
 

--- a/tests/unit_tests/test_universe.py
+++ b/tests/unit_tests/test_universe.py
@@ -1,5 +1,4 @@
 import lxml.etree as ET
-
 import numpy as np
 import openmc
 import pytest


### PR DESCRIPTION
# Description

Very simple PR here that just fixes where `import lxml` appears in Python scripts. Per PEP8, [imports should be grouped](https://peps.python.org/pep-0008/#imports) in the following order: standard-library imports, third-party imports, local imports. A few unused imports have been removed while I was at it.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>
