### PR TITLE
Allow get_microxs_and_flux to use OPENMC_CHAIN_FILE environment variable

### DIFF
--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -27,10 +27,9 @@ _valid_rxns.append('fission')
 
 
 def _resolve_chain_file_path(chain_file: str):
-    # Determine what reactions and nuclides are available in chain
     if chain_file is None:
         chain_file = openmc.config.get('chain_file')
-        if 'chain_file' in openmc.config:
+        if 'chain_file' not in openmc.config:
             raise DataError(
                 "No depletion chain specified and could not find depletion "
                 "chain in openmc.config['chain_file']"


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

I noticed the `get_microxs_and_flux` function was not allowing me to use the chain file specified by the environment variable. This PR corrects that.



# Checklist

- [x] I have performed a self-review of my own code
~~- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
~~- [ ] I have made corresponding changes to the documentation (if applicable)~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
