### PR TITLE
Show available temperatures for nuclear data when one temperature is not found

### DIFF
--- a/include/openmc/string_utils.h
+++ b/include/openmc/string_utils.h
@@ -25,9 +25,15 @@ bool ends_with(const std::string& value, const std::string& ending);
 
 bool starts_with(const std::string& value, const std::string& beginning);
 
-std::string concatenate_vec(const std::vector<double>& temps);
-
-std::string concatenate_xt(const xt::xarray<double>& temps);
+template<typename T>
+inline std::string concatenate(const T& temps)
+{
+  std::ostringstream oss;
+  for (const auto& temp : temps) {
+    oss << temp << " ";
+  }
+  return oss.str();
+}
 
 } // namespace openmc
 #endif // OPENMC_STRING_UTILS_H

--- a/include/openmc/string_utils.h
+++ b/include/openmc/string_utils.h
@@ -26,16 +26,16 @@ bool ends_with(const std::string& value, const std::string& ending);
 bool starts_with(const std::string& value, const std::string& beginning);
 
 template<typename T>
-inline std::string concatenate(const T& values, const std::string& del = " ")
+inline std::string concatenate(const T& values, const std::string& del = ", ")
 {
-  std::ostringstream oss;
+  if (values.size() == 0)
+    return "";
+
+  std::stringstream oss;
   auto it = values.begin();
-  if (it != values.end()) {
-    oss << *it; // Insert the first element without a delimiter
-    ++it;
-  }
-  for (; it != values.end(); ++it) {
-    oss << del << *it;
+  oss << *it++;
+  while (it != values.end()) {
+    oss << del << *it++;
   }
   return oss.str();
 }

--- a/include/openmc/string_utils.h
+++ b/include/openmc/string_utils.h
@@ -26,11 +26,16 @@ bool ends_with(const std::string& value, const std::string& ending);
 bool starts_with(const std::string& value, const std::string& beginning);
 
 template<typename T>
-inline std::string concatenate(const T& temps)
+inline std::string concatenate(const T& values, const std::string& del = " ")
 {
   std::ostringstream oss;
-  for (const auto& temp : temps) {
-    oss << temp << " ";
+  auto it = values.begin();
+  if (it != values.end()) {
+    oss << *it; // Insert the first element without a delimiter
+    ++it;
+  }
+  for (; it != values.end(); ++it) {
+    oss << del << *it;
   }
   return oss.str();
 }

--- a/include/openmc/string_utils.h
+++ b/include/openmc/string_utils.h
@@ -1,9 +1,8 @@
 #ifndef OPENMC_STRING_UTILS_H
 #define OPENMC_STRING_UTILS_H
 
+#include <sstream>
 #include <string>
-
-#include "xtensor/xarray.hpp"
 
 #include "openmc/vector.h"
 

--- a/include/openmc/string_utils.h
+++ b/include/openmc/string_utils.h
@@ -3,6 +3,8 @@
 
 #include <string>
 
+#include "xtensor/xarray.hpp"
+
 #include "openmc/vector.h"
 
 namespace openmc {
@@ -15,13 +17,17 @@ std::string to_element(const std::string& name);
 
 void to_lower(std::string& str);
 
-int word_count(std::string const& str);
+int word_count(const std::string& str);
 
 vector<std::string> split(const std::string& in);
 
 bool ends_with(const std::string& value, const std::string& ending);
 
 bool starts_with(const std::string& value, const std::string& beginning);
+
+std::string concatenate_vec(const std::vector<double>& temps);
+
+std::string concatenate_xt(const xt::xarray<double>& temps);
 
 } // namespace openmc
 #endif // OPENMC_STRING_UTILS_H

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -112,7 +112,7 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
           "for {} at or near {} K. Available temperatures "
           "are {} K. Consider making use of openmc.Settings.temperature "
           "to specify how intermediate temperatures are treated.",
-          in_name, std::round(T), concatenate(temps_available, ", ")));
+          in_name, std::round(T), concatenate(temps_available)));
       }
     }
     break;

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -129,12 +129,12 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
             (temperature[i] < temps_available[j + 1])) {
           if (std::find(temps_to_read.begin(), temps_to_read.end(),
                 temps_available[j]) == temps_to_read.end()) {
-            temps_to_read.push_back(std::round((int)temps_available[j]));
+            temps_to_read.push_back(temps_available[j]);
           }
 
           if (std::find(temps_to_read.begin(), temps_to_read.end(),
                 temps_available[j + 1]) == temps_to_read.end()) {
-            temps_to_read.push_back(std::round((int)temps_available[j + 1]));
+            temps_to_read.push_back(temps_available[j + 1]);
           }
           break;
         }

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -110,9 +110,9 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
         fatal_error(fmt::format(
           "MGXS library does not contain cross sections "
           "for {} at or near {} K. Available temperatures "
-          "are {} K consider making use of openmc.Settings.temperature "
+          "are {} K. Consider making use of openmc.Settings.temperature "
           "to specify how intermediate temperatures are treated.",
-          in_name, std::round(T), concatenate(temps_available)));
+          in_name, std::round(T), concatenate(temps_available, ", ")));
       }
     }
     break;

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -77,7 +77,7 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
     read_double(kT_group, dset_names[i], &temps_available[i], true);
 
     // convert eV to Kelvin
