### PR TITLE
Allow zero bins in tally triggers

### DIFF
--- a/docs/source/io_formats/tallies.rst
+++ b/docs/source/io_formats/tallies.rst
@@ -100,7 +100,7 @@ The ``<tally>`` element accepts the following sub-elements:
 
      *Default*: None
 
-   :allow_zero:
+   :ignore_zeros:
      Whether to allow zero tally bins to be ignored when assessing the
      convergece of the precision trigger. If True, only nonzero tally scores
      will be compared to the trigger's threshold.

--- a/docs/source/io_formats/tallies.rst
+++ b/docs/source/io_formats/tallies.rst
@@ -105,6 +105,11 @@ The ``<tally>`` element accepts the following sub-elements:
      convergece of the precision trigger. If True, only nonzero tally scores
      will be compared to the trigger's threshold.
 
+     .. note:: The ``ignore_zeros`` option can cause the tally trigger to fire
+               prematurely if there are no hits in any bins at the first
+               evalulation. It is the user's responsibility to specify enough
+               particles per batch to get a nonzero score in at least one bin.
+     
      *Default*: False
 
    :scores:

--- a/docs/source/io_formats/tallies.rst
+++ b/docs/source/io_formats/tallies.rst
@@ -100,6 +100,13 @@ The ``<tally>`` element accepts the following sub-elements:
 
      *Default*: None
 
+   :allow_zero:
+     Whether to allow zero tally bins to be ignored when assessing the
+     convergece of the precision trigger. If True, only nonzero tally scores
+     will be compared to the trigger's threshold.
+
+     *Default*: False
+
    :scores:
      The score(s) in this tally to which the trigger should be applied.
 

