### PR TITLE
moved apt get to optional ci parts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,15 +111,24 @@ jobs:
         run: |
           sudo apt -y update
           sudo apt install -y libpng-dev \
-                              libmpich-dev \
                               libnetcdf-dev \
                               libpnetcdf-dev \
                               libhdf5-serial-dev \
-                              libhdf5-mpich-dev \
-                              libeigen3-dev
+                              libeigen3-dev \
+
+      - name: Optional apt dependencies for mpi
+        shell: bash
+        run: |
+          sudo apt install -y libhdf5-mpich-dev \
+                              libmpich-dev
           sudo update-alternatives --set mpi /usr/bin/mpicc.mpich
           sudo update-alternatives --set mpirun /usr/bin/mpirun.mpich
           sudo update-alternatives --set mpi-x86_64-linux-gnu /usr/include/x86_64-linux-gnu/mpich
+
+      - name: Optional apt dependencies for vectfit
+        shell: bash
+        if: ${{ matrix.vectfit == 'y' }}
+        run: sudo apt-get install -y libblas-dev liblapack-dev
 
       - name: install
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
                               libhdf5-serial-dev \
                               libeigen3-dev
 
-      - name: Optional apt dependencies for mpi
+      - name: Optional apt dependencies for MPI
         shell: bash
         if: ${{ matrix.mpi == 'y' }}
         run: |
@@ -129,7 +129,7 @@ jobs:
       - name: Optional apt dependencies for vectfit
         shell: bash
         if: ${{ matrix.vectfit == 'y' }}
-        run: sudo apt-get install -y libblas-dev liblapack-dev
+        run: sudo apt install -y libblas-dev liblapack-dev
 
       - name: install
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,11 @@ jobs:
                               libnetcdf-dev \
                               libpnetcdf-dev \
                               libhdf5-serial-dev \
-                              libeigen3-dev \
+                              libeigen3-dev
 
       - name: Optional apt dependencies for mpi
         shell: bash
+        if: ${{ matrix.mpi == 'y' }}
         run: |
           sudo apt install -y libhdf5-mpich-dev \
                               libmpich-dev

--- a/tools/ci/gha-install-vectfit.sh
+++ b/tools/ci/gha-install-vectfit.sh
@@ -16,8 +16,6 @@ XTENSOR_PYTHON_REPO='https://github.com/xtensor-stack/xtensor-python'
 XTENSOR_BLAS_BRANCH='0.17.1'
 XTENSOR_BLAS_REPO='https://github.com/xtensor-stack/xtensor-blas'
 
-sudo apt-get install -y libblas-dev liblapack-dev
-
 cd $HOME
 git clone -b $PYBIND_BRANCH $PYBIND_REPO
 cd pybind11 && mkdir build && cd build && cmake .. && sudo make install


### PR DESCRIPTION
# Description

This helps make the tools/ci scripts more operating system agonistic by moving the only ubuntu specific command (```apt-get```) from the ```gha-install-vectfit.sh``` script. In the future we may want to run this sh script on mac os or another linux os which doesn't have access to apt get so it would be useful to remove this park of the sh script. Now the ```apt-get``` command is in the CI where all the other ```apt-get``` commands are located

While adding the conditional section to the CI runner I noticed that we do apt-get install of many packages for all of the matrix combinations. I split out the mpi related one as and set them to run only if mpi is requested on the matrix. This should save a small amount of CI time for these runs.

Fixes # (issue)
not an issue but working towards getting the ci running on mac

# Checklist

- [x] I have performed a self-review of my own code

