### PR TITLE
Ensure particle direction is normalized for plotting / volume calculations

### DIFF
--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -1,6 +1,7 @@
 #ifndef OPENMC_PLOT_H
 #define OPENMC_PLOT_H
 
+#include <cmath>
 #include <sstream>
 #include <unordered_map>
 
@@ -200,7 +201,7 @@ T SlicePlotBase::get_map() const
   xyz[out_i] = origin_[out_i] + width_[1] / 2. - out_pixel / 2.;
 
   // arbitrary direction
-  Direction dir = {0.7071, 0.7071, 0.0};
+  Direction dir = {1. / std::sqrt(2.), 1. / std::sqrt(2.), 0.0};
 
 #pragma omp parallel
   {

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -159,7 +159,7 @@ vector<VolumeCalculation::Result> VolumeCalculation::execute() const
         p.n_coord() = 1;
         Position xi {prn(&seed), prn(&seed), prn(&seed)};
         p.r() = lower_left_ + xi * (upper_right_ - lower_left_);
-        p.u() = {0.5, 0.5, 0.5};
+        p.u() = {1. / std::sqrt(3.), 1. / std::sqrt(3.), 1. / std::sqrt(3.)};
 
         // If this location is not in the geometry at all, move on to next block
         if (!exhaustive_find_cell(p))


### PR DESCRIPTION
# Description

When generating a plot or running a volume calculation, OpenMC repeatedly makes calls to `exhaustive_find_cell` to determine which cell/material contains a given point. For CSG geometries, the direction of the particle isn't actually used when performing the "find cell" operation and so the value that is assigned is currently some arbitrary value: `{0.7071, 0.7071, 0.}` for plotting and `{0.5, 0.5, 0.5}` for volume calculations. However, for DAGMC geometries, the direction is used for ray-fire operations to determine which volume contains a given point:
https://github.com/openmc-dev/openmc/blob/f5900293fa9debff910301e1ac9304ab9aea4b3a/src/dagmc.cpp#L655

It turns out that MOAB expects the direction being passed to be properly normalized, so the values above cause problems. In particular, **if you've compiled OpenMC with DAGMC support and are not using [double-down](https://github.com/pshriwise/double-down), volume calculations give incorrect results**. By ensuring that the arbitrary direction assigned to the particle is normalized before sending to MOAB, the incorrect volume calculation results are fixed.

I also noticed that this fixes some plotting artifacts that are observed when using the [plotter](https://github.com/openmc-dev/plotter/). For example, here's a snapshot of a DAGMC geometry without and with the fix from this PR:

<img src="https://github.com/openmc-dev/openmc/assets/743095/abaeb2d2-e2d8-4bb4-b650-723dc8e55d3c" width="400px" />

<img src="https://github.com/openmc-dev/openmc/assets/743095/e26da1d5-9b83-41fb-9c41-6a4653d44333" width="400px" />

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)