-    temps_available[i] /= K_BOLTZMANN;
+    temps_available[i] = std::round(temps_available[i] / K_BOLTZMANN);
 
     // Done with dset_names, so delete it
     delete[] dset_names[i];
@@ -128,12 +128,12 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
         if ((temps_available[j] <= temperature[i]) &&
             (temperature[i] < temps_available[j + 1])) {
           if (std::find(temps_to_read.begin(), temps_to_read.end(),
-                std::round(temps_available[j])) == temps_to_read.end()) {
+                temps_available[j]) == temps_to_read.end()) {
             temps_to_read.push_back(std::round((int)temps_available[j]));
           }
 
           if (std::find(temps_to_read.begin(), temps_to_read.end(),
-                std::round(temps_available[j + 1])) == temps_to_read.end()) {
+                temps_available[j + 1]) == temps_to_read.end()) {
             temps_to_read.push_back(std::round((int)temps_available[j + 1]));
           }
           break;

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -112,7 +112,7 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
           "for {} at or near {} K. Available temperatures "
           "are {} K consider making use of openmc.Settings.temperature "
           "to specify how intermediate temperatures are treated.",
-          in_name, std::round(T), concatenate_xt(temps_available)));
+          in_name, std::round(T), concatenate(temps_available)));
       }
     }
     break;

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -163,7 +163,7 @@ Nuclide::Nuclide(hid_t group, const vector<double>& temperature)
           "for {}  at or near {} K. Available temperatures "
           "are {} K consider making use of openmc.Settings.temperature "
           "to specify how intermediate temperatures are treated.",
-          name_, std::to_string(T_desired), concatenate_vec(temps_available)));
+          name_, std::to_string(T_desired), concatenate(temps_available)));
       }
     }
     break;

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -163,8 +163,7 @@ Nuclide::Nuclide(hid_t group, const vector<double>& temperature)
           "for {}  at or near {} K. Available temperatures "
           "are {} K. Consider making use of openmc.Settings.temperature "
           "to specify how intermediate temperatures are treated.",
-          name_, std::to_string(T_desired),
-          concatenate(temps_available, ", ")));
+          name_, std::to_string(T_desired), concatenate(temps_available)));
       }
     }
     break;

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -161,9 +161,10 @@ Nuclide::Nuclide(hid_t group, const vector<double>& temperature)
         fatal_error(fmt::format(
           "Nuclear data library does not contain cross sections "
           "for {}  at or near {} K. Available temperatures "
-          "are {} K consider making use of openmc.Settings.temperature "
+          "are {} K. Consider making use of openmc.Settings.temperature "
           "to specify how intermediate temperatures are treated.",
-          name_, std::to_string(T_desired), concatenate(temps_available)));
+          name_, std::to_string(T_desired),
+          concatenate(temps_available, ", ")));
       }
     }
     break;

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -86,7 +86,7 @@ Nuclide::Nuclide(hid_t group, const vector<double>& temperature)
   for (const auto& name : dset_names) {
     double T;
     read_dataset(kT_group, name.c_str(), T);
-    temps_available.push_back(T / K_BOLTZMANN);
+    temps_available.push_back(std::round(T / K_BOLTZMANN));
   }
   std::sort(temps_available.begin(), temps_available.end());
 
