### PR TITLE
added error checking on cylindrical mesh 

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1381,10 +1381,8 @@ class CylindricalMesh(StructuredMesh):
     @r_grid.setter
     def r_grid(self, grid):
         cv.check_type('mesh r_grid', grid, Iterable, Real)
-        if len(grid) < 2:
-            raise ValueError("The r_grid must have at least two points.")
-        if any(grid[i] >= grid[i + 1] for i in range(len(grid) - 1)):
-            raise ValueError("The r_grid must be strictly increasing.")
+        cv.check_length('mesh r_grid', grid, 2)
+        cv.check_increasing('mesh r_grid', grid)
         self._r_grid = np.asarray(grid, dtype=float)
 
     @property
@@ -1394,16 +1392,12 @@ class CylindricalMesh(StructuredMesh):
     @phi_grid.setter
     def phi_grid(self, grid):
         cv.check_type('mesh phi_grid', grid, Iterable, Real)
-        if (len(grid) < 2 or
-                grid[0] >= grid[-1] or
-                not (0 <= grid[0] < 2 * pi) or
-                not (0 < grid[-1] <= 2 * pi)):
-            raise ValueError(
-                "The phi_grid must have at least two points, start with a "
-                "value in [0, 2pi), end with a value in (0, 2pi], and must "
-                "be strictly increasing."
-            )
-        self._phi_grid = np.asarray(grid, dtype=float)
+        cv.check_length('mesh phi_grid', grid, 2)
+        cv.check_increasing('mesh phi_grid', grid)
+        grid = np.asarray(grid, dtype=float)
+        if np.any((grid < 0.0) | (grid > 2*pi)):
+            raise ValueError("phi_grid values must be in [0, 2π].")
+        self._phi_grid = grid
 
     @property
     def z_grid(self):
@@ -1412,10 +1406,8 @@ class CylindricalMesh(StructuredMesh):
     @z_grid.setter
     def z_grid(self, grid):
         cv.check_type('mesh z_grid', grid, Iterable, Real)
-        if len(grid) < 2:
-            raise ValueError("The z_grid must have at least two points.")
-        if any(grid[i] >= grid[i + 1] for i in range(len(grid) - 1)):
-            raise ValueError("The z_grid must be strictly increasing.")
+        cv.check_length('mesh z_grid', grid, 2)
+        cv.check_increasing('mesh z_grid', grid)
         self._z_grid = np.asarray(grid, dtype=float)
 
     @property
@@ -1850,7 +1842,10 @@ class SphericalMesh(StructuredMesh):
         cv.check_type('mesh theta_grid', grid, Iterable, Real)
         cv.check_length('mesh theta_grid', grid, 2)
         cv.check_increasing('mesh theta_grid', grid)
-        self._theta_grid = np.asarray(grid, dtype=float)
+        grid = np.asarray(grid, dtype=float)
+        if np.any((grid < 0.0) | (grid > pi)):
+            raise ValueError("theta_grid values must be in [0, π].")
+        self._theta_grid = grid
 
     @property
     def phi_grid(self):
@@ -1861,7 +1856,10 @@ class SphericalMesh(StructuredMesh):
         cv.check_type('mesh phi_grid', grid, Iterable, Real)
         cv.check_length('mesh phi_grid', grid, 2)
         cv.check_increasing('mesh phi_grid', grid)
-        self._phi_grid = np.asarray(grid, dtype=float)
+        grid = np.asarray(grid, dtype=float)
+        if np.any((grid < 0.0) | (grid > 2*pi)):
+            raise ValueError("phi_grid values must be in [0, 2π].")
+        self._phi_grid = grid
 
     @property
     def _grids(self):

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1291,9 +1291,10 @@ class CylindricalMesh(StructuredMesh):
     @r_grid.setter
     def r_grid(self, grid):
         cv.check_type('mesh r_grid', grid, Iterable, Real)
-        if len(grid) < 2 or grid[0] >= grid[-1]:
-            raise ValueError("The r_grid must have at least two points "
-                             "and must be increasing.")
+        if len(grid) < 2:
+            raise ValueError("The r_grid must have at least two points.")
+        if any(grid[i] >= grid[i + 1] for i in range(len(grid) - 1)):
+            raise ValueError("The r_grid must be strictly increasing.")
         self._r_grid = np.asarray(grid, dtype=float)
 
     @property
@@ -1321,9 +1322,10 @@ class CylindricalMesh(StructuredMesh):
     @z_grid.setter
     def z_grid(self, grid):
         cv.check_type('mesh z_grid', grid, Iterable, Real)
