### PR TITLE
Make creation of spatial trees based on usage for unstructured mesh.

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -75,6 +75,8 @@ public:
   virtual ~Mesh() = default;
 
   // Methods
+  //! Perform any preparation needed to support use in mesh filters
+  virtual void prepare_for_tallies() {};
 
   //! Update a position to the local coordinates of the mesh
   virtual void local_coords(Position& r) const {};
@@ -663,6 +665,9 @@ public:
   static const std::string mesh_lib_type;
 
   // Overridden Methods
+
+  //! Perform any preparation needed to support use in mesh filters
+  void prepare_for_tallies() override;
 
   Position sample_element(int32_t bin, uint64_t* seed) const override;
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2058,6 +2058,13 @@ void MOABMesh::initialize()
       }
     }
   }
+}
+
+void MOABMesh::prepare_for_tallies()
+{
+  // if the KDTree has already been constructed, do nothing
+  if (kdtree_)
+    return;
 
   // build acceleration data structures
   compute_barycentric_data(ehs_);

--- a/src/tallies/filter_mesh.cpp
+++ b/src/tallies/filter_mesh.cpp
@@ -28,6 +28,9 @@ void MeshFilter::from_xml(pugi::xml_node node)
       fmt::format("Could not find mesh {} specified on tally filter.", id));
   }
 
+  // perform any additional perparation for mesh tallies here
+  model::meshes[search->second]->prepare_for_tallies();
+
   if (check_for_node(node, "translation")) {
     set_translation(get_node_array<double>(node, "translation"));
   }

--- a/src/tallies/filter_mesh.cpp
+++ b/src/tallies/filter_mesh.cpp
@@ -28,9 +28,6 @@ void MeshFilter::from_xml(pugi::xml_node node)
       fmt::format("Could not find mesh {} specified on tally filter.", id));
   }
 
-  // perform any additional perparation for mesh tallies here
-  model::meshes[search->second]->prepare_for_tallies();
-
   if (check_for_node(node, "translation")) {
     set_translation(get_node_array<double>(node, "translation"));
   }
@@ -80,8 +77,10 @@ std::string MeshFilter::text_label(int bin) const
 
 void MeshFilter::set_mesh(int32_t mesh)
 {
+  // perform any additional perparation for mesh tallies here
   mesh_ = mesh;
   n_bins_ = model::meshes[mesh_]->n_bins();
+  model::meshes[mesh_]->prepare_for_tallies();
 }
 
 void MeshFilter::set_translation(const Position& translation)


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR adds a method to the `Mesh` class to perform any additional setup to support a mesh's use in a `MeshFilter` for tallies during filter initialization. This should allow us to skip the tree build and generation of barycentric coordinate transformation data, which can be needlessly time-consuming if the mesh isn't used for a tally.

Fixes #2814


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~
- [x] ~I have made corresponding changes to the documentation (if applicable)~
- [x] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
