### PR TITLE
Adding material.get_element_atom_densities 

### DIFF
--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -549,7 +549,18 @@ def gnds_name(Z, A, m=0):
     return f'{ATOMIC_SYMBOL[Z]}{A}'
 
 
-def isotopes(element):
+
+def _get_element_symbol(element: str) -> str:
+    if len(element) > 2:
+        symbol = ELEMENT_SYMBOL.get(element.lower())
+        if symbol is None:
+            raise ValueError(f'Element name "{element}" not recognized')
+        return symbol
+    else:
+        return element
+
+
+def isotopes(element: str) -> list[tuple[str, float]]:
     """Return naturally occurring isotopes and their abundances
 
     .. versionadded:: 0.12.1
@@ -570,12 +581,7 @@ def isotopes(element):
         If the element name is not recognized
 
     """
-    # Convert name to symbol if needed
-    if len(element) > 2:
-        symbol = ELEMENT_SYMBOL.get(element.lower())
-        if symbol is None:
-            raise ValueError(f'Element name "{element}" not recognised')
-        element = symbol
+    element = _get_element_symbol(element)
 
     # Get the nuclides present in nature
     result = []

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1090,7 +1090,7 @@ class Material(IDManagerMixin):
         Returns
         -------
         elements : dict
-            Dictionary whose keys are element name and value is densities in
+            Dictionary whose keys are element names and values are densities in
             [atom/b-cm]
 
         """

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1090,14 +1090,13 @@ class Material(IDManagerMixin):
         Returns
         -------
         elements : dict
-            Dictionary whose keys are element names and values are densities in
+            Dictionary whose keys are element name and value is densities in
             [atom/b-cm]
 
         """
 
-        from openmc.data import ATOMIC_SYMBOL
         if element is not None:
-            acceptable_elements = [key for key in ATOMIC_SYMBOL.values() if key != 'n']
+            acceptable_elements = [key for key in openmc.data.ATOMIC_SYMBOL.values() if key != 'n']
             if element not in acceptable_elements:
                 raise ValueError(f"Element should be one of {acceptable_elements}, not '{element}'")
 
@@ -1106,11 +1105,10 @@ class Material(IDManagerMixin):
         # Initialize an empty dictionary for summed values
         summed_elements = {}
 
-        # Iterate through each item in the original dictionary
         for nuclide, density in nuc_densities.items():
-            # Extract element name (ignoring isotope number)
-            nuc_element = ATOMIC_SYMBOL[openmc.data.zam(nuclide)[0]]
-            # Sum the values for each element
+
+            nuc_element = openmc.data.ATOMIC_SYMBOL[openmc.data.zam(nuclide)[0]]
+
             if nuc_element in summed_elements:
                 summed_elements[nuc_element] += float(density)
             else:

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -380,6 +380,22 @@ def test_get_nuclide_atom_densities_specific(uo2):
     assert all_nuc['O16'] == one_nuc['O16']
 
 
+def test_get_element_atom_densities(uo2):
+    for element, density in uo2.get_element_atom_densities().items():
+        assert element in ('U', 'O')
+        assert density > 0
+
+def test_get_element_atom_densities_specific(uo2):
+    one_nuc = uo2.get_element_atom_densities(element='O')
+    assert list(one_nuc.keys()) == ['O']
+    assert list(one_nuc.values())[0] > 0
+
+    with pytest.raises(TypeError):
+        uo2.get_element_atom_densities(element='Li')
+
+    with pytest.raises(TypeError):
+        uo2.get_element_atom_densities(element='no an element name')
+
 def test_get_nuclide_atoms():
     mat = openmc.Material()
     mat.add_nuclide('Li6', 1.0)

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -385,6 +385,7 @@ def test_get_element_atom_densities(uo2):
         assert element in ('U', 'O')
         assert density > 0
 
+
 def test_get_element_atom_densities_specific(uo2):
     one_nuc = uo2.get_element_atom_densities(element='O')
     assert list(one_nuc.keys()) == ['O']

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -387,15 +387,20 @@ def test_get_element_atom_densities(uo2):
 
 
 def test_get_element_atom_densities_specific(uo2):
-    one_nuc = uo2.get_element_atom_densities(element='O')
+    one_nuc = uo2.get_element_atom_densities('O')
     assert list(one_nuc.keys()) == ['O']
     assert list(one_nuc.values())[0] > 0
 
-    with pytest.raises(ValueError):
-        uo2.get_element_atom_densities(element='Li')
+    one_nuc = uo2.get_element_atom_densities('uranium')
+    assert list(one_nuc.keys()) == ['U']
+    assert list(one_nuc.values())[0] > 0
 
-    with pytest.raises(ValueError):
-        uo2.get_element_atom_densities(element='no an element name')
+    with pytest.raises(ValueError, match='not found'):
+        uo2.get_element_atom_densities('Li')
+
+    with pytest.raises(ValueError, match='not recognized'):
+        uo2.get_element_atom_densities('proximium')
+
 
 def test_get_nuclide_atoms():
     mat = openmc.Material()

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -390,10 +390,10 @@ def test_get_element_atom_densities_specific(uo2):
     assert list(one_nuc.keys()) == ['O']
     assert list(one_nuc.values())[0] > 0
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         uo2.get_element_atom_densities(element='Li')
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         uo2.get_element_atom_densities(element='no an element name')
 
 def test_get_nuclide_atoms():


### PR DESCRIPTION

## Description

We have a ```openmc.Material.get_nuclide_atom_densities``` and this PR aims to add ```openmc.Material.get_element_atom_densities```

This would be useful for @rherrero-pf and myself when we perform DPA simulations we need to get the atom density for elements.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
