### PR TITLE
enable polymorphisme for mix_materials

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1536,7 +1536,7 @@ class Material(IDManagerMixin):
         if name is None:
             name = '-'.join([f'{m.name}({f})' for m, f in
                              zip(materials, fracs)])
-        new_mat = openmc.Material(name=name)
+        new_mat = cls(name=name)
 
         # Compute atom fractions of nuclides and add them to the new material
         tot_nuclides_per_cc = np.sum([dens for dens in nuclides_per_cc.values()])


### PR DESCRIPTION
# Description

minor change to enable polymorphisme.

Fixes # (issue)
I have a class that inherits from openmc.Materials. In this class, I use the mix_material function to create a material, but this results in an openmc.Material instance. I want the created material to have access to the methods of my class instead of those of openmc.Material.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
