### PR TITLE
Ensure RegularMesh repr shows value for width of the mesh

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -777,7 +777,7 @@ class RegularMesh(StructuredMesh):
         string += '{0: <16}{1}{2}\n'.format('\tDimensions', '=\t', self.n_dimension)
         string += '{0: <16}{1}{2}\n'.format('\tVoxels', '=\t', self._dimension)
         string += '{0: <16}{1}{2}\n'.format('\tLower left', '=\t', self._lower_left)
-        string += '{0: <16}{1}{2}\n'.format('\tUpper Right', '=\t', self._upper_right)
+        string += '{0: <16}{1}{2}\n'.format('\tUpper Right', '=\t', self.upper_right)
         string += '{0: <16}{1}{2}\n'.format('\tWidth', '=\t', self.width)
         return string
 

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -778,7 +778,7 @@ class RegularMesh(StructuredMesh):
         string += '{0: <16}{1}{2}\n'.format('\tVoxels', '=\t', self._dimension)
         string += '{0: <16}{1}{2}\n'.format('\tLower left', '=\t', self._lower_left)
         string += '{0: <16}{1}{2}\n'.format('\tUpper Right', '=\t', self._upper_right)
-        string += '{0: <16}{1}{2}\n'.format('\tWidth', '=\t', self._width)
+        string += '{0: <16}{1}{2}\n'.format('\tWidth', '=\t', self.width)
         return string
 
     @classmethod


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Dear All. After debugging I figured out that the property decorator of width was never called, which caused the None value to be displayed. Now it is displayed correctly.

```python
>>> mesh = openmc.RegularMesh()
>>> mesh.lower_left = (-5., -1., -10.)
>>> mesh.upper_right = (5., 1., 10.)
>>> mesh.dimension = (10, 2, 20)
>>> mesh.width
[1.0, 1.0, 1.0]
>>> mesh
RegularMesh
	ID             =	1
	Name           =	
	Dimensions     =	3
	Voxels         =	(10, 2, 20)
	Lower left     =	(-5.0, -1.0, -10.0)
	Upper Right    =	(5.0, 1.0, 10.0)
	Width          =	[1.0, 1.0, 1.0]
```

I ran the tests, but unfortunately I could not get some of them to pass (10 failed and 3 errors), see the attached log file for more information. At quick glance they do not seem to be anything related to my PR, but I cannot say that for sure. I built OpenMC on Debian 12.

Fixes #3091

# Checklist

- [X] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
[log.log](https://github.com/user-attachments/files/16394442/log.log)
