### PR TITLE
Update quickinstall instructions for macOS

### DIFF
--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -137,15 +137,11 @@ packages should be installed, for example in Homebrew via:
 
 The compiler provided by the above LLVM package should be used in place of the
 one provisioned by XCode, which does not support the multithreading library used
-by OpenMC. Consequently, the C++ compiler should explicitly be set before
-proceeding:
-
-.. code-block:: sh
-
-   export CC=/usr/local/opt/llvm/bin/clang
-   export CXX=/usr/local/opt/llvm/bin/clang++
-   export LDFLAGS="-L/usr/local/opt/llvm/lib"
-   export CPPFLAGS="-I/usr/local/opt/llvm/include"
+by OpenMC. To ensure CMake picks up the correct compiler, make sure that either
+the :envvar:`CXX` environment variable is set to the brew-installed ``clang++``
+or that the directory containing it is on your :envvar:`PATH` environment
+variable. Common locations for the brew-installed compiler are
+``/opt/homebrew/opt/llvm/bin`` and ``/usr/local/opt/llvm/bin``.
 
 After the packages have been installed, follow the instructions to build from
 source below.

--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -142,7 +142,10 @@ proceeding:
 
 .. code-block:: sh
 
-   export CXX=/opt/homebrew/opt/llvm/bin/clang++
+    export CC=/usr/local/opt/llvm/bin/clang
+    export CXX=/usr/local/opt/llvm/bin/clang++
+    export LDFLAGS="-L/usr/local/opt/llvm/lib"
+    export CPPFLAGS="-I/usr/local/opt/llvm/include"
 
 After the packages have been installed, follow the instructions to build from
 source below.

--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -142,10 +142,10 @@ proceeding:
 
 .. code-block:: sh
 
-    export CC=/usr/local/opt/llvm/bin/clang
-    export CXX=/usr/local/opt/llvm/bin/clang++
-    export LDFLAGS="-L/usr/local/opt/llvm/lib"
-    export CPPFLAGS="-I/usr/local/opt/llvm/include"
+   export CC=/usr/local/opt/llvm/bin/clang
+   export CXX=/usr/local/opt/llvm/bin/clang++
+   export LDFLAGS="-L/usr/local/opt/llvm/lib"
+   export CPPFLAGS="-I/usr/local/opt/llvm/include"
 
 After the packages have been installed, follow the instructions to build from
 source below.


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Please include a summary of the change and which issue is fixed if applicable. Please also include relevant motivation and context.

The path for clang++ compiler doesn't seem to be correct. Per [Stack Overflow](https://stackoverflow.com/a/53889826 ), this seemed to work for my M2 MacBook Pro. 

Fixes # (issue)
N/A

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
