### PR TITLE
Avoid high memory use when writing unstructured mesh VTK files

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -2181,7 +2181,6 @@ class UnstructuredMesh(MeshBase):
         grid.SetPoints(vtk_pnts)
 
         n_skipped = 0
-        elems = []
         for elem_type, conn in zip(self.element_types, self.connectivity):
             if elem_type == self._LINEAR_TET:
                 elem = vtk.vtkTetra()
@@ -2195,14 +2194,12 @@ class UnstructuredMesh(MeshBase):
                 if c == -1:
                     break
                 elem.GetPointIds().SetId(i, c)
-            elems.append(elem)
+
+            grid.InsertNextCell(elem.GetCellType(), elem.GetPointIds())
 
         if n_skipped > 0:
             warnings.warn(f'{n_skipped} elements were not written because '
                           'they are not of type linear tet/hex')
-
-        for elem in elems:
-            grid.InsertNextCell(elem.GetCellType(), elem.GetPointIds())
 
         # check that datasets are the correct size
         datasets_out = []


### PR DESCRIPTION
# Description

I found that when trying to export unstructured mesh tally data to a VTK file using the `UnstructuredMesh.write_data_to_vtk` method, it blew out the memory on my machine. After a little digging, I was able to attribute this to the fact that in that method, we're holding a list of `vtkTetra` elements, which doesn't appear to be necessary. With this fix, the memory use is much lower.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>