### PR TITLE
Added fix to cfloat_endf for length 11 endf floats

### DIFF
--- a/openmc/data/endf.c
+++ b/openmc/data/endf.c
@@ -14,7 +14,7 @@
 
 double cfloat_endf(const char* buffer, int n)
 {
-  char arr[12]; // 11 characters plus a null terminator
+  char arr[13]; // 11 characters plus e and a null terminator
   int j = 0; // current position in arr
   int found_significand = 0;
   int found_exponent = 0;

--- a/tests/unit_tests/test_endf.py
+++ b/tests/unit_tests/test_endf.py
@@ -23,6 +23,7 @@ def test_float_endf():
     assert endf.float_endf('-1.+2') == approx(-100.0)
     assert endf.float_endf('        ') == 0.0
     assert endf.float_endf('9.876540000000000') == approx(9.87654)
+    assert endf.float_endf('-2.225002+6') == approx(-2.225002e+6)
 
 
 def test_int_endf():


### PR DESCRIPTION
# Description

Fix for issue also found in endf-python (see PR:https://github.com/paulromano/endf-python/pull/7).

Some ENDF files have length 11 floats. E.g. ENDF/B-VIII.0 incident neutron data for deuterium there is -2.225002+6 at the beginning of the MF = 3, MT = 16 record. This is the QM/QI value.

The current float converter has arr length 12 so doesn't have space for both the e and the null terminator. Therefore the above example makes the code crash.

The proposed change is simply to make the arr length 13 to accommodate the length 11 endf floats.

