### PR TITLE
Enforce non-negative percents for material.add_nuclide to prevent unintended ao/wo flipping

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -728,6 +728,7 @@ class Material(IDManagerMixin):
 
         cv.check_type('nuclide', element, str)
         cv.check_type('percent', percent, Real)
+        cv.check_greater_than('percent', percent, 0, equality=True)
         cv.check_value('percent type', percent_type, {'ao', 'wo'})
 
         # Make sure element name is just that

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -519,6 +519,7 @@ class Material(IDManagerMixin):
         cv.check_type('nuclide', nuclide, str)
         cv.check_type('percent', percent, Real)
         cv.check_value('percent type', percent_type, {'ao', 'wo'})
+        cv.check_greater_than('percent', percent, 0, equality=True)
 
         if self._macroscopic is not None:
             msg = 'Unable to add a Nuclide to Material ID="{}" as a ' \

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Mapping, MutableSequence
+from collections.abc import Iterable, Mapping, MutableSequence, Sequence
 from enum import Enum
 import itertools
 from math import ceil
@@ -819,7 +819,7 @@ class Settings:
 
     @track.setter
     def track(self, track: typing.Iterable[typing.Iterable[int]]):
-        cv.check_type('track', track, Iterable)
+        cv.check_type('track', track, Sequence)
         for t in track:
             if len(t) != 3:
                 msg = f'Unable to set the track to "{t}" since its length is not 3'


### PR DESCRIPTION


<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

### Description

In the Python API, when adding nuclides to a material, there appears to be an unintentional second way to flip between at% and wt% definitions as was discovered in #2669.

Behind the scenes and on the C++ side of things, OpenMC differentiates between at% and wt% inputs with sign, with negatively signed values indicating the latter. Thus, in the Python API, when the ``add_nuclide`` method is called with 'wo', the input percentage later has its sign flipped when running OpenMC. 

However, what this means is that ``material.add_nuclide(nuc, -(percent), 'wo')`` is interpreted as an at% input, which can lead to the unintentional mixing of 'ao' and 'wo' for a material if by chance a stray negative sign were entered. This throws an error at runtime that fails to indicate that all ``add_nuclide`` percent values should be positive for composition type consistency.

# Quick Fix
Simply requiring a non-negative value when calling ``add_nuclide`` makes the fix much more apparent by returning a negative ``ValueError`` when the given ``percent`` is negative.

While there's a chance some users manually utilize the negative percent to toggle between ao and wo, it's clear this is  undocumented and likely unintentional behavior, and it's more transparent to just require 'ao' or 'wo' for controlling percent composition type.

# Checklist

- [X] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [X] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

