### PR TITLE
Added checks that tolerance value is between 0 and 1

### DIFF
--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -280,6 +280,9 @@ class Discrete(Univariate):
         Discrete distribution with low-importance points removed
 
         """
+        cv.check_less_than("tolerance", tolerance, 1.0, equality=True)
+        cv.check_greater_than("tolerance", tolerance, 0.0, equality=True)
+
         # Determine (reversed) sorted order of probabilities
         intensity = self.p * self.x
         index_sort = np.argsort(intensity)[::-1]

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -89,6 +89,12 @@ def test_clip_discrete():
     d_same = d.clip(1e-6, inplace=True)
     assert d_same is d
 
+    with pytest.raises(ValueError):
+        d.clip(-1.)
+    
+    with pytest.raises(ValueError):
+        d.clip(5)
+
 
 def test_uniform():
     a, b = 10.0, 20.0


### PR DESCRIPTION
# Description

While using material.get_decay_photon_energy() I realised that you can set the clip_tolerance to greater than 1 and the simulation will run.  However this value should be a fraction.   I have added 2 checks to the clip method that ensure the value is between 0 and 1 to protect against misuse in future.  I have also added to the tests to confirm that these checks work.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

