### PR TITLE
Enable adaptive mesh support on libMesh tallies

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -979,7 +979,7 @@ private:
   libMesh::dof_id_type
     first_element_id_; //!< id of the first element in the mesh
 
-  bool is_adaptive_ = false; //!< whether this mesh has adaptivity enabled or not
+  const bool adaptive_; //!< whether this mesh has adaptivity enabled or not
   std::vector<libMesh::dof_id_type>
     bin_to_elem_map_; //!< mapping bin indices to dof indices for active elements
   std::vector<int>

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -899,8 +899,7 @@ public:
   // Constructors
   LibMesh(pugi::xml_node node);
   LibMesh(const std::string& filename, double length_multiplier = 1.0);
-  LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier = 1.0,
-    bool build_eqn_sys = true);
+  LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier = 1.0);
 
   static const std::string mesh_lib_type;
 
@@ -949,6 +948,7 @@ public:
 private:
   void initialize() override;
   void set_mesh_pointer_from_filename(const std::string& filename);
+  void build_eqn_sys();
 
   // Methods
 
@@ -965,9 +965,7 @@ private:
   libMesh::MeshBase* m_; //!< pointer to libMesh MeshBase instance, always set
                          //!< during intialization
   vector<unique_ptr<libMesh::PointLocatorBase>>
-    pl_;                      //!< per-thread point locators
-  bool build_eqn_sys_ = true; //!< whether a libMesh equation system should be
-                              //!< built for output or not
+    pl_; //!< per-thread point locators
   unique_ptr<libMesh::EquationSystems> equation_systems_ =
     nullptr; //!< pointer to the libMesh EquationSystems
              //!< instance

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -982,7 +982,7 @@ private:
   bool is_adaptive_ = false; //!< whether this mesh has adaptivity enabled or not
   std::vector<libMesh::dof_id_type>
     bin_to_elem_map_; //!< mapping bin indices to dof indices for active elements
-  std::unordered_map<libMesh::dof_id_type, int>
+  std::vector<int>
     elem_to_bin_map_; //!< mapping dof indices to bin indices for active elements
 };
 

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -899,7 +899,7 @@ public:
   // Constructors
   LibMesh(pugi::xml_node node);
   LibMesh(const std::string& filename, double length_multiplier = 1.0);
-  LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier = 1.0);
+  LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier = 1.0, bool build_eqn_sys = true);
 
   static const std::string mesh_lib_type;
 
@@ -965,8 +965,11 @@ private:
                          //!< during intialization
   vector<unique_ptr<libMesh::PointLocatorBase>>
     pl_; //!< per-thread point locators
+  bool build_eqn_sys_ = true; //!< whether a libMesh equation system should be built
+                              //!< for output or not
   unique_ptr<libMesh::EquationSystems>
-    equation_systems_; //!< pointer to the equation systems of the mesh
+    equation_systems_ = nullptr; //!< pointer to the libMesh EquationSystems
+                                 //!< instance
   std::string
     eq_system_name_; //!< name of the equation system holding OpenMC results
   std::unordered_map<std::string, unsigned int>
@@ -975,6 +978,12 @@ private:
   libMesh::BoundingBox bbox_; //!< bounding box of the mesh
   libMesh::dof_id_type
     first_element_id_; //!< id of the first element in the mesh
+
+  bool is_adaptive_ = false; //!< whether this mesh has adaptivity enabled or not
+  std::vector<libMesh::dof_id_type>
+    bin_to_elem_map_; //!< mapping bin indices to dof indices for active elements
+  std::unordered_map<libMesh::dof_id_type, int>
+    elem_to_bin_map_; //!< mapping dof indices to bin indices for active elements
 };
 
 #endif

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -966,9 +966,9 @@ private:
                          //!< during intialization
   vector<unique_ptr<libMesh::PointLocatorBase>>
     pl_; //!< per-thread point locators
