### PR TITLE
added check for length of value passed into EnergyFilter

### DIFF
--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1349,6 +1349,10 @@ class EnergyFilter(RealFilter):
     """
     units = 'eV'
 
+    def __init__(self, values, filter_id=None):
+        cv.check_length('values', values, 2)
+        super().__init__(values, filter_id)
+
     def get_bin_index(self, filter_bin):
         # Use lower energy bound to find index for RealFilters
         deltas = np.abs(self.bins[:, 1] - filter_bin[1]) / filter_bin[1]

--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -1,6 +1,6 @@
 import numpy as np
 import openmc
-from pytest import fixture, approx
+from pytest import fixture, approx, raises
 
 
 @fixture(scope='module')
@@ -246,6 +246,11 @@ def test_energy():
     f = openmc.EnergyFilter.from_group_structure('CCFE-709')
     assert f.bins.shape == (709, 2)
     assert len(f.values) == 710
+
+
+def test_energyfilter_error_handling():
+    with raises(ValueError):
+        openmc.EnergyFilter([1e6])
 
 
 def test_lethargy_bin_width():


### PR DESCRIPTION
Motivated put [this](https://openmc.discourse.group/t/neutron-flux-in-a-graphite-stack/3916/20?u=shimwell) thread on the forum where a user was able to make an EnergyFilter with a single value. In the docstring the energyfilter requires at least a pair of numbers to work.

This PR adds a check on the EnergyFilter value length to ensure it is a minimum value of 2.

# Description

Please include a summary of the change and which issue is fixed if applicable. Please also include relevant motivation and context.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

