### PR TITLE
Include batch statistics discussion in methodology introduction

### DIFF
--- a/docs/source/methods/introduction.rst
+++ b/docs/source/methods/introduction.rst
@@ -31,12 +31,6 @@ simulate:
 where :math:`\sigma^2` is the variance of the sample mean and :math:`N` is the
 number of realizations.
 
-OpenMC uses batch statistics. That is, OpenMC counts batches, which are the 
-aggregated tallies of generations of simulated particles, as individual 
-realizations. See :ref:`Statistics <tallies_statistics>` for further theoretical
-background regarding uncertainty or :ref:`Run Strategy <usersguide_particles>` 
-for configuring statistically sound simulations.
-
 ------------------------
 Overview of Program Flow
 ------------------------

--- a/docs/source/methods/introduction.rst
+++ b/docs/source/methods/introduction.rst
@@ -31,6 +31,12 @@ simulate:
 where :math:`\sigma^2` is the variance of the sample mean and :math:`N` is the
 number of realizations.
 
+OpenMC uses batch statistics. That is, OpenMC counts batches, which are the 
+aggregated tallies of generations of simulated particles, as individual 
+realizations. See :ref:`Statistics <tallies_statistics>` for further theoretical
+background regarding uncertainty or :ref:`Run Strategy <usersguide_particles>` 
+for configuring statistically sound simulations.
+
 ------------------------
 Overview of Program Flow
 ------------------------

--- a/docs/source/methods/tallies.rst
+++ b/docs/source/methods/tallies.rst
@@ -207,6 +207,8 @@ the change-in-angle), we must use an analog estimator.
 
 .. TODO: Add description of surface current tallies
 
+.. _tallies_statistics:
+
 ----------
 Statistics
 ----------

--- a/docs/source/methods/tallies.rst
+++ b/docs/source/methods/tallies.rst
@@ -5,7 +5,7 @@ Tallies
 =======
 
 The methods discussed in this section are written specifically for continuous-
-energy mode. However, they can also apply to the multi-group mode if the 
+energy mode. However, they can also apply to the multi-group mode if the
 particle's energy is instead interpreted as the particle's group.
 
 ------------------
@@ -269,6 +269,14 @@ normal, log-normal, Weibull, etc. The central limit theorem states that as
 
 Estimating Statistics of a Random Variable
 ------------------------------------------
+
+After running OpenMC, each tallied quantity has a reported mean and standard
+deviation. The below sections explain how these quantities are computed. Note
+that OpenMC uses **batch statistics**, meaning that each observation for a tally
+random variable corresponds to the aggregation of tally contributions from
+multiple source particles that are grouped together into a single batch. See
+:ref:`usersguide_particles` for more information on how the number of source
+particles and statistical batches are specified.
 
 Mean
 ++++

--- a/docs/source/methods/tallies.rst
+++ b/docs/source/methods/tallies.rst
@@ -4,9 +4,9 @@
 Tallies
 =======
 
-Note that the methods discussed in this section are written specifically for
-continuous-energy mode but equivalent apply to the multi-group mode if the
-particle's energy is replaced with the particle's group
+The methods discussed in this section are written specifically for continuous-
+energy mode. However, they can also apply to the multi-group mode if the 
+particle's energy is instead interpreted as the particle's group.
 
 ------------------
 Filters and Scores


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

### Description

In #2562, it was pointed out that in the [Theory and Methodology](https://docs.openmc.org/en/latest/methods/introduction.html) section of the docs, there were relatively few lines explaining that OpenMC uses batch statistics as the default (and only) mode of presenting variance. This could be problematic considering that it's possible for different codes that a user may be familiar with to use other methods (significantly MCNP, which uses "fast_history" as default for its tallies).

This PR adds a short snippet to the methodology introduction page stating the use of batch statistics. It also embeds some links to other statistics-relevant parts of the documentation, namely [Statistics](https://docs.openmc.org/en/latest/methods/tallies.html#statistics) and [Run Strategy](https://docs.openmc.org/en/latest/usersguide/settings.html#run-strategy).

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [X] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
