### PR TITLE
Ensure libMesh::ReplicatedMesh is used for LibMesh tallies

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2935,6 +2935,11 @@ LibMesh::LibMesh(pugi::xml_node node) : UnstructuredMesh(node), adaptive_(false)
 LibMesh::LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier)
   : adaptive_(input_mesh.n_active_elem() != input_mesh.n_elem())
 {
+  if (!dynamic_cast<libMesh::ReplicatedMesh*>(&input_mesh)) {
+    fatal_error("At present LibMesh tallies require a replicated mesh. Please "
+                "ensure 'input_mesh' is a libMesh::ReplicatedMesh.");
+  }
+
   m_ = &input_mesh;
   set_length_multiplier(length_multiplier);
   initialize();
@@ -2952,7 +2957,8 @@ LibMesh::LibMesh(const std::string& filename, double length_multiplier)
 void LibMesh::set_mesh_pointer_from_filename(const std::string& filename)
 {
   filename_ = filename;
-  unique_m_ = make_unique<libMesh::Mesh>(*settings::libmesh_comm, n_dimension_);
+  unique_m_ =
+    make_unique<libMesh::ReplicatedMesh>(*settings::libmesh_comm, n_dimension_);
   m_ = unique_m_.get();
   m_->read(filename_);
 }


### PR DESCRIPTION
# Description

This PR implements a quick check in `LibMesh::LibMesh(libMesh::MeshBase& input_mesh ...)` to ensure that the `input_mesh` points to a `libMesh::ReplicatedMesh` instance, alongside explicitly instantiating a `libMesh::ReplicatedMesh` in `LibMesh::set_mesh_pointer_from_filename(...)` (suggested by @pshriwise while discussing #3206). This enforces the currently assumed behaviour that the entire mesh exists on all MPI ranks.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
