### PR TITLE
correct the material expansion and volume assigning in differentiate_burnup_mats

### DIFF
--- a/openmc/deplete/coupled_operator.py
+++ b/openmc/deplete/coupled_operator.py
@@ -168,7 +168,9 @@ class CoupledOperator(OpenMCOperator):
         Specifies how the volumes of the new materials should be found. Default
         is to 'divide equally' which divides the original material volume
         equally between the new materials, 'match cell' sets the volume of the
-        material to volume of the cell they fill.
+        material to volume of the cell they fill. When the cell has multiple
+        instances, users should confirm the volumes of all the instances are
+        the same and set the cell volume as the volume of one instance.
 
         .. versionadded:: 0.14.0
 

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -62,7 +62,9 @@ class OpenMCOperator(TransportOperator):
         Specifies how the volumes of the new materials should be found. Default
         is to 'divide equally' which divides the original material volume
         equally between the new materials, 'match cell' sets the volume of the
-        material to volume of the cell they fill.
+        material to volume of the cell they fill. When the cell has multiple
+        instances, users should confirm the volumes of all the instances are
+        the same and set the cell volume as the volume of one instance.
 
         .. versionadded:: 0.14.0
 

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1054,18 +1054,16 @@ class Model:
             for cell in self.geometry.get_all_material_cells().values():
                 if cell.fill in distribmats:
                     mat = cell.fill
-                    if diff_volume_method == 'divide equally':
-                        cell.fill = [mat.clone() for _ in range(cell.num_instances)]
-                    elif diff_volume_method == 'match cell':
-                        for _ in range(cell.num_instances):
-                            cell.fill = mat.clone()
-                            if not cell.volume:
-                                raise ValueError(
-                                    f"Volume of cell ID={cell.id} not specified. "
-                                    "Set volumes of cells prior to using "
-                                    "diff_volume_method='match cell'."
-                                )
-                            cell.fill.volume = cell.volume
+                    cell.fill = [mat.clone() for _ in range(cell.num_instances)]
+                    if self.diff_volume_method == "match cell":
+                        if not cell.volume:
+                            raise ValueError(
+                                f"Volume of cell ID={cell.id} not specified. "
+                                "Set volumes of cells prior to using "
+                                "diff_volume_method='match cell'."
+                            )
+                        for mat in cell.fill:
+                            mat.volume = cell.volume
 
         if self.materials is not None:
             self.materials = openmc.Materials(

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1032,7 +1032,10 @@ class Model:
             Specifies how the volumes of the new materials should be found.
             Default is to 'divide equally' which divides the original material
             volume equally between the new materials, 'match cell' sets the
-            volume of the material to volume of the cell they fill.
+            volume of the material to volume of the cell they fill. When the
+            cell has multiple instances, users should confirm the volumes of
+            all the instances are the same and set the cell volume as the
+            volume of one instance.
         """
         # Count the number of instances for each cell and material
         self.geometry.determine_paths(instances_only=True)


### PR DESCRIPTION
…burnable_mats

<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

As is detailed documented in Issue #2807, when using "match cell" mode in differentiate_burnable_mats, the generated materials may be overwritten by the last material. This may result in that cells with multiple instances still have only one material assigned.

Fixes are very straightforward: copies of the original material should be assigned to the cell multiple times, and thus the cell.fill change from a mat to a mat list. As this process is the same as "divide equally" mode, I merged the if-elif branches. The difference is about the volume assigning of the materials, which is located in the new if-block. Also, the cell.volume check is required only once for each cell.

Fixes #2807

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x]  I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
