### PR TITLE
Mkdir to always allow parents and exist ok

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -497,7 +497,7 @@ class Model:
         # if this is an XML file location and the file's parent directory does
         # not exist, create it before continuing
         elif not xml_path.parent.exists():
-            xml_path.mkdir(parents=True, exist_ok=True)
+            xml_path.parent.mkdir(parents=True, exist_ok=True)
 
         if remove_surfs:
             warnings.warn("remove_surfs kwarg will be deprecated soon, please "

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -449,7 +449,7 @@ class Model:
         # Create directory if required
         d = Path(directory)
         if not d.is_dir():
-            d.mkdir(parents=True)
+            d.mkdir(parents=True, exist_ok=True)
 
         self.settings.export_to_xml(d)
         self.geometry.export_to_xml(d, remove_surfs=remove_surfs)
@@ -490,14 +490,14 @@ class Model:
         # exist, create it and place a 'model.xml' file there.
         if not str(xml_path).endswith('.xml'):
             if not xml_path.exists():
-                os.mkdir(xml_path)
+                xml_path.mkdir(parents=True, exist_ok=True)
             elif not xml_path.is_dir():
                 raise FileExistsError(f"File exists and is not a directory: '{xml_path}'")
             xml_path /= 'model.xml'
         # if this is an XML file location and the file's parent directory does
         # not exist, create it before continuing
         elif not xml_path.parent.exists():
-            os.mkdir(xml_path.parent)
+            xml_path.mkdir(parents=True, exist_ok=True)
 
         if remove_surfs:
             warnings.warn("remove_surfs kwarg will be deprecated soon, please "


### PR DESCRIPTION
# Description

Following up on PR #2889 I think this PR allows the provided path to be a subdirectory with multiple levels of directory. I also spotted a few other places in model.py where we assume the directory is just one level deep so I updated them as well by adding ```parents=True``` to the mkdir command

Fixes # (issue)
addresses comment in PR #2889 https://github.com/openmc-dev/openmc/pull/2889#issuecomment-1993980764

# Checklist

- [x] I have performed a self-review of my own code

