### PR TITLE
Ensure that two surfaces with different boundary type are not considered redundant

### DIFF
--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -701,7 +701,7 @@ class Geometry:
             coeffs = tuple(round(surf._coefficients[k],
                                  self.surface_precision)
                            for k in surf._coeff_keys)
-            key = (surf._type,) + coeffs
+            key = (surf._type, surf._boundary_type) + coeffs
             redundancies[key].append(surf)
 
         redundant_surfaces = {replace.id: keep

--- a/tests/unit_tests/test_geometry.py
+++ b/tests/unit_tests/test_geometry.py
@@ -390,3 +390,16 @@ def test_get_all_nuclides():
     c2 = openmc.Cell(fill=m2, region=+s)
     geom = openmc.Geometry([c1, c2])
     assert geom.get_all_nuclides() == ['Be9', 'Fe56']
+
+
+def test_redundant_surfaces():
+    # Make sure boundary condition is accounted for
+    s1 = openmc.Sphere(r=5.0)
+    s2 = openmc.Sphere(r=5.0, boundary_type="vacuum")
+    c1 = openmc.Cell(region=-s1)
+    c2 = openmc.Cell(region=+s1)
+    u_lower = openmc.Universe(cells=[c1, c2])
+    c3 = openmc.Cell(fill=u_lower, region=-s2)
+    geom = openmc.Geometry([c3])
+    redundant_surfs = geom.remove_redundant_surfaces()
+    assert len(redundant_surfs) == 0


### PR DESCRIPTION
# Description

Right now, if you are exporting a model and ask it to remove redundant surfaces (`Geometry.merge_surfaces = True`), it compares the surface type and coefficients to determine whether two surfaces are considered equivalent. However, the `boundary_type` is not currently accounted for, which can cause problems if you have one surface with a boundary condition applied and another surface with no BC that is used on a lower universe level. This PR simply makes a change to account for the `boundary_type` when determining whether two surfaces are equivalent.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)