### PR TITLE
Allow pure decay IndependentOperator

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -848,7 +848,7 @@ class Integrator(ABC):
                 print(f"[openmc.deplete] t={t} (final operator evaluation)")
             res_list = [self.operator(n, source_rate if final_step else 0.0)]
             StepResult.save(self.operator, [n], res_list, [t, t],
-                         source_rate, self._i_res + len(self), proc_time)
+                         source_rate, self._i_res + len(self), proc_time, path)
             self.operator.write_bos_data(len(self) + self._i_res)
 
         self.operator.finalize()

--- a/openmc/deplete/independent_operator.py
+++ b/openmc/deplete/independent_operator.py
@@ -226,7 +226,8 @@ class IndependentOperator(OpenMCOperator):
 
         """
         check_type('nuclides', nuclides, dict, str)
-        materials = cls._consolidate_nuclides_to_material(nuclides, nuc_units, volume)
+        materials = cls._consolidate_nuclides_to_material(
+            nuclides, nuc_units, volume)
         fluxes = [flux]
         micros = [micro_xs]
         return cls(materials,
@@ -240,7 +241,6 @@ class IndependentOperator(OpenMCOperator):
                    reduce_chain=reduce_chain,
                    reduce_chain_level=reduce_chain_level,
                    fission_yield_opts=fission_yield_opts)
-
 
     @staticmethod
     def _consolidate_nuclides_to_material(nuclides, nuc_units, volume):
@@ -270,7 +270,6 @@ class IndependentOperator(OpenMCOperator):
         self.prev_res[-1].transfer_volumes(model)
         self.materials = model.materials
 
-
         # Store previous results in operator
         # Distribute reaction rates according to those tracked
         # on this process
@@ -281,7 +280,6 @@ class IndependentOperator(OpenMCOperator):
             for res_obj in prev_results:
                 new_res = res_obj.distribute(self.local_mats, mat_indexes)
                 self.prev_res.append(new_res)
-
 
     def _get_nuclides_with_data(self, cross_sections: List[MicroXS]) -> Set[str]:
         """Finds nuclides with cross section data"""
@@ -316,7 +314,8 @@ class IndependentOperator(OpenMCOperator):
             rates = op.reaction_rates
             super().__init__(rates.n_nuc, rates.n_react)
 
-            self.nuc_ind_map = {ind: nuc for nuc, ind in rates.index_nuc.items()}
+            self.nuc_ind_map = {ind: nuc for nuc,
+                                ind in rates.index_nuc.items()}
             self.rx_ind_map = {ind: rxn for rxn, ind in rates.index_rx.items()}
             self._op = op
 
@@ -353,7 +352,8 @@ class IndependentOperator(OpenMCOperator):
 
                     # Determine reaction rate by multiplying xs in [b] by flux
                     # in [n-cm/src] to give [(reactions/src)*b-cm/atom]
-                    self._results_cache[i_nuc, i_rx] = (xs[nuc, rx] * flux).sum()
+                    self._results_cache[i_nuc, i_rx] = (
+                        xs[nuc, rx] * flux).sum()
 
             return self._results_cache
 
@@ -411,6 +411,12 @@ class IndependentOperator(OpenMCOperator):
         """
 
         self._update_materials_and_nuclides(vec)
+
+        # If the source rate is zero, return zero reaction rates
+        if source_rate == 0.0:
+            rates = self.reaction_rates.copy()
+            rates.fill(0.0)
+            return OperatorResult(ufloat(0.0, 0.0), rates)
 
         rates = self._calculate_reaction_rates(source_rate)
         keff = self._keff

