### PR TITLE
Enforce sequence type when setting Setting.track

### DIFF
--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Mapping, MutableSequence
+from collections.abc import Iterable, Mapping, MutableSequence, Sequence
 from enum import Enum
 import itertools
 from math import ceil
@@ -819,7 +819,7 @@ class Settings:
 
     @track.setter
     def track(self, track: typing.Iterable[typing.Iterable[int]]):
-        cv.check_type('track', track, Iterable)
+        cv.check_type('track', track, Sequence)
         for t in track:
             if len(t) != 3:
                 msg = f'Unable to set the track to "{t}" since its length is not 3'


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

### Description
As is, ``settings.track`` currently checks whether the input is an iterable, and then it steps through the requested particle tracks (as specified by 3-tuples) to do some additional checking with a ``for`` loop. 

But in the particular case of #2984, there's an issue when an _iterator_ is passed to ``settings.track`` , for instance an ``itertools.chain`` object. When we step through this object with the ``for`` loop, we  _exhaust_ the iterator, so at the end of ``@track.setter``, we assign essentially an empty value to ``settings.track``.

And what's more, though the iterator is exhausted, it still is not None, thus triggering the function ``_create_track_subelement`` which leads to the creation of an empty XML element without any complaints.

# Quick Solution
Simply enforcing the ``Sequence`` and not ``Iterable`` type should eliminate the issue found in #2984 while still permitting the intended input ([tuple or list as on the docs](https://docs.openmc.org/en/latest/pythonapi/generated/openmc.Settings.html)).

# Checklist

- [X] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [X] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
