### PR TITLE
add dagmc fill materials to homogenized materials method

### DIFF
--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -124,15 +124,6 @@ def get_microxs_and_flux(
     flux_tally.scores = ['flux']
     model.tallies = openmc.Tallies([rr_tally, flux_tally])
 
-    if openmc.lib.is_initialized:
-        openmc.lib.finalize()
-
-        if comm.rank == 0:
-            model.export_to_model_xml()
-        comm.barrier()
-        # Reinitialize with tallies
-        openmc.lib.init(intracomm=comm)
-
     # create temporary run
     with TemporaryDirectory() as temp_dir:
         if run_kwargs is None:
@@ -380,3 +371,4 @@ class MicroXS:
         )
         df = pd.DataFrame({'xs': self.data.flatten()}, index=multi_index)
         df.to_csv(*args, **kwargs)
+

--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -124,6 +124,15 @@ def get_microxs_and_flux(
     flux_tally.scores = ['flux']
     model.tallies = openmc.Tallies([rr_tally, flux_tally])
 
+    if openmc.lib.is_initialized:
+        openmc.lib.finalize()
+
+        if comm.rank == 0:
+            model.export_to_model_xml()
+        comm.barrier()
+        # Reinitialize with tallies
+        openmc.lib.init(intracomm=comm)
+
     # create temporary run
     with TemporaryDirectory() as temp_dir:
         if run_kwargs is None:
@@ -371,4 +380,3 @@ class MicroXS:
         )
         df = pd.DataFrame({'xs': self.data.flatten()}, index=multi_index)
         df.to_csv(*args, **kwargs)
-

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -208,6 +208,15 @@ class MeshBase(IDManagerMixin, ABC):
 
         # Create homogenized material for each element
         materials = model.geometry.get_all_materials()
+
+        for cell_id,cell in model.geometry.get_all_cells().items():
+            if isinstance(cell.fill, openmc.DAGMCUniverse):
+                dagmc_materials = {
+                        mat.id:mat for mat in model.materials
+                         if mat.name in cell.fill.material_names
+                 }
+                materials.update(dagmc_materials)
+
         homogenized_materials = []
         for mat_volume_list in mat_volume_by_element:
             material_ids, volumes = [list(x) for x in zip(*mat_volume_list)]

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -209,13 +209,16 @@ class MeshBase(IDManagerMixin, ABC):
         # Create homogenized material for each element
         materials = model.geometry.get_all_materials()
 
-        for cell_id,cell in model.geometry.get_all_cells().items():
+        # Account for materials in DAGMC universes
+        # TODO: This should really get incorporated in lower-level calls to
+        # get_all_materials, but right now it requires information from the
+        # Model object
+        for cell in model.geometry.get_all_cells().values():
             if isinstance(cell.fill, openmc.DAGMCUniverse):
-                dagmc_materials = {
-                        mat.id:mat for mat in model.materials
-                         if mat.name in cell.fill.material_names
-                 }
-                materials.update(dagmc_materials)
+                names = cell.fill.material_names
+                materials.update({
+                    mat.id: mat for mat in model.materials if mat.name in names
+                })
 
         homogenized_materials = []
         for mat_volume_list in mat_volume_by_element:


### PR DESCRIPTION
# Description

This PR extends `get_homogenized_materials` to cells filled with a `DAGMCUniverse`, check for the material it contains and
add them for the homogenization. 

# Checklist

- [x] I have performed a self-review of my own code
~- [] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
~- [] I have made corresponding changes to the documentation (if applicable)~
~- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
