### PR TITLE
Update minimum Python version to 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,6 @@ jobs:
         vectfit: [n]
 
         include:
-          - python-version: "3.7"
-            omp: n
-            mpi: n
           - python-version: "3.8"
             omp: n
             mpi: n
@@ -45,6 +42,9 @@ jobs:
             omp: n
             mpi: n
           - python-version: "3.11"
+            omp: n
+            mpi: n
+          - python-version: "3.12"
             omp: n
             mpi: n
           - dagmc: y

--- a/docs/source/devguide/styleguide.rst
+++ b/docs/source/devguide/styleguide.rst
@@ -146,7 +146,7 @@ Style for Python code should follow PEP8_.
 
 Docstrings for functions and methods should follow numpydoc_ style.
 
-Python code should work with Python 3.7+.
+Python code should work with Python 3.8+.
 
 Use of third-party Python packages should be limited to numpy_, scipy_,
 matplotlib_, pandas_, and h5py_. Use of other third-party packages must be

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -540,7 +540,7 @@ to install the Python package in :ref:`"editable" mode <devguide_editable>`.
 Prerequisites
 -------------
 
-The Python API works with Python 3.7+. In addition to Python itself, the API
+The Python API works with Python 3.8+. In addition to Python itself, the API
 relies on a number of third-party packages. All prerequisites can be installed
 using Conda_ (recommended), pip_, or through the package manager in most Linux
 distributions.

--- a/setup.py
+++ b/setup.py
@@ -53,16 +53,15 @@ kwargs = {
         'Topic :: Scientific/Engineering'
         'Programming Language :: C++',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
     # Dependencies
-    'python_requires': '>=3.7',
+    'python_requires': '>=3.8',
     'install_requires': [
         'numpy>=1.9', 'h5py', 'scipy', 'ipython', 'matplotlib',
         'pandas', 'lxml', 'uncertainties'

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ kwargs = {
     'python_requires': '>=3.8',
     'install_requires': [
         'numpy>=1.9', 'h5py', 'scipy', 'ipython', 'matplotlib',
-        'pandas', 'lxml', 'uncertainties'
+        'pandas', 'lxml', 'uncertainties', 'setuptools'
     ],
     'extras_require': {
         'depletion-mpi': ['mpi4py'],

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ kwargs = {
     'python_requires': '>=3.8',
     'install_requires': [
         'numpy>=1.9', 'h5py', 'scipy', 'ipython', 'matplotlib',
-        'pandas', 'lxml', 'uncertainties', 'setuptools'
+        'pandas', 'lxml', 'uncertainties'
     ],
     'extras_require': {
         'depletion-mpi': ['mpi4py'],

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -36,7 +36,7 @@ fi
 # correct version of MPI
 if [[ $MPI == 'y' ]]; then
     # setuptools 69.4.0 causes problems with mpi4py installation
-    pip install --upgrade "setuptools<69.4.0" build
+    pip install --upgrade "setuptools<69.4.0" build wheel
     pip install --no-build-isolation --no-binary=mpi4py mpi4py
 
     export CC=mpicc

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -35,6 +35,8 @@ fi
 # For MPI configurations, make sure mpi4py and h5py are built against the
 # correct version of MPI
 if [[ $MPI == 'y' ]]; then
+    # setuptools 69.4.0 causes problems with mpi4py installation
+    pip install "setuptools<69.4.0"
     pip install --no-binary=mpi4py mpi4py
 
     export CC=mpicc

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -36,7 +36,7 @@ fi
 # correct version of MPI
 if [[ $MPI == 'y' ]]; then
     # setuptools 69.4.0 causes problems with mpi4py installation
-    pip install "setuptools<69.4.0"
+    pip install --upgrade "setuptools<69.4.0"
     pip install --no-binary=mpi4py mpi4py
 
     export CC=mpicc

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -36,8 +36,8 @@ fi
 # correct version of MPI
 if [[ $MPI == 'y' ]]; then
     # setuptools 69.4.0 causes problems with mpi4py installation
-    pip install --upgrade "setuptools<69.4.0"
-    pip install --no-binary=mpi4py mpi4py
+    pip install --upgrade "setuptools<69.4.0" build
+    pip install --no-build-isolation --no-binary=mpi4py mpi4py
 
     export CC=mpicc
     export HDF5_MPI=ON

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -35,9 +35,7 @@ fi
 # For MPI configurations, make sure mpi4py and h5py are built against the
 # correct version of MPI
 if [[ $MPI == 'y' ]]; then
-    # setuptools 69.4.0 causes problems with mpi4py installation
-    pip install --upgrade "setuptools<69.4.0" build wheel
-    pip install --no-build-isolation --no-binary=mpi4py mpi4py
+    pip install --no-binary=mpi4py mpi4py
 
     export CC=mpicc
     export HDF5_MPI=ON


### PR DESCRIPTION
# Description

This PR updates our minimum Python version to 3.8 since 3.7 is already past EOL. For CI configurations, I've replaced 3.7 with a new configuration for 3.12 so that it is tested.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)