### PR TITLE
Fix creation of meshes when from loading settings from XML

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -2316,7 +2316,7 @@ def _read_meshes(elem):
         A dictionary with mesh IDs as keys and openmc.MeshBase
         instanaces as values
     """
-    out = dict()
+    out = {}
     for mesh_elem in elem.findall('mesh'):
         mesh = MeshBase.from_xml_element(mesh_elem)
         out[mesh.id] = mesh

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1604,15 +1604,14 @@ class Settings:
                 if value is not None:
                     self.cutoff[key] = float(value)
 
-    def _entropy_mesh_from_xml_element(self, root, meshes=None):
+    def _entropy_mesh_from_xml_element(self, root, meshes):
         text = get_text(root, 'entropy_mesh')
-        if text is not None:
-            path = f"./mesh[@id='{int(text)}']"
-            elem = root.find(path)
-            if elem is not None:
-                self.entropy_mesh = RegularMesh.from_xml_element(elem)
-        if meshes is not None and self.entropy_mesh is not None:
-            meshes[self.entropy_mesh.id] = self.entropy_mesh
+        if text is None:
+            return
+        mesh_id = int(text)
+        if mesh_id not in meshes:
+            raise ValueError(f'Could not locate mesh with ID "{mesh_id}"')
+        self.entropy_mesh = meshes[mesh_id]
 
     def _trigger_from_xml_element(self, root):
         elem = root.find('trigger')
@@ -1672,15 +1671,14 @@ class Settings:
             values = [int(x) for x in text.split()]
             self.track = list(zip(values[::3], values[1::3], values[2::3]))
 
-    def _ufs_mesh_from_xml_element(self, root, meshes=None):
+    def _ufs_mesh_from_xml_element(self, root, meshes):
         text = get_text(root, 'ufs_mesh')
-        if text is not None:
-            path = f"./mesh[@id='{int(text)}']"
-            elem = root.find(path)
-            if elem is not None:
-                self.ufs_mesh = RegularMesh.from_xml_element(elem)
-        if meshes is not None and self.ufs_mesh is not None:
-            meshes[self.ufs_mesh.id] = self.ufs_mesh
+        if text is None:
+            return
+        mesh_id = int(text)
+        if mesh_id not in meshes:
+            raise ValueError(f'Could not locate mesh with ID "{mesh_id}"')
+        self.ufs_mesh = meshes[mesh_id]
 
     def _resonance_scattering_from_xml_element(self, root):
         elem = root.find('resonance_scattering')
@@ -1744,15 +1742,12 @@ class Settings:
 
     def _weight_windows_from_xml_element(self, root, meshes=None):
         for elem in root.findall('weight_windows'):
-            ww = WeightWindows.from_xml_element(elem, root)
+            ww = WeightWindows.from_xml_element(elem, meshes)
             self.weight_windows.append(ww)
 
         text = get_text(root, 'weight_windows_on')
         if text is not None:
             self.weight_windows_on = text in ('true', '1')
-
-        if meshes is not None and self.weight_windows:
-            meshes.update({ww.mesh.id: ww.mesh for ww in self.weight_windows})
 
     def _weight_window_checkpoints_from_xml_element(self, root):
         elem = root.find('weight_window_checkpoints')

--- a/openmc/stats/multivariate.py
+++ b/openmc/stats/multivariate.py
@@ -744,7 +744,7 @@ class MeshSpatial(Spatial):
 
         # check if this mesh has been read in from another location already
         if mesh_id not in meshes:
-            raise RuntimeError(f'Could not locate mesh with ID "{mesh_id}"')
+            raise ValueError(f'Could not locate mesh with ID "{mesh_id}"')
 
         volume_normalized = elem.get("volume_normalized")
         volume_normalized = get_text(elem, 'volume_normalized').lower() == 'true'

--- a/openmc/weight_windows.py
+++ b/openmc/weight_windows.py
@@ -354,15 +354,15 @@ class WeightWindows(IDManagerMixin):
         return element
 
     @classmethod
-    def from_xml_element(cls, elem: ET.Element, root: ET.Element) -> WeightWindows:
+    def from_xml_element(cls, elem: ET.Element, meshes: Dict[int, MeshBase]) -> WeightWindows:
         """Generate weight window settings from an XML element
 
         Parameters
         ----------
         elem : lxml.etree._Element
             XML element
-        root : lxml.etree._Element
-            Root element for the file where meshes can be found
+        meshes : dict
+            Dictionary mapping IDs to mesh objects
 
         Returns
         -------
@@ -371,10 +371,9 @@ class WeightWindows(IDManagerMixin):
         """
         # Get mesh for weight windows
         mesh_id = int(get_text(elem, 'mesh'))
-        path = f"./mesh[@id='{mesh_id}']"
-        mesh_elem = root.find(path)
-        if mesh_elem is not None:
-            mesh = MeshBase.from_xml_element(mesh_elem)
+        if mesh_id not in meshes:
+            raise ValueError(f'Could not locate mesh with ID "{mesh_id}"')
+        mesh = meshes[mesh_id]
 
         # Read all other parameters
         lower_ww_bounds = [float(l) for l in get_text(elem, 'lower_ww_bounds').split()]


### PR DESCRIPTION
# Description

Right now, if you call `Model.from_xml` or `Model.from_model_xml` on a model that has meshes in the `<settings>` element, you end up with warnings like the following:
```
/home/romano/openmc/openmc/mixin.py:70: IDWarning: Another MeshBase instance already exists with id=1.
  warn(msg, IDWarning)
```
This PR fixes this by properly checking if a mesh has already been created and passed through to `Settings.from_xml_element`.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>