### PR TITLE
Determine whether nuclides are fissionable in volume calc mode

### DIFF
--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -72,6 +72,7 @@ Nuclide::Nuclide(hid_t group, const vector<double>& temperature)
         read_attribute(rx_group, "mt", mt);
         if (is_fission(mt)) {
           fissionable_ = true;
+          break;
         }
       }
     }

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -63,6 +63,18 @@ Nuclide::Nuclide(hid_t group, const vector<double>& temperature)
   read_attribute(group, "atomic_weight_ratio", awr_);
 
   if (settings::run_mode == RunMode::VOLUME) {
+    // Determine whether nuclide is fissionable and then exit
+    int mt;
+    hid_t rxs_group = open_group(group, "reactions");
+    for (auto name : group_names(rxs_group)) {
+      if (starts_with(name, "reaction_")) {
+        hid_t rx_group = open_group(rxs_group, name.c_str());
+        read_attribute(rx_group, "mt", mt);
+        if (is_fission(mt)) {
+          fissionable_ = true;
+        }
+      }
+    }
     return;
   }
 

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -963,7 +963,8 @@ def test_sample_external_source(run_in_tmpdir, mpi_intracomm):
     model.settings.source = openmc.IndependentSource(
         space=openmc.stats.Box([-5., -5., -5.], [5., 5., 5.]),
         angle=openmc.stats.Monodirectional((0., 0., 1.)),
-        energy=openmc.stats.Discrete([1.0e5], [1.0])
+        energy=openmc.stats.Discrete([1.0e5], [1.0]),
+        constraints={'fissionable': True}
     )
     model.settings.particles = 1000
     model.settings.batches = 10
@@ -992,4 +993,9 @@ def test_sample_external_source(run_in_tmpdir, mpi_intracomm):
         assert p1.time == p2.time
         assert p1.wgt == p2.wgt
 
+    openmc.lib.finalize()
+
+    # Make sure sampling works in volume calculation mode
+    openmc.lib.init(["-c"])
+    openmc.lib.sample_external_source(100)
     openmc.lib.finalize()


### PR DESCRIPTION
# Description

This PR fixes a potential issue in sampling external source sites when OpenMC is loaded in volume calculation mode (which is used by the plotter). When running in volume calculation mode, we only load a select few attributes from nuclide .h5 files. Right now, we don't determine whether a nuclide is fissionable. However, for a proposed improvement to our plotter (see openmc-dev/plotter#131), it will be possible to sampling external source sites, which may require information on whether a material is fissionable if the "fissionable only" constraint is applied to the source. Without that information, a source with the "fissionable only" constraint will always be rejected because it won't think any material is fissionable (because the underlying nuclides aren't fissionable). This branch adds a small block of logic to determine if a nuclide is fissionable when it is loaded in volume calculation mode.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)