### PR TITLE
remove indirection in FilterMatch

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -5,6 +5,7 @@
 #define OPENMC_MESH_H
 
 #include <unordered_map>
+#include <utility> // pair
 
 #include "hdf5.h"
 #include "pugixml.hpp"
@@ -35,6 +36,8 @@
 #include "libmesh/mesh.h"
 #include "libmesh/point.h"
 #endif
+
+using std::pair;
 
 namespace openmc {
 
@@ -94,19 +97,22 @@ public:
   //! \param[in] r0 Previous position of the particle
   //! \param[in] r1 Current position of the particle
   //! \param[in] u Particle direction
-  //! \param[out] bins Bins that were crossed
+  //! \param[out] bins Pairs of bin index and length in it
   //! \param[out] lengths Fraction of tracklength in each bin
   virtual void bins_crossed(Position r0, Position r1, const Direction& u,
-    vector<int>& bins, vector<double>& lengths) const = 0;
+    vector<pair<int, double>>& bins) const = 0;
 
   //! Determine which surface bins were crossed by a particle
   //
   //! \param[in] r0 Previous position of the particle
   //! \param[in] r1 Current position of the particle
   //! \param[in] u Particle direction
-  //! \param[out] bins Surface bins that were crossed
-  virtual void surface_bins_crossed(
-    Position r0, Position r1, const Direction& u, vector<int>& bins) const = 0;
+  //! \param[out] bins Surface bins that were crossed. The integers
+  //!             correspond to bin indices while the doubles are
+  //!             always one. These are present to maintain a simple
+  //!             interface with FilterMatch, where this is used.
+  virtual void surface_bins_crossed(Position r0, Position r1,
+    const Direction& u, vector<pair<int, double>>& bins) const = 0;
 
   //! Get bin at a given position in space
   //
@@ -198,10 +204,10 @@ public:
   int n_surface_bins() const override;
 
   void bins_crossed(Position r0, Position r1, const Direction& u,
-    vector<int>& bins, vector<double>& lengths) const override;
+    vector<pair<int, double>>& bins) const override;
 
   void surface_bins_crossed(Position r0, Position r1, const Direction& u,
-    vector<int>& bins) const override;
+    vector<pair<int, double>>& bins) const override;
 
   //! Determine which cell or surface bins were crossed by a particle
   //
@@ -570,7 +576,7 @@ public:
   // Overridden Methods
 
   void surface_bins_crossed(Position r0, Position r1, const Direction& u,
-    vector<int>& bins) const override;
+    vector<pair<int, double>>& bins) const override;
 
   void to_hdf5(hid_t group) const override;
 
@@ -667,7 +673,7 @@ public:
   Position sample_element(int32_t bin, uint64_t* seed) const override;
 
   void bins_crossed(Position r0, Position r1, const Direction& u,
-    vector<int>& bins, vector<double>& lengths) const override;
+    vector<pair<int, double>>& bins) const override;
 
   int get_bin(Position r) const override;
 
@@ -830,7 +836,7 @@ public:
 
   // Overridden Methods
   void bins_crossed(Position r0, Position r1, const Direction& u,
-    vector<int>& bins, vector<double>& lengths) const override;
+    vector<pair<int, double>>& bins) const override;
 
   Position sample_element(int32_t bin, uint64_t* seed) const override;
 

--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -140,11 +140,11 @@ private:
   //! \return Temperature index and interpolation factor
   std::pair<gsl::index, double> find_temperature(double T) const;
 
-  static int XS_TOTAL;
-  static int XS_ABSORPTION;
-  static int XS_FISSION;
-  static int XS_NU_FISSION;
-  static int XS_PHOTON_PROD;
+  static constexpr int XS_TOTAL = 0;
+  static constexpr int XS_ABSORPTION = 1;
+  static constexpr int XS_FISSION = 2;
+  static constexpr int XS_NU_FISSION = 3;
+  static constexpr int XS_PHOTON_PROD = 4;
 };
 
 //==============================================================================

--- a/include/openmc/tallies/filter_match.h
+++ b/include/openmc/tallies/filter_match.h
@@ -1,18 +1,136 @@
 #ifndef OPENMC_TALLIES_FILTERMATCH_H
 #define OPENMC_TALLIES_FILTERMATCH_H
 
