### PR TITLE
Consolidate Parametric Functionality in C and Python APIs

### DIFF
--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -73,6 +73,7 @@ void openmc_get_tally_next_id(int32_t* id);
 int openmc_global_tallies(double** ptr);
 int openmc_hard_reset();
 int openmc_init(int argc, char* argv[], const void* intracomm);
+int openmc_reload_model_geometry();
 bool openmc_is_statepoint_batch();
 int openmc_legendre_filter_get_order(int32_t index, int* order);
 int openmc_legendre_filter_set_order(int32_t index, int order);

--- a/include/openmc/initialize.h
+++ b/include/openmc/initialize.h
@@ -14,6 +14,8 @@ int parse_command_line(int argc, char* argv[]);
 void initialize_mpi(MPI_Comm intracomm);
 #endif
 
+//! Setup locale and initialize model in memory
+void init_model_in_memory();
 //! Read material, geometry, settings, and tallies from a single XML file
 bool read_model_xml();
 //! Read inputs from separate XML files

--- a/include/openmc/simulation.h
+++ b/include/openmc/simulation.h
@@ -25,6 +25,7 @@ namespace simulation {
 extern "C" int current_batch; //!< current batch
 extern "C" int current_gen;   //!< current fission generation
 extern "C" bool initialized;  //!< has simulation been initialized?
+extern "C" bool reloading;    //!< is the model being reloaded?
 extern "C" double keff;       //!< average k over batches
 extern "C" double keff_std;   //!< standard deviation of average k
 extern "C" double k_col_abs; //!< sum over batches of k_collision * k_absorption

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -51,6 +51,8 @@ _dll.openmc_hard_reset.errcheck = _error_handler
 _dll.openmc_init.argtypes = [c_int, POINTER(POINTER(c_char)), c_void_p]
 _dll.openmc_init.restype = c_int
 _dll.openmc_init.errcheck = _error_handler
+_dll.openmc_reload_model_geometry.restype = c_int
+_dll.openmc_reload_model_geometry.errcheck = _error_handler
 _dll.openmc_get_keff.argtypes = [POINTER(c_double*2)]
 _dll.openmc_get_keff.restype = c_int
 _dll.openmc_get_keff.errcheck = _error_handler
@@ -521,6 +523,26 @@ def simulation_init():
 def simulation_finalize():
     """Finalize simulation"""
     _dll.openmc_simulation_finalize()
+
+
+def reload_model_geometry(output=False):
+    """Reload model geometry and simulation settings from
+    the xml files into memory.
+
+    .. note:: Only the geometry and simulation settings are reloaded,
+              cross sections and materials are kept unchanged.
+
+    .. versionadded:: 0.14.1
+
+    Parameters
+    ----------
+    output : bool, optional
+        Whether or not to show output. Defaults to hiding output
+
+    """
+
+    with quiet_dll(output):
+        _dll.openmc_reload_model_geometry()
 
 
 def source_bank():

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from collections import defaultdict, namedtuple, Counter
 from collections.abc import Iterable
 from copy import deepcopy
-from numbers import Real
+from numbers import Real, Integral
 from pathlib import Path
 import re
 import typing  # imported separately as py3.8 requires typing.Iterable
@@ -1629,6 +1629,73 @@ class Materials(cv.CheckedList):
     def make_isotropic_in_lab(self):
         for material in self:
             material.make_isotropic_in_lab()
+
+    def get_material_by_id(self, id) -> openmc.Material:
+        """Return material with specified id
+
+        .. versionadded:: 0.14.1
+
+        Parameters
+        ----------
+        id : int
+            The id to match
+
+        Returns
+        -------
+        openmc.Material
+            Material with matching id
+
+        """
+        cv.check_type('id', id, Integral)
+        cv.check_greater_than('id', id, 0, equality=True)
+
+        for mat in self:
+            if mat.id == id:
+                return mat
+
+        msg = f'No material instance exists with id={id}.'
+        raise IndexError(msg)
+
+    def get_materials_by_name(self, name, case_sensitive=False, sort=False) \
+        -> openmc.Materials:
+        """Return a list of materials with matching names.
+
+        .. versionadded:: 0.14.1
+
+        Parameters
+        ----------
+        name : str
+            The name to match
+        case_sensitive : bool
+            Whether to distinguish upper and lower case letters
+            in each material's name. Letter case is not distinguished
+            by default.
+        sort : bool, optional
+            Whether to sort the matched materials by id
+            number to establish a predictable ordering.
+
+        Returns
+        -------
+        openmc.Materials
+            Materials matching the queried name
+
+        """
+        cv.check_type('name', name, str)
+
+        matches = openmc.Materials()
+        match_name = name if case_sensitive else name.lower()
+        for mat in self:
+            mat_name = mat.name if case_sensitive else mat.name.lower()
+            if mat_name == match_name:
+                matches.append(mat)
+        if sort is True:
+            matches.sort(key=lambda x: x.id)
+
+        if len(matches) == 0:
+            msg = f'No materials found with names that match {match_name}.'
+            warnings.warn(msg, UserWarning)
+
+        return matches
 
     def _write_xml(self, file, header=True, level=0, spaces_per_level=2,
                    trailing_indent=True, nuclides_to_ignore=None):

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -220,6 +220,15 @@ class Material(IDManagerMixin):
     def nuclides(self) -> List[namedtuple]:
         return self._nuclides
 
+    @nuclides.setter
+    def nuclides(self, nuclides: List[namedtuple]):
+        for nuclide in nuclides:
+            cv.check_type('Name', nuclide.name, str)
+            cv.check_type('Percent', nuclide.percent, Real)
+            cv.check_value('Percent type',
+                           nuclide.percent_type, ['ao', 'wo'])
+        self._nuclides = nuclides
+
     @property
     def isotropic(self) -> List[str]:
         return self._isotropic

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -716,6 +716,229 @@ class Model:
                     last_statepoint = sp
         return last_statepoint
 
+    def search_for_keff(self, model_updater, updater_static_args=None,
+                        initial_guess=None, target=1.0, bracket=None,
+                        tol=None, bracketed_method='bisect',
+                        print_iterations=False, init_args=None,
+                        started_initialized=False, run_args=None, **kwargs):
+        """Perform an accelerated keff search by modifying the model in
+        memory using the C API.
+
+        .. versionadded:: 0.14.1
+
+        Parameters
+        ----------
+        model_updater : collections.Callable
+            Callable function which updates an `openmc.Model` object passed
+            to it using a single numerical input variable. Cell temperature, rotation
+            and translation updates are allowed, as well as material density and
+            composition updates.
+        updater_static_args : dict, optional
+            Keyword-based arguments to pass to the `model_updater` method
+            which do not change during the reactivity calculation. Defaults
+            to no arguments.
+        initial_guess : Real, optional
+            Initial guess for the parameter to be searched in
+            `model_updater`. One of `guess` or `bracket` must be provided.
+        target : Real, optional
+            keff value to search for, defaults to 1.0.
+        bracket : None or Iterable of Real, optional
+            Bracketing interval to search for the solution; if not provided,
+            a generic non-bracketing method is used. If provided, the brackets
+            are used. Defaults to no brackets provided. One of `guess` or `bracket`
+            must be provided. If both are provided, the bracket will be
+            preferentially used.
+        tol : float
+            Tolerance to pass to the search method
+        bracketed_method : {'brentq', 'brenth', 'ridder', 'bisect'}, optional
+            Solution method to use; only applies if
+            `bracket` is set, otherwise the Secant method is used.
+            Defaults to 'bisect'.
+        print_iterations : bool
+            Whether or not to print the guess and the result during the iteration
+            process. Defaults to False.
+        init_args : dict, optional
+            Keyword arguments to pass to :meth:`openmc.Model.init_lib`. Defaults
+            to no arguments.
+        started_initialized : bool
+            Whether or not to initialize and finalize the C API interface. Defaults
+            to False, which assumes the C API interface was previously inactive.
+        run_args : dict, optional
+            Keyword arguments to pass to :meth:`openmc.Model.run`. Defaults to no
+            arguments.
+        **kwargs
+            All remaining keyword arguments are passed to the root-finding
+            method.
+
+        Returns
+        -------
+        zero_value : float
+            Estimated value of the variable parameter where keff is the
+            targeted value
+        guesses : List of Real
+            List of guesses attempted by the search
+        results : List of 2-tuple of Real
+            List of keffs and uncertainties corresponding to the guess attempted by
+            the search
+
+        """
+
+        if updater_static_args is None:
+            updater_static_args = {}
+        else:
+            check_type('updater_static_args', updater_static_args, dict)
+        if init_args is None:
+            init_args = {}
+        else:
+            check_type('init_args', init_args, dict)
+
+        # Initialize C API and export initial model xml file
+        if not started_initialized:
+            self.init_lib(**init_args)
+
+        # Define dummy function that updates the model and
+        # returns a copy. This function allows reuse of the
+        # openmc.search_for_keff method.
+        def wrapper(guess):
+            model_updater(self, guess, **updater_static_args)
+            return self
+
+        # Call openmc.search_for_keff with dummy function
+        # and pass all other parameters explicitly.
+        zero_value, guesses, results = openmc.search_for_keff(
+            model_builder=wrapper,
+            initial_guess=initial_guess, target=target,
+            bracket=bracket, model_args=None, tol=tol,
+            bracketed_method=bracketed_method,
+            print_iterations=print_iterations,
+            run_args=run_args, **kwargs)
+
+        # Deallocate resources
+        if not started_initialized:
+            self.finalize_lib()
+
+        return zero_value, guesses, results
+
+    def calculate_reactivity_coeffs(self, param_list,
+                                   model_updater, updater_static_args=None,
+                                   print_output=True, init_args=None,
+                                   started_initialized=False, **kwargs):
+        """Perform an accelerated reactivity calculation by modifying the
+        model in memory using the C API.
+
+        .. versionadded:: 0.14.1
+
+        Parameters
+        ----------
+        param_list : collections.Iterable
+            Iterable of floats to pass to the `model_updater` method
+            that serves as the indepedent variable during the reactivity
+            calculation.
+        model_updater : collections.Callable
+            Callable function which updates an `openmc.Model` object passed
+            to it using a single numerical input variable. Cell temperature,
+            rotation and translation updates are allowed,
+            as well as material density and composition updates.
+        updater_static_args : dict, optional
+            Keyword-based arguments to pass to the `model_updater` method
+            which do not change during the reactivity calculation. Defaults
+            to no arguments.
+        print_output : bool
+            Whether or not to output the results during the calculation
+            process. Defaults to True.
+        init_args : dict, optional
+            Keyword arguments to pass to :meth:`openmc.Model.init_lib`. Defaults
+            to no arguments.
+        started_initialized : bool
+            Whether or not to initialize and finalize the C API interface. Defaults
+            to False, which assumes the C API interface was previously inactive.
+        **kwargs
+            All remaining keyword arguments are passed to :meth:`openmc.Model.run`
+
+        Returns
+        -------
+        values : List of float
+            Numerical outputs of the `model_updater` method. Defaults to a
+            duplicate of the param_list input variable if the method returns
+            None.
+        coefficients : List of float
+            List of the calculated reactivity coefficients
+
+        """
+
+        check_iterable_type('param_list', param_list, float)
+
+        if updater_static_args is None:
+            updater_static_args = {}
+        else:
+            check_type('updater_static_args', updater_static_args, dict)
+        check_type('model_updater', model_updater, Callable)
+        check_type('model_updater',
+                   model_updater(self, param_list[0], **updater_static_args),
+                   float, none_ok=True)
+
+        if init_args is None:
+            init_args = {}
+        else:
+            check_type('init_args', init_args, dict)
+
+        check_type('print_output', print_output, bool)
+
+        # Check the return of model_updater method. If there is output,
+        # we need to save the output to return it to the user.
+        if model_updater(self, param_list[0], **updater_static_args) is None:
+            duplicate_input = True
+            values = param_list
+        else:
+            duplicate_input = False
+            values = []
+
+        # Define container for the calculated data
+        coefficients = []
+
+        # Initialize C API and export initial model xml file
+        if not started_initialized:
+            self.init_lib(**init_args)
+
+        # Update model and calculate raw keff for each input value
+        for param in param_list:
+            # Update model and record the input corresponding
+            # to the keff simulation.
+            if duplicate_input is True:
+                input = param
+                model_updater(self, input, **updater_static_args)
+            else:
+                input = model_updater(self, param, **updater_static_args)
+            values.append(input)
+
+            # Run using C API in memory and save raw simulation output
+            sp_filepath = self.run(**kwargs)
+            with openmc.StatePoint(sp_filepath) as sp:
+                raw_output = sp.keff
+                if print_output:
+                    text = 'Input Variable : {:.3f}; Model produced \
+                        a keff of {:1.5f} +/- {:1.5f}'
+                    print(text.format(input,  raw_output.n, raw_output.s))
+                coefficients.append(raw_output)
+
+        # Forward difference raw keff values and calculate reactivity
+        # coefficients.
+        for i in range(0, len(values) - 1):
+            coeff = coefficients[i + 1] - coefficients[i]
+            coeff /= coefficients[i + 1] * coefficients[i]
+            coeff /= values[i + 1] - values[i]
+            coefficients[i] = coeff
+
+        # Discard last data point due to forward differencing
+        del values[-1]
+        del coefficients[-1]
+
+        # Deallocate resources
+        if not started_initialized:
+            self.finalize_lib()
+
+        return values, coefficients
+
     def calculate_volumes(self, threads=None, output=True, cwd='.',
                           openmc_exec='openmc', mpi_args=None,
                           apply_volumes=True):

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -330,7 +330,7 @@ void read_ce_cross_sections_xml()
 
 void finalize_cross_sections()
 {
-  if (settings::run_mode != RunMode::PLOTTING) {
+  if (settings::run_mode != RunMode::PLOTTING && !simulation::reloading) {
     simulation::time_read_xs.start();
     if (settings::run_CE) {
       // Determine desired temperatures for each nuclide and S(a,b) table

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -35,14 +35,16 @@ void free_memory()
 {
   free_memory_geometry();
   free_memory_surfaces();
-  free_memory_material();
   free_memory_volume();
   free_memory_simulation();
-  free_memory_photon();
   free_memory_settings();
-  free_memory_thermal();
-  library_clear();
-  nuclides_clear();
+  if (!simulation::reloading) {
+    free_memory_material();
+    free_memory_photon();
+    free_memory_thermal();
+    library_clear();
+    nuclides_clear();
+  }
   free_memory_source();
   free_memory_mesh();
   free_memory_tally();

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -294,6 +294,7 @@ namespace simulation {
 int current_batch;
 int current_gen;
 bool initialized {false};
+bool reloading {false};
 double keff {1.0};
 double keff_std;
 double k_col_abs {0.0};

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -414,20 +414,26 @@ def test_mass():
 
 
 def test_materials(run_in_tmpdir):
-    m1 = openmc.Material()
+    m1 = openmc.Material(name='UO2')
     m1.add_nuclide('U235', 1.0, 'wo')
     m1.add_nuclide('O16', 2.0, 'wo')
     m1.set_density('g/cm3', 10.0)
     m1.depletable = True
     m1.temperature = 900.0
+    MATID_m1 = m1.id
 
-    m2 = openmc.Material()
+    m2 = openmc.Material(name='H2O')
     m2.add_nuclide('H1', 2.0)
     m2.add_nuclide('O16', 1.0)
     m2.add_s_alpha_beta('c_H_in_H2O')
     m2.set_density('kg/m3', 1000.0)
 
     mats = openmc.Materials([m1, m2])
+
+    assert m1.name == mats.get_material_by_id(MATID_m1).name
+    assert m2.id == mats.get_materials_by_name('H2O',
+                        case_sensitive=True, sort=True)[0].id
+
     mats.cross_sections = '/some/fake/cross_sections.xml'
     mats.export_to_xml()
 


### PR DESCRIPTION
# Description

## Background

A couple of months ago, I started a discussion on the forum as I was getting started on this topic: https://openmc.discourse.group/t/dedicated-parametric-simulation-module-development/3502

All models are parametric by default when built via the Python API. Unfortunately, there is an unnecessary overhead of cross sections reloads which wastes CPU run time. During repetitive model rebuilds and reruns which have single point changes, such as for reactivity coefficient calculation, reactor design scoping or keff searches, those reloads become inefficient and waste time.

## Use Cases and Problem Statement

There are use cases of in-memory parametric simulation. For reactor design scoping, the simulations' low complexity leads to short calculation times while the initialization and cross section load times dominate.

For shutdown configuration and stability margin calculations, models require single point modifications to material compositions or control configurations to find the value that make the core just critical. The keff search algorithm provides a way to find the required data. However, it rebuilds and reloads whole model instead of offering users ways to modify the model in-memory to accelerate calculations which makes these sorts of investigations inefficient in OpenMC.

Users could avoid overheads by loading the model through the C API and openmc.Model class but it was found during discussion on the forum that its documentation is not very visible nor complete. There are no official examples and the general user might feel discouraged to have to tangle with the C API to gain this added performance or functionality. The documentation and ease of understanding problem might need another dedicated PR later but this PR aims to simplify things in the code and make things more user friendly.

## Contents

I have discovered a lot of functionality I thought didn't exist at that time of the forum post by reviewing the code directly along with relying on existing documentation. Following that, I have attempted to consolidate functionality already present in openmc.lib and introduce new functions which enable users to fully exploit OpenMC's unique advantage in the modelling community when it comes to parametric simulations.

Prior to this PR, the only in-memory changes allowed were limited to cell temperatures, translations and rotations, along with material densities. With this PR, the following new scenarios are possible for model updates in-memory which formally complete the parametric modelling feature set:

1. Material composition updates accounting for new nuclides
2. C API accelerated keff searches through the openmc.Model class
3. C API accelerated reactivity calculation through the openmc.Model class
4. Geometry/Cell updates in memory through the openmc.Model class

## Issues

As of now, there are 2 standing issues with this PR:

1. The geometry parameterization in memory is clunky, I've not been able to find other elegant ways to do it.
2. The nuclides being loaded or modified in memory may not have cross section data loaded at the right temperatures.

All feedback, comments and suggestions welcome!

## Credits

Credits to @shimwell and @gridley for their code and examples which helped me to get to this point!

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
