### PR TITLE
abort on cmake config if openmp requested but not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,12 +193,10 @@ endif()
 if(NOT MSVC)
 
 if(OPENMC_USE_OPENMP)
-  find_package(OpenMP)
-  if(OPENMP_FOUND)
-    # In CMake 3.9+, can use the OpenMP::OpenMP_CXX imported target
-    list(APPEND cxxflags ${OpenMP_CXX_FLAGS})
-    list(APPEND ldflags ${OpenMP_CXX_FLAGS})
-  endif()
+  find_package(OpenMP REQUIRED)
+  # In CMake 3.9+, can use the OpenMP::OpenMP_CXX imported target
+  list(APPEND cxxflags ${OpenMP_CXX_FLAGS})
+  list(APPEND ldflags ${OpenMP_CXX_FLAGS})
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

We should not let CMake silently fail if CMake can't find OpenMP. Currently, the CMake flags for OpenMP can be set, but if it's not available on the system (a rarity but for Macs by default it seems!) the configuration proceeds anyway. I found it strange that this fancy Apple silicon was lagging, and of course observing the output header, no thread count info was provided!

This is an unexpected failure with a one-line fix. If a user wishes to not use OpenMP, it should be reflected in the CMake configuration flags.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
