### PR TITLE
Update fmt submodule to version 11.0.2

### DIFF
--- a/include/openmc/output.h
+++ b/include/openmc/output.h
@@ -76,7 +76,7 @@ struct formatter<std::array<T, 2>> {
   }
 
   template<typename FormatContext>
-  auto format(const std::array<T, 2>& arr, FormatContext& ctx)
+  auto format(const std::array<T, 2>& arr, FormatContext& ctx) const
   {
     return format_to(ctx.out(), "({}, {})", arr[0], arr[1]);
   }

--- a/include/openmc/position.h
+++ b/include/openmc/position.h
@@ -221,7 +221,7 @@ namespace fmt {
 template<>
 struct formatter<openmc::Position> : formatter<std::string> {
   template<typename FormatContext>
-  auto format(const openmc::Position& pos, FormatContext& ctx)
+  auto format(const openmc::Position& pos, FormatContext& ctx) const
   {
     return formatter<std::string>::format(
       fmt::format("({}, {}, {})", pos.x, pos.y, pos.z), ctx);


### PR DESCRIPTION
# Description

I realized after the fact that #3157 inadvertently changed the commit that the fmt submodule is pointing to. Rather than revert it to what it was, I took the liberty to update to the latest version.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)<s/>