### PR TITLE
Fix for UWUW Macro Conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,11 @@ jobs:
           echo "$HOME/NJOY2016/build" >> $GITHUB_PATH
           $GITHUB_WORKSPACE/tools/ci/gha-install.sh
 
+      - name: display-config
+        shell: bash
+        run: |
+          openmc -v
+
       - name: cache-xs
         uses: actions/cache@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,7 +516,7 @@ if(OPENMC_USE_DAGMC)
   endif()
 elseif(OPENMC_USE_UWUW)
   set(OPENMC_USE_UWUW OFF)
-  message(FATAL_ERROR "DAGMC is required for use of UWUW materials.")
+  message(FATAL_ERROR "DAGMC must be enabled when UWUW is enabled.")
 endif()
 
 if(OPENMC_USE_LIBMESH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ option(OPENMC_USE_LIBMESH     "Enable support for libMesh unstructured mesh tall
 option(OPENMC_USE_MPI         "Enable MPI"                                           OFF)
 option(OPENMC_USE_MCPL        "Enable MCPL"                                          OFF)
 option(OPENMC_USE_NCRYSTAL    "Enable support for NCrystal scattering"               OFF)
-option(OPENMC_USE_UWUW        "Enable UWUW"                                          OFF)
+option(OPENMC_USE_UWUW        "Enable UWUW"                                          ON)
 
 # Warnings for deprecated options
 foreach(OLD_OPT IN ITEMS "openmp" "profile" "coverage" "dagmc" "libmesh")
@@ -546,7 +546,7 @@ if(OPENMC_USE_NCRYSTAL)
 endif()
 
 if (OPENMC_USE_UWUW)
-  target_compile_definitions(libopenmc PRIVATE UWUW)
+  target_compile_definitions(libopenmc PRIVATE UWUW_HPP)
   target_link_libraries(libopenmc uwuw-shared)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,6 +509,14 @@ endif()
 if(OPENMC_USE_DAGMC)
   target_compile_definitions(libopenmc PRIVATE DAGMC)
   target_link_libraries(libopenmc dagmc-shared)
+
+  if(OPENMC_USE_UWUW)
+    target_compile_definitions(libopenmc PRIVATE DAGMC_UWUW)
+    target_link_libraries(libopenmc uwuw-shared)
+  endif()
+elseif(OPENMC_USE_UWUW)
+  set(OPENMC_USE_UWUW OFF)
+  message(WARNING "UWUW is enabled but DAGMC was not found. Disabling.")
 endif()
 
 if(OPENMC_USE_LIBMESH)
@@ -543,11 +551,6 @@ endif()
 if(OPENMC_USE_NCRYSTAL)
   target_compile_definitions(libopenmc PRIVATE NCRYSTAL)
   target_link_libraries(libopenmc NCrystal::NCrystal)
-endif()
-
-if (OPENMC_USE_UWUW)
-  target_compile_definitions(libopenmc PRIVATE UWUW_HPP)
-  target_link_libraries(libopenmc uwuw-shared)
 endif()
 
 #===============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,7 +516,7 @@ if(OPENMC_USE_DAGMC)
   endif()
 elseif(OPENMC_USE_UWUW)
   set(OPENMC_USE_UWUW OFF)
-  message(WARNING "UWUW is enabled but DAGMC was not found. Disabling.")
+  message(FATAL_ERROR "DAGMC is required for use of UWUW materials.")
 endif()
 
 if(OPENMC_USE_LIBMESH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ option(OPENMC_USE_LIBMESH     "Enable support for libMesh unstructured mesh tall
 option(OPENMC_USE_MPI         "Enable MPI"                                           OFF)
 option(OPENMC_USE_MCPL        "Enable MCPL"                                          OFF)
 option(OPENMC_USE_NCRYSTAL    "Enable support for NCrystal scattering"               OFF)
-option(OPENMC_USE_UWUW        "Enable UWUW"                                          ON)
+option(OPENMC_USE_UWUW        "Enable UWUW"                                          OFF)
 
 # Warnings for deprecated options
 foreach(OLD_OPT IN ITEMS "openmp" "profile" "coverage" "dagmc" "libmesh")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,7 +511,7 @@ if(OPENMC_USE_DAGMC)
   target_link_libraries(libopenmc dagmc-shared)
 
   if(OPENMC_USE_UWUW)
-    target_compile_definitions(libopenmc PRIVATE DAGMC_UWUW)
+    target_compile_definitions(libopenmc PRIVATE OPENMC_UWUW)
     target_link_libraries(libopenmc uwuw-shared)
   endif()
 elseif(OPENMC_USE_UWUW)

--- a/cmake/OpenMCConfig.cmake.in
+++ b/cmake/OpenMCConfig.cmake.in
@@ -38,3 +38,7 @@ endif()
 if(@OPENMC_USE_MCPL@)
   find_package(MCPL REQUIRED)
 endif()
+
+if(@OPENMC_USE_UWUW@ AND NOT @DAGMC_BUILD_UWUW@)
+  message(FATAL_ERROR "UWUW is enabled but DAGMC was not configured with UWUW.")
+endif()

--- a/cmake/OpenMCConfig.cmake.in
+++ b/cmake/OpenMCConfig.cmake.in
@@ -40,5 +40,5 @@ if(@OPENMC_USE_MCPL@)
 endif()
 
 if(@OPENMC_USE_UWUW@)
-  find_package(UWUW REQUIRED)
+  find_package(OPEMC_UWUW REQUIRED)
 endif()

--- a/cmake/OpenMCConfig.cmake.in
+++ b/cmake/OpenMCConfig.cmake.in
@@ -38,7 +38,3 @@ endif()
 if(@OPENMC_USE_MCPL@)
   find_package(MCPL REQUIRED)
 endif()
-
-if(@OPENMC_USE_UWUW@)
-  find_package(OPEMC_UWUW REQUIRED)
-endif()

--- a/cmake/OpenMCConfig.cmake.in
+++ b/cmake/OpenMCConfig.cmake.in
@@ -39,6 +39,6 @@ if(@OPENMC_USE_MCPL@)
   find_package(MCPL REQUIRED)
 endif()
 
-if(@OPENMC_USE_UWUW@ AND NOT @DAGMC_BUILD_UWUW@)
+if(@OPENMC_USE_UWUW@ AND NOT ${DAGMC_BUILD_UWUW})
   message(FATAL_ERROR "UWUW is enabled but DAGMC was not configured with UWUW.")
 endif()

--- a/cmake/OpenMCConfig.cmake.in
+++ b/cmake/OpenMCConfig.cmake.in
@@ -40,5 +40,5 @@ if(@OPENMC_USE_MCPL@)
 endif()
 
 if(@OPENMC_USE_UWUW@ AND NOT ${DAGMC_BUILD_UWUW})
-  message(FATAL_ERROR "UWUW is enabled but DAGMC was not configured with UWUW.")
+  message(FATAL_ERROR "UWUW is enabled in OpenMC but the DAGMC installation discovered was not configured with UWUW.")
 endif()

--- a/include/openmc/dagmc.h
+++ b/include/openmc/dagmc.h
@@ -125,7 +125,7 @@ public:
   //! \param[in] vol_handle The DAGMC material assignment string
   //! \param[in] c The OpenMC cell to which the material is assigned
   void uwuw_assign_material(
-    moab::EntityHandle vol_handle, std::unique_ptr<DAGCell>& c);
+    moab::EntityHandle vol_handle, std::unique_ptr<DAGCell>& c) const;
 
   //! Assign a material to a cell based
   //! \param[in] mat_string The DAGMC material assignment string

--- a/include/openmc/dagmc.h
+++ b/include/openmc/dagmc.h
@@ -125,7 +125,7 @@ public:
   //! \param[in] vol_handle The DAGMC material assignment string
   //! \param[in] c The OpenMC cell to which the material is assigned
   void uwuw_assign_material(
-    moab::EntityHandle vol_handle, std::unique_ptr<DAGCell>& c) const;
+    moab::EntityHandle vol_handle, std::unique_ptr<DAGCell>& c);
 
   //! Assign a material to a cell based
   //! \param[in] mat_string The DAGMC material assignment string

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -11,7 +11,7 @@
 #include "openmc/settings.h"
 #include "openmc/string_utils.h"
 
-#ifdef UWUW_HPP
+#ifdef DAGMC_UWUW
 #include "uwuw.hpp"
 #endif
 #include <fmt/core.h>
@@ -29,7 +29,7 @@ const bool DAGMC_ENABLED = true;
 const bool DAGMC_ENABLED = false;
 #endif
 
-#ifdef UWUW_HPP
+#ifdef DAGMC_UWUW
 const bool UWUW_ENABLED = true;
 #else
 const bool UWUW_ENABLED = false;
@@ -431,16 +431,16 @@ void DAGUniverse::to_hdf5(hid_t universes_group) const
 
 bool DAGUniverse::uses_uwuw() const
 {
-#ifdef UWUW_HPP
+#ifdef DAGMC_UWUW
   return uwuw_ && !uwuw_->material_library.empty();
 #else
   return false;
-#endif // UWUW_HPP
+#endif // DAGMC_UWUW
 }
 
 std::string DAGUniverse::get_uwuw_materials_xml() const
 {
-#ifdef UWUW_HPP
+#ifdef DAGMC_UWUW
   if (!uses_uwuw()) {
     throw std::runtime_error("This DAGMC Universe does not use UWUW materials");
   }
@@ -460,12 +460,12 @@ std::string DAGUniverse::get_uwuw_materials_xml() const
   return ss.str();
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif // UWUW_HPP
+#endif // DAGMC_UWUW
 }
 
 void DAGUniverse::write_uwuw_materials_xml(const std::string& outfile) const
 {
-#ifdef UWUW_HPP
+#ifdef DAGMC_UWUW
   if (!uses_uwuw()) {
     throw std::runtime_error(
       "This DAGMC universe does not use UWUW materials.");
@@ -478,7 +478,7 @@ void DAGUniverse::write_uwuw_materials_xml(const std::string& outfile) const
   mats_xml.close();
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif // UWUW_HPP
+#endif // DAGMC_UWUW
 }
 
 void DAGUniverse::legacy_assign_material(
@@ -540,7 +540,7 @@ void DAGUniverse::legacy_assign_material(
 
 void DAGUniverse::read_uwuw_materials()
 {
-#ifdef UWUW_HPP
+#ifdef DAGMC_UWUW
   // If no filename was provided, don't read UWUW materials
   if (filename_ == "")
     return;
@@ -580,13 +580,13 @@ void DAGUniverse::read_uwuw_materials()
   }
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif // UWUW_HPP
+#endif // DAGMC_UWUW
 }
 
 void DAGUniverse::uwuw_assign_material(
   moab::EntityHandle vol_handle, std::unique_ptr<DAGCell>& c)
 {
-#ifdef UWUW_HPP
+#ifdef DAGMC_UWUW
   // read materials from uwuw material file
   read_uwuw_materials();
 
@@ -605,7 +605,7 @@ void DAGUniverse::uwuw_assign_material(
   }
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif // UWUW_HPP
+#endif // DAGMC_UWUW
 }
 //==============================================================================
 // DAGMC Cell implementation

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -11,7 +11,7 @@
 #include "openmc/settings.h"
 #include "openmc/string_utils.h"
 
-#ifdef UWUW
+#ifdef UWUW_HPP
 #include "uwuw.hpp"
 #endif
 #include <fmt/core.h>
@@ -29,7 +29,7 @@ const bool DAGMC_ENABLED = true;
 const bool DAGMC_ENABLED = false;
 #endif
 
-#ifdef UWUW
+#ifdef UWUW_HPP
 const bool UWUW_ENABLED = true;
 #else
 const bool UWUW_ENABLED = false;
@@ -431,16 +431,16 @@ void DAGUniverse::to_hdf5(hid_t universes_group) const
 
 bool DAGUniverse::uses_uwuw() const
 {
-#ifdef UWUW
+#ifdef UWUW_HPP
   return uwuw_ && !uwuw_->material_library.empty();
 #else
   return false;
-#endif // UWUW
+#endif // UWUW_HPP
 }
 
 std::string DAGUniverse::get_uwuw_materials_xml() const
 {
-#ifdef UWUW
+#ifdef UWUW_HPP
   if (!uses_uwuw()) {
     throw std::runtime_error("This DAGMC Universe does not use UWUW materials");
   }
@@ -460,12 +460,12 @@ std::string DAGUniverse::get_uwuw_materials_xml() const
   return ss.str();
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif // UWUW
+#endif // UWUW_HPP
 }
 
 void DAGUniverse::write_uwuw_materials_xml(const std::string& outfile) const
 {
-#ifdef UWUW
+#ifdef UWUW_HPP
   if (!uses_uwuw()) {
     throw std::runtime_error(
       "This DAGMC universe does not use UWUW materials.");
@@ -478,7 +478,7 @@ void DAGUniverse::write_uwuw_materials_xml(const std::string& outfile) const
   mats_xml.close();
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif
+#endif // UWUW_HPP
 }
 
 void DAGUniverse::legacy_assign_material(
@@ -540,7 +540,7 @@ void DAGUniverse::legacy_assign_material(
 
 void DAGUniverse::read_uwuw_materials()
 {
-#ifdef UWUW
+#ifdef UWUW_HPP
   // If no filename was provided, don't read UWUW materials
   if (filename_ == "")
     return;
@@ -580,13 +580,13 @@ void DAGUniverse::read_uwuw_materials()
   }
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif
+#endif // UWUW_HPP
 }
 
 void DAGUniverse::uwuw_assign_material(
-  moab::EntityHandle vol_handle, std::unique_ptr<DAGCell>& c) const
+  moab::EntityHandle vol_handle, std::unique_ptr<DAGCell>& c)
 {
-#ifdef UWUW
+#ifdef UWUW_HPP
   // read materials from uwuw material file
   read_uwuw_materials();
 
@@ -601,11 +601,11 @@ void DAGUniverse::uwuw_assign_material(
   } else {
     fatal_error(fmt::format("Material with value '{}' not found in the "
                             "UWUW material library",
-      mat_str));
+                            uwuw_mat));  // Replaced mat_str with uwuw_mat
   }
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif
+#endif // UWUW_HPP
 }
 //==============================================================================
 // DAGMC Cell implementation

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -112,6 +112,11 @@ void DAGUniverse::initialize()
 {
   geom_type() = GeometryType::DAG;
 
+#ifdef OPENMC_UWUW
+  // read uwuw materials from the .h5m file if present
+  read_uwuw_materials();
+#endif
+
   init_dagmc();
 
   init_metadata();
@@ -587,9 +592,6 @@ void DAGUniverse::uwuw_assign_material(
   moab::EntityHandle vol_handle, std::unique_ptr<DAGCell>& c)
 {
 #ifdef OPENMC_UWUW
-  // read materials from uwuw material file
-  read_uwuw_materials();
-
   // lookup material in uwuw if present
   std::string uwuw_mat = dmd_ptr->volume_material_property_data_eh[vol_handle];
   if (uwuw_->material_library.count(uwuw_mat) != 0) {

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -601,7 +601,7 @@ void DAGUniverse::uwuw_assign_material(
   } else {
     fatal_error(fmt::format("Material with value '{}' not found in the "
                             "UWUW material library",
-                            uwuw_mat));  // Replaced mat_str with uwuw_mat
+      mat_str));
   }
 #else
   fatal_error("DAGMC was not configured with UWUW.");

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -11,7 +11,7 @@
 #include "openmc/settings.h"
 #include "openmc/string_utils.h"
 
-#ifdef DAGMC_UWUW
+#ifdef OPENMC_UWUW
 #include "uwuw.hpp"
 #endif
 #include <fmt/core.h>
@@ -29,7 +29,7 @@ const bool DAGMC_ENABLED = true;
 const bool DAGMC_ENABLED = false;
 #endif
 
-#ifdef DAGMC_UWUW
+#ifdef OPENMC_UWUW
 const bool UWUW_ENABLED = true;
 #else
 const bool UWUW_ENABLED = false;
@@ -431,16 +431,16 @@ void DAGUniverse::to_hdf5(hid_t universes_group) const
 
 bool DAGUniverse::uses_uwuw() const
 {
-#ifdef DAGMC_UWUW
+#ifdef OPENMC_UWUW
   return uwuw_ && !uwuw_->material_library.empty();
 #else
   return false;
-#endif // DAGMC_UWUW
+#endif // OPENMC_UWUW
 }
 
 std::string DAGUniverse::get_uwuw_materials_xml() const
 {
-#ifdef DAGMC_UWUW
+#ifdef OPENMC_UWUW
   if (!uses_uwuw()) {
     throw std::runtime_error("This DAGMC Universe does not use UWUW materials");
   }
@@ -460,12 +460,12 @@ std::string DAGUniverse::get_uwuw_materials_xml() const
   return ss.str();
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif // DAGMC_UWUW
+#endif // OPENMC_UWUW
 }
 
 void DAGUniverse::write_uwuw_materials_xml(const std::string& outfile) const
 {
-#ifdef DAGMC_UWUW
+#ifdef OPENMC_UWUW
   if (!uses_uwuw()) {
     throw std::runtime_error(
       "This DAGMC universe does not use UWUW materials.");
@@ -478,7 +478,7 @@ void DAGUniverse::write_uwuw_materials_xml(const std::string& outfile) const
   mats_xml.close();
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif // DAGMC_UWUW
+#endif // OPENMC_UWUW
 }
 
 void DAGUniverse::legacy_assign_material(
@@ -540,7 +540,7 @@ void DAGUniverse::legacy_assign_material(
 
 void DAGUniverse::read_uwuw_materials()
 {
-#ifdef DAGMC_UWUW
+#ifdef OPENMC_UWUW
   // If no filename was provided, don't read UWUW materials
   if (filename_ == "")
     return;
@@ -580,13 +580,13 @@ void DAGUniverse::read_uwuw_materials()
   }
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif // DAGMC_UWUW
+#endif // OPENMC_UWUW
 }
 
 void DAGUniverse::uwuw_assign_material(
   moab::EntityHandle vol_handle, std::unique_ptr<DAGCell>& c)
 {
-#ifdef DAGMC_UWUW
+#ifdef OPENMC_UWUW
   // read materials from uwuw material file
   read_uwuw_materials();
 
@@ -605,7 +605,7 @@ void DAGUniverse::uwuw_assign_material(
   }
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif // DAGMC_UWUW
+#endif // OPENMC_UWUW
 }
 //==============================================================================
 // DAGMC Cell implementation

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -589,7 +589,7 @@ void DAGUniverse::read_uwuw_materials()
 }
 
 void DAGUniverse::uwuw_assign_material(
-  moab::EntityHandle vol_handle, std::unique_ptr<DAGCell>& c)
+  moab::EntityHandle vol_handle, std::unique_ptr<DAGCell>& c) const
 {
 #ifdef OPENMC_UWUW
   // lookup material in uwuw if present

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -601,7 +601,7 @@ void DAGUniverse::uwuw_assign_material(
   } else {
     fatal_error(fmt::format("Material with value '{}' not found in the "
                             "UWUW material library",
-      mat_str));
+      uwuw_mat));
   }
 #else
   fatal_error("DAGMC was not configured with UWUW.");

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -347,7 +347,7 @@ void print_build_info()
 #ifdef COVERAGEBUILD
   coverage = y;
 #endif
-#ifdef UWUW
+#ifdef UWUW_HPP
   uwuw = y;
 #endif
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -347,7 +347,7 @@ void print_build_info()
 #ifdef COVERAGEBUILD
   coverage = y;
 #endif
-#ifdef UWUW_HPP
+#ifdef DAGMC_UWUW
   uwuw = y;
 #endif
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -347,7 +347,7 @@ void print_build_info()
 #ifdef COVERAGEBUILD
   coverage = y;
 #endif
-#ifdef DAGMC_UWUW
+#ifdef OPENMC_UWUW
   uwuw = y;
 #endif
 


### PR DESCRIPTION
### Description:

This PR resolves the following issues in the OpenMC DAGMC interface:

1. **Macro Conflict Fix:**

   - The `UWUW` macro was causing conflicts during compilation as it was treated as a numeric constant.
   - To resolve this, the macro `UWUW` has been replaced with `UWUW_HPP` to avoid naming conflicts with numeric constants.
   
   **Changes:**

   - In `CMakeLists.txt`, the line:
     ```cmake
     target_compile_definitions(libopenmc PRIVATE UWUW)
     ```
     has been updated to:
     ```cmake
     target_compile_definitions(libopenmc PRIVATE UWUW_HPP)
     ```

   - All relevant files that referenced `UWUW` have been updated accordingly.

2. **Const Qualifier Removal:**

   - The `const` qualifier was removed from the function `uwuw_assign_material` in both the declaration (in `dagmc.h`) and the definition (in `dagmc.cpp`).
   - This allows for modifying class member variables within the function, which is necessary for proper material assignment in the DAGMC interface.