### PR TITLE
docs: add missing max_splits in settings specification

### DIFF
--- a/docs/source/io_formats/settings.rst
+++ b/docs/source/io_formats/settings.rst
@@ -276,6 +276,13 @@ then, OpenMC will only use up to the :math:`P_1` data.
   .. note:: This element is not used in the continuous-energy
     :ref:`energy_mode`.
 
+---------------------------
+``<max_splits>`` Element
+---------------------------
+
+The ``<max_splits>`` element indicates the number of times a particle can split during a history. 
+
+  *Default*: 1000
 
 --------------------------------------
 ``<max_write_lost_particles>`` Element


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR adds `max_splits` which is missing in the documentation. Also, thanks for teade to point out the difference between `max_split` and `max_splits` in https://github.com/openmc-dev/openmc/issues/2774#issue-1990206396 which confused me a lot before.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
