### PR TITLE
Add print warning if no natural isotopes when using add_element and wrote unit test

### DIFF
--- a/openmc/element.py
+++ b/openmc/element.py
@@ -124,7 +124,6 @@ class Element(str):
             cv.check_greater_than('enrichment', enrichment, 0., equality=True)
 
         # Get the nuclides present in nature
-        print(natural_isotopes(self))
         natural_nuclides = {name for name, abundance in natural_isotopes(self)}
 
         # Issue warning if no existing nuclides

--- a/openmc/element.py
+++ b/openmc/element.py
@@ -128,7 +128,7 @@ class Element(str):
 
         # Issue warning if no existing nuclides
         if len(natural_nuclides) == 0:
-            warnings.warn(f"No natural isotopes found for {self}.", NoNaturalIsotopesWarning)
+            warnings.warn(f'No naturally occurring nuclides were found for element {self.name}')
 
         # Create dict to store the expanded nuclides and abundances
         abundances = {}
@@ -326,8 +326,3 @@ class Element(str):
             isotopes.append((nuclide, percent * abundance, percent_type))
 
         return isotopes
-
-
-class NoNaturalIsotopesWarning(Warning):
-    """Custom warning to indicate the absence of natural isotopes."""
-    pass

--- a/openmc/element.py
+++ b/openmc/element.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 import lxml.etree as ET
 
@@ -80,6 +81,8 @@ class Element(str):
 
         Raises
         ------
+        NoNaturalIsotopesWarning
+            No natural isotopes of the element
         ValueError
             No data is available for any of natural isotopes of the element
         ValueError
@@ -121,7 +124,12 @@ class Element(str):
             cv.check_greater_than('enrichment', enrichment, 0., equality=True)
 
         # Get the nuclides present in nature
+        print(natural_isotopes(self))
         natural_nuclides = {name for name, abundance in natural_isotopes(self)}
+
+        # Issue warning if no existing nuclides
+        if len(natural_nuclides) == 0:
+            warnings.warn(f"No natural isotopes found for {self}.", NoNaturalIsotopesWarning)
 
         # Create dict to store the expanded nuclides and abundances
         abundances = {}
@@ -319,3 +327,8 @@ class Element(str):
             isotopes.append((nuclide, percent * abundance, percent_type))
 
         return isotopes
+
+
+class NoNaturalIsotopesWarning(Warning):
+    """Custom warning to indicate the absence of natural isotopes."""
+    pass

--- a/tests/unit_tests/test_element.py
+++ b/tests/unit_tests/test_element.py
@@ -39,9 +39,12 @@ def test_expand_enrichment():
 
 def test_expand_no_isotopes():
     """ Test that correct warning is raised for elements with no isotopes """
-    with warns(openmc.NoNaturalIsotopesWarning):
+    with warns(Warning) as record:
         element = openmc.Element('Tc')
         element.expand(100.0, 'ao')
+
+    # Check if at least one warning was captured
+    assert len(record) > 0  # Ensures that at least one warning was raised
 
 
 def test_expand_exceptions():

--- a/tests/unit_tests/test_element.py
+++ b/tests/unit_tests/test_element.py
@@ -1,5 +1,5 @@
 import openmc
-from pytest import approx, raises
+from pytest import approx, raises, warns
 
 from openmc.data import NATURAL_ABUNDANCE, atomic_mass
 
@@ -37,9 +37,15 @@ def test_expand_enrichment():
         assert isotope[1] == approx(ref[isotope[0]])
 
 
+def test_expand_no_isotopes():
+    """ Test that correct warning is raised for elements with no isotopes """
+    with warns(openmc.NoNaturalIsotopesWarning):
+        element = openmc.Element('Tc')
+        element.expand(100.0, 'ao')
+
+
 def test_expand_exceptions():
     """ Test that correct exceptions are raised for invalid input """
-
     # 1 Isotope Element
     with raises(ValueError):
         element = openmc.Element('Be')


### PR DESCRIPTION
# Description

When adding nuclides to a material with add_element, OpenMC will silently do nothing if there are no natural nuclides of that element (e.g., plutonium). It would be nice if the user encountered a warning about this, because if the user was trying to do this in the first place they did not realize/recognize that there weren't actually any natural isotopes for that element. I added a warning when this happens.

Fixes # 2926

# Checklist

- [X] I have performed a self-review of my own code
- [X] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works (if applicable)