### PR TITLE
removed error raising when calling warn

### DIFF
--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -213,7 +213,7 @@ class OpenMCOperator(TransportOperator):
                     msg = (f"Nuclilde {nuclide} in material {mat.id} is not "
                            "present in the depletion chain and has no cross "
                            "section data.")
-                    raise warn(msg)
+                    warn(msg)
             if mat.depletable:
                 burnable_mats.add(str(mat.id))
                 if mat.volume is None:


### PR DESCRIPTION
I triggered this warn statement and noticed that the ```raise``` in front of the ```warn``` causes the program to terminate with and error stating one can only raise errors. I believe ```warn``` should not be ```raised``` like we have elsewhere in the code. 

Fixes # (issue)
code having fatal error when it should just warn user

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)