### PR TITLE
added missing meshes to lib docs

### DIFF
--- a/docs/source/pythonapi/capi.rst
+++ b/docs/source/pythonapi/capi.rst
@@ -54,11 +54,14 @@ Classes
    :template: myclass.rst
 
    Cell
+   CylindricalMesh
    EnergyFilter
    MaterialFilter
    Material
    MeshFilter
    MeshSurfaceFilter
    Nuclide
+   RectilinearMesh
    RegularMesh
+   SphericalMesh
    Tally


### PR DESCRIPTION
# Description

I think some of the mesh classes that exisit in openmc lib are missing from the list of classes in the docs

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
