### PR TITLE
Fixes in MicroXS.from_multigroup_flux

### DIFF
--- a/openmc/deplete/independent_operator.py
+++ b/openmc/deplete/independent_operator.py
@@ -44,7 +44,7 @@ class IndependentOperator(OpenMCOperator):
 
     Parameters
     ----------
-    materials : openmc.Materials
+    materials : iterable of openmc.Material
         Materials to deplete.
     fluxes : list of numpy.ndarray
         Flux in each group in [n-cm/src] for each domain
@@ -127,8 +127,9 @@ class IndependentOperator(OpenMCOperator):
                  reduce_chain_level=None,
                  fission_yield_opts=None):
         # Validate micro-xs parameters
-        check_type('materials', materials, openmc.Materials)
+        check_type('materials', materials, Iterable, openmc.Material)
         check_type('micros', micros, Iterable, MicroXS)
+        materials = openmc.Materials(materials)
 
         if not (len(fluxes) == len(micros) == len(materials)):
             msg = (f'The length of fluxes ({len(fluxes)}) should be equal to '

--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -198,6 +198,8 @@ class MicroXS:
     """
     def __init__(self, data: np.ndarray, nuclides: list[str], reactions: list[str]):
         # Validate inputs
+        if len(data.shape) != 3:
+            raise ValueError('Data array must be 3D.')
         if data.shape[:2] != (len(nuclides), len(reactions)):
             raise ValueError(
                 f'Nuclides list of length {len(nuclides)} and '
@@ -291,11 +293,11 @@ class MicroXS:
         mts = [REACTION_MT[name] for name in reactions]
 
         # Normalize multigroup flux
-        multigroup_flux = np.asarray(multigroup_flux)
+        multigroup_flux = np.array(multigroup_flux)
         multigroup_flux /= multigroup_flux.sum()
 
-        # Create 2D array for microscopic cross sections
-        microxs_arr = np.zeros((len(nuclides), len(mts)))
+        # Create 3D array for microscopic cross sections
+        microxs_arr = np.zeros((len(nuclides), len(mts), 1))
 
         # Create a material with all nuclides
         mat_all_nucs = openmc.Material()
@@ -327,7 +329,7 @@ class MicroXS:
                         xs = lib_nuc.collapse_rate(
                             mt, temperature, energies, multigroup_flux
                         )
-                        microxs_arr[nuc_index, mt_index] = xs
+                        microxs_arr[nuc_index, mt_index, 0] = xs
 
         return cls(microxs_arr, nuclides, reactions)
 

--- a/tests/unit_tests/test_deplete_decay.py
+++ b/tests/unit_tests/test_deplete_decay.py
@@ -20,7 +20,7 @@ def test_deplete_decay_products(run_in_tmpdir):
         """)
 
     # Create MicroXS object with no cross sections
-    micro_xs = openmc.deplete.MicroXS(np.empty((0, 0)), [], [])
+    micro_xs = openmc.deplete.MicroXS(np.empty((0, 0, 0)), [], [])
 
     # Create depletion operator with no reactions
     op = openmc.deplete.IndependentOperator.from_nuclides(
@@ -59,7 +59,7 @@ def test_deplete_decay_step_fissionable(run_in_tmpdir):
     """
 
     # Set up a pure decay operator
-    micro_xs = openmc.deplete.MicroXS(np.empty((0, 0)), [], [])
+    micro_xs = openmc.deplete.MicroXS(np.empty((0, 0, 0)), [], [])
     mat = openmc.Material()
     mat.name = 'I do not decay.'
     mat.add_nuclide('U238', 1.0, 'ao')

--- a/tests/unit_tests/test_deplete_independent_operator.py
+++ b/tests/unit_tests/test_deplete_independent_operator.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from openmc import Material, Materials
+from openmc import Material
 from openmc.deplete import IndependentOperator, MicroXS
 
 CHAIN_PATH = Path(__file__).parents[1] / "chain_simple.xml"
@@ -34,7 +34,7 @@ def test_operator_init():
     fuel.set_density("g/cc", 10.4)
     fuel.depletable = True
     fuel.volume = 1
-    materials = Materials([fuel])
+    materials = [fuel]
     fluxes = [1.0]
     micros = [micro_xs]
     IndependentOperator(materials, fluxes, micros, CHAIN_PATH)
@@ -47,7 +47,7 @@ def test_error_handling():
     fuel.set_density("g/cc", 1)
     fuel.depletable = True
     fuel.volume = 1
-    materials = Materials([fuel])
+    materials = [fuel]
     fluxes = [1.0, 2.0]
     micros = [micro_xs]
     with pytest.raises(ValueError, match=r"The length of fluxes \(2\)"):

--- a/tests/unit_tests/test_deplete_microxs.py
+++ b/tests/unit_tests/test_deplete_microxs.py
@@ -96,8 +96,12 @@ def test_multigroup_flux_same():
     energies = [0., 6.25e-1, 5.53e3, 8.21e5, 2.e7]
     flux_per_ev = [0.3, 0.3, 1.0, 1.0]
     flux = flux_per_ev * np.diff(energies)
+    flux_sum = flux.sum()
     microxs_4g = MicroXS.from_multigroup_flux(
         energies=energies, multigroup_flux=flux, chain_file=chain_file)
+
+    # from_multigroup_flux should not modify the flux
+    assert flux.sum() == flux_sum
 
     # Generate micro XS based on 2-group flux, where the boundaries line up with
     # the 4 group flux and have the same flux per eV across the full energy

--- a/tests/unit_tests/test_deplete_microxs.py
+++ b/tests/unit_tests/test_deplete_microxs.py
@@ -46,9 +46,7 @@ def test_from_array():
     data.shape = (12, 2, 1)
 
     MicroXS(data, nuclides, reactions)
-    with pytest.raises(ValueError, match=r'Nuclides list of length \d* and '
-                       r'reactions array of length \d* do not '
-                       r'match dimensions of data array of shape \(\d*\, \d*\)'):
+    with pytest.raises(ValueError, match='Data array must be 3D'):
         MicroXS(data[:, 0], nuclides, reactions)
 
 


### PR DESCRIPTION
# Description

This PR fixes two issues in `MicroXS.from_multigroup_flux`. First, as described in #3121, when a `MicroXS` object is created using this classmethod, it cannot be written to csv, This was found to be due to the fact that it was creating a 2D array with shape (nuclides, reactions) instead of a 3D array with shape (nuclides, reactions, group) as it should have been. The other issue I observed is that this method modifies the value of `multigroup_flux` that is passed in, which can be undesirable for the user.

One other small fix in here is for the `IndependentOperator` class, which now accepts a normal list of materials (before you had to pass an instance of `openmc.Materials`).

Fixes #3121

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)