### PR TITLE
Fix docstring for Model.plot

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -820,14 +820,14 @@ class Model:
 
         Parameters
         ----------
-        n_samples : dict
+        n_samples : int, optional
             The number of source particles to sample and add to plot. Defaults
             to None which doesn't plot any particles on the plot.
         plane_tolerance: float
             When plotting a plane the source locations within the plane +/-
             the plane_tolerance will be included and those outside of the
             plane_tolerance will not be shown
-        source_kwargs : dict
+        source_kwargs : dict, optional
             Keyword arguments passed to :func:`matplotlib.pyplot.scatter`.
         **kwargs
             Keyword arguments passed to :func:`openmc.Universe.plot`


### PR DESCRIPTION
# Description

Simple fix for a docstring I noticed was wrong.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>