### PR TITLE
Prepare point query data structures on meshes when applying Weight Windows

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -83,8 +83,8 @@ public:
   virtual ~Mesh() = default;
 
   // Methods
-  //! Perform any preparation needed to support use in mesh filters
-  virtual void prepare_for_tallies() {};
+  //! Perform any preparation needed to support point location within the mesh
+  virtual void prepare_for_point_location() {};
 
   //! Update a position to the local coordinates of the mesh
   virtual void local_coords(Position& r) const {};
@@ -737,7 +737,7 @@ public:
   // Overridden Methods
 
   //! Perform any preparation needed to support use in mesh filters
-  void prepare_for_tallies() override;
+  void prepare_for_point_location() override;
 
   Position sample_element(int32_t bin, uint64_t* seed) const override;
 

--- a/openmc/weight_windows.py
+++ b/openmc/weight_windows.py
@@ -328,8 +328,9 @@ class WeightWindows(IDManagerMixin):
         subelement = ET.SubElement(element, 'particle_type')
         subelement.text = self.particle_type
 
-        subelement = ET.SubElement(element, 'energy_bounds')
-        subelement.text = ' '.join(str(e) for e in self.energy_bounds)
+        if self.energy_bounds is not None:
+            subelement = ET.SubElement(element, 'energy_bounds')
+            subelement.text = ' '.join(str(e) for e in self.energy_bounds)
 
         subelement = ET.SubElement(element, 'lower_ww_bounds')
         subelement.text = ' '.join(str(b) for b in self.lower_ww_bounds.ravel('F'))

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2366,8 +2366,7 @@ void MOABMesh::build_kdtree(const moab::Range& all_tets)
 
   // create a kd-tree instance
   write_message(
-    fmt::format("Building adaptive k-d tree for tet mesh with ID {}...", id_),
-    7);
+    7, "Building adaptive k-d tree for tet mesh with ID {}...", id_);
   kdtree_ = make_unique<moab::AdaptiveKDTree>(mbi_.get());
 
   // Determine what options to use

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2365,7 +2365,9 @@ void MOABMesh::build_kdtree(const moab::Range& all_tets)
   all_tets_and_tris.merge(all_tris);
 
   // create a kd-tree instance
-  write_message(fmt::format("Building adaptive k-d tree for tet mesh with ID {}...", id_), 7);
+  write_message(
+    fmt::format("Building adaptive k-d tree for tet mesh with ID {}...", id_),
+    7);
   kdtree_ = make_unique<moab::AdaptiveKDTree>(mbi_.get());
 
   // Determine what options to use

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2315,7 +2315,7 @@ void MOABMesh::initialize()
   this->determine_bounds();
 }
 
-void MOABMesh::prepare_for_tallies()
+void MOABMesh::prepare_for_point_location()
 {
   // if the KDTree has already been constructed, do nothing
   if (kdtree_)

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2365,7 +2365,7 @@ void MOABMesh::build_kdtree(const moab::Range& all_tets)
   all_tets_and_tris.merge(all_tris);
 
   // create a kd-tree instance
-  write_message("Building adaptive k-d tree for tet mesh...", 7);
+  write_message(fmt::format("Building adaptive k-d tree for tet mesh with ID {}...", id_), 7);
   kdtree_ = make_unique<moab::AdaptiveKDTree>(mbi_.get());
 
   // Determine what options to use

--- a/src/tallies/filter_mesh.cpp
+++ b/src/tallies/filter_mesh.cpp
@@ -80,7 +80,7 @@ void MeshFilter::set_mesh(int32_t mesh)
   // perform any additional perparation for mesh tallies here
   mesh_ = mesh;
   n_bins_ = model::meshes[mesh_]->n_bins();
-  model::meshes[mesh_]->prepare_for_tallies();
+  model::meshes[mesh_]->prepare_for_point_location();
 }
 
 void MeshFilter::set_translation(const Position& translation)

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -165,7 +165,7 @@ WeightWindows::WeightWindows(pugi::xml_node node)
 
   // Determine associated mesh
   int32_t mesh_id = std::stoi(get_node_value(node, "mesh"));
-  mesh_idx_ = model::mesh_map.at(mesh_id);
+  set_mesh(model::mesh_map.at(mesh_id));
 
   // energy bounds
   if (check_for_node(node, "energy_bounds"))
@@ -340,6 +340,7 @@ void WeightWindows::set_mesh(int32_t mesh_idx)
     fatal_error(fmt::format("Could not find a mesh for index {}", mesh_idx));
 
   mesh_idx_ = mesh_idx;
