### PR TITLE
Fix issue with Cell::get_contained_cells() utility function

### DIFF
--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1272,6 +1272,9 @@ struct ParentCellStack {
   //! compute an instance for the provided distribcell index
   int32_t compute_instance(int32_t distribcell_index) const
   {
+    if (distribcell_index == C_NONE)
+      return 0;
+
     int32_t instance = 0;
     for (const auto& parent_cell : this->parent_cells_) {
       auto& cell = model::cells[parent_cell.cell_index];


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR fixes an issue in the `Cell::find_parent_cells` and `Cell::Cell::get_contained_cells` utility functions. As it is now, the functions I think are only working when distrib materials are used. However, if used on regular cells, then there is an error mode that pops up. In particular, they pop up in the `ParentCellStack::compute_instance(int32_t distribcell_index)` function, which looks like:

```C++
 //! compute an instance for the provided distribcell index
  int32_t compute_instance(int32_t distribcell_index) const
  {
    int32_t instance = 0;
    for (const auto& parent_cell : this->parent_cells_) {
      auto& cell = model::cells[parent_cell.cell_index];
      if (cell->type_ == Fill::UNIVERSE) {
        instance += cell->offset_[distribcell_index];
      } else if (cell->type_ == Fill::LATTICE) {
        auto& lattice = model::lattices[cell->fill_];
        instance +=
          lattice->offset(distribcell_index, parent_cell.lattice_index);
      }
    }
    return instance;
  }
```

As the inputted `distribcell_index` will be `-1` when inputted for non-distribcell cell, this will lead to reading at the `-1` index of the `offset_` array, leading to undefined behavior.

I'm not sure how helpful it would be to develop a standalone regression test for this issue, as it deals with undefined memory access so may not expose the issue. I can confirm though that on a feature branch I'm working on for random ray the fix works (as the new feature calls the `Cell::Cell::get_contained_cells` function and only works correctly when the fix is in place). Let me know though @pshriwise if you'd like to see a test go in for this and I can cook one up.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

