### PR TITLE
Allow MeshSource to take a 1D array of sources

### DIFF
--- a/tests/unit_tests/test_source_mesh.py
+++ b/tests/unit_tests/test_source_mesh.py
@@ -276,12 +276,12 @@ def test_mesh_source_independent(run_in_tmpdir, void_model, mesh_type):
     # for each element, set a single-non zero source with particles
     # traveling out of the mesh (and geometry) w/o crossing any other
     # mesh elements
-    for i, j, k in mesh.indices:
+    for flat_index, (i, j, k) in enumerate(mesh.indices):
         ijk = (i-1, j-1, k-1)
         # zero-out all source strengths and set the strength
         # on the element of interest
         mesh_source.strength = 0.0
-        mesh_source.sources[ijk].strength = 1.0
+        mesh_source.sources[flat_index].strength = 1.0
 
         sp_file = model.run()
 
@@ -375,10 +375,7 @@ def test_mesh_source_file(run_in_tmpdir):
     mesh.upper_right = (2, 3, 4)
     mesh.dimension = (1, 1, 1)
 
-    mesh_source_arr = np.asarray([file_source]).reshape(mesh.dimension)
-    source = openmc.MeshSource(mesh, mesh_source_arr)
-
-    model.settings.source = source
+    model.settings.source = openmc.MeshSource(mesh, [file_source])
 
     model.export_to_model_xml()
 


### PR DESCRIPTION
# Description

Right now, the `MeshSource` class requires that when you provide sources for each element of a structured mesh, you pass it a multidimensional array that has the same shape as the mesh. So, if you have a `RegularMesh` with `mesh.dimension = (10, 2, 5)`, then the array of sources also has to be of shape `(10, 2, 5)`. This PR allows you to pass a flat array of sources in the order of the mesh element indices. This makes it a more mesh agnostic since the same interface can be used for both structured and unstructured meshes (passing a flat array).

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)