### PR TITLE
Update random_dist.h comment to be less specific

### DIFF
--- a/include/openmc/random_dist.h
+++ b/include/openmc/random_dist.h
@@ -48,9 +48,9 @@ extern "C" double maxwell_spectrum(double T, uint64_t* seed);
 extern "C" double watt_spectrum(double a, double b, uint64_t* seed);
 
 //==============================================================================
-//! Samples an energy from the Gaussian energy-dependent fission distribution.
+//! Samples an energy from the Gaussian distribution.
 //!
-//! Samples from a Normal distribution with a given mean and standard deviation
+//! Samples from a normal distribution with a given mean and standard deviation
 //! The PDF is defined as s(x) = (1/2*sigma*sqrt(2) * e-((mu-x)/2*sigma)^2
 //! Its sampled according to
 //! http://www-pdg.lbl.gov/2009/reviews/rpp2009-rev-monte-carlo-techniques.pdf


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

The comment describing our normal distribution sampling routine for some reason calls it the "Gaussian fisison energy distribution". This PR clarifies the comment so as to not confuse people; there is nothing intrinsically related to fission here.
