### PR TITLE
added ```decay_neutron_energy``` function to match existing ```decay_photon_energy```

### DIFF
--- a/openmc/config.py
+++ b/openmc/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import warnings
 
 from openmc.data import DataLibrary
-from openmc.data.decay import _DECAY_ENERGY, _DECAY_PHOTON_ENERGY
+from openmc.data.decay import _DECAY_ENERGY, _DECAY_PARTICLE_ENERGY
 
 __all__ = ["config"]
 
@@ -25,8 +25,8 @@ class _Config(MutableMapping):
             del os.environ['OPENMC_MG_CROSS_SECTIONS']
         elif key == 'chain_file':
             del os.environ['OPENMC_CHAIN_FILE']
-            # Reset photon source data since it relies on chain file
-            _DECAY_PHOTON_ENERGY.clear()
+            # Reset particle source data since it relies on chain file
+            _DECAY_PARTICLE_ENERGY = {"photon": {}, "neutron": {}}
 
     def __setitem__(self, key, value):
         if key == 'cross_sections':
@@ -39,8 +39,8 @@ class _Config(MutableMapping):
         elif key == 'chain_file':
             self._set_path(key, value)
             os.environ['OPENMC_CHAIN_FILE'] = str(value)
-            # Reset photon source data since it relies on chain file
-            _DECAY_PHOTON_ENERGY.clear()
+            # Reset particle source data since it relies on chain file
+            _DECAY_PARTICLE_ENERGY = {"photon": {}, "neutron": {}}
             _DECAY_ENERGY.clear()
         else:
             raise KeyError(f'Unrecognized config key: {key}. Acceptable keys '

--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -47,6 +47,10 @@ _RADIATION_TYPES = {
     11: 'neutrino'
 }
 
+# used to cache values, populated when decay data is loaded
+_DECAY_PARTICLE_ENERGY = {"photon": {}, "neutron": {}}
+_DECAY_ENERGY = {}
+
 
 def get_decay_modes(value):
     """Return sequence of decay modes given an ENDF RTYP value.
@@ -575,8 +579,50 @@ class Decay(EqualityMixin):
         self._sources = merged_sources
         return self._sources
 
+def decay_particle_energy(nuclide: str, particle: str) -> Optional[Univariate]:
+    """Get photon energy distribution resulting from the decay of a nuclide
 
-_DECAY_PHOTON_ENERGY = {}
+    This function relies on data stored in a depletion chain. Before calling it
+    for the first time, you need to ensure that a depletion chain has been
+    specified in openmc.config['chain_file'].
+
+    .. versionadded:: 0.15.1
+
+    Parameters
+    ----------
+    nuclide : str
+        Name of nuclide, e.g., 'Co58'
+    particle : str
+        Type of particle, e.g., 'photon' or 'neutron'
+
+    Returns
+    -------
+    openmc.stats.Univariate or None
+        Distribution of energies in [eV] of particle emitted from decay, or None
+        if no particle source exists. Note that the probabilities represent
+        intensities, given as [Bq].
+    """
+
+    if not _DECAY_PARTICLE_ENERGY[particle]:
+        chain_file = openmc.config.get('chain_file')
+        if chain_file is None:
+            raise DataError(
+                "A depletion chain file must be specified with "
+                "openmc.config['chain_file'] in order to load decay data."
+            )
+
+        from openmc.deplete import Chain
+        chain = Chain.from_xml(chain_file)
+        for nuc in chain.nuclides:
+            if particle in nuc.sources:
+                _DECAY_PARTICLE_ENERGY[particle][nuc.name] = nuc.sources[particle]
+
+        # If the chain file contained no sources at all, warn the user
+        if not _DECAY_PARTICLE_ENERGY[particle]:
+            warn(f"Chain file '{chain_file}' does not have any decay {particle} "
+                 "sources listed.")
+
+    return _DECAY_PARTICLE_ENERGY[particle].get(nuclide)
 
 
 def decay_photon_energy(nuclide: str) -> Optional[Univariate]:
@@ -600,29 +646,31 @@ def decay_photon_energy(nuclide: str) -> Optional[Univariate]:
         if no photon source exists. Note that the probabilities represent
         intensities, given as [Bq].
     """
-    if not _DECAY_PHOTON_ENERGY:
-        chain_file = openmc.config.get('chain_file')
-        if chain_file is None:
-            raise DataError(
-                "A depletion chain file must be specified with "
-                "openmc.config['chain_file'] in order to load decay data."
-            )
-
-        from openmc.deplete import Chain
-        chain = Chain.from_xml(chain_file)
-        for nuc in chain.nuclides:
-            if 'photon' in nuc.sources:
-                _DECAY_PHOTON_ENERGY[nuc.name] = nuc.sources['photon']
-
-        # If the chain file contained no sources at all, warn the user
-        if not _DECAY_PHOTON_ENERGY:
-            warn(f"Chain file '{chain_file}' does not have any decay photon "
-                 "sources listed.")
-
-    return _DECAY_PHOTON_ENERGY.get(nuclide)
+    return decay_particle_energy(nuclide=nuclide, particle="photon")
 
 
-_DECAY_ENERGY = {}
+def decay_neutron_energy(nuclide: str) -> Optional[Univariate]:
+    """Get neutron energy distribution resulting from the decay of a nuclide
+
+    This function relies on data stored in a depletion chain. Before calling it
+    for the first time, you need to ensure that a depletion chain has been
+    specified in openmc.config['chain_file'].
+
+    .. versionadded:: 0.15.1
+
+    Parameters
+    ----------
+    nuclide : str
+        Name of nuclide, e.g., 'N17'
+
+    Returns
+    -------
+    openmc.stats.Univariate or None
+        Distribution of energies in [eV] of neutrons emitted from decay, or None
+        if no neutron source exists. Note that the probabilities represent
+        intensities, given as [Bq].
+    """
+    return decay_particle_energy(nuclide=nuclide, particle="neutron")
 
 
 def decay_energy(nuclide: str):


### PR DESCRIPTION
# Description

It would be useful to have a ```openmc.data.decay_neutron_energy``` to match the already existing ```openmc.data.decay_photon_energy```

For my use case I've been doing a few simulations with activated water and one of the products is N17 which is a neutron emitter. I'm keen to know the emission details of the neutrons

I notice there are other nuclides of (Cm, Cf, Bk, Am, Sm, Th, U, Pu) that also decay via neutron emission.

This PR makes use of the existing ```decay_photon_energy``` code and a bit more generic so that is can get neutron or photon sources

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)

