### PR TITLE
Fix Chain.form_matrix to work with scipy 1.12

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -597,8 +597,11 @@ class Chain:
         --------
         :meth:`get_default_fission_yields`
         """
-        matrix = defaultdict(float)
         reactions = set()
+
+        # Use DOK matrix as intermediate representation for matrix
+        n = len(self)
+        matrix = sp.dok_matrix((n, n))
 
         if fission_yields is None:
             fission_yields = self.get_default_fission_yields()
@@ -674,11 +677,8 @@ class Chain:
                 # Clear set of reactions
                 reactions.clear()
 
-        # Use DOK matrix as intermediate representation, then convert to CSC and return
-        n = len(self)
-        matrix_dok = sp.dok_matrix((n, n))
-        dict.update(matrix_dok, matrix)
-        return matrix_dok.tocsc()
+        # Return CSC representation instead of DOK
+        return matrix.tocsc()
 
     def form_rr_term(self, tr_rates, mats):
         """Function to form the transfer rate term matrices.
@@ -711,7 +711,9 @@ class Chain:
             Sparse matrix representing transfer term.
 
         """
-        matrix = defaultdict(float)
+        # Use DOK as intermediate representation
+        n = len(self)
+        matrix = sp.dok_matrix((n, n))
 
         for i, nuc in enumerate(self.nuclides):
             elm = re.split(r'\d+', nuc.name)[0]
@@ -737,10 +739,9 @@ class Chain:
                 else:
                     matrix[i, i] = 0.0
             #Nothing else is allowed
-        n = len(self)
-        matrix_dok = sp.dok_matrix((n, n))
-        dict.update(matrix_dok, matrix)
-        return matrix_dok.tocsc()
+
+        # Return CSC instead of DOK
+        return matrix.tocsc()
 
     def get_branch_ratios(self, reaction="(n,gamma)"):
         """Return a dictionary with reaction branching ratios

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ kwargs = {
     # Dependencies
     'python_requires': '>=3.7',
     'install_requires': [
-        'numpy>=1.9', 'h5py', 'scipy<1.12', 'ipython', 'matplotlib',
+        'numpy>=1.9', 'h5py', 'scipy', 'ipython', 'matplotlib',
         'pandas', 'lxml', 'uncertainties'
     ],
     'extras_require': {


### PR DESCRIPTION
# Description

The release of scipy 1.12 apparently broke OpenMC's depletion solver, which we deployed a temporary workaround for in #2854 by forcing CI to use an older version. This PR fixes the underlying issue so that the depletion solver works with scipy 1.12.

The problem was this line:
https://github.com/openmc-dev/openmc/blob/23f19a0310f462c81313d4e21f3cb08a3695e85f/openmc/deplete/chain.py#L680

In this line, `matrix_dok` is a `scipy.sparse.dok_matrix` object, which prior to scipy 1.12 directly subclassed the `dict` class. However, in scipy 1.12 the design was changed so that a dictionary was stored as an attribute rather than the class subclassing `dict` directly (see scipy/scipy#18929), which breaks the implicit assumption of the line above that it can be treated like a dictionary. The reason this was originally done in OpenMC was because the performance of building a dictionary of (i, j) to matrix element values and then using that to update the DOK matrix all at once was found to be faster than incrementally updating a `dok_matrix`, but with the updates in scipy 1.12, the performance for this operation directly on the `dok_matrix` is supposed to be improved. So, my solution in this PR is to get rid of the temporary dict used to map (i, j) to matrix elements and instead update the `dok_matrix` directly.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>