### PR TITLE
Implement bounding_box operation for meshes

### DIFF
--- a/cmake/Modules/FindLIBMESH.cmake
+++ b/cmake/Modules/FindLIBMESH.cmake
@@ -14,7 +14,7 @@ if(DEFINED ENV{METHOD})
   message(STATUS "Using environment variable METHOD to determine libMesh build: ${LIBMESH_PC_FILE}")
 endif()
 
-include(FindPkgConfig)
+find_package(PkgConfig REQUIRED)
 set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${LIBMESH_PC}")
 set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH True)
 pkg_check_modules(LIBMESH REQUIRED ${LIBMESH_PC_FILE}>=1.7.0 IMPORTED_TARGET)

--- a/include/openmc/bounding_box.h
+++ b/include/openmc/bounding_box.h
@@ -1,0 +1,61 @@
+#ifndef OPENMC_BOUNDING_BOX_H
+#define OPENMC_BOUNDING_BOX_H
+
+#include <algorithm> // for min, max
+
+#include "openmc/constants.h"
+
+namespace openmc {
+
+//==============================================================================
+//! Coordinates for an axis-aligned cuboid that bounds a geometric object.
+//==============================================================================
+
+struct BoundingBox {
+  double xmin = -INFTY;
+  double xmax = INFTY;
+  double ymin = -INFTY;
+  double ymax = INFTY;
+  double zmin = -INFTY;
+  double zmax = INFTY;
+
+  inline BoundingBox operator&(const BoundingBox& other)
+  {
+    BoundingBox result = *this;
+    return result &= other;
+  }
+
+  inline BoundingBox operator|(const BoundingBox& other)
+  {
+    BoundingBox result = *this;
+    return result |= other;
+  }
+
+  // intersect operator
+  inline BoundingBox& operator&=(const BoundingBox& other)
+  {
+    xmin = std::max(xmin, other.xmin);
+    xmax = std::min(xmax, other.xmax);
+    ymin = std::max(ymin, other.ymin);
+    ymax = std::min(ymax, other.ymax);
+    zmin = std::max(zmin, other.zmin);
+    zmax = std::min(zmax, other.zmax);
+    return *this;
+  }
+
+  // union operator
+  inline BoundingBox& operator|=(const BoundingBox& other)
+  {
+    xmin = std::min(xmin, other.xmin);
+    xmax = std::max(xmax, other.xmax);
+    ymin = std::min(ymin, other.ymin);
+    ymax = std::max(ymax, other.ymax);
+    zmin = std::min(zmin, other.zmin);
+    zmax = std::max(zmax, other.zmax);
+    return *this;
+  }
+};
+
+} // namespace openmc
+
+#endif

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -12,6 +12,7 @@
 #include "pugixml.hpp"
 #include <gsl/gsl-lite.hpp>
 
+#include "openmc/bounding_box.h"
 #include "openmc/constants.h"
 #include "openmc/memory.h" // for unique_ptr
 #include "openmc/neighbor_list.h"

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -713,12 +713,13 @@ protected:
     -1.0};              //!< Multiplicative factor applied to mesh coordinates
   std::string options_; //!< Options for search data structures
 
+  //! Determine lower-left and upper-right bounds of mesh
+  void determine_bounds();
+
 private:
   //! Setup method for the mesh. Builds data structures,
   //! sets up element mapping, creates bounding boxes, etc.
   virtual void initialize() = 0;
-
-  void determine_bounds();
 };
 
 #ifdef DAGMC

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -11,11 +11,11 @@
 #include "xtensor/xtensor.hpp"
 #include <gsl/gsl-lite.hpp>
 
+#include "openmc/bounding_box.h"
 #include "openmc/error.h"
 #include "openmc/memory.h" // for unique_ptr
 #include "openmc/particle.h"
 #include "openmc/position.h"
-#include "openmc/surface.h" // for BoundingBox
 #include "openmc/vector.h"
 #include "openmc/xml_interface.h"
 

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -15,6 +15,7 @@
 #include "openmc/memory.h" // for unique_ptr
 #include "openmc/particle.h"
 #include "openmc/position.h"
+#include "openmc/surface.h" // for BoundingBox
 #include "openmc/vector.h"
 #include "openmc/xml_interface.h"
 
@@ -185,9 +186,24 @@ public:
   vector<MaterialVolume> material_volumes(
     int n_sample, int bin, uint64_t* seed) const;
 
+  //! Determine bounding box of mesh
+  //
+  //! \return Bounding box of mesh
+  BoundingBox bounding_box() const
+  {
+    auto ll = this->lower_left();
+    auto ur = this->upper_right();
+    return {ll.x, ur.x, ll.y, ur.y, ll.z, ur.z};
+  }
+
+  virtual Position lower_left() const = 0;
+  virtual Position upper_right() const = 0;
+
   // Data members
