### PR TITLE
Print warning if no natural isotopes when using add_element and wrote unit test

### DIFF
--- a/openmc/element.py
+++ b/openmc/element.py
@@ -126,7 +126,7 @@ class Element(str):
 
         # Issue warning if no existing nuclides
         if len(natural_nuclides) == 0:
-            warnings.warn(f"No natural isotopes found for {self}.", NoNaturalIsotopesWarning)
+            warnings.warn(f"No naturally occurring isotopes found for {self}.")
 
         # Create dict to store the expanded nuclides and abundances
         abundances = {}
@@ -324,8 +324,3 @@ class Element(str):
             isotopes.append((nuclide, percent * abundance, percent_type))
 
         return isotopes
-
-
-class NoNaturalIsotopesWarning(Warning):
-    """Custom warning to indicate the absence of natural isotopes."""
-    pass

--- a/openmc/element.py
+++ b/openmc/element.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 import lxml.etree as ET
 
@@ -122,6 +123,10 @@ class Element(str):
 
         # Get the nuclides present in nature
         natural_nuclides = {name for name, abundance in natural_isotopes(self)}
+
+        # Issue warning if no existing nuclides
+        if len(natural_nuclides) == 0:
+            warnings.warn(f"No natural isotopes found for {self}.", NoNaturalIsotopesWarning)
 
         # Create dict to store the expanded nuclides and abundances
         abundances = {}
@@ -319,3 +324,8 @@ class Element(str):
             isotopes.append((nuclide, percent * abundance, percent_type))
 
         return isotopes
+
+
+class NoNaturalIsotopesWarning(Warning):
+    """Custom warning to indicate the absence of natural isotopes."""
+    pass

--- a/tests/unit_tests/test_element.py
+++ b/tests/unit_tests/test_element.py
@@ -38,8 +38,8 @@ def test_expand_enrichment():
 
 
 def test_expand_no_isotopes():
-    """ Test that correct warning is raised for elements with no isotopes """
-    with warns(openmc.NoNaturalIsotopesWarning):
+    """Test that correct warning is raised for elements with no isotopes"""
+    with warns(UserWarning, match='No naturally occurring'):
         element = openmc.Element('Tc')
         element.expand(100.0, 'ao')
 

--- a/tests/unit_tests/test_element.py
+++ b/tests/unit_tests/test_element.py
@@ -1,5 +1,5 @@
 import openmc
-from pytest import approx, raises
+from pytest import approx, raises, warns
 
 from openmc.data import NATURAL_ABUNDANCE, atomic_mass
 
@@ -35,6 +35,13 @@ def test_expand_enrichment():
     # Verify the enrichment by weight
     for isotope in lithium.expand(100.0, 'wo', 25.0, 'Li7', 'wo'):
         assert isotope[1] == approx(ref[isotope[0]])
+
+
+def test_expand_no_isotopes():
+    """ Test that correct warning is raised for elements with no isotopes """
+    with warns(openmc.NoNaturalIsotopesWarning):
+        element = openmc.Element('Tc')
+        element.expand(100.0, 'ao')
 
 
 def test_expand_exceptions():


### PR DESCRIPTION
# Description

When adding nuclides to a material with add_element, OpenMC will silently do nothing if there are no natural nuclides of that element (e.g., plutonium, technetium). It would be nice if the user encountered a warning about this, because if the user was trying to do this in the first place, they did not realize/recognize that there aren't actually any natural isotopes for that element.

I created a custom Warning class called 'NoNaturalIsotopesWarning' so warnings can be correctly filtered by the end user instead of just calling Warnings.warn(""). 

I added a check [here](https://github.com/openmc-dev/openmc/blob/9fee6534b6e873d24a4df7fe42d0bf5a988e207a/openmc/element.py#L320) in the expand method to check the length of nuclides found and print a warning if `len(natural_nuclides) == 0`.

Fixes # 2926

# Checklist

- [X] I have performed a self-review of my own code
- [X] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works (if applicable)
