### PR TITLE
removed unused which function in CI scripts

### DIFF
--- a/tools/ci/gha-install.py
+++ b/tools/ci/gha-install.py
@@ -2,22 +2,6 @@ import os
 import shutil
 import subprocess
 
-def which(program):
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            path = path.strip('"')
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-    return None
-
 
 def install(omp=False, mpi=False, phdf5=False, dagmc=False, libmesh=False, ncrystal=False):
     # Create build directory and change to it


### PR DESCRIPTION
I noticed we have an unused function here in the CI called ```which```.

We make use of ```shutil.which``` elsewhere in the code but I think this function in the CI script is unused so I guess we can remove it.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
