### PR TITLE
Statepoint file loading refactor and CAPI function

### DIFF
--- a/docs/source/pythonapi/capi.rst
+++ b/docs/source/pythonapi/capi.rst
@@ -43,6 +43,7 @@ Functions
    simulation_init
    simulation_finalize
    source_bank
+   statepoint_load
    statepoint_write
 
 Classes

--- a/docs/source/usersguide/settings.rst
+++ b/docs/source/usersguide/settings.rst
@@ -628,3 +628,37 @@ instance, whereas the :meth:`openmc.Track.filter` method returns a new
           .. code-block:: sh
 
             openmc-track-combine tracks_p*.h5 --out tracks.h5
+
+Simulation Restarts
+-------------------
+
+OpenMC can be run in a mode where it reads in a statepoint file and continues a
+simulation from the ending point of the statepoint file. A restart simulation
+can be performed by passing the path to the statepoint file to the OpenMC
+executable:
+
+.. code-block:: sh
+
+  openmc -r statepoint.100.h5
+
+OR
+
+.. code-block:: python
+
+  openmc.run(restart_file='statepoint.100.h5')
+
+OR
+
+.. code-block:: python
+
+
+  model.run(restart_file='statepoint.100.h5')
+
+The restart simulation will execute until the number of batches specified in the
+:class:`openmc.Settings` object on a model (or in the :ref:`settings XML file
+<io_settings>`) is satisfied. Note that if the number of batches in the
+statepoint file is the same as that speficied in the settings object/XML file
+(i.e. if the inputs were not modified before the restart run), no particles will
+be transported and OpenMC will exit immediately.
+
+.. note:: A statepoint file must match the input model to be successfully used in a restart simulation.

--- a/docs/source/usersguide/settings.rst
+++ b/docs/source/usersguide/settings.rst
@@ -629,8 +629,9 @@ instance, whereas the :meth:`openmc.Track.filter` method returns a new
 
             openmc-track-combine tracks_p*.h5 --out tracks.h5
 
-Simulation Restarts
--------------------
+-----------------------
+Restarting a Simulation
+-----------------------
 
 OpenMC can be run in a mode where it reads in a statepoint file and continues a
 simulation from the ending point of the statepoint file. A restart simulation
@@ -639,26 +640,25 @@ executable:
 
 .. code-block:: sh
 
-  openmc -r statepoint.100.h5
+    openmc -r statepoint.100.h5
 
-OR
-
-.. code-block:: python
-
-  openmc.run(restart_file='statepoint.100.h5')
-
-OR
+From the Python API, the `restart_file` argument provides the same behavior:
 
 .. code-block:: python
 
+    openmc.run(restart_file='statepoint.100.h5')
 
-  model.run(restart_file='statepoint.100.h5')
+or if using the :class:`~openmc.Model` class:
+
+.. code-block:: python
+
+    model.run(restart_file='statepoint.100.h5')
 
 The restart simulation will execute until the number of batches specified in the
