### PR TITLE
Fix config change not propagating through to decay energies

### DIFF
--- a/openmc/config.py
+++ b/openmc/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import warnings
 
 from openmc.data import DataLibrary
-from openmc.data.decay import _DECAY_PHOTON_ENERGY
+from openmc.data.decay import _DECAY_ENERGY, _DECAY_PHOTON_ENERGY
 
 __all__ = ["config"]
 
@@ -41,6 +41,7 @@ class _Config(MutableMapping):
             os.environ['OPENMC_CHAIN_FILE'] = str(value)
             # Reset photon source data since it relies on chain file
             _DECAY_PHOTON_ENERGY.clear()
+            _DECAY_ENERGY.clear()
         else:
             raise KeyError(f'Unrecognized config key: {key}. Acceptable keys '
                            'are "cross_sections", "mg_cross_sections" and '
@@ -76,7 +77,7 @@ def _default_config():
     if (chain_file is None and
         config.get('cross_sections') is not None and
         config['cross_sections'].exists()
-    ):
+        ):
         # Check for depletion chain in cross_sections.xml
         data = DataLibrary.from_xml(config['cross_sections'])
         for lib in reversed(data.libraries):


### PR DESCRIPTION
# Description

Changing the `openmc.config` chain file was not propagating through to changing the `DECAY_ENERGIES` variable, giving incorrect results if a user wished to compare decay heats between two chains.

For example, I was trying to assess how much error the CASL decay chain introduced compared to the full ENDF chain. I was finding some strange results, with decay heat far below 7% for a PWR pin cell.

Fixes #2824

Also ran autopep8 on config.py.


### Before this change (wrong)

![image](https://github.com/openmc-dev/openmc/assets/18088906/3ddc6c2a-6db2-44a3-b771-d69c2afaa0ce)


### After this change (right, expected 7% decay heat)

![image](https://github.com/openmc-dev/openmc/assets/18088906/db2685c3-bade-430e-a6b3-4228f10fbe6f)
