### PR TITLE
packages used for testing moved to tests section of pyprojects.tom

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,15 +46,8 @@ docs = [
     "sphinxcontrib-svg2pdfconverter",
     "sphinx-rtd-theme==1.0.0"
 ]
-test = [
-    "packaging",
-    "pytest",
-    "pytest-cov",
-    "colorama",
-    "openpyxl",
-    "cpp-coveralls",
-    "coveralls",
-]
+test = ["packaging", "pytest", "pytest-cov", "colorama", "openpyxl"]
+ci = ["cpp-coveralls", "coveralls"]
 vtk = ["vtk"]
 
 [project.urls]

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -48,4 +48,4 @@ fi
 python tools/ci/gha-install.py
 
 # Install Python API in editable mode
-pip install -e .[test,vtk]
+pip install -e .[test,vtk,ci]


### PR DESCRIPTION
Just spotted these stray pip installable packages in the CI and think they might be better placed in the pyprojects.toml with the other packages needed for testing. These two would help the developer check coverage when adding features.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)