### PR TITLE
allowing varible offsets for polygon.offset

### DIFF
--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from copy import copy
@@ -1324,12 +1325,12 @@ class Polygon(CompositeSurface):
             surfsets.append(surf_ops)
         return surfsets
 
-    def offset(self, distance: float | Iterable[float] | np.ndarray) -> "Polygon":
+    def offset(self, distance: float | Sequence[float] | np.ndarray) -> Polygon:
         """Offset this polygon by a set distance
 
         Parameters
         ----------
-        distance : float or iterable or np.ndarray
+        distance : float or sequence of float or np.ndarray
             The distance to offset the polygon by. Positive is outward
             (expanding) and negative is inward (shrinking). If a float is
             provided, the same offset is applied to all vertices. If a list or
@@ -1344,10 +1345,10 @@ class Polygon(CompositeSurface):
 
         if isinstance(distance, float):
             distance = np.full(len(self.points), distance)
-        elif isinstance(distance, (list, tuple)):
+        elif isinstance(distance, Sequence):
             distance = np.array(distance)
         elif not isinstance(distance, np.ndarray):
-            raise TypeError("Distance must be a float, list, tuple, or numpy array")
+            raise TypeError("Distance must be a float or sequence of float.")
 
         if len(distance) != len(self.points):
             raise ValueError(

--- a/tests/unit_tests/test_surface_composite.py
+++ b/tests/unit_tests/test_surface_composite.py
@@ -347,10 +347,13 @@ def test_polygon():
         assert any([points_in[i] in reg for reg in star_poly.regions])
         assert points_in[i] not in +star_poly
         assert (0, 0, 0) not in -star_poly
-        if basis != 'rz':
-            offset_star = star_poly.offset(.6)
-            assert (0, 0, 0) in -offset_star
-            assert any([(0, 0, 0) in reg for reg in offset_star.regions])
+        if basis != "rz":
+            for offsets in [0.6, np.array([0.6] * 10), [0.6] * 10]:
+                offset_star = star_poly.offset(offsets)
+                assert (0, 0, 0) in -offset_star
+                assert any([(0, 0, 0) in reg for reg in offset_star.regions])
+            with pytest.raises(ValueError):
+                star_poly.offset([0.6, 0.6])
 
     # check invalid Polygon input points
     # duplicate points not just at start and end


### PR DESCRIPTION
# Description

This PR allows the polygon offset distance to be an iterable of values for a non constant offset. I hear this is useful for stellerators :-)

![varible_offset_poly](https://github.com/user-attachments/assets/6dc6200b-6450-4ed7-b078-30759be38dda)


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)


example script
```python
import openmc
import numpy as np
import matplotlib.pyplot as plt

star = np.array(
    [
        [1.0, 2.0],
        [0.70610737, 1.4045085],
        [0.04894348, 1.30901699],
        [0.52447174, 0.8454915],
        [0.41221475, 0.19098301],
        [1.0, 0.5],
        [1.58778525, 0.19098301],
        [1.47552826, 0.8454915],
        [1.95105652, 1.30901699],
        [1.29389263, 1.4045085],
        [1.0, 2.0],
    ]
)

surf_poly = openmc.model.Polygon(star, basis="rz")
surf_poly2 = surf_poly.offset(
    [
        0.5,
        0.1,
        0.1,
        0.1,
        0.1,
        1.0,
        0.1,
        0.1,
        0.1,
        0.1,
    ]
)

region_poly = -surf_poly
region_poly2 = -surf_poly2 & +surf_poly

cell_poly = openmc.Cell(region=region_poly)
cell_poly2 = openmc.Cell(region=region_poly2)

my_geometry = openmc.Geometry([cell_poly, cell_poly2])
my_geometry.plot(basis="yz", width=(8, 8), color_by="cell")

plt.show()
```