--- a/openmc/deplete/independent_operator.py
+++ b/openmc/deplete/independent_operator.py
@@ -226,8 +226,7 @@ class IndependentOperator(OpenMCOperator):
 
         """
         check_type('nuclides', nuclides, dict, str)
-        materials = cls._consolidate_nuclides_to_material(
-            nuclides, nuc_units, volume)
+        materials = cls._consolidate_nuclides_to_material(nuclides, nuc_units, volume)
         fluxes = [flux]
         micros = [micro_xs]
         return cls(materials,
@@ -314,8 +313,7 @@ class IndependentOperator(OpenMCOperator):
             rates = op.reaction_rates
             super().__init__(rates.n_nuc, rates.n_react)
 
-            self.nuc_ind_map = {ind: nuc for nuc,
-                                ind in rates.index_nuc.items()}
+            self.nuc_ind_map = {ind: nuc for nuc, ind in rates.index_nuc.items()}
             self.rx_ind_map = {ind: rxn for rxn, ind in rates.index_rx.items()}
             self._op = op
 
@@ -352,8 +350,7 @@ class IndependentOperator(OpenMCOperator):
 
                     # Determine reaction rate by multiplying xs in [b] by flux
                     # in [n-cm/src] to give [(reactions/src)*b-cm/atom]
-                    self._results_cache[i_nuc, i_rx] = (
-                        xs[nuc, rx] * flux).sum()
+                    self._results_cache[i_nuc, i_rx] = (xs[nuc, rx] * flux).sum()
 
             return self._results_cache
 

--- a/tests/unit_tests/test_deplete_decay.py
+++ b/tests/unit_tests/test_deplete_decay.py
@@ -74,7 +74,7 @@ def test_deplete_decay_step_fissionable(run_in_tmpdir):
     )
     integrator.integrate()
 
-    # Get concentration of H1 and He4
+    # Get concentration of U238. It should be unchanged since this chain has no U238 decay.
     results = openmc.deplete.Results('depletion_results.h5')
     _, u238 = results.get_atoms("1", "U238")
 

--- a/tests/unit_tests/test_deplete_decay.py
+++ b/tests/unit_tests/test_deplete_decay.py
@@ -68,7 +68,7 @@ def test_deplete_decay_step_fissionable(run_in_tmpdir):
     op = openmc.deplete.IndependentOperator(
         mats, [1.0], [micro_xs], Path(__file__).parents[1] / "chain_simple.xml")
 
-    # Create time-integrator and integrate
+    # Create time integrator and integrate
     integrator = openmc.deplete.PredictorIntegrator(
         op, [1.0], power=[0.0], timestep_units='s'
     )

--- a/tests/unit_tests/test_deplete_decay.py
+++ b/tests/unit_tests/test_deplete_decay.py
@@ -64,6 +64,8 @@ def test_deplete_decay_step_fissionable(run_in_tmpdir):
     mat.add_nuclide('U238', 1.0, 'ao')
     mat.volume = 10.0
     mat.set_density('g/cc', 1.0)
+    original_atoms = mat.get_nuclide_atoms()['U238']
+
     mats = openmc.Materials([mat])
     op = openmc.deplete.IndependentOperator(
         mats, [1.0], [micro_xs], Path(__file__).parents[1] / "chain_simple.xml")
@@ -78,4 +80,4 @@ def test_deplete_decay_step_fissionable(run_in_tmpdir):
     results = openmc.deplete.Results('depletion_results.h5')
     _, u238 = results.get_atoms("1", "U238")
 
-    assert u238[1] == pytest.approx(2.52977141e+22)
+    assert u238[1] == pytest.approx(original_atoms)

--- a/tests/unit_tests/test_deplete_decay.py
+++ b/tests/unit_tests/test_deplete_decay.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import openmc.deplete
 import numpy as np
 import pytest
@@ -45,3 +47,35 @@ def test_deplete_decay_products(run_in_tmpdir):
     # H1 and He4
     assert h1[1] == pytest.approx(1e24)
     assert he4[1] == pytest.approx(1e24)
+
+
+def test_deplete_decay_step_fissionable(run_in_tmpdir):
+    """Ensures that power is not computed in zero power cases with
+    fissionable material present. This tests decay calculations without
+    power, although this specific example does not exhibit any decay.
+
+    Proves github issue #2963 is fixed
+    """
+
+    # Set up a pure decay operator
+    micro_xs = openmc.deplete.MicroXS(np.empty((0, 0)), [], [])
+    mat = openmc.Material()
+    mat.name = 'I decay slowly!'
+    mat.add_nuclide('U238', 1.0, 'ao')
+    mat.volume = 10.0
+    mat.set_density('g/cc', 1.0)
+    mats = openmc.Materials([mat])
+    op = openmc.deplete.IndependentOperator(
+        mats, [1.0], [micro_xs], Path(__file__).parents[1] / "chain_simple.xml")
+
+    # Create time-integrator and integrate
+    integrator = openmc.deplete.PredictorIntegrator(
+        op, [1.0], power=[0.0], timestep_units='s'
+    )
+    integrator.integrate()
+
+    # Get concentration of H1 and He4
+    results = openmc.deplete.Results('depletion_results.h5')
+    _, u238 = results.get_atoms("1", "U238")
+
+    assert u238[1] == pytest.approx(2.52977141e+22)

--- a/tests/unit_tests/test_deplete_decay.py
+++ b/tests/unit_tests/test_deplete_decay.py
@@ -60,7 +60,7 @@ def test_deplete_decay_step_fissionable(run_in_tmpdir):
     # Set up a pure decay operator
     micro_xs = openmc.deplete.MicroXS(np.empty((0, 0)), [], [])
     mat = openmc.Material()
-    mat.name = 'I decay slowly!'
+    mat.name = 'I do not decay.'
     mat.add_nuclide('U238', 1.0, 'ao')
     mat.volume = 10.0
     mat.set_density('g/cc', 1.0)


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Fixes #2963 

Fixes #2968 

EDIT this also fixes #2968 with the second commit it adds.

Autopep8'd the independent operator file, and adds handling for decay only steps as we have in the coupled operator. This prevents an error where the heating is calculated as zero and an error is thrown erroneously. After taking this PR, the following code can produce this nice little plot in which we track the first two decay progeny of U239. It has a half life around 1400s and we can see that behavior nicely in this plot. Notably I need to turn off multiprocessing to have this work, described below.

It's so nice to have standalone decay like this, thanks @paulromano for implementing the `IndependentOperator` 🙂

```
import numpy as np
import openmc
import openmc.deplete
import matplotlib.pyplot as plt

# TODO I need help on why this does not work
openmc.deplete.USE_MULTIPROCESSING = False

chain_file = '/Users/gavin/Code/chain_endfb80_pwr.xml'
openmc.config['chain_file'] = chain_file
openmc.config['cross_sections'] = '/Users/gavin/Code/endfb-viii.0-hdf5/cross_sections.xml'

decay_times = np.ones(100) * 50.0

# Create one material to deplete. It is ten grams of U239.
mat = openmc.Material()
mat.name = 'I decay!'
mat.add_nuclide('U239', 1.0, 'ao')
mat.volume = 10.0
mat.set_density('g/cc', 1.0)

mats = openmc.Materials([mat])

empty_micro = openmc.deplete.MicroXS(np.array([]).reshape((0, 0)), [], [])
op = openmc.deplete.IndependentOperator(mats, [1.0], [empty_micro], chain_file)
integ = openmc.deplete.PredictorIntegrator(op, decay_times, power=0.0, timestep_units='s')
integ.integrate()

results = openmc.deplete.Results()

atoms_u239 = results.get_mass(mat, 'U239')
atoms_pu239 = results.get_mass(mat, 'Pu239')
atoms_np239 = results.get_mass(mat, 'Np239')
plt.semilogy(atoms_u239[0], atoms_u239[1])
plt.semilogy(atoms_np239[0], atoms_np239[1])
plt.semilogy(atoms_pu239[0], atoms_pu239[1])
plt.legend(('U239', 'Np239', 'Pu239'))
plt.xlabel('Time (s)')
plt.ylabel('Mass (g)')
plt.ylim([0.01, 11.0])
plt.show()

```

<img width="597" alt="image" src="https://github.com/openmc-dev/openmc/assets/18088906/0c46b423-105d-4fa0-8f2c-ba6acd4ae577">


HOWEVER I am running into issues with multiprocessing set to true and may need some help. This error recurrently appears if depletion multiprocessing is turned on:

```
    super().__init__(process_obj)
  File "/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/popen_spawn_posix.py", line 42, in _launch
    prep_data = spawn.get_preparation_data(process_obj._name)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/spawn.py", line 164, in get_preparation_data
    _check_not_importing_main()
  File "/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/spawn.py", line 140, in _check_not_importing_main
    raise RuntimeError('''
RuntimeError: 
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.

        To fix this issue, refer to the "Safe importing of main module"
        section in https://docs.python.org/3/library/multiprocessing.html
```

I guess we've missed some idiom here and haven't hit this race condition before because this case runs the depletion solver without much latency? If anyone knows where this `freeze_support` might reasonably go, I would very much appreciate your input.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
