### PR TITLE
Add missing show_overlaps option to plots.xml input file documentation

### DIFF
--- a/docs/source/io_formats/plots.rst
+++ b/docs/source/io_formats/plots.rst
@@ -151,6 +151,18 @@ attributes or sub-elements.  These are not used in "voxel" plots:
 
     *Default*: 255 255 255 (white)
 
+  :show_overlaps:
+    Indicates whether overlapping regions of different cells are shown. 
+
+    *Default*: None
+
+  :overlap_color:
+    Specifies the RGB color of overlapping regions of different cells. Does not 
+    do anything if ``show_overlaps`` is "false" or not specified. Should be 3 
+    integers separated by spaces.
+
+    *Default*: 255 0 0 (red)
+  
   :meshlines:
     The ``meshlines`` sub-element allows for plotting the boundaries of a
     regular mesh on top of a plot. Only one ``meshlines`` element is allowed per


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

The ``show_overlaps`` and ``overlap_color`` optional elements for plot.xml input files were not listed in the documentation as described in #3066. This PR adds a bare bones description for these elements.


# Checklist

- [X] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
