### PR TITLE
added extra error checking on spherical mesh creation

### DIFF
--- a/openmc/checkvalue.py
+++ b/openmc/checkvalue.py
@@ -171,6 +171,34 @@ def check_length(name, value, length_min, length_max=None):
         raise ValueError(msg)
 
 
+def check_increasing(name, value, equality=False):
+    """Ensure that a list's elements are strictly or loosely increasing.
+
+    Parameters
+    ----------
+    name : str
+        Description of value being checked
+    value : collections.Sized
+        Object to check if increasing
+    equality : bool, optional
+        Whether equality is allowed. Defaults to False.
+
+    """
+
+    if equality:
+        for i in range(1, len(value)):
+            if value[i] < value[i-1]:
+                msg = (f'Unable to set "{name}" to "{value}" since its elements must '
+                   f'be loosely increasing"')
+                raise ValueError(msg)
+    elif not equality:
+        for i in range(1, len(value)):
+            if value[i] <= value[i-1]:
+                msg = (f'Unable to set "{name}" to "{value}" since its elements must '
+                   f'be strictly increasing"')
+                raise ValueError(msg)
+
+
 def check_value(name, value, accepted_values):
     """Ensure that an object's value is contained in a set of acceptable values.
 

--- a/openmc/checkvalue.py
+++ b/openmc/checkvalue.py
@@ -171,30 +171,27 @@ def check_length(name, value, length_min, length_max=None):
         raise ValueError(msg)
 
 
-def check_increasing(name, value, equality=False):
+def check_increasing(name: str, value, equality: bool = False):
     """Ensure that a list's elements are strictly or loosely increasing.
 
     Parameters
     ----------
     name : str
         Description of value being checked
-    value : collections.Sized
+    value : iterable
         Object to check if increasing
     equality : bool, optional
         Whether equality is allowed. Defaults to False.
 
     """
-
     if equality:
         if not np.all(np.diff(value) >= 0.0):
-            msg = (f'Unable to set "{name}" to "{value}" since its elements must '
-                   'be loosely increasing"')
-            raise ValueError(msg)
+            raise ValueError(f'Unable to set "{name}" to "{value}" since its '
+                             'elements must be increasing.')
     elif not equality:
         if not np.all(np.diff(value) > 0.0):
-            msg = (f'Unable to set "{name}" to "{value}" since its elements must '
-                   'be strictly increasing"')
-            raise ValueError(msg)
+            raise ValueError(f'Unable to set "{name}" to "{value}" since its '
+                             'elements must be strictly increasing.')
 
 
 def check_value(name, value, accepted_values):

--- a/openmc/checkvalue.py
+++ b/openmc/checkvalue.py
@@ -189,13 +189,13 @@ def check_increasing(name, value, equality=False):
         for i in range(1, len(value)):
             if value[i] < value[i-1]:
                 msg = (f'Unable to set "{name}" to "{value}" since its elements must '
-                   f'be loosely increasing"')
+                   'be loosely increasing"')
                 raise ValueError(msg)
     elif not equality:
         for i in range(1, len(value)):
             if value[i] <= value[i-1]:
                 msg = (f'Unable to set "{name}" to "{value}" since its elements must '
-                   f'be strictly increasing"')
+                   'be strictly increasing"')
                 raise ValueError(msg)
 
 

--- a/openmc/checkvalue.py
+++ b/openmc/checkvalue.py
@@ -186,17 +186,15 @@ def check_increasing(name, value, equality=False):
     """
 
     if equality:
