### PR TITLE
Fix path handling for thermal ACE generation

### DIFF
--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -400,7 +400,7 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
     if acer:
         ace = (output_dir / "ace") if acer is True else Path(acer)
         xsdir = (ace.parent / "xsdir") if xsdir is None else xsdir
-        with open(ace, 'w') as ace_file, open(xsdir, 'w') as xsdir_file:
+        with ace.open('w') as ace_file, xsdir.open('w') as xsdir_file:
             for temperature in temperatures:
                 # Get contents of ACE file
                 text = (output_dir / f"ace_{temperature:.1f}").read_text()
@@ -426,7 +426,7 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
 
 
 def make_ace_thermal(filename, filename_thermal, temperatures=None,
-                     ace='ace', xsdir=None, output_dir=None, error=0.001,
+                     ace=None, xsdir=None, output_dir=None, error=0.001,
                      iwt=2, evaluation=None, evaluation_thermal=None,
                      table_name=None, zaids=None, nmix=None, **kwargs):
     """Generate thermal scattering ACE file from ENDF files
@@ -441,7 +441,7 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
         Temperatures in Kelvin to produce data at. If omitted, data is produced
         at all temperatures given in the ENDF thermal scattering sublibrary.
     ace : str, optional
-        Path of ACE file to write
+        Path of ACE file to write. Default to ``"ace"``.
     xsdir : str, optional
         Path of xsdir file to write. Defaults to ``"xsdir"`` in the same
         directory as ``ace``
@@ -589,30 +589,16 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
     commands += 'stop\n'
     run(commands, tapein, tapeout, **kwargs)
 
-    # Determine the path for the final ACE and xsdir files
-    # If 'ace' is an absolute path, use it directly
-    # If 'ace' is a relative path, place it in the current directory
-    if not os.path.isabs(ace):
-        ace = os.path.abspath(ace)
-
-    # Determine xsdir path similarly
-    if xsdir is None:
-        xsdir = os.path.join(os.path.dirname(ace), 'xsdir')
-    else:
-        if not os.path.isabs(xsdir):
-            xsdir = os.path.abspath(xsdir)
-            
+    ace = (output_dir / "ace") if ace is None else Path(ace)
     xsdir = (ace.parent / "xsdir") if xsdir is None else Path(xsdir)
-    with open(ace, 'w') as ace_file, open(xsdir, 'w') as xsdir_file:
+    with ace.open('w') as ace_file, xsdir.open('w') as xsdir_file:
         # Concatenate ACE and xsdir files together
         for temperature in temperatures:
-            ace_in = os.path.join(output_dir, f"ace_{temperature:.1f}")
-            with open(ace_in, 'r') as f:
-                ace_file.write(f.read())
+            ace_in = output_dir / f"ace_{temperature:.1f}"
+            ace_file.write(ace_in.read_text())
 
-            xsdir_in = os.path.join(output_dir, f"xsdir_{temperature:.1f}")
-            with open(xsdir_in, 'r') as f:
-                xsdir_file.write(f.read())
+            xsdir_in = output_dir / f"xsdir_{temperature:.1f}"
+            xsdir_file.write(xsdir_in.read_text())
 
     # Remove ACE/xsdir files for each temperature
     for temperature in temperatures:

--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -400,7 +400,7 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
     if acer:
         ace = (output_dir / "ace") if acer is True else Path(acer)
         xsdir = (ace.parent / "xsdir") if xsdir is None else xsdir
-        with ace.open('w') as ace_file, xsdir.open('w') as xsdir_file:
+        with open(ace, 'w') as ace_file, open(xsdir, 'w') as xsdir_file:
             for temperature in temperatures:
                 # Get contents of ACE file
                 text = (output_dir / f"ace_{temperature:.1f}").read_text()
@@ -589,16 +589,30 @@ def make_ace_thermal(filename, filename_thermal, temperatures=None,
     commands += 'stop\n'
     run(commands, tapein, tapeout, **kwargs)
 
-    ace = output_dir / ace
+    # Determine the path for the final ACE and xsdir files
+    # If 'ace' is an absolute path, use it directly
+    # If 'ace' is a relative path, place it in the current directory
+    if not os.path.isabs(ace):
+        ace = os.path.abspath(ace)
+
+    # Determine xsdir path similarly
+    if xsdir is None:
+        xsdir = os.path.join(os.path.dirname(ace), 'xsdir')
+    else:
+        if not os.path.isabs(xsdir):
+            xsdir = os.path.abspath(xsdir)
+            
     xsdir = (ace.parent / "xsdir") if xsdir is None else Path(xsdir)
-    with ace.open('w') as ace_file, xsdir.open('w') as xsdir_file:
+    with open(ace, 'w') as ace_file, open(xsdir, 'w') as xsdir_file:
         # Concatenate ACE and xsdir files together
         for temperature in temperatures:
-            ace_in = output_dir / f"ace_{temperature:.1f}"
-            ace_file.write(ace_in.read_text())
+            ace_in = os.path.join(output_dir, f"ace_{temperature:.1f}")
+            with open(ace_in, 'r') as f:
+                ace_file.write(f.read())
 
-            xsdir_in = output_dir / f"xsdir_{temperature:.1f}"
-            xsdir_file.write(xsdir_in.read_text())
+            xsdir_in = os.path.join(output_dir, f"xsdir_{temperature:.1f}")
+            with open(xsdir_in, 'r') as f:
+                xsdir_file.write(f.read())
 
     # Remove ACE/xsdir files for each temperature
     for temperature in temperatures:

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -839,13 +839,22 @@ class ThermalScattering(EqualityMixin):
         with tempfile.TemporaryDirectory() as tmpdir:
             # Run NJOY to create an ACE library
             kwargs.setdefault('output_dir', tmpdir)
-            kwargs.setdefault('ace', os.path.join(kwargs['output_dir'], 'ace'))
+
+            # Get the ace filename from kwargs or default to 'ace'
+            ace_filename = kwargs.get('ace', 'ace')
+            kwargs['ace'] = ace_filename
+
             kwargs['evaluation'] = evaluation
             kwargs['evaluation_thermal'] = evaluation_thermal
             make_ace_thermal(filename, filename_thermal, temperatures, **kwargs)
 
+            # Read the ACE file from the correct path
+            ace_path = kwargs['ace']
+            if not os.path.isabs(ace_path):
+                ace_path = os.path.abspath(ace_path)
+
+            lib = Library(ace_path)
             # Create instance from ACE tables within library
-            lib = Library(kwargs['ace'])
             name = kwargs.get('table_name')
             data = cls.from_ace(lib.tables[0], name=name)
             for table in lib.tables[1:]:
@@ -867,7 +876,6 @@ class ThermalScattering(EqualityMixin):
                         if isinstance(rx_endf.xs[t], (IncoherentElastic, Sum)):
                             rx.xs[t] = rx_endf.xs[t]
                             rx.distribution[t] = rx_endf.distribution[t]
-
         return data
 
     @classmethod

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -839,22 +839,13 @@ class ThermalScattering(EqualityMixin):
         with tempfile.TemporaryDirectory() as tmpdir:
             # Run NJOY to create an ACE library
             kwargs.setdefault('output_dir', tmpdir)
-
-            # Get the ace filename from kwargs or default to 'ace'
-            ace_filename = kwargs.get('ace', 'ace')
-            kwargs['ace'] = ace_filename
-
+            kwargs.setdefault('ace', os.path.join(kwargs['output_dir'], 'ace'))
             kwargs['evaluation'] = evaluation
             kwargs['evaluation_thermal'] = evaluation_thermal
             make_ace_thermal(filename, filename_thermal, temperatures, **kwargs)
 
-            # Read the ACE file from the correct path
-            ace_path = kwargs['ace']
-            if not os.path.isabs(ace_path):
-                ace_path = os.path.abspath(ace_path)
-
-            lib = Library(ace_path)
             # Create instance from ACE tables within library
+            lib = Library(kwargs['ace'])
             name = kwargs.get('table_name')
             data = cls.from_ace(lib.tables[0], name=name)
             for table in lib.tables[1:]:
@@ -876,6 +867,7 @@ class ThermalScattering(EqualityMixin):
                         if isinstance(rx_endf.xs[t], (IncoherentElastic, Sum)):
                             rx.xs[t] = rx_endf.xs[t]
                             rx.distribution[t] = rx_endf.distribution[t]
+
         return data
 
     @classmethod


### PR DESCRIPTION
# Description

**Description:** This PR fixes a bug in `openmc.data.ThermalScattering.from_njoy()` where the ACE file is written to a temporary `output_dir` but the function attempts to read it from the current working directory, causing a `FileNotFoundError`.


Fixes #3170 

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

