### PR TITLE
Ensure that implicit complement cells appear last in DAGMC universes

### DIFF
--- a/tests/regression_tests/dagmc/external/main.cpp
+++ b/tests/regression_tests/dagmc/external/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char* argv[])
   // Initialize acceleration data structures
   rval = dag_ptr->init_OBBTree();
   if (rval != moab::MB_SUCCESS) {
-    fatal_error("Failed to initialise OBB tree");
+    fatal_error("Failed to initialize OBB tree");
   }
 
   // Get rid of existing geometry
@@ -61,6 +61,20 @@ int main(int argc, char* argv[])
 
   // Add cells to universes
   openmc::populate_universes();
+
+  // Make sure implicit complement appears last
+  auto dag_univ = dynamic_cast<DAGUniverse*>(model::universes.back().get());
+  int n = dag_univ->cells_.size();
+  for (int i = 0; i < n - 1; ++i) {
+    if (dag_univ->cells_[i] == dag_univ->implicit_complement_idx()) {
+      fatal_error("Implicit complement cell should appear last in vector of "
+                  "cells for DAGMC universe.");
+    }
+  }
+  if (dag_univ->cells_.back() != dag_univ->implicit_complement_idx()) {
+    fatal_error(
+      "Last cell in DAGMC universe is not an implicit complement cell.");
+  }
 
   // Set root universe
   openmc::model::root_universe = openmc::find_root_universe();


### PR DESCRIPTION
# Description

The bug that this fixes is described in lots of detail at svalinn/DAGMC#934. It's debatable whether this is a DAGMC or OpenMC bug, but in either case, this PR will fix the behavior. Namely, for some DAGMC models, using MOAB 5.4+ currently results in particles incorrectly being found in the implicit complement volume when they shouldn't be. The change here ensures that all other volumes are checked first.

@pshriwise I don't have a test for this because I can't think of how one would do it. Let me know if you have any ideas.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)