### PR TITLE
Update `fmt` Formatters for Compatibility with Versions below 11

### DIFF
--- a/include/openmc/output.h
+++ b/include/openmc/output.h
@@ -76,8 +76,11 @@ struct formatter<std::array<T, 2>> {
   }
 
   template<typename FormatContext>
-  auto format(const std::array<T, 2>& arr, FormatContext& ctx) const
-  {
+#if FMT_VERSION >= 110000  // Version 11.0.0 and above
+  auto format(const std::array<T, 2>& arr, FormatContext& ctx) const {
+#else  // For versions below 11.0.0
+  auto format(const std::array<T, 2>& arr, FormatContext& ctx) {
+#endif
     return format_to(ctx.out(), "({}, {})", arr[0], arr[1]);
   }
 };

--- a/include/openmc/output.h
+++ b/include/openmc/output.h
@@ -76,13 +76,14 @@ struct formatter<std::array<T, 2>> {
   }
 
   template<typename FormatContext>
-#if FMT_VERSION >= 110000  // Version 11.0.0 and above
+#if FMT_VERSION >= 110000 // Version 11.0.0 and above
   auto format(const std::array<T, 2>& arr, FormatContext& ctx) const {
-#else  // For versions below 11.0.0
-  auto format(const std::array<T, 2>& arr, FormatContext& ctx) {
+#else // For versions below 11.0.0
+  auto format(const std::array<T, 2>& arr, FormatContext& ctx)
+  {
 #endif
     return format_to(ctx.out(), "({}, {})", arr[0], arr[1]);
-  }
-};
+}
+}; // namespace fmt
 
 } // namespace fmt

--- a/include/openmc/position.h
+++ b/include/openmc/position.h
@@ -218,11 +218,14 @@ using Direction = Position;
 
 namespace fmt {
 
-template<>
+template <>
 struct formatter<openmc::Position> : formatter<std::string> {
-  template<typename FormatContext>
-  auto format(const openmc::Position& pos, FormatContext& ctx) const
-  {
+  template <typename FormatContext>
+#if FMT_VERSION >= 110000  // Version 11.0.0 and above
+  auto format(const openmc::Position& pos, FormatContext& ctx) const {
+#else  // For versions below 11.0.0
+  auto format(const openmc::Position& pos, FormatContext& ctx) {
+#endif
     return formatter<std::string>::format(
       fmt::format("({}, {}, {})", pos.x, pos.y, pos.z), ctx);
   }

--- a/include/openmc/position.h
+++ b/include/openmc/position.h
@@ -218,18 +218,19 @@ using Direction = Position;
 
 namespace fmt {
 
-template <>
+template<>
 struct formatter<openmc::Position> : formatter<std::string> {
-  template <typename FormatContext>
-#if FMT_VERSION >= 110000  // Version 11.0.0 and above
+  template<typename FormatContext>
+#if FMT_VERSION >= 110000 // Version 11.0.0 and above
   auto format(const openmc::Position& pos, FormatContext& ctx) const {
-#else  // For versions below 11.0.0
-  auto format(const openmc::Position& pos, FormatContext& ctx) {
+#else // For versions below 11.0.0
+  auto format(const openmc::Position& pos, FormatContext& ctx)
+  {
 #endif
     return formatter<std::string>::format(
       fmt::format("({}, {}, {})", pos.x, pos.y, pos.z), ctx);
-  }
-};
+}
+}; // namespace fmt
 
 } // namespace fmt
 


### PR DESCRIPTION
### Description
This PR updates the custom `fmt` formatters for `openmc::Position` and `std::array<T, 2>` to ensure compatibility with `fmt` library version below 11. The update uses preprocessor directives to conditionally define the `format` function as `const` for `fmt` versions 11.0.0 and above.

### Changes
- Updated `formatter<openmc::Position>`:
  - Added a conditional `const` qualifier to the `format` function based on `FMT_VERSION`.
- Updated `formatter<std::array<T, 2>>`:
  - Added a conditional `const` qualifier to the `format` function based on `FMT_VERSION`.