### PR TITLE
Implement policy for Python, C++, and CMake versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,6 @@ jobs:
         vectfit: [n]
 
         include:
-          - python-version: "3.8"
-            omp: n
-            mpi: n
-          - python-version: "3.9"
-            omp: n
-            mpi: n
           - python-version: "3.11"
             omp: n
             mpi: n

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 project(openmc C CXX)
 
 # Set version numbers
@@ -15,11 +15,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 # Set module path
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
-
-# Allow user to specify <project>_ROOT variables
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
-  cmake_policy(SET CMP0074 NEW)
-endif()
 
 # Enable correct usage of CXX_EXTENSIONS
 if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)
@@ -271,11 +266,6 @@ endif()
 #===============================================================================
 # xtensor header-only library
 #===============================================================================
-
-# CMake 3.13+ will complain about policy CMP0079 unless it is set explicitly
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
-  cmake_policy(SET CMP0079 NEW)
-endif()
 
 find_package_write_status(xtensor)
 if (NOT xtensor_FOUND)
@@ -580,9 +570,9 @@ target_compile_options(openmc PRIVATE ${cxxflags})
 target_include_directories(openmc PRIVATE ${CMAKE_BINARY_DIR}/include)
 target_link_libraries(openmc libopenmc)
 
-# Ensure C++14 standard is used and turn off GNU extensions
-target_compile_features(openmc PUBLIC cxx_std_14)
-target_compile_features(libopenmc PUBLIC cxx_std_14)
+# Ensure C++17 standard is used and turn off GNU extensions
+target_compile_features(openmc PUBLIC cxx_std_17)
+target_compile_features(libopenmc PUBLIC cxx_std_17)
 set_target_properties(openmc libopenmc PROPERTIES CXX_EXTENSIONS OFF)
 
 #===============================================================================

--- a/docs/source/devguide/index.rst
+++ b/docs/source/devguide/index.rst
@@ -15,6 +15,7 @@ other related topics.
     contributing
     workflow
     styleguide
+    policies
     tests
     user-input
     docbuild

--- a/docs/source/devguide/policies.rst
+++ b/docs/source/devguide/policies.rst
@@ -1,0 +1,35 @@
+.. _devguide_policies:
+
+========
+Policies
+========
+
+---------------------
+Python Version Policy
+---------------------
+
+OpenMC follows the Scientific Python Ecosystem Coordination guidelines `SPEC 0
+<https://scientific-python.org/specs/spec-0000/>`_ on minimum supported
+versions, which recommends that support for Python versions be dropped 3 years
+after their initial release.
+
+-------------------
+C++ Standard Policy
+-------------------
+
+C++ code in OpenMC must conform to the most recent C++ standard that is fully
+supported in the `version of the gcc compiler
+<https://gcc.gnu.org/projects/cxx-status.html>`_ that is distributed with the
+oldest version of Ubuntu that is still within its `standard support period
+<https://ubuntu.com/about/release-cycle>`_. Ubuntu 20.04 LTS will be supported
+through April 2025 and is distributed with gcc 9.3.0, which fully supports the
+C++17 standard.
+
+--------------------
+CMake Version Policy
+--------------------
+
+Similar to the C++ standard policy, the minimum supported version of CMake
+corresponds to whatever version is distributed with the oldest version of Ubuntu
+still within its standard support period. Ubuntu 20.04 LTS is distributed with
+CMake 3.16.

--- a/docs/source/devguide/styleguide.rst
+++ b/docs/source/devguide/styleguide.rst
@@ -40,7 +40,7 @@ Follow the `C++ Core Guidelines`_ except when they conflict with another
 guideline listed here. For convenience, many important guidelines from that
 list are repeated here.
 
-Conform to the C++14 standard.
+Conform to the C++17 standard.
 
 Always use C++-style comments (``//``) as opposed to C-style (``/**/``). (It
 is more difficult to comment out a large section of code that uses C-style

--- a/examples/custom_source/CMakeLists.txt
+++ b/examples/custom_source/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 project(openmc_sources CXX)
 add_library(source SHARED source_ring.cpp)
 find_package(OpenMC REQUIRED)

--- a/examples/parameterized_custom_source/CMakeLists.txt
+++ b/examples/parameterized_custom_source/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 project(openmc_sources CXX)
 add_library(parameterized_source SHARED parameterized_source_ring.cpp)
 find_package(OpenMC REQUIRED)

--- a/setup.py
+++ b/setup.py
@@ -53,15 +53,13 @@ kwargs = {
         'Topic :: Scientific/Engineering'
         'Programming Language :: C++',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
     ],
 
     # Dependencies
-    'python_requires': '>=3.8',
+    'python_requires': '>=3.10',
     'install_requires': [
         'numpy>=1.9', 'h5py', 'scipy', 'ipython', 'matplotlib',
         'pandas', 'lxml', 'uncertainties', 'setuptools'

--- a/tests/regression_tests/deplete_with_transfer_rates/test.py
+++ b/tests/regression_tests/deplete_with_transfer_rates/test.py
@@ -46,7 +46,6 @@ def model():
 
     return openmc.Model(geometry, materials, settings)
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="Requires Python 3.9+")
 @pytest.mark.parametrize("rate, dest_mat, power, ref_result", [
     (1e-5, None, 0.0, 'no_depletion_only_removal'),
     (-1e-5, None, 0.0, 'no_depletion_only_feed'),

--- a/tests/unit_tests/test_data_photon.py
+++ b/tests/unit_tests/test_data_photon.py
@@ -121,8 +121,6 @@ def test_reactions(element, reaction):
         reactions[18]
 
 
-# TODO: Remove skip when support is Python 3.9+
-@pytest.mark.skipif(not hasattr(pd.options, 'future'), reason='pandas version too old')
 @pytest.mark.parametrize('element', ['Pu'], indirect=True)
 def test_export_to_hdf5(tmpdir, element):
     filename = str(tmpdir.join('tmp.h5'))


### PR DESCRIPTION
# Description

This PR institutes policies for what minimum versions of Python, the C++ standard, and CMake we are committing to support in OpenMC. The policy I've drafted here is as follows:

- For Python, we would follow [SPEC 0](https://scientific-python.org/specs/spec-0000/), which would currently put us Python 3.10+.
- For C++, we would follow whatever standard is fully supported in the version of gcc that is released with the oldest currently-supported version of Ubuntu. Since Ubuntu 20.04 is the oldest version currently supported, it comes with gcc 9.3.0, and gcc 9.3.0 fully supports the C++17 standard, this means developers would be allowed to use features from C++17 (but not C++20).
- CMake follows the same rule as C++; because Ubuntu 20.04 comes with CMake 3.16, that would become our minimum supported version.

Overall the changes here will help to minimize some of the friction that we experience from having to support old versions of Python/C++/CMake. I'm definitely open to other suggestions though so please add your comments and thoughts!

@pshriwise @jtramm @gridley @shimwell @aprilnovak @makeclean @drewejohnson 