### PR TITLE
Add MPI calls to DAGMC external test. 

### DIFF
--- a/tests/regression_tests/dagmc/external/main.cpp
+++ b/tests/regression_tests/dagmc/external/main.cpp
@@ -6,6 +6,7 @@
 #include "openmc/geometry_aux.h"
 #include "openmc/material.h"
 #include "openmc/nuclide.h"
+#include "openmc/message_passing.h"
 #include <iostream>
 
 int main(int argc, char* argv[])
@@ -14,7 +15,12 @@ int main(int argc, char* argv[])
   int openmc_err;
 
   // Initialise OpenMC
+#ifdef OPENMC_MPI
+  MPI_Comm world = MPI_COMM_WORLD;
+  openmc_err = openmc_init(argc, argv, &world);
+#else
   openmc_err = openmc_init(argc, argv, nullptr);
+#endif
   if (openmc_err == -1) {
     // This happens for the -h and -v flags
     return EXIT_SUCCESS;
@@ -103,6 +109,10 @@ int main(int argc, char* argv[])
   openmc_err = openmc_finalize();
   if (openmc_err)
     fatal_error(openmc_err_msg);
+
+#ifdef OPENMC_MPI
+  MPI_Finalize();
+#endif
 
   return EXIT_SUCCESS;
 }

--- a/tests/regression_tests/dagmc/external/main.cpp
+++ b/tests/regression_tests/dagmc/external/main.cpp
@@ -5,8 +5,8 @@
 #include "openmc/geometry.h"
 #include "openmc/geometry_aux.h"
 #include "openmc/material.h"
-#include "openmc/nuclide.h"
 #include "openmc/message_passing.h"
+#include "openmc/nuclide.h"
 #include <iostream>
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
# Description

As I was making some updates for the unstructured mesh class I ran across a failure of the DAGMC test that supplies an external DAGMC instance when that test is executed with MPI.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- ~[ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~
- ~[ ] I have made corresponding changes to the documentation (if applicable)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
