### PR TITLE
Add `openmc_mesh_get_volumes` C API function

### DIFF
--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -106,6 +106,7 @@ int openmc_mesh_filter_set_translation(int32_t index, double translation[3]);
 int openmc_mesh_get_id(int32_t index, int32_t* id);
 int openmc_mesh_set_id(int32_t index, int32_t id);
 int openmc_mesh_get_n_elements(int32_t index, size_t* n);
+int openmc_mesh_get_volumes(int32_t index, double* volumes);
 int openmc_mesh_material_volumes(int32_t index, int n_sample, int bin,
   int result_size, void* result, int* hits, uint64_t* seed);
 int openmc_meshsurface_filter_get_mesh(int32_t index, int32_t* index_mesh);

--- a/openmc/lib/mesh.py
+++ b/openmc/lib/mesh.py
@@ -39,6 +39,9 @@ _dll.openmc_mesh_set_id.errcheck = _error_handler
 _dll.openmc_mesh_get_n_elements.argtypes = [c_int32, POINTER(c_size_t)]
 _dll.openmc_mesh_get_n_elements.restype = c_int
 _dll.openmc_mesh_get_n_elements.errcheck = _error_handler
+_dll.openmc_mesh_get_volumes.argtypes = [c_int32, POINTER(c_double)]
+_dll.openmc_mesh_get_volumes.restype = c_int
+_dll.openmc_mesh_get_volumes.errcheck = _error_handler
 _dll.openmc_mesh_material_volumes.argtypes = [
     c_int32, c_int, c_int, c_int, POINTER(_MaterialVolume),
     POINTER(c_int), POINTER(c_uint64)]
@@ -149,10 +152,17 @@ class Mesh(_FortranObjectWithID):
         _dll.openmc_mesh_set_id(self._index, mesh_id)
 
     @property
-    def n_elements(self):
+    def n_elements(self) -> int:
         n = c_size_t()
         _dll.openmc_mesh_get_n_elements(self._index, n)
         return n.value
+
+    @property
+    def volumes(self) -> np.ndarray:
+        volumes = np.empty((self.n_elements,))
+        _dll.openmc_mesh_get_volumes(
+            self._index, volumes.ctypes.data_as(POINTER(c_double)))
+        return volumes
 
     def material_volumes(
             self,
@@ -276,6 +286,10 @@ class RegularMesh(Mesh):
         are given, it is assumed that the mesh is an x-y mesh.
     width : numpy.ndarray
         The width of mesh cells in each direction.
+    n_elements : int
+        Total number of mesh elements.
+    volumes : numpy.ndarray
+        Volume of each mesh element in [cm^3]
 
     """
     mesh_type = 'regular'
@@ -358,6 +372,10 @@ class RectilinearMesh(Mesh):
         The upper-right corner of the structrued mesh.
     width : numpy.ndarray
         The width of mesh cells in each direction.
+    n_elements : int
+        Total number of mesh elements.
+    volumes : numpy.ndarray
+        Volume of each mesh element in [cm^3]
 
     """
     mesh_type = 'rectilinear'
@@ -457,6 +475,10 @@ class CylindricalMesh(Mesh):
         The upper-right corner of the structrued mesh.
     width : numpy.ndarray
         The width of mesh cells in each direction.
+    n_elements : int
+        Total number of mesh elements.
+    volumes : numpy.ndarray
+        Volume of each mesh element in [cm^3]
 
     """
     mesh_type = 'cylindrical'
@@ -555,6 +577,10 @@ class SphericalMesh(Mesh):
         The upper-right corner of the structrued mesh.
     width : numpy.ndarray
         The width of mesh cells in each direction.
+    n_elements : int
+        Total number of mesh elements.
+    volumes : numpy.ndarray
+        Volume of each mesh element in [cm^3]
 
     """
     mesh_type = 'spherical'

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -571,7 +571,7 @@ class Material(IDManagerMixin):
 
         for component, params in components.items():
             cv.check_type('component', component, str)
-            if isinstance(params, float):
+            if isinstance(params, Real):
                 params = {'percent': params}
 
             else:

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1881,6 +1881,17 @@ extern "C" int openmc_mesh_get_n_elements(int32_t index, size_t* n)
   return 0;
 }
 
+//! Get the volume of each element in the mesh
+extern "C" int openmc_mesh_get_volumes(int32_t index, double* volumes)
+{
+  if (int err = check_mesh(index))
+    return err;
+  for (int i = 0; i < model::meshes[index]->n_bins(); ++i) {
+    volumes[i] = model::meshes[index]->volume(i);
+  }
+  return 0;
+}
+
 extern "C" int openmc_mesh_material_volumes(int32_t index, int n_sample,
   int bin, int result_size, void* result, int* hits, uint64_t* seed)
 {


### PR DESCRIPTION
# Description

This PR adds an `openmc_mesh_get_volumes` C API function and corresponding Python binding as the `openmc.lib.Mesh.volumes` property. I'm planning on using this downstream in the plotter application to be able to plot volume-normalized mesh tallies.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)