### PR TITLE
Improve description of probabilities for openmc.stats.Tabular class

### DIFF
--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -856,15 +856,12 @@ class Tabular(Univariate):
         points. Defaults to 'linear-linear'.
 
     Notes
-    -----
+    ----------
     The probabilities `p` are interpreted per unit of the corresponding independent 
     variable `x`. This follows the definition of a probability density function (PDF)
     in probability theory, where the PDF represents the relative likelihood of the 
-    random variable taking on a particular value per unit of the variable.
-
-    Example
-    -------
-    If `x` represents energy in eV, then `p` should represent probabilities per eV.
+    random variable taking on a particular value per unit of the variable. For example, 
+    if `x` represents energy in eV, then `p` should represent probabilities per eV.
 
     """
 

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -837,7 +837,8 @@ class Tabular(Univariate):
         Tabulated values of the random variable
     p : Iterable of float
         Tabulated probabilities. For histogram interpolation, if the length of
-        `p` is the same as `x`, the last value is ignored.
+        `p` is the same as `x`, the last value is ignored. Probabilities `p` are
+        given per unit of `x`.
     interpolation : {'histogram', 'linear-linear', 'linear-log', 'log-linear', 'log-log'}, optional
         Indicates how the density function is interpolated between tabulated
         points. Defaults to 'linear-linear'.
@@ -853,6 +854,17 @@ class Tabular(Univariate):
     interpolation : {'histogram', 'linear-linear', 'linear-log', 'log-linear', 'log-log'}
         Indicates how the density function is interpolated between tabulated
         points. Defaults to 'linear-linear'.
+
+    Notes
+    -----
+    The probabilities `p` are interpreted per unit of the corresponding independent 
+    variable `x`. This follows the definition of a probability density function (PDF)
+    in probability theory, where the PDF represents the relative likelihood of the 
+    random variable taking on a particular value per unit of the variable.
+
+    Example
+    -------
+    If `x` represents energy in eV, then `p` should represent probabilities per eV.
 
     """
 

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -856,12 +856,13 @@ class Tabular(Univariate):
         points. Defaults to 'linear-linear'.
 
     Notes
-    ----------
-    The probabilities `p` are interpreted per unit of the corresponding independent 
-    variable `x`. This follows the definition of a probability density function (PDF)
-    in probability theory, where the PDF represents the relative likelihood of the 
-    random variable taking on a particular value per unit of the variable. For example, 
-    if `x` represents energy in eV, then `p` should represent probabilities per eV.
+    -----
+    The probabilities `p` are interpreted per unit of the corresponding
+    independent variable `x`. This follows the definition of a probability
+    density function (PDF) in probability theory, where the PDF represents the
+    relative likelihood of the random variable taking on a particular value per
+    unit of the variable. For example, if `x` represents energy in eV, then `p`
+    should represent probabilities per eV.
 
     """
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

The docstring for the `openmc.stats.Tabular` class did not mention that the tabulated probabilities `p` were given per unit of the independent variable `x` as described in #3089. This PR clarifies this by adding to the Parameters section and introducing a Notes and Example section.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
