### PR TITLE
Add OrthogonalBox composite surface

### DIFF
--- a/docs/source/pythonapi/model.rst
+++ b/docs/source/pythonapi/model.rst
@@ -26,6 +26,7 @@ Composite Surfaces
    openmc.model.CylinderSector
    openmc.model.HexagonalPrism
    openmc.model.IsogonalOctagon
+   openmc.model.OrthogonalBox
    openmc.model.Polygon
    openmc.model.RectangularParallelepiped
    openmc.model.RectangularPrism

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -645,6 +645,53 @@ class RectangularParallelepiped(CompositeSurface):
         return +self.xmax | -self.xmin | +self.ymax | -self.ymin | +self.zmax | -self.zmin
 
 
+class Box(CompositeSurface):
+    _surface_names = ('xmin', 'xmax', 'ymin', 'ymax', 'zmin', 'zmax')
+
+    def __init__(self, v, a1, a2, a3, **kwargs):
+        vx, vy, vz = v
+        a1x, a1y, a1z = a1
+        a2x, a2y, a2z = a2
+        a3x, a3y, a3z = a3
+
+        # Only support boxes with axis-aligned vectors
+        if any(x != 0.0 for x in (a1y, a1z, a2x, a2z, a3x, a3y)):
+            raise NotImplementedError('Box composite surface with non-axis-aligned '
+                                      'vector not supported.')
+
+        # Determine each side of the box
+        if a1x > 0:
+            xmin, xmax = vx, vx + a1x
+        else:
+            xmin, xmax = vx + a1x, vx
+        if a2y > 0:
+            ymin, ymax = vy, vy + a2y
+        else:
+            ymin, ymax = vy + a2y, vy
+        if a3z > 0:
+            zmin, zmax = vz, vz + a3z
+        else:
+            zmin, zmax = vz + a3z, vz
+
+        # Create surfaces
+        self.xmin = openmc.XPlane(xmin, **kwargs)
+        self.xmax = openmc.XPlane(xmax, **kwargs)
+        self.ymin = openmc.YPlane(ymin, **kwargs)
+        self.ymax = openmc.YPlane(ymax, **kwargs)
+        self.zmin = openmc.ZPlane(zmin, **kwargs)
+        self.zmax = openmc.ZPlane(zmax, **kwargs)
+
+    def __neg__(self):
+        return (+self.xmin & -self.xmax &
+                +self.ymin & -self.ymax &
+                +self.zmin & -self.zmax)
+
+    def __pos__(self):
+        return (-self.xmin | +self.xmax |
+                -self.ymin | +self.ymax |
+                -self.zmin | +self.zmax)
+
+
 class XConeOneSided(CompositeSurface):
     """One-sided cone parallel the x-axis
 


### PR DESCRIPTION
# Description

This PR implements a new `openmc.model.OrthogonalBox` composite surface that matches the BOX macrobody from MCNP.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)