### PR TITLE
Expose `Material::depletable` in the CAPI

### DIFF
--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -94,6 +94,7 @@ int openmc_material_get_name(int32_t index, const char** name);
 int openmc_material_set_name(int32_t index, const char* name);
 int openmc_material_set_volume(int32_t index, double volume);
 int openmc_material_get_depletable(int32_t index, bool* depletable);
+int openmc_material_set_depletable(int32_t index, bool depletable);
 int openmc_material_filter_get_bins(
   int32_t index, const int32_t** bins, size_t* n);
 int openmc_material_filter_set_bins(

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -93,6 +93,7 @@ int openmc_material_set_id(int32_t index, int32_t id);
 int openmc_material_get_name(int32_t index, const char** name);
 int openmc_material_set_name(int32_t index, const char* name);
 int openmc_material_set_volume(int32_t index, double volume);
+int openmc_material_get_depletable(int32_t index, bool* depletable);
 int openmc_material_filter_get_bins(
   int32_t index, const int32_t** bins, size_t* n);
 int openmc_material_filter_set_bins(

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -158,6 +158,10 @@ public:
   //! \return Temperature in [K]
   double temperature() const;
 
+  //! Whether or not the material is depletable
+  bool depletable() const { return depletable_; }
+  bool& depletable() { return depletable_; }
+
   //! Get pointer to NCrystal material object
   //! \return Pointer to NCrystal material object
   const NCrystalMat& ncrystal_mat() const { return ncrystal_mat_; };

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -94,7 +94,7 @@ public:
   //  which will get auto-assigned to the next available ID. After creating
   //  the new material, it is added to openmc::model::materials.
   //! \return reference to the cloned material
-  Material & clone();
+  Material& clone();
 
   //----------------------------------------------------------------------------
   // Accessors
@@ -149,6 +149,7 @@ public:
   //! Get whether material is fissionable
   //! \return Whether material is fissionable
   bool fissionable() const { return fissionable_; }
+  bool& fissionable() { return fissionable_; }
 
   //! Get volume of material
   //! \return Volume in [cm^3]
@@ -177,11 +178,8 @@ public:
   double density_;                      //!< Total atom density in [atom/b-cm]
   double density_gpcc_;                 //!< Total atom density in [g/cm^3]
   double volume_ {-1.0};                //!< Volume in [cm^3]
-  bool fissionable_ {
-    false};                 //!< Does this material contain fissionable nuclides
-  bool depletable_ {false}; //!< Is the material depletable?
-  vector<bool> p0_;         //!< Indicate which nuclides are to be treated with
-                            //!< iso-in-lab scattering
+  vector<bool> p0_; //!< Indicate which nuclides are to be treated with
+                    //!< iso-in-lab scattering
 
   // To improve performance of tallying, we store an array (direct address
   // table) that indicates for each nuclide in data::nuclides the index of the
@@ -214,6 +212,9 @@ private:
   // Private data members
   gsl::index index_;
 
+  bool depletable_ {false}; //!< Is the material depletable?
+  bool fissionable_ {
+    false}; //!< Does this material contain fissionable nuclides
   //! \brief Default temperature for cells containing this material.
   //!
   //! A negative value indicates no default temperature was specified.

--- a/openmc/lib/material.py
+++ b/openmc/lib/material.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from ctypes import c_int, c_int32, c_double, c_char_p, POINTER, c_size_t
+from ctypes import c_bool, c_int, c_int32, c_double, c_char_p, POINTER, c_size_t
 from weakref import WeakValueDictionary
 
 import numpy as np
@@ -60,6 +60,9 @@ _dll.openmc_material_set_name.errcheck = _error_handler
 _dll.openmc_material_set_volume.argtypes = [c_int32, c_double]
 _dll.openmc_material_set_volume.restype = c_int
 _dll.openmc_material_set_volume.errcheck = _error_handler
+_dll.openmc_material_get_depletable.argtypes = [c_int32, POINTER(c_bool)]
+_dll.openmc_material_get_depletable.restype = c_int
+_dll.openmc_material_get_depletable.errcheck = _error_handler
 _dll.n_materials.argtypes = []
 _dll.n_materials.restype = c_size_t
 
@@ -168,6 +171,12 @@ class Material(_FortranObjectWithID):
     @volume.setter
     def volume(self, volume):
         _dll.openmc_material_set_volume(self._index, volume)
+
+    @property
+    def depletable(self):
+        depletable = c_bool()
+        _dll.openmc_material_get_depletable(self._index, depletable)
+        return depletable.value
 
     @property
     def nuclides(self):

--- a/openmc/lib/material.py
+++ b/openmc/lib/material.py
@@ -95,6 +95,8 @@ class Material(_FortranObjectWithID):
         List of nuclides in the material
     densities : numpy.ndarray
         Array of densities in atom/b-cm
+    depletable : bool
+        Whether this material is marked as depletable
     name : str
         Name of the material
     temperature : float

--- a/openmc/lib/material.py
+++ b/openmc/lib/material.py
@@ -63,6 +63,9 @@ _dll.openmc_material_set_volume.errcheck = _error_handler
 _dll.openmc_material_get_depletable.argtypes = [c_int32, POINTER(c_bool)]
 _dll.openmc_material_get_depletable.restype = c_int
 _dll.openmc_material_get_depletable.errcheck = _error_handler
+_dll.openmc_material_set_depletable.argtypes = [c_int32, c_bool]
+_dll.openmc_material_set_depletable.restype = c_int
+_dll.openmc_material_set_depletable.errcheck = _error_handler
 _dll.n_materials.argtypes = []
 _dll.n_materials.restype = c_size_t
 
@@ -177,6 +180,10 @@ class Material(_FortranObjectWithID):
         depletable = c_bool()
         _dll.openmc_material_get_depletable(self._index, depletable)
         return depletable.value
+
+    @depletable.setter
+    def depletable(self, depletable):
+        _dll.openmc_material_set_depletable(self._index, depletable)
 
     @property
     def nuclides(self):

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -51,7 +51,7 @@ void dispatch_xs_event(int64_t buffer_idx)
 {
   Particle& p = simulation::particles[buffer_idx];
   if (p.material() == MATERIAL_VOID ||
-      !model::materials[p.material()]->fissionable_) {
+      !model::materials[p.material()]->fissionable()) {
     simulation::calculate_nonfuel_xs_queue.thread_safe_append({p, buffer_idx});
   } else {
     simulation::calculate_fuel_xs_queue.thread_safe_append({p, buffer_idx});

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -1557,7 +1557,18 @@ extern "C" int openmc_material_get_depletable(int32_t index, bool* depletable) {
   }
 
   const auto& mat = model::materials[index];
-  *depletable = mat->depletable_;
+  *depletable = mat->depletable();
+
+  return 0;
+}
+
+extern "C" int openmc_material_set_depletable(int32_t index, bool depletable) {
+   if (index < 0 || index >= model::materials.size()) {
+    set_errmsg("Index in materials array is out of bounds.");
+    return OPENMC_E_OUT_OF_BOUNDS;
+  }
+
+  model::materials[index]->depletable() = depletable;
 
   return 0;
 }

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -1550,6 +1550,18 @@ extern "C" int openmc_material_set_volume(int32_t index, double volume)
   }
 }
 
+extern "C" int openmc_material_get_depletable(int32_t index, bool* depletable) {
+   if (index < 0 || index >= model::materials.size()) {
+    set_errmsg("Index in materials array is out of bounds.");
+    return OPENMC_E_OUT_OF_BOUNDS;
+  }
+
+  const auto& mat = model::materials[index];
+  *depletable = mat->depletable_;
+
+  return 0;
+}
+
 extern "C" int openmc_extend_materials(
   int32_t n, int32_t* index_start, int32_t* index_end)
 {

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -68,7 +68,7 @@ Material::Material(pugi::xml_node node)
   }
 
   if (check_for_node(node, "depletable")) {
-    depletable() = get_node_value_bool(node, "depletable");
+    depletable_ = get_node_value_bool(node, "depletable");
   }
 
   bool sum_density {false};
@@ -372,8 +372,8 @@ Material& Material::clone()
   mat->density_ = density_;
   mat->density_gpcc_ = density_gpcc_;
   mat->volume_ = volume_;
-  mat->fissionable_ = fissionable_;
-  mat->depletable() = depletable();
+  mat->fissionable() = fissionable_;
+  mat->depletable() = depletable_;
   mat->p0_ = p0_;
   mat->mat_nuclide_index_ = mat_nuclide_index_;
   mat->thermal_tables_ = thermal_tables_;
@@ -1557,8 +1557,7 @@ extern "C" int openmc_material_get_depletable(int32_t index, bool* depletable)
     return OPENMC_E_OUT_OF_BOUNDS;
   }
 
