### PR TITLE
Implemented contains for BoundingBox containing other BoundingBox

### DIFF
--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -103,20 +103,12 @@ class BoundingBox:
 
         """
         # test for a single point
-        if isinstance(other, (tuple, list)):
+        if isinstance(other, (tuple, list, np.ndarray)):
             point = other
             check_length("Point", point, 3, 3)
             return all(point > self.lower_left) and all(point < self.upper_right)
         elif isinstance(other, BoundingBox):
-            return all(
-                [
-                    all(other_p > self_p) and all(other_p < self_p)
-                    for other_p, self_p in zip(
-                        [other.lower_left, other.upper_right],
-                        [self.lower_left, self.upper_right],
-                    )
-                ]
-            )
+            return all([p in self for p in [other.lower_left, other.upper_right]])
         else:
             raise TypeError(
                 f"Unable to test if {other} is in the bounding box."

--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -98,9 +98,7 @@ class BoundingBox:
     def __contains__(self, other):
         """Check whether or not a point or another bounding box is in the bounding box.
 
-        For another bounding box to be in the parent it must lie fully inside of it,
-        with no overlap.
-
+        For another bounding box to be in the parent it must lie fully inside of it.
         """
         # test for a single point
         if isinstance(other, (tuple, list, np.ndarray)):
@@ -111,7 +109,7 @@ class BoundingBox:
             return all([p in self for p in [other.lower_left, other.upper_right]])
         else:
             raise TypeError(
-                f"Unable to test if {other} is in the bounding box."
+                f"Unable to determine if {other} is in the bounding box."
                 f" Expected a tuple or a bounding box, but {type(other)} given"
             )
 

--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -95,9 +95,33 @@ class BoundingBox:
         new |= other
         return new
 
-    def __contains__(self, point):
-        """Check whether or not a point is in the bounding box"""
-        return all(point > self.lower_left) and all(point < self.upper_right)
+    def __contains__(self, other):
+        """Check whether or not a point or another bounding box is in the bounding box.
+
+        For another bounding box to be in the parent it must lie fully inside of it,
+        with no overlap.
+
+        """
+        # test for a single point
+        if isinstance(other, (tuple, list)):
+            point = other
+            check_length("Point", point, 3, 3)
+            return all(point > self.lower_left) and all(point < self.upper_right)
+        elif isinstance(other, BoundingBox):
+            return all(
+                [
+                    all(other_p > self_p) and all(other_p < self_p)
+                    for other_p, self_p in zip(
+                        [other.lower_left, other.upper_right],
+                        [self.lower_left, self.upper_right],
+                    )
+                ]
+            )
+        else:
+            raise TypeError(
+                f"Unable to test if {other} is in the bounding box."
+                f" Expected a tuple or a bounding box, but {type(other)} given"
+            )
 
     @property
     def center(self) -> np.ndarray:

--- a/tests/unit_tests/test_bounding_box.py
+++ b/tests/unit_tests/test_bounding_box.py
@@ -78,9 +78,9 @@ def test_bounding_box_input_checking():
 
 
 def test_bounding_box_extents():
-    assert test_bb_1.extent['xy'] == (-10., 1., -20., 2.)
-    assert test_bb_1.extent['xz'] == (-10., 1., -30., 3.)
-    assert test_bb_1.extent['yz'] == (-20., 2., -30., 3.)
+    assert test_bb_1.extent["xy"] == (-10.0, 1.0, -20.0, 2.0)
+    assert test_bb_1.extent["xz"] == (-10.0, 1.0, -30.0, 3.0)
+    assert test_bb_1.extent["yz"] == (-20.0, 2.0, -30.0, 3.0)
 
 
 def test_bounding_box_methods():
@@ -157,25 +157,27 @@ def test_bounding_box_methods():
     assert all(test_bb[0] == [-50.1, -50.1, -12.1])
     assert all(test_bb[1] == [50.1, 14.1, 50.1])
 
+
 @pytest.mark.parametrize(
     "bb, other, expected",
     [
         (test_bb_1, (0, 0, 0), True),
         (test_bb_2, (3, 3, 3), False),
         (test_bb_1, test_bb_2, False),
-        (test_bb_1, openmc.BoundingBox((-9, -19, -29), (0, 0, 0)), True)
+        (test_bb_1, openmc.BoundingBox((-9, -19, -29), (0, 0, 0)), True),
     ],
 )
 def test_bounding_box_contains(bb, other, expected):
     assert (other in bb) == expected
 
+
 @pytest.mark.parametrize(
     "invalid, ex",
     [
-        ((1,0), ValueError),
-        ((1,2,3,4), ValueError),
+        ((1, 0), ValueError),
+        ((1, 2, 3, 4), ValueError),
         ("foo", TypeError),
-    ]
+    ],
 )
 def test_bounding_box_contains_checking(invalid, ex):
     with pytest.raises(ex):

--- a/tests/unit_tests/test_bounding_box.py
+++ b/tests/unit_tests/test_bounding_box.py
@@ -163,8 +163,14 @@ def test_bounding_box_methods():
     [
         (test_bb_1, (0, 0, 0), True),
         (test_bb_2, (3, 3, 3), False),
+        # completely disjoint
         (test_bb_1, test_bb_2, False),
+        # contained but touching border
+        (test_bb_1, test_bb_3, False),
+        # Fully contained
         (test_bb_1, openmc.BoundingBox((-9, -19, -29), (0, 0, 0)), True),
+        # intersecting boxes
+        (test_bb_1, openmc.BoundingBox((-9, -19, -29), (1, 2, 5)), False),
     ],
 )
 def test_bounding_box_contains(bb, other, expected):

--- a/tests/unit_tests/test_bounding_box.py
+++ b/tests/unit_tests/test_bounding_box.py
@@ -45,7 +45,7 @@ def test_bounding_upper_right(bb, expected):
 
 
 @pytest.mark.parametrize(
-    "bb, expected",
+    "bb, expected", 
     [
         (test_bb_1, np.array([-4.5, -9.0, -13.5])),
         (test_bb_2, np.array([6.0, 12.0, 18.0])),
@@ -156,3 +156,27 @@ def test_bounding_box_methods():
 
     assert all(test_bb[0] == [-50.1, -50.1, -12.1])
     assert all(test_bb[1] == [50.1, 14.1, 50.1])
+
+@pytest.mark.parametrize(
+    "bb, other, expected",
+    [
+        (test_bb_1, (0, 0, 0), True),
+        (test_bb_2, (3, 3, 3), False),
+        (test_bb_1, test_bb_2, False),
+        (test_bb_1, openmc.BoundingBox((-9, -19, -29), (0, 0, 0)), True)
+    ],
+)
+def test_bounding_box_contains(bb, other, expected):
+    assert (other in bb) == expected
+
+@pytest.mark.parametrize(
+    "invalid, ex",
+    [
+        ((1,0), ValueError),
+        ((1,2,3,4), ValueError),
+        ("foo", TypeError),
+    ]
+)
+def test_bounding_box_contains_checking(invalid, ex):
+    with pytest.raises(ex):
+        invalid in test_bb_1

--- a/tests/unit_tests/test_bounding_box.py
+++ b/tests/unit_tests/test_bounding_box.py
@@ -45,7 +45,7 @@ def test_bounding_upper_right(bb, expected):
 
 
 @pytest.mark.parametrize(
-    "bb, expected", 
+    "bb, expected",
     [
         (test_bb_1, np.array([-4.5, -9.0, -13.5])),
         (test_bb_2, np.array([6.0, 12.0, 18.0])),


### PR DESCRIPTION
# Description

This is a quality of life feature request that tests if things are inside of a `BoundingBox`. Originally the goal was to have `if point in box` and `if other_box in box`. Turns out since #2759, `if point in box` has been implemented.

This PR does the following:

* Implement checking if a bounding box is inside of another: `if other_box in box`
* Implements length enforcement for points so: `[1]*100 in box` gives a helpful error.
* Implements type checking so `if "foo" in box` gives a helpful error.
* Adds two unit tests to test the `__contains__` function for `BoundingBox` to test it's accuracy, and the other tests it's error handling. 


It is unclear if this should be explicitly documented for users or not. 

Fixes #2896 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
