### PR TITLE
Apply memoization in `get_all_universes`

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -426,15 +426,15 @@ class Cell(IDManagerMixin):
             instances
 
         """
+        if memo is None:
+            memo = set()
+
+        if self in memo:
+            return {}
+
+        memo.add(self)
 
         cells = {}
-
-        if memo and self in memo:
-            return cells
-
-        if memo is not None:
-            memo.add(self)
-
         if self.fill_type in ('universe', 'lattice'):
             cells.update(self.fill.get_all_cells(memo))
 
@@ -476,14 +476,13 @@ class Cell(IDManagerMixin):
             :class:`Universe` instances
 
         """
+        if memo is None:
+            memo = set()
+        if self in memo:
+            return {}
+        memo.add(self)
+
         universes = {}
-
-        if memo and self in memo:
-            return universes
-
-        if memo is not None:
-            memo.add(self)
-
         if self.fill_type == 'universe':
             universes[self.fill.id] = self.fill
             universes.update(self.fill.get_all_universes(memo))
@@ -683,10 +682,11 @@ class Cell(IDManagerMixin):
             # thus far.
             def create_surface_elements(node, element, memo=None):
                 if isinstance(node, Halfspace):
-                    if memo and node.surface in memo:
+                    if memo is None:
+                        memo = set()
+                    if node.surface in memo:
                         return
-                    if memo is not None:
-                        memo.add(node.surface)
+                    memo.add(node.surface)
                     xml_element.append(node.surface.to_xml_element())
 
                 elif isinstance(node, Complement):

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -465,7 +465,7 @@ class Cell(IDManagerMixin):
 
         return materials
 
-    def get_all_universes(self):
+    def get_all_universes(self, memo=None):
         """Return all universes that are contained within this one if any of
         its cells are filled with a universe or lattice.
 
@@ -481,9 +481,9 @@ class Cell(IDManagerMixin):
 
         if self.fill_type == 'universe':
             universes[self.fill.id] = self.fill
-            universes.update(self.fill.get_all_universes())
+            universes.update(self.fill.get_all_universes(memo))
         elif self.fill_type == 'lattice':
-            universes.update(self.fill.get_all_universes())
+            universes.update(self.fill.get_all_universes(memo))
 
         return universes
 

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -476,8 +476,13 @@ class Cell(IDManagerMixin):
             :class:`Universe` instances
 
         """
-
         universes = {}
+
+        if memo and self in memo:
+            return universes
+
+        if memo is not None:
+            memo.add(self)
 
         if self.fill_type == 'universe':
             universes[self.fill.id] = self.fill

--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -428,10 +428,8 @@ class Cell(IDManagerMixin):
         """
         if memo is None:
             memo = set()
-
-        if self in memo:
+        elif self in memo:
             return {}
-
         memo.add(self)
 
         cells = {}
@@ -491,7 +489,7 @@ class Cell(IDManagerMixin):
 
         return universes
 
-    def clone(self, clone_materials=True, clone_regions=True,  memo=None):
+    def clone(self, clone_materials=True, clone_regions=True, memo=None):
         """Create a copy of this cell with a new unique ID, and clones
         the cell's region and fill.
 
@@ -684,7 +682,7 @@ class Cell(IDManagerMixin):
                 if isinstance(node, Halfspace):
                     if memo is None:
                         memo = set()
-                    if node.surface in memo:
+                    elif node.surface in memo:
                         return
                     memo.add(node.surface)
                     xml_element.append(node.surface.to_xml_element())

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -389,7 +389,7 @@ class Geometry:
         """
         universes = {}
         universes[self.root_universe.id] = self.root_universe
-        universes.update(self.root_universe.get_all_universes())
+        universes.update(self.root_universe.get_all_universes(memo=set()))
         return universes
 
     def get_all_nuclides(self) -> typing.List[str]:

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -134,7 +134,7 @@ class Geometry:
 
         # Create XML representation
         element = ET.Element("geometry")
-        self.root_universe.create_xml_subelement(element, memo=set())
+        self.root_universe.create_xml_subelement(element)
 
         # Sort the elements in the file
         element[:] = sorted(element, key=lambda x: (
@@ -373,7 +373,7 @@ class Geometry:
 
         """
         if self.root_universe is not None:
-            return self.root_universe.get_all_cells(memo=set())
+            return self.root_universe.get_all_cells()
         else:
             return {}
 
@@ -389,7 +389,7 @@ class Geometry:
         """
         universes = {}
         universes[self.root_universe.id] = self.root_universe
-        universes.update(self.root_universe.get_all_universes(memo=set()))
+        universes.update(self.root_universe.get_all_universes())
         return universes
 
     def get_all_nuclides(self) -> typing.List[str]:
@@ -417,7 +417,7 @@ class Geometry:
 
         """
         if self.root_universe is not None:
