### PR TITLE
Apply weight windows at collisions in multigroup transport mode.

### DIFF
--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -19,6 +19,7 @@
 #include "openmc/settings.h"
 #include "openmc/simulation.h"
 #include "openmc/tallies/tally.h"
+#include "openmc/weight_windows.h"
 
 namespace openmc {
 
@@ -26,6 +27,9 @@ void collision_mg(Particle& p)
 {
   // Add to the collision counter for the particle
   p.n_collision()++;
+
+  if (settings::weight_window_checkpoint_collision)
+    apply_weight_windows(p);
 
   // Sample the reaction type
   sample_reaction(p);


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

The `apply_weight_windows` check is not being invoked for collisions in multigroup transport. This small PR fixes that.

Thanks for revealing this @jtramm!

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
