### PR TITLE
Add TimedMeshFilter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,7 @@ list(APPEND libopenmc_SOURCES
   src/tallies/filter_sptl_legendre.cpp
   src/tallies/filter_surface.cpp
   src/tallies/filter_time.cpp
+  src/tallies/filter_timed_mesh.cpp
   src/tallies/filter_universe.cpp
   src/tallies/filter_zernike.cpp
   src/tallies/tally.cpp

--- a/include/openmc/tallies/filter.h
+++ b/include/openmc/tallies/filter.h
@@ -42,6 +42,7 @@ enum class FilterType {
   SPATIAL_LEGENDRE,
   SURFACE,
   TIME,
+  TIMED_MESH,
   UNIVERSE,
   ZERNIKE,
   ZERNIKE_RADIAL

--- a/include/openmc/tallies/filter_timed_mesh.h
+++ b/include/openmc/tallies/filter_timed_mesh.h
@@ -1,0 +1,74 @@
+#ifndef OPENMC_TALLIES_FILTER_TIMED_MESH_H
+#define OPENMC_TALLIES_FILTER_TIMED_MESH_H
+
+#include <cstdint>
+
+#include "openmc/constants.h"
+#include "openmc/position.h"
+#include "openmc/tallies/filter.h"
+
+namespace openmc {
+
+//==============================================================================
+//! Indexes the time-location of particle events to a time gridn and a regular 
+//  mesh. For tracklength tallies, it will produce multiple valid bins and the
+//  bin weight will correspond to the fraction of the track length that lies in
+//! that bin.
+//==============================================================================
+
+class TimedMeshFilter : public Filter {
+public:
+  //----------------------------------------------------------------------------
+  // Constructors, destructors
+
+  ~TimedMeshFilter() = default;
+
+  //----------------------------------------------------------------------------
+  // Methods
+
+  std::string type_str() const override { return "timedmesh"; }
+  FilterType type() const override { return FilterType::TIMED_MESH; }
+
+  void from_xml(pugi::xml_node node) override;
+
+  void get_all_bins(const Particle& p, TallyEstimator estimator,
+    FilterMatch& match) const override;
+
+  void to_statepoint(hid_t filter_group) const override;
+
+  std::string text_label(int bin) const override;
+
+  //----------------------------------------------------------------------------
+  // Accessors
+
+  int32_t mesh() const { return mesh_; }
+
+  void set_mesh(int32_t mesh);
+
+  void set_translation(const Position& translation);
+
+  void set_translation(const double translation[3]);
+
+  const Position& translation() const { return translation_; }
+
+  bool translated() const { return translated_; }
+  
+  const vector<double>& time_grid() const { return time_grid_; }
+  
+  void set_time_grid(gsl::span<const double> time_grid);
+  
+  void reset_bins();
+
+protected:
+  //----------------------------------------------------------------------------
+  // Data members
+
+  int32_t mesh_;            //!< Index of the mesh
+  int mesh_n_bins_;
+  bool translated_ {false}; //!< Whether or not the filter is translated
+  Position translation_ {0.0, 0.0, 0.0}; //!< Filter translation
+  vector<double> time_grid_ {0.0, INFTY};
+};
+
+} // namespace openmc
+#endif // OPENMC_TALLIES_FILTER_TIMED_MESH_H

--- a/include/openmc/tallies/filter_timed_mesh.h
+++ b/include/openmc/tallies/filter_timed_mesh.h
@@ -10,7 +10,7 @@
 namespace openmc {
 
 //==============================================================================
-//! Indexes the time-location of particle events to a time gridn and a regular 
+//! Indexes the time-location of particle events to a time gridn and a regular
 //  mesh. For tracklength tallies, it will produce multiple valid bins and the
 //  bin weight will correspond to the fraction of the track length that lies in
 //! that bin.
@@ -52,18 +52,18 @@ public:
   const Position& translation() const { return translation_; }
 
   bool translated() const { return translated_; }
-  
+
   const vector<double>& time_grid() const { return time_grid_; }
-  
+
   void set_time_grid(gsl::span<const double> time_grid);
-  
+
   void reset_bins();
 
 protected:
   //----------------------------------------------------------------------------
   // Data members
 
-  int32_t mesh_;            //!< Index of the mesh
+  int32_t mesh_; //!< Index of the mesh
   int mesh_n_bins_;
   bool translated_ {false}; //!< Whether or not the filter is translated
   Position translation_ {0.0, 0.0, 0.0}; //!< Filter translation

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1153,7 +1153,7 @@ class TimedMeshFilter(Filter):
     """
 
     def __init__(self, mesh, time_grid, filter_id=None):
-        self._time_grid = np.array([0.0, np.inf]) # Temporary
+        self._time_grid = np.array([0.0, np.inf])  # Temporary
         self.mesh = mesh
         self.time_grid = time_grid
         self.id = filter_id

--- a/openmc/lib/filter.py
+++ b/openmc/lib/filter.py
@@ -647,6 +647,8 @@ _FILTER_TYPE_MAP = {
     'sphericalharmonics': SphericalHarmonicsFilter,
     'spatiallegendre': SpatialLegendreFilter,
     'surface': SurfaceFilter,
+    'time': TimeFilter,
+    'timedmesh': TimedMeshFilter,
     'universe': UniverseFilter,
     'zernike': ZernikeFilter,
     'zernikeradial': ZernikeRadialFilter

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -44,6 +44,15 @@ namespace openmc {
 
 double Particle::speed() const
 {
+  // Multigroup speed?
+  if (!settings::run_CE) {
+    auto& macro_xs = data::mg.macro_xs_[this->material()];
+    int macro_t = this->mg_xs_cache().t;
+    int macro_a = macro_xs.get_angle_index(this->u());
+    return 1.0 / macro_xs.get_xs(MgxsType::INVERSE_VELOCITY, this->g(), nullptr,
+                   nullptr, nullptr, macro_t, macro_a);
+  }
+
   // Determine mass in eV/c^2
   double mass;
   switch (this->type()) {

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -253,6 +253,9 @@ void Particle::event_advance()
     double push_back_distance = speed() * dt;
     this->move_distance(-push_back_distance);
     hit_time_boundary = true;
+
+    // Reduce the distance traveled for tallying
+    distance -= push_back_distance;
   }
 
   // Score track-length tallies

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -127,7 +127,7 @@ void create_fission_sites(Particle& p)
     SourceSite site;
     site.r = p.r();
     site.particle = ParticleType::neutron;
-    site.time = p.time;
+    site.time = p.time();
     site.wgt = 1. / weight;
     site.parent_id = p.id();
     site.progeny_id = p.n_progeny()++;

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -127,6 +127,7 @@ void create_fission_sites(Particle& p)
     SourceSite site;
     site.r = p.r();
     site.particle = ParticleType::neutron;
+    site.time = p.time;
     site.wgt = 1. / weight;
     site.parent_id = p.id();
     site.progeny_id = p.n_progeny()++;

--- a/src/tallies/filter.cpp
+++ b/src/tallies/filter.cpp
@@ -32,6 +32,7 @@
 #include "openmc/tallies/filter_sptl_legendre.h"
 #include "openmc/tallies/filter_surface.h"
 #include "openmc/tallies/filter_time.h"
+#include "openmc/tallies/filter_timed_mesh.h"
 #include "openmc/tallies/filter_universe.h"
 #include "openmc/tallies/filter_zernike.h"
 #include "openmc/xml_interface.h"
@@ -145,6 +146,8 @@ Filter* Filter::create(const std::string& type, int32_t id)
     return Filter::create<SphericalHarmonicsFilter>(id);
   } else if (type == "time") {
     return Filter::create<TimeFilter>(id);
+  } else if (type == "timedmesh") {
+    return Filter::create<TimedMeshFilter>(id);
   } else if (type == "universe") {
     return Filter::create<UniverseFilter>(id);
   } else if (type == "zernike") {

--- a/src/tallies/filter_timed_mesh.cpp
+++ b/src/tallies/filter_timed_mesh.cpp
@@ -1,0 +1,230 @@
+#include "openmc/tallies/filter_timed_mesh.h"
+
+#include <fmt/core.h>
+#include <gsl/gsl-lite.hpp>
+
+#include "openmc/capi.h"
+#include "openmc/constants.h"
+#include "openmc/error.h"
+#include "openmc/mesh.h"
+#include "openmc/search.h"
+#include "openmc/xml_interface.h"
+
+namespace openmc {
+
+void TimedMeshFilter::from_xml(pugi::xml_node node)
+{
+  pugi::xml_node bin_node = node.child("bins");
+
+  //----------------------------------------------------------------------------
+  // Mesh
+
+  auto mesh_bins_ = get_node_array<int32_t>(bin_node, "mesh_bins");
+  if (mesh_bins_.size() != 1) {
+    fatal_error(
+      "Only one mesh can be specified per " + type_str() + " mesh filter.");
+  }
+
+  auto id = mesh_bins_[0];
+  auto search = model::mesh_map.find(id);
+  if (search != model::mesh_map.end()) {
+    set_mesh(search->second);
+  } else {
+    fatal_error(
+      fmt::format("Could not find mesh {} specified on tally filter.", id));
+  }
+
+  if (check_for_node(node, "translation")) {
+    set_translation(get_node_array<double>(node, "translation"));
+  }
+  
+  //----------------------------------------------------------------------------
+  // Time bins
+
+  auto time_grid = get_node_array<double>(bin_node, "time_bins");
+  this->set_time_grid(time_grid);
+}
+
+void TimedMeshFilter::set_mesh(int32_t mesh)
+{
+  // perform any additional perparation for mesh tallies here
+  mesh_ = mesh;
+  model::meshes[mesh_]->prepare_for_tallies();
+
+  reset_bins();
+}
+
+void TimedMeshFilter::set_time_grid(gsl::span<const double> time_grid)
+{
+  // Clear existing bins
+  time_grid_.clear();
+  time_grid_.reserve(time_grid.size());
+
+  // Ensure time grid is sorted and don't have duplicates
+  if (std::adjacent_find(time_grid.cbegin(), time_grid.cend(), std::greater_equal<>()) !=
+      time_grid.end()) {
+    throw std::runtime_error {"Time grid must be monotonically increasing."};
+  }
+
+  // Copy grid
+  std::copy(time_grid.cbegin(), time_grid.cend(), std::back_inserter(time_grid_));
+
+  reset_bins();
+}
+
+void TimedMeshFilter::reset_bins()
+{
+  mesh_n_bins_ = model::meshes[mesh_]->n_bins();
+  n_bins_ = (time_grid_.size() - 1) * mesh_n_bins_;
+}
+
+void TimedMeshFilter::get_all_bins(
+  const Particle& p, TallyEstimator estimator, FilterMatch& match) const
+{
+  // Get the start/end time of the particle for this track
+  const auto t_start = p.time_last();
+  const auto t_end = p.time();
+
+  // If time interval is entirely out of time bin range, exit
+  if (t_end < time_grid_.front() || t_start >= time_grid_.back())
+    return;
+
+  // Get the start/end positions, direction, and speed
+  Position last_r = p.r_last();
+  Position r = p.r();
+  Position u = p.u();
+  const auto speed = p.speed();
+  
+  // apply translation if present
+  if (translated_) {
+    last_r -= translation();
+    r -= translation();
+  }
+
+  if (estimator != TallyEstimator::TRACKLENGTH) {
+    // -------------------------------------------------------------------------
+    // Non-tracklength estimators
+    // Find a match based on the exact time-position of the particle
+
+    // Proceed only if inside time grid
+    if (t_end < time_grid_.back())
+      return;
+
+    auto time_bin = lower_bound_index(time_grid_.begin(), time_grid_.end(), t_end);
+    auto mesh_bin = model::meshes[mesh_]->get_bin(r);
+
+    // Inside the mesh?
+    if (mesh_bin < 0)
+      return;
+
+    auto bin = time_bin * mesh_n_bins_ + mesh_bin;
+    match.bins_.push_back(bin);
+    match.weights_.push_back(1.0);
+
+  } else {
+    // -------------------------------------------------------------------------
+    // For tracklength estimator, we have to check the start/end time-position 
+    // of the current track and find where it overlaps with time-mesh bins and
+    // score accordingly.
+
+    // Determine first time bin containing a portion of time interval
+    auto i_time_bin = lower_bound_index(time_grid_.begin(), time_grid_.end(), t_start);
+
+    //std::cout<<last_r.x<<"  "<<r.x<<"  "<<u.x<<"  "<<t_start<<"  "<<t_end<<"  "<<speed<<"\n";
+
+    // If time interval is zero, add a match corresponding to the starting time
+    if (t_end == t_start) {
+      model::meshes[mesh_]->bins_crossed(last_r, r, u, match.bins_, match.weights_);
+      // Offset the bin location accordingly
+      match.bins_.back() += i_time_bin * mesh_n_bins_;
+
+      /*
+      std::cout<<"end = start\n";
+      double sum {0.0};
+      for (int i = 0; i < match.bins_.size(); i++) {
+        std::cout<<"    "<<match.bins_[i]<<"  "<<match.weights_[i]<<"\n";
+        sum += match.weights_[i];
+      }
+      std::cout<<sum<<"\n";
+      */
+
+      return;
+    }
+
+    // Find matching bins
+    double dt_total = t_end - t_start;
+    for (; i_time_bin < time_grid_.size() - 1; ++i_time_bin) {
+      const double t_left = std::max(t_start, time_grid_[i_time_bin]);
+      const double t_right = std::min(t_end, time_grid_[i_time_bin + 1]);
+
+      // Time interval and its fraction
+      const double dt = t_right - t_left;
+      const double fraction = dt / dt_total;
+
+      // Starting and ending position in this time interval
+      const Position r_start = last_r + u * speed * (t_left - t_start);
+      const Position r_end = r_start + u * speed * dt;
+
+      // Mesh sweep in this time interval
+      const auto n_match_old = match.bins_.size();
+      model::meshes[mesh_]->bins_crossed(
+        r_start, r_end, u, match.bins_, match.weights_);
+      const auto n_match = match.bins_.size() - n_match_old;
+
+      // Update the newly-added bins and weights
+      const auto offset = i_time_bin * mesh_n_bins_;
+      for (int i = 0; i < n_match; i++) {
+        match.bins_[match.bins_.size() - i - 1] += offset;
+        match.weights_[match.weights_.size() - i - 1] *= fraction;
+      }
+
+      if (t_end < time_grid_[i_time_bin + 1])
+        break;
+    }
+    
+    /*
+    double sum {0.0};
+    for (int i = 0; i < match.bins_.size(); i++) {
+      std::cout<<"    "<<match.bins_[i]<<"  "<<match.weights_[i]<<"\n";
+      sum += match.weights_[i];
+    }
+    std::cout<<sum<<"\n";
+    */
+  }
+}
+
+void TimedMeshFilter::to_statepoint(hid_t filter_group) const
+{
+  Filter::to_statepoint(filter_group);
+  write_dataset(filter_group, "time_bins", time_grid_);
+  write_dataset(filter_group, "mesh_bins", model::meshes[mesh_]->id_);
+  if (translated_) {
+    write_dataset(filter_group, "translation", translation_);
+  }
+}
+
+std::string TimedMeshFilter::text_label(int bin) const
+{
+  int bin_time = bin / mesh_n_bins_;
+  int bin_mesh = bin % mesh_n_bins_;
+
+  auto& mesh = *model::meshes.at(mesh_);
+
+  std::string label_time = fmt::format("Time [{}, {}) : ", time_grid_[bin], time_grid_[bin + 1]);
+  std::string label_mesh = mesh.bin_label(bin_mesh);
+
+  return label_time + label_mesh;
+}
+
+void TimedMeshFilter::set_translation(const Position& translation)
+{
+  translated_ = true;
+  translation_ = translation;
+}
+
+void TimedMeshFilter::set_translation(const double translation[3])
+{
+  this->set_translation({translation[0], translation[1], translation[2]});
+}
+
+} // namespace openmc

--- a/src/tallies/filter_timed_mesh.cpp
+++ b/src/tallies/filter_timed_mesh.cpp
@@ -37,7 +37,7 @@ void TimedMeshFilter::from_xml(pugi::xml_node node)
   if (check_for_node(node, "translation")) {
     set_translation(get_node_array<double>(node, "translation"));
   }
-  
+
   //----------------------------------------------------------------------------
   // Time bins
 
@@ -61,13 +61,14 @@ void TimedMeshFilter::set_time_grid(gsl::span<const double> time_grid)
   time_grid_.reserve(time_grid.size());
 
   // Ensure time grid is sorted and don't have duplicates
-  if (std::adjacent_find(time_grid.cbegin(), time_grid.cend(), std::greater_equal<>()) !=
-      time_grid.end()) {
+  if (std::adjacent_find(time_grid.cbegin(), time_grid.cend(),
+        std::greater_equal<>()) != time_grid.end()) {
     throw std::runtime_error {"Time grid must be monotonically increasing."};
   }
 
   // Copy grid
-  std::copy(time_grid.cbegin(), time_grid.cend(), std::back_inserter(time_grid_));
+  std::copy(
+    time_grid.cbegin(), time_grid.cend(), std::back_inserter(time_grid_));
 
   reset_bins();
 }
@@ -94,7 +95,7 @@ void TimedMeshFilter::get_all_bins(
   Position r = p.r();
   Position u = p.u();
   const auto speed = p.speed();
-  
+
   // apply translation if present
   if (translated_) {
     last_r -= translation();
@@ -110,7 +111,8 @@ void TimedMeshFilter::get_all_bins(
     if (t_end < time_grid_.back())
       return;
 
-    auto time_bin = lower_bound_index(time_grid_.begin(), time_grid_.end(), t_end);
+    auto time_bin =
+      lower_bound_index(time_grid_.begin(), time_grid_.end(), t_end);
     auto mesh_bin = model::meshes[mesh_]->get_bin(r);
 
     // Inside the mesh?
@@ -123,18 +125,21 @@ void TimedMeshFilter::get_all_bins(
 
   } else {
     // -------------------------------------------------------------------------
-    // For tracklength estimator, we have to check the start/end time-position 
+    // For tracklength estimator, we have to check the start/end time-position
     // of the current track and find where it overlaps with time-mesh bins and
     // score accordingly.
 
     // Determine first time bin containing a portion of time interval
-    auto i_time_bin = lower_bound_index(time_grid_.begin(), time_grid_.end(), t_start);
+    auto i_time_bin =
+      lower_bound_index(time_grid_.begin(), time_grid_.end(), t_start);
 
-    //std::cout<<last_r.x<<"  "<<r.x<<"  "<<u.x<<"  "<<t_start<<"  "<<t_end<<"  "<<speed<<"\n";
+    // std::cout<<last_r.x<<"  "<<r.x<<"  "<<u.x<<"  "<<t_start<<"  "<<t_end<<"
+    // "<<speed<<"\n";
 
     // If time interval is zero, add a match corresponding to the starting time
     if (t_end == t_start) {
-      model::meshes[mesh_]->bins_crossed(last_r, r, u, match.bins_, match.weights_);
+      model::meshes[mesh_]->bins_crossed(
+        last_r, r, u, match.bins_, match.weights_);
       // Offset the bin location accordingly
       match.bins_.back() += i_time_bin * mesh_n_bins_;
 
@@ -181,7 +186,7 @@ void TimedMeshFilter::get_all_bins(
       if (t_end < time_grid_[i_time_bin + 1])
         break;
     }
-    
+
     /*
     double sum {0.0};
     for (int i = 0; i < match.bins_.size(); i++) {
@@ -210,7 +215,8 @@ std::string TimedMeshFilter::text_label(int bin) const
 
   auto& mesh = *model::meshes.at(mesh_);
 
-  std::string label_time = fmt::format("Time [{}, {}) : ", time_grid_[bin], time_grid_[bin + 1]);
+  std::string label_time =
+    fmt::format("Time [{}, {}) : ", time_grid_[bin], time_grid_[bin + 1]);
   std::string label_mesh = mesh.bin_label(bin_mesh);
 
   return label_time + label_mesh;

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -31,6 +31,7 @@
 #include "openmc/tallies/filter_particle.h"
 #include "openmc/tallies/filter_sph_harm.h"
 #include "openmc/tallies/filter_surface.h"
+#include "openmc/tallies/filter_timed_mesh.h"
 #include "openmc/xml_interface.h"
 
 #include "xtensor/xadapt.hpp"
@@ -323,6 +324,14 @@ Tally::Tally(pugi::xml_node node)
     auto df = dynamic_cast<MeshFilter*>(model::tally_filters[i].get());
     if (df) {
       auto lm = dynamic_cast<LibMesh*>(model::meshes[df->mesh()].get());
+      if (lm && estimator_ == TallyEstimator::TRACKLENGTH) {
+        fatal_error("A tracklength estimator cannot be used with "
+                    "an unstructured LibMesh tally.");
+      }
+    }
+    auto df2 = dynamic_cast<TimedMeshFilter*>(model::tally_filters[i].get());
+    if (df2) {
+      auto lm = dynamic_cast<LibMesh*>(model::meshes[df2->mesh()].get());
       if (lm && estimator_ == TallyEstimator::TRACKLENGTH) {
         fatal_error("A tracklength estimator cannot be used with "
                     "an unstructured LibMesh tally.");


### PR DESCRIPTION
# Description

There has been a known tallying issue in using a combination of `TimeFilter` and `MeshFilter` with the track-length estimator (for example, as mentioned in [[1]](https://openmc.discourse.group/t/validation-of-time-filter/1619), [[2]](https://openmc.discourse.group/t/timefilter-on-flux-tally/2592), and [[3]](https://github.com/openmc-dev/openmc/pull/2898)). This is because neutron tracks span 4 dimensions (x, y, z, and t), so filtering both in time and space needs to be done simultaneously, not separately, as in the case of using `TimeFilter` + `MeshFilter`.

This PR adds `TimedMeshFilter` that accurately filters events with respect to a given time grid and a given mesh, even with the track-length estimator.

# Verification

[The 1D 1G AZURV1 problem](https://www.researchgate.net/publication/255214090_Homogeneous_Infinite_Media_Time-Dependent_Analytical_Benchmarks) (a supercritical version, input script attached below) is used for verification. Note that there are known bugs in the OpenMC's time-dependent MG mode (see [[3]](https://github.com/openmc-dev/openmc/pull/2898)), so to make it works correctly, some of the fixes in [[3]](https://github.com/openmc-dev/openmc/pull/2898) are implemented in this PR as well.

Below are OpenMC results (10 batches, 100k particles/batch) for
(1) TimeFilter + MeshFilter with collision estimator,
(2) TimeFilter + MeshFilter with track-length estimator, and
(3) TimedMeshFilter with track-length estimator.

![old_collision](https://github.com/user-attachments/assets/f4748134-814a-40b1-9a4a-b9099dd25e3d)
![old_tracklength](https://github.com/user-attachments/assets/53f48c54-7c34-4efe-a8ee-9ee640aac539)
![new_tracklength](https://github.com/user-attachments/assets/609d2dd9-2f06-48f1-a129-041a3f43f47b)

TimeFilter + MeshFilter results in an accurate solution if used with collition estimator, but it gives a wrong solution if used with track-length estimator. In particular, note that TimeFilter + MeshFilter with tracklength estimator produces nonphysical solution (non-zero flux beyond the physical wavefront of the neutrons)! TimedMeshFilter with track-lengh estimator, however, produces accurate results.

To drive home the verification, here are the error convergences of the three cases as a function of the number of particles per batch $N$:

![error](https://github.com/user-attachments/assets/4c7bc254-ab2e-4be4-96d3-9c7fa3a835e2)

Here is the input script for the verification test:
```
import openmc
import numpy as np
import h5py

# ===========================================================================
# Set Library
# ===========================================================================

SigmaC = 1.0/3.0
SigmaF = 1.0/3.0
nu = 2.3
SigmaA = SigmaC + SigmaF
SigmaS = 1.0/3.0
SigmaT = SigmaA + SigmaS
v = 1.0

groups = openmc.mgxs.EnergyGroups([0.0, 2e7])

xsdata = openmc.XSdata("mat", groups)
xsdata.order = 0

xsdata.set_inverse_velocity([1.0 / v], temperature=294.0)

xsdata.set_total([SigmaT], temperature=294.0)
xsdata.set_absorption([SigmaA], temperature=294.0)
xsdata.set_scatter_matrix(np.ones((1, 1, 1)) * SigmaS, temperature=294.0)

xsdata.set_nu_fission([nu * SigmaF], temperature=294.0)
mg_cross_sections_file = openmc.MGXSLibrary(groups)
mg_cross_sections_file.add_xsdata(xsdata)
mg_cross_sections_file.export_to_hdf5("mgxs.h5")

# ===========================================================================
# Exporting to OpenMC materials.xml file
# ===========================================================================

materials = {}
materials["mat"] = openmc.Material(name="mat")
materials["mat"].set_density("macro", 1.0)
materials["mat"].add_macroscopic("mat")
materials_file = openmc.Materials(materials.values())
materials_file.cross_sections = "mgxs.h5"
materials_file.export_to_xml()

# ===========================================================================
# Exporting to OpenMC geometry.xml file
# ===========================================================================

# Instantiate ZCylinder surfaces
surf_Z1 = openmc.XPlane(surface_id=1, x0=-1e10, boundary_type="reflective")
surf_Z2 = openmc.XPlane(surface_id=2, x0=1e10, boundary_type="reflective")

# Instantiate Cells
cell_F = openmc.Cell(cell_id=1, name="F")

# Use surface half-spaces to define regions
cell_F.region = +surf_Z1 & -surf_Z2

# Register Materials with Cells
cell_F.fill = materials["mat"]

# Instantiate Universes
root = openmc.Universe(universe_id=0, name="root universe", cells=[cell_F])

# Instantiate a Geometry, register the root Universe, and export to XML
geometry = openmc.Geometry(root)
geometry.export_to_xml()

# ===========================================================================
# Exporting to OpenMC settings.xml file
# ===========================================================================

# Instantiate a Settings object, set all runtime parameters, and export to XML
settings_file = openmc.Settings()
settings_file.run_mode = "fixed source"
settings_file.particles = 100000
settings_file.batches = 10
settings_file.output = {"tallies": False}
settings_file.cutoff = {"time_neutron": 20}
settings_file.energy_mode = "multi-group"

# Create an initial uniform spatial source distribution over fissionable zones
delta_dist = openmc.stats.Point()
isotropic = openmc.stats.Isotropic()
settings_file.source = openmc.IndependentSource(space=delta_dist, angle=isotropic)
settings_file.export_to_xml()


# ===========================================================================
# Exporting to OpenMC tallies.xml file
# ===========================================================================

# Create a mesh filter that can be used in a tally
mesh = openmc.RegularMesh()
mesh.dimension = (201, 1, 1)
mesh.lower_left = (-20.5, -1e10, -1e10)
mesh.upper_right = (20.5, 1e10, 1e10)
time_grid = np.linspace(0.0, 20.0, 41)

mesh_filter = openmc.MeshFilter(mesh)
time_filter = openmc.TimeFilter(time_grid)
timed_mesh_filter = openmc.TimedMeshFilter(mesh, time_grid)

# Now use the mesh filter in a tally and indicate what scores are desired
tally1 = openmc.Tally(name="old-collision")
tally1.estimator = "collision"
tally1.filters = [time_filter, mesh_filter]
tally1.scores = ["flux"]

tally2 = openmc.Tally(name="old-tracklength")
tally2.estimator = "tracklength"
tally2.filters = [time_filter, mesh_filter]
tally2.scores = ["flux"]

tally3 = openmc.Tally(name="new-tracklength")
tally3.estimator = "tracklength"
tally3.filters = [timed_mesh_filter]
tally3.scores = ["flux"]

# Instantiate a Tallies collection and export to XML
tallies = openmc.Tallies([tally1, tally2, tally3])
tallies.export_to_xml()

```
# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)