+#include <cassert>
+#include <utility>
+
+using std::pair;
+
 namespace openmc {
 
-//==============================================================================
-//! Stores bins and weights for filtered tally events.
-//==============================================================================
-
+/*
+ * Defines the interface for storing instances
+ * of matches against a Filter class's bins. For example,
+ * if using a mesh filter and track length estimator,
+ * each crossing of a mesh segment corresponds to a single
+ * entry in the vector stored by FilterMatch. FilterMatch
+ * is stored in a vector on each Particle class with indices
+ * corresponding to each filter in the problem.
+ *
+ * For the vast majority of filters, only a single match
+ * gets stored. Another example of a filter with multiple
+ * possible matches are the functional expansions like
+ * LegendreFilter.
+ *
+ * Because many, many types of filter only have a single
+ * match, this class optimizes for that case. For example,
+ * computationally expensive depletion calculations tend
+ * to only employ filters which only match against one
+ * bin. As such, a cache-friendliness optimization is that
+ * we store the first bin/weight pair locally, then the
+ * rest in a vector. Most of the time, the indirection
+ * into the vector need not be used.
+ *
+ * In 2/2/2024, this sped up a depletion simulation
+ * on a laptop by XX% and the improvement is similar
+ * elsewhere.
+ */
 class FilterMatch {
 public:
-  vector<int> bins_;
-  vector<double> weights_;
-  int i_bin_;
-  bool bins_present_ {false};
+  // If using this interface, we assume this filter has
+  // only single matches. Therefore we store the match
+  // info locally in this object to avoid indirection.
+  void set(int i)
+  {
+    w_ = 1.0;
+    i_ = i;
+  }
+  void set(int i, double w)
+  {
+    w_ = w;
+    i_ = i;
+  }
+
+  pair<int, double> get()
+  {
+    assert(!is_vector_);
+    assert(i_ >= 0); // ensure it was set
+    return {i_, w_};
+  }
+
+  // FilterBinIter uses this and increments it through
+  // the tallying process.
+  int& i_bin() { return i_bin_; }
+
+  // Determine whether this match has been set already
+  bool bins_present() { return is_vector_ || i_ >= 0; }
+
+  /* When using this interface, it's assumed
+   * that many possible matches are going to get
+   * pushed back and the cache optimization technique
+   * is abandoned. We therefore treat the starting
+   * match as a zero weight entry, and then return
+   * the vector storage for mesh to push back into.
+   */
+  vector<pair<int, double>>& vector_pairs()
+  {
+    is_vector_ = true;
+    return bins_;
+  }
+
+  void reset()
+  {
+    if (is_vector_) {
+      bins_.clear();
+      is_vector_ = false;
+    }
+
+    w_ = 0.0;
+    i_ = -1;
+    i_bin_ = 0;
+  }
+
+  // These return the bin/weight at the current i_bin_ value
+  int bin()
+  {
+    assert(!is_vector_ ? i_bin_ == 0 : true);
+    if (is_vector_) {
+      return bins_[i_bin_].first;
+    } else {
+      return i_;
+    }
+  }
+  double weight()
+  {
+    assert(!is_vector_ ? i_bin_ == 0 : true);
+    if (is_vector_) {
+      return bins_[i_bin_].second;
+    } else {
+      return w_;
+    }
+  }
+
+  int size()
+  {
+    if (is_vector_)
+      return bins_.size();
+    else
+      return 1;
+  }
+
+private:
+  // For scalar filter matches, these local variables
+  // are used
+  double w_ {0.0};
+  int i_ {-1};
+
+  int i_bin_ {0};
+
+  // For vector filter matches, the vector
+  // below gets used. It is best to avoid using
+  // it in order to avoid on-the-fly allocations.
+  vector<pair<int, double>> bins_;
+  bool is_vector_ {false};
 };
 
 } // namespace openmc

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -42,12 +42,6 @@ vector<unique_ptr<Nuclide>> nuclides;
 // Nuclide implementation
 //==============================================================================
 
