### PR TITLE
Compute homogenized materials over mesh elements

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -10,8 +10,6 @@ from collections.abc import Iterable, Callable
 from copy import deepcopy
 from inspect import signature
 from numbers import Real, Integral
-from contextlib import contextmanager
-import os
 from pathlib import Path
 import time
 from typing import Optional, Union, Sequence
@@ -22,6 +20,7 @@ from uncertainties import ufloat
 
 from openmc.checkvalue import check_type, check_greater_than, PathLike
 from openmc.mpi import comm
+from openmc.utility_funcs import change_directory
 from openmc import Material
 from .stepresult import StepResult
 from .chain import Chain
@@ -60,25 +59,6 @@ try:
 except AttributeError:
     # Can't set __doc__ on properties on Python 3.4
     pass
-
-@contextmanager
-def change_directory(output_dir):
-    """
-    Helper function for managing the current directory.
-
-    Parameters
-    ----------
-    output_dir : pathlib.Path
-        Directory to switch to.
-    """
-    orig_dir  = os.getcwd()
-    output_dir = Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        os.chdir(output_dir)
-        yield
-    finally:
-        os.chdir(orig_dir)
 
 
 class TransportOperator(ABC):

--- a/openmc/deplete/independent_operator.py
+++ b/openmc/deplete/independent_operator.py
@@ -130,7 +130,6 @@ class IndependentOperator(OpenMCOperator):
         # Validate micro-xs parameters
         check_type('materials', materials, openmc.Materials)
         check_type('micros', micros, Iterable, MicroXS)
-        check_type('fluxes', fluxes, Iterable, float)
 
         if not (len(fluxes) == len(micros) == len(materials)):
             msg = (f'The length of fluxes ({len(fluxes)}) should be equal to '

--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -13,11 +13,11 @@ import numpy as np
 
 from openmc.checkvalue import check_type, check_value, check_iterable_type, PathLike
 from openmc.exceptions import DataError
+from openmc.utility_funcs import change_directory
 from openmc import StatePoint
 from openmc.mgxs import GROUP_STRUCTURES
 from openmc.data import REACTION_MT
 import openmc
-from .abc import change_directory
 from .chain import Chain, REACTIONS
 from .coupled_operator import _find_cross_sections, _get_nuclides_with_data
 import openmc.lib
@@ -283,38 +283,37 @@ class MicroXS:
         # Create 2D array for microscopic cross sections
         microxs_arr = np.zeros((len(nuclides), len(mts)))
 
-        with TemporaryDirectory() as tmpdir:
-            # Create a material with all nuclides
-            mat_all_nucs = openmc.Material()
-            for nuc in nuclides:
-                if nuc in nuclides_with_data:
-                    mat_all_nucs.add_nuclide(nuc, 1.0)
-            mat_all_nucs.set_density("atom/b-cm", 1.0)
+        # Create a material with all nuclides
+        mat_all_nucs = openmc.Material()
+        for nuc in nuclides:
+            if nuc in nuclides_with_data:
+                mat_all_nucs.add_nuclide(nuc, 1.0)
+        mat_all_nucs.set_density("atom/b-cm", 1.0)
 
-            # Create simple model containing the above material
-            surf1 = openmc.Sphere(boundary_type="vacuum")
-            surf1_cell = openmc.Cell(fill=mat_all_nucs, region=-surf1)
-            model = openmc.Model()
-            model.geometry = openmc.Geometry([surf1_cell])
-            model.settings = openmc.Settings(
-                particles=1, batches=1, output={'summary': False})
+        # Create simple model containing the above material
+        surf1 = openmc.Sphere(boundary_type="vacuum")
+        surf1_cell = openmc.Cell(fill=mat_all_nucs, region=-surf1)
+        model = openmc.Model()
+        model.geometry = openmc.Geometry([surf1_cell])
+        model.settings = openmc.Settings(
+            particles=1, batches=1, output={'summary': False})
 
-            with change_directory(tmpdir):
-                # Export model within temporary directory
-                model.export_to_model_xml()
+        with change_directory(tmpdir=True):
+            # Export model within temporary directory
+            model.export_to_model_xml()
 
-                with openmc.lib.run_in_memory(**init_kwargs):
-                    # For each nuclide and reaction, compute the flux-averaged
-                    # cross section
-                    for nuc_index, nuc in enumerate(nuclides):
-                        if nuc not in nuclides_with_data:
-                            continue
-                        lib_nuc = openmc.lib.nuclides[nuc]
-                        for mt_index, mt in enumerate(mts):
-                            xs = lib_nuc.collapse_rate(
-                                mt, temperature, energies, multigroup_flux
-                            )
-                            microxs_arr[nuc_index, mt_index] = xs
+            with openmc.lib.run_in_memory(**init_kwargs):
+                # For each nuclide and reaction, compute the flux-averaged
+                # cross section
+                for nuc_index, nuc in enumerate(nuclides):
+                    if nuc not in nuclides_with_data:
+                        continue
+                    lib_nuc = openmc.lib.nuclides[nuc]
+                    for mt_index, mt in enumerate(mts):
+                        xs = lib_nuc.collapse_rate(
+                            mt, temperature, energies, multigroup_flux
+                        )
+                        microxs_arr[nuc_index, mt_index] = xs
 
         return cls(microxs_arr, nuclides, reactions)
 

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -17,6 +17,7 @@ import numpy as np
 import openmc
 import openmc.checkvalue as cv
 from openmc.checkvalue import PathLike
+from openmc.utility_funcs import change_directory
 from ._xml import get_text
 from .mixin import IDManagerMixin
 from .surface import _BOUNDARY_TYPES
@@ -154,6 +155,8 @@ class MeshBase(IDManagerMixin, ABC):
     ) -> List[openmc.Material]:
         """Generate homogenized materials over each element in a mesh.
 
+        .. versionadded:: 0.14.1
+
         Parameters
         ----------
         model : openmc.Model
@@ -172,7 +175,7 @@ class MeshBase(IDManagerMixin, ABC):
         """
         import openmc.lib
 
