### PR TITLE
Make sure direction is set when checking source spatial constraints

### DIFF
--- a/src/source.cpp
+++ b/src/source.cpp
@@ -211,6 +211,7 @@ bool Source::satisfies_spatial_constraints(Position r) const
 {
   GeometryState geom_state;
   geom_state.r() = r;
+  geom_state.u() = {0.0, 0.0, 1.0};
 
   // Reject particle if it's not in the geometry at all
   bool found = exhaustive_find_cell(geom_state);


### PR DESCRIPTION
# Description

When #2916 refactored how source constraints are handled, it looks like a bug was introduced for checking spatial constraints. Namely, a `GeomState` object is created and the position is set, but the direction was not set (see [here](https://github.com/openmc-dev/openmc/blob/a7d6939c11a2d905d0aab3c57a97cd82e7018b3a/src/source.cpp#L186-L189) for the previous code). I noticed recently when running a DAGMC geometry that this was resulting in the source being rejected when it shouldn't have been. This PR fixes this by setting an arbitrary direction on the `GeomState` object as we did before.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>