### PR TITLE
Fix ParticleFilter to work with set inputs

### DIFF
--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -764,8 +764,9 @@ class ParticleFilter(Filter):
 
     @Filter.bins.setter
     def bins(self, bins):
-        bins = np.atleast_1d(bins)
-        cv.check_iterable_type('filter bins', bins, str)
+        cv.check_type('bins', bins, Iterable, str)
+        if type(bins) != set:
+            bins = np.atleast_1d(bins)
         for edge in bins:
             cv.check_value('filter bin', edge, _PARTICLES)
         self._bins = bins

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from abc import ABCMeta
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 import hashlib
 from itertools import product
 from numbers import Real, Integral
@@ -736,7 +736,7 @@ class ParticleFilter(Filter):
 
     Parameters
     ----------
-    bins : str, or iterable of str
+    bins : str, or sequence of str
         The particles to tally represented as strings ('neutron', 'photon',
         'electron', 'positron').
     filter_id : int
@@ -744,7 +744,7 @@ class ParticleFilter(Filter):
 
     Attributes
     ----------
-    bins : iterable of str
+    bins : sequence of str
         The particles to tally
     id : int
         Unique identifier for the filter
@@ -764,9 +764,8 @@ class ParticleFilter(Filter):
 
     @Filter.bins.setter
     def bins(self, bins):
-        cv.check_type('bins', bins, Iterable, str)
-        if type(bins) != set:
-            bins = np.atleast_1d(bins)
+        cv.check_type('bins', bins, Sequence, str)
+        bins = np.atleast_1d(bins)    
         for edge in bins:
             cv.check_value('filter bin', edge, _PARTICLES)
         self._bins = bins


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->
#### Description

In #2964, it was pointed out that `openmc.ParticleFilter`, despite its documentation permitting sets (more broadly Iterables), throws a `TypeError` when given one. This PR fixes this issue.

The specific issue is that the attribute setter calls the function `np.atleast_1d()` on the input, which does not register sets as one-dimensional (and rightfully so, since sets don't have dimensions that can be indexed).

This function causes a set to be wrapped in a list, which causes issues with `cv.check_iterable_type()` since the depth of the iterable is increased beyond 1.

### Quick Fix

Allowing set inputs for `ParticleFilter` seems uniquely appropriate, given its requirement for unique elements, and the rest of the code works fine with any iterable, set or not. In any case, only minor tweaks are required to make sets work.

I've opted to simply avoid calling `np.atleast_1d()` on sets, and use `cv.check_type()` which has extra provisions for checking if an Iterable contains a certain type in lieu of `cv.check_iterable_type()`.

### Side Issue
Despite its name, `cv.check_iterable_type()` only works on Sequences since it traverses the input with indexing. A more accurate name would probably be `cv.check_sequence_type()`, but then every other instance of this function must also be changed to reflect this.

# Checklist

- [X] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [X] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
