### PR TITLE
only add png or h5 extension if not present in plots.py

### DIFF
--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -2,7 +2,6 @@ from collections.abc import Iterable, Mapping
 from numbers import Integral, Real
 from pathlib import Path
 from typing import Optional
-from os.path import splitext
 
 import h5py
 import lxml.etree as ET
@@ -174,9 +173,9 @@ def _get_plot_image(plot, cwd):
     # Make sure .png file was created
     png_filename = plot.filename if plot.filename is not None else f'plot_{plot.id}'
 
-    # add file extension if not already present. The C++ code
-    # added it automatically if it wasn't present.
-    if splitext(png_filename)[1] != ".png":
+    # Add file extension if not already present. The C++ code added it
+    # automatically if it wasn't present.
+    if Path(png_filename).suffix != ".png":
         png_filename += ".png"
 
     png_file = Path(cwd) / png_filename
@@ -967,8 +966,7 @@ class Plot(PlotBase):
 
         """
         if self.type != 'voxel':
-            raise ValueError(
-                'Generating a VTK file only works for voxel plots')
+            raise ValueError('Generating a VTK file only works for voxel plots')
 
         # Create plots.xml
         Plots([self]).export_to_xml(cwd)
@@ -979,7 +977,7 @@ class Plot(PlotBase):
         h5_voxel_filename = self.filename if self.filename is not None else f'plot_{self.id}'
 
         # Add file extension if not already present
-        if splitext(h5_voxel_filename)[1] != ".h5":
+        if Path(h5_voxel_filename).suffix != ".h5":
             h5_voxel_filename += ".h5"
 
         h5_voxel_file = Path(cwd) / h5_voxel_filename

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable, Mapping
 from numbers import Integral, Real
 from pathlib import Path
 from typing import Optional
+from os.path import splitext
 
 import h5py
 import lxml.etree as ET
@@ -171,8 +172,14 @@ def _get_plot_image(plot, cwd):
     from IPython.display import Image
 
     # Make sure .png file was created
-    stem = plot.filename if plot.filename is not None else f'plot_{plot.id}'
-    png_file = Path(cwd) / f'{stem}.png'
+    png_filename = plot.filename if plot.filename is not None else f'plot_{plot.id}'
+
+    # add file extension if not already present. The C++ code
+    # added it automatically if it wasn't present.
+    if splitext(png_filename)[1] != ".png":
+        png_filename += ".png"
+
+    png_file = Path(cwd) / png_filename
     if not png_file.exists():
         raise FileNotFoundError(
             f"Could not find .png image for plot {plot.id}. Your version of "
@@ -630,7 +637,7 @@ class Plot(PlotBase):
         cv.check_type('plot meshlines', meshlines, dict)
         if 'type' not in meshlines:
             msg = f'Unable to set the meshlines to "{meshlines}" which ' \
-                  'does not have a "type" key'
+                'does not have a "type" key'
             raise ValueError(msg)
 
         elif meshlines['type'] not in ['tally', 'entropy', 'ufs', 'cmfd']:
@@ -960,7 +967,8 @@ class Plot(PlotBase):
 
         """
         if self.type != 'voxel':
-            raise ValueError('Generating a VTK file only works for voxel plots')
+            raise ValueError(
+                'Generating a VTK file only works for voxel plots')
 
         # Create plots.xml
         Plots([self]).export_to_xml(cwd)
@@ -968,8 +976,13 @@ class Plot(PlotBase):
         # Run OpenMC in geometry plotting mode and produces a h5 file
         openmc.plot_geometry(False, openmc_exec, cwd)
 
-        stem = self.filename if self.filename is not None else f'plot_{self.id}'
-        h5_voxel_file = Path(cwd) / f'{stem}.h5'
+        h5_voxel_filename = self.filename if self.filename is not None else f'plot_{self.id}'
+
+        # Add file extension if not already present
+        if splitext(h5_voxel_filename)[1] != ".h5":
+            h5_voxel_filename += ".h5"
+
+        h5_voxel_file = Path(cwd) / h5_voxel_filename
         if output is None:
             output = h5_voxel_file.with_suffix('.vti')
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Do not add .png to file if it's already present in plots.py. This makes the behavior consistent with the C++ code.

Fixes #2535 

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