-  const auto& mat = model::materials[index];
-  *depletable = mat->depletable();
+  *depletable = model::materials[index]->depletable();
 
   return 0;
 }

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -68,7 +68,7 @@ Material::Material(pugi::xml_node node)
   }
 
   if (check_for_node(node, "depletable")) {
-    depletable_ = get_node_value_bool(node, "depletable");
+    depletable() = get_node_value_bool(node, "depletable");
   }
 
   bool sum_density {false};
@@ -373,7 +373,7 @@ Material& Material::clone()
   mat->density_gpcc_ = density_gpcc_;
   mat->volume_ = volume_;
   mat->fissionable_ = fissionable_;
-  mat->depletable_ = depletable_;
+  mat->depletable() = depletable();
   mat->p0_ = p0_;
   mat->mat_nuclide_index_ = mat_nuclide_index_;
   mat->thermal_tables_ = thermal_tables_;
@@ -1068,7 +1068,7 @@ void Material::to_hdf5(hid_t group) const
 {
   hid_t material_group = create_group(group, "material " + std::to_string(id_));
 
-  write_attribute(material_group, "depletable", static_cast<int>(depletable_));
+  write_attribute(material_group, "depletable", static_cast<int>(depletable()));
   if (volume_ > 0.0) {
     write_attribute(material_group, "volume", volume_);
   }
@@ -1550,8 +1550,9 @@ extern "C" int openmc_material_set_volume(int32_t index, double volume)
   }
 }
 
