### PR TITLE
Adding openmc.read_source_file

### DIFF
--- a/docs/source/pythonapi/base.rst
+++ b/docs/source/pythonapi/base.rst
@@ -35,6 +35,7 @@ Simulation Settings
    :nosignatures:
    :template: myfunction.rst
 
+   openmc.read_source_file
    openmc.write_source_file
    openmc.wwinp_to_wws
 

--- a/openmc/source.py
+++ b/openmc/source.py
@@ -888,7 +888,9 @@ def write_source_file(
 
 
 def read_source_file(filename: PathLike) -> typing.List[SourceParticle]:
-    """Read a source file and return a list of source particles
+    """Read a source file and return a list of source particles.
+
+    .. versionadded:: 0.14.1
 
     Parameters
     ----------
@@ -913,7 +915,7 @@ def read_source_file(filename: PathLike) -> typing.List[SourceParticle]:
         raise ValueError(f'File {filename} is not a source file')
 
     source_particles = []
-    for r, u, E, time, wgt, delayed_group, surf_id, particle in arr:
-        source_particles.append(SourceParticle(r, u, E, time, wgt, delayed_group, surf_id, ParticleType(particle)))
+    for *params, particle in arr:
+        source_particles.append(SourceParticle(*params, ParticleType(particle)))
 
     return source_particles

--- a/openmc/source.py
+++ b/openmc/source.py
@@ -885,3 +885,35 @@ def write_source_file(
     with h5py.File(filename, **kwargs) as fh:
         fh.attrs['filetype'] = np.string_("source")
         fh.create_dataset('source_bank', data=arr, dtype=source_dtype)
+
+
+def read_source_file(filename: PathLike) -> typing.List[SourceParticle]:
+    """Read a source file and return a list of source particles
+
+    Parameters
+    ----------
+    filename : str or path-like
+        Path to source file to read
+
+    Returns
+    -------
+    list of SourceParticle
+        Source particles read from file
+
+    See Also
+    --------
+    openmc.SourceParticle
+
+    """
+    with h5py.File(filename, 'r') as fh:
+        filetype = fh.attrs['filetype']
+        arr = fh['source_bank'][...]
+
+    if filetype != b'source':
+        raise ValueError(f'File {filename} is not a source file')
+
+    source_particles = []
+    for r, u, E, time, wgt, delayed_group, surf_id, particle in arr:
+        source_particles.append(SourceParticle(r, u, E, time, wgt, delayed_group, surf_id, ParticleType(particle)))
+
+    return source_particles

--- a/tests/unit_tests/test_source_file.py
+++ b/tests/unit_tests/test_source_file.py
@@ -24,12 +24,10 @@ def test_source_file(run_in_tmpdir):
     # Create source file
     openmc.write_source_file(source, 'test_source.h5')
 
-
     # Get array of source particles from file
     with h5py.File('test_source.h5', 'r') as fh:
         filetype = fh.attrs['filetype']
         arr = fh['source_bank'][...]
-
 
     # Ensure data is consistent
     assert filetype == b'source'

--- a/tests/unit_tests/test_source_file.py
+++ b/tests/unit_tests/test_source_file.py
@@ -24,10 +24,12 @@ def test_source_file(run_in_tmpdir):
     # Create source file
     openmc.write_source_file(source, 'test_source.h5')
 
+
     # Get array of source particles from file
     with h5py.File('test_source.h5', 'r') as fh:
         filetype = fh.attrs['filetype']
         arr = fh['source_bank'][...]
+
 
     # Ensure data is consistent
     assert filetype == b'source'
@@ -43,6 +45,30 @@ def test_source_file(run_in_tmpdir):
     assert np.all(arr['wgt'] == 1.0)
     assert np.all(arr['delayed_group'] == 0)
     assert np.all(arr['particle'] == 0)
+
+
+    # Ensure sites read in are consistent
+    sites = openmc.read_source_file('test_source.h5')
+
+    assert filetype == b'source'
+    xs = np.array([site.r[0] for site in sites])
+    ys = np.array([site.r[1] for site in sites])
+    zs = np.array([site.r[2] for site in sites])
+    assert np.all((xs > 0.0) & (xs < 1.0))
+    assert np.all(ys == np.arange(1000))
+    assert np.all(zs == 0.0)
+    u = np.array([s.u for s in sites])
+    assert np.all(u[..., 0] == 0.0)
+    assert np.all(u[..., 1] == 0.0)
+    assert np.all(u[..., 2] == 1.0)
+    E = np.array([s.E for s in sites])
+    assert np.all(E == n - np.arange(n))
+    wgt = np.array([s.wgt for s in sites])
+    assert np.all(wgt == 1.0)
+    dgs = np.array([s.delayed_group for s in sites])
+    assert np.all(dgs == 0)
+    p_types = np.array([s.particle for s in sites])
+    assert np.all(p_types == 0)
 
 
 def test_wrong_source_attributes(run_in_tmpdir):


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

We currently have the ability to write a list of `openmc.SourceParticle` objects to an HDF5 file, but no ability to read a file into a list of those objects that I'm aware of. I found it useful to be able to do so today and added that function so I thought I'd contribute it 
here.

I added testing of this function to `test_source_file.py`, but left the checks using `h5py` in place as it hammers on that file spec a bit so I think it's still useful to have them around.

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
