### PR TITLE
Reset timers at correct place in deplete

### DIFF
--- a/openmc/deplete/coupled_operator.py
+++ b/openmc/deplete/coupled_operator.py
@@ -428,6 +428,7 @@ class CoupledOperator(OpenMCOperator):
         """
         # Reset results in OpenMC
         openmc.lib.reset()
+        openmc.lib.reset_timers()
 
         self._update_materials_and_nuclides(vec)
 
@@ -507,8 +508,6 @@ class CoupledOperator(OpenMCOperator):
         openmc.lib.statepoint_write(
             "openmc_simulation_n{}.h5".format(step),
             write_source=False)
-
-        openmc.lib.reset_timers()
 
     def finalize(self):
         """Finalize a depletion simulation and release resources."""


### PR DESCRIPTION
# Description

The particle/second and overall time reports in `openmc.deplete` are always wrong when using the `CoupledOperator`.  It turns out that we're only resetting the simulation timers when beginning-of-step material compositions are written, but this causes the run times to be summed as the simulation goes. We call `openmc.lib.reset()` after each transport solve, but don't reset the timers for some reason. As a result, you see a reported steadily decreasing particle tracking rate in each depletion step. For CECM with its two steps, it looks like:

```
 Total time for initialization     = 0.0000e+00 seconds
   Reading cross sections          = 0.0000e+00 seconds
 Total time in simulation          = 2.5036e+01 seconds
   Time in transport only          = 2.4877e+01 seconds
   Time in inactive batches        = 2.4421e+00 seconds
   Time in active batches          = 2.2594e+01 seconds
   Time synchronizing fission bank = 3.0581e-02 seconds
     Sampling source sites         = 2.6034e-02 seconds
     SEND/RECV source sites        = 4.4951e-03 seconds
   Time accumulating tallies       = 1.0246e-01 seconds
   Time writing statepoints        = 3.1361e-03 seconds
 Total time for finalization       = 5.0679e-05 seconds
 Total time elapsed                = 2.5147e+01 seconds
 Calculation Rate (inactive)       = 40947.9 particles/second
 Calculation Rate (active)         = 39834 particles/second

<BLAH BLAH TRANSPORT SOLVE OUTPUT>

 Total time for initialization     = 0.0000e+00 seconds
   Reading cross sections          = 0.0000e+00 seconds
 Total time in simulation          = 5.0078e+01 seconds
   Time in transport only          = 4.9802e+01 seconds
   Time in inactive batches        = 4.9050e+00 seconds
   Time in active batches          = 4.5173e+01 seconds
   Time synchronizing fission bank = 6.2849e-02 seconds
     Sampling source sites         = 5.2417e-02 seconds
     SEND/RECV source sites        = 1.0335e-02 seconds
   Time accumulating tallies       = 1.6187e-01 seconds
   Time writing statepoints        = 5.7461e-03 seconds
 Total time for finalization       = 1.1893e-04 seconds
 Total time elapsed                = 5.0306e+01 seconds
 Calculation Rate (inactive)       = 20387.5 particles/second
 Calculation Rate (active)         = 19923.2 particles/second
```

even though the tracking rate is not actually slowing down. This was quite confusing to me, as it seemed like we were somehow slowing down the simulation in the intermediate depletion steps!

After making the change here, the correct particle tracking rates are reported at each substep.