### PR TITLE
Add -DCMAKE_BUILD_TYPE=Release flag for MOAB in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,8 @@ RUN if [ "$build_dagmc" = "on" ]; then \
         mkdir -p $HOME/MOAB && cd $HOME/MOAB \
         && git clone  --single-branch -b ${MOAB_TAG} --depth 1 ${MOAB_REPO} \
         && mkdir build && cd build \
-        && cmake ../moab -DENABLE_HDF5=ON \
+        && cmake ../moab -DCMAKE_BUILD_TYPE=Release \
+                      -DENABLE_HDF5=ON \
                       -DENABLE_NETCDF=ON \
                       -DBUILD_SHARED_LIBS=OFF \
                       -DENABLE_FORTRAN=OFF \


### PR DESCRIPTION
# Description

This sets the build type of MOAB to `Release`  instead of the default `RelWithDebInfo` in the Dockerfile. This can results in a large performance gain when using DAGMC transport

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