-        if len(grid) < 2 or grid[0] >= grid[-1]:
-            raise ValueError("The z_grid must have at least two points "
-                             "and must be increasing.")
+        if len(grid) < 2:
+            raise ValueError("The z_grid must have at least two points.")
+        if any(grid[i] >= grid[i + 1] for i in range(len(grid) - 1)):
+            raise ValueError("The z_grid must be strictly increasing.")
         self._z_grid = np.asarray(grid, dtype=float)
 
     @property

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1291,6 +1291,9 @@ class CylindricalMesh(StructuredMesh):
     @r_grid.setter
     def r_grid(self, grid):
         cv.check_type('mesh r_grid', grid, Iterable, Real)
+        if len(grid) < 2 or grid[0] >= grid[-1]:
+            raise ValueError("The r_grid must have at least two points "
+                             "and must be increasing.")
         self._r_grid = np.asarray(grid, dtype=float)
 
     @property
@@ -1300,6 +1303,15 @@ class CylindricalMesh(StructuredMesh):
     @phi_grid.setter
     def phi_grid(self, grid):
         cv.check_type('mesh phi_grid', grid, Iterable, Real)
+        if (len(grid) < 2 or
+                grid[0] >= grid[-1] or
+                not (0 <= grid[0] < 2 * pi) or
+                not (0 < grid[-1] <= 2 * pi)):
+            raise ValueError(
+                "The phi_grid must have at least two points, start with a "
+                "value in [0, 2pi), end with a value in (0, 2pi], and must "
+                "be strictly increasing."
+            )
         self._phi_grid = np.asarray(grid, dtype=float)
 
     @property
@@ -1309,6 +1321,9 @@ class CylindricalMesh(StructuredMesh):
     @z_grid.setter
     def z_grid(self, grid):
         cv.check_type('mesh z_grid', grid, Iterable, Real)
+        if len(grid) < 2 or grid[0] >= grid[-1]:
+            raise ValueError("The z_grid must have at least two points "
+                             "and must be increasing.")
         self._z_grid = np.asarray(grid, dtype=float)
 
     @property

--- a/tests/unit_tests/mesh_to_vtk/test_vtk_dims.py
+++ b/tests/unit_tests/mesh_to_vtk/test_vtk_dims.py
@@ -153,7 +153,7 @@ def test_write_data_to_vtk_round_trip(run_in_tmpdir):
 
     smesh = openmc.SphericalMesh(
         r_grid=(0.0, 1.0, 2.0),
-        theta_grid=(0.0, 2.0, 4.0, 5.0),
+        theta_grid=(0.0, 0.5, 1.0, 2.0),
         phi_grid=(0.0, 3.0, 6.0),
     )
     rmesh = openmc.RegularMesh()

--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -169,53 +169,38 @@ def test_CylindricalMesh_initiation():
 
 def test_invalid_cylindrical_mesh_errors():
     # Test invalid r_grid values
-    with pytest.raises(
-        ValueError,
-        match="r_grid must have at least two points and must be increasing."
-    ):
+    with pytest.raises(ValueError):
         openmc.CylindricalMesh(r_grid=[5, 1], phi_grid=[0, pi], z_grid=[0, 10])
 
-    with pytest.raises(
-        ValueError,
-        match="r_grid must have at least two points and must be increasing."
-    ):
+    with pytest.raises(ValueError):
+        openmc.CylindricalMesh(r_grid=[1, 2, 4, 3], phi_grid=[0, pi], z_grid=[0, 10])
+
+    with pytest.raises(ValueError):
         openmc.CylindricalMesh(r_grid=[1], phi_grid=[0, pi], z_grid=[0, 10])
 
     # Test invalid phi_grid values
-    with pytest.raises(
-        ValueError,
-        match="phi_grid must start with a value in \[0, 2pi\)"
-    ):
+    with pytest.raises(ValueError):
         openmc.CylindricalMesh(r_grid=[0, 1, 2], phi_grid=[-1, 3], z_grid=[0, 10])
     
-    with pytest.raises(
-        ValueError, 
-        match="phi_grid must end with a value in \(0, 2pi\] and be strictly increasing."
-    ):
+    with pytest.raises(ValueError):
         openmc.CylindricalMesh(
             r_grid=[0, 1, 2],
             phi_grid=[0, 2*pi + 0.1],
             z_grid=[0, 10]
         )
 
-    with pytest.raises(
-        ValueError,
-        match="phi_grid must have at least two points and be strictly increasing."
-    ):
+    with pytest.raises(ValueError):
         openmc.CylindricalMesh(r_grid=[0, 1, 2], phi_grid=[pi], z_grid=[0, 10])
 
     # Test invalid z_grid values
-    with pytest.raises(
-        ValueError,
-        match="z_grid must have at least two points and must be increasing."
-    ):
+    with pytest.raises(ValueError):
         openmc.CylindricalMesh(r_grid=[0, 1, 2], phi_grid=[0, pi], z_grid=[5])
     
