### PR TITLE
Avoiding more numpy 2.0 deprecation warnings

### DIFF
--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -972,11 +972,12 @@ class Polygon(CompositeSurface):
         # Check if polygon is self-intersecting by comparing edges pairwise
         n = len(points)
         for i in range(n):
-            p0 = points[i, :]
-            p1 = points[(i + 1) % n, :]
+            # Append 0 to make vectors 3 dimensional for np.cross
+            p0 = np.append(points[i, :], 0)
+            p1 = np.append(points[(i + 1) % n, :], 0)
             for j in range(i + 1, n):
-                p2 = points[j, :]
-                p3 = points[(j + 1) % n, :]
+                p2 = np.append(points[j, :], 0)
+                p3 = np.append(points[(j + 1) % n, :], 0)
                 # Compute orientation of p0 wrt p2->p3 line segment
                 cp0 = np.cross(p3-p0, p2-p0)
                 # Compute orientation of p1 wrt p2->p3 line segment

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -971,25 +971,20 @@ class Polygon(CompositeSurface):
 
         # Check if polygon is self-intersecting by comparing edges pairwise
         n = len(points)
-        # numpy 2.0 deprecated np.cross for 2D arrays and this is the
-        # recommended replacement for this functionality
-        def cross2d(x, y):
-            return x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]
-
         for i in range(n):
-            p0 = points[i, :]
-            p1 = points[(i + 1) % n, :]
+            p0 = np.append(points[i, :], 0)
+            p1 = np.append(points[(i + 1) % n, :], 0)
             for j in range(i + 1, n):
-                p2 = points[j, :]
-                p3 = points[(j + 1) % n, :]
+                p2 = np.append(points[j, :], 0)
+                p3 = np.append(points[(j + 1) % n, :], 0)
                 # Compute orientation of p0 wrt p2->p3 line segment
-                cp0 = cross2d(p3-p0, p2-p0)
+                cp0 = np.cross(p3-p0, p2-p0)[-1]
                 # Compute orientation of p1 wrt p2->p3 line segment
-                cp1 = cross2d(p3-p1, p2-p1)
+                cp1 = np.cross(p3-p1, p2-p1)[-1]
                 # Compute orientation of p2 wrt p0->p1 line segment
-                cp2 = cross2d(p1-p2, p0-p2)
+                cp2 = np.cross(p1-p2, p0-p2)[-1]
                 # Compute orientation of p3 wrt p0->p1 line segment
-                cp3 = cross2d(p1-p3, p0-p3)
+                cp3 = np.cross(p1-p3, p0-p3)[-1]
 
                 # Group cross products in an array and find out how many are 0
                 cross_products = np.array([[cp0, cp1], [cp2, cp3]])

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -971,21 +971,25 @@ class Polygon(CompositeSurface):
 
         # Check if polygon is self-intersecting by comparing edges pairwise
         n = len(points)
+        # numpy 2.0 deprecated np.cross for 2D arrays and this is the
+        # recommended replacement for this functionality
+        def cross2d(x, y):
+            return x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]
+
         for i in range(n):
-            # Append 0 to make vectors 3 dimensional for np.cross
-            p0 = np.append(points[i, :], 0)
-            p1 = np.append(points[(i + 1) % n, :], 0)
+            p0 = points[i, :]
+            p1 = points[(i + 1) % n, :]
             for j in range(i + 1, n):
-                p2 = np.append(points[j, :], 0)
-                p3 = np.append(points[(j + 1) % n, :], 0)
+                p2 = points[j, :]
+                p3 = points[(j + 1) % n, :]
                 # Compute orientation of p0 wrt p2->p3 line segment
-                cp0 = np.cross(p3-p0, p2-p0)
+                cp0 = cross2d(p3-p0, p2-p0)
                 # Compute orientation of p1 wrt p2->p3 line segment
-                cp1 = np.cross(p3-p1, p2-p1)
+                cp1 = cross2d(p3-p1, p2-p1)
                 # Compute orientation of p2 wrt p0->p1 line segment
-                cp2 = np.cross(p1-p2, p0-p2)
+                cp2 = cross2d(p1-p2, p0-p2)
                 # Compute orientation of p3 wrt p0->p1 line segment
-                cp3 = np.cross(p1-p3, p0-p3)
+                cp3 = cross2d(p1-p3, p0-p3)
 
                 # Group cross products in an array and find out how many are 0
                 cross_products = np.array([[cp0, cp1], [cp2, cp3]])


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Numpy 2.0 deprecates `np.cross` for 2D arrays which was used in the `Polygon` class. To address this we simply append a 0 to the points for the dimension perpendicular to the plane and take the only non-zero component of the cross product which is that last dimension. 

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