-        for i in range(1, len(value)):
-            if value[i] < value[i-1]:
-                msg = (f'Unable to set "{name}" to "{value}" since its elements must '
+        if not np.all(np.diff(value) >= 0.0):
+            msg = (f'Unable to set "{name}" to "{value}" since its elements must '
                    'be loosely increasing"')
-                raise ValueError(msg)
+            raise ValueError(msg)
     elif not equality:
-        for i in range(1, len(value)):
-            if value[i] <= value[i-1]:
-                msg = (f'Unable to set "{name}" to "{value}" since its elements must '
+        if not np.all(np.diff(value) > 0.0):
+            msg = (f'Unable to set "{name}" to "{value}" since its elements must '
                    'be strictly increasing"')
-                raise ValueError(msg)
+            raise ValueError(msg)
 
 
 def check_value(name, value, accepted_values):

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1730,7 +1730,8 @@ class SphericalMesh(StructuredMesh):
     @r_grid.setter
     def r_grid(self, grid):
         cv.check_type('mesh r_grid', grid, Iterable, Real)
-        cv.check_greater_than('mesh r_grid', grid[-1], grid[0])
+        cv.check_length('mesh r_grid', grid, 2)
+        cv.check_increasing('mesh r_grid', grid)
         self._r_grid = np.asarray(grid, dtype=float)
 
     @property
@@ -1740,7 +1741,8 @@ class SphericalMesh(StructuredMesh):
     @theta_grid.setter
     def theta_grid(self, grid):
         cv.check_type('mesh theta_grid', grid, Iterable, Real)
-        cv.check_greater_than('mesh theta_grid', grid[-1], grid[0])
+        cv.check_length('mesh theta_grid', grid, 2)
+        cv.check_increasing('mesh theta_grid', grid)
         self._theta_grid = np.asarray(grid, dtype=float)
 
     @property
@@ -1750,7 +1752,8 @@ class SphericalMesh(StructuredMesh):
     @phi_grid.setter
     def phi_grid(self, grid):
         cv.check_type('mesh phi_grid', grid, Iterable, Real)
-        cv.check_greater_than('mesh phi_grid', grid[-1], grid[0])
+        cv.check_length('mesh phi_grid', grid, 2)
+        cv.check_increasing('mesh phi_grid', grid)
         self._phi_grid = np.asarray(grid, dtype=float)
 
     @property

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1730,6 +1730,7 @@ class SphericalMesh(StructuredMesh):
     @r_grid.setter
     def r_grid(self, grid):
         cv.check_type('mesh r_grid', grid, Iterable, Real)
+        cv.check_greater_than('mesh r_grid', grid[-1], grid[0])
         self._r_grid = np.asarray(grid, dtype=float)
 
     @property
@@ -1739,6 +1740,7 @@ class SphericalMesh(StructuredMesh):
     @theta_grid.setter
     def theta_grid(self, grid):
         cv.check_type('mesh theta_grid', grid, Iterable, Real)
+        cv.check_greater_than('mesh theta_grid', grid[-1], grid[0])
         self._theta_grid = np.asarray(grid, dtype=float)
 
     @property
@@ -1748,6 +1750,7 @@ class SphericalMesh(StructuredMesh):
     @phi_grid.setter
     def phi_grid(self, grid):
         cv.check_type('mesh phi_grid', grid, Iterable, Real)
+        cv.check_greater_than('mesh phi_grid', grid[-1], grid[0])
         self._phi_grid = np.asarray(grid, dtype=float)
 
     @property

--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -132,6 +132,18 @@ def test_SphericalMesh_initiation():
     mesh.r_grid = (0, 11)
     assert (mesh.r_grid == np.array([0., 11.])).all()
 
+    # test invalid r_grid values
+    with pytest.raises(ValueError):
+        mesh.r_grid = (1, 1)
+
+    # test invalid theta_grid values
+    with pytest.raises(ValueError):
+        mesh.theta_grid = (2, 1)
+
+    # test invalid phi_grid values
+    with pytest.raises(ValueError):
+        mesh.phi_grid = (2, 1)
+
     # waffles and pancakes are unfortunately not valid radii
     with pytest.raises(TypeError):
         openmc.SphericalMesh(('🧇', '🥞'))

--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -134,15 +134,24 @@ def test_SphericalMesh_initiation():
 
     # test invalid r_grid values
     with pytest.raises(ValueError):
-        mesh.r_grid = (1, 1)
+        openmc.SphericalMesh(r_grid=[1, 1])
+
+    with pytest.raises(ValueError):
+        openmc.SphericalMesh(r_grid=[0])
 
     # test invalid theta_grid values
     with pytest.raises(ValueError):
-        mesh.theta_grid = (2, 1)
+        openmc.SphericalMesh(r_grid=[1, 2], theta_grid=[1, 1])
+
+    with pytest.raises(ValueError):
+        openmc.SphericalMesh(r_grid=[1, 2], theta_grid=[0])
 
     # test invalid phi_grid values
     with pytest.raises(ValueError):
-        mesh.phi_grid = (2, 1)
+        openmc.SphericalMesh(r_grid=[1, 2], phi_grid=[1, 1])
+
+    with pytest.raises(ValueError):
+        openmc.SphericalMesh(r_grid=[1, 2], phi_grid=[0])
 
     # waffles and pancakes are unfortunately not valid radii
     with pytest.raises(TypeError):


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Adding an additional check to ensure r_grid, phi_grid, and theta_grid values make sense when creating a spherical mesh, and raise a Value Error when they do not.  This way a Value Error will be raised when a user creates attempts to create a spherical mesh with a r_grid, phi_grid, or theta_grid minimum that is greater than or equal to the maximum.  

Fixes # 2933

https://github.com/openmc-dev/openmc/issues/2933

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
