### PR TITLE
sets used instead of lists when membership testing

### DIFF
--- a/openmc/arithmetic.py
+++ b/openmc/arithmetic.py
@@ -10,10 +10,10 @@ from .filter import _FILTER_TYPES
 
 
 # Acceptable tally arithmetic binary operations
-_TALLY_ARITHMETIC_OPS = ('+', '-', '*', '/', '^')
+_TALLY_ARITHMETIC_OPS = {'+', '-', '*', '/', '^'}
 
 # Acceptable tally aggregation operations
-_TALLY_AGGREGATE_OPS = ('sum', 'avg')
+_TALLY_AGGREGATE_OPS = {'sum', 'avg'}
 
 
 class CrossScore:

--- a/openmc/arithmetic.py
+++ b/openmc/arithmetic.py
@@ -10,10 +10,10 @@ from .filter import _FILTER_TYPES
 
 
 # Acceptable tally arithmetic binary operations
-_TALLY_ARITHMETIC_OPS = ['+', '-', '*', '/', '^']
+_TALLY_ARITHMETIC_OPS = ('+', '-', '*', '/', '^')
 
 # Acceptable tally aggregation operations
-_TALLY_AGGREGATE_OPS = ['sum', 'avg']
+_TALLY_AGGREGATE_OPS = ('sum', 'avg')
 
 
 class CrossScore:

--- a/openmc/data/photon.py
+++ b/openmc/data/photon.py
@@ -28,10 +28,10 @@ CM_PER_ANGSTROM = 1.0e-8
 R0 = CM_PER_ANGSTROM * PLANCK_C / (2.0 * pi * FINE_STRUCTURE * MASS_ELECTRON_EV)
 
 # Electron subshell labels
