### PR TITLE
Ensure that Model.run() works when specifying a custom XML path

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -488,8 +488,11 @@ class Model:
         # if the provided path doesn't end with the XML extension, assume the
         # input path is meant to be a directory. If the directory does not
         # exist, create it and place a 'model.xml' file there.
-        if not str(xml_path).endswith('.xml') and not xml_path.exists():
-            os.mkdir(xml_path)
+        if not str(xml_path).endswith('.xml'):
+            if not xml_path.exists():
+                os.mkdir(xml_path)
+            elif not xml_path.is_dir():
+                raise FileExistsError(f"File exists and is not a directory: '{xml_path}'")
             xml_path /= 'model.xml'
         # if this is an XML file location and the file's parent directory does
         # not exist, create it before continuing

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -709,9 +709,10 @@ class Model:
                     self.export_to_model_xml(**export_kwargs)
                 else:
                     self.export_to_xml(**export_kwargs)
+                path_input = export_kwargs.get("path", None)
                 openmc.run(particles, threads, geometry_debug, restart_file,
                            tracks, output, Path('.'), openmc_exec, mpi_args,
-                           event_based)
+                           event_based, path_input)
 
             # Get output directory and return the last statepoint written
             if self.settings.output and 'path' in self.settings.output:

--- a/tests/unit_tests/test_deplete_chain.py
+++ b/tests/unit_tests/test_deplete_chain.py
@@ -5,6 +5,7 @@ from itertools import product
 from math import log
 import os
 from pathlib import Path
+import warnings
 
 import numpy as np
 from openmc.mpi import comm
@@ -438,9 +439,9 @@ def test_validate(simple_chain):
     simple_chain["C"].yield_data = {0.0253: {"A": 1.4, "B": 0.6}}
 
     assert simple_chain.validate(strict=True, tolerance=0.0)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         assert simple_chain.validate(strict=False, quiet=False, tolerance=0.0)
-    assert len(record) == 0
 
     # Mess up "earlier" nuclide's reactions
     decay_mode = simple_chain["A"].decay_modes.pop()

--- a/tests/unit_tests/test_deplete_nuclide.py
+++ b/tests/unit_tests/test_deplete_nuclide.py
@@ -1,6 +1,7 @@
 """Tests for the openmc.deplete.Nuclide class."""
 
 import copy
+import warnings
 
 import lxml.etree as ET
 import numpy as np
@@ -277,9 +278,9 @@ def test_validate():
     }
 
     # nuclide is good and should have no warnings raise
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         assert nuc.validate(strict=True, quiet=False, tolerance=0.0)
-    assert len(record) == 0
 
     # invalidate decay modes
     decay = nuc.decay_modes.pop()

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -588,3 +588,6 @@ def test_single_xml_exec(run_in_tmpdir):
 
     # Make sure path can be specified with run
     pincell_model.run(path='my_model.xml')
+
+    os.mkdir('subdir')
+    pincell_model.run(path='subdir')

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -585,3 +585,6 @@ def test_single_xml_exec(run_in_tmpdir):
 
     with pytest.raises(RuntimeError, match='input_dir'):
         openmc.run(path_input='input_dir/pincell.xml')
+
+    # Make sure path can be specified with run
+    pincell_model.run(path='my_model.xml')


### PR DESCRIPTION
# Description

The `Model.run()` method allows you to specify keyword arguments that are passed to `export_to_model_xml`. If you pass a `path` keyword argument, it will be used to write the corresponding XML file but it is not taken into account in the call to `openmc.run` which will cause it to look for "model.xml" (or a set of individual XML files). This change ensures that when the user calls `model.run(path=...)`, the right path is used in the call to `openmc.run()`.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)