-  unique_ptr<libMesh::EquationSystems> equation_systems_ =
-    nullptr; //!< pointer to the libMesh EquationSystems
-             //!< instance
+  unique_ptr<libMesh::EquationSystems>
+    equation_systems_; //!< pointer to the libMesh EquationSystems
+                       //!< instance
   std::string
     eq_system_name_; //!< name of the equation system holding OpenMC results
   std::unordered_map<std::string, unsigned int>

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -899,7 +899,8 @@ public:
   // Constructors
   LibMesh(pugi::xml_node node);
   LibMesh(const std::string& filename, double length_multiplier = 1.0);
-  LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier = 1.0, bool build_eqn_sys = true);
+  LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier = 1.0,
+    bool build_eqn_sys = true);
 
   static const std::string mesh_lib_type;
 
@@ -964,12 +965,12 @@ private:
   libMesh::MeshBase* m_; //!< pointer to libMesh MeshBase instance, always set
                          //!< during intialization
   vector<unique_ptr<libMesh::PointLocatorBase>>
-    pl_; //!< per-thread point locators
-  bool build_eqn_sys_ = true; //!< whether a libMesh equation system should be built
-                              //!< for output or not
-  unique_ptr<libMesh::EquationSystems>
-    equation_systems_ = nullptr; //!< pointer to the libMesh EquationSystems
-                                 //!< instance
+    pl_;                      //!< per-thread point locators
+  bool build_eqn_sys_ = true; //!< whether a libMesh equation system should be
+                              //!< built for output or not
+  unique_ptr<libMesh::EquationSystems> equation_systems_ =
+    nullptr; //!< pointer to the libMesh EquationSystems
+             //!< instance
   std::string
     eq_system_name_; //!< name of the equation system holding OpenMC results
   std::unordered_map<std::string, unsigned int>
@@ -981,9 +982,10 @@ private:
 
   const bool adaptive_; //!< whether this mesh has adaptivity enabled or not
   std::vector<libMesh::dof_id_type>
