### PR TITLE
Make sure time boundary doesn't prevent secondary particle creation

### DIFF
--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -762,13 +762,15 @@ void transport_history_based_single_particle(Particle& p)
 {
   while (p.alive()) {
     p.event_calculate_xs();
-    if (!p.alive())
-      break;
-    p.event_advance();
-    if (p.collision_distance() > p.boundary().distance) {
-      p.event_cross_surface();
-    } else {
-      p.event_collide();
+    if (p.alive()) {
+      p.event_advance();
+    }
+    if (p.alive()) {
+      if (p.collision_distance() > p.boundary().distance) {
+        p.event_cross_surface();
+      } else if (p.alive()) {
+        p.event_collide();
+      }
     }
     p.event_revive_from_secondary();
   }


### PR DESCRIPTION
# Description

This PR fixes a bug related to when a time boundary is in use that can result in secondary particles not be simulated. The sequence of events that leads to this is as follows:
- In `Particle::event_advance`, a time boundary results in the particle's weight getting set to zero.
- However, this doesn't stop the particle from undergoing a collision because there is no conditional check that the particle is still alive when `Particle::event_collide` is called. This can result in zero-weight secondaries getting created.
- Immediately after that, `Particle::event_revive_from_secondary` sets the particle's state to one of the just-created zero-weight secondaries, which then causes the event loop to terminate because `Particle::alive()` is false.
- Thus, any other secondary particles that were still present in the secondary bank don't get simulated.

The solution is to just add a check after calling `event_advance()` that the particle is still alive before processing a surface crossing or collision.

Fixes #3039

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