-  int id_ {-1};          //!< User-specified ID
-  int n_dimension_ {-1}; //!< Number of dimensions
+  xt::xtensor<double, 1> lower_left_;  //!< Lower-left coordinates of mesh
+  xt::xtensor<double, 1> upper_right_; //!< Upper-right coordinates of mesh
+  int id_ {-1};                        //!< User-specified ID
+  int n_dimension_ {-1};               //!< Number of dimensions
 };
 
 class StructuredMesh : public Mesh {
@@ -325,14 +341,30 @@ public:
     return this->volume(get_indices_from_bin(bin));
   }
 
+  Position lower_left() const override
+  {
+    int n = lower_left_.size();
+    Position ll {lower_left_[0], 0.0, 0.0};
+    ll.y = (n >= 2) ? lower_left_[1] : -INFTY;
+    ll.z = (n == 3) ? lower_left_[2] : -INFTY;
+    return ll;
+  };
+
+  Position upper_right() const override
+  {
+    int n = upper_right_.size();
+    Position ur {upper_right_[0], 0.0, 0.0};
+    ur.y = (n >= 2) ? upper_right_[1] : INFTY;
+    ur.z = (n == 3) ? upper_right_[2] : INFTY;
+    return ur;
+  };
+
   //! Get the volume of a specified element
   //! \param[in] ijk Mesh index to return the volume for
   //! \return Volume of the bin
   virtual double volume(const MeshIndex& ijk) const = 0;
 
   // Data members
-  xt::xtensor<double, 1> lower_left_;  //!< Lower-left coordinates of mesh
-  xt::xtensor<double, 1> upper_right_; //!< Upper-right coordinates of mesh
   std::array<int, 3> shape_; //!< Number of mesh elements in each dimension
 
 protected:
@@ -655,6 +687,15 @@ public:
 
   ElementType element_type(int bin) const;
 
+  Position lower_left() const override
+  {
+    return {lower_left_[0], lower_left_[1], lower_left_[2]};
+  }
+  Position upper_right() const override
+  {
+    return {upper_right_[0], upper_right_[1], upper_right_[2]};
+  }
+
 protected:
   //! Set the length multiplier to apply to each point in the mesh
   void set_length_multiplier(const double length_multiplier);
@@ -676,6 +717,8 @@ private:
   //! Setup method for the mesh. Builds data structures,
   //! sets up element mapping, creates bounding boxes, etc.
   virtual void initialize() = 0;
+
+  void determine_bounds();
 };
 
 #ifdef DAGMC

--- a/include/openmc/surface.h
+++ b/include/openmc/surface.h
@@ -9,6 +9,7 @@
 #include "pugixml.hpp"
 
 #include "openmc/boundary_condition.h"
+#include "openmc/bounding_box.h"
 #include "openmc/constants.h"
 #include "openmc/memory.h" // for unique_ptr
 #include "openmc/particle.h"
@@ -27,55 +28,6 @@ namespace model {
 extern std::unordered_map<int, int> surface_map;
 extern vector<unique_ptr<Surface>> surfaces;
 } // namespace model
-
-//==============================================================================
-//! Coordinates for an axis-aligned cuboid that bounds a geometric object.
-//==============================================================================
-
-struct BoundingBox {
-  double xmin = -INFTY;
-  double xmax = INFTY;
-  double ymin = -INFTY;
-  double ymax = INFTY;
-  double zmin = -INFTY;
-  double zmax = INFTY;
-
-  inline BoundingBox operator&(const BoundingBox& other)
-  {
-    BoundingBox result = *this;
-    return result &= other;
-  }
-
-  inline BoundingBox operator|(const BoundingBox& other)
-  {
-    BoundingBox result = *this;
-    return result |= other;
-  }
-
-  // intersect operator
-  inline BoundingBox& operator&=(const BoundingBox& other)
-  {
-    xmin = std::max(xmin, other.xmin);
-    xmax = std::min(xmax, other.xmax);
-    ymin = std::max(ymin, other.ymin);
-    ymax = std::min(ymax, other.ymax);
-    zmin = std::max(zmin, other.zmin);
-    zmax = std::min(zmax, other.zmax);
-    return *this;
-  }
-
-  // union operator
-  inline BoundingBox& operator|=(const BoundingBox& other)
-  {
-    xmin = std::min(xmin, other.xmin);
-    xmax = std::max(xmax, other.xmax);
-    ymin = std::min(ymin, other.ymin);
-    ymax = std::max(ymax, other.ymax);
-    zmin = std::min(zmin, other.zmin);
-    zmax = std::max(zmax, other.zmax);
-    return *this;
-  }
-};
 
 //==============================================================================
 //! A geometry primitive used to define regions of 3D space.

--- a/include/openmc/universe.h
+++ b/include/openmc/universe.h
@@ -1,6 +1,7 @@
 #ifndef OPENMC_UNIVERSE_H
 #define OPENMC_UNIVERSE_H
 
