### PR TITLE
Fetch DAGMC if not found in cmakelists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ option(OPENMC_USE_OPENMP      "Enable shared-memory parallelism with OpenMP"    
 option(OPENMC_BUILD_TESTS     "Build tests"                                          ON)
 option(OPENMC_ENABLE_PROFILE  "Compile with profiling flags"                         OFF)
 option(OPENMC_ENABLE_COVERAGE "Compile with coverage analysis flags"                 OFF)
-option(OPENMC_USE_DAGMC       "Enable support for DAGMC (CAD) geometry"              ON)
+option(OPENMC_USE_DAGMC       "Enable support for DAGMC (CAD) geometry"              OFF)
 option(OPENMC_USE_LIBMESH     "Enable support for libMesh unstructured mesh tallies" OFF)
 option(OPENMC_USE_MPI         "Enable MPI"                                           OFF)
 option(OPENMC_USE_MCPL        "Enable MCPL"                                          OFF)


### PR DESCRIPTION
# Description

Marked as draft as this PR is mainly to check with @gonuke and @pshriwise if they would be keen on something like this?

Many other packages are included via submodule and they get smoothly installed during the compile so I was looking for ways of making the DAGMC install a bit smoother for users

I was just wondering if it is worth making the inclusion of DAGMC when compiling a little easier by automatically fetching the repo if it is requested and not found locally.

Changes like this to the cmakelists file could allow users to compile with dagmc like this

cmake .. -DOPENMC_USE_DAGMC=ON

This would provide a different route instead of cloning dagmc, compiling dagmc, cloning moab, compiling moab, passing directories to each cmake command etc.

ps this would need a small change in dagmc to fetch moab for this to work and changes in moab to make the repo more compatible with the fetch content. [This](https://bitbucket.org/fathomteam/moab/issues/185/request-for-moab-compatible-with) issue is related 

Fixes # (issue)

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
