### PR TITLE
Support track file writing for particle restart runs.

### DIFF
--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -87,8 +87,10 @@ void run_particle_restart()
   read_particle_restart(p, previous_run_mode);
 
   // write track if that was requested on command line
-  if (settings::write_all_tracks)
+  if (settings::write_all_tracks) {
+    open_track_file();
     p.write_track() = true;
+  }
 
   // Set all tallies to 0 for now (just tracking errors)
   model::tallies.clear();
@@ -121,8 +123,13 @@ void run_particle_restart()
   // Transport neutron
   transport_history_based_single_particle(p);
 
+
   // Write output if particle made it
   print_particle(p);
+
+  if (settings::write_all_tracks) {
+    close_track_file();
+  }
 }
 
 } // namespace openmc

--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -123,7 +123,6 @@ void run_particle_restart()
   // Transport neutron
   transport_history_based_single_particle(p);
 
-
   // Write output if particle made it
   print_particle(p);
 

--- a/tests/unit_tests/test_tracks.py
+++ b/tests/unit_tests/test_tracks.py
@@ -1,7 +1,6 @@
-import glob
-import h5py
 from pathlib import Path
 
+import h5py
 import numpy as np
 import openmc
 import pytest
@@ -160,6 +159,7 @@ def test_write_to_vtk(sphere_model):
     assert isinstance(polydata, vtk.vtkPolyData)
     assert Path('tracks.vtp').is_file()
 
+
 def test_restart_track(run_in_tmpdir, sphere_model):
     # cut the sphere model in half with an improper boundary condition
     plane = openmc.XPlane(x0=-1.0)
@@ -170,9 +170,9 @@ def test_restart_track(run_in_tmpdir, sphere_model):
     with pytest.raises(RuntimeError, match='Maximum number of lost particles has been reached.'):
         sphere_model.run(output=False)
 
-    lost_particle_files = glob.glob('particle_*.h5')
+    lost_particle_files = list(Path.cwd().glob('particle_*.h5'))
     assert len(lost_particle_files) > 0
-    particle_file = Path(lost_particle_files[0]).resolve()
+    particle_file = lost_particle_files[0]
      # restart the lost particle with tracks enabled
     sphere_model.run(tracks=True, restart_file=particle_file)
     tracks_file = Path('tracks.h5')

--- a/tests/unit_tests/test_tracks.py
+++ b/tests/unit_tests/test_tracks.py
@@ -1,3 +1,5 @@
+import glob
+import h5py
 from pathlib import Path
 
 import numpy as np
@@ -157,3 +159,34 @@ def test_write_to_vtk(sphere_model):
 
     assert isinstance(polydata, vtk.vtkPolyData)
     assert Path('tracks.vtp').is_file()
+
+def test_restart_track(run_in_tmpdir, sphere_model):
+    # cut the sphere model in half with an improper boundary condition
+    plane = openmc.XPlane(x0=-1.0)
+    for cell in sphere_model.geometry.get_all_cells().values():
+        cell.region &= +plane
+
+    # generate lost particle files
+    with pytest.raises(RuntimeError, match='Maximum number of lost particles has been reached.'):
+        sphere_model.run(output=False)
+
+    lost_particle_files = glob.glob('particle_*.h5')
+    assert len(lost_particle_files) > 0
+    particle_file = Path(lost_particle_files[0]).resolve()
+     # restart the lost particle with tracks enabled
+    sphere_model.run(tracks=True, restart_file=particle_file)
+    tracks_file = Path('tracks.h5')
+    assert tracks_file.is_file()
+
+    # check that the last track of the file matches the lost particle file
+    tracks = openmc.Tracks(tracks_file)
+    initial_state = tracks[0].particle_tracks[0].states[0]
+    restart_r = np.array(initial_state['r'])
+    restart_u = np.array(initial_state['u'])
+
+    with h5py.File(particle_file, 'r') as lost_particle_file:
+        lost_r = np.array(lost_particle_file['xyz'][()])
+        lost_u = np.array(lost_particle_file['uvw'][()])
+
+    pytest.approx(restart_r, lost_r)
+    pytest.approx(restart_u, lost_u)


### PR DESCRIPTION
# Description

This PR should help streamline lost particle debugging by enabling a track file write with the following workflow:

```shell
# run produces lost particle files
openmc
# restart with a particle file and produce a `tracks.h5` file with the resulting track for debugging
openmc -r <particle_file> -t
```

or in Python

```python
# produces a `RuntimeError`
model.run()
# apply a particle file and produce the track
model.run(restart_file=particle_filepath, tracks=True)
```

This just involved opening and closing a track file for the `run_particle_restart` function. Those calls are typically made in `openmc_simulation_init` but that function isn't called for a particle restart run. I've added a test to ensure the above workflow is possible going forward.

Fixes #2956 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
