### PR TITLE
added damage-energy as optional reaction for micro

### DIFF
--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -24,6 +24,7 @@ import openmc.lib
 
 _valid_rxns = list(REACTIONS)
 _valid_rxns.append('fission')
+_valid_rxns.append('damage-energy')
 
 
 def _resolve_chain_file_path(chain_file: str):


### PR DESCRIPTION
# Description

This PR attempts to add ```damage-energy``` to the reactions available for MicroXS. This would help with [this forum](https://openmc.discourse.group/t/dpa-calculation/4028) post where a user requested the ability to get DPA from a flux spectrum.

Fixes # (issue)
[forum issue](https://openmc.discourse.group/t/dpa-calculation/4028)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)