-            return self.root_universe.get_all_materials(memo=set())
+            return self.root_universe.get_all_materials()
         else:
             return {}
 

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -170,11 +170,13 @@ class Lattice(IDManagerMixin, ABC):
         """
         cells = {}
 
-        if memo and self in memo:
+        if memo is None:
+            memo = set()
+
+        if self in memo:
             return cells
 
-        if memo is not None:
-            memo.add(self)
+        memo.add(self)
 
         unique_universes = self.get_unique_universes()
 
@@ -193,6 +195,9 @@ class Lattice(IDManagerMixin, ABC):
             :class:`Material` instances
 
         """
+
+        if memo is None:
+            memo = set()
 
         materials = {}
 
@@ -213,16 +218,17 @@ class Lattice(IDManagerMixin, ABC):
             :class:`Universe` instances
 
         """
-
         # Initialize a dictionary of all Universes contained by the Lattice
         # in each nested Universe level
         all_universes = {}
 
-        if memo and self in memo:
+        if memo is None:
+            memo = set()
+
+        if self in memo:
             return all_universes
 
-        if memo is not None:
-            memo.add(self)
+        memo.add(self)
 
         # Get all unique Universes contained in each of the lattice cells
         unique_universes = self.get_unique_universes()
@@ -852,10 +858,13 @@ class RectLattice(Lattice):
 
         """
         # If the element already contains the Lattice subelement, then return
-        if memo and self in memo:
+        if memo is None:
+            memo = set()
+
+        if self in memo:
             return
-        if memo is not None:
-            memo.add(self)
+
+        memo.add(self)
 
         # Make sure universes have been assigned
         if self.universes is None:
@@ -1423,10 +1432,11 @@ class HexLattice(Lattice):
 
     def create_xml_subelement(self, xml_element, memo=None):
         # If this subelement has already been written, return
-        if memo and self in memo:
+        if memo is None:
+            memo = set()
+        if self in memo:
             return
-        if memo is not None:
-            memo.add(self)
+        memo.add(self)
 
         lattice_subelement = ET.Element("hex_lattice")
         lattice_subelement.set("id", str(self._id))

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -172,10 +172,8 @@ class Lattice(IDManagerMixin, ABC):
 
         if memo is None:
             memo = set()
-
-        if self in memo:
+        elif self in memo:
             return cells
-
         memo.add(self)
 
         unique_universes = self.get_unique_universes()
@@ -224,10 +222,8 @@ class Lattice(IDManagerMixin, ABC):
 
         if memo is None:
             memo = set()
-
-        if self in memo:
+        elif self in memo:
             return all_universes
-
         memo.add(self)
 
         # Get all unique Universes contained in each of the lattice cells
@@ -860,10 +856,8 @@ class RectLattice(Lattice):
         # If the element already contains the Lattice subelement, then return
         if memo is None:
             memo = set()
-
-        if self in memo:
+        elif self in memo:
             return
-
         memo.add(self)
 
         # Make sure universes have been assigned
@@ -1434,7 +1428,7 @@ class HexLattice(Lattice):
         # If this subelement has already been written, return
         if memo is None:
             memo = set()
-        if self in memo:
+        elif self in memo:
             return
         memo.add(self)
 

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -203,7 +203,7 @@ class Lattice(IDManagerMixin, ABC):
 
         return materials
 
-    def get_all_universes(self):
+    def get_all_universes(self, memo):
         """Return all universes that are contained within the lattice
 
         Returns
@@ -217,6 +217,12 @@ class Lattice(IDManagerMixin, ABC):
         # Initialize a dictionary of all Universes contained by the Lattice
         # in each nested Universe level
         all_universes = {}
+
+        if memo and self in memo:
+            return all_universes
+
+        if memo is not None:
+            memo.add(self)
 
         # Get all unique Universes contained in each of the lattice cells
         unique_universes = self.get_unique_universes()

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -203,7 +203,7 @@ class Lattice(IDManagerMixin, ABC):
 
         return materials
 
-    def get_all_universes(self, memo):
+    def get_all_universes(self, memo=None):
         """Return all universes that are contained within the lattice
 
         Returns
@@ -232,7 +232,7 @@ class Lattice(IDManagerMixin, ABC):
 
         # Append all Universes containing each cell to the dictionary
         for universe in unique_universes.values():
-            all_universes.update(universe.get_all_universes())
+            all_universes.update(universe.get_all_universes(memo))
 
         return all_universes
 

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -3209,6 +3209,7 @@ class Tallies(cv.CheckedList):
     def to_xml_element(self, memo=None):
         """Creates a 'tallies' element to be written to an XML file.
         """
