### PR TITLE
Added utility to automatically look for cross_Sections.xml

### DIFF
--- a/include/openmc/cross_sections.h
+++ b/include/openmc/cross_sections.h
@@ -58,6 +58,9 @@ extern vector<Library> libraries;
 // Non-member functions
 //==============================================================================
 
+// Determine if directory is folder or file
+bool is_directory(const std::string& path);
+
 //! Read cross sections file (either XML or multigroup H5) and populate data
 //! libraries
 void read_cross_sections_xml();

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -23,6 +23,7 @@
 #include "pugixml.hpp"
 
 #include <cstdlib> // for getenv
+#include <sys/stat.h>
 #include <unordered_set>
 
 namespace openmc {
@@ -90,6 +91,15 @@ Library::Library(pugi::xml_node node, const std::string& directory)
 //==============================================================================
 // Non-member functions
 //==============================================================================
+
+bool is_directory(const std::string& path)
+{
+  struct stat statbuf;
+  if (stat(path.c_str(), &statbuf) != 0) {
+    return false;
+  }
+  return S_ISDIR(statbuf.st_mode);
+}
 
 void read_cross_sections_xml()
 {
@@ -283,6 +293,11 @@ void read_ce_cross_sections_xml()
 {
   // Check if cross_sections.xml exists
   const auto& filename = settings::path_cross_sections;
+  if (is_directory(settings::path_cross_sections)) {
+    settings::path_cross_sections += "/cross_sections.xml";
+    warning("OPENMC_CROSS_SECTIONS is set to a directory. "
+            "Automatically looking for 'cross_sections.xml' in the directory.");
+  }
   if (!file_exists(filename)) {
     // Could not find cross_sections.xml file
     fatal_error("Cross sections XML file '" + filename + "' does not exist.");


### PR DESCRIPTION
# Description

Added is_directory non-member function which determines if the environment path set by user is a folder or a file. Added functionality to automatically check for "cross_sections.xml" if the path is a folder.

Closes #3048 

# Checklist

- [✅] I have performed a self-review of my own code
- [✅] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)