### PR TITLE
Set OpenMCOperator materials to the model materials when diff_burnable_mats = True

### DIFF
--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -142,6 +142,7 @@ class OpenMCOperator(TransportOperator):
 
         if diff_burnable_mats:
             self._differentiate_burnable_mats()
+            self.materials = self.model.materials
 
         # Determine which nuclides have cross section data
         # This nuclides variables contains every nuclides


### PR DESCRIPTION


<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

In a [post on the forum](https://openmc.discourse.group/t/problem-with-diff-burnable-mats-in-the-depletion-of-fuel-assembly/2148), a user mentioned that using `diff_burnable_mats = True` in depletion calculations causes an error message on the form of `ERROR: Could not find material 6 specified on cell 1`. The issue still persists on `0.14.0`, and does not seem to have been solved by #2037.

This seems to be due to the `materials.xml` file not containing the differentiated materials which is caused by the fact that `OpenMCOperator.materials` is still set to the old list of materials. Hence the change outlined in the PR would update `OpenMCOperator.materials` in the case that `diff_burnable_mats = True`. 

I am however not sure if this change should be done later in the `OpenMCOperator.__init__` code than what this PR suggests, and frankly I am not sure if this is even the best way of solving this issue, but it did work for my own work.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
