### PR TITLE
Add delta_function convenience function

### DIFF
--- a/docs/source/pythonapi/stats.rst
+++ b/docs/source/pythonapi/stats.rst
@@ -28,6 +28,7 @@ Univariate Probability Distributions
    :nosignatures:
    :template: myfunction.rst
 
+   openmc.stats.delta_function
    openmc.stats.muir
 
 Angular Distributions

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -312,6 +312,27 @@ class Discrete(Univariate):
             return type(self)(new_x, new_p)
 
 
+def delta_function(value: float, intensity: float = 1.0) -> Discrete:
+    """Return a discrete distribution with a single point.
+
+    .. versionadded:: 0.15.1
+
+    Parameters
+    ----------
+    value : float
+        Value of the random variable.
+    intensity : float, optional
+        When used for an energy distribution, this can be used to assign an
+        intensity.
+
+    Returns
+    -------
+    Discrete distribution with a single point
+
+    """
+    return Discrete([value], [intensity])
+
+
 class Uniform(Univariate):
     """Distribution with constant probability over a finite interval [a,b]
 

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -50,6 +50,13 @@ def test_discrete():
     assert_sample_mean(samples, exp_mean)
 
 
+def test_delta_function():
+    d = openmc.stats.delta_function(14.1e6)
+    assert isinstance(d, openmc.stats.Discrete)
+    np.testing.assert_array_equal(d.x, [14.1e6])
+    np.testing.assert_array_equal(d.p, [1.0])
+
+
 def test_merge_discrete():
     x1 = [0.0, 1.0, 10.0]
     p1 = [0.3, 0.2, 0.5]


### PR DESCRIPTION
# Description

This PR adds a `delta_function` convenience function that is just syntactic sugar for a discrete distribution with a single point. That is, the following are equivalent:
```Python
d1 = openmc.stats.Discrete([100.e3], [1.0])  # explicit
d2 = openmc.stats.delta_function(100.e3)     # syntactic sugar
```

The `delta_function` function returns an instance of `Discrete`, so it does not introduce a new class. I've also added an optional `intensity` argument that can be used if the user is defining a source energy distribution.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)