+#include "openmc/bounding_box.h"
 #include "openmc/cell.h"
 
 namespace openmc {

--- a/openmc/bounding_box.py
+++ b/openmc/bounding_box.py
@@ -42,7 +42,8 @@ class BoundingBox:
 
     def __repr__(self) -> str:
         return "BoundingBox(lower_left={}, upper_right={})".format(
-            tuple(self.lower_left), tuple(self.upper_right))
+            tuple(float(x) for x in self.lower_left),
+            tuple(float(x) for x in self.upper_right))
 
     def __getitem__(self, key) -> np.ndarray:
         return self._bounds[key]

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -330,18 +330,12 @@ void UnstructuredMesh::determine_bounds()
   int n = this->n_vertices();
   for (int i = 0; i < n; ++i) {
     auto v = this->vertex(i);
-    if (v.x < xmin)
-      xmin = v.x;
-    if (v.y < ymin)
-      ymin = v.y;
-    if (v.z < zmin)
-      zmin = v.z;
-    if (v.x > xmax)
-      xmax = v.x;
-    if (v.y > ymax)
-      ymax = v.y;
-    if (v.z > zmax)
-      zmax = v.z;
+    xmin = std::min(v.x, xmin);
+    ymin = std::min(v.y, ymin);
+    zmin = std::min(v.z, zmin);
+    xmax = std::max(v.x, xmax);
+    ymax = std::max(v.y, ymax);
+    zmax = std::max(v.z, zmax);
   }
   lower_left_ = {xmin, ymin, zmin};
   upper_right_ = {xmax, ymax, zmax};

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2316,6 +2316,9 @@ void MOABMesh::initialize()
       }
     }
   }
+
+  // Determine bounds of mesh
+  this->determine_bounds();
 }
 
 void MOABMesh::prepare_for_tallies()
@@ -3003,6 +3006,10 @@ void LibMesh::initialize()
 
   // bounding box for the mesh for quick rejection checks
   bbox_ = libMesh::MeshTools::create_bounding_box(*m_);
+  libMesh::Point ll = bbox_.min();
+  libMesh::Point ur = bbox_.max();
+  lower_left_ = {ll(0), ll(1), ll(2)};
+  upper_right_ = {ur(0), ur(1), ur(2)};
 }
 
 // Sample position within a tet for LibMesh type tets

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -296,7 +296,7 @@ void Particle::event_cross_surface()
     if (surf->surf_source_ && surf->bc_) {
       add_surf_source_to_bank(*this, *surf);
     }
-    cross_surface(*surf);
+    this->cross_surface(*surf);
     // If no BC, add particle to surface source after crossing surface
     if (surf->surf_source_ && !surf->bc_) {
       add_surf_source_to_bank(*this, *surf);

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -570,6 +570,12 @@ def test_regular_mesh(lib_init):
 
     np.testing.assert_allclose(mesh.volumes, 1.0)
 
+    # bounding box
+    mesh.set_parameters(lower_left=ll, upper_right=ur)
+    bbox = mesh.bounding_box
+    np.testing.assert_allclose(bbox.lower_left, ll)
+    np.testing.assert_allclose(bbox.upper_right, ur)
+
     meshes = openmc.lib.meshes
     assert isinstance(meshes, Mapping)
     assert len(meshes) == 1
@@ -650,6 +656,11 @@ def test_rectilinear_mesh(lib_init):
 
     np.testing.assert_allclose(mesh.volumes, 1000.0)
 
+    # bounding box
+    bbox = mesh.bounding_box
+    np.testing.assert_allclose(bbox.lower_left, (-10., 0., 10.))
+    np.testing.assert_allclose(bbox.upper_right, (10., 20., 30.))
+
     with pytest.raises(exc.AllocationError):
         mesh2 = openmc.lib.RectilinearMesh(mesh.id)
 
@@ -696,6 +707,11 @@ def test_cylindrical_mesh(lib_init):
 
     np.testing.assert_allclose(mesh.volumes[::2], 10/360 * pi * 5**2 * 10)
     np.testing.assert_allclose(mesh.volumes[1::2], 10/360 * pi * (10**2 - 5**2) * 10)
+
+    # bounding box
+    bbox = mesh.bounding_box
+    np.testing.assert_allclose(bbox.lower_left, (-10., -10., 10.))
+    np.testing.assert_allclose(bbox.upper_right, (10., 10., 30.))
 
     with pytest.raises(exc.AllocationError):
         mesh2 = openmc.lib.CylindricalMesh(mesh.id)
@@ -749,6 +765,11 @@ def test_spherical_mesh(lib_init):
     np.testing.assert_allclose(mesh.volumes[1::4], f * (10**3 - 5**3) * dtheta(0., 10.))
     np.testing.assert_allclose(mesh.volumes[2::4], f * 5**3 * dtheta(10., 20.))
     np.testing.assert_allclose(mesh.volumes[3::4], f * (10**3 - 5**3) * dtheta(10., 20.))
+
+    # bounding box
+    bbox = mesh.bounding_box
+    np.testing.assert_allclose(bbox.lower_left, (-10., -10., -10.))
+    np.testing.assert_allclose(bbox.upper_right, (10., 10., 10.))
 
     with pytest.raises(exc.AllocationError):
         mesh2 = openmc.lib.SphericalMesh(mesh.id)


### PR DESCRIPTION
# Description

This PR adds a `bounding_box()` method on the mesh classes in C++ and corresponding bindings in openmc.lib. I need this functionality for an improvement of our capability to compute material volumes within mesh elements that I'm working on.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)