### PR TITLE
updated package versions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,21 +34,21 @@ ARG build_libmesh
 ENV HOME=/root
 
 # Embree variables
-ENV EMBREE_TAG='v3.12.2'
+ENV EMBREE_TAG='v4.3.1'
 ENV EMBREE_REPO='https://github.com/embree/embree'
 ENV EMBREE_INSTALL_DIR=$HOME/EMBREE/
 
 # MOAB variables
-ENV MOAB_TAG='5.3.0'
+ENV MOAB_TAG='5.5.1'
 ENV MOAB_REPO='https://bitbucket.org/fathomteam/moab/'
 
 # Double-Down variables
-ENV DD_TAG='v1.0.0'
+ENV DD_TAG='v1.1.0'
 ENV DD_REPO='https://github.com/pshriwise/double-down'
 ENV DD_INSTALL_DIR=$HOME/Double_down
 
 # DAGMC variables
-ENV DAGMC_BRANCH='v3.2.1'
+ENV DAGMC_BRANCH='v3.2.3'
 ENV DAGMC_REPO='https://github.com/svalinn/DAGMC'
 ENV DAGMC_INSTALL_DIR=$HOME/DAGMC/
 


### PR DESCRIPTION
# Description

I might have accidentally broken the dockerfile building for dagmc variants in PR #2890.

This PR fixes the dockerfile for dagmc building. This was achieved by updating dagmc which necessitated updating a few more versions, we now are very similar to the versions used in the [dagmc docker image](https://github.com/svalinn/DAGMC/blob/develop/CI/Dockerfile)

```
sudo docker build -t openmc_dagmc --build-arg build_dagmc=on --build-arg compile_cores=4 --build-arg openmc_branch=develop .
[sudo] password for j: 
[+] Building 1.2s (13/13) FINISHED                                                    docker:default
 => [internal] load .dockerignore                                                               0.0s
 => => transferring context: 2B                                                                 0.0s
 => [internal] load build definition from Dockerfile                                            0.1s
 => => transferring dockerfile: 9.12kB                                                          0.0s
 => [internal] load metadata for docker.io/library/debian:bookworm-slim                         0.9s
 => [dependencies 1/7] FROM docker.io/library/debian:bookworm-slim@sha256:ccb33c3ac5b02588fc1d  0.0s
 => CACHED [dependencies 2/7] RUN apt-get update -y &&     apt-get upgrade -y &&     apt-get i  0.0s
 => CACHED [dependencies 3/7] RUN python3 -m venv openmc_venv                                   0.0s
 => CACHED [dependencies 4/7] RUN pip install --upgrade pip                                     0.0s
 => CACHED [dependencies 5/7] RUN cd /root     && git clone --single-branch --depth 1 https://  0.0s
 => CACHED [dependencies 6/7] RUN if [ "on" = "on" ]; then         apt-get -y install libeigen  0.0s
 => CACHED [dependencies 7/7] RUN if [ "off" = "on" ]; then         apt-get -y install m4 libn  0.0s
 => CACHED [build 1/1] RUN mkdir -p /root/OpenMC && cd /root/OpenMC     && git clone --shallow  0.0s
 => CACHED [release 1/1] RUN /root/OpenMC/openmc/tools/ci/download-xs.sh                        0.0s
 => exporting to image                                                                          0.0s
 => => exporting layers                                                                         0.0s
 => => writing image sha256:4578d1c420ad505ee4416e510530a6155cbccb4fed33009ecd0d184c2da36a9b    0.0s
 => => naming to docker.io/library/openmc_dagmc                                                 0.0s
```

# Checklist

- [x] I have performed a self-review of my own code