-extern "C" int openmc_material_get_depletable(int32_t index, bool* depletable) {
-   if (index < 0 || index >= model::materials.size()) {
+extern "C" int openmc_material_get_depletable(int32_t index, bool* depletable)
+{
+  if (index < 0 || index >= model::materials.size()) {
     set_errmsg("Index in materials array is out of bounds.");
     return OPENMC_E_OUT_OF_BOUNDS;
   }
@@ -1562,8 +1563,9 @@ extern "C" int openmc_material_get_depletable(int32_t index, bool* depletable) {
   return 0;
 }
 
-extern "C" int openmc_material_set_depletable(int32_t index, bool depletable) {
-   if (index < 0 || index >= model::materials.size()) {
+extern "C" int openmc_material_set_depletable(int32_t index, bool depletable)
+{
+  if (index < 0 || index >= model::materials.size()) {
     set_errmsg("Index in materials array is out of bounds.");
     return OPENMC_E_OUT_OF_BOUNDS;
   }

--- a/src/mgxs_interface.cpp
+++ b/src/mgxs_interface.cpp
@@ -284,7 +284,7 @@ void mark_fissionable_mgxs_materials()
   for (const auto& mat : model::materials) {
     for (int i_nuc : mat->nuclide_) {
       if (data::mg.nuclides_[i_nuc].fissionable) {
-        mat->fissionable_ = true;
+        mat->fissionable() = true;
       }
     }
   }

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -43,7 +43,7 @@ void sample_reaction(Particle& p)
   // change when sampling fission sites. The following block handles all
   // absorption (including fission)
 
-  if (model::materials[p.material()]->fissionable_) {
+  if (model::materials[p.material()]->fissionable()) {
     if (settings::run_mode == RunMode::EIGENVALUE ||
         (settings::run_mode == RunMode::FIXED_SOURCE &&
           settings::create_fission_neutrons)) {

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -201,7 +201,7 @@ SourceSite IndependentSource::sample(uint64_t* seed) const
           if (mat_index == MATERIAL_VOID) {
             found = false;
           } else {
-            found = model::materials[mat_index]->fissionable_;
+            found = model::materials[mat_index]->fissionable();
           }
         }
       }

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -206,6 +206,8 @@ def test_material(lib_init):
     m.name = "Not hot borated water"
     assert m.name == "Not hot borated water"
 
+    assert m.depletable == False
+
 
 def test_properties_density(lib_init):
     m = openmc.lib.materials[1]

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -207,6 +207,8 @@ def test_material(lib_init):
     assert m.name == "Not hot borated water"
 
     assert m.depletable == False
+    m.depletable = True
+    assert m.depletable == True
 
 
 def test_properties_density(lib_init):


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Exposes the `depletable` attribute of materials in the CAPI and `openmc.lib`. Also makes an accessor for the attribute on the C++ class.

Along the way I noticed that the `fissionable_` data member was public despite having an accessor so I moved it to the `private` section along with `depletable_` and added a non-const accessor.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
