### PR TITLE
changing y axis label for heating plots

### DIFF
--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -68,20 +68,19 @@ def _get_legend_label(this, type):
 def _get_yaxis_label(reactions, divisor_types):
     """Gets a y axis label for the type of data plotted"""
 
-    heat_combos = {"heating"}, {"heating-local"}, {"heating", "heating-local"}
+    heat_values = {"heating", "heating-local", "damage-energy"}
 
     # if all the types are heating a different stem and unit is needed
-    if all(set(value) in heat_combos for value in reactions.values()):
+    if all(set(value).issubset(heat_values) for value in reactions.values()):
         stem = "Heating"
     elif all(isinstance(item, str) for item in reactions.keys()):
         for nuc_reactions in reactions.values():
             for reaction in nuc_reactions:
-                if reaction in ["heating", "heating-local"]:
-                    msg = (
+                if reaction in heat_values:
+                    raise TypeError(
                         "Mixture of heating and Microscopic reactions. "
                         "Invalid type for plotting"
                     )
-                    raise TypeError(msg)
         stem = "Microscopic"
     elif all(isinstance(item, openmc.Material) for item in reactions.keys()):
         stem = 'Macroscopic'
@@ -96,7 +95,7 @@ def _get_yaxis_label(reactions, divisor_types):
         units = {
             "Macroscopic": "[1/cm]",
             "Microscopic": "[b]",
-            "Heating": "[eV barn]",
+            "Heating": "[eV-barn]",
         }[stem]
 
     return f'{stem} {mid} {units}'

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -74,7 +74,6 @@ def _get_yaxis_label(reactions, divisor_types):
     if all(set(value) in heat_combos for value in reactions.values()):
         stem = "Heating"
     elif all(isinstance(item, str) for item in reactions.keys()):
-        print(reactions.values())
         for nuc_reactions in reactions.values():
             for reaction in nuc_reactions:
                 if reaction in ["heating", "heating-local"]:

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -97,7 +97,7 @@ def _get_yaxis_label(reactions, divisor_types):
         units = {
             "Macroscopic": "[1/cm]",
             "Microscopic": "[b]",
-            "Heating": "[eV/collision]",
+            "Heating": "[eV barn]",
         }[stem]
 
     return f'{stem} {mid} {units}'

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -68,24 +68,39 @@ def _get_legend_label(this, type):
 def _get_yaxis_label(reactions, divisor_types):
     """Gets a y axis label for the type of data plotted"""
 
-    if all(isinstance(item, str) for item in reactions.keys()):
-        stem = 'Microscopic'
-        if divisor_types:
-            mid, units = 'Data', ''
-        else:
-            mid, units = 'Cross Section', '[b]'
+    heat_combos = {"heating"}, {"heating-local"}, {"heating", "heating-local"}
+
+    # if all the types are heating a different stem and unit is needed
+    if all(set(value) in heat_combos for value in reactions.values()):
+        stem = "Heating"
+    elif all(isinstance(item, str) for item in reactions.keys()):
+        print(reactions.values())
+        for nuc_reactions in reactions.values():
+            for reaction in nuc_reactions:
+                if reaction in ["heating", "heating-local"]:
+                    msg = (
+                        "Mixture of heating and Microscopic reactions. "
+                        "Invalid type for plotting"
+                    )
+                    raise TypeError(msg)
+        stem = "Microscopic"
     elif all(isinstance(item, openmc.Material) for item in reactions.keys()):
         stem = 'Macroscopic'
-        if divisor_types:
-            mid, units = 'Data', ''
-        else:
-            mid, units = 'Cross Section', '[1/cm]'
     else:
         msg = "Mixture of openmc.Material and elements/nuclides. Invalid type for plotting"
         raise TypeError(msg)
 
-    return f'{stem} {mid} {units}'
+    if divisor_types:
+        mid, units = "Data", ""
+    else:
+        mid = "Cross Section"
+        units = {
+            "Macroscopic": "[1/cm]",
+            "Microscopic": "[b]",
+            "Heating": "[eV/collision]",
+        }[stem]
 
+    return f'{stem} {mid} {units}'
 
 def _get_title(reactions):
     """Gets a title for the type of data plotted"""

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -116,7 +116,7 @@ def test_plot_axes_labels():
         },
         divisor_types=False,
     )
-    assert axis_label == "Heating Cross Section [eV/collision]"
+    assert axis_label == "Heating Cross Section [eV barn]"
 
     with pytest.raises(TypeError):
         axis_label = openmc.plotter.plot_xs(

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -113,10 +113,11 @@ def test_plot_axes_labels():
         reactions={
             "Li": ["heating", "heating-local"],
             "Li7": ["heating"],
+            "Be": ["damage-energy"],
         },
         divisor_types=False,
     )
-    assert axis_label == "Heating Cross Section [eV barn]"
+    assert axis_label == "Heating Cross Section [eV-barn]"
 
     with pytest.raises(TypeError):
         axis_label = openmc.plotter.plot_xs(

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -109,6 +109,20 @@ def test_plot_axes_labels():
     )
     assert axis_label == 'Microscopic Cross Section [b]'
 
+    axis_label = openmc.plotter._get_yaxis_label(
+        reactions={
+            "Li": ["heating", "heating-local"],
+            "Li7": ["heating"],
+        },
+        divisor_types=False,
+    )
+    assert axis_label == "Heating Cross Section [eV/collision]"
+
+    with pytest.raises(TypeError):
+        axis_label = openmc.plotter.plot_xs(
+            reactions={"Li": ["heating", "heating-local"], "Be9": ["(n,2n)"]}
+        )
+
     # just materials
     mat1 = openmc.Material()
     mat1.add_nuclide('Fe56', 1)


### PR DESCRIPTION
While plotting some heating cross sections we noticed that the units on the Y axis were in barns when perhaps they should be in eV/collision or something else.

This PR adds special handeling if the ```heating``` or ```heating-local``` types are plotted.
It also checks that the cross sections are not mixing heat with non heat cross sections as these can't share a Y axis units

I've added tests for the new use cases

Here is a before and after screen shot
![Screenshot from 2024-01-26 16-08-24](https://github.com/openmc-dev/openmc/assets/8583900/37777539-844f-4455-8637-cb8da143155c)

sample code for these plots
```python
import matplotlib.pyplot as plt
import openmc

fig = openmc.plotter.plot_xs(
    reactions={
        "Be9": ["heating-local"],
        "Li6": ["heating"],
    },
)
plt.show()
```
tagging  @rlbarker for your interest


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