--- a/include/openmc/tallies/trigger.h
+++ b/include/openmc/tallies/trigger.h
@@ -23,6 +23,7 @@ enum class TriggerMetric {
 struct Trigger {
   TriggerMetric metric; //!< The type of uncertainty (e.g. std dev) measured
   double threshold;     //!< Uncertainty value below which trigger is satisfied
+  bool allow_zero;      //!< Whether to allow zero tally bins to be ignored
   int score_index;      //!< Index of the relevant score in the tally's arrays
 };
 

--- a/include/openmc/tallies/trigger.h
+++ b/include/openmc/tallies/trigger.h
@@ -23,7 +23,7 @@ enum class TriggerMetric {
 struct Trigger {
   TriggerMetric metric; //!< The type of uncertainty (e.g. std dev) measured
   double threshold;     //!< Uncertainty value below which trigger is satisfied
-  bool allow_zero;      //!< Whether to allow zero tally bins to be ignored
+  bool ignore_zeros;    //!< Whether to allow zero tally bins to be ignored
   int score_index;      //!< Index of the relevant score in the tally's arrays
 };
 

--- a/openmc/trigger.py
+++ b/openmc/trigger.py
@@ -129,9 +129,9 @@ class Trigger(EqualityMixin):
         threshold = float(elem.get("threshold"))
         allow_zero = str(elem.get("allow_zero", "false")).lower()
         # Try to convert to bool. Let Trigger error out on instantiation.
-        if allow_zero == "true":
+        if allow_zero in ("true", "1"):
             allow_zero = True
-        elif allow_zero == "false":
+        elif allow_zero in ("false", "0"):
             allow_zero = False
         trigger = cls(trigger_type, threshold, allow_zero)
 

--- a/openmc/trigger.py
+++ b/openmc/trigger.py
@@ -17,7 +17,7 @@ class Trigger(EqualityMixin):
         relative error of scores.
     threshold : float
         The threshold for the trigger type.
-    allow_zero : bool
+    ignore_zeros : bool
         Whether to allow zero tally bins to be ignored.
 
         .. versionadded:: 0.14.1
@@ -31,22 +31,22 @@ class Trigger(EqualityMixin):
         The threshold for the trigger type.
     scores : list of str
         Scores which should be checked against the trigger
-    allow_zero : bool
+    ignore_zeros : bool
         Whether to allow zero tally bins to be ignored.
 
     """
 
-    def __init__(self, trigger_type: str, threshold: float, allow_zero: bool=False):
+    def __init__(self, trigger_type: str, threshold: float, ignore_zeros: bool=False):
         self.trigger_type = trigger_type
         self.threshold = threshold
-        self.allow_zero = allow_zero
+        self.ignore_zeros = ignore_zeros
         self._scores = []
 
     def __repr__(self):
         string = 'Trigger\n'
         string += '{: <16}=\t{}\n'.format('\tType', self._trigger_type)
         string += '{: <16}=\t{}\n'.format('\tThreshold', self._threshold)
-        string += '{: <16}=\t{}\n'.format('\tAllow Zero', self._allow_zero)
+        string += '{: <16}=\t{}\n'.format('\tIgnore Zeros', self._ignore_zeros)
         string += '{: <16}=\t{}\n'.format('\tScores', self._scores)
         return string
 
@@ -70,13 +70,13 @@ class Trigger(EqualityMixin):
         self._threshold = threshold
     
     @property
-    def allow_zero(self):
-        return self._allow_zero
+    def ignore_zeros(self):
+        return self._ignore_zeros
     
-    @allow_zero.setter
-    def allow_zero(self, allow_zero):
-        cv.check_type('tally trigger allows zeroes', allow_zero, bool)
-        self._allow_zero = allow_zero
+    @ignore_zeros.setter
+    def ignore_zeros(self, ignore_zeros):
+        cv.check_type('tally trigger ignores zeros', ignore_zeros, bool)
+        self._ignore_zeros = ignore_zeros
 
     @property
     def scores(self):
@@ -105,8 +105,8 @@ class Trigger(EqualityMixin):
         element = ET.Element("trigger")
         element.set("type", self._trigger_type)
         element.set("threshold", str(self._threshold))
-        if self._allow_zero:
-            element.set("allow_zero", "true")
+        if self._ignore_zeros:
+            element.set("ignore_zeros", "true")
         if len(self._scores) != 0:
             element.set("scores", ' '.join(self._scores))
         return element
@@ -129,13 +129,13 @@ class Trigger(EqualityMixin):
         # Generate trigger object
         trigger_type = elem.get("type")
         threshold = float(elem.get("threshold"))
-        allow_zero = str(elem.get("allow_zero", "false")).lower()
+        ignore_zeros = str(elem.get("ignore_zeros", "false")).lower()
         # Try to convert to bool. Let Trigger error out on instantiation.
-        if allow_zero in ("true", "1"):
-            allow_zero = True
-        elif allow_zero in ("false", "0"):
-            allow_zero = False
-        trigger = cls(trigger_type, threshold, allow_zero)
+        if ignore_zeros in ("true", "1"):
+            ignore_zeros = True
+        elif ignore_zeros in ("false", "0"):
+            ignore_zeros = False
+        trigger = cls(trigger_type, threshold, ignore_zeros)
 
         # Add scores if present
         scores = elem.get("scores")

--- a/openmc/trigger.py
+++ b/openmc/trigger.py
@@ -18,7 +18,9 @@ class Trigger(EqualityMixin):
     threshold : float
         The threshold for the trigger type.
     ignore_zeros : bool
-        Whether to allow zero tally bins to be ignored.
+        Whether to allow zero tally bins to be ignored. Note that this option
+        can cause the trigger to fire prematurely if there are zero scores in
+        any bin at the first evaluation.
 
         .. versionadded:: 0.14.1
 

--- a/openmc/trigger.py
+++ b/openmc/trigger.py
@@ -20,6 +20,8 @@ class Trigger(EqualityMixin):
     allow_zero : bool
         Whether to allow zero tally bins to be ignored.
 
+        .. versionadded:: 0.14.1
+
     Attributes
     ----------
     trigger_type : {'variance', 'std_dev', 'rel_err'}

--- a/openmc/trigger.py
+++ b/openmc/trigger.py
@@ -38,7 +38,7 @@ class Trigger(EqualityMixin):
 
     """
 
-    def __init__(self, trigger_type: str, threshold: float, ignore_zeros: bool=False):
+    def __init__(self, trigger_type: str, threshold: float, ignore_zeros: bool = False):
         self.trigger_type = trigger_type
         self.threshold = threshold
         self.ignore_zeros = ignore_zeros
@@ -70,11 +70,11 @@ class Trigger(EqualityMixin):
     def threshold(self, threshold):
         cv.check_type('tally trigger threshold', threshold, Real)
         self._threshold = threshold
-    
+
     @property
     def ignore_zeros(self):
         return self._ignore_zeros
-    
+
     @ignore_zeros.setter
     def ignore_zeros(self, ignore_zeros):
         cv.check_type('tally trigger ignores zeros', ignore_zeros, bool)
@@ -133,10 +133,7 @@ class Trigger(EqualityMixin):
         threshold = float(elem.get("threshold"))
         ignore_zeros = str(elem.get("ignore_zeros", "false")).lower()
         # Try to convert to bool. Let Trigger error out on instantiation.
-        if ignore_zeros in ("true", "1"):
-            ignore_zeros = True
-        elif ignore_zeros in ("false", "0"):
-            ignore_zeros = False
+        ignore_zeros = ignore_zeros in ('true', '1')
         trigger = cls(trigger_type, threshold, ignore_zeros)
 
         # Add scores if present

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -689,6 +689,12 @@ void Tally::init_triggers(pugi::xml_node node)
         "Must specify trigger threshold for tally {} in tally XML file", id_));
     }
 
