### PR TITLE
f strings instead of .format for string editing 

### DIFF
--- a/openmc/arithmetic.py
+++ b/openmc/arithmetic.py
@@ -54,8 +54,7 @@ class CrossScore:
         return str(other) == str(self)
 
     def __repr__(self):
-        return '({} {} {})'.format(self.left_score, self.binary_op,
-                                   self.right_score)
+        return f'({self.left_score} {self.binary_op} {self.right_score})'
 
     @property
     def left_score(self):
@@ -271,7 +270,7 @@ class CrossFilter:
     def type(self):
         left_type = self.left_filter.type
         right_type = self.right_filter.type
-        return '({} {} {})'.format(left_type, self.binary_op, right_type)
+        return f'({left_type} {self.binary_op} {right_type})'
 
     @property
     def bins(self):

--- a/openmc/cmfd.py
+++ b/openmc/cmfd.py
@@ -135,7 +135,7 @@ class CMFDMesh:
         return outstr
 
     def _get_repr(self, list_var, label):
-        outstr = "\t{:<11} = ".format(label)
+        outstr = f"\t{label:<11} = "
         if list(list_var):
             outstr += ", ".join(str(i) for i in list_var)
         return outstr
@@ -242,9 +242,9 @@ class CMFDMesh:
 
         check_length('CMFD mesh grid', grid, grid_length)
         for i in range(grid_length):
