### PR TITLE
Export model.tallies to XML in CoupledOperator

### DIFF
--- a/openmc/deplete/coupled_operator.py
+++ b/openmc/deplete/coupled_operator.py
@@ -242,8 +242,6 @@ class CoupledOperator(OpenMCOperator):
                 warn("Fission Q dictionary will not be used")
                 fission_q = None
         self.model = model
-        self.settings = model.settings
-        self.geometry = model.geometry
 
         # determine set of materials in the model
         if not model.materials:
@@ -358,7 +356,7 @@ class CoupledOperator(OpenMCOperator):
         if normalization_mode == "fission-q":
             self._normalization_helper = ChainFissionHelper()
         elif normalization_mode == "energy-deposition":
-            score = "heating" if self.settings.photon_transport else "heating-local"
+            score = "heating" if self.model.settings.photon_transport else "heating-local"
             self._normalization_helper = EnergyScoreHelper(score)
         else:
             self._normalization_helper = SourceRateHelper()
@@ -380,8 +378,12 @@ class CoupledOperator(OpenMCOperator):
 
         # Create XML files
         if comm.rank == 0:
-            self.geometry.export_to_xml()
-            self.settings.export_to_xml()
+            self.model.geometry.export_to_xml()
+            self.model.settings.export_to_xml()
+            if self.model.plots:
+                self.model.plots.export_to_xml()
+            if self.model.tallies:
+                self.model.tallies.export_to_xml()
             self._generate_materials_xml()
 
         # Initialize OpenMC library

--- a/openmc/deplete/coupled_operator.py
+++ b/openmc/deplete/coupled_operator.py
@@ -178,10 +178,6 @@ class CoupledOperator(OpenMCOperator):
     ----------
     model : openmc.model.Model
         OpenMC model object
-    geometry : openmc.Geometry
-        OpenMC geometry object
-    settings : openmc.Settings
-        OpenMC settings object
     output_dir : pathlib.Path
         Path to output directory to save results.
     round_number : bool
@@ -529,6 +525,36 @@ class CoupledOperator(OpenMCOperator):
         """Finalize a depletion simulation and release resources."""
         if self.cleanup_when_done:
             openmc.lib.finalize()
+
+    # The next few class variables and methods should be removed after one
+    # release cycle or so. For now, we will provide compatibility to
+    # accessing CoupledOperator.settings and CoupledOperator.geometry. In
+    # the future these should stay on the Model class.
+
+    var_warning_msg = "The CoupledOperator.{0} variable should be \
+accessed through CoupledOperator.model.{0}."
+    geometry_warning_msg = var_warning_msg.format("geometry")
+    settings_warning_msg = var_warning_msg.format("settings")
+
+    @property
+    def settings(self):
+        warn(self.settings_warning_msg, FutureWarning)
+        return self.model.settings
+
+    @settings.setter
+    def settings(self, new_settings):
+        warn(self.settings_warning_msg, FutureWarning)
+        self.model.settings = new_settings
+
+    @property
+    def geometry(self):
+        warn(self.geometry_warning_msg, FutureWarning)
+        return self.model.geometry
+
+    @geometry.setter
+    def geometry(self, new_geometry):
+        warn(self.geometry_warning_msg, FutureWarning)
+        self.model.geometry = new_geometry
 
 
 # Retain deprecated name for the time being

--- a/tests/unit_tests/test_deplete_coupled_operator.py
+++ b/tests/unit_tests/test_deplete_coupled_operator.py
@@ -38,7 +38,8 @@ def model():
 
     pin_surfaces = [openmc.ZCylinder(r=r) for r in radii]
     pin_univ = openmc.model.pin(pin_surfaces, materials)
-    bound_box = openmc.model.RectangularPrism(1.24, 1.24, boundary_type="reflective")
+    bound_box = openmc.model.RectangularPrism(
+        1.24, 1.24, boundary_type="reflective")
     root_cell = openmc.Cell(fill=pin_univ, region=-bound_box)
     geometry = openmc.Geometry([root_cell])
 
@@ -95,7 +96,7 @@ def test_diff_volume_method_match_cell(model_with_volumes):
         chain_file=CHAIN_PATH
     )
 
-    all_cells = list(operator.geometry.get_all_cells().values())
+    all_cells = list(operator.model.geometry.get_all_cells().values())
     assert all_cells[0].fill.volume == 4.19
     assert all_cells[1].fill.volume == 33.51
     # mat2 is not depletable
@@ -112,9 +113,8 @@ def test_diff_volume_method_divide_equally(model_with_volumes):
         chain_file=CHAIN_PATH
     )
 
-    all_cells = list(operator.geometry.get_all_cells().values())
+    all_cells = list(operator.model.geometry.get_all_cells().values())
     assert all_cells[0].fill[0].volume == 51
     assert all_cells[1].fill[0].volume == 51
     # mat2 is not depletable
     assert all_cells[2].fill.volume is None
-

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -457,6 +457,20 @@ def test_deplete(run_in_tmpdir, pin_model_attributes, mpi_intracomm):
     assert after_xe + after_u == pytest.approx(initial_u, abs=1e-15)
     assert test_model.is_initialized is False
 
+    # check the tally output
+    def check_tally_output():
+        with openmc.StatePoint('openmc_simulation_n0.h5') as sp:
+            flux = sp.get_tally(id=1).get_values(scores=['flux'])[0, 0, 0]
+            fission = sp.get_tally(id=1).get_values(
+                scores=['fission'])[0, 0, 0]
+
+            # we're mainly just checking that the result was produced,
+            # so a rough numerical comparison doesn't hurt to have.
+            assert flux == pytest.approx(13.1, abs=0.2)
+            assert fission == pytest.approx(0.47, abs=0.2)
+
+    check_tally_output()
+
     # Reset the initial material densities
     mats[0].nuclides.clear()
     densities = initial_mat.get_nuclide_atom_densities()
@@ -480,6 +494,8 @@ def test_deplete(run_in_tmpdir, pin_model_attributes, mpi_intracomm):
     # And end by comparing to the previous case
     assert after_xe == pytest.approx(after_lib_xe, abs=1e-15)
     assert after_u == pytest.approx(after_lib_u, abs=1e-15)
+
+    check_tally_output()
 
     test_model.finalize_lib()
 
@@ -531,6 +547,7 @@ def test_calc_volumes(run_in_tmpdir, pin_model_attributes, mpi_intracomm):
 
     test_model.finalize_lib()
 
+
 def test_model_xml(run_in_tmpdir):
 
     # load a model from examples
@@ -548,6 +565,7 @@ def test_model_xml(run_in_tmpdir):
     # make sure we can also export this again to separate
     # XML files
     new_model.export_to_xml()
+
 
 def test_single_xml_exec(run_in_tmpdir):
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

The cause of the related issue was that the relatively new `Model` object's tallies variable was not being exported to XML. The older `CoupledOperator` code anticipated that users would have run `tallies.export_to_xml()`, but that's not how we do stuff with the `Model` class. Since the depletion interface now uses `Model`, that's a confusing expectation! It's by far best to have the `CoupledOperator` also export the tallies and plots file if they're present on `Model`.

Fixes #2839

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
