### PR TITLE
Fixing plot xs for when plotting element string reaction

### DIFF
--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -59,10 +59,15 @@ def _get_legend_label(this, type):
     """Gets a label for the element or nuclide or material and reaction plotted"""
     if isinstance(this, str):
         if type in openmc.data.DADZ:
-            z, a, m = openmc.data.zam(this)
-            da, dz = openmc.data.DADZ[type]
-            gnds_name = openmc.data.gnds_name(z + dz, a + da, m)
-            return f'{this} {type} {gnds_name}'
+            if this in ELEMENT_NAMES:
+                return f'{this} {type}'
+            else:  # this is a nuclide so the legend can contain more information
+                z, a, m = openmc.data.zam(this)
+                da, dz = openmc.data.DADZ[type]
+                gnds_name = openmc.data.gnds_name(z + dz, a + da, m)
+                # makes a string with nuclide reaction and new nuclide
+                # For example "Be9 (n,2n) Be8"
+                return f'{this} {type} {gnds_name}'
         return f'{this} {type}'
     elif this.name == '':
         return f'Material {this.id} {type}'

--- a/tests/unit_tests/test_plotter.py
+++ b/tests/unit_tests/test_plotter.py
@@ -75,7 +75,7 @@ def test_calculate_cexs_with_materials(test_mat):
 @pytest.mark.parametrize("this", ["Be", "Be9"])
 def test_plot_xs(this):
     from matplotlib.figure import Figure
-    assert isinstance(openmc.plot_xs({this: ['total', 'elastic']}), Figure)
+    assert isinstance(openmc.plot_xs({this: ['total', 'elastic', 16, '(n,2n)']}), Figure)
 
 
 def test_plot_xs_mat(test_mat):


### PR DESCRIPTION
# Description

Currently when we plot the cross section of an element using a string to specify the reaction and this combination crashes the code

For example
```python
openmc.plot_xs(reactions = {"Be": ["(n,2n)"]})
>>> ValueError: 'Be' does not appear to be a nuclide name in GNDS format
```

So I've added some code to handle this case and also added to and existing test to check this combination.


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