-int Nuclide::XS_TOTAL {0};
-int Nuclide::XS_ABSORPTION {1};
-int Nuclide::XS_FISSION {2};
-int Nuclide::XS_NU_FISSION {3};
-int Nuclide::XS_PHOTON_PROD {4};
-
 Nuclide::Nuclide(hid_t group, const vector<double>& temperature)
 {
   // Set index of nuclide in global vector

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -677,7 +677,7 @@ void write_tallies()
           const auto& filt {*model::tally_filters[i_filt]};
           auto& match {filter_matches[i_filt]};
           fmt::print(tallies_out, "{0:{1}}{2}\n", "", indent + 1,
-            filt.text_label(match.i_bin_));
+            filt.text_label(match.i_bin()));
         }
         indent += 2;
       }

--- a/src/tallies/filter_azimuthal.cpp
+++ b/src/tallies/filter_azimuthal.cpp
@@ -60,8 +60,7 @@ void AzimuthalFilter::get_all_bins(
 
   if (phi >= bins_.front() && phi <= bins_.back()) {
     auto bin = lower_bound_index(bins_.begin(), bins_.end(), phi);
-    match.bins_.push_back(bin);
-    match.weights_.push_back(1.0);
+    match.set(bin);
   }
 }
 

--- a/src/tallies/filter_cell.cpp
+++ b/src/tallies/filter_cell.cpp
@@ -49,8 +49,7 @@ void CellFilter::get_all_bins(
   for (int i = 0; i < p.n_coord(); i++) {
     auto search = map_.find(p.coord(i).cell);
     if (search != map_.end()) {
-      match.bins_.push_back(search->second);
-      match.weights_.push_back(1.0);
+      match.set(search->second);
     }
   }
 }

--- a/src/tallies/filter_cell_instance.cpp
+++ b/src/tallies/filter_cell_instance.cpp
@@ -79,8 +79,7 @@ void CellInstanceFilter::get_all_bins(
     auto search = map_.find({index_cell, instance});
     if (search != map_.end()) {
       int index_bin = search->second;
-      match.bins_.push_back(index_bin);
-      match.weights_.push_back(1.0);
+      match.set(index_bin);
     }
   }
 
@@ -97,8 +96,7 @@ void CellInstanceFilter::get_all_bins(
     gsl::index instance = cell_instance_at_level(p, i);
     auto search = map_.find({index_cell, instance});
     if (search != map_.end()) {
-      match.bins_.push_back(search->second);
-      match.weights_.push_back(1.0);
+      match.set(search->second);
     }
   }
 }

--- a/src/tallies/filter_cellborn.cpp
+++ b/src/tallies/filter_cellborn.cpp
@@ -9,8 +9,7 @@ void CellBornFilter::get_all_bins(
 {
   auto search = map_.find(p.cell_born());
   if (search != map_.end()) {
-    match.bins_.push_back(search->second);
-    match.weights_.push_back(1.0);
+    match.set(search->second);
   }
 }
 

--- a/src/tallies/filter_cellfrom.cpp
+++ b/src/tallies/filter_cellfrom.cpp
@@ -10,8 +10,7 @@ void CellFromFilter::get_all_bins(
   for (int i = 0; i < p.n_coord_last(); i++) {
     auto search = map_.find(p.cell_last(i));
     if (search != map_.end()) {
-      match.bins_.push_back(search->second);
-      match.weights_.push_back(1.0);
+      match.set(search->second);
     }
   }
 }

--- a/src/tallies/filter_collision.cpp
+++ b/src/tallies/filter_collision.cpp
@@ -44,8 +44,7 @@ void CollisionFilter::get_all_bins(
   // Bin the collision number. Must fit exactly the desired collision number.
   auto search = map_.find(n);
   if (search != map_.end()) {
-    match.bins_.push_back(search->second);
-    match.weights_.push_back(1.0);
+    match.set(search->second);
   }
 }
 

--- a/src/tallies/filter_delayedgroup.cpp
+++ b/src/tallies/filter_delayedgroup.cpp
@@ -39,8 +39,7 @@ void DelayedGroupFilter::set_groups(gsl::span<int> groups)
 void DelayedGroupFilter::get_all_bins(
   const Particle& p, TallyEstimator estimator, FilterMatch& match) const
 {
-  match.bins_.push_back(0);
-  match.weights_.push_back(1.0);
+  match.set(0);
 }
 
 void DelayedGroupFilter::to_statepoint(hid_t filter_group) const

--- a/src/tallies/filter_distribcell.cpp
+++ b/src/tallies/filter_distribcell.cpp
@@ -52,8 +52,7 @@ void DistribcellFilter::get_all_bins(
       }
     }
     if (cell_ == p.coord(i).cell) {
-      match.bins_.push_back(offset);
-      match.weights_.push_back(1.0);
+      match.set(offset);
       return;
     }
   }