+        memo = memo if memo is not None else set()
         element = ET.Element("tallies")
         self._create_mesh_subelements(element, memo)
         self._create_filter_subelements(element)

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -100,9 +100,16 @@ class UniverseBase(ABC, IDManagerMixin):
             :class:`Universe` instances
 
         """
+
+        if memo and self in memo:
+            return {}
+
+        if memo is not None:
+            memo.add(self)
+
         # Append all Universes within each Cell to the dictionary
         universes = {}
-        for cell in self.get_all_cells(memo).values():
+        for cell in self.get_all_cells(memo=set()).values():
             universes.update(cell.get_all_universes(memo))
 
         return universes

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -90,7 +90,7 @@ class UniverseBase(ABC, IDManagerMixin):
         else:
             raise ValueError('No volume information found for this universe.')
 
-    def get_all_universes(self):
+    def get_all_universes(self, memo=None):
         """Return all universes that are contained within this one.
 
         Returns
@@ -102,8 +102,8 @@ class UniverseBase(ABC, IDManagerMixin):
         """
         # Append all Universes within each Cell to the dictionary
         universes = {}
-        for cell in self.get_all_cells().values():
-            universes.update(cell.get_all_universes())
+        for cell in self.get_all_cells(memo).values():
+            universes.update(cell.get_all_universes(memo))
 
         return universes
 

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -100,16 +100,17 @@ class UniverseBase(ABC, IDManagerMixin):
             :class:`Universe` instances
 
         """
+        if memo is None:
+            memo = set()
 
-        if memo and self in memo:
+        if self in memo:
             return {}
 
-        if memo is not None:
-            memo.add(self)
+        memo.add(self)
 
         # Append all Universes within each Cell to the dictionary
         universes = {}
-        for cell in self.get_all_cells(memo=set()).values():
+        for cell in self.get_all_cells().values():
             universes.update(cell.get_all_universes(memo))
 
         return universes
@@ -646,15 +647,16 @@ class Universe(UniverseBase):
 
         """
 
-        cells = {}
+        if memo is None:
+            memo = set()
 
-        if memo and self in memo:
-            return cells
+        if self in memo:
+            return {}
 
-        if memo is not None:
-            memo.add(self)
+        memo.add(self)
 
         # Add this Universe's cells to the dictionary
+        cells = {}
         cells.update(self._cells)
 
         # Append all Cells in each Cell in the Universe to the dictionary
@@ -674,6 +676,9 @@ class Universe(UniverseBase):
 
         """
 
+        if memo is None:
+            memo = set()
+
         materials = {}
 
         # Append all Cells in each Cell in the Universe to the dictionary
@@ -684,15 +689,17 @@ class Universe(UniverseBase):
         return materials
 
     def create_xml_subelement(self, xml_element, memo=None):
+        if memo is None:
+            memo = set()
+
         # Iterate over all Cells
         for cell in self._cells.values():
 
             # If the cell was already written, move on
-            if memo and cell in memo:
+            if cell in memo:
                 continue
 
-            if memo is not None:
-                memo.add(cell)
+            memo.add(cell)
 
             # Create XML subelement for this Cell
             cell_element = cell.create_xml_subelement(xml_element, memo)
@@ -935,11 +942,13 @@ class DAGMCUniverse(UniverseBase):
         return self._n_geom_elements('surface')
 
     def create_xml_subelement(self, xml_element, memo=None):
-        if memo and self in memo:
+        if memo is None:
+            memo = set()
+
+        if self in memo:
             return
 
-        if memo is not None:
-            memo.add(self)
+        memo.add(self)
 
         # Set xml element values
         dagmc_element = ET.Element('dagmc_universe')

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -102,10 +102,8 @@ class UniverseBase(ABC, IDManagerMixin):
         """
         if memo is None:
             memo = set()
-
-        if self in memo:
+        elif self in memo:
             return {}
-
         memo.add(self)
 
         # Append all Universes within each Cell to the dictionary
@@ -649,10 +647,8 @@ class Universe(UniverseBase):
 
         if memo is None:
             memo = set()
-
-        if self in memo:
+        elif self in memo:
             return {}
-
         memo.add(self)
 
         # Add this Universe's cells to the dictionary


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

While working on a model with TRISO compacts, @aprilnovak noticed that the `Geometry.get_all_universes`  method was taking a long time (3+ hours) -- preplexing as the `get_all_cells` call was taking less than a second. 

It turns out that we weren't using the memoization objects we have in place for this call/chain-of-calls in the geometry objects. This PR adds the use of memoization for that call.

I haven't added any tests here as the set of tests we have in place exercises these methods significantly -- they should just be faster now.

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~I have made corresponding changes to the documentation (if applicable)~
- [x] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
