### PR TITLE
fix expansion filter merging

### DIFF
--- a/openmc/filter_expansion.py
+++ b/openmc/filter_expansion.py
@@ -53,6 +53,36 @@ class ExpansionFilter(Filter):
         order = int(elem.find('order').text)
         return cls(order, filter_id=filter_id)
 
+    def merge(self, other):
+        """Merge this filter with another.
+
+        This overrides the behavior of the
+        parent Filter class, since its merging
+        technique is to take the union of the set
+        of bins of each filter. That technique does
+        not apply to expansion filters, since the
+        argument should be the maximum filter order
+        rather than the list of all bins.
+
+        Parameters
+        ----------
+        other : openmc.Filter
+            Filter to merge with
+
+        Returns
+        -------
+        merged_filter : openmc.Filter
+            Filter resulting from the merge
+
+        """
+
+        if not self.can_merge(other):
+            msg = f'Unable to merge "{type(self)}" with "{type(other)}"'
+            raise ValueError(msg)
+
+        # Create a new filter with these bins and a new auto-generated ID
+        return type(self)(max(self.order, other.order))
+
 
 class LegendreFilter(ExpansionFilter):
     r"""Score Legendre expansion moments up to specified order.

--- a/openmc/filter_expansion.py
+++ b/openmc/filter_expansion.py
@@ -56,13 +56,11 @@ class ExpansionFilter(Filter):
     def merge(self, other):
         """Merge this filter with another.
 
-        This overrides the behavior of the
-        parent Filter class, since its merging
-        technique is to take the union of the set
-        of bins of each filter. That technique does
-        not apply to expansion filters, since the
-        argument should be the maximum filter order
-        rather than the list of all bins.
+        This overrides the behavior of the parent Filter class, since its
+        merging technique is to take the union of the set of bins of each
+        filter. That technique does not apply to expansion filters, since the
+        argument should be the maximum filter order rather than the list of all
+        bins.
 
         Parameters
         ----------


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Lets expansion filters be merged by addressing the fact that they don't just take a list of bins as a constructor argument.

Fixes #2881 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