+  model::meshes[mesh_idx_]->prepare_for_tallies();
   allocate_ww_bounds();
 }
 

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -147,7 +147,8 @@ WeightWindows::WeightWindows(int32_t id)
 WeightWindows::WeightWindows(pugi::xml_node node)
 {
   // Make sure required elements are present
-  const vector<std::string> required_elems {"id", "particle_type", "lower_ww_bounds", "upper_ww_bounds"};
+  const vector<std::string> required_elems {
+    "id", "particle_type", "lower_ww_bounds", "upper_ww_bounds"};
   for (const auto& elem : required_elems) {
     if (!check_for_node(node, elem.c_str())) {
       fatal_error(fmt::format("Must specify <{}> for weight windows.", elem));

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -339,7 +339,7 @@ void WeightWindows::set_mesh(int32_t mesh_idx)
     fatal_error(fmt::format("Could not find a mesh for index {}", mesh_idx));
 
   mesh_idx_ = mesh_idx;
-  model::meshes[mesh_idx_]->prepare_for_tallies();
+  model::meshes[mesh_idx_]->prepare_for_point_location();
   allocate_ww_bounds();
 }
 

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -147,8 +147,7 @@ WeightWindows::WeightWindows(int32_t id)
 WeightWindows::WeightWindows(pugi::xml_node node)
 {
   // Make sure required elements are present
-  const vector<std::string> required_elems {"id", "particle_type",
-    "energy_bounds", "lower_ww_bounds", "upper_ww_bounds"};
+  const vector<std::string> required_elems {"id", "particle_type", "lower_ww_bounds", "upper_ww_bounds"};
   for (const auto& elem : required_elems) {
     if (!check_for_node(node, elem.c_str())) {
       fatal_error(fmt::format("Must specify <{}> for weight windows.", elem));

--- a/tests/unit_tests/weightwindows/test.py
+++ b/tests/unit_tests/weightwindows/test.py
@@ -316,8 +316,7 @@ def test_unstructured_mesh_applied_wws(request, run_in_tmpdir, library):
     water.add_nuclide('O16', 1.0)
     water.set_density('g/cc', 1.0)
     box = openmc.model.RectangularParallelepiped(*(3*[-10, 10]), boundary_type='vacuum')
-    cell = openmc.Cell(region=-box,
-                       fill=water)
+    cell = openmc.Cell(region=-box, fill=water)
 
     geometry = openmc.Geometry([cell])
     mesh_file = str(request.fspath.dirpath() / 'test_mesh_tets.exo')
@@ -327,7 +326,7 @@ def test_unstructured_mesh_applied_wws(request, run_in_tmpdir, library):
 
     wws = openmc.WeightWindows(mesh, dummy_wws, upper_bound_ratio=5.0)
 
-    model = openmc.Model(geometry, settings=openmc.Settings())
+    model = openmc.Model(geometry)
     model.settings.weight_windows = wws
     model.settings.weight_windows_on = True
     model.settings.run_mode = 'fixed source'

--- a/tests/unit_tests/weightwindows/test.py
+++ b/tests/unit_tests/weightwindows/test.py
@@ -297,3 +297,40 @@ def test_ww_attrs_capi(run_in_tmpdir, model):
     assert wws.particle == openmc.ParticleType.PHOTON
 
     openmc.lib.finalize()
+
+
+@pytest.mark.parametrize('library', ('libmesh', 'moab'))
+def test_unstructured_mesh_applied_wws(request, run_in_tmpdir, library):
+    """
+    Ensure that weight windows on unstructured mesh work when
+    they aren't part of a tally or weight window generator
+    """
+
+    if library == 'libmesh' and not openmc.lib._libmesh_enabled():
+        pytest.skip('LibMesh not enabled in this build.')
+    if library == 'moab' and not openmc.lib._dagmc_enabled():
+        pytest.skip('DAGMC (and MOAB) mesh not enabled in this build.')
+
+    water = openmc.Material(name='water')
+    water.add_nuclide('H1', 2.0)
+    water.add_nuclide('O16', 1.0)
+    water.set_density('g/cc', 1.0)
+    box = openmc.model.RectangularParallelepiped(*(3*[-10, 10]), boundary_type='vacuum')
+    cell = openmc.Cell(region=-box,
+                       fill=water)
+
+    geometry = openmc.Geometry([cell])
+    mesh_file = str(request.fspath.dirpath() / 'test_mesh_tets.exo')
+    mesh = openmc.UnstructuredMesh(mesh_file, library)
+
+    dummy_wws = np.ones((12_000,))
+
+    wws = openmc.WeightWindows(mesh, dummy_wws, upper_bound_ratio=5.0)
+
+    model = openmc.Model(geometry, settings=openmc.Settings())
+    model.settings.weight_windows = wws
+    model.settings.weight_windows_on = True
+    model.settings.run_mode = 'fixed source'
+    model.settings.particles = 100
+    model.settings.batches = 2
+    model.run()

--- a/tests/unit_tests/weightwindows/test_mesh_tets.exo
+++ b/tests/unit_tests/weightwindows/test_mesh_tets.exo
@@ -1,0 +1,1 @@
+../../regression_tests/unstructured_mesh/test_mesh_tets.e


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

https://github.com/openmc-dev/openmc/pull/2815 ensured that creation of spatial data structures for the `Mesh` objects (only affecting unstructured mesh) only occurs if the mesh is being used in tally operations. This skips the build of spatial data structures (kdTree for MOAB and Octree for LibMesh) when unstructured meshes are used for sources, providing a big speedup in initialization time.

One use case where these data structures are important outside of tallying is the application of weight windows on unstructured mesh -- point location is required there, but the data structures aren't currently built in this case. This PR adds that call in the `WeightWindows::set_mesh` method and applies that method in the XML node constructor for the object.

It also removes the requirement that energy bounds are specified on the XML node. There is code in place to set the default bounds of the weight windows to the min/max energies for the particle type to which the weight windows apply. That code is now exercised when energy bounds are absent as intended.

A test has been added that runs a problem with dummy weight windows applied to one of the unstructured meshes in the test suite to ensure that this capability runs without error.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