-_SUBSHELLS = [None, 'K', 'L1', 'L2', 'L3', 'M1', 'M2', 'M3', 'M4', 'M5',
+_SUBSHELLS = (None, 'K', 'L1', 'L2', 'L3', 'M1', 'M2', 'M3', 'M4', 'M5',
               'N1', 'N2', 'N3', 'N4', 'N5', 'N6', 'N7', 'O1', 'O2', 'O3',
               'O4', 'O5', 'O6', 'O7', 'O8', 'O9', 'P1', 'P2', 'P3', 'P4',
-              'P5', 'P6', 'P7', 'P8', 'P9', 'P10', 'P11', 'Q1', 'Q2', 'Q3']
+              'P5', 'P6', 'P7', 'P8', 'P9', 'P10', 'P11', 'Q1', 'Q2', 'Q3')
 
 _REACTION_NAME = {
     501: ('Total photon interaction', 'total'),

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -34,7 +34,7 @@ _CURRENT_NAMES = (
     'z-min out', 'z-min in', 'z-max out', 'z-max in'
 )
 
-_PARTICLES = {'neutron', 'photon', 'electron', 'positron'}
+_PARTICLES = ('neutron', 'photon', 'electron', 'positron')
 
 
 class FilterMeta(ABCMeta):

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -34,7 +34,7 @@ _CURRENT_NAMES = (
     'z-min out', 'z-min in', 'z-max out', 'z-max in'
 )
 
-_PARTICLES = ('neutron', 'photon', 'electron', 'positron')
+_PARTICLES = {'neutron', 'photon', 'electron', 'positron'}
 
 
 class FilterMeta(ABCMeta):

--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -18,17 +18,17 @@ ROOM_TEMPERATURE_KELVIN = 294.0
 # Supported incoming particle MGXS angular treatment representations
 REPRESENTATION_ISOTROPIC = 'isotropic'
 REPRESENTATION_ANGLE = 'angle'
-_REPRESENTATIONS = (
+_REPRESENTATIONS = {
     REPRESENTATION_ISOTROPIC,
     REPRESENTATION_ANGLE
-)
+}
 
 # Supported scattering angular distribution representations
-_SCATTER_TYPES = (
+_SCATTER_TYPES = {
     SCATTER_TABULAR,
     SCATTER_LEGENDRE,
     SCATTER_HISTOGRAM
-)
+}
 
 # Number of mu points for conversion between scattering formats
 _NMU = 257

--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -18,21 +18,17 @@ ROOM_TEMPERATURE_KELVIN = 294.0
 # Supported incoming particle MGXS angular treatment representations
 REPRESENTATION_ISOTROPIC = 'isotropic'
 REPRESENTATION_ANGLE = 'angle'
-_REPRESENTATIONS = [
+_REPRESENTATIONS = (
     REPRESENTATION_ISOTROPIC,
     REPRESENTATION_ANGLE
-]
+)
 
 # Supported scattering angular distribution representations
-_SCATTER_TYPES = [
+_SCATTER_TYPES = (
     SCATTER_TABULAR,
     SCATTER_LEGENDRE,
     SCATTER_HISTOGRAM
-]
-
-# List of MGXS indexing schemes
-_XS_SHAPES = ["[G][G'][Order]", "[G]", "[G']", "[G][G']", "[DG]", "[DG][G]",
-              "[DG][G']", "[DG][G][G']"]
+)
 
 # Number of mu points for conversion between scattering formats
 _NMU = 257

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -14,7 +14,7 @@ from openmc.checkvalue import PathLike
 from ._xml import clean_indentation, get_elem_tuple, reorder_attributes, get_text
 from .mixin import IDManagerMixin
 
-_BASES = ['xy', 'xz', 'yz']
+_BASES = ('xy', 'xz', 'yz')
 
 _SVG_COLORS = {
     'aliceblue': (240, 248, 255),

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -14,7 +14,7 @@ from openmc.checkvalue import PathLike
 from ._xml import clean_indentation, get_elem_tuple, reorder_attributes, get_text
 from .mixin import IDManagerMixin
 
-_BASES = ('xy', 'xz', 'yz')
+_BASES = {'xy', 'xz', 'yz'}
 
 _SVG_COLORS = {
     'aliceblue': (240, 248, 255),

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -7,15 +7,15 @@ import openmc.checkvalue as cv
 import openmc.data
 
 # Supported keywords for continuous-energy cross section plotting
-PLOT_TYPES = ['total', 'scatter', 'elastic', 'inelastic', 'fission',
+PLOT_TYPES = ('total', 'scatter', 'elastic', 'inelastic', 'fission',
               'absorption', 'capture', 'nu-fission', 'nu-scatter', 'unity',
-              'slowing-down power', 'damage']
+              'slowing-down power', 'damage')
 
 # Supported keywords for multi-group cross section plotting
-PLOT_TYPES_MGXS = ['total', 'absorption', 'scatter', 'fission',
+PLOT_TYPES_MGXS = ('total', 'absorption', 'scatter', 'fission',
                    'kappa-fission', 'nu-fission', 'prompt-nu-fission',
                    'deleyed-nu-fission', 'chi', 'chi-prompt', 'chi-delayed',
-                   'inverse-velocity', 'beta', 'decay-rate', 'unity']
+                   'inverse-velocity', 'beta', 'decay-rate', 'unity')
 # Create a dictionary which can be used to convert PLOT_TYPES_MGXS to the
 # openmc.XSdata attribute name needed to access the data
 _PLOT_MGXS_ATTR = {line: line.replace(' ', '_').replace('-', '_')

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -7,15 +7,15 @@ import openmc.checkvalue as cv
 import openmc.data
 
 # Supported keywords for continuous-energy cross section plotting
-PLOT_TYPES = ('total', 'scatter', 'elastic', 'inelastic', 'fission',
+PLOT_TYPES = {'total', 'scatter', 'elastic', 'inelastic', 'fission',
               'absorption', 'capture', 'nu-fission', 'nu-scatter', 'unity',
-              'slowing-down power', 'damage')
+              'slowing-down power', 'damage'}
 
 # Supported keywords for multi-group cross section plotting
-PLOT_TYPES_MGXS = ('total', 'absorption', 'scatter', 'fission',
+PLOT_TYPES_MGXS = {'total', 'absorption', 'scatter', 'fission',
                    'kappa-fission', 'nu-fission', 'prompt-nu-fission',
                    'deleyed-nu-fission', 'chi', 'chi-prompt', 'chi-delayed',
-                   'inverse-velocity', 'beta', 'decay-rate', 'unity')
+                   'inverse-velocity', 'beta', 'decay-rate', 'unity'}
 # Create a dictionary which can be used to convert PLOT_TYPES_MGXS to the
 # openmc.XSdata attribute name needed to access the data
 _PLOT_MGXS_ATTR = {line: line.replace(' ', '_').replace('-', '_')

--- a/openmc/search.py
+++ b/openmc/search.py
@@ -8,7 +8,7 @@ import openmc.model
 import openmc.checkvalue as cv
 
 
-_SCALAR_BRACKETED_METHODS = ('brentq', 'brenth', 'ridder', 'bisect')
+_SCALAR_BRACKETED_METHODS = {'brentq', 'brenth', 'ridder', 'bisect'}
 
 
 def _search_keff(guess, target, model_builder, model_args, print_iterations,

--- a/openmc/search.py
+++ b/openmc/search.py
@@ -8,7 +8,7 @@ import openmc.model
 import openmc.checkvalue as cv
 
 
-_SCALAR_BRACKETED_METHODS = ['brentq', 'brenth', 'ridder', 'bisect']
+_SCALAR_BRACKETED_METHODS = ('brentq', 'brenth', 'ridder', 'bisect')
 
 
 def _search_keff(guess, target, model_builder, model_args, print_iterations,

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -26,7 +26,7 @@ class RunMode(Enum):
     PARTICLE_RESTART = 'particle restart'
 
 
-_RES_SCAT_METHODS = ['dbrc', 'rvs']
+_RES_SCAT_METHODS = ('dbrc', 'rvs')
 
 
 class Settings:

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -26,7 +26,7 @@ class RunMode(Enum):
     PARTICLE_RESTART = 'particle restart'
 
 
-_RES_SCAT_METHODS = ('dbrc', 'rvs')
+_RES_SCAT_METHODS = {'dbrc', 'rvs'}
 
 
 class Settings:

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -16,13 +16,13 @@ import openmc.checkvalue as cv
 from .._xml import get_text
 from ..mixin import EqualityMixin
 
-_INTERPOLATION_SCHEMES = [
+_INTERPOLATION_SCHEMES = (
     'histogram',
     'linear-linear',
     'linear-log',
     'log-linear',
     'log-log'
-]
+)
 
 
 class Univariate(EqualityMixin, ABC):

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -16,13 +16,13 @@ import openmc.checkvalue as cv
 from .._xml import get_text
 from ..mixin import EqualityMixin
 
-_INTERPOLATION_SCHEMES = (
+_INTERPOLATION_SCHEMES = {
     'histogram',
     'linear-linear',
     'linear-log',
     'log-linear',
     'log-log'
-)
+}
 
 
 class Univariate(EqualityMixin, ABC):

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -14,8 +14,8 @@ from .region import Region, Intersection, Union
 from .bounding_box import BoundingBox
 
 
-_BOUNDARY_TYPES = ('transmission', 'vacuum', 'reflective', 'periodic', 'white')
-_ALBEDO_BOUNDARIES = ('reflective', 'periodic', 'white')
+_BOUNDARY_TYPES = {'transmission', 'vacuum', 'reflective', 'periodic', 'white'}
+_ALBEDO_BOUNDARIES = {'reflective', 'periodic', 'white'}
 
 _WARNING_UPPER = """\
 "{}(...) accepts an argument named '{}', not '{}'. Future versions of OpenMC \

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -14,8 +14,8 @@ from .region import Region, Intersection, Union
 from .bounding_box import BoundingBox
 
 
-_BOUNDARY_TYPES = ['transmission', 'vacuum', 'reflective', 'periodic', 'white']
-_ALBEDO_BOUNDARIES = ['reflective', 'periodic', 'white']
+_BOUNDARY_TYPES = ('transmission', 'vacuum', 'reflective', 'periodic', 'white')
+_ALBEDO_BOUNDARIES = ('reflective', 'periodic', 'white')
 
 _WARNING_UPPER = """\
 "{}(...) accepts an argument named '{}', not '{}'. Future versions of OpenMC \


### PR DESCRIPTION
# Description

I think this will make nearly no difference on speed and we probably don't want to worry about the speed of python code. However I think sets are slightly quicker for membership checking compared to lists. Although they might be slower to create in the first place. Perhaps it makes sense to make these constants sets as they are used in the cv.checkvalue to check the user input is in the available options.

Also I noticed one defined constant that is not used ```_XS_SHAPES``` so I've removed that


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
