### PR TITLE
Provide error message if a cell path can't be determined

### DIFF
--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -544,6 +544,13 @@ std::string distribcell_path_inner(int32_t target_cell, int32_t map,
     }
   }
 
+  // if we get through the loop without finding an appropriate entry, throw
+  // an error
+  if (cell_it == search_univ.cells_.crend()) {
+    fatal_error(fmt::format("Failed to generate a text label for distribcell with ID {}."
+                            "The current label is: '{}'", model::cells[target_cell]->id_, path.str()));
+  }
+
   // Add the cell to the path string.
   Cell& c = *model::cells[*cell_it];
   path << "c" << c.id_ << "->";

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -547,8 +547,10 @@ std::string distribcell_path_inner(int32_t target_cell, int32_t map,
   // if we get through the loop without finding an appropriate entry, throw
   // an error
   if (cell_it == search_univ.cells_.crend()) {
-    fatal_error(fmt::format("Failed to generate a text label for distribcell with ID {}."
-                            "The current label is: '{}'", model::cells[target_cell]->id_, path.str()));
+    fatal_error(
+      fmt::format("Failed to generate a text label for distribcell with ID {}."
+                  "The current label is: '{}'",
+        model::cells[target_cell]->id_, path.str()));
   }
 
   // Add the cell to the path string.


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

@lewisgross1296 reported a segmentation fault when generatig text labels for a tally using a distribcell filter and hexagonal lattices (more info in #2798). 

This small PR adds an error message in the case that we search all of the cells in a universe without finding an appropriate universe or lattice fill to continue the search.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~
- [x] ~I have made corresponding changes to the documentation (if applicable)~
- [x] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
