### PR TITLE
Hexagonal Lattice Roundtrip

### DIFF
--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -1564,6 +1564,7 @@ class HexLattice(Lattice):
                             alpha -= 1
                             if not lat.is_valid_index((x, alpha, z)):
                                 # Reached the bottom
+                                j += 1
                                 break
                     j += 1
             else:
@@ -1583,6 +1584,7 @@ class HexLattice(Lattice):
 
                         # Check if we've reached the bottom
                         if y == -n_rings:
+                            j += 1
                             break
 
                         while not lat.is_valid_index((alpha, y, z)):

--- a/tests/unit_tests/test_lattice.py
+++ b/tests/unit_tests/test_lattice.py
@@ -1,7 +1,5 @@
 from math import sqrt
 
-from pathlib import Path
-
 import lxml.etree as ET
 import openmc
 import pytest
@@ -380,31 +378,29 @@ def test_unset_universes():
     with pytest.raises(ValueError):
         hex_lattice.create_xml_subelement(elem)
 
+
 @pytest.mark.parametrize("orientation", ['x', 'y'])
-def test_hex_lattice_roundtrip(request, orientation):
+def test_hex_lattice_roundtrip(orientation):
     openmc.reset_auto_ids()
 
     # ensure that the lattice universes are the same on all axial levels
     def check_lattice_universes(og_lattice, xml_lattice):
-        for aixal_og, axial_rt in zip(og_lattice.universes, xml_lattice.universes):
-            for ring_og, ring_rt in zip(aixal_og, axial_rt):
+        for axial_og, axial_rt in zip(og_lattice.universes, xml_lattice.universes):
+            for ring_og, ring_rt in zip(axial_og, axial_rt):
                 assert [u.id for u in ring_og] == [u.id for u in ring_rt]
 
-    path = Path(request.fspath).parent
-
-    latt = openmc.HexLattice(lattice_id=100)
+    latt = openmc.HexLattice()
     latt.pitch = (1.0, 1.0)
     latt.center = (0.0, 0.0, 0.0)
     latt.orientation = orientation
 
     # fill the lattice with universes in increasing order and repeat for
     # the second actial level
-    lvl_one_univs = [openmc.Universe(cells=[openmc.Cell()]) for i in range(19)]
-    lvl_one_univs = [lvl_one_univs[-12:], lvl_one_univs[1:7], lvl_one_univs[0:1]]
+    lvl_one_univs = [openmc.Universe(cells=[openmc.Cell()]) for _ in range(19)]
+    lvl_one_univs = [lvl_one_univs[-12:], lvl_one_univs[1:7], lvl_one_univs[:1]]
     latt.universes = [lvl_one_univs, lvl_one_univs]
 
-    outer_univ = openmc.Universe(cells=[openmc.Cell(fill=latt)])
-    geom = openmc.Geometry(root=outer_univ)
+    geom = openmc.Geometry([openmc.Cell(fill=latt)])
     geom.export_to_xml()
 
     xml_geom = openmc.Geometry.from_xml(materials=openmc.Materials())
@@ -414,8 +410,8 @@ def test_hex_lattice_roundtrip(request, orientation):
     check_lattice_universes(latt, xml_latt)
 
     # same test but with unique universes for each axial level
-    lvl_two_univs = [openmc.Universe(cells=[openmc.Cell()]) for i in range(19)]
-    lvl_two_univs = [lvl_two_univs[-12:], lvl_two_univs[1:7], lvl_two_univs[0:1]]
+    lvl_two_univs = [openmc.Universe(cells=[openmc.Cell()]) for _ in range(19)]
+    lvl_two_univs = [lvl_two_univs[-12:], lvl_two_univs[1:7], lvl_two_univs[:1]]
     latt.universes = [lvl_one_univs, lvl_two_univs]
 
     geom.export_to_xml()


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This fixes a bug described in #3002 where hexagonal lattices don't round trip in and out of XML correctly. A break condition in `HexagonalLattice.from_xml_element` was occurring before the index into the flat array of universe IDs is incremented, causing the next universe ID used for the second axial to be the last universe from the first layer. The universes in the resulting `HexagonalLattice` object are scrambled. This is a silent bug unless one of the universe IDs is omitted from the new lattice entirely in which case it's possible (but not guaranteed) that the abandoned universe will be read in later as part of the cell parsing and treated as the root universe of the geometry.

I've added a test to check that the universes of a multi-layer hex lattice are roundtripped correctly both: a) when the universes in each layer are the same and b) when the universes for each lattice cell are unique.

Fixes #3002 

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~ I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~I have made corresponding changes to the documentation (if applicable)~
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
