### PR TITLE
Added error if cross sections path is a folder

### DIFF
--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -283,6 +283,10 @@ void read_ce_cross_sections_xml()
 {
   // Check if cross_sections.xml exists
   const auto& filename = settings::path_cross_sections;
+  if (dir_exists(filename)) {
+    fatal_error("OPENMC_CROSS_SECTIONS is set to a directory. "
+                "It should be set to an XML file.");
+  }
   if (!file_exists(filename)) {
     // Could not find cross_sections.xml file
     fatal_error("Cross sections XML file '" + filename + "' does not exist.");


### PR DESCRIPTION
# Description

Added utility to raise an error if the user set the cross sections environment variable to a folder rather than the cross_sections.xml file.

Fixes #3048 

# Checklist

- [ ✅] I have performed a self-review of my own code
- [ ✅] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
