### PR TITLE
Fix bin index to DoF ID mapping bug in adaptive libMesh meshes

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3009,8 +3009,8 @@ void LibMesh::initialize()
   if (adaptive_) {
     bin_to_elem_map_.reserve(m_->n_active_elem());
     elem_to_bin_map_.resize(m_->n_elem(), -1);
-    for (auto it = m_->active_elements_begin();
-         it != m_->active_elements_end(); it++) {
+    for (auto it = m_->active_elements_begin(); it != m_->active_elements_end();
+         it++) {
       auto elem = *it;
 
       bin_to_elem_map_.push_back(elem->id());

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3007,10 +3007,10 @@ void LibMesh::initialize()
   // contiguous in ID space, so we need to map from bin indices (defined over
   // active elements) to global dof ids
   if (adaptive_) {
-    bin_to_elem_map_.reserve(m_->n_active_local_elem());
-    elem_to_bin_map_.resize(m_->n_local_elem(), -1);
-    for (auto it = m_->active_local_elements_begin();
-         it != m_->active_local_elements_end(); it++) {
+    bin_to_elem_map_.reserve(m_->n_active_elem());
+    elem_to_bin_map_.resize(m_->n_elem(), -1);
+    for (auto it = m_->active_elements_begin();
+         it != m_->active_elements_end(); it++) {
       auto elem = *it;
 
       bin_to_elem_map_.push_back(elem->id());


### PR DESCRIPTION
# Description

#3185 added support for adaptive mesh-based libMesh tallies in applications that use OpenMC's C/C++ API, which was enabled by a bin index to element DoF ID map (and it's corresponding inverse map). These maps are generated by looping over all local active elements, which works fine when running with OpenMP. When running with MPI libMesh "assigns" elements to each processor, and sets up local element iterators to only loop over those assigned elements. This results in a partial map for bin indices to DoF IDs being generated. Unfortunately, I only tested #3185 in serial and with shared memory parallelism which allowed this bug to slip through the cracks.

This PR fixes this bug by using the non-local element iterators / number of elements.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
