### PR TITLE
Consistency in treatment of paths for files specified within the Model class

### DIFF
--- a/docs/source/usersguide/geometry.rst
+++ b/docs/source/usersguide/geometry.rst
@@ -474,7 +474,7 @@ applied as universes in the OpenMC geometry file. A geometry represented
 entirely by a DAGMC geometry will contain only the DAGMC universe. Using a
 :class:`openmc.DAGMCUniverse` looks like the following::
 
-   dag_univ = openmc.DAGMCUniverse(filename='dagmc.h5m')
+   dag_univ = openmc.DAGMCUniverse('dagmc.h5m')
    geometry = openmc.Geometry(dag_univ)
    geometry.export_to_xml()
 
@@ -495,13 +495,22 @@ It is important in these cases to understand the DAGMC model's position
 with respect to the CSG geometry. DAGMC geometries can be plotted with
 OpenMC to verify that the model matches one's expectations.
 
-**Note:** DAGMC geometries used in OpenMC are currently required to be clean,
-meaning that all surfaces have been `imprinted and merged
-<https://svalinn.github.io/DAGMC/usersguide/cubit_basics.html>`_ successfully
-and that the model is `watertight
-<https://svalinn.github.io/DAGMC/usersguide/tools.html#make-watertight>`_.
-Future implementations of DAGMC geometry will support small volume overlaps and
-un-merged surfaces.
+By default, when you specify a .h5m file for a :class:`~openmc.DAGMCUniverse`
+instance, it will store the absolute path to the .h5m file. If you prefer to
+store the relative path, you can set the ``'resolve_paths'`` configuration
+variable::
+
+  openmc.config['resolve_paths'] = False
+  dag_univ = openmc.DAGMCUniverse('dagmc.h5m')
+
+.. note::
+    DAGMC geometries used in OpenMC are currently required to be clean,
+    meaning that all surfaces have been `imprinted and merged
+    <https://svalinn.github.io/DAGMC/usersguide/cubit_basics.html>`_ successfully
+    and that the model is `watertight
+    <https://svalinn.github.io/DAGMC/usersguide/tools.html#make-watertight>`_.
+    Future implementations of DAGMC geometry will support small volume overlaps and
+    un-merged surfaces.
 
 Cell, Surface, and Material IDs
 -------------------------------

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -16,6 +16,7 @@ import openmc.data
 import openmc.checkvalue as cv
 from ._xml import clean_indentation, reorder_attributes
 from .mixin import IDManagerMixin
+from .utility_funcs import input_path
 from openmc.checkvalue import PathLike
 from openmc.stats import Univariate, Discrete, Mixture
 
@@ -1600,7 +1601,7 @@ class Materials(cv.CheckedList):
     @cross_sections.setter
     def cross_sections(self, cross_sections):
         if cross_sections is not None:
-            self._cross_sections = Path(cross_sections).resolve()
+            self._cross_sections = input_path(cross_sections)
 
     def append(self, material):
         """Append material to collection

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1600,7 +1600,7 @@ class Materials(cv.CheckedList):
     @cross_sections.setter
     def cross_sections(self, cross_sections):
         if cross_sections is not None:
-            self._cross_sections = Path(cross_sections)
+            self._cross_sections = Path(cross_sections).resolve()
 
     def append(self, material):
         """Append material to collection

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -5,8 +5,6 @@ from collections.abc import Iterable, Sequence
 from functools import wraps
 from math import pi, sqrt, atan2
 from numbers import Integral, Real
-from pathlib import Path
-import tempfile
 
 import h5py
 import lxml.etree as ET
@@ -19,6 +17,7 @@ from openmc.utility_funcs import change_directory
 from ._xml import get_text
 from .mixin import IDManagerMixin
 from .surface import _BOUNDARY_TYPES
+from .utility_funcs import input_path
 
 
 class MeshBase(IDManagerMixin, ABC):
@@ -2159,7 +2158,7 @@ class UnstructuredMesh(MeshBase):
     @filename.setter
     def filename(self, filename):
         cv.check_type('Unstructured Mesh filename', filename, PathLike)
-        self._filename = Path(filename)
+        self._filename = input_path(filename)
 
     @property
     def library(self):

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -2072,7 +2072,7 @@ class UnstructuredMesh(MeshBase):
 
     Parameters
     ----------