-    bin_to_elem_map_; //!< mapping bin indices to dof indices for active elements
-  std::vector<int>
-    elem_to_bin_map_; //!< mapping dof indices to bin indices for active elements
+    bin_to_elem_map_; //!< mapping bin indices to dof indices for active
+                      //!< elements
+  std::vector<int> elem_to_bin_map_; //!< mapping dof indices to bin indices for
+                                     //!< active elements
 };
 
 #endif

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3099,9 +3099,11 @@ int LibMesh::n_surface_bins() const
 void LibMesh::add_score(const std::string& var_name)
 {
   if (adaptive_) {
-    fatal_error(fmt::format(
+    warning(fmt::format(
       "Exodus output cannot be provided as unstructured mesh {} is adaptive.",
       this->id_));
+
+    return;
   }
 
   if (!equation_systems_) {
@@ -3140,9 +3142,11 @@ void LibMesh::set_score_data(const std::string& var_name,
   const vector<double>& values, const vector<double>& std_dev)
 {
   if (adaptive_) {
-    fatal_error(fmt::format(
+    warning(fmt::format(
       "Exodus output cannot be provided as unstructured mesh {} is adaptive.",
       this->id_));
+
+    return;
   }
 
   if (!equation_systems_) {
@@ -3189,9 +3193,11 @@ void LibMesh::set_score_data(const std::string& var_name,
 void LibMesh::write(const std::string& filename) const
 {
   if (adaptive_) {
-    fatal_error(fmt::format(
+    warning(fmt::format(
       "Exodus output cannot be provided as unstructured mesh {} is adaptive.",
       this->id_));
+
+    return;
   }
 
   write_message(fmt::format(

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3007,8 +3007,9 @@ void LibMesh::initialize()
   if (m_->n_active_elem() != m_->n_elem()) {
     is_adaptive_ = true;
     bin_to_elem_map_.reserve(m_->n_active_local_elem());
+    elem_to_bin_map_.resize(m_->n_local_elem(), 0);
     for (auto it = m_->local_elements_begin(); it != m_->local_elements_end();
-       it++) {
+         it++) {
       auto elem = *it;
 
       if (!elem->active()) {
@@ -3016,7 +3017,7 @@ void LibMesh::initialize()
       }
 
       bin_to_elem_map_.push_back(elem->id());
-      elem_to_bin_map_.emplace(elem->id(), bin_to_elem_map_.size() - 1);
+      elem_to_bin_map_[elem->id()] = bin_to_elem_map_.size() - 1;
     }
   }
 
@@ -3211,7 +3212,9 @@ int LibMesh::get_bin(Position r) const
 
 int LibMesh::get_bin_from_element(const libMesh::Elem* elem) const
 {
-  int bin = is_adaptive_ ? elem_to_bin_map_.at(elem->id()) : elem->id() - first_element_id_;
+  // TODO: figure out how to get rid of the vector lookup to improve performance
+  // when tallying on adaptive LibMeshes.
+  int bin = is_adaptive_ ? elem_to_bin_map_[elem->id()] : elem->id() - first_element_id_;
   if (bin >= n_bins() || bin < 0) {
     fatal_error(fmt::format("Invalid bin: {}", bin));
   }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3008,7 +3008,7 @@ void LibMesh::initialize()
   // active elements) to global dof ids
   if (adaptive_) {
     bin_to_elem_map_.reserve(m_->n_active_local_elem());
-    elem_to_bin_map_.resize(m_->n_local_elem(), 0);
+    elem_to_bin_map_.resize(m_->n_local_elem(), -1);
     for (auto it = m_->active_local_elements_begin();
          it != m_->active_local_elements_end(); it++) {
       auto elem = *it;

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3145,6 +3145,10 @@ void LibMesh::set_score_data(const std::string& var_name,
       this->id_));
   }
 
+  if (!equation_systems_) {
+    build_eqn_sys();
+  }
+
   auto& eqn_sys = equation_systems_->get_system(eq_system_name_);
 
   if (!eqn_sys.is_initialized()) {

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3004,7 +3004,7 @@ void LibMesh::initialize()
   first_element_id_ = first_elem->id();
 
   // if the mesh is adaptive elements aren't guaranteed by libMesh to be
-  // contiguous in memory, so we need to map from bin indices (defined over
+  // contiguous in ID space, so we need to map from bin indices (defined over
   // active elements) to global dof ids
   if (adaptive_) {
     bin_to_elem_map_.reserve(m_->n_active_local_elem());


### PR DESCRIPTION
# Description

This PR allows for the use of adaptive meshes (which have an adaptive mesh refinement hierarchy) in unstructured mesh tallies which use a `LibMesh`. Adaptive meshes (unlike libMesh meshes which set `allow_renumbering = false`) do not guarantee that active elements (which we want to tally on) are contiguous in memory relative to their DoF ids, which results in errors when OpenMC computes bin indices as bin are defined over `[0, num_active_elem]`. This results in scrambled tallies for libMesh meshes which have an adaptivity hierarchy. An additional issue is that the `libMesh::EquationSystems` object added by OpenMC to enable `LibMesh` exodus output reacts poorly to adaptive meshes, throwing errors when the mesh is refined/coarsened or dumped to exodus after an OpenMC solve. 

To fix the first issue, an indirection layer is added which maps between element DoF ids and bin indices. This is generated when `LibMesh` is initialized based on a constant adaptivity flag (`adaptive_`). The indirection layer is used in `get_bin_from_element(...)` and `get_element_from_bin(...)` only when `adaptive_ = true`. This should result in no performance changes for existing users that use libMesh-based tallies without adaptivity, though it does result in a small (but noticeable) decrease in tally performance on adaptive libMesh meshes compared to creating a deep copy of the mesh which only contains active elements (due to cache misses).

The second issue is resolved by constructing and setting up the `libMesh::EquationSystems` class in `LibMesh::add_score(...)` if it hasn't been initialized.

I've tested these changes in Cardinal to make sure adaptive mesh tallies work, and the results generated are equivalent to the previous approach we took. Regression tests for libMesh tallies also pass on my machine, so OpenMC users should be unaffected by this fix for adaptive meshes.

Closes #3182 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~