-            check_type('CMFD mesh {}-grid'.format(dims[i]), grid[i], Iterable,
+            check_type(f'CMFD mesh {dims[i]}-grid', grid[i], Iterable,
                        Real)
-            check_greater_than('CMFD mesh {}-grid length'.format(dims[i]),
+            check_greater_than(f'CMFD mesh {dims[i]}-grid length',
                                len(grid[i]), 1)
         self._grid = [np.array(g) for g in grid]
         self._display_mesh_warning('rectilinear', 'CMFD mesh grid')
@@ -612,7 +612,7 @@ class CMFDRun:
         for key, value in display.items():
             check_value('display key', key,
                         ('balance', 'entropy', 'dominance', 'source'))
-            check_type("display['{}']".format(key), value, bool)
+            check_type(f"display['{key}']", value, bool)
             self._display[key] = value
 
     @downscatter.setter
@@ -928,7 +928,7 @@ class CMFDRun:
             with h5py.File(filename, 'a') as f:
                 if 'cmfd' not in f:
                     if openmc.lib.settings.verbosity >= 5:
-                        print(' Writing CMFD data to {}...'.format(filename))
+                        print(f' Writing CMFD data to {filename}...')
                         sys.stdout.flush()
                     cmfd_group = f.create_group("cmfd")
                     cmfd_group.attrs['cmfd_on'] = self._cmfd_on
@@ -1134,12 +1134,12 @@ class CMFDRun:
         with h5py.File(filename, 'r') as f:
             if 'cmfd' not in f:
                 raise OpenMCError('Could not find CMFD parameters in ',
-                                  'file {}'.format(filename))
+                                  f'file {filename}')
             else:
                 # Overwrite CMFD values from statepoint
                 if (openmc.lib.master() and
                         openmc.lib.settings.verbosity >= 5):
-                    print(' Loading CMFD data from {}...'.format(filename))
+                    print(f' Loading CMFD data from {filename}...')
                     sys.stdout.flush()
                 cmfd_group = f['cmfd']
 
@@ -1409,8 +1409,7 @@ class CMFDRun:
                 # Get all data entries for particular row in matrix
                 data = matrix.data[matrix.indptr[row]:matrix.indptr[row+1]]
                 for i in range(len(cols)):
-                    fh.write('{:3d}, {:3d}, {:0.8f}\n'.format(
-                        row, cols[i], data[i]))
+                    fh.write(f'{row:3d}, {cols[i]:3d}, {data[i]:0.8f}\n')
 
         # Save matrix in scipy format
         sparse.save_npz(base_filename, matrix)

--- a/openmc/data/ace.py
+++ b/openmc/data/ace.py
@@ -143,7 +143,7 @@ def ascii_to_binary(ascii_file, binary_file):
             # that XSS will start at the second record
             nxs = [int(x) for x in ' '.join(lines[idx + 6:idx + 8]).split()]
             jxs = [int(x) for x in ' '.join(lines[idx + 8:idx + 12]).split()]
-            binary_file.write(struct.pack(str('=16i32i{}x'.format(record_length - 500)),
+            binary_file.write(struct.pack(str(f'=16i32i{record_length - 500}x'),
                                           *(nxs + jxs)))
 
             # Read/write XSS array. Null bytes are added to form a complete record
@@ -152,8 +152,7 @@ def ascii_to_binary(ascii_file, binary_file):
             start = idx + _ACE_HEADER_SIZE
             xss = np.fromstring(' '.join(lines[start:start + n_lines]), sep=' ')
             extra_bytes = record_length - ((len(xss)*8 - 1) % record_length + 1)
-            binary_file.write(struct.pack(str('={}d{}x'.format(
-                nxs[0], extra_bytes)), *xss))
+            binary_file.write(struct.pack(str(f'={nxs[0]}d{extra_bytes}x'), *xss))
 
             # Advance to next table in file
             idx += _ACE_HEADER_SIZE + n_lines
@@ -184,8 +183,7 @@ def get_table(filename, name=None):
         if lib.tables:
             return lib.tables[0]
         else:
-            raise ValueError('Could not find ACE table with name: {}'
-                             .format(name))
+            raise ValueError(f'Could not find ACE table with name: {name}')
 
 
 # The beginning of an ASCII ACE file consists of 12 lines that include the name,
@@ -295,14 +293,14 @@ class Library(EqualityMixin):
 
             if verbose:
                 kelvin = round(temperature * EV_PER_MEV / K_BOLTZMANN)
-                print("Loading nuclide {} at {} K".format(name, kelvin))
+                print(f"Loading nuclide {name} at {kelvin} K")
 
             # Read JXS
             jxs = list(struct.unpack(str('=32i'), ace_file.read(128)))
 
             # Read XSS
             ace_file.seek(start_position + recl_length)
-            xss = list(struct.unpack(str('={}d'.format(length)),
+            xss = list(struct.unpack(str(f'={length}d'),
                                      ace_file.read(length*8)))
 
             # Insert zeros at beginning of NXS, JXS, and XSS arrays so that the
@@ -393,7 +391,7 @@ class Library(EqualityMixin):
 
             if verbose:
                 kelvin = round(temperature * EV_PER_MEV / K_BOLTZMANN)
-                print("Loading nuclide {} at {} K".format(name, kelvin))
+                print(f"Loading nuclide {name} at {kelvin} K")
 
             # Insert zeros at beginning of NXS, JXS, and XSS arrays so that the
             # indexing will be the same as Fortran. This makes it easier to
@@ -455,8 +453,7 @@ class TableType(enum.Enum):
         for member in cls:
             if suffix.endswith(member.value):
                 return member
-        raise ValueError("Suffix '{}' has no corresponding ACE table type."
-                         .format(suffix))
+        raise ValueError(f"Suffix '{suffix}' has no corresponding ACE table type.")
 
 
 class Table(EqualityMixin):
@@ -507,7 +504,7 @@ class Table(EqualityMixin):
         return TableType.from_suffix(xs[-1])
 
     def __repr__(self):
-        return "<ACE Table: {}>".format(self.name)
+        return f"<ACE Table: {self.name}>"
 
 
 def get_libraries_from_xsdir(path):

--- a/openmc/data/angle_energy.py
+++ b/openmc/data/angle_energy.py
@@ -112,7 +112,6 @@ class AngleEnergy(EqualityMixin, ABC):
             distribution = openmc.data.NBodyPhaseSpace.from_ace(
                 ace, idx, rx.q_value)
         else:
-            raise ValueError("Unsupported ACE secondary energy "
-                             "distribution law {}".format(law))
+            raise ValueError(f"Unsupported ACE secondary energy distribution law {law}")
 
         return distribution

--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -128,7 +128,7 @@ class FissionProductYields(EqualityMixin):
                     isomeric_state = int(values[4*j + 1])
                     name = ATOMIC_SYMBOL[Z] + str(A)
                     if isomeric_state > 0:
-                        name += '_m{}'.format(isomeric_state)
+                        name += f'_m{isomeric_state}'
                     yield_j = ufloat(values[4*j + 2], values[4*j + 3])
                     yields[name] = yield_j
 
@@ -257,9 +257,9 @@ class DecayMode(EqualityMixin):
                         Z += delta_Z
 
         if self._daughter_state > 0:
-            return '{}{}_m{}'.format(ATOMIC_SYMBOL[Z], A, self._daughter_state)
+            return f'{ATOMIC_SYMBOL[Z]}{A}_m{self._daughter_state}'
         else:
-            return '{}{}'.format(ATOMIC_SYMBOL[Z], A)
+            return f'{ATOMIC_SYMBOL[Z]}{A}'
 
     @property
     def parent(self):
@@ -350,10 +350,9 @@ class Decay(EqualityMixin):
         self.nuclide['mass_number'] = A
         self.nuclide['isomeric_state'] = metastable
         if metastable > 0:
-            self.nuclide['name'] = '{}{}_m{}'.format(ATOMIC_SYMBOL[Z], A,
-                                                     metastable)
+            self.nuclide['name'] = f'{ATOMIC_SYMBOL[Z]}{A}_m{metastable}'
         else:
-            self.nuclide['name'] = '{}{}'.format(ATOMIC_SYMBOL[Z], A)
+            self.nuclide['name'] = f'{ATOMIC_SYMBOL[Z]}{A}'
         self.nuclide['mass'] = items[1]  # AWR
         self.nuclide['excited_state'] = items[2]  # State of the original nuclide
         self.nuclide['stable'] = (items[4] == 1)  # Nucleus stability flag

--- a/openmc/data/effective_dose/dose.py
+++ b/openmc/data/effective_dose/dose.py
@@ -60,7 +60,7 @@ def dose_coefficients(particle, geometry='AP'):
     # Get all data for selected particle
     data = _DOSE_ICRP116.get(particle)
     if data is None:
-        raise ValueError("{} has no effective dose data".format(particle))
+        raise ValueError(f"{particle} has no effective dose data")
 
     # Determine index for selected geometry
     if particle in ('neutron', 'photon', 'proton', 'photon kerma'):

--- a/openmc/data/endf.py
+++ b/openmc/data/endf.py
@@ -449,8 +449,7 @@ class Evaluation:
 
     def __repr__(self):
         name = self.target['zsymam'].replace(' ', '')
-        return '<{} for {} {}>'.format(self.info['sublibrary'], name,
-                                       self.info['library'])
+        return f"<{self.info['sublibrary']} for {name} {self.info['library']}>"
 
     def _read_header(self):
         file_obj = io.StringIO(self.section[1, 451])

--- a/openmc/data/energy_distribution.py
+++ b/openmc/data/energy_distribution.py
@@ -53,8 +53,7 @@ class EnergyDistribution(EqualityMixin, ABC):
         elif energy_type == 'continuous':
             return ContinuousTabular.from_hdf5(group)
         else:
-            raise ValueError("Unknown energy distribution type: {}"
-                             .format(energy_type))
+            raise ValueError(f"Unknown energy distribution type: {energy_type}")
 
     @staticmethod
     def from_endf(file_obj, params):

--- a/openmc/data/library.py
+++ b/openmc/data/library.py
@@ -93,8 +93,7 @@ class DataLibrary(list):
                 materials = list(h5file)
         else:
             raise ValueError(
-                "File type {} not supported by {}"
-                .format(path.name, self.__class__.__name__))
+                f"File type {path.name} not supported by {self.__class__.__name__}")
 
         library = {'path': str(path), 'type': filetype, 'materials': materials}
         self.append(library)

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -194,9 +194,8 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
         test_xs_ref[i] = np.interp(test_energy, energy, ce_xs[i])
 
     if log:
-        print("  energy: {:.3e} to {:.3e} eV ({} points)".format(
-              energy[0], energy[-1], ne))
-        print("  error tolerance: rtol={}, atol={}".format(rtol, atol))
+        print(f"  energy: {energy[0]:.3e} to {energy[-1]:.3e} eV ({ne} points)")
+        print(f"  error tolerance: rtol={rtol}, atol={atol}")
 
     # transform xs (sigma) and energy (E) to f (sigma*E) and s (sqrt(E)) to be
     # compatible with the multipole representation
@@ -230,8 +229,8 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
         orders = list(range(lowest_order, highest_order + 1, 2))
 
     if log:
-        print("Found {} peaks".format(n_peaks))
-        print("Fitting orders from {} to {}".format(orders[0], orders[-1]))
+        print(f"Found {n_peaks} peaks")
+        print(f"Fitting orders from {orders[0]} to {orders[-1]}")
 
     # perform VF with increasing orders
     found_ideal = False
@@ -239,7 +238,7 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
     best_quality = best_ratio = -np.inf
     for i, order in enumerate(orders):
         if log:
-            print("Order={}({}/{})".format(order, i, len(orders)))
+            print(f"Order={order}({i}/{len(orders)})")
         # initial guessed poles
         poles_r = np.linspace(s[0], s[-1], order//2)
         poles = poles_r + poles_r*0.01j
@@ -249,7 +248,7 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
         # fitting iteration
         for i_vf in range(n_vf_iter):
             if log >= DETAILED_LOGGING:
-                print("VF iteration {}/{}".format(i_vf + 1, n_vf_iter))
+                print(f"VF iteration {i_vf + 1}/{n_vf_iter}")
 
             # call vf
             poles, residues, cf, f_fit, rms = vf.vectfit(f, s, poles, weight)
@@ -268,7 +267,7 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
             # re-calculate residues if poles changed
             if n_real_poles > 0:
                 if log >= DETAILED_LOGGING:
-                    print("  # real poles: {}".format(n_real_poles))
+                    print(f"  # real poles: {n_real_poles}")
                 new_poles, residues, cf, f_fit, rms = \
                       vf.vectfit(f, s, new_poles, weight, skip_pole=True)
 
@@ -296,10 +295,10 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
                 quality = -np.inf
 
             if log >= DETAILED_LOGGING:
-                print("  # poles: {}".format(new_poles.size))
-                print("  Max relative error: {:.3f}%".format(maxre*100))
-                print("  Satisfaction: {:.1f}%, {:.1f}%".format(ratio*100, ratio2*100))
-                print("  Quality: {:.2f}".format(quality))
+                print(f"  # poles: {new_poles.size}")
+                print(f"  Max relative error: {maxre * 100:.3f}%")
+                print(f"  Satisfaction: {ratio * 100:.1f}%, {ratio2 * 100:.1f}%")
+                print(f"  Quality: {quality:.2f}")
 
             if quality > best_quality:
                 if log >= DETAILED_LOGGING:
@@ -354,7 +353,7 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
     mp_residues = np.concatenate((best_residues[:, real_idx],
                                   best_residues[:, conj_idx]*2), axis=1)/1j
     if log:
-        print("Final number of poles: {}".format(mp_poles.size))
+        print(f"Final number of poles: {mp_poles.size}")
 
     if path_out:
         if not os.path.exists(path_out):
@@ -378,14 +377,14 @@ def _vectfit_xs(energy, ce_xs, mts, rtol=1e-3, atol=1e-5, orders=None,
             ax2.set_ylabel('relative error', color='r')
             ax2.tick_params('y', colors='r')
 
-            plt.title("MT {} vector fitted with {} poles".format(mt, mp_poles.size))
+            plt.title(f"MT {mt} vector fitted with {mp_poles.size} poles")
             fig.tight_layout()
             fig_file = os.path.join(path_out, "{:.0f}-{:.0f}_MT{}.png".format(
                                     energy[0], energy[-1], mt))
             plt.savefig(fig_file)
             plt.close()
             if log:
-                print("Saved figure: {}".format(fig_file))
+                print(f"Saved figure: {fig_file}")
 
     return (mp_poles, mp_residues)
 
@@ -423,7 +422,7 @@ def vectfit_nuclide(endf_file, njoy_error=5e-4, vf_pieces=None,
 
     # make 0K ACE data using njoy
     if log:
-        print("Running NJOY to get 0K point-wise data (error={})...".format(njoy_error))
+        print(f"Running NJOY to get 0K point-wise data (error={njoy_error})...")
 
     nuc_ce = IncidentNeutron.from_njoy(endf_file, temperatures=[0.0],
              error=njoy_error, broadr=False, heatr=False, purr=False)
@@ -477,9 +476,8 @@ def vectfit_nuclide(endf_file, njoy_error=5e-4, vf_pieces=None,
         mts = [2, 27]
 
     if log:
-        print("  MTs: {}".format(mts))
-        print("  Energy range: {:.3e} to {:.3e} eV ({} points)".format(
-              E_min, E_max, n_points))
+        print(f"  MTs: {mts}")
+        print(f"  Energy range: {E_min:.3e} to {E_max:.3e} eV ({n_points} points)")
 
     # ======================================================================
     # PERFORM VECTOR FITTING
@@ -500,7 +498,7 @@ def vectfit_nuclide(endf_file, njoy_error=5e-4, vf_pieces=None,
     # VF piece by piece
     for i_piece in range(vf_pieces):
         if log:
-            print("Vector fitting piece {}/{}...".format(i_piece + 1, vf_pieces))
+            print(f"Vector fitting piece {i_piece + 1}/{vf_pieces}...")
         # start E of this piece
         e_bound = (sqrt(E_min) + piece_width*(i_piece-0.5))**2
         if i_piece == 0 or sqrt(alpha*e_bound) < 4.0:
@@ -534,12 +532,12 @@ def vectfit_nuclide(endf_file, njoy_error=5e-4, vf_pieces=None,
         if not os.path.exists(path_out):
             os.makedirs(path_out)
         if not mp_filename:
-            mp_filename = "{}_mp.pickle".format(nuc_ce.name)
+            mp_filename = f"{nuc_ce.name}_mp.pickle"
         mp_filename = os.path.join(path_out, mp_filename)
         with open(mp_filename, 'wb') as f:
             pickle.dump(mp_data, f)
         if log:
-            print("Dumped multipole data to file: {}".format(mp_filename))
+            print(f"Dumped multipole data to file: {mp_filename}")
 
     return mp_data
 
@@ -605,9 +603,8 @@ def _windowing(mp_data, n_cf, rtol=1e-3, atol=1e-5, n_win=None, spacing=None,
 
     if log:
         print("Windowing:")
-        print("  config: # windows={}, spacing={}, CF order={}".format(
-               n_win, spacing, n_cf))
-        print("  error tolerance: rtol={}, atol={}".format(rtol, atol))
+        print(f"  config: # windows={n_win}, spacing={spacing}, CF order={n_cf}")
+        print(f"  error tolerance: rtol={rtol}, atol={atol}")
 
     # sort poles (and residues) by the real component of the pole
     for ip in range(n_pieces):
@@ -623,7 +620,7 @@ def _windowing(mp_data, n_cf, rtol=1e-3, atol=1e-5, n_win=None, spacing=None,
     win_data = []
     for iw in range(n_win):
         if log >= DETAILED_LOGGING:
-            print("Processing window {}/{}...".format(iw + 1, n_win))
+            print(f"Processing window {iw + 1}/{n_win}...")
 
         # inner window boundaries
         inbegin = sqrt(E_min) + spacing * iw
@@ -658,7 +655,7 @@ def _windowing(mp_data, n_cf, rtol=1e-3, atol=1e-5, n_win=None, spacing=None,
         lp = rp = center_pole_ind
         while True:
             if log >= DETAILED_LOGGING:
-                print("Trying poles {} to {}".format(lp, rp))
+                print(f"Trying poles {lp} to {rp}")
 
             # calculate the cross sections contributed by the windowed poles
             if rp > lp:
@@ -1108,7 +1105,7 @@ class WindowedMultipole(EqualityMixin):
         for n_w in np.unique(np.linspace(n_win_min, n_win_max, 20, dtype=int)):
             for n_cf in range(10, 1, -1):
                 if log:
-                    print("Testing N_win={} N_cf={}".format(n_w, n_cf))
+                    print(f"Testing N_win={n_w} N_cf={n_cf}")
 
                 # update arguments dictionary
                 kwargs.update(n_win=n_w, n_cf=n_cf)

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -122,10 +122,10 @@ class IncidentNeutron(EqualityMixin):
             if len(mts) > 0:
                 return self._get_redundant_reaction(mt, mts)
             else:
-                raise KeyError('No reaction with MT={}.'.format(mt))
+                raise KeyError(f'No reaction with MT={mt}.')
 
     def __repr__(self):
-        return "<IncidentNeutron: {}>".format(self.name)
+        return f"<IncidentNeutron: {self.name}>"
 
     def __iter__(self):
         return iter(self.reactions.values())
@@ -231,7 +231,7 @@ class IncidentNeutron(EqualityMixin):
 
     @property
     def temperatures(self):
-        return ["{}K".format(int(round(kT / K_BOLTZMANN))) for kT in self.kTs]
+        return [f"{int(round(kT / K_BOLTZMANN))}K" for kT in self.kTs]
 
     @property
     def atomic_symbol(self):
@@ -261,7 +261,7 @@ class IncidentNeutron(EqualityMixin):
         # Check if temprature already exists
         strT = data.temperatures[0]
         if strT in self.temperatures:
-            warn('Cross sections at T={} already exist.'.format(strT))
+            warn(f'Cross sections at T={strT} already exist.')
             return
 
         # Check that name matches
@@ -461,7 +461,7 @@ class IncidentNeutron(EqualityMixin):
                     if not (photon_rx or rx.mt in keep_mts):
                         continue
 
-                rx_group = rxs_group.create_group('reaction_{:03}'.format(rx.mt))
+                rx_group = rxs_group.create_group(f'reaction_{rx.mt:03}')
                 rx.to_hdf5(rx_group)
 
                 # Write total nu data if available
@@ -593,7 +593,7 @@ class IncidentNeutron(EqualityMixin):
         zaid, xs = ace.name.split('.')
         if not xs.endswith('c'):
             raise TypeError(
-                "{} is not a continuous-energy neutron ACE table.".format(ace))
+                f"{ace} is not a continuous-energy neutron ACE table.")
         name, element, Z, mass_number, metastable = \
             get_metadata(int(zaid), metastable_scheme)
 
@@ -732,9 +732,9 @@ class IncidentNeutron(EqualityMixin):
         # Determine name
         element = ATOMIC_SYMBOL[atomic_number]
         if metastable > 0:
-            name = '{}{}_m{}'.format(element, mass_number, metastable)
+            name = f'{element}{mass_number}_m{metastable}'
         else:
-            name = '{}{}'.format(element, mass_number)
+            name = f'{element}{mass_number}'
 
         # Instantiate incident neutron data
         data = cls(name, atomic_number, mass_number, metastable,

--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -188,7 +188,7 @@ def run(commands, tapein, tapeout, input_filename=None, stdout=False,
     with tempfile.TemporaryDirectory() as tmpdir:
         # Copy evaluations to appropriates 'tapes'
         for tape_num, filename in tapein.items():
-            tmpfilename = os.path.join(tmpdir, 'tape{}'.format(tape_num))
+            tmpfilename = os.path.join(tmpdir, f'tape{tape_num}')
             shutil.copy(str(filename), tmpfilename)
 
         # Start up NJOY process
@@ -216,7 +216,7 @@ def run(commands, tapein, tapeout, input_filename=None, stdout=False,
 
         # Copy output files back to original directory
         for tape_num, filename in tapeout.items():
-            tmpfilename = os.path.join(tmpdir, 'tape{}'.format(tape_num))
+            tmpfilename = os.path.join(tmpdir, f'tape{tape_num}')
             if os.path.isfile(tmpfilename):
                 shutil.move(tmpfilename, str(filename))
 
@@ -317,7 +317,7 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
     else:
         output_dir = Path(output_dir)
         if not output_dir.is_dir():
-            raise IOError("{} is not a directory".format(output_dir))
+            raise IOError(f"{output_dir} is not a directory")
 
     ev = evaluation if evaluation is not None else endf.Evaluation(filename)
     mat = ev.material
@@ -389,12 +389,12 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
             # Extend input with an ACER run for each temperature
             nace = nacer_in + 1 + 2*i
             ndir = nace + 1
-            ext = '{:02}'.format(i + 1)
+            ext = f'{i + 1:02}'
             commands += _TEMPLATE_ACER.format(**locals())
 
             # Indicate tapes to save for each ACER run
-            tapeout[nace] = output_dir / "ace_{:.1f}".format(temperature)
-            tapeout[ndir] = output_dir / "xsdir_{:.1f}".format(temperature)
+            tapeout[nace] = output_dir / f"ace_{temperature:.1f}"
+            tapeout[ndir] = output_dir / f"xsdir_{temperature:.1f}"
     commands += 'stop\n'
     run(commands, tapein, tapeout, **kwargs)
 
@@ -404,7 +404,7 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
         with ace.open('w') as ace_file, xsdir.open('w') as xsdir_file:
             for temperature in temperatures:
                 # Get contents of ACE file
-                text = (output_dir / "ace_{:.1f}".format(temperature)).read_text()
+                text = (output_dir / f"ace_{temperature:.1f}").read_text()
 
                 # If the target is metastable, make sure that ZAID in the ACE
                 # file reflects this by adding 400
@@ -417,13 +417,13 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
                 ace_file.write(text)
 
                 # Concatenate into destination xsdir file
-                xsdir_in = output_dir / "xsdir_{:.1f}".format(temperature)
+                xsdir_in = output_dir / f"xsdir_{temperature:.1f}"
                 xsdir_file.write(xsdir_in.read_text())
 
         # Remove ACE/xsdir files for each temperature
         for temperature in temperatures:
-            (output_dir / "ace_{:.1f}".format(temperature)).unlink()
-            (output_dir / "xsdir_{:.1f}".format(temperature)).unlink()
+            (output_dir / f"ace_{temperature:.1f}").unlink()
+            (output_dir / f"xsdir_{temperature:.1f}").unlink()
 
 
 def make_ace_thermal(filename, filename_thermal, temperatures=None,
@@ -480,7 +480,7 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
     else:
         output_dir = Path(output_dir)
         if not output_dir.is_dir():
-            raise IOError("{} is not a directory".format(output_dir))
+            raise IOError(f"{output_dir} is not a directory")
 
     ev = evaluation if evaluation is not None else endf.Evaluation(filename)
     mat = ev.material
@@ -581,12 +581,12 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
         # Extend input with an ACER run for each temperature
         nace = nthermal_acer_in + 1 + 2*i
         ndir = nace + 1
-        ext = '{:02}'.format(i + 1)
+        ext = f'{i + 1:02}'
         commands += _THERMAL_TEMPLATE_ACER.format(**locals())
 
         # Indicate tapes to save for each ACER run
-        tapeout[nace] = output_dir / "ace_{:.1f}".format(temperature)
-        tapeout[ndir] = output_dir / "xsdir_{:.1f}".format(temperature)
+        tapeout[nace] = output_dir / f"ace_{temperature:.1f}"
+        tapeout[ndir] = output_dir / f"xsdir_{temperature:.1f}"
     commands += 'stop\n'
     run(commands, tapein, tapeout, **kwargs)
 
@@ -595,13 +595,13 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
     with ace.open('w') as ace_file, xsdir.open('w') as xsdir_file:
         # Concatenate ACE and xsdir files together
         for temperature in temperatures:
-            ace_in = output_dir / "ace_{:.1f}".format(temperature)
+            ace_in = output_dir / f"ace_{temperature:.1f}"
             ace_file.write(ace_in.read_text())
 
-            xsdir_in = output_dir / "xsdir_{:.1f}".format(temperature)
+            xsdir_in = output_dir / f"xsdir_{temperature:.1f}"
             xsdir_file.write(xsdir_in.read_text())
 
     # Remove ACE/xsdir files for each temperature
     for temperature in temperatures:
-        (output_dir / "ace_{:.1f}".format(temperature)).unlink()
-        (output_dir / "xsdir_{:.1f}".format(temperature)).unlink()
+        (output_dir / f"ace_{temperature:.1f}").unlink()
+        (output_dir / f"xsdir_{temperature:.1f}").unlink()

--- a/openmc/data/photon.py
+++ b/openmc/data/photon.py
@@ -451,10 +451,10 @@ class IncidentPhoton(EqualityMixin):
         if mt in self.reactions:
             return self.reactions[mt]
         else:
-            raise KeyError('No reaction with MT={}.'.format(mt))
+            raise KeyError(f'No reaction with MT={mt}.')
 
     def __repr__(self):
-        return "<IncidentPhoton: {}>".format(self.name)
+        return f"<IncidentPhoton: {self.name}>"
 
     def __iter__(self):
         return iter(self.reactions.values())
@@ -508,7 +508,7 @@ class IncidentPhoton(EqualityMixin):
         # Get atomic number based on name of ACE table
         zaid, xs = ace.name.split('.')
         if not xs.endswith('p'):
-            raise TypeError("{} is not a photoatomic transport ACE table.".format(ace))
+            raise TypeError(f"{ace} is not a photoatomic transport ACE table.")
         Z = get_metadata(int(zaid))[2]
 
         # Read each reaction
@@ -638,7 +638,7 @@ class IncidentPhoton(EqualityMixin):
             with h5py.File(filename, 'r') as f:
                 _COMPTON_PROFILES['pz'] = f['pz'][()]
                 for i in range(1, 101):
-                    group = f['{:03}'.format(i)]
+                    group = f[f'{i:03}']
                     num_electrons = group['num_electrons'][()]
                     binding_energy = group['binding_energy'][()]*EV_PER_MEV
                     J = group['J'][()]
@@ -713,7 +713,7 @@ class IncidentPhoton(EqualityMixin):
 
         # Check for necessary reactions
         for mt in (502, 504, 522):
-            assert mt in data, "Reaction {} not found".format(mt)
+            assert mt in data, f"Reaction {mt} not found"
 
         # Read atomic relaxation
         data.atomic_relaxation = AtomicRelaxation.from_hdf5(group['subshells'])
@@ -836,7 +836,7 @@ class IncidentPhoton(EqualityMixin):
             filename = os.path.join(os.path.dirname(__file__), 'density_effect.h5')
             with h5py.File(filename, 'r') as f:
                 for i in range(1, 101):
-                    group = f['{:03}'.format(i)]
+                    group = f[f'{i:03}']
                     _BREMSSTRAHLUNG[i] = {
                         'I': group.attrs['I'],
                         'num_electrons': group['num_electrons'][()],
@@ -924,10 +924,9 @@ class PhotonReaction(EqualityMixin):
 
     def __repr__(self):
         if self.mt in _REACTION_NAME:
-            return "<Photon Reaction: MT={} {}>".format(
-                self.mt, _REACTION_NAME[self.mt][0])
+            return f"<Photon Reaction: MT={self.mt} {_REACTION_NAME[self.mt][0]}>"
         else:
-            return "<Photon Reaction: MT={}>".format(self.mt)
+            return f"<Photon Reaction: MT={self.mt}>"
 
     @property
     def anomalous_real(self):

--- a/openmc/data/product.py
+++ b/openmc/data/product.py
@@ -135,7 +135,7 @@ class Product(EqualityMixin):
         # Write applicability/distribution
         group.attrs['n_distribution'] = len(self.distribution)
         for i, d in enumerate(self.distribution):
-            dgroup = group.create_group('distribution_{}'.format(i))
+            dgroup = group.create_group(f'distribution_{i}')
             if self.applicability:
                 self.applicability[i].to_hdf5(dgroup, 'applicability')
             d.to_hdf5(dgroup)
@@ -170,7 +170,7 @@ class Product(EqualityMixin):
         distribution = []
         applicability = []
         for i in range(n_distribution):
-            dgroup = group['distribution_{}'.format(i)]
+            dgroup = group[f'distribution_{i}']
             if 'applicability' in dgroup:
                 applicability.append(Tabulated1D.from_hdf5(
                     dgroup['applicability']))

--- a/openmc/data/reaction.py
+++ b/openmc/data/reaction.py
@@ -56,13 +56,13 @@ REACTION_NAME = {1: '(n,total)', 2: '(n,elastic)', 4: '(n,level)',
                  301: 'heating', 444: 'damage-energy',
                  649: '(n,pc)', 699: '(n,dc)', 749: '(n,tc)', 799: '(n,3Hec)',
                  849: '(n,ac)', 891: '(n,2nc)', 901: 'heating-local'}
-REACTION_NAME.update({i: '(n,n{})'.format(i - 50) for i in range(51, 91)})
-REACTION_NAME.update({i: '(n,p{})'.format(i - 600) for i in range(600, 649)})
-REACTION_NAME.update({i: '(n,d{})'.format(i - 650) for i in range(650, 699)})
-REACTION_NAME.update({i: '(n,t{})'.format(i - 700) for i in range(700, 749)})
-REACTION_NAME.update({i: '(n,3He{})'.format(i - 750) for i in range(750, 799)})
-REACTION_NAME.update({i: '(n,a{})'.format(i - 800) for i in range(800, 849)})
-REACTION_NAME.update({i: '(n,2n{})'.format(i - 875) for i in range(875, 891)})
+REACTION_NAME.update({i: f'(n,n{i - 50})' for i in range(51, 91)})
+REACTION_NAME.update({i: f'(n,p{i - 600})' for i in range(600, 649)})
+REACTION_NAME.update({i: f'(n,d{i - 650})' for i in range(650, 699)})
+REACTION_NAME.update({i: f'(n,t{i - 700})' for i in range(700, 749)})
+REACTION_NAME.update({i: f'(n,3He{i - 750})' for i in range(750, 799)})
+REACTION_NAME.update({i: f'(n,a{i - 800})' for i in range(800, 849)})
+REACTION_NAME.update({i: f'(n,2n{i - 875})' for i in range(875, 891)})
 
 REACTION_MT = {name: mt for mt, name in REACTION_NAME.items()}
 REACTION_MT['fission'] = 18
@@ -119,7 +119,7 @@ def _get_products(ev, mt):
             p = Product('electron')
         else:
             Z, A = divmod(za, 1000)
-            p = Product('{}{}'.format(ATOMIC_SYMBOL[Z], A))
+            p = Product(f'{ATOMIC_SYMBOL[Z]}{A}')
 
         p.yield_ = yield_
 
@@ -557,9 +557,9 @@ def _get_activation_products(ev, rx):
             # Get GNDS name for product
             symbol = ATOMIC_SYMBOL[Z]
             if excited_state > 0:
-                name = '{}{}_e{}'.format(symbol, A, excited_state)
+                name = f'{symbol}{A}_e{excited_state}'
             else:
-                name = '{}{}'.format(symbol, A)
+                name = f'{symbol}{A}'
 
             p = Product(name)
             if mf == 9:
@@ -656,8 +656,7 @@ def _get_photon_products_ace(ace, rx):
             photon.yield_ = Tabulated1D(energy, yield_)
 
         else:
-            raise ValueError("MFTYPE must be 12, 13, 16. Got {0}".format(
-                mftype))
+            raise ValueError(f"MFTYPE must be 12, 13, 16. Got {mftype}")
 
         # ==================================================================
         # Photon energy distribution
@@ -846,9 +845,9 @@ class Reaction(EqualityMixin):
 
     def __repr__(self):
         if self.mt in REACTION_NAME:
-            return "<Reaction: MT={} {}>".format(self.mt, REACTION_NAME[self.mt])
+            return f"<Reaction: MT={self.mt} {REACTION_NAME[self.mt]}>"
         else:
-            return "<Reaction: MT={}>".format(self.mt)
+            return f"<Reaction: MT={self.mt}>"
 
     @property
     def center_of_mass(self):
@@ -933,7 +932,7 @@ class Reaction(EqualityMixin):
                 threshold_idx = getattr(self.xs[T], '_threshold_idx', 0)
                 dset.attrs['threshold_idx'] = threshold_idx
         for i, p in enumerate(self.products):
-            pgroup = group.create_group('product_{}'.format(i))
+            pgroup = group.create_group(f'product_{i}')
             p.to_hdf5(pgroup)
 
     @classmethod
@@ -985,7 +984,7 @@ class Reaction(EqualityMixin):
 
         # Read reaction products
         for i in range(n_product):
-            pgroup = group['product_{}'.format(i)]
+            pgroup = group[f'product_{i}']
             rx.products.append(Product.from_hdf5(pgroup))
 
         return rx

--- a/openmc/data/resonance.py
+++ b/openmc/data/resonance.py
@@ -830,7 +830,7 @@ class RMatrixLimited(ResonanceRange):
                 elif mt == 102:
                     columns.append('captureWidth')
                 else:
-                    columns.append('width (MT={})'.format(mt))
+                    columns.append(f'width (MT={mt})')
 
             # Create Pandas dataframe with resonance parameters
             parameters = pd.DataFrame.from_records(records, columns=columns)
@@ -896,7 +896,7 @@ class SpinGroup:
         self.parameters = parameters
 
     def __repr__(self):
-        return '<SpinGroup: Jpi={}{}>'.format(self.spin, self.parity)
+        return f'<SpinGroup: Jpi={self.spin}{self.parity}>'
 
 
 class Unresolved(ResonanceRange):

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -90,7 +90,7 @@ _THERMAL_NAMES = {
 def _temperature_str(T):
     # round() normally returns an int when called with a single argument, but
     # numpy floats overload rounding to return another float
-    return "{}K".format(int(round(T)))
+    return f"{int(round(T))}K"
 
 
 def get_thermal_name(name):
@@ -439,7 +439,7 @@ class ThermalScattering(EqualityMixin):
 
     def __repr__(self):
         if hasattr(self, 'name'):
-            return "<Thermal Scattering Data: {}>".format(self.name)
+            return f"<Thermal Scattering Data: {self.name}>"
         else:
             return "<Thermal Scattering Data>"
 
@@ -506,7 +506,7 @@ class ThermalScattering(EqualityMixin):
         # Check if temprature already exists
         strT = data.temperatures[0]
         if strT in self.temperatures:
-            warn('S(a,b) data at T={} already exists.'.format(strT))
+            warn(f'S(a,b) data at T={strT} already exists.')
             return
 
         # Check that name matches
@@ -614,7 +614,7 @@ class ThermalScattering(EqualityMixin):
         # Get new name that is GND-consistent
         ace_name, xs = ace.name.split('.')
         if not xs.endswith('t'):
-            raise TypeError("{} is not a thermal scattering ACE table.".format(ace))
+            raise TypeError(f"{ace} is not a thermal scattering ACE table.")
         if name is None:
             name = get_thermal_name(ace_name)
 

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -647,7 +647,7 @@ class Integrator(ABC):
                 days = watt_days_per_kg * kilograms / rate
                 seconds.append(days*_SECONDS_PER_DAY)
             else:
-                raise ValueError("Invalid timestep unit '{}'".format(unit))
+                raise ValueError(f"Invalid timestep unit '{unit}'")
 
         self.timesteps = np.asarray(seconds)
         self.source_rates = np.asarray(source_rates)
@@ -664,8 +664,7 @@ class Integrator(ABC):
                 self._solver = CRAM16
             else:
                 raise ValueError(
-                    "Solver {} not understood. Expected 'cram48' or "
-                    "'cram16'".format(solver))
+                    f"Solver {solver} not understood. Expected 'cram48' or 'cram16'")
         else:
             self.solver = solver
 
@@ -677,14 +676,13 @@ class Integrator(ABC):
     def solver(self, func):
         if not isinstance(func, Callable):
             raise TypeError(
-                "Solver must be callable, not {}".format(type(func)))
+                f"Solver must be callable, not {type(func)}")
         try:
             sig = signature(func)
         except ValueError:
             # Guard against callables that aren't introspectable, e.g.
             # fortran functions wrapped by F2PY
-            warn("Could not determine arguments to {}. Proceeding "
-                 "anyways".format(func))
+            warn(f"Could not determine arguments to {func}. Proceeding anyways")
             self._solver = func
             return
 
@@ -696,8 +694,7 @@ class Integrator(ABC):
         for ix, param in enumerate(sig.parameters.values()):
             if param.kind in {param.KEYWORD_ONLY, param.VAR_KEYWORD}:
                 raise ValueError(
-                    "Keyword arguments like {} at position {} are not "
-                    "allowed".format(ix, param))
+                    f"Keyword arguments like {ix} at position {param} are not allowed")
 
         self._solver = func
 

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -141,7 +141,7 @@ def replace_missing(product, decay_data):
 
     # First check if ground state is available
     if state:
-        product = '{}{}'.format(symbol, A)
+        product = f'{symbol}{A}'
 
     # Find isotope with longest half-life
     half_life = 0.0
@@ -172,7 +172,7 @@ def replace_missing(product, decay_data):
                 Z += 1
             else:
                 Z -= 1
-        product = '{}{}'.format(openmc.data.ATOMIC_SYMBOL[Z], A)
+        product = f'{openmc.data.ATOMIC_SYMBOL[Z]}{A}'
 
     return product
 
@@ -417,7 +417,7 @@ class Chain:
                     if mts & reactions_available:
                         A = data.nuclide['mass_number'] + delta_A
                         Z = data.nuclide['atomic_number'] + delta_Z
-                        daughter = '{}{}'.format(openmc.data.ATOMIC_SYMBOL[Z], A)
+                        daughter = f'{openmc.data.ATOMIC_SYMBOL[Z]}{A}'
 
                         if daughter not in decay_data:
                             daughter = replace_missing(daughter, decay_data)
@@ -483,7 +483,7 @@ class Chain:
         if missing_daughter:
             print('The following decay modes have daughters with no decay data:')
             for mode in missing_daughter:
-                print('  {}'.format(mode))
+                print(f'  {mode}')
             print('')
 
         if missing_rx_product:
@@ -495,7 +495,7 @@ class Chain:
         if missing_fpy:
             print('The following fissionable nuclides have no fission product yields:')
             for parent, replacement in missing_fpy:
-                print('  {}, replaced with {}'.format(parent, replacement))
+                print(f'  {parent}, replaced with {replacement}')
             print('')
 
         if missing_fp:
@@ -873,8 +873,7 @@ class Chain:
             if len(indexes) == 0:
                 if strict:
                     raise AttributeError(
-                        "Nuclide {} does not have {} reactions".format(
-                            parent, reaction))
+                        f"Nuclide {parent} does not have {reaction} reactions")
                 missing_reaction.add(parent)
                 continue
 
@@ -896,8 +895,7 @@ class Chain:
 
         if len(rxn_ix_map) == 0:
             raise IndexError(
-                "No {} reactions found in this {}".format(
-                    reaction, self.__class__.__name__))
+                f"No {reaction} reactions found in this {self.__class__.__name__}")
 
         if len(missing_parents) > 0:
             warn("The following nuclides were not found in {}: {}".format(
@@ -908,14 +906,14 @@ class Chain:
                  "{}".format(reaction, ", ".join(sorted(missing_reaction))))
 
         if len(missing_products) > 0:
-            tail = ("{} -> {}".format(k, v)
+            tail = (f"{k} -> {v}"
                     for k, v in sorted(missing_products.items()))
             warn("The following products were not found in the {} and "
                  "parents were unmodified: \n{}".format(
                      self.__class__.__name__, ", ".join(tail)))
 
         if len(bad_sums) > 0:
-            tail = ("{}: {:5.3f}".format(k, s)
+            tail = (f"{k}: {s:5.3f}"
                     for k, s in sorted(bad_sums.items()))
             warn("The following parent nuclides were given {} branch ratios "
                  "with a sum outside tolerance of 1 +/- {:5.3e}:\n{}".format(

--- a/openmc/deplete/coupled_operator.py
+++ b/openmc/deplete/coupled_operator.py
@@ -518,7 +518,7 @@ class CoupledOperator(OpenMCOperator):
 
         """
         openmc.lib.statepoint_write(
-            "openmc_simulation_n{}.h5".format(step),
+            f"openmc_simulation_n{step}.h5",
             write_source=False)
 
     def finalize(self):

--- a/openmc/deplete/nuclide.py
+++ b/openmc/deplete/nuclide.py
@@ -275,7 +275,7 @@ class Nuclide:
             if parent is not None:
                 assert root is not None
                 fpy_elem = root.find(
-                    './/nuclide[@name="{}"]/neutron_fission_yields'.format(parent)
+                    f'.//nuclide[@name="{parent}"]/neutron_fission_yields'
                 )
                 if fpy_elem is None:
                     raise ValueError(
@@ -413,7 +413,7 @@ class Nuclide:
                     continue
                 msg = msg_func(
                     name=self.name, actual=sum_br, expected=1.0, tol=tolerance,
-                    prop="{} reaction branch ratios".format(rxn_type))
+                    prop=f"{rxn_type} reaction branch ratios")
                 if strict:
                     raise ValueError(msg)
                 elif quiet:
@@ -430,7 +430,7 @@ class Nuclide:
                 msg = msg_func(
                     name=self.name, actual=sum_yield,
                     expected=2.0, tol=tolerance,
-                    prop="fission yields (E = {:7.4e} eV)".format(energy))
+                    prop=f"fission yields (E = {energy:7.4e} eV)")
                 if strict:
                     raise ValueError(msg)
                 elif quiet:
@@ -695,8 +695,7 @@ class FissionYield(Mapping):
         return self * scalar
 
     def __repr__(self):
-        return "<{} containing {} products and yields>".format(
-            self.__class__.__name__, len(self))
+        return f"<{self.__class__.__name__} containing {len(self)} products and yields>"
 
     def __deepcopy__(self, memo):
         result = FissionYield(self.products, self.yields.copy())

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -1851,7 +1851,7 @@ class HexLattice(Lattice):
         largest_index = 6*(num_rings - 1)
         n_digits_index = len(str(largest_index))
         n_digits_ring = len(str(num_rings - 1))
-        str_form = '({{:{}}},{{:{}}})'.format(n_digits_ring, n_digits_index)
+        str_form = f'({{:{n_digits_ring}}},{{:{n_digits_index}}})'
         pad = ' '*(n_digits_index + n_digits_ring + 3)
 
         # Initialize the list for each row.
@@ -1956,7 +1956,7 @@ class HexLattice(Lattice):
         largest_index = 6*(num_rings - 1)
         n_digits_index = len(str(largest_index))
         n_digits_ring = len(str(num_rings - 1))
-        str_form = '({{:{}}},{{:{}}})'.format(n_digits_ring, n_digits_index)
+        str_form = f'({{:{n_digits_ring}}},{{:{n_digits_index}}})'
         pad = ' '*(n_digits_index + n_digits_ring + 3)
 
         # Initialize the list for each row.

--- a/openmc/lib/__init__.py
+++ b/openmc/lib/__init__.py
@@ -28,7 +28,7 @@ else:
 if os.environ.get('READTHEDOCS', None) != 'True':
     # Open shared library
     _filename = pkg_resources.resource_filename(
-        __name__, 'libopenmc.{}'.format(_suffix))
+        __name__, f'libopenmc.{_suffix}')
     _dll = CDLL(_filename)
 else:
     # For documentation builds, we don't actually have the shared library

--- a/openmc/lib/cell.py
+++ b/openmc/lib/cell.py
@@ -268,7 +268,7 @@ class Cell(_FortranObjectWithID):
             return rotation_data[9:]
         else:
             raise ValueError(
-                'Invalid size of rotation matrix: {}'.format(rot_size))
+                f'Invalid size of rotation matrix: {rot_size}')
 
     @rotation.setter
     def rotation(self, rotation_data):

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -629,7 +629,7 @@ class _DLLGlobal:
 
 class _FortranObject:
     def __repr__(self):
-        return "<{}(index={})>".format(type(self).__name__, self._index)
+        return f"<{type(self).__name__}(index={self._index})>"
 
 
 class _FortranObjectWithID(_FortranObject):
@@ -641,7 +641,7 @@ class _FortranObjectWithID(_FortranObject):
         self.id
 
     def __repr__(self):
-        return "<{}(id={})>".format(type(self).__name__, self.id)
+        return f"<{type(self).__name__}(id={self.id})>"
 
 
 @contextmanager

--- a/openmc/lib/error.py
+++ b/openmc/lib/error.py
@@ -37,5 +37,5 @@ def _error_handler(err, func, args):
         warn(msg)
     elif err < 0:
         if not msg:
-            msg = "Unknown error encountered (code {}).".format(err)
+            msg = f"Unknown error encountered (code {err})."
         raise exc.OpenMCError(msg)

--- a/openmc/lib/plot.py
+++ b/openmc/lib/plot.py
@@ -31,7 +31,7 @@ class _Position(Structure):
         elif idx == 2:
             return self.z
         else:
-            raise IndexError("{} index is invalid for _Position".format(idx))
+            raise IndexError(f"{idx} index is invalid for _Position")
 
     def __setitem__(self, idx, val):
         if idx == 0:
@@ -41,10 +41,10 @@ class _Position(Structure):
         elif idx == 2:
             self.z = val
         else:
-            raise IndexError("{} index is invalid for _Position".format(idx))
+            raise IndexError(f"{idx} index is invalid for _Position")
 
     def __repr__(self):
-        return "({}, {}, {})".format(self.x, self.y, self.z)
+        return f"({self.x}, {self.y}, {self.z})"
 
 
 class _PlotBase(Structure):
@@ -127,7 +127,7 @@ class _PlotBase(Structure):
         elif self.basis_ == 3:
             return 'yz'
 
-        raise ValueError("Plot basis {} is invalid".format(self.basis_))
+        raise ValueError(f"Plot basis {self.basis_} is invalid")
 
     @basis.setter
     def basis(self, basis):
@@ -135,7 +135,7 @@ class _PlotBase(Structure):
             valid_bases = ('xy', 'xz', 'yz')
             basis = basis.lower()
             if basis not in valid_bases:
-                raise ValueError("{} is not a valid plot basis.".format(basis))
+                raise ValueError(f"{basis} is not a valid plot basis.")
 
             if basis == 'xy':
                 self.basis_ = 1
@@ -148,12 +148,11 @@ class _PlotBase(Structure):
         if isinstance(basis, int):
             valid_bases = (1, 2, 3)
             if basis not in valid_bases:
-                raise ValueError("{} is not a valid plot basis.".format(basis))
+                raise ValueError(f"{basis} is not a valid plot basis.")
             self.basis_ = basis
             return
 
-        raise ValueError("{} of type {} is an"
-                         " invalid plot basis".format(basis, type(basis)))
+        raise ValueError(f"{basis} of type {type(basis)} is an invalid plot basis")
 
     @property
     def h_res(self):
@@ -199,14 +198,14 @@ class _PlotBase(Structure):
         out_str = ["-----",
                    "Plot:",
                    "-----",
-                   "Origin: {}".format(self.origin),
-                   "Width: {}".format(self.width),
-                   "Height: {}".format(self.height),
-                   "Basis: {}".format(self.basis),
-                   "HRes: {}".format(self.h_res),
-                   "VRes: {}".format(self.v_res),
-                   "Color Overlaps: {}".format(self.color_overlaps),
-                   "Level: {}".format(self.level)]
+                   f"Origin: {self.origin}",
+                   f"Width: {self.width}",
+                   f"Height: {self.height}",
+                   f"Basis: {self.basis}",
+                   f"HRes: {self.h_res}",
+                   f"VRes: {self.v_res}",
+                   f"Color Overlaps: {self.color_overlaps}",
+                   f"Level: {self.level}"]
         return '\n'.join(out_str)
 
 

--- a/openmc/lib/settings.py
+++ b/openmc/lib/settings.py
@@ -53,7 +53,7 @@ class _Settings:
                 current_idx.value = idx
                 break
         else:
-            raise ValueError('Invalid run mode: {}'.format(mode))
+            raise ValueError(f'Invalid run mode: {mode}')
 
     @property
     def path_statepoint(self):

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -152,7 +152,7 @@ class Material(IDManagerMixin):
 
         for nuclide, percent, percent_type in self._nuclides:
             string += '{: <16}'.format('\t{}'.format(nuclide))
-            string += '=\t{: <12} [{}]\n'.format(percent, percent_type)
+            string += f'=\t{percent: <12} [{percent_type}]\n'
 
         if self._macroscopic is not None:
             string += '{: <16}\n'.format('\tMacroscopic Data')
@@ -469,8 +469,7 @@ class Material(IDManagerMixin):
                 raise ValueError('No volume information found for material ID={}.'
                                  .format(self.id))
         else:
-            raise ValueError('No volume information found for material ID={}.'
-                             .format(self.id))
+            raise ValueError(f'No volume information found for material ID={self.id}.')
 
     def set_density(self, units: str, density: Optional[float] = None):
         """Set the density of the material
@@ -500,7 +499,7 @@ class Material(IDManagerMixin):
                       '"sum" unit'.format(self.id)
                 raise ValueError(msg)
 
-            cv.check_type('the density for Material ID="{}"'.format(self.id),
+            cv.check_type(f'the density for Material ID="{self.id}"',
                           density, Real)
             self._density = density
 
@@ -743,20 +742,18 @@ class Material(IDManagerMixin):
             el = element.lower()
             element = openmc.data.ELEMENT_SYMBOL.get(el)
             if element is None:
-                msg = 'Element name "{}" not recognised'.format(el)
+                msg = f'Element name "{el}" not recognised'
                 raise ValueError(msg)
         else:
             if element[0].islower():
-                msg = 'Element name "{}" should start with an uppercase ' \
-                      'letter'.format(element)
+                msg = f'Element name "{element}" should start with an uppercase letter'
                 raise ValueError(msg)
             if len(element) == 2 and element[1].isupper():
-                msg = 'Element name "{}" should end with a lowercase ' \
-                      'letter'.format(element)
+                msg = f'Element name "{element}" should end with a lowercase letter'
                 raise ValueError(msg)
             # skips the first entry of ATOMIC_SYMBOL which is n for neutron
             if element not in list(openmc.data.ATOMIC_SYMBOL.values())[1:]:
-                msg = 'Element name "{}" not recognised'.format(element)
+                msg = f'Element name "{element}" not recognised'
                 raise ValueError(msg)
 
         if self._macroscopic is not None:
@@ -847,8 +844,7 @@ class Material(IDManagerMixin):
             for token in row:
                 if token.isalpha():
                     if token == "n" or token not in openmc.data.ATOMIC_NUMBER:
-                        msg = 'Formula entry {} not an element symbol.' \
-                              .format(token)
+                        msg = f'Formula entry {token} not an element symbol.'
                         raise ValueError(msg)
                 elif token not in ['(', ')', ''] and not token.isdigit():
                         msg = 'Formula must be made from a sequence of ' \
@@ -1373,8 +1369,7 @@ class Material(IDManagerMixin):
                 subelement.set("value", str(self._density))
             subelement.set("units", self._density_units)
         else:
-            raise ValueError('Density has not been set for material {}!'
-                             .format(self.id))
+            raise ValueError(f'Density has not been set for material {self.id}!')
 
         if self._macroscopic is None:
             # Create nuclide XML subelements
@@ -1480,7 +1475,7 @@ class Material(IDManagerMixin):
 
         # Create the new material with the desired name
         if name is None:
-            name = '-'.join(['{}({})'.format(m.name, f) for m, f in
+            name = '-'.join([f'{m.name}({f})' for m, f in
                              zip(materials, fracs)])
         new_mat = openmc.Material(name=name)
 

--- a/openmc/mgxs/library.py
+++ b/openmc/mgxs/library.py
@@ -685,7 +685,7 @@ class Library:
 
         # Check that requested domain is included in library
         if mgxs_type not in self.mgxs_types:
-            msg = 'Unable to find MGXS type "{0}"'.format(mgxs_type)
+            msg = f'Unable to find MGXS type "{mgxs_type}"'
             raise ValueError(msg)
 
         return self.all_mgxs[domain_id][mgxs_type]
@@ -901,7 +901,7 @@ class Library:
         if not os.path.exists(directory):
             os.makedirs(directory)
 
-        full_filename = os.path.join(directory, '{}.pkl'.format(filename))
+        full_filename = os.path.join(directory, f'{filename}.pkl')
         full_filename = full_filename.replace(' ', '-')
 
         # Load and return pickled Library object

--- a/openmc/mgxs/mdgxs.py
+++ b/openmc/mgxs/mdgxs.py
@@ -612,7 +612,7 @@ class MDGXS(MGXS):
         string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
 
         # Generate the header for an individual XS
-        xs_header = '\tCross Sections [{0}]:'.format(self.get_units(xs_type))
+        xs_header = f'\tCross Sections [{self.get_units(xs_type)}]:'
 
         # If cross section data has not been computed, only print string header
         if self.tallies is None:
@@ -641,7 +641,7 @@ class MDGXS(MGXS):
                     string += '{0: <16}=\t{1}\n'.format('\tNuclide', nuclide)
 
                 # Add the cross section header
-                string += '{0: <16}\n'.format(xs_header)
+                string += f'{xs_header: <16}\n'
 
                 for delayed_group in self.delayed_groups:
 
@@ -875,7 +875,7 @@ class MDGXS(MGXS):
         # Sort the dataframe by domain type id (e.g., distribcell id) and
         # energy groups such that data is from fast to thermal
         if self.domain_type == 'mesh':
-            mesh_str = 'mesh {0}'.format(self.domain.id)
+            mesh_str = f'mesh {self.domain.id}'
             df.sort_values(by=[(mesh_str, 'x'), (mesh_str, 'y'),
                                (mesh_str, 'z')] + columns, inplace=True)
         else:
@@ -2496,7 +2496,7 @@ class MatrixMDGXS(MDGXS):
         string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
 
         # Generate the header for an individual XS
-        xs_header = '\tCross Sections [{0}]:'.format(self.get_units(xs_type))
+        xs_header = f'\tCross Sections [{self.get_units(xs_type)}]:'
 
         # If cross section data has not been computed, only print string header
         if self.tallies is None:
@@ -2532,7 +2532,7 @@ class MatrixMDGXS(MDGXS):
                     string += '{: <16}=\t{}\n'.format('\tNuclide', nuclide)
 
                 # Build header for cross section type
-                string += '{: <16}\n'.format(xs_header)
+                string += f'{xs_header: <16}\n'
 
                 if self.delayed_groups is not None:
 

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -1427,7 +1427,7 @@ class MGXS:
                                         filter_bins=subdomains)
             avg_xs.tallies[tally_type] = tally_avg
 
-        avg_xs._domain_type = 'sum({0})'.format(self.domain_type)
+        avg_xs._domain_type = f'sum({self.domain_type})'
         avg_xs.sparse = self.sparse
         return avg_xs
 
@@ -1478,7 +1478,7 @@ class MGXS:
         # Clone this MGXS to initialize the homogenized version
         homogenized_mgxs = copy.deepcopy(self)
         homogenized_mgxs._derived = True
-        name = 'hom({}, '.format(self.domain.name)
+        name = f'hom({self.domain.name}, '
 
         # Get the domain filter
         filter_type = _DOMAIN_TO_FILTER[self.domain_type]
@@ -1505,7 +1505,7 @@ class MGXS:
             denom_tally += other_denom_tally
 
             # Update the name for the homogenzied MGXS
-            name += '{}, '.format(mgxs.domain.name)
+            name += f'{mgxs.domain.name}, '
 
         # Set the properties of the homogenized MGXS
         homogenized_mgxs._rxn_rate_tally = rxn_rate_tally
@@ -1745,7 +1745,7 @@ class MGXS:
         string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
 
         # Generate the header for an individual XS
-        xs_header = '\tCross Sections [{0}]:'.format(self.get_units(xs_type))
+        xs_header = f'\tCross Sections [{self.get_units(xs_type)}]:'
 
         # If cross section data has not been computed, only print string header
         if self.tallies is None:
@@ -1773,7 +1773,7 @@ class MGXS:
                     string += '{0: <16}=\t{1}\n'.format('\tNuclide', nuclide)
 
                 # Build header for cross section type
-                string += '{0: <16}\n'.format(xs_header)
+                string += f'{xs_header: <16}\n'
                 template = '{0: <12}Group {1} [{2: <10} - {3: <10}eV]:\t'
 
                 average_xs = self.get_xs(nuclides=[nuclide],
@@ -2131,7 +2131,7 @@ class MGXS:
         # Sort the dataframe by domain type id (e.g., distribcell id) and
         # energy groups such that data is from fast to thermal
         if self.domain_type == 'mesh':
-            mesh_str = 'mesh {0}'.format(self.domain.id)
+            mesh_str = f'mesh {self.domain.id}'
             df.sort_values(by=[(mesh_str, 'x'), (mesh_str, 'y'),
                                (mesh_str, 'z')] + columns, inplace=True)
         else:
@@ -2472,7 +2472,7 @@ class MatrixMGXS(MGXS):
         string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
 
         # Generate the header for an individual XS
-        xs_header = '\tCross Sections [{0}]:'.format(self.get_units(xs_type))
+        xs_header = f'\tCross Sections [{self.get_units(xs_type)}]:'
 
         # If cross section data has not been computed, only print string header
         if self.tallies is None:
@@ -2508,7 +2508,7 @@ class MatrixMGXS(MGXS):
                     string += '{0: <16}=\t{1}\n'.format('\tNuclide', nuclide)
 
                 # Build header for cross section type
-                string += '{0: <16}\n'.format(xs_header)
+                string += f'{xs_header: <16}\n'
                 template = '{0: <12}Group {1} -> Group {2}:\t\t'
 
                 average_xs = self.get_xs(nuclides=[nuclide],
@@ -4476,7 +4476,7 @@ class ScatterMatrixXS(MatrixMGXS):
             slice_xs.legendre_order = legendre_order
 
             # Slice the scattering tally
-            filter_bins = [tuple(['P{}'.format(i)
+            filter_bins = [tuple([f'P{i}'
                                   for i in range(self.legendre_order + 1)])]
             slice_xs.tallies[self.rxn_type] = \
                 slice_xs.tallies[self.rxn_type].get_slice(
@@ -4613,7 +4613,7 @@ class ScatterMatrixXS(MatrixMGXS):
                 cv.check_less_than(
                     'moment', moment, self.legendre_order, equality=True)
                 filters.append(openmc.LegendreFilter)
-                filter_bins.append(('P{}'.format(moment),))
+                filter_bins.append((f'P{moment}',))
                 num_angle_bins = 1
             else:
                 num_angle_bins = self.legendre_order + 1
@@ -4804,7 +4804,7 @@ class ScatterMatrixXS(MatrixMGXS):
         cv.check_value('xs_type', xs_type, ['macro', 'micro'])
 
         if self.correction != 'P0' and self.scatter_format == SCATTER_LEGENDRE:
-            rxn_type = '{0} (P{1})'.format(self.mgxs_type, moment)
+            rxn_type = f'{self.mgxs_type} (P{moment})'
         else:
             rxn_type = self.mgxs_type
 
@@ -4815,7 +4815,7 @@ class ScatterMatrixXS(MatrixMGXS):
         string += '{0: <16}=\t{1}\n'.format('\tDomain ID', self.domain.id)
 
         # Generate the header for an individual XS
-        xs_header = '\tCross Sections [{0}]:'.format(self.get_units(xs_type))
+        xs_header = f'\tCross Sections [{self.get_units(xs_type)}]:'
 
         # If cross section data has not been computed, only print string header
         if self.tallies is None:
@@ -4851,7 +4851,7 @@ class ScatterMatrixXS(MatrixMGXS):
                     string += '{0: <16}=\t{1}\n'.format('\tNuclide', nuclide)
 
                 # Build header for cross section type
-                string += '{0: <16}\n'.format(xs_header)
+                string += f'{xs_header: <16}\n'
 
                 average_xs = self.get_xs(nuclides=[nuclide],
                                          subdomains=[subdomain],
@@ -4903,8 +4903,7 @@ class ScatterMatrixXS(MatrixMGXS):
                         for azi in range(len(azi_bins) - 1):
                             azi_low, azi_high = azi_bins[azi: azi + 2]
                             string += \
-                                '\t\tPolar Angle: [{0:5f} - {1:5f}]'.format(
-                                    pol_low, pol_high) + \
+                                f'\t\tPolar Angle: [{pol_low:5f} - {pol_high:5f}]' + \
                                 '\tAzimuthal Angle: [{0:5f} - {1:5f}]'.format(
                                     azi_low, azi_high) + '\n'
                             string += print_groups_and_histogram(
@@ -6226,7 +6225,7 @@ class MeshSurfaceMGXS(MGXS):
             if 'group out' in df:
                 df = df[df['group out'].isin(groups)]
 
-        mesh_str = 'mesh {0}'.format(self.domain.id)
+        mesh_str = f'mesh {self.domain.id}'
         col_key = (mesh_str, 'surf')
         surfaces = df.pop(col_key)
         df.insert(len(self.domain.dimension), col_key, surfaces)

--- a/openmc/model/funcs.py
+++ b/openmc/model/funcs.py
@@ -221,8 +221,7 @@ def pin(surfaces, items, subdivisions=None, divide_vols=True,
         center_getter = attrgetter("z0", "y0")
     else:
         raise TypeError(
-            "Not configured to interpret {} surfaces".format(
-                surf_type.__name__))
+            f"Not configured to interpret {surf_type.__name__} surfaces")
 
     centers = set()
     prev_rad = 0

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -46,7 +46,7 @@ class CompositeSurface(ABC):
                 getattr(self, name).boundary_type = boundary_type
 
     def __repr__(self):
-        return "<{} at 0x{:x}>".format(type(self).__name__, id(self))
+        return f"<{type(self).__name__} at 0x{id(self):x}>"
 
     @property
     @abstractmethod

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -634,8 +634,7 @@ class Plot(PlotBase):
             raise ValueError(msg)
 
         elif meshlines['type'] not in ['tally', 'entropy', 'ufs', 'cmfd']:
-            msg = 'Unable to set the meshlines with ' \
-                  'type "{}"'.format(meshlines['type'])
+            msg = f"Unable to set the meshlines with type \"{meshlines['type']}\""
             raise ValueError(msg)
 
         if 'id' in meshlines:

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -383,7 +383,7 @@ class Uniform(Univariate):
         """
         element = ET.Element(element_name)
         element.set("type", "uniform")
-        element.set("parameters", '{} {}'.format(self.a, self.b))
+        element.set("parameters", f'{self.a} {self.b}')
         return element
 
     @classmethod
@@ -672,7 +672,7 @@ class Watt(Univariate):
         """
         element = ET.Element(element_name)
         element.set("type", "watt")
-        element.set("parameters", '{} {}'.format(self.a, self.b))
+        element.set("parameters", f'{self.a} {self.b}')
         return element
 
     @classmethod
@@ -762,7 +762,7 @@ class Normal(Univariate):
         """
         element = ET.Element(element_name)
         element.set("type", "normal")
-        element.set("parameters", '{} {}'.format(self.mean_value, self.std_dev))
+        element.set("parameters", f'{self.mean_value} {self.std_dev}')
         return element
 
     @classmethod

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -187,8 +187,7 @@ class Surface(IDManagerMixin, ABC):
         coefficients = '{0: <20}'.format('\tCoefficients') + '\n'
 
         for coeff in self._coefficients:
-            coefficients += '{0: <20}{1}{2}\n'.format(
-                coeff, '=\t', self._coefficients[coeff])
+            coefficients += f'{coeff: <20}=\t{self._coefficients[coeff]}\n'
 
         string += coefficients
 

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -2149,7 +2149,7 @@ class Tally(IDManagerMixin):
             new_tally.sparse = self.sparse
 
         else:
-            msg = 'Unable to add "{}" to Tally ID="{}"'.format(other, self.id)
+            msg = f'Unable to add "{other}" to Tally ID="{self.id}"'
             raise ValueError(msg)
 
         return new_tally
@@ -2220,7 +2220,7 @@ class Tally(IDManagerMixin):
             new_tally.sparse = self.sparse
 
         else:
-            msg = 'Unable to subtract "{}" from Tally ID="{}"'.format(other, self.id)
+            msg = f'Unable to subtract "{other}" from Tally ID="{self.id}"'
             raise ValueError(msg)
 
         return new_tally
@@ -2291,7 +2291,7 @@ class Tally(IDManagerMixin):
             new_tally.sparse = self.sparse
 
         else:
-            msg = 'Unable to multiply Tally ID="{}" by "{}"'.format(self.id, other)
+            msg = f'Unable to multiply Tally ID="{self.id}" by "{other}"'
             raise ValueError(msg)
 
         return new_tally
@@ -2362,7 +2362,7 @@ class Tally(IDManagerMixin):
             new_tally.sparse = self.sparse
 
         else:
-            msg = 'Unable to divide Tally ID="{}" by "{}"'.format(self.id, other)
+            msg = f'Unable to divide Tally ID="{self.id}" by "{other}"'
             raise ValueError(msg)
 
         return new_tally
@@ -2437,7 +2437,7 @@ class Tally(IDManagerMixin):
             new_tally.sparse = self.sparse
 
         else:
-            msg = 'Unable to raise Tally ID="{}" to power "{}"'.format(self.id, power)
+            msg = f'Unable to raise Tally ID="{self.id}" to power "{power}"'
             raise ValueError(msg)
 
         return new_tally
@@ -3105,8 +3105,7 @@ class Tallies(cv.CheckedList):
 
         """
         if not isinstance(tally, Tally):
-            msg = 'Unable to add a non-Tally "{}" to the ' \
-                  'Tallies instance'.format(tally)
+            msg = f'Unable to add a non-Tally "{tally}" to the Tallies instance'
             raise TypeError(msg)
 
         if merge:


### PR DESCRIPTION

# Description

following on from my previous PRs replacing ```.format``` with f strings.

I've always preferred the concise f string and appreciate saving a few lines of code. 

I recently found out f strings are also [faster](https://www.reddit.com/r/Python/comments/pivojb/performance_comparison_of_string_formatting/) than .format. I think they get evaluated at compile time instead of run time which might be part of the reason.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
