### PR TITLE
Automatically look for cross_sections.xml if path is directory

### DIFF
--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -283,6 +283,11 @@ void read_ce_cross_sections_xml()
 {
   // Check if cross_sections.xml exists
   const auto& filename = settings::path_cross_sections;
+  if (dir_exists(filename)) {
+    settings::path_cross_sections += "/cross_sections.xml";
+    warning("OPENMC_CROSS_SECTIONS is set to a directory. "
+            "Automatically looking for 'cross_sections.xml' in the directory.");
+  }
   if (!file_exists(filename)) {
     // Could not find cross_sections.xml file
     fatal_error("Cross sections XML file '" + filename + "' does not exist.");


### PR DESCRIPTION
# Description

Added the option to check automatically for "cross_sections.xml" if the user accidentaly set path to a folder instead of the file.

closes #3048 

# Checklist

- [✅] I have performed a self-review of my own code
- [✅] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

Notes: 
1- I had previously done this in #3054, however i didnt notice file_utils at all so i redefined headers and a new function in that pr. This one utilizes the already defined functions. 
2- #3042 is moving to std::filesystem, but I dont think this would change anything in this commit since the functions remain defined in file_utils