-        with tempfile.TemporaryDirectory() as temp_dir:
+        with change_directory(tmpdir=True):
             # In order to get mesh into model, we temporarily replace the
             # tallies with a single mesh tally using the current mesh
             original_tallies = model.tallies

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -151,6 +151,7 @@ class MeshBase(IDManagerMixin, ABC):
             self,
             model: openmc.Model,
             n_samples: int = 10_000,
+            prn_seed: Optional[int] = None,
             **kwargs
     ) -> List[openmc.Material]:
         """Generate homogenized materials over each element in a mesh.
@@ -164,6 +165,9 @@ class MeshBase(IDManagerMixin, ABC):
             geometry.
         n_samples : int
             Number of samples in each mesh element.
+        prn_seed : int, optional
+            Pseudorandom number generator (PRNG) seed; if None, one will be
+            generated randomly.
         **kwargs
             Keyword-arguments passed to :func:`openmc.lib.init`.
 
@@ -195,7 +199,7 @@ class MeshBase(IDManagerMixin, ABC):
                     (mat.id if mat is not None else None, volume)
                     for mat, volume in mat_volume_list
                 ]
-                for mat_volume_list in mesh.material_volumes(n_samples)
+                for mat_volume_list in mesh.material_volumes(n_samples, prn_seed)
             ]
             openmc.lib.finalize()
 
@@ -206,7 +210,7 @@ class MeshBase(IDManagerMixin, ABC):
         materials = model.geometry.get_all_materials()
         homogenized_materials = []
         for mat_volume_list in mat_volume_by_element:
-            material_ids, volumes = zip(*mat_volume_list)
+            material_ids, volumes = [list(x) for x in zip(*mat_volume_list)]
             total_volume = sum(volumes)
 
             # Check for void material and remove

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from collections.abc import Iterable
-from contextlib import contextmanager
 from functools import lru_cache
 import os
 from pathlib import Path
@@ -18,18 +17,7 @@ from openmc.dummy_comm import DummyCommunicator
 from openmc.executor import _process_CLI_arguments
 from openmc.checkvalue import check_type, check_value, PathLike
 from openmc.exceptions import InvalidIDError
-
-
-@contextmanager
-def _change_directory(working_dir):
-    """A context manager for executing in a provided working directory"""
-    start_dir = Path.cwd()
-    Path.mkdir(working_dir, parents=True, exist_ok=True)
-    os.chdir(working_dir)
-    try:
-        yield
-    finally:
-        os.chdir(start_dir)
+from openmc.utility_funcs import change_directory
 
 
 class Model:
@@ -395,7 +383,7 @@ class Model:
         # Store whether or not the library was initialized when we started
         started_initialized = self.is_initialized
 
-        with _change_directory(Path(directory)):
+        with change_directory(directory):
             with openmc.lib.quiet_dll(output):
                 # TODO: Support use of IndependentOperator too
                 depletion_operator = dep.CoupledOperator(self, **op_kwargs)
@@ -677,7 +665,7 @@ class Model:
         last_statepoint = None
 
         # Operate in the provided working directory
-        with _change_directory(Path(cwd)):
+        with change_directory(cwd):
             if self.is_initialized:
                 # Handle the run options as applicable
                 # First dont allow ones that must be set via init
@@ -767,7 +755,7 @@ class Model:
             raise ValueError("The Settings.volume_calculations attribute must"
                              " be specified before executing this method!")
 
-        with _change_directory(Path(cwd)):
+        with change_directory(cwd):
             if self.is_initialized:
                 if threads is not None:
                     msg = "Threads must be set via Model.is_initialized(...)"
@@ -829,7 +817,7 @@ class Model:
             raise ValueError("The Model.plots attribute must be specified "
                              "before executing this method!")
 
-        with _change_directory(Path(cwd)):
+        with change_directory(cwd):
             if self.is_initialized:
                 # Compute the volumes
                 openmc.lib.plot_geometry(output)

--- a/openmc/utility_funcs.py
+++ b/openmc/utility_funcs.py
@@ -1,0 +1,38 @@
+from contextlib import contextmanager
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Optional
+
+from .checkvalue import PathLike
+
+@contextmanager
+def change_directory(working_dir: Optional[PathLike] = None, *, tmpdir: bool = False):
+    """Context manager for executing in a provided working directory
+
+    Parameters
+    ----------
+    working_dir : path-like
+        Directory to switch to.
+    tmpdir : bool
+        Whether to use a temporary directory instead of a specific working directory
+
+    """
+    orig_dir = Path.cwd()
+
+    # Set up temporary directory if requested
+    if tmpdir:
+        tmp = TemporaryDirectory()
+        working_dir = tmp.name
+    elif working_dir is None:
+        raise ValueError('Must pass working_dir argument or specify tmpdir=True.')
+
+    working_dir = Path(working_dir)
+    working_dir.mkdir(parents=True, exist_ok=True)
+    os.chdir(working_dir)
+    try:
+        yield
+    finally:
+        os.chdir(orig_dir)
+        if tmpdir:
+            tmp.cleanup()


### PR DESCRIPTION
# Description

This PR adds a new `get_homogenized_materials` method to the `MeshBase` class that allows a user to easily get materials that have been homogenized over mesh elements. Right now, my main intended use case for this is mesh-based R2S calculations where the homogenized materials will be activated and lead to decay photon sources.

A few other notes about changes in this PR:
- We had two separate `change_directory` context manager definitions in the code. I've centralized them in a new utility_funcs.py module and added an easy toggle for getting a temporary directory.
- A check that was added by @shimwell in #2799 was removed because it doesn't work for when multigroup fluxes are passed to `IndependentOperator`

@pshriwise @eepeterson Can one of you review this?

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)<s/>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)