### PR TITLE
Reset values of lattice offset tables when allocated

### DIFF
--- a/include/openmc/lattice.h
+++ b/include/openmc/lattice.h
@@ -71,7 +71,8 @@ public:
   //! Allocate offset table for distribcell.
   void allocate_offset_table(int n_maps)
   {
-    offsets_.resize(n_maps * universes_.size(), C_NONE);
+    offsets_.resize(n_maps * universes_.size());
+    std::fill(offsets_.begin(), offsets_.end(), C_NONE);
   }
 
   //! Populate the distribcell offset tables.


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Fill lattice offset table with `C_NONE` when allocating/reallocating.

I haven't added tests here, but I can look into it if requested. It would likely involve adding something to the C++ test suite.

Fixes #3187 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