+    // Read whether to allow zero-tally bins to be ignored.
+    bool allow_zero = false;
+    if (check_for_node(trigger_node, "allow_zero")) {
+      allow_zero = get_node_value_bool(trigger_node, "allow_zero");
+    }
+
     // Read the trigger scores.
     vector<std::string> trigger_scores;
     if (check_for_node(trigger_node, "scores")) {
@@ -702,7 +708,7 @@ void Tally::init_triggers(pugi::xml_node node)
       if (score_str == "all") {
         triggers_.reserve(triggers_.size() + this->scores_.size());
         for (auto i_score = 0; i_score < this->scores_.size(); ++i_score) {
-          triggers_.push_back({metric, threshold, i_score});
+          triggers_.push_back({metric, threshold, allow_zero, i_score});
         }
       } else {
         int i_score = 0;
@@ -716,7 +722,7 @@ void Tally::init_triggers(pugi::xml_node node)
                         "{} but it was listed in a trigger on that tally",
               score_str, id_));
         }
-        triggers_.push_back({metric, threshold, i_score});
+        triggers_.push_back({metric, threshold, allow_zero, i_score});
       }
     }
   }

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -690,9 +690,9 @@ void Tally::init_triggers(pugi::xml_node node)
     }
 
     // Read whether to allow zero-tally bins to be ignored.
-    bool allow_zero = false;
-    if (check_for_node(trigger_node, "allow_zero")) {
-      allow_zero = get_node_value_bool(trigger_node, "allow_zero");
+    bool ignore_zeros = false;
+    if (check_for_node(trigger_node, "ignore_zeros")) {
+      ignore_zeros = get_node_value_bool(trigger_node, "ignore_zeros");
     }
 
     // Read the trigger scores.
@@ -708,7 +708,7 @@ void Tally::init_triggers(pugi::xml_node node)
       if (score_str == "all") {
         triggers_.reserve(triggers_.size() + this->scores_.size());
         for (auto i_score = 0; i_score < this->scores_.size(); ++i_score) {
-          triggers_.push_back({metric, threshold, allow_zero, i_score});
+          triggers_.push_back({metric, threshold, ignore_zeros, i_score});
         }
       } else {
         int i_score = 0;
@@ -722,7 +722,7 @@ void Tally::init_triggers(pugi::xml_node node)
                         "{} but it was listed in a trigger on that tally",
               score_str, id_));
         }
-        triggers_.push_back({metric, threshold, allow_zero, i_score});
+        triggers_.push_back({metric, threshold, ignore_zeros, i_score});
       }
     }
   }

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -78,8 +78,8 @@ void check_tally_triggers(double& ratio, int& tally_id, int& score)
           get_tally_uncertainty(i_tally, trigger.score_index, filter_index);
 
         // If there is a score without contributions, set ratio to inf and