@@ -176,8 +176,8 @@ Nuclide::Nuclide(hid_t group, const vector<double>& temperature)
       for (int j = 0; j < temps_available.size() - 1; ++j) {
         if (temps_available[j] <= T_desired &&
             T_desired < temps_available[j + 1]) {
-          int T_j = std::round(temps_available[j]);
-          int T_j1 = std::round(temps_available[j + 1]);
+          int T_j = temps_available[j];
+          int T_j1 = temps_available[j + 1];
           if (!contains(temps_to_read, T_j)) {
             temps_to_read.push_back(T_j);
           }
@@ -194,14 +194,14 @@ Nuclide::Nuclide(hid_t group, const vector<double>& temperature)
         if (std::abs(T_desired - temps_available.front()) <=
             settings::temperature_tolerance) {
           if (!contains(temps_to_read, temps_available.front())) {
-            temps_to_read.push_back(std::round(temps_available.front()));
+            temps_to_read.push_back(temps_available.front());
           }
           continue;
         }
         if (std::abs(T_desired - temps_available.back()) <=
             settings::temperature_tolerance) {
           if (!contains(temps_to_read, temps_available.back())) {
-            temps_to_read.push_back(std::round(temps_available.back()));
+            temps_to_read.push_back(temps_available.back());
           }
           continue;
         }

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -158,9 +158,12 @@ Nuclide::Nuclide(hid_t group, const vector<double>& temperature)
           }
         }
       } else {
-        fatal_error(
-          "Nuclear data library does not contain cross sections for " + name_ +
-          " at or near " + std::to_string(T_desired) + " K.");
+        fatal_error(fmt::format(
+          "Nuclear data library does not contain cross sections "
+          "for {}  at or near {} K. Available temperatures "
+          "are {} K consider making use of openmc.Settings.temperature "
+          "to specify how intermediate temperatures are treated.",
+          name_, std::to_string(T_desired), concatenate_vec(temps_available)));
       }
     }
     break;

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -2,9 +2,6 @@
 
 #include <algorithm> // for equal
 #include <cctype>    // for tolower, isspace
-#include <sstream>
-
-#include "xtensor/xarray.hpp"
 
 namespace openmc {
 

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -88,22 +88,4 @@ bool starts_with(const std::string& value, const std::string& beginning)
   return std::equal(beginning.begin(), beginning.end(), value.begin());
 }
 
-std::string concatenate_vec(const std::vector<double>& temps)
-{
-  std::ostringstream oss;
-  for (const auto& temp : temps) {
-    oss << temp << " ";
-  }
-  return oss.str();
-}
-
-std::string concatenate_xt(const xt::xarray<double>& temps)
-{
-  std::ostringstream oss;
-  for (const auto& temp : temps) {
-    oss << temp << " ";
-  }
-  return oss.str();
-}
-
 } // namespace openmc

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -4,6 +4,8 @@
 #include <cctype>    // for tolower, isspace
 #include <sstream>
 
+#include "xtensor/xarray.hpp"
+
 namespace openmc {
 
 std::string& strtrim(std::string& s)
@@ -36,7 +38,7 @@ void to_lower(std::string& str)
     str[i] = std::tolower(str[i]);
 }
 
-int word_count(std::string const& str)
+int word_count(const std::string& str)
 {
   std::stringstream stream(str);
   std::string dum;
@@ -84,6 +86,24 @@ bool starts_with(const std::string& value, const std::string& beginning)
   if (beginning.size() > value.size())
     return false;
   return std::equal(beginning.begin(), beginning.end(), value.begin());
+}
+
+std::string concatenate_vec(const std::vector<double>& temps)
+{
+  std::ostringstream oss;
+  for (const auto& temp : temps) {
+    oss << temp << " ";
+  }
+  return oss.str();
+}
+
+std::string concatenate_xt(const xt::xarray<double>& temps)
+{
+  std::ostringstream oss;
+  for (const auto& temp : temps) {
+    oss << temp << " ";
+  }
+  return oss.str();
 }
 
 } // namespace openmc

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -95,8 +95,7 @@ ThermalScattering::ThermalScattering(
           "for {}  at or near {} K. Available temperatures "
           "are {} K consider making use of openmc.Settings.temperature "
           "to specify how intermediate temperatures are treated.",
-          name_, std::to_string(std::round(T)),
-          concatenate_xt(temps_available)));
+          name_, std::to_string(std::round(T)), concatenate(temps_available)));
       }
     }
     break;

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -19,6 +19,7 @@
 #include "openmc/secondary_correlated.h"
 #include "openmc/secondary_thermal.h"
 #include "openmc/settings.h"
