### PR TITLE
Fix distribcell labels for lattices used as fill in multiple cells

### DIFF
--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -530,7 +530,7 @@ std::string distribcell_path_inner(int32_t target_cell, int32_t map,
     if (c.type_ != Fill::MATERIAL) {
       int32_t temp_offset;
       if (c.type_ == Fill::UNIVERSE) {
-        temp_offset = offset + c.offset_[map];
+        temp_offset = offset + c.offset_[map]; // should also apply to lattice fills?
       } else {
         Lattice& lat = *model::lattices[c.fill_];
         int32_t indx = lat.universes_.size() * map + lat.begin().indx_;
@@ -539,7 +539,7 @@ std::string distribcell_path_inner(int32_t target_cell, int32_t map,
 
       // The desired cell is the first cell that gives an offset smaller or
       // equal to the target offset.
-      if (temp_offset <= target_offset)
+      if (temp_offset <= target_offset - c.offset_[map])
         break;
     }
   }
@@ -561,11 +561,11 @@ std::string distribcell_path_inner(int32_t target_cell, int32_t map,
     for (ReverseLatticeIter it = lat.rbegin(); it != lat.rend(); ++it) {
       int32_t indx = lat.universes_.size() * map + it.indx_;
       int32_t temp_offset = offset + lat.offsets_[indx];
-      if (temp_offset <= target_offset) {
+      if (temp_offset <= target_offset - c.offset_[map]) {
         offset = temp_offset;
         path << "(" << lat.index_to_string(it.indx_) << ")->";
         path << distribcell_path_inner(
-          target_cell, map, target_offset, *model::universes[*it], offset);
+          target_cell, map, target_offset, *model::universes[*it], offset+c.offset_[map]);
         return path.str();
       }
     }

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -564,8 +564,8 @@ std::string distribcell_path_inner(int32_t target_cell, int32_t map,
       if (temp_offset <= target_offset - c.offset_[map]) {
         offset = temp_offset;
         path << "(" << lat.index_to_string(it.indx_) << ")->";
-        path << distribcell_path_inner(
-          target_cell, map, target_offset, *model::universes[*it], offset+c.offset_[map]);
+        path << distribcell_path_inner(target_cell, map, target_offset,
+          *model::universes[*it], offset + c.offset_[map]);
         return path.str();
       }
     }

--- a/src/geometry_aux.cpp
+++ b/src/geometry_aux.cpp
@@ -530,7 +530,7 @@ std::string distribcell_path_inner(int32_t target_cell, int32_t map,
     if (c.type_ != Fill::MATERIAL) {
       int32_t temp_offset;
       if (c.type_ == Fill::UNIVERSE) {
-        temp_offset = offset + c.offset_[map]; // should also apply to lattice fills?
+        temp_offset = offset + c.offset_[map];
       } else {
         Lattice& lat = *model::lattices[c.fill_];
         int32_t indx = lat.universes_.size() * map + lat.begin().indx_;

--- a/src/tallies/filter_distribcell.cpp
+++ b/src/tallies/filter_distribcell.cpp
@@ -48,7 +48,7 @@ void DistribcellFilter::get_all_bins(
       auto& lat {*model::lattices[p.coord(i + 1).lattice]};
       const auto& i_xyz {p.coord(i + 1).lattice_i};
       if (lat.are_valid_indices(i_xyz)) {
-        offset += lat.offset(distribcell_index, i_xyz);
+        offset += lat.offset(distribcell_index, i_xyz) + c.offset_[distribcell_index];
       }
     }
     if (cell_ == p.coord(i).cell) {

--- a/src/tallies/filter_distribcell.cpp
+++ b/src/tallies/filter_distribcell.cpp
@@ -48,7 +48,8 @@ void DistribcellFilter::get_all_bins(
       auto& lat {*model::lattices[p.coord(i + 1).lattice]};
       const auto& i_xyz {p.coord(i + 1).lattice_i};
       if (lat.are_valid_indices(i_xyz)) {
-        offset += lat.offset(distribcell_index, i_xyz) + c.offset_[distribcell_index];
+        offset +=
+          lat.offset(distribcell_index, i_xyz) + c.offset_[distribcell_index];
       }
     }
     if (cell_ == p.coord(i).cell) {

--- a/tests/unit_tests/test_cell_instance.py
+++ b/tests/unit_tests/test_cell_instance.py
@@ -52,8 +52,6 @@ def double_lattice_model():
     space = openmc.stats.Box(*bbox)
     source = openmc.IndependentSource(space=space)
     model.settings.source = source
-    # TODO: fix problem with tally output for multilattice models
-    model.settings.output = {'tallies': False}
 
     # Add necessary settings and export
     model.settings.batches = 10

--- a/tests/unit_tests/test_cell_instance.py
+++ b/tests/unit_tests/test_cell_instance.py
@@ -9,6 +9,7 @@ from tests import cdtemp
 
 @pytest.fixture(scope='module', autouse=True)
 def double_lattice_model():
+    openmc.reset_auto_ids()
     model = openmc.Model()
 
     # Create a single material

--- a/tests/unit_tests/test_cell_instance.py
+++ b/tests/unit_tests/test_cell_instance.py
@@ -39,6 +39,22 @@ def double_lattice_model():
     cell_with_lattice2.translation = (2., 0., 0.)
     model.geometry = openmc.Geometry([cell_with_lattice1, cell_with_lattice2])
 
+    tally = openmc.Tally()
+    dcell_filter = openmc.DistribcellFilter(c)
+    tally.filters = [dcell_filter]
+    tally.scores = ['flux']
+    model.tallies = [tally]
+
+    # Add box source that covers the model space well
+    bbox = model.geometry.bounding_box
+    bbox[0][2] = -0.5
+    bbox[1][2] = 0.5
+    space = openmc.stats.Box(*bbox)
+    source = openmc.IndependentSource(space=space)
+    model.settings.source = source
+    # TODO: fix problem with tally output for multilattice models
+    model.settings.output = {'tallies': False}
+
     # Add necessary settings and export
     model.settings.batches = 10
     model.settings.inactive = 0
@@ -71,3 +87,10 @@ expected_results = [
 def test_cell_instance_multilattice(r, expected_cell_instance):
     _, cell_instance = openmc.lib.find_cell(r)
     assert cell_instance == expected_cell_instance
+
+
+def test_cell_instance_multilattice_results():
+    openmc.run()
+    openmc.lib.run()
+    tally_results = openmc.lib.tallies[1].mean
+    assert (tally_results != 0.0).all()

--- a/tests/unit_tests/test_cell_instance.py
+++ b/tests/unit_tests/test_cell_instance.py
@@ -40,8 +40,7 @@ def double_lattice_model():
     model.geometry = openmc.Geometry([cell_with_lattice1, cell_with_lattice2])
 
     tally = openmc.Tally()
-    dcell_filter = openmc.DistribcellFilter(c)
-    tally.filters = [dcell_filter]
+    tally.filters = [openmc.DistribcellFilter(c)]
     tally.scores = ['flux']
     model.tallies = [tally]
 
@@ -50,8 +49,7 @@ def double_lattice_model():
     bbox[0][2] = -0.5
     bbox[1][2] = 0.5
     space = openmc.stats.Box(*bbox)
-    source = openmc.IndependentSource(space=space)
-    model.settings.source = source
+    model.settings.source = openmc.IndependentSource(space=space)
 
     # Add necessary settings and export
     model.settings.batches = 10
@@ -88,7 +86,6 @@ def test_cell_instance_multilattice(r, expected_cell_instance):
 
 
 def test_cell_instance_multilattice_results():
-    openmc.run()
     openmc.lib.run()
     tally_results = openmc.lib.tallies[1].mean
     assert (tally_results != 0.0).all()


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Partial fix for #2798. This fixes the creation of distribcell filter bin labels for the `tallies.out` file and the `DistribcellFilter::get_all_bins` for models that fill more than one cell with the same lattice. Without this change, all tally cell instance results are attributed to the set of cell instances in the first use of the lattice. I've extended the `test_cell_instances.py` to ensure that the tallies.out file is written successfully and that tally results are present for all bins in the test problem to verify that this fix is correct.

Note: This fix only applies to the `RectangularLattice` further corrections are needed for `HexagonalLattice`'s (see #2798) for more info.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~
- [x] ~I have made corresponding changes to the documentation (if applicable)~
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
