### PR TITLE
Correction for histogram interpolation of Tabular distributions

### DIFF
--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -698,8 +698,8 @@ class ThermalScattering(EqualityMixin):
                 # add an outgoing energy 0 eV that has a PDF of 0 (and of
                 # course, a CDF of 0 as well).
                 if eout_i.c[0] > 0.:
-                    eout_i.x = np.insert(eout_i.x, 0, 0.)
-                    eout_i.p = np.insert(eout_i.p, 0, 0.)
+                    eout_i._x = np.insert(eout_i.x, 0, 0.)
+                    eout_i._p = np.insert(eout_i.p, 0, 0.)
                     eout_i.c = np.insert(eout_i.c, 0, 0.)
 
                     # For this added outgoing energy (of 0 eV) we add a set of

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -210,8 +210,7 @@ def test_tabular():
     assert d.integral() == pytest.approx(1.0)
 
     # test histogram sampling
-    with pytest.warns():
-        d = openmc.stats.Tabular(x, p, interpolation='histogram')
+    d = openmc.stats.Tabular(x, p, interpolation='histogram')
     samples = d.sample(n_samples)
     assert_sample_mean(samples, d.mean())
 

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -230,13 +230,10 @@ def test_tabular():
         d = openmc.stats.Tabular(x, p[:-1], interpolation='linear-linear')
         d.cdf()
 
-    # update with probabilities of corrcet length for linear-linear
-    # interpolation and call the CDF method again
-    d.p = p
+    # Use probabilities of correct length for linear-linear interpolation and
+    # call the CDF method
+    d = openmc.stats.Tabular(x, p, interpolation='linear-linear')
     d.cdf()
-
-    with pytest.warns():
-        d.p = p[:-1]
 
 
 def test_legendre():


### PR DESCRIPTION
# Description

The `openmc.stats.Tabular` class assumes that the length of the probabilities provided is equal to the length of the table values. This causes errors when one passes N -1 probabilities for N table values in histogram interpolation

![image](https://github.com/openmc-dev/openmc/assets/4563941/b0e5a895-60a8-4416-999d-b21b88e31161)

because we index into the probabilities as `[:-1]`. This changes that index based on the size of the table values. 

Several warnings have also been added in the `Tabular.p` property setter to check its length against the size of the table values (if they are set).

# Checklist

- [x] I have performed a self-review of my own code
~- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
~- [ ] I have made corresponding changes to the documentation (if applicable)~
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
