### PR TITLE
Updating file extension for Excel files when exporting MGXS data

### DIFF
--- a/openmc/mgxs/mdgxs.py
+++ b/openmc/mgxs/mdgxs.py
@@ -743,9 +743,9 @@ class MDGXS(MGXS):
             df.to_csv(filename + '.csv', index=False)
         elif format == 'excel':
             if self.domain_type == 'mesh':
-                df.to_excel(filename + '.xls')
+                df.to_excel(filename + '.xlsx')
             else:
-                df.to_excel(filename + '.xls', index=False)
+                df.to_excel(filename + '.xlsx', index=False)
         elif format == 'pickle':
             df.to_pickle(filename + '.pkl')
         elif format == 'latex':

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -2001,9 +2001,9 @@ class MGXS:
             df.to_csv(filename + '.csv', index=False)
         elif format == 'excel':
             if self.domain_type == 'mesh':
-                df.to_excel(filename + '.xls')
+                df.to_excel(filename + '.xlsx')
             else:
-                df.to_excel(filename + '.xls', index=False)
+                df.to_excel(filename + '.xlsx', index=False)
         elif format == 'pickle':
             df.to_pickle(filename + '.pkl')
         elif format == 'latex':

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ kwargs = {
         'depletion-mpi': ['mpi4py'],
         'docs': ['sphinx', 'sphinxcontrib-katex', 'sphinx-numfig', 'jupyter',
                  'sphinxcontrib-svg2pdfconverter', 'sphinx-rtd-theme'],
-        'test': ['pytest', 'pytest-cov', 'colorama'],
+        'test': ['pytest', 'pytest-cov', 'colorama', 'openpyxl'],
         'vtk': ['vtk'],
     },
     # Cython is used to add resonance reconstruction and fast float_endf

--- a/tests/regression_tests/mgxs_library_hdf5/test.py
+++ b/tests/regression_tests/mgxs_library_hdf5/test.py
@@ -54,6 +54,11 @@ class MGXSTestHarness(PyAPITestHarness):
         # Export the MGXS Library to an HDF5 file
         self.mgxs_lib.build_hdf5_store(directory='.')
 
+        # Test export of the MGXS Library to an Excel spreadsheet
+        for mgxs in self.mgxs_lib.all_mgxs.values():
+            for xs in mgxs.values():
+                xs.export_xs_data('mgxs', xs_type='macro', format='excel')
+
         # Open the MGXS HDF5 file
         with h5py.File('mgxs.h5', 'r') as f:
 
@@ -76,9 +81,8 @@ class MGXSTestHarness(PyAPITestHarness):
 
     def _cleanup(self):
         super()._cleanup()
-        f = 'mgxs.h5'
-        if os.path.exists(f):
-            os.remove(f)
+        files = ['mgxs.h5', 'mgxs.xlsx']
+        (os.remove(f) for f in files if os.path.exists(f))
 
 
 def test_mgxs_library_hdf5():


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

As I was updating some of the notebook material to work with v0.14.0, I noticed that exporting MGXS/MDGXS data to an excel format with extension `.xls` no longer works b/c `pandas` deprecated support for that format sometime last year. Relevant `pandas` PR is [here](https://github.com/pandas-dev/pandas/commit/bcb8346e8106be4267ec77dfc603d0d77a3fda81).

This simply updates the extension of excel files to `.xlsx` to comply with the change in `pandas`. I didn't add any tests here since the excel writing option is an optional dependency for `pandas`, but I'd be happy to do so if 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
