### PR TITLE
Add unstructured mesh file suffix to docstring

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -2072,8 +2072,9 @@ class UnstructuredMesh(MeshBase):
     Parameters
     ----------
     filename : path-like
-        Location of the unstructured mesh file. Supported files for 'moab' library are
-        .h5 and .vtk. Supported files for 'libmesh' library are exodus mesh files .exo.
+        Location of the unstructured mesh file. Supported files for 'moab'
+        library are .h5 and .vtk. Supported files for 'libmesh' library are
+        exodus mesh files .exo.
     library : {'moab', 'libmesh'}
         Mesh library used for the unstructured mesh tally
     mesh_id : int

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -2072,7 +2072,8 @@ class UnstructuredMesh(MeshBase):
     Parameters
     ----------
     filename : path-like
-        Location of the unstructured mesh file
+        Location of the unstructured mesh file. Supported files for 'moab' library are
+        .h5 and .vtk. Supported files for 'libmesh' library are exodus mesh files .exo.
     library : {'moab', 'libmesh'}
         Mesh library used for the unstructured mesh tally
     mesh_id : int


### PR DESCRIPTION
# Description

As discovered in #3210 the ```openmc.UnstructuredMesh``` accepts vtk, h5 and exo files depending on which library is selected. This PR adds to the doc string to make the file type / extention clearer

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)