### PR TITLE
Correct openmc.Geometry initializer to accept iterables of openmc.Cell

### DIFF
--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -41,7 +41,7 @@ class Geometry:
 
     def __init__(
         self,
-        root: typing.Optional[openmc.UniverseBase] = None,
+        root: openmc.UniverseBase | typing.Iterable[openmc.Cell] | None = None,
         merge_surfaces: bool = False,
         surface_precision: int = 10
     ):


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

### Description
In #3079, it was pointed out that the `openmc.Geometry` constructor should accept an optional object of either `openmc.Universe` or `Iterable[openmc.Cell]`, but was coded only to accept the former.

### Quick Fix
With [PEP 604](https://peps.python.org/pep-0604/), we can change `Optional[type] = None` to the no-strings-attached alternate form `type | None = None` made available in Python 3.10+. Since `|` is also another way to express `typing.Union[]`, it's easy enough to add the other needed case for `openmc.Geometry`.

In any case, in the rest of the codebase, the `Optional[type]` syntax appears 163 more times. It shouldn't be too difficult to refactor all of that into `type | None = None` for conciseness and readability, though that's probably for a different PR.

# Checklist

- [X] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [X] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
