### PR TITLE
Add C to list of cmake project languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
-project(openmc CXX)
+project(openmc C CXX)
 
 # Set version numbers
 set(OPENMC_VERSION_MAJOR 0)


### PR DESCRIPTION
# Description

The recently merged #2894 removed C from the list of languages in `project(...)`. However, this causes an error when calling `find_package(HDF5 REQUIRED COMPONENTS C HL)` because it is looking for the C interface. The error is as follows:
```
CMake Error at /usr/share/cmake-3.22/Modules/FindHDF5.cmake:241 (try_compile):
  Unknown extension ".c" for file

    /home/romano/openmc/build/CMakeFiles/hdf5/cmake_hdf5_test.c

  try_compile() works only for enabled languages.  Currently these are:

    CXX

  See project() command to enable other languages.
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindHDF5.cmake:596 (_HDF5_test_regular_compiler_C)
  CMakeLists.txt:165 (find_package)
```

@gridley Can you confirm that re-adding C to the list of languages doesn't cause issues on macOS since you had removed it in #2894? I'm assuming not but just want to be sure.

FWIW this appears to be a [bug in CMake](https://gitlab.kitware.com/cmake/cmake/-/issues/24241) that was fixed about a year ago, so very recent versions of CMake wouldn't have this behavior.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>