### PR TITLE
Fix compilation on CentOS 7 (missing link to libdl)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,7 +497,7 @@ endif()
 # target_link_libraries treats any arguments starting with - but not -l as
 # linker flags. Thus, we can pass both linker flags and libraries together.
 target_link_libraries(libopenmc ${ldflags} ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES}
-                      xtensor gsl::gsl-lite-v1 fmt::fmt)
+                      xtensor gsl::gsl-lite-v1 fmt::fmt ${CMAKE_DL_LIBS})
 
 if(TARGET pugixml::pugixml)
   target_link_libraries(libopenmc pugixml::pugixml)


### PR DESCRIPTION
# Description

This PR fixes compilation on CentOS 7.

Fixes #2848.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~ (not applicable)
- [ ] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~ (not applicable)
- [ ] ~~I have made corresponding changes to the documentation (if applicable)~~ (not applicable)
- [ ] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~ (not sure this is possible?)

