### PR TITLE
Adding energy axis units to plot xs

### DIFF
--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -100,7 +100,7 @@ def _get_title(reactions):
 def plot_xs(reactions, divisor_types=None, temperature=294., axis=None,
             sab_name=None, ce_cross_sections=None, mg_cross_sections=None,
             enrichment=None, plot_CE=True, orders=None, divisor_orders=None,
-            **kwargs):
+            energy_axis_units="eV", **kwargs):
     """Creates a figure of continuous-energy cross sections for this item.
 
     Parameters
@@ -143,6 +143,10 @@ def plot_xs(reactions, divisor_types=None, temperature=294., axis=None,
     **kwargs :
         All keyword arguments are passed to
         :func:`matplotlib.pyplot.figure`.
+
+        .. versionadded:: 0.14.1
+    energy_axis_units : {'eV', 'KeV', 'MeV'}
+        Units used on the plot energy axis
 
     Returns
     -------
@@ -212,6 +216,9 @@ def plot_xs(reactions, divisor_types=None, temperature=294., axis=None,
                     if divisor_types[line] != 'unity':
                         types[line] += ' / ' + divisor_types[line]
 
+        axis_scaling_factor = {"eV": 1.0, "KeV": 1e-3, "MeV": 1e-6}
+        E = E * axis_scaling_factor[energy_axis_units]
+
         # Plot the data
         for i in range(len(data)):
             data[i, :] = np.nan_to_num(data[i, :])
@@ -227,9 +234,12 @@ def plot_xs(reactions, divisor_types=None, temperature=294., axis=None,
         ax.set_xscale('log')
         ax.set_yscale('log')
 
-    ax.set_xlabel('Energy [eV]')
+    ax.set_xlabel(f"Energy [{energy_axis_units}]")
     if plot_CE:
-        ax.set_xlim(_MIN_E, _MAX_E)
+        ax.set_xlim(
+            _MIN_E * axis_scaling_factor[energy_axis_units],
+            _MAX_E * axis_scaling_factor[energy_axis_units],
+        )
     else:
         ax.set_xlim(E[-1], E[0])
 

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -143,10 +143,10 @@ def plot_xs(reactions, divisor_types=None, temperature=294., axis=None,
     **kwargs :
         All keyword arguments are passed to
         :func:`matplotlib.pyplot.figure`.
-
-        .. versionadded:: 0.14.1
     energy_axis_units : {'eV', 'keV', 'MeV'}
         Units used on the plot energy axis
+
+        .. versionadded:: 0.14.1
 
     Returns
     -------
@@ -160,7 +160,7 @@ def plot_xs(reactions, divisor_types=None, temperature=294., axis=None,
     import matplotlib.pyplot as plt
 
     cv.check_type("plot_CE", plot_CE, bool)
-    cv.check_value("energy_axis_units", energy_axis_units, ["eV", "keV", "MeV"])
+    cv.check_value("energy_axis_units", energy_axis_units, {"eV", "keV", "MeV"})
 
     axis_scaling_factor = {"eV": 1.0, "keV": 1e-3, "MeV": 1e-6}
 
@@ -219,7 +219,7 @@ def plot_xs(reactions, divisor_types=None, temperature=294., axis=None,
                     if divisor_types[line] != 'unity':
                         types[line] += ' / ' + divisor_types[line]
 
-        E = E * axis_scaling_factor[energy_axis_units]
+        E *= axis_scaling_factor[energy_axis_units]
 
         # Plot the data
         for i in range(len(data)):

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -145,7 +145,7 @@ def plot_xs(reactions, divisor_types=None, temperature=294., axis=None,
         :func:`matplotlib.pyplot.figure`.
 
         .. versionadded:: 0.14.1
-    energy_axis_units : {'eV', 'KeV', 'MeV'}
+    energy_axis_units : {'eV', 'keV', 'MeV'}
         Units used on the plot energy axis
 
     Returns
@@ -160,6 +160,9 @@ def plot_xs(reactions, divisor_types=None, temperature=294., axis=None,
     import matplotlib.pyplot as plt
 
     cv.check_type("plot_CE", plot_CE, bool)
+    cv.check_value("energy_axis_units", energy_axis_units, ["eV", "keV", "MeV"])
+
+    axis_scaling_factor = {"eV": 1.0, "keV": 1e-3, "MeV": 1e-6}
 
     # Generate the plot
     if axis is None:
@@ -216,7 +219,6 @@ def plot_xs(reactions, divisor_types=None, temperature=294., axis=None,
                     if divisor_types[line] != 'unity':
                         types[line] += ' / ' + divisor_types[line]
 
-        axis_scaling_factor = {"eV": 1.0, "KeV": 1e-3, "MeV": 1e-6}
         E = E * axis_scaling_factor[energy_axis_units]
 
         # Plot the data

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -77,15 +77,18 @@ def test_plot_xs(this):
     from matplotlib.figure import Figure
     assert isinstance(openmc.plot_xs({this: ['total', 'elastic']}), Figure)
 
+
 def test_plot_xs_mat(test_mat):
     from matplotlib.figure import Figure
     assert isinstance(openmc.plot_xs({test_mat: ['total']}), Figure)
 
-@pytest.mark.parametrize("this", ["eV", "keV", "MeV"])
-def test_plot_xs_energy_axis(this):
-    plot=openmc.plot_xs({'Be9': ['(n,2n)']}, energy_axis_units=this)
+
+@pytest.mark.parametrize("units", ["eV", "keV", "MeV"])
+def test_plot_xs_energy_axis(units):
+    plot = openmc.plot_xs({'Be9': ['(n,2n)']}, energy_axis_units=units)
     axis_text = plot.get_axes()[0].get_xaxis().get_label().get_text()
-    assert axis_text == f'Energy [{this}]'
+    assert axis_text == f'Energy [{units}]'
+
 
 def test_plot_axes_labels():
     # just nuclides

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -81,7 +81,7 @@ def test_plot_xs_mat(test_mat):
     from matplotlib.figure import Figure
     assert isinstance(openmc.plot_xs({test_mat: ['total']}), Figure)
 
-@pytest.mark.parametrize("this", ["eV", "KeV", "MeV"])
+@pytest.mark.parametrize("this", ["eV", "keV", "MeV"])
 def test_plot_xs_energy_axis(this):
     plot=openmc.plot_xs({'Be9': ['(n,2n)']}, energy_axis_units=this)
     axis_text = plot.get_axes()[0].get_xaxis().get_label().get_text()

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -81,6 +81,12 @@ def test_plot_xs_mat(test_mat):
     from matplotlib.figure import Figure
     assert isinstance(openmc.plot_xs({test_mat: ['total']}), Figure)
 
+@pytest.mark.parametrize("this", ["eV", "KeV", "MeV"])
+def test_plot_xs_energy_axis(this):
+    plot=openmc.plot_xs({'Be9': ['(n,2n)']}, energy_axis_units=this)
+    axis_text = plot.get_axes()[0].get_xaxis().get_label().get_text()
+    assert axis_text == f'Energy [{this}]'
+
 def test_plot_axes_labels():
     # just nuclides
     axis_label = openmc.plotter._get_yaxis_label(


### PR DESCRIPTION
# Description

A tiny PR that removes the hard coding of energy units in eV when plotting cross sections.

I nearly always want to plot in MeV so it would be handy to be able to change these units.

The default remains ```eV``` so there will be no change of output or usage for existing users.

I added a small test that grabs the axis labels and checks their content is as expected and some value checking on the input value

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)