### PR TITLE
Resolve warnings related to numpy 2.0

### DIFF
--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -1866,7 +1866,7 @@ class XSdata:
                                 table_fine[..., imu] += ((l + 0.5)
                                      * eval_legendre(l, mu_fine[imu]) *
                                      orig_data[..., l])
-                        new_data[..., h_bin] = integrate(table_fine, mu_fine)
+                        new_data[..., h_bin] = integrate(table_fine, x=mu_fine)
 
             elif self.scatter_format == SCATTER_TABULAR:
                 # Calculate the mu points of the current data
@@ -1880,7 +1880,7 @@ class XSdata:
                     for l in range(xsdata.num_orders):
                         y = (interp1d(mu_self, orig_data)(mu_fine) *
                              eval_legendre(l, mu_fine))
-                        new_data[..., l] = integrate(y, mu_fine)
+                        new_data[..., l] = integrate(y, x=mu_fine)
 
                 elif target_format == SCATTER_TABULAR:
                     # Simply use an interpolating function to get the new data
@@ -1899,7 +1899,7 @@ class XSdata:
                     interp = interp1d(mu_self, orig_data)
                     for h_bin in range(xsdata.num_orders):
                         mu_fine = np.linspace(mu[h_bin], mu[h_bin + 1], _NMU)
-                        new_data[..., h_bin] = integrate(interp(mu_fine), mu_fine)
+                        new_data[..., h_bin] = integrate(interp(mu_fine), x=mu_fine)
 
             elif self.scatter_format == SCATTER_HISTOGRAM:
                 # The histogram format does not have enough information to
@@ -1925,7 +1925,7 @@ class XSdata:
                     mu_fine = np.linspace(-1, 1, _NMU)
                     for l in range(xsdata.num_orders):
                         y = interp(mu_fine) * norm * eval_legendre(l, mu_fine)
-                        new_data[..., l] = integrate(y, mu_fine)
+                        new_data[..., l] = integrate(y, x=mu_fine)
 
                 elif target_format == SCATTER_TABULAR:
                     # Simply use an interpolating function to get the new data
@@ -1944,7 +1944,7 @@ class XSdata:
                     for h_bin in range(xsdata.num_orders):
                         mu_fine = np.linspace(mu[h_bin], mu[h_bin + 1], _NMU)
                         new_data[..., h_bin] = \
-                            norm * integrate(interp(mu_fine), mu_fine)
+                            norm * integrate(interp(mu_fine), x=mu_fine)
 
             # Remove small values resulting from numerical precision issues
             new_data[..., np.abs(new_data) < 1.E-10] = 0.

--- a/openmc/statepoint.py
+++ b/openmc/statepoint.py
@@ -235,7 +235,7 @@ class StatePoint:
         if self._global_tallies is None:
             data = self._f['global_tallies'][()]
             gt = np.zeros(data.shape[0], dtype=[
-                ('name', 'a14'), ('sum', 'f8'), ('sum_sq', 'f8'),
+                ('name', 'S14'), ('sum', 'f8'), ('sum_sq', 'f8'),
                 ('mean', 'f8'), ('std_dev', 'f8')])
             gt['name'] = ['k-collision', 'k-absorption', 'k-tracklength',
                           'leakage']

--- a/tests/regression_tests/mg_temperature/build_2g.py
+++ b/tests/regression_tests/mg_temperature/build_2g.py
@@ -289,8 +289,9 @@ def build_inf_model(xsnames, xslibname, temperature, tempmethod='nearest'):
     settings_file.output = {'summary': False}
     # Create an initial uniform spatial source distribution over fissionable zones
     bounds = [-INF, -INF, -INF, INF, INF, INF]
-    uniform_dist = openmc.stats.Box(bounds[:3], bounds[3:], only_fissionable=True)
+    uniform_dist = openmc.stats.Box(bounds[:3], bounds[3:])
     settings_file.temperature = {'method': tempmethod}
-    settings_file.source = openmc.IndependentSource(space=uniform_dist)
+    settings_file.source = openmc.IndependentSource(
+        space=uniform_dist, constraints={'fissionable': True})
     model.settings = settings_file
     model.export_to_model_xml()

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -376,15 +376,6 @@ def test_box():
     d = openmc.stats.Box.from_xml_element(elem)
     assert d.lower_left == pytest.approx(lower_left)
     assert d.upper_right == pytest.approx(upper_right)
-    assert not d.only_fissionable
-
-    # only fissionable parameter
-    d2 = openmc.stats.Box(lower_left, upper_right, True)
-    assert d2.only_fissionable
-    elem = d2.to_xml_element()
-    assert elem.attrib['type'] == 'fission'
-    d = openmc.stats.Spatial.from_xml_element(elem)
-    assert isinstance(d, openmc.stats.Box)
 
 
 def test_point():


### PR DESCRIPTION
# Description

Now that NumPy 2.0 has been released, I'm noticing a few more warnings about deprecations in our CI test output. This PR gets rid of these warnings.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>