-:class:`openmc.Settings` object on a model (or in the :ref:`settings XML file
+:class:`~openmc.Settings` object on a model (or in the :ref:`settings XML file
 <io_settings>`) is satisfied. Note that if the number of batches in the
-statepoint file is the same as that speficied in the settings object/XML file
-(i.e. if the inputs were not modified before the restart run), no particles will
-be transported and OpenMC will exit immediately.
+statepoint file is the same as that specified in the settings object (i.e., if
+the inputs were not modified before the restart run), no particles will be
+transported and OpenMC will exit immediately.
 
 .. note:: A statepoint file must match the input model to be successfully used in a restart simulation.

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -150,6 +150,7 @@ int openmc_sphharm_filter_get_cosine(int32_t index, char cosine[]);
 int openmc_sphharm_filter_set_order(int32_t index, int order);
 int openmc_sphharm_filter_set_cosine(int32_t index, const char cosine[]);
 int openmc_statepoint_write(const char* filename, bool* write_source);
+int openmc_statepoint_load(const char* filename);
 int openmc_tally_allocate(int32_t index, const char* type);
 int openmc_tally_get_active(int32_t index, bool* active);
 int openmc_tally_get_estimator(int32_t index, int* estimator);

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -573,18 +573,16 @@ def statepoint_write(filename=None, write_source=True):
     _dll.openmc_statepoint_write(filename, c_bool(write_source))
 
 
-def statepoint_load(filename=None):
+def statepoint_load(filename):
     """Load a statepoint file.
 
     Parameters
     ----------
-    filename : str or None
-        Path to the statepoint to load. If None is passed, a default name that
-        contains the current batch will be written.
+    filename : str
+        Path to the statepoint to load.
 
     """
-    if filename is not None:
-        filename = c_char_p(str(filename).encode())
+    filename = c_char_p(str(filename).encode())
     _dll.openmc_statepoint_load(filename)
 
 

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -573,12 +573,12 @@ def statepoint_write(filename=None, write_source=True):
     _dll.openmc_statepoint_write(filename, c_bool(write_source))
 
 
-def statepoint_load(filename):
+def statepoint_load(filename: PathLike):
     """Load a statepoint file.
 
     Parameters
     ----------
-    filename : str
+    filename : path-like
         Path to the statepoint to load.
 
     """

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -96,6 +96,8 @@ _dll.openmc_statepoint_write.argtypes = [c_char_p, POINTER(c_bool)]
 _dll.openmc_statepoint_write.restype = c_int
 _dll.openmc_statepoint_write.errcheck = _error_handler
 _dll.openmc_statepoint_load.argtypes = [c_char_p]
+_dll.openmc_statepoint_load.restype = c_int
+_dll.openmc_statepoint_load.errcheck = _error_handler
 _dll.openmc_statepoint_write.restype = c_int
 _dll.openmc_statepoint_write.errcheck = _error_handler
 _dll.openmc_global_bounding_box.argtypes = [POINTER(c_double),
@@ -570,7 +572,17 @@ def statepoint_write(filename=None, write_source=True):
         filename = c_char_p(filename.encode())
     _dll.openmc_statepoint_write(filename, c_bool(write_source))
 
+
 def statepoint_load(filename=None):
+    """Load a statepoint file.
+
+    Parameters
+    ----------
+    filename : str or None
+        Path to the statepoint to load. If None is passed, a default name that
+        contains the current batch will be written.
+
+    """
     if filename is not None:
         filename = c_char_p(str(filename).encode())
     _dll.openmc_statepoint_load(filename)

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -95,6 +95,9 @@ _dll.openmc_simulation_finalize.errcheck = _error_handler
 _dll.openmc_statepoint_write.argtypes = [c_char_p, POINTER(c_bool)]
 _dll.openmc_statepoint_write.restype = c_int
 _dll.openmc_statepoint_write.errcheck = _error_handler
+_dll.openmc_statepoint_load.argtypes = [c_char_p]
+_dll.openmc_statepoint_write.restype = c_int
+_dll.openmc_statepoint_write.errcheck = _error_handler
 _dll.openmc_global_bounding_box.argtypes = [POINTER(c_double),
                                             POINTER(c_double)]
 _dll.openmc_global_bounding_box.restype = c_int
@@ -566,6 +569,11 @@ def statepoint_write(filename=None, write_source=True):
     if filename is not None:
         filename = c_char_p(filename.encode())
     _dll.openmc_statepoint_write(filename, c_bool(write_source))
+
+def statepoint_load(filename=None):
+    if filename is not None:
+        filename = c_char_p(str(filename).encode())
+    _dll.openmc_statepoint_load(filename)
 
 
 @contextmanager

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -214,6 +214,11 @@ int openmc_next_batch(int* status)
   using namespace openmc;
   using openmc::simulation::current_gen;
 
+  if (status && simulation::current_batch >= settings::n_max_batches) {
+    *status = STATUS_EXIT_MAX_BATCH;
+    return 0;
+  }
+
   // Make sure simulation has been initialized
   if (!simulation::initialized) {
     set_errmsg("Simulation has not been initialized yet.");

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -215,7 +215,8 @@ int openmc_next_batch(int* status)
   using openmc::simulation::current_gen;
 
   if (simulation::current_batch >= settings::n_max_batches) {
-    if (status) *status = STATUS_EXIT_MAX_BATCH;
+    if (status)
+      *status = STATUS_EXIT_MAX_BATCH;
     return 0;
   }
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -214,8 +214,8 @@ int openmc_next_batch(int* status)
   using namespace openmc;
   using openmc::simulation::current_gen;
 
-  if (status && simulation::current_batch >= settings::n_max_batches) {
-    *status = STATUS_EXIT_MAX_BATCH;
+  if (simulation::current_batch >= settings::n_max_batches) {
+    if (status) *status = STATUS_EXIT_MAX_BATCH;
     return 0;
   }
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -51,19 +51,17 @@
 
 int openmc_run()
 {
-
   openmc::simulation::time_total.start();
   openmc_simulation_init();
 
-  // this check ensures that a batch isn't executed in the case that
-  // the maximum number of batches has already been run in the
-  // statepoint file specified for use in the restart run
+  // Ensure that a batch isn't executed in the case that the maximum number of
+  // batches has already been run in a restart statepoint file
+  int status = 0;
   if (openmc::simulation::current_batch >= openmc::settings::n_max_batches) {
-    return 0;
+    status = openmc::STATUS_EXIT_MAX_BATCH;
   }
 
   int err = 0;
-  int status = 0;
   while (status == 0 && err == 0) {
     err = openmc_next_batch(&status);
   }

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -51,12 +51,14 @@
 
 int openmc_run()
 {
-  using namespace openmc;
 
   openmc::simulation::time_total.start();
   openmc_simulation_init();
 
-  if (simulation::current_batch >= settings::n_max_batches) {
+  // this check ensures that a batch isn't executed in the case that
+  // the maximum number of batches has already been run in the
+  // statepoint file specified for use in the restart run
+  if (openmc::simulation::current_batch >= openmc::settings::n_max_batches) {
     return 0;
   }
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -51,8 +51,14 @@
 
 int openmc_run()
 {
+  using namespace openmc;
+
   openmc::simulation::time_total.start();
   openmc_simulation_init();
+
+  if (simulation::current_batch >= settings::n_max_batches) {
+    return 0;
+  }
 
   int err = 0;
   int status = 0;
@@ -213,12 +219,6 @@ int openmc_next_batch(int* status)
 {
   using namespace openmc;
   using openmc::simulation::current_gen;
-
-  if (simulation::current_batch >= settings::n_max_batches) {
-    if (status)
-      *status = STATUS_EXIT_MAX_BATCH;
-    return 0;
-  }
 
   // Make sure simulation has been initialized
   if (!simulation::initialized) {

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -430,8 +430,8 @@ extern "C" int openmc_statepoint_load(const char* filename)
 
   if (simulation::restart_batch >= settings::n_max_batches) {
     warning(fmt::format(
-      "The number of batches specified for simulation ({}) is smaller"
-      " than or equal to the number of batches in the restart statepoint file ({})",
+      "The number of batches specified for simulation ({}) is smaller "
+      "than or equal to the number of batches in the restart statepoint file ({})",
       settings::n_max_batches, simulation::restart_batch));
   }
 

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -364,7 +364,8 @@ void restart_set_keff()
 
 void load_state_point()
 {
-  write_message(fmt::format("Loading state point {}...", settings::path_statepoint_c), 5);
+  write_message(
+    fmt::format("Loading state point {}...", settings::path_statepoint_c), 5);
   openmc_statepoint_load(settings::path_statepoint.c_str());
 }
 
@@ -431,7 +432,8 @@ extern "C" int openmc_statepoint_load(const char* filename)
   if (simulation::restart_batch >= settings::n_max_batches) {
     warning(fmt::format(
       "The number of batches specified for simulation ({}) is smaller "
-      "than or equal to the number of batches in the restart statepoint file ({})",
+      "than or equal to the number of batches in the restart statepoint file "
+      "({})",
       settings::n_max_batches, simulation::restart_batch));
   }
 

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -373,9 +373,9 @@ void statepoint_version_check(hid_t file_id)
 {
   // Read revision number for state point file and make sure it matches with
   // current version
-  array<int, 2> array;
-  read_attribute(file_id, "version", array);
-  if (array != VERSION_STATEPOINT) {
+  array<int, 2> version_array;
+  read_attribute(file_id, "version", version_array);
+  if (version_array != VERSION_STATEPOINT) {
     fatal_error(
       "State point version does not match current version in OpenMC.");
   }

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -365,10 +365,10 @@ void restart_set_keff()
 void load_state_point()
 {
   // Write message
-  write_message("Loading state point " + settings::path_statepoint + "...", 5);
+  write_message(fmt::format("Loading state point {}...", settings::path_statepoint_c), 5);
 
   // Open file for reading
-  hid_t file_id = file_open(settings::path_statepoint.c_str(), 'r', true);
+  hid_t file_id = file_open(settings::path_statepoint_c, 'r', true);
 
   // Read filetype
   std::string word;
@@ -420,12 +420,12 @@ void load_state_point()
   // Read batch number to restart at
   read_dataset(file_id, "current_batch", simulation::restart_batch);
 
-  if (simulation::restart_batch >= settings::n_max_batches) {
-    fatal_error(fmt::format(
-      "The number of batches specified for simulation ({}) is smaller"
-      " than the number of batches in the restart statepoint file ({})",
-      settings::n_max_batches, simulation::restart_batch));
-  }
+  // if (simulation::restart_batch >= settings::n_max_batches) {
+  //   fatal_error(fmt::format(
+  //     "The number of batches specified for simulation ({}) is smaller"
+  //     " than the number of batches in the restart statepoint file ({})",
+  //     settings::n_max_batches, simulation::restart_batch));
+  // }
 
   // Logical flag for source present in statepoint file
   bool source_present;
@@ -923,8 +923,6 @@ void write_tally_results_nr(hid_t file_id)
 
   for (const auto& t : model::tallies) {
     // Skip any tallies that are not active
-    if (!t->active_)
-      continue;
     if (!t->writable_)
       continue;
 
@@ -988,6 +986,14 @@ void write_tally_results_nr(hid_t file_id)
 
     close_group(tallies_group);
   }
+}
+
+extern "C" int openmc_statepoint_load(const char* filename) {
+  const char*  tmp = settings::path_statepoint_c;
+  if (filename)  settings::path_statepoint_c = filename;
+  load_state_point();
+  settings::path_statepoint_c = tmp;
+  return 0;
 }
 
 } // namespace openmc

--- a/tests/regression_tests/statepoint_restart/test.py
+++ b/tests/regression_tests/statepoint_restart/test.py
@@ -82,8 +82,6 @@ def test_batch_check(request, capsys):
         assert sp_file is None
 
         output = capsys.readouterr().out
-        output = re.sub(' +', ' ', output.replace('\n',' '))
-        print(output)
         assert "WARNING" in output
         assert "The number of batches specified for simulation" in output
 

--- a/tests/regression_tests/statepoint_restart/test.py
+++ b/tests/regression_tests/statepoint_restart/test.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import re
 
 import openmc
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR contains a slight refactor of the statepoint loading so it can more cleanly be exposed as part of the CAPI. 

It is also a continuation of #2390 in that the scenario where a statepoint is loaded with `n_batches` equal to `settings::n_max_batches` is softened to a warning. This allows previously executed statepoint files can be loaded into an initialized `openmc.lib` instance to recover tally information. An additional check for the current batch vs the max number of batches is added to `openmc_next_batch` to ensure that no particles will be transported in the case that the warning condition is triggered. 

I think this results in reasonable behavior in the case that a user feeds a statepoint file from a complete OpenMC run back into the `openmc` executable without modification of the batches in the settings file: OpenMC will initialize, load the statepoint file, produce the warning message as part of the statepoint file load, run zero batches, and finalize. Importantly, it will not overwrite the existing statepoint file in this case either. It's somewhat unfortunate that a user will have to wait for problem initialization to get this result, but this was true before these changes as well.

We're using this as part of a project with Cardinal to load reaction rate tallies into a separately initialized OpenMC problem to leverage the depletion module for the Bateman eq. solve before sending updated material compositions back into Cardinal.

I went ahead and added a section on simulation restarts as I didn't see any information on it outside of the restart flag passed to the executable.

The restart regression test needed some updating after this to use a fixture that allowed for a check that the correct warning is present. 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
~- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have ~added~ modified tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
