### PR TITLE
added subfolders when looking for dose coefficient txt files in Pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ include = ['openmc*', 'scripts*']
 exclude = ['tests*']
 
 [tool.setuptools.package-data]
-"openmc.data.effective_dose" = ["*.txt"]
+"openmc.data.effective_dose" = ["**/*.txt"]
 "openmc.data" = ["*.txt", "*.DAT", "*.json", "*.h5"]
 "openmc.lib" = ["libopenmc.dylib", "libopenmc.so"]
 


### PR DESCRIPTION
# Description

When doing ```pip install .``` within openmc the ```.txt``` files from the subfolders of the ```/home/jon/openmc/openmc/data/effective_dose/``` are not being copied over to the system install directory.

I noticed this as a [CI failure ](https://github.com/fusion-energy/neutronics-workshop/actions/runs/11392262095/job/31697927613)while updating my neutronics-workshop examples

I believe the reason we didn't catch it in openmc CI when PR #3020 was merged in is because we don't use the src folder layout so when we run pytest it imports the local openmc folder as the package and this folder includes all the txt files as mentioned in [this issue](https://github.com/openmc-dev/openmc/issues/1226)

Anyway it is a small fix to add ** so that the pyproject includes the subdirectories ```icrp116``` and ```icrp74``` and other future subdirectories

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