+#include "openmc/string_utils.h"
 
 namespace openmc {
 
@@ -89,9 +90,13 @@ ThermalScattering::ThermalScattering(
           temps_to_read.push_back(std::round(temp_actual));
         }
       } else {
-        fatal_error(fmt::format("Nuclear data library does not contain cross "
-                                "sections for {} at or near {} K.",
-          name_, std::round(T)));
+        fatal_error(fmt::format(
+          "Nuclear data library does not contain cross sections "
+          "for {}  at or near {} K. Available temperatures "
+          "are {} K consider making use of openmc.Settings.temperature "
+          "to specify how intermediate temperatures are treated.",
+          name_, std::to_string(std::round(T)),
+          concatenate_xt(temps_available)));
       }
     }
     break;

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -93,9 +93,9 @@ ThermalScattering::ThermalScattering(
         fatal_error(fmt::format(
           "Nuclear data library does not contain cross sections "
           "for {}  at or near {} K. Available temperatures "
-          "are {} K consider making use of openmc.Settings.temperature "
+          "are {} K. Consider making use of openmc.Settings.temperature "
           "to specify how intermediate temperatures are treated.",
-          name_, std::to_string(std::round(T)), concatenate(temps_available)));
+          name_, std::round(T), concatenate(temps_available, ", ")));
       }
     }
     break;

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -60,7 +60,7 @@ ThermalScattering::ThermalScattering(
     // Read temperature value
     double T;
     read_dataset(kT_group, dset_names[i].data(), T);
-    temps_available[i] = T / K_BOLTZMANN;
+    temps_available[i] = std::round(T / K_BOLTZMANN);
   }
   std::sort(temps_available.begin(), temps_available.end());
 
@@ -107,8 +107,8 @@ ThermalScattering::ThermalScattering(
       bool found = false;
       for (int j = 0; j < temps_available.size() - 1; ++j) {
         if (temps_available[j] <= T && T < temps_available[j + 1]) {
-          int T_j = std::round(temps_available[j]);
-          int T_j1 = std::round(temps_available[j + 1]);
+          int T_j = temps_available[j];
+          int T_j1 = temps_available[j + 1];
           if (std::find(temps_to_read.begin(), temps_to_read.end(), T_j) ==
               temps_to_read.end()) {
             temps_to_read.push_back(T_j);
@@ -126,14 +126,14 @@ ThermalScattering::ThermalScattering(
         if (std::abs(T - temps_available[0]) <=
             settings::temperature_tolerance) {
           if (std::find(temps_to_read.begin(), temps_to_read.end(),
-                std::round(temps_available[0])) == temps_to_read.end()) {
-            temps_to_read.push_back(std::round(temps_available[0]));
+                temps_available[0]) == temps_to_read.end()) {
+            temps_to_read.push_back(temps_available[0]);
           }
         } else if (std::abs(T - temps_available[n - 1]) <=
                    settings::temperature_tolerance) {
           if (std::find(temps_to_read.begin(), temps_to_read.end(),
-                std::round(temps_available[n - 1])) == temps_to_read.end()) {
-            temps_to_read.push_back(std::round(temps_available[n - 1]));
+                temps_available[n - 1]) == temps_to_read.end()) {
+            temps_to_read.push_back(temps_available[n - 1]);
           }
         } else {
           fatal_error(

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -95,7 +95,7 @@ ThermalScattering::ThermalScattering(
           "for {}  at or near {} K. Available temperatures "
           "are {} K. Consider making use of openmc.Settings.temperature "
           "to specify how intermediate temperatures are treated.",
-          name_, std::round(T), concatenate(temps_available, ", ")));
+          name_, std::round(T), concatenate(temps_available)));
       }
     }
     break;


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Please include a summary of the change and which issue is fixed if applicable. Please also include relevant motivation and context.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
