### PR TITLE
Model h5m subdir

### DIFF
--- a/include/openmc/file_utils.h
+++ b/include/openmc/file_utils.h
@@ -16,6 +16,11 @@ bool dir_exists(const std::string& path);
 //! \return Whether file exists
 bool file_exists(const std::string& filename);
 
+//! Determine directory containing given file
+//! \param[in] filename Path to file
+//! \return Name of directory containing file
+std::string dir_name(const std::string& filename);
+
 // Gets the file extension of whatever string is passed in. This is defined as
 // a sequence of strictly alphanumeric characters which follow the last period,
 // i.e. at least one alphabet character is present, and zero or more numbers.

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -49,8 +49,8 @@ DAGUniverse::DAGUniverse(pugi::xml_node node)
 
   if (check_for_node(node, "filename")) {
     filename_ = get_node_value(node, "filename");
-    if (!file_exists(filename_)) {
-      fatal_error(fmt::format("DAGMC file '{}' could not be found", filename_));
+    if (!starts_with(filename_, "/")) {
+      filename_ = dir_name(settings::path_input) + filename_;
     }
   } else {
     fatal_error("Must specify a file for the DAGMC universe");
@@ -123,7 +123,6 @@ void DAGUniverse::init_dagmc()
   dagmc_instance_ = std::make_shared<moab::DagMC>();
 
   // load the DAGMC geometry
-  filename_ = settings::path_input + filename_;
   if (!file_exists(filename_)) {
     fatal_error("Geometry DAGMC file '" + filename_ + "' does not exist!");
   }

--- a/src/file_utils.cpp
+++ b/src/file_utils.cpp
@@ -26,6 +26,12 @@ bool file_exists(const std::string& filename)
   return s.good();
 }
 
+std::string dir_name(const std::string& filename)
+{
+  size_t pos = filename.find_last_of("\\/");
+  return (std::string::npos == pos) ? "" : filename.substr(0, pos + 1);
+}
+
 std::string get_file_extension(const std::string& filename)
 {
   // try our best to work on windows...

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -304,8 +304,9 @@ int parse_command_line(int argc, char* argv[])
         settings::path_input));
     }
 
-    // Add slash at end of directory if it isn't the
-    if (!ends_with(settings::path_input, "/")) {
+    // Add slash at end of directory if it isn't there
+    if (!ends_with(settings::path_input, "/") &&
+        dir_exists(settings::path_input)) {
       settings::path_input += "/";
     }
   }
@@ -315,18 +316,11 @@ int parse_command_line(int argc, char* argv[])
 
 bool read_model_xml()
 {
-  std::string model_filename =
-    settings::path_input.empty() ? "." : settings::path_input;
-
-  // some string cleanup
-  // a trailing "/" is applied to path_input if it's specified,
-  // remove it for the first attempt at reading the input file
-  if (ends_with(model_filename, "/"))
-    model_filename.pop_back();
+  std::string model_filename = settings::path_input;
 
   // if the current filename is a directory, append the default model filename
-  if (dir_exists(model_filename))
-    model_filename += "/model.xml";
+  if (model_filename.empty() || dir_exists(model_filename))
+    model_filename += "model.xml";
 
   // if this file doesn't exist, stop here
   if (!file_exists(model_filename))

--- a/tests/unit_tests/dagmc/test_h5m_subdir.py
+++ b/tests/unit_tests/dagmc/test_h5m_subdir.py
@@ -1,0 +1,40 @@
+import shutil
+from pathlib import Path
+
+import openmc
+import openmc.lib
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not openmc.lib._dagmc_enabled(), reason="DAGMC CAD geometry is not enabled."
+)
+
+
+@pytest.mark.parametrize("absolute", [True, False])
+def test_model_h5m_in_subdirectory(run_in_tmpdir, request, absolute):
+    # Create new subdirectory and copy h5m file there
+    h5m = Path(request.fspath).parent / "dagmc.h5m"
+    subdir = Path("h5m")
+    subdir.mkdir()
+    shutil.copy(h5m, subdir)
+
+    # Create simple model with h5m file in subdirectory
+    if absolute:
+        dag_univ = openmc.DAGMCUniverse((subdir / "dagmc.h5m").absolute())
+    else:
+        dag_univ = openmc.DAGMCUniverse(subdir / "dagmc.h5m")
+    model = openmc.Model()
+    model.geometry = openmc.Geometry(dag_univ.bounded_universe())
+    mat1 = openmc.Material(name="41")
+    mat1.add_nuclide("H1", 1.0)
+    mat2 = openmc.Material(name="no-void fuel")
+    mat2.add_nuclide("U235", 1.0)
+    model.materials = [mat1, mat2]
+    model.settings.batches = 10
+    model.settings.inactive = 5
+    model.settings.particles = 1000
+
+    # Make sure model can load
+    model.export_to_model_xml()
+    openmc.lib.init(["model.xml"])
+    openmc.lib.finalize()


### PR DESCRIPTION
# Description

If you have a model.xml file with a DAGMC universe that references a .h5m file in a directory other than the directory where the model.xml file lives, you'll get a fatal error if you run `openmc model.xml`. This PR fixes this behavior and does a little bit of cleanup with how `settings::path_input` is handled.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)