### PR TITLE
Allow mesh material homogenization to include or exclude voids

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -152,6 +152,7 @@ class MeshBase(IDManagerMixin, ABC):
             model: openmc.Model,
             n_samples: int = 10_000,
             prn_seed: Optional[int] = None,
+            include_void: bool = True,
             **kwargs
     ) -> List[openmc.Material]:
         """Generate homogenized materials over each element in a mesh.
@@ -168,6 +169,8 @@ class MeshBase(IDManagerMixin, ABC):
         prn_seed : int, optional
             Pseudorandom number generator (PRNG) seed; if None, one will be
             generated randomly.
+        include_void : bool, optional
+            Whether homogenization should include voids.
         **kwargs
             Keyword-arguments passed to :func:`openmc.lib.init`.
 
@@ -221,6 +224,10 @@ class MeshBase(IDManagerMixin, ABC):
             else:
                 material_ids.pop(index_void)
                 volumes.pop(index_void)
+
+            # If void should be excluded, adjust total volume
+            if not include_void:
+                total_volume = sum(volumes)
 
             # Compute volume fractions
             volume_fracs = np.array(volumes) / total_volume

--- a/tests/unit_tests/test_mesh.py
+++ b/tests/unit_tests/test_mesh.py
@@ -365,3 +365,9 @@ def test_mesh_get_homogenized_materials():
 
     # Mesh element that overlaps void should have half density
     assert m4.get_mass_density('H1') == pytest.approx(0.5, rel=1e-2)
+
+    # If not including void, density of homogenized material should be same as
+    # original material
+    m5, = mesh_void.get_homogenized_materials(
+        model, n_samples=1000, include_void=False)
+    assert m5.get_mass_density('H1') == pytest.approx(1.0)


### PR DESCRIPTION
# Description

This PR adds an `include_void` argument to `Mesh.get_homogenized_materials`. The default is True, which means that homogenization will account for voids (they will effectively increase the volume and decrease the density of homogenized materials). If it is False, voids will be ignored and won't impact the density of the mixture of materials.

To speak to the motivation, I found this to be necessary for a mesh-based R2S workflow where I was only sourcing decay photons in material (using domain rejection to avoid any voids).

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)