### PR TITLE
Setting surf_source_ attribute for DAGMC surfaces.

### DIFF
--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -280,6 +280,10 @@ void DAGUniverse::init_geometry()
     s->id_ = adjust_geometry_ids_ ? next_surf_id++
                                   : dagmc_instance_->id_by_index(2, i + 1);
 
+    // set surface source attribute if needed
+    if (contains(settings::source_write_surf_id, s->id_))
+      s->surf_source_ = true;
+
     // set BCs
     std::string bc_value =
       dmd_ptr->get_surface_property("boundary", surf_handle);

--- a/tests/regression_tests/dagmc/legacy/test.py
+++ b/tests/regression_tests/dagmc/legacy/test.py
@@ -4,6 +4,7 @@ import openmc
 import openmc.lib
 
 import h5py
+import numpy as np
 import pytest
 from tests.testing_harness import PyAPITestHarness
 
@@ -74,10 +75,11 @@ def test_missing_material_name(model):
     exp_error_msg = "Material with name/ID 'no-void fuel' not found for volume (cell) 1"
     assert exp_error_msg in str(exec_info.value)
 
+
 def test_surf_source(model):
     # create a surface source read on this model to ensure
     # particles are being generated correctly
-    surf_src_info = {'surface_ids' : [1, 2, 3], 'max_particles': 100}
+    surf_src_info = {'surface_ids' : [1], 'max_particles': 100}
     model.settings.surf_source_write = surf_src_info
     model.run()
 
@@ -85,6 +87,13 @@ def test_surf_source(model):
         assert fh.attrs['filetype'] == b'source'
         arr = fh['source_bank'][...]
     assert arr.size == 100
+
+    # check that all particles are on surface 1 (radius = 7)
+    xs = arr[:]['r']['x']
+    ys = arr[:]['r']['y']
+    rad = np.sqrt(xs**2 + ys**2)
+    assert np.allclose(rad, 7.0)
+
 
 def test_dagmc(model):
     harness = PyAPITestHarness('statepoint.5.h5', model)

--- a/tests/regression_tests/dagmc/legacy/test.py
+++ b/tests/regression_tests/dagmc/legacy/test.py
@@ -80,7 +80,8 @@ def test_missing_material_name(model):
 def test_surf_source(model):
     # create a surface source read on this model to ensure
     # particles are being generated correctly
-    model.settings.surf_source_write = {'surface_ids': [1], 'max_particles': 100}
+    n = 100
+    model.settings.surf_source_write = {'surface_ids': [1], 'max_particles': n}
 
     # If running in MPI mode, setup proper keyword arguments for run()
     kwargs = {'openmc_exec': config['exe']}
@@ -91,7 +92,8 @@ def test_surf_source(model):
     with h5py.File('surface_source.h5') as fh:
         assert fh.attrs['filetype'] == b'source'
         arr = fh['source_bank'][...]
-    assert arr.size == 100
+    expected_size = n * int(config['mpi_np']) if config['mpi'] else n
+    assert arr.size == expected_size
 
     # check that all particles are on surface 1 (radius = 7)
     xs = arr[:]['r']['x']


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Addresses empty surface source files when this feature is applied to DAGMC surfaces. This is because the `DAGSurface::surf_source_`  attribute isn't being set. `DAGSurface`'s aren't created using the XML node constructor and in turn don't apply the code from the `Surface::Surface(pugi::xml_node node)` surface constructor. 

This simply adds the same check in the `DAGSurface` constructor. In addition to a min-test that particles are generated in the correct location (on the barrel of surafce 1). I then put together a quick and dirty external source site display feature in the plotter to prove to myself it was working using the fuel pin regression test:

**note:: source sites are projected onto the slice plane regardless of whether or not they are on or approximately on that plane** 

## Model (colored by cell)

![image](https://github.com/openmc-dev/openmc/assets/4563941/dacb1455-d0eb-45ed-ac7f-d51ade53b7df)

## Surface 1 (cylinder barrel)

![image](https://github.com/openmc-dev/openmc/assets/4563941/7e37caab-8089-4c9d-a0f0-3759a7c07353)

## Surface 2 (lower Z surface)

![image](https://github.com/openmc-dev/openmc/assets/4563941/03ddec10-d9a6-4a1b-985a-90a12503b1df)

## Surface 3 (upper Z surface)

![image](https://github.com/openmc-dev/openmc/assets/4563941/2b2bb498-1b77-45e8-ab80-6e0a287572bd)

## Surfaces 1, 2, and 3

![image](https://github.com/openmc-dev/openmc/assets/4563941/cb52eb45-fdfb-44c4-a370-b4e5a57682b7)

![image](https://github.com/openmc-dev/openmc/assets/4563941/e3456735-0295-43ab-ba11-7a01b8211015)

Fixes #2856 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~
- [x] ~I have made corresponding changes to the documentation (if applicable)~
- [x] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
