### PR TITLE
Adjust decay data reader to better handle non-normalized branching ratios

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -386,10 +386,9 @@ class Chain:
             if not data.nuclide['stable'] and data.half_life.nominal_value != 0.0:
                 nuclide.half_life = data.half_life.nominal_value
                 nuclide.decay_energy = data.decay_energy.nominal_value
-                sum_br = 0.0
                 branch_ratios = []
                 branch_ids = []
-                for mode in data.modes: 
+                for mode in data.modes:
                     type_ = ','.join(mode.modes)
                     if mode.daughter in decay_data:
                         target = mode.daughter
@@ -398,27 +397,22 @@ class Chain:
                             parent, type_, mode.daughter))
                         target = replace_missing(mode.daughter, decay_data)
                     br = mode.branching_ratio.nominal_value
-                    sum_br += br
                     branch_ratios.append(br)
                     branch_ids.append((type_, target))
 
-                if sum_br != 1.0:
+                if not math.isclose(sum(branch_ratios), 1.0):
                     max_br = max(branch_ratios)
                     max_index = branch_ratios.index(max_br)
 
-                    # Adjust max_br so branching ratios sum to unity
+                    # Adjust maximum branching ratio so they sum to unity
                     new_br = max_br - sum(branch_ratios) + 1.0
                     branch_ratios[max_index] = new_br
-                    if not math.isclose(sum_br, 1.0, rel_tol=1e-3):
-                        print(
-                            f'{parent} branch ratios sum: {sum_br}, changed '
-                            f'branch {branch_ids[max_index]} from '
-                            f'{max_br} to {new_br}.'
-                        )
+                    assert math.isclose(sum(branch_ratios), 1.0)
 
                 # Append decay modes
-                for br, id in zip(branch_ratios, branch_ids):
-                    nuclide.add_decay_mode(id[0], id[1], br)
+                for br, (type_, target) in zip(branch_ratios, branch_ids):
+                    nuclide.add_decay_mode(type_, target, br)
+
                 nuclide.sources = data.sources
 
             fissionable = False


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

In #2999, it was discovered that the decay data reader for depletion problems would occasionally give negative branching ratios, particularly in cases where parent nuclides had branching ratio sums that were not equal to unity. 

In those cases, the code tweaks the last decay mode's branching ratio to whatever value required for the sum to reach unity. This can be an issue if that last branching ratio is small and the sum is greater than one, which results in subtracting the overshoot from the last branching ratio.

### Quick Fix

Instead of going through the decay modes and calling `add_decay_mode()` at the end of each iteration, buffer the information by placing the needed arguments for `add_decay_mode()` into temporary lists. Then check for a unity sum of the branching ratios; if not, then **adjust the largest branching ratio** by the appropriate amount. This was the solution proposed by @paulromano in the mentioned issue.

If the adjustment is particularly large (currently `rel_tol = 1e-3`), then issue an alert regarding that change. This is to filter out microscopic BR changes.

### Tests and Results

Now, when creating an `openmc.deplete.Chain` object, branching ratios are a lot more transparent. For instance, with JEFF-3.3, the output is:
```
> chain = openmc.deplete.Chain.from_endf(...)
...
Creating depletion_chain...
Ag122 branch ratios sum: 0.998, changed branch ('beta-', 'Cd122') from 0.998 to 1.0.
In129_m1 branch ratios sum: 0.997, changed branch ('beta-', 'Sn129') from 0.997 to 1.0.
Er152 branch ratios sum: 1.01, changed branch ('alpha', 'Dy148') from 0.91 to 0.9.
Ir169 branch ratios sum: 0.45, changed branch ('alpha', 'Re165') from 0.45 to 1.0.
Pt168 branch ratios sum: 0.993, changed branch ('alpha', 'Os164') from 0.993 to 1.0.
... [there's a lot more]
```
And we no longer have any issues with negative BRs:
```
>  for mode in chain.nuclides[chain.nuclide_dict["Cs120"]].decay_modes
>     print(mode)
DecayTuple(type='ec/beta+', target='Xe120', branching_ratio=0.9999997300000001)
DecayTuple(type='ec/beta+,alpha', target='Te116', branching_ratio=2e-07)
DecayTuple(type='ec/beta+,p', target='I119', branching_ratio=7e-08)
```
But importantly, owing to magical float valuations (i.e. `1.0 != 1`) as well as possibly legitimate discrepancies in the decay data, the number of nuclides that get adjusted branching ratios is much larger than expected, so a more rigorous solution might be justified.

One such solution might be (from #2999):
> Though having BRs adding up to more that one is weird, I am not sure tweaking the last one is the right approach, as it leads to unphysical effects. Why not renormalize all BRs by dividing them by the total?

If anyone wants to weigh in, please do!

# Checklist

- [X] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [X] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