-        // exit early, unless zero score is allowed for this trigger.
-        if (uncert_pair.first == -1 && !trigger.allow_zero) {
+        // exit early, unless zero scores are ignored for this trigger.
+        if (uncert_pair.first == -1 && !trigger.ignore_zeros) {
           ratio = INFINITY;
           score = t.scores_[trigger.score_index];
           tally_id = t.id_;

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -77,9 +77,9 @@ void check_tally_triggers(double& ratio, int& tally_id, int& score)
         auto uncert_pair =
           get_tally_uncertainty(i_tally, trigger.score_index, filter_index);
 
-        // if there is a score without contributions, set ratio to inf and
-        // exit early
-        if (uncert_pair.first == -1) {
+        // If there is a score without contributions, set ratio to inf and
+        // exit early, unless zero score is allowed for this trigger.
+        if (uncert_pair.first == -1 && ! trigger.allow_zero) {
           ratio = INFINITY;
           score = t.scores_[trigger.score_index];
           tally_id = t.id_;

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -167,7 +167,7 @@ void check_triggers()
   // See if the current batch is one for which the triggers must be checked.
   if (!settings::trigger_on)
     return;
-  if (current_batch < n_batches)
+  if (current_batch <= n_batches)
     return;
   if (((current_batch - n_batches) % interval) != 0)
     return;

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -79,7 +79,7 @@ void check_tally_triggers(double& ratio, int& tally_id, int& score)
 
         // If there is a score without contributions, set ratio to inf and
         // exit early, unless zero score is allowed for this trigger.
-        if (uncert_pair.first == -1 && ! trigger.allow_zero) {
+        if (uncert_pair.first == -1 && !trigger.allow_zero) {
           ratio = INFINITY;
           score = t.scores_[trigger.score_index];
           tally_id = t.id_;

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -167,7 +167,7 @@ void check_triggers()
   // See if the current batch is one for which the triggers must be checked.
   if (!settings::trigger_on)
     return;
-  if (current_batch <= n_batches)
+  if (current_batch < n_batches)
     return;
   if (((current_batch - n_batches) % interval) != 0)
     return;

--- a/tests/unit_tests/test_triggers.py
+++ b/tests/unit_tests/test_triggers.py
@@ -76,8 +76,8 @@ def test_tally_trigger_null_score(run_in_tmpdir):
 
 def test_tally_trigger_zero_ignored(run_in_tmpdir):
     pincell = openmc.examples.pwr_pin_cell()
- 
-    # create an energy filter below and around the O-16(n,p) threshold
+
+    # create an energy filter below and around the O-16(n,p) threshold (1.02e7 eV)
     e_filter = openmc.EnergyFilter([0.0, 1e7, 2e7])
 
     # create a tally with triggers applied

--- a/tests/unit_tests/test_triggers.py
+++ b/tests/unit_tests/test_triggers.py
@@ -95,6 +95,7 @@ def test_tally_trigger_zero_allowed(run_in_tmpdir):
 
     pincell.tallies = [tally]
 
+    pincell.settings.particles = 1000  # we need a few more particles for this
     pincell.settings.trigger_active = True
     pincell.settings.trigger_max_batches = 50
     pincell.settings.trigger_batch_interval = 20

--- a/tests/unit_tests/test_triggers.py
+++ b/tests/unit_tests/test_triggers.py
@@ -74,7 +74,7 @@ def test_tally_trigger_null_score(run_in_tmpdir):
         assert total_batches == pincell.settings.trigger_max_batches
 
 
-def test_tally_trigger_zero_allowed(run_in_tmpdir):
+def test_tally_trigger_zero_ignored(run_in_tmpdir):
     pincell = openmc.examples.pwr_pin_cell()
  
     # create an energy filter below and around the O-16(n,p) threshold
@@ -89,7 +89,7 @@ def test_tally_trigger_zero_allowed(run_in_tmpdir):
     # 100% relative error: should be immediately satisfied in nonzero bin
     trigger = openmc.Trigger('rel_err', 1.0)
     trigger.scores = ['(n,p)']
-    trigger.allow_zero = True
+    trigger.ignore_zeros = True
 
     tally.triggers = [trigger]
 

--- a/tests/unit_tests/test_triggers.py
+++ b/tests/unit_tests/test_triggers.py
@@ -73,3 +73,42 @@ def test_tally_trigger_null_score(run_in_tmpdir):
         total_batches = sp.n_realizations + sp.n_inactive
         assert total_batches == pincell.settings.trigger_max_batches
 
+
+def test_tally_trigger_zero_allowed(run_in_tmpdir):
+    pincell = openmc.examples.pwr_pin_cell()
+ 
+    # create an energy filter below and around the O-16(n,p) threshold
+    e_filter = openmc.EnergyFilter([0.0, 1e7, 2e7])
+
+    # create a tally with triggers applied
+    tally = openmc.Tally()
+    tally.filters = [e_filter]
+    tally.scores = ['(n,p)']
+    tally.nuclides = ["O16"]
+
+    # 100% relative error: should be immediately satisfied in nonzero bin
+    trigger = openmc.Trigger('rel_err', 1.0)
+    trigger.scores = ['(n,p)']
+    trigger.allow_zero = True
+
+    tally.triggers = [trigger]
+
+    pincell.tallies = [tally]
+
+    pincell.settings.trigger_active = True
+    pincell.settings.trigger_max_batches = 50
+    pincell.settings.trigger_batch_interval = 20
+
+    sp_file = pincell.run()
+
+    with openmc.StatePoint(sp_file) as sp:
+        # verify that the first bin is zero and the second is nonzero
+        tally_out = sp.get_tally(id=tally.id)
+        below, above = tally_out.mean.squeeze()
+        assert below == 0.0, "Tally events observed below expected threshold"
+        assert above > 0, "No tally events observed. Test with more particles."
+
+        # we expect that the trigger fires before max batches are hit
+        total_batches = sp.n_realizations + sp.n_inactive
+        assert total_batches < pincell.settings.trigger_max_batches
+


### PR DESCRIPTION
Resolve https://github.com/openmc-dev/openmc/issues/2899 


# Description

Add the ability to ignore tally bins with zero scores when evaluating tally triggers.

 * New `allow_zero` option for `Trigger` class and _tallies.xml_. (default: False)
 * If there is a score without contributions, do not set the trigger threshold ratio to infinity if the trigger allows zero scores.
 * Ensure that a full trigger batch interval is run before evaluating triggers (see discussion).
 * Add a unit test. The O-16(n,p) reaction is tallied using an energy filter with two bins, one of which is entirely below the threshold energy. The low energy bin should always have a score of zero.
 * Update "Tallies Specification" documentation.


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)


# Questions and Discussion

## OpenMC's tally trigger behavior

After OpenMC completes inactive batches, it runs a few active batches to begin gathering tally statistics. Then, tally triggers are evaluated.

This can present a problem with the new 'allow_zero' option. When triggers are evaluated this early, tally bins may not yet have any scores. Normally, this sets the error metric to infinity, but when `allow_zero == True`, the trigger can "fire" prematurely if _none_ of the tally bins have any hits yet. This can happen for rare events, such as shielding problems and small-xs reactions.

Currently, this check is performed immediately after those initial active batches are performed, regardless of the user's tally trigger 'trigger_batch_interval' setting; let's call this "interval 0". In commit 29b07827f8d48c4e8eb5385f58c777a1f8441787, `check_triggers()` is changed to skip "interval 0", so that the check is only performed after each full interval. This way, users can ensure a minimum number of active batches and avoid false positives when zero-score bins are allowed.

This does change the default tally trigger behavior. Since the default 'trigger_batch_interval' is 1, this will add 1 additional batch before checking tally triggers even if they do not enable `allow_zero` on any tallies. I think this is the best balance between straightforwardly addressing the problem and being unobtrusive to existing tally trigger users, but let's discuss.

**Alternatives**
  - One alternative would be to check if `allow_zero` is used on _any_ tallies, and only skip the 0th interval if it is. The advantage is that this would then have no impact on existing workflows. The disadvantage is that the trigger checking behavior with and without the option would be inconsistent.
  - Another alternative would be to continue checking at the 0th interval, document that this can cause problems with rare events, and make it the user's responsibility.

## Testing

Is the single unit test sufficient, or is a regression test necessary as well?

## Bool

How do we want to handle Booleans in the XML, without using `eval` (unsafe) or `distutils` (deprecated)? Here, I just check if a lowercase string is in ("true", "1"), or ("false", "0"), and otherwise crash. This is similar to how bools are handled in _settings.py_, but with the inconsistency that an unrecognized string (e.g., "rtue" or "yes") won't default to `False`.