-    with pytest.raises(
-        ValueError,
-        match="z_grid values must be increasing."
-    ):
+    with pytest.raises(ValueError):
         openmc.CylindricalMesh(r_grid=[0, 1, 2], phi_grid=[0, pi], z_grid=[5, 1])
+
+    with pytest.raises(ValueError):
+        openmc.CylindricalMesh(r_grid=[1, 2, 4, 3], phi_grid=[0, pi], z_grid=[0, 10, 5])
 
 def test_centroids():
     # regular mesh

--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -167,6 +167,55 @@ def test_CylindricalMesh_initiation():
     with pytest.raises(TypeError):
         openmc.SphericalMesh(('🧇', '🥞'))
 
+def test_invalid_cylindrical_mesh_errors():
+    # Test invalid r_grid values
+    with pytest.raises(
+        ValueError,
+        match="r_grid must have at least two points and must be increasing."
+    ):
+        openmc.CylindricalMesh(r_grid=[5, 1], phi_grid=[0, pi], z_grid=[0, 10])
+
+    with pytest.raises(
+        ValueError,
+        match="r_grid must have at least two points and must be increasing."
+    ):
+        openmc.CylindricalMesh(r_grid=[1], phi_grid=[0, pi], z_grid=[0, 10])
+
+    # Test invalid phi_grid values
+    with pytest.raises(
+        ValueError,
+        match="phi_grid must start with a value in \[0, 2pi\)"
+    ):
+        openmc.CylindricalMesh(r_grid=[0, 1, 2], phi_grid=[-1, 3], z_grid=[0, 10])
+    
+    with pytest.raises(
+        ValueError, 
+        match="phi_grid must end with a value in \(0, 2pi\] and be strictly increasing."
+    ):
+        openmc.CylindricalMesh(
+            r_grid=[0, 1, 2],
+            phi_grid=[0, 2*pi + 0.1],
+            z_grid=[0, 10]
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="phi_grid must have at least two points and be strictly increasing."
+    ):
+        openmc.CylindricalMesh(r_grid=[0, 1, 2], phi_grid=[pi], z_grid=[0, 10])
+
+    # Test invalid z_grid values
+    with pytest.raises(
+        ValueError,
+        match="z_grid must have at least two points and must be increasing."
+    ):
+        openmc.CylindricalMesh(r_grid=[0, 1, 2], phi_grid=[0, pi], z_grid=[5])
+    
+    with pytest.raises(
+        ValueError,
+        match="z_grid values must be increasing."
+    ):
+        openmc.CylindricalMesh(r_grid=[0, 1, 2], phi_grid=[0, pi], z_grid=[5, 1])
 
 def test_centroids():
     # regular mesh

--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -188,6 +188,7 @@ def test_CylindricalMesh_initiation():
     with pytest.raises(TypeError):
         openmc.SphericalMesh(('🧇', '🥞'))
 
+
 def test_invalid_cylindrical_mesh_errors():
     # Test invalid r_grid values
     with pytest.raises(ValueError):
@@ -202,7 +203,7 @@ def test_invalid_cylindrical_mesh_errors():
     # Test invalid phi_grid values
     with pytest.raises(ValueError):
         openmc.CylindricalMesh(r_grid=[0, 1, 2], phi_grid=[-1, 3], z_grid=[0, 10])
-    
+
     with pytest.raises(ValueError):
         openmc.CylindricalMesh(
             r_grid=[0, 1, 2],
@@ -216,12 +217,13 @@ def test_invalid_cylindrical_mesh_errors():
     # Test invalid z_grid values
     with pytest.raises(ValueError):
         openmc.CylindricalMesh(r_grid=[0, 1, 2], phi_grid=[0, pi], z_grid=[5])
-    
+
     with pytest.raises(ValueError):
         openmc.CylindricalMesh(r_grid=[0, 1, 2], phi_grid=[0, pi], z_grid=[5, 1])
 
     with pytest.raises(ValueError):
         openmc.CylindricalMesh(r_grid=[1, 2, 4, 3], phi_grid=[0, pi], z_grid=[0, 10, 5])
+
 
 def test_centroids():
     # regular mesh


### PR DESCRIPTION
# Description
Added an error-checking method for cylindrical_mesh inputs with the same maximum and minimum range values. Added a unit test for invalid bounds of r_grid, phi_grid, and z_grid. The creation of error checking was prompted by the need to enforce logical constraints. This ensures that each grid value represents a correctly sized segment. 

Fixes #2933 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the style guidelines (https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files 
- [x] I have added tests that prove my fix is effective or that my feature works 
