### PR TITLE
Improve cache hit rate in depletion calcs at the expense of extra memory

### DIFF
--- a/include/openmc/nuclide.h
+++ b/include/openmc/nuclide.h
@@ -130,6 +130,9 @@ public:
   array<size_t, 902> reaction_index_;      //!< Index of each reaction
   vector<int> index_inelastic_scatter_;
 
+  // Depletion rx index starting at XS_PHOTON_PROD+1 in xs_ arrays
+  vector<int> present_depletion_rx_;
+
 private:
   void create_derived(
     const Function1D* prompt_photons, const Function1D* delayed_photons);
@@ -140,11 +143,11 @@ private:
   //! \return Temperature index and interpolation factor
   std::pair<gsl::index, double> find_temperature(double T) const;
 
-  static int XS_TOTAL;
-  static int XS_ABSORPTION;
-  static int XS_FISSION;
-  static int XS_NU_FISSION;
-  static int XS_PHOTON_PROD;
+  static constexpr int XS_TOTAL = 0;
+  static constexpr int XS_ABSORPTION = 1;
+  static constexpr int XS_FISSION = 2;
+  static constexpr int XS_NU_FISSION = 3;
+  static constexpr int XS_PHOTON_PROD = 4;
 };
 
 //==============================================================================

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -362,8 +362,6 @@ void Nuclide::create_derived(
       grid.energy.size(), 5 + present_depletion_rx_.size()};
     xs_.emplace_back(shape, 0.0);
   }
-  std::cout << name_ << "has an extra " << present_depletion_rx_.size()
-            << " reactions" << std::endl;
 
   for (int i = 0; i < reactions_.size(); ++i) {
     const auto& rx {reactions_[i]};


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Increase cache hit rate by redundantly storing depletion reactions on the main nuclide energy grid. Thresholds are zero-padded. I found that this increased the tracking rate by 10% on a reasonably large depletion problem (CASL chain), at a cost of 580 extra MB of storage.

Maybe this should be an option that can be turned on? It would be really nice to just have unionized energy grid instead as an option.

I'm mainly just throwing this out here as something to consider. If others think it's best to use a bit less memory not have as high performance, all good by me! I think that on GPU this would be a particularly nice performance improvement since diverged memory accesses are so costly, but I'm yet to test that out.