### PR TITLE
Make sure skewed dataset is cast to bool properly

### DIFF
--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -453,7 +453,7 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
     error : float, optional
         Fractional error tolerance for NJOY processing
     iwt : int
-        `iwt` parameter used in NJOR/ACER card 9
+        `iwt` parameter used in NJOY/ACER card 9
     evaluation : openmc.data.endf.Evaluation, optional
         If the ENDF neutron sublibrary file contains multiple material
         evaluations, this argument indicates which evaluation to use.

--- a/openmc/data/thermal_angle_energy.py
+++ b/openmc/data/thermal_angle_energy.py
@@ -225,7 +225,7 @@ class IncoherentInelasticAEDiscrete(AngleEnergy):
         """
         energy_out = group['energy_out'][()]
         mu_out = group['mu_out'][()]
-        skewed = bool(group['skewed'])
+        skewed = bool(group['skewed'][()])
         return cls(energy_out, mu_out, skewed)
 
 


### PR DESCRIPTION
# Description

I ran into a bug loading a thermal scattering file from HDF5 recently. Namely, the `skewed` dataset for discrete incoherent inelastic angle-energy distribution is not read and converted to a bool properly. Right now, we're applying `bool(...)` on the dataset object itself, which is always true because it's not an empty object. We should be applying `bool(...)` on the value of the dataset. Below is a demonstration of the bug from a Python prompt (pay attention to the last two lines with `bool`). Note that when passing iwt=1 when generating the data, `skewed` _should_ be false:
```
In [3]: lch4 = openmc.data.ThermalScattering.from_njoy(
   ...:     '/opt/data/endf/endf-b-viii.0/neutrons/n-001_H_001.endf',
   ...:     '/opt/data/endf/endf-b-viii.0/thermal_scatt/tsl-l-CH4.endf',
   ...:     iwt=1, stdout=True)

 njoy 2016.68  30Sep22                                       05/14/24 12:42:03
 *****************************************************************************

 reconr...                                                                0.0s

 broadr...                                                                0.0s

 thermr...                                                                0.1s

 wrote thermal data for temp = 1.0000E+02                                 2.5s

 thermr...                                                                2.5s

 ***warning***maximum value of beta limits the allowed energy transfer
 the sct approx. will be used for transfers larger than  1.389 ev.

 wrote thermal data for temp = 1.0000E+02                                13.8s

 acer...                                                                 13.8s
                                                                         14.3s
 *****************************************************************************

In [4]: lch4.export_to_hdf5('lch4_iwt1.h5')

In [5]: f = h5py.File('lch4_iwt1.h5', 'r')

In [6]: skewed_dataset = f['c_H_in_CH4_liquid/100K/inelastic/distribution/skewed']

In [7]: bool(skewed_dataset)
Out[7]: True

In [8]: bool(skewed_dataset[()])
Out[8]: False
```

Unfortunately we don't have any thermal scattering data in our test cross section set that triggers this problem and I'm hesitant to add another test that runs NJOY because of the time required, so for now I haven't added a test.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)