--- a/src/tallies/filter_energy.cpp
+++ b/src/tallies/filter_energy.cpp
@@ -61,11 +61,10 @@ void EnergyFilter::get_all_bins(
 {
   if (p.g() != C_NONE && matches_transport_groups_) {
     if (estimator == TallyEstimator::TRACKLENGTH) {
-      match.bins_.push_back(data::mg.num_energy_groups_ - p.g() - 1);
+      match.set(data::mg.num_energy_groups_ - p.g() - 1);
     } else {
-      match.bins_.push_back(data::mg.num_energy_groups_ - p.g_last() - 1);
+      match.set(data::mg.num_energy_groups_ - p.g_last() - 1);
     }
-    match.weights_.push_back(1.0);
 
   } else {
     // Get the pre-collision energy of the particle.
@@ -74,8 +73,7 @@ void EnergyFilter::get_all_bins(
     // Bin the energy.
     if (E >= bins_.front() && E <= bins_.back()) {
       auto bin = lower_bound_index(bins_.begin(), bins_.end(), E);
-      match.bins_.push_back(bin);
-      match.weights_.push_back(1.0);
+      match.set(bin);
     }
   }
 }
@@ -99,14 +97,12 @@ void EnergyoutFilter::get_all_bins(
   const Particle& p, TallyEstimator estimator, FilterMatch& match) const
 {
   if (p.g() != C_NONE && matches_transport_groups_) {
-    match.bins_.push_back(data::mg.num_energy_groups_ - p.g() - 1);
-    match.weights_.push_back(1.0);
+    match.set(data::mg.num_energy_groups_ - p.g() - 1);
 
   } else {
     if (p.E() >= bins_.front() && p.E() <= bins_.back()) {
       auto bin = lower_bound_index(bins_.begin(), bins_.end(), p.E());
-      match.bins_.push_back(bin);
-      match.weights_.push_back(1.0);
+      match.set(bin);
     }
   }
 }

--- a/src/tallies/filter_energyfunc.cpp
+++ b/src/tallies/filter_energyfunc.cpp
@@ -98,8 +98,7 @@ void EnergyFunctionFilter::get_all_bins(
     double w = interpolate(energy_, y_, p.E_last(), interpolation_);
 
     // Interpolate on the lin-lin grid.
-    match.bins_.push_back(0);
-    match.weights_.push_back(w);
+    match.set(0, w);
   }
 }
 

--- a/src/tallies/filter_legendre.cpp
+++ b/src/tallies/filter_legendre.cpp
@@ -24,11 +24,14 @@ void LegendreFilter::set_order(int order)
 void LegendreFilter::get_all_bins(
   const Particle& p, TallyEstimator estimator, FilterMatch& match) const
 {
+  // TODO use recursive formula. Allocating on the fly
+  // is expensive.
   vector<double> wgt(n_bins_);
   calc_pn_c(order_, p.mu(), wgt.data());
+
+  auto& match_vector = match.vector_pairs();
   for (int i = 0; i < n_bins_; i++) {
-    match.bins_.push_back(i);
-    match.weights_.push_back(wgt[i]);
+    match_vector.push_back({i, wgt[i]});
   }
 }
 

--- a/src/tallies/filter_material.cpp
+++ b/src/tallies/filter_material.cpp
@@ -47,8 +47,7 @@ void MaterialFilter::get_all_bins(
 {
   auto search = map_.find(p.material());
   if (search != map_.end()) {
-    match.bins_.push_back(search->second);
-    match.weights_.push_back(1.0);
+    match.set(search->second);
   }
 }
 

--- a/src/tallies/filter_materialfrom.cpp
+++ b/src/tallies/filter_materialfrom.cpp
@@ -10,8 +10,7 @@ void MaterialFromFilter::get_all_bins(
 {
   auto search = map_.find(p.material_last());
   if (search != map_.end()) {
-    match.bins_.push_back(search->second);
-    match.weights_.push_back(1.0);
+    match.set(search->second);
   }
 }
 

--- a/src/tallies/filter_mesh.cpp
+++ b/src/tallies/filter_mesh.cpp
@@ -50,12 +50,10 @@ void MeshFilter::get_all_bins(
   if (estimator != TallyEstimator::TRACKLENGTH) {
     auto bin = model::meshes[mesh_]->get_bin(r);
     if (bin >= 0) {
-      match.bins_.push_back(bin);
-      match.weights_.push_back(1.0);
+      match.set(bin);
     }
   } else {
-    model::meshes[mesh_]->bins_crossed(
-      last_r, r, u, match.bins_, match.weights_);
+    model::meshes[mesh_]->bins_crossed(last_r, r, u, match.vector_pairs());
   }
 }
 

--- a/src/tallies/filter_meshsurface.cpp
+++ b/src/tallies/filter_meshsurface.cpp
@@ -18,9 +18,7 @@ void MeshSurfaceFilter::get_all_bins(
   }
 
   Direction u = p.u();
-  model::meshes[mesh_]->surface_bins_crossed(r0, r1, u, match.bins_);
-  for (auto b : match.bins_)
-    match.weights_.push_back(1.0);
+  model::meshes[mesh_]->surface_bins_crossed(r0, r1, u, match.vector_pairs());
 }
 
 std::string MeshSurfaceFilter::text_label(int bin) const

--- a/src/tallies/filter_mu.cpp
+++ b/src/tallies/filter_mu.cpp
@@ -53,8 +53,7 @@ void MuFilter::get_all_bins(
 {
   if (p.mu() >= bins_.front() && p.mu() <= bins_.back()) {
     auto bin = lower_bound_index(bins_.begin(), bins_.end(), p.mu());
-    match.bins_.push_back(bin);
-    match.weights_.push_back(1.0);
+    match.set(bin);
   }
 }
 

--- a/src/tallies/filter_particle.cpp
+++ b/src/tallies/filter_particle.cpp
@@ -34,10 +34,11 @@ void ParticleFilter::set_particles(gsl::span<ParticleType> particles)
 void ParticleFilter::get_all_bins(
   const Particle& p, TallyEstimator estimator, FilterMatch& match) const
 {
+  // TODO improve this. Build a map with p.type() cast to int
+  // as array indices mapping to particles_ indices.
   for (auto i = 0; i < particles_.size(); i++) {
     if (particles_[i] == p.type()) {
-      match.bins_.push_back(i);
-      match.weights_.push_back(1.0);
+      match.set(i);
     }
   }
 }

--- a/src/tallies/filter_polar.cpp
+++ b/src/tallies/filter_polar.cpp
@@ -58,8 +58,7 @@ void PolarFilter::get_all_bins(
 
   if (theta >= bins_.front() && theta <= bins_.back()) {
     auto bin = lower_bound_index(bins_.begin(), bins_.end(), theta);
-    match.bins_.push_back(bin);
-    match.weights_.push_back(1.0);
+    match.set(bin);
   }
 }
 

--- a/src/tallies/filter_sph_harm.cpp
+++ b/src/tallies/filter_sph_harm.cpp
@@ -56,6 +56,10 @@ void SphericalHarmonicsFilter::get_all_bins(
     }
   }
 
+  // TODO allocating on the fly is expensive. Find a way
+  // to use the recursively defined basis functions in
+  // the below loop.
+
   // Find the Rn,m values
   vector<double> rn(n_bins_);
   calc_rn(order_, p.u_last(), rn.data());
@@ -66,9 +70,9 @@ void SphericalHarmonicsFilter::get_all_bins(
     int num_nm = 2 * n + 1;
 
     // Append the matching (bin,weight) for each moment
+    auto& match_vector = match.vector_pairs();
     for (int i = 0; i < num_nm; i++) {
-      match.weights_.push_back(wgt[n] * rn[j]);
-      match.bins_.push_back(j);
+      match_vector.push_back({j, wgt[n] * rn[j]});
       ++j;
     }
   }

--- a/src/tallies/filter_sptl_legendre.cpp
+++ b/src/tallies/filter_sptl_legendre.cpp
@@ -77,12 +77,16 @@ void SpatialLegendreFilter::get_all_bins(
     // Compute the normalized coordinate value.
     double x_norm = 2.0 * (x - min_) / (max_ - min_) - 1.0;
 
+    // TODO implement recursively defined Legendre polynomials
+    // to avoid expensive on-the-fly memory allocations
+
     // Compute and return the Legendre weights.
     vector<double> wgt(order_ + 1);
+
     calc_pn_c(order_, x_norm, wgt.data());
+    auto& match_vector = match.vector_pairs();
     for (int i = 0; i < order_ + 1; i++) {
-      match.bins_.push_back(i);
-      match.weights_.push_back(wgt[i]);
+      match_vector.push_back({i, wgt[i]});
     }
   }
 }

--- a/src/tallies/filter_surface.cpp
+++ b/src/tallies/filter_surface.cpp
@@ -49,12 +49,7 @@ void SurfaceFilter::get_all_bins(
 {
   auto search = map_.find(std::abs(p.surface()) - 1);
   if (search != map_.end()) {
-    match.bins_.push_back(search->second);
-    if (p.surface() < 0) {
-      match.weights_.push_back(-1.0);
-    } else {
-      match.weights_.push_back(1.0);
-    }
+    match.set(search->second, p.surface() < 0 ? -1.0 : 1.0);
   }
 }
 

--- a/src/tallies/filter_universe.cpp
+++ b/src/tallies/filter_universe.cpp
@@ -48,8 +48,7 @@ void UniverseFilter::get_all_bins(
   for (int i = 0; i < p.n_coord(); i++) {
     auto search = map_.find(p.coord(i).universe);
     if (search != map_.end()) {
-      match.bins_.push_back(search->second);
-      match.weights_.push_back(1.0);
+      match.set(search->second);
     }
   }
 }

--- a/src/tallies/filter_zernike.cpp
+++ b/src/tallies/filter_zernike.cpp
@@ -36,12 +36,16 @@ void ZernikeFilter::get_all_bins(
   double theta = std::atan2(y, x);
 
   if (r <= 1.0) {
+
     // Compute and return the Zernike weights.
+    // TODO this allocates on the fly and is thus slow.
+    // Find a recursive definition if possible.
     vector<double> zn(n_bins_);
     calc_zn(order_, r, theta, zn.data());
+
+    auto& match_vector = match.vector_pairs();
     for (int i = 0; i < n_bins_; i++) {
-      match.bins_.push_back(i);
-      match.weights_.push_back(zn[i]);
+      match_vector.push_back({i, zn[i]});
     }
   }
 }
@@ -94,9 +98,9 @@ void ZernikeRadialFilter::get_all_bins(
     // Compute and return the Zernike weights.
     vector<double> zn(n_bins_);
     calc_zn_rad(order_, r, zn.data());
+    auto& match_vector = match.vector_pairs();
     for (int i = 0; i < n_bins_; i++) {
-      match.bins_.push_back(i);
-      match.weights_.push_back(zn[i]);
+      match_vector.emplace_back(i, zn[i]);
     }
   }
 }


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Slight refactor of FilterMatch that removes a large amount of indirection. Since most filters will only ever match a single bin, this code handles that case explicitly by letting FilterMatch keep track of whether it is a vector or scalar match type. I am yet to test it out on more cores, but it seems to work well on my laptop so far.

Another aspect is that it doesn't really make sense cache-wise to keep two separate vectors of int/double when they're always accessed synchronously (and in potentially very different locations in memory!). As a result, for the case when FilterMatches are vector, I've refactored to make them a vector<pair<int, double>> rather than vector<int> and vector<double> side by side.

Another aspect is having the FilterMatch provide a bin() and weight() method that refer to the bin/weight combination referred to i_bin, which the FilterBinIter is incrementing. This removed a lot of code where we access i_bin, save it, then index into arrays with that. Way easier to just have the FilterMatch handle that.

Will provide some numbers if I'm able to get a speedup on a many-core machine for a depletion calculation.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)

<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