-    filename : str or pathlib.Path
+    filename : path-like
         Location of the unstructured mesh file
     library : {'moab', 'libmesh'}
         Mesh library used for the unstructured mesh tally
@@ -2158,8 +2158,8 @@ class UnstructuredMesh(MeshBase):
 
     @filename.setter
     def filename(self, filename):
-        cv.check_type('Unstructured Mesh filename', filename, (str, Path))
-        self._filename = filename
+        cv.check_type('Unstructured Mesh filename', filename, PathLike)
+        self._filename = Path(filename)
 
     @property
     def library(self):

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -14,6 +14,7 @@ from . import (RegularMesh, SourceBase, MeshSource, IndependentSource,
 from ._xml import clean_indentation, get_text, reorder_attributes
 from openmc.checkvalue import PathLike
 from .mesh import _read_meshes
+from .utility_funcs import input_path
 
 
 class RunMode(Enum):
@@ -709,7 +710,7 @@ class Settings:
 
         # Resolve path to surface source file
         if 'path' in ssr:
-            self._surf_source_read['path'] = Path(ssr['path']).resolve()
+            self._surf_source_read['path'] = input_path(ssr['path'])
 
     @property
     def surf_source_write(self) -> dict:
@@ -1068,7 +1069,7 @@ class Settings:
     @weight_windows_file.setter
     def weight_windows_file(self, value: PathLike):
         cv.check_type('weight windows file', value, PathLike)
-        self._weight_windows_file = Path(value).resolve()
+        self._weight_windows_file = input_path(value)
 
     @property
     def weight_window_generators(self) -> list[WeightWindowGenerator]:

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -8,13 +8,14 @@ from pathlib import Path
 import lxml.etree as ET
 
 import openmc.checkvalue as cv
-from openmc.stats.multivariate import MeshSpatial
-from . import (RegularMesh, SourceBase, MeshSource, IndependentSource,
-               VolumeCalculation, WeightWindows, WeightWindowGenerator)
-from ._xml import clean_indentation, get_text, reorder_attributes
 from openmc.checkvalue import PathLike
-from .mesh import _read_meshes
+from openmc.stats.multivariate import MeshSpatial
+from ._xml import clean_indentation, get_text, reorder_attributes
+from .mesh import _read_meshes, RegularMesh
+from .source import SourceBase, MeshSource, IndependentSource
 from .utility_funcs import input_path
+from .volume import VolumeCalculation
+from .weight_windows import WeightWindows, WeightWindowGenerator
 
 
 class RunMode(Enum):

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -698,14 +698,18 @@ class Settings:
         return self._surf_source_read
 
     @surf_source_read.setter
-    def surf_source_read(self, surf_source_read: dict):
-        cv.check_type('surface source reading options', surf_source_read, Mapping)
-        for key, value in surf_source_read.items():
+    def surf_source_read(self, ssr: dict):
+        cv.check_type('surface source reading options', ssr, Mapping)
+        for key, value in ssr.items():
             cv.check_value('surface source reading key', key,
                            ('path'))
             if key == 'path':
-                cv.check_type('path to surface source file', value, str)
-        self._surf_source_read = surf_source_read
+                cv.check_type('path to surface source file', value, PathLike)
+        self._surf_source_read = dict(ssr)
+
+        # Resolve path to surface source file
+        if 'path' in ssr:
+            self._surf_source_read['path'] = Path(ssr['path']).resolve()
 
     @property
     def surf_source_write(self) -> dict:
@@ -1063,8 +1067,8 @@ class Settings:
 
     @weight_windows_file.setter
     def weight_windows_file(self, value: PathLike):
-        cv.check_type('weight windows file', value, (str, Path))
-        self._weight_windows_file = value
+        cv.check_type('weight windows file', value, PathLike)
+        self._weight_windows_file = Path(value).resolve()
 
     @property
     def weight_window_generators(self) -> list[WeightWindowGenerator]:
@@ -1238,7 +1242,7 @@ class Settings:
             element = ET.SubElement(root, "surf_source_read")
             if 'path' in self._surf_source_read:
                 subelement = ET.SubElement(element, "path")
-                subelement.text = self._surf_source_read['path']
+                subelement.text = str(self._surf_source_read['path'])
 
     def _create_surf_source_write_subelement(self, root):
         if self._surf_source_write:
@@ -1498,7 +1502,7 @@ class Settings:
     def _create_weight_windows_file_element(self, root):
         if self.weight_windows_file is not None:
             element = ET.Element("weight_windows_file")
-            element.text = self.weight_windows_file
+            element.text = str(self.weight_windows_file)
             root.append(element)
 
     def _create_weight_window_checkpoints_subelement(self, root):
@@ -1642,9 +1646,11 @@ class Settings:
     def _surf_source_read_from_xml_element(self, root):
         elem = root.find('surf_source_read')
         if elem is not None:
+            ssr = {}
             value = get_text(elem, 'path')
             if value is not None:
-                self.surf_source_read['path'] = value
+                ssr['path'] = value
+            self.surf_source_read = ssr
 
     def _surf_source_write_from_xml_element(self, root):
         elem = root.find('surf_source_write')

--- a/openmc/source.py
+++ b/openmc/source.py
@@ -18,6 +18,7 @@ from openmc.stats.multivariate import UnitSphere, Spatial
 from openmc.stats.univariate import Univariate
 from ._xml import get_text
 from .mesh import MeshBase, StructuredMesh, UnstructuredMesh
+from .utility_funcs import input_path
 
 
 class SourceBase(ABC):
@@ -723,7 +724,7 @@ class CompiledSource(SourceBase):
     @library.setter
     def library(self, library_name: PathLike):
         cv.check_type('library', library_name, PathLike)
-        self._library = Path(library_name).resolve()
+        self._library = input_path(library_name)
 
     @property
     def parameters(self) -> str:
@@ -842,7 +843,7 @@ class FileSource(SourceBase):
     @path.setter
     def path(self, p: PathLike):
         cv.check_type('source file', p, PathLike)
-        self._path = Path(p).resolve()
+        self._path = input_path(p)
 
     def populate_xml_element(self, element):
         """Add necessary file source information to an XML element

--- a/openmc/source.py
+++ b/openmc/source.py
@@ -723,7 +723,7 @@ class CompiledSource(SourceBase):
     @library.setter
     def library(self, library_name: PathLike):
         cv.check_type('library', library_name, PathLike)
-        self._library = Path(library_name)
+        self._library = Path(library_name).resolve()
 
     @property
     def parameters(self) -> str:
@@ -789,7 +789,7 @@ class FileSource(SourceBase):
 
     Parameters
     ----------
-    path : str or pathlib.Path
+    path : path-like
         Path to the source file from which sites should be sampled
     strength : float
         Strength of the source (default is 1.0)
@@ -824,14 +824,12 @@ class FileSource(SourceBase):
 
     def __init__(
         self,
-        path: PathLike | None = None,
+        path: PathLike,
         strength: float = 1.0,
         constraints: dict[str, Any] | None = None
     ):
         super().__init__(strength=strength, constraints=constraints)
-        self._path = None
-        if path is not None:
-            self.path = path
+        self.path = path
 
     @property
     def type(self) -> str:
@@ -843,8 +841,8 @@ class FileSource(SourceBase):
 
     @path.setter
     def path(self, p: PathLike):
-        cv.check_type('source file', p, str)
-        self._path = p
+        cv.check_type('source file', p, PathLike)
+        self._path = Path(p).resolve()
 
     def populate_xml_element(self, element):
         """Add necessary file source information to an XML element
@@ -856,7 +854,7 @@ class FileSource(SourceBase):
 
         """
         if self.path is not None:
-            element.set("file", self.path)
+            element.set("file", str(self.path))
 
     @classmethod
     def from_xml_element(cls, elem: ET.Element) -> openmc.FileSource:

--- a/openmc/source.py
+++ b/openmc/source.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from enum import IntEnum
 from numbers import Real
+from pathlib import Path
 import warnings
 from typing import Any
 
@@ -662,7 +663,7 @@ class CompiledSource(SourceBase):
 
     Parameters
     ----------
-    library : str or None
+    library : path-like
         Path to a compiled shared library
     parameters : str
         Parameters to be provided to the compiled shared library function
@@ -684,7 +685,7 @@ class CompiledSource(SourceBase):
 
     Attributes
     ----------
-    library : str or None
+    library : pathlib.Path
         Path to a compiled shared library
     parameters : str
         Parameters to be provided to the compiled shared library function
@@ -700,17 +701,13 @@ class CompiledSource(SourceBase):
     """
     def __init__(
         self,
-        library: str | None  = None,
+        library: PathLike,
         parameters: str | None = None,
         strength: float = 1.0,
         constraints: dict[str, Any] | None = None
     ) -> None:
         super().__init__(strength=strength, constraints=constraints)
-
-        self._library = None
-        if library is not None:
-            self.library = library
-
+        self.library = library
         self._parameters = None
         if parameters is not None:
             self.parameters = parameters
@@ -720,13 +717,13 @@ class CompiledSource(SourceBase):
         return "compiled"
 
     @property
-    def library(self) -> str:
+    def library(self) -> Path:
         return self._library
 
     @library.setter
-    def library(self, library_name):
-        cv.check_type('library', library_name, str)
-        self._library = library_name
+    def library(self, library_name: PathLike):
+        cv.check_type('library', library_name, PathLike)
+        self._library = Path(library_name)
 
     @property
     def parameters(self) -> str:
@@ -746,7 +743,7 @@ class CompiledSource(SourceBase):
             XML element containing source data
 
         """
-        element.set("library", self.library)
+        element.set("library", str(self.library))
 
         if self.parameters is not None:
             element.set("parameters", self.parameters)

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -17,6 +17,7 @@ from ._xml import get_text
 from .checkvalue import check_type, check_value
 from .mixin import IDManagerMixin
 from .surface import _BOUNDARY_TYPES
+from .utility_funcs import input_path
 
 
 class UniverseBase(ABC, IDManagerMixin):
@@ -852,7 +853,7 @@ class DAGMCUniverse(UniverseBase):
     @filename.setter
     def filename(self, val: cv.PathLike):
         cv.check_type('DAGMC filename', val, cv.PathLike)
-        self._filename = Path(val).resolve()
+        self._filename = input_path(val)
 
     @property
     def auto_geom_ids(self):

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -766,7 +766,7 @@ class DAGMCUniverse(UniverseBase):
 
     Parameters
     ----------
-    filename : str
+    filename : path-like
         Path to the DAGMC file used to represent this universe.
     universe_id : int, optional
         Unique identifier of the universe. If not specified, an identifier will
@@ -820,7 +820,7 @@ class DAGMCUniverse(UniverseBase):
     """
 
     def __init__(self,
-                 filename,
+                 filename: cv.PathLike,
                  universe_id=None,
                  name='',
                  auto_geom_ids=False,
@@ -850,9 +850,9 @@ class DAGMCUniverse(UniverseBase):
         return self._filename
 
     @filename.setter
-    def filename(self, val):
-        cv.check_type('DAGMC filename', val, (Path, str))
-        self._filename = val
+    def filename(self, val: cv.PathLike):
+        cv.check_type('DAGMC filename', val, cv.PathLike)
+        self._filename = Path(val).resolve()
 
     @property
     def auto_geom_ids(self):
@@ -915,8 +915,7 @@ class DAGMCUniverse(UniverseBase):
         def decode_str_tag(tag_val):
             return tag_val.tobytes().decode().replace('\x00', '')
 
-        dagmc_filepath = Path(self.filename).resolve()
-        with h5py.File(dagmc_filepath) as dagmc_file:
+        with h5py.File(self.filename) as dagmc_file:
             category_data = dagmc_file['tstt/tags/CATEGORY/values']
             category_strs = map(decode_str_tag, category_data)
             n = sum([v == geom_type.capitalize() for v in category_strs])

--- a/openmc/utility_funcs.py
+++ b/openmc/utility_funcs.py
@@ -3,7 +3,9 @@ import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import openmc
 from .checkvalue import PathLike
+
 
 @contextmanager
 def change_directory(working_dir: PathLike | None = None, *, tmpdir: bool = False):
@@ -35,3 +37,23 @@ def change_directory(working_dir: PathLike | None = None, *, tmpdir: bool = Fals
         os.chdir(orig_dir)
         if tmpdir:
             tmp.cleanup()
+
+
+def input_path(filename: PathLike) -> Path:
+    """Return a path object for an input file based on global configuration
+
+    Parameters
+    ----------
+    filename : PathLike
+        Path to input file
+
+    Returns
+    -------
+    pathlib.Path
+        Path object
+
+    """
+    if openmc.config['resolve_paths']:
+        return Path(filename).resolve()
+    else:
+        return Path(filename)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import openmc
 
 from tests.regression_tests import config as regression_config
 
@@ -27,3 +28,9 @@ def run_in_tmpdir(tmpdir):
         yield
     finally:
         orig.chdir()
+
+
+@pytest.fixture(scope='session', autouse=True)
+def resolve_paths():
+    with openmc.config.patch('resolve_paths', False):
+        yield

--- a/tests/regression_tests/source_dlopen/test.py
+++ b/tests/regression_tests/source_dlopen/test.py
@@ -72,8 +72,7 @@ def model():
     model.tallies = openmc.Tallies([tally])
 
     # custom source from shared library
-    source = openmc.CompiledSource()
-    source.library = 'build/libsource.so'
+    source = openmc.CompiledSource('build/libsource.so')
     model.settings.source = source
 
     return model

--- a/tests/regression_tests/source_parameterized_dlopen/test.py
+++ b/tests/regression_tests/source_parameterized_dlopen/test.py
@@ -71,8 +71,7 @@ def model():
     model.tallies = openmc.Tallies([tally])
 
     # custom source from shared library
-    source = openmc.CompiledSource()
-    source.library = 'build/libsource.so'
+    source = openmc.CompiledSource('build/libsource.so')
     source.parameters = '1e3'
     model.settings.source = source
 

--- a/tests/regression_tests/surface_source/test.py
+++ b/tests/regression_tests/surface_source/test.py
@@ -51,7 +51,9 @@ def model(request):
         openmc_model.settings.surf_source_write = {'surface_ids': [1],
                                                    'max_particles': 1000}
     elif surf_source_op == 'read':
-        openmc_model.settings.surf_source_read = {'path': 'surface_source_true.h5'}
+        # Avoid resolving the path to the surface source file for testing
+        openmc_model.settings.surf_source_read = {}
+        openmc_model.settings._surf_source_read['path'] = 'surface_source_true.h5'
 
     # Tallies
     tal = openmc.Tally()

--- a/tests/regression_tests/surface_source/test.py
+++ b/tests/regression_tests/surface_source/test.py
@@ -51,9 +51,7 @@ def model(request):
         openmc_model.settings.surf_source_write = {'surface_ids': [1],
                                                    'max_particles': 1000}
     elif surf_source_op == 'read':
-        # Avoid resolving the path to the surface source file for testing
-        openmc_model.settings.surf_source_read = {}
-        openmc_model.settings._surf_source_read['path'] = 'surface_source_true.h5'
+        openmc_model.settings.surf_source_read = {'path': 'surface_source_true.h5'}
 
     # Tallies
     tal = openmc.Tally()

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -19,7 +19,10 @@ def test_config_basics():
     assert isinstance(openmc.config, Mapping)
     for key, value in openmc.config.items():
         assert isinstance(key, str)
-        assert isinstance(value, os.PathLike)
+        if key == 'resolve_paths':
+            assert isinstance(value, bool)
+        else:
+            assert isinstance(value, os.PathLike)
 
     # Set and delete
     openmc.config['cross_sections'] = '/path/to/cross_sections.xml'
@@ -30,6 +33,13 @@ def test_config_basics():
     # Can't use any key
     with pytest.raises(KeyError):
         openmc.config['🐖'] = '/like/to/eat/bacon'
+
+
+def test_config_patch():
+    openmc.config['cross_sections'] = '/path/to/cross_sections.xml'
+    with openmc.config.patch('cross_sections', '/path/to/other.xml'):
+        assert str(openmc.config['cross_sections']) == '/path/to/other.xml'
+    assert str(openmc.config['cross_sections']) == '/path/to/cross_sections.xml'
 
 
 def test_config_set_envvar():

--- a/tests/unit_tests/test_settings.py
+++ b/tests/unit_tests/test_settings.py
@@ -91,7 +91,7 @@ def test_export_to_xml(run_in_tmpdir):
     assert s.sourcepoint == {'batches': [50, 150, 500, 1000], 'separate': True,
                              'write': True, 'overwrite': True, 'mcpl': True}
     assert s.statepoint == {'batches': [50, 150, 500, 1000]}
-    assert s.surf_source_read == {'path': 'surface_source_1.h5'}
+    assert s.surf_source_read['path'].name == 'surface_source_1.h5'
     assert s.surf_source_write == {'surface_ids': [2], 'max_particles': 200}
     assert s.confidence_intervals
     assert s.ptables

--- a/tests/unit_tests/test_source.py
+++ b/tests/unit_tests/test_source.py
@@ -61,9 +61,9 @@ def test_source_file():
 
 
 def test_source_dlopen():
-    library = './libsource.so'
-    src = openmc.CompiledSource(library=library)
-    assert src.library == library
+    library = 'libsource.so'
+    src = openmc.CompiledSource(library)
+    assert str(src.library) == library
 
     elem = src.to_xml_element()
     assert 'library' in elem.attrib

--- a/tests/unit_tests/test_source.py
+++ b/tests/unit_tests/test_source.py
@@ -53,7 +53,7 @@ def test_spherical_uniform():
 def test_source_file():
     filename = 'source.h5'
     src = openmc.FileSource(path=filename)
-    assert src.path == filename
+    assert src.path.name == filename
 
     elem = src.to_xml_element()
     assert 'strength' in elem.attrib
@@ -63,7 +63,7 @@ def test_source_file():
 def test_source_dlopen():
     library = 'libsource.so'
     src = openmc.CompiledSource(library)
-    assert str(src.library) == library
+    assert src.library.name == library
 
     elem = src.to_xml_element()
     assert 'library' in elem.attrib

--- a/tests/unit_tests/test_temp_interp.py
+++ b/tests/unit_tests/test_temp_interp.py
@@ -152,7 +152,7 @@ def model(tmp_path_factory):
     mat = openmc.Material()
     mat.add_nuclide('U235', 1.0)
     model.materials.append(mat)
-    model.materials.cross_sections = str(Path('cross_sections_fake.xml').resolve())
+    model.materials.cross_sections = 'cross_sections_fake.xml'
 
     sph = openmc.Sphere(r=100.0, boundary_type='reflective')
     cell = openmc.Cell(fill=mat, region=-sph)
@@ -257,7 +257,7 @@ def test_temperature_slightly_above(run_in_tmpdir):
     mat2.add_nuclide('U235', 1.0)
     mat2.temperature = 600.0
     model.materials.extend([mat1, mat2])
-    model.materials.cross_sections = str(Path('cross_sections_fake.xml').resolve())
+    model.materials.cross_sections = 'cross_sections_fake.xml'
 
     sph1 = openmc.Sphere(r=1.0)
     sph2 = openmc.Sphere(r=4.0, boundary_type='reflective')


### PR DESCRIPTION
# Description

There are a number of places where a model you're defining requires the path to a file, including:
- The path to a library for `CompiledSource`
- The path to a source file for `FileSource`
- A `.h5m` file for a `DAGMCUniverse`
- The path to a surface source file for `Settings.surf_source_read`
- The path to an unstructured mesh for tallying

Right now, OpenMC will store the path exactly as the user specified it (either absolute or relative). There are two possible issues with this:
  1) If the user gave a relative path, any function that relies on running the model in a temporary directory (e.g., in-line plotting) won't work because within the temporary directory, the relative path is incorrect.
  2) If the user gave an absolute path, moving the model files to a different directory or renaming the current directory will result in the path being invalid.

So there is no single solution that works for all scenarios. Always storing relative paths will break in scenario 1, and always storing absolute paths will break in scenario 2.

This PR provides a partial solution to this issue by introducing a new `openmc.config['resolve_paths']` configuration variable that indicates whether paths should be resolved at the time they are set. Right now the default is **True** so that scenario 1 above works by default. For example, if a user is building a model that relies on a DAGMC .h5m file that was specified as a relative path, they can still do in-line plotting of it. However, if the user wants relative paths to be stored, they can always set
```Python
openmc.config['resolve_paths'] = False
```

For our test suite, we _don't_ want absolute paths because they will end up getting stored in the reference input files and won't be same between any two systems, so I've introduced a session-scope fixture that sets the `resolve_paths` configuration variable to False.

## Alternatives

Another option I thought of (and that was discussed with @pshriwise) was to have `resolve_paths` be an argument for any method that exports to XML. However, I decided not to go this route mostly because it would require changing _a lot_ of method signatures relating to XML export. The configuration variable allowed me to achieve the same affect without modifying method signatures.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)