### PR TITLE
Adjust for secondary particle energy directly in heating scores

### DIFF
--- a/include/openmc/particle.h
+++ b/include/openmc/particle.h
@@ -50,10 +50,14 @@ public:
   //! \param wgt Weight of the secondary particle
   //! \param u Direction of the secondary particle
   //! \param E Energy of the secondary particle in [eV]
-  //! \param accumulate_E Whether to accumulate the energy of the secondary
-  //!        for adjustment to heating tallies
   //! \param type Particle type
-  void create_secondary(double wgt, Direction u, double E, ParticleType type, bool accumulate_E = true);
+  void create_secondary(double wgt, Direction u, double E, ParticleType type);
+
+  //! split a particle
+  //
+  //! creates a new particle with weight wgt
+  //! \param wgt Weight of the new particle
+  void split(double wgt);
 
   //! initialize from a source site
   //

--- a/include/openmc/particle.h
+++ b/include/openmc/particle.h
@@ -50,8 +50,10 @@ public:
   //! \param wgt Weight of the secondary particle
   //! \param u Direction of the secondary particle
   //! \param E Energy of the secondary particle in [eV]
+  //! \param accumulate_E Whether to accumulate the energy of the secondary
+  //!        for adjustment to heating tallies
   //! \param type Particle type
-  void create_secondary(double wgt, Direction u, double E, ParticleType type);
+  void create_secondary(double wgt, Direction u, double E, ParticleType type, bool accumulate_E = true);
 
   //! initialize from a source site
   //

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -418,7 +418,7 @@ private:
   int delayed_group_ {0};
 
   int n_bank_ {0};
-  int n_bank_second_ {0};
+  double bank_second_E_ {0.0};
   double wgt_bank_ {0.0};
   int n_delayed_bank_[MAX_DELAYED_GROUPS];
 
@@ -532,11 +532,10 @@ public:
   int& delayed_group() { return delayed_group_; } // delayed group
 
   // Post-collision data
+  double& bank_second_E() { return bank_second_E_; } // energy of last reaction secondaries
+  const double& bank_second_E() const { return bank_second_E_; }
+
   int& n_bank() { return n_bank_; } // number of banked fission sites
-  int& n_bank_second()
-  {
-    return n_bank_second_;
-  }                                        // number of secondaries banked
   double& wgt_bank() { return wgt_bank_; } // weight of banked fission sites
   int* n_delayed_bank()
   {

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -532,10 +532,13 @@ public:
   int& delayed_group() { return delayed_group_; } // delayed group
 
   // Post-collision data
-  double& bank_second_E() { return bank_second_E_; } // energy of last reaction secondaries
+  double& bank_second_E()
+  {
+    return bank_second_E_;
+  } // energy of last reaction secondaries
   const double& bank_second_E() const { return bank_second_E_; }
 
-  int& n_bank() { return n_bank_; } // number of banked fission sites
+  int& n_bank() { return n_bank_; }        // number of banked fission sites
   double& wgt_bank() { return wgt_bank_; } // weight of banked fission sites
   int* n_delayed_bank()
   {

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -101,7 +101,7 @@ void Particle::create_secondary(
   bank.E = settings::run_CE ? E : g();
   bank.time = time();
 
-  n_bank_second() += 1;
+  bank_second_E() += bank.E;
 }
 
 void Particle::from_source(const SourceSite* src)
@@ -356,7 +356,7 @@ void Particle::event_collide()
 
   // Reset banked weight during collision
   n_bank() = 0;
-  n_bank_second() = 0;
+  bank_second_E() = 0.0;
   wgt_bank() = 0.0;
   zero_delayed_bank();
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -83,7 +83,7 @@ void Particle::move_distance(double length)
 }
 
 void Particle::create_secondary(
-  double wgt, Direction u, double E, ParticleType type, bool accumulate_E)
+  double wgt, Direction u, double E, ParticleType type)
 {
   // If energy is below cutoff for this particle, don't create secondary
   // particle
@@ -100,9 +100,18 @@ void Particle::create_secondary(
   bank.u = u;
   bank.E = settings::run_CE ? E : g();
   bank.time = time();
+  bank_second_E() += bank.E;
+}
 
-  if (accumulate_E)
-    bank_second_E() += bank.E;
+void Particle::split(double wgt) {
+  secondary_bank().emplace_back();
+  auto& bank {secondary_bank().back()};
+  bank.particle = type();
+  bank.wgt = wgt;
+  bank.r = r();
+  bank.u = u();
+  bank.E = settings::run_CE ? E() : g();
+  bank.time = time();
 }
 
 void Particle::from_source(const SourceSite* src)

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -91,9 +91,7 @@ void Particle::create_secondary(
     return;
   }
 
-  secondary_bank().emplace_back();
-
-  auto& bank {secondary_bank().back()};
+  auto& bank = secondary_bank().emplace_back();
   bank.particle = type;
   bank.wgt = wgt;
   bank.r = r();
@@ -105,8 +103,7 @@ void Particle::create_secondary(
 
 void Particle::split(double wgt)
 {
-  secondary_bank().emplace_back();
-  auto& bank {secondary_bank().back()};
+  auto& bank = secondary_bank().emplace_back();
   bank.particle = type();
   bank.wgt = wgt;
   bank.r = r();

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -103,7 +103,8 @@ void Particle::create_secondary(
   bank_second_E() += bank.E;
 }
 
-void Particle::split(double wgt) {
+void Particle::split(double wgt)
+{
   secondary_bank().emplace_back();
   auto& bank {secondary_bank().back()};
   bank.particle = type();

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -83,7 +83,7 @@ void Particle::move_distance(double length)
 }
 
 void Particle::create_secondary(
-  double wgt, Direction u, double E, ParticleType type)
+  double wgt, Direction u, double E, ParticleType type, bool accumulate_E)
 {
   // If energy is below cutoff for this particle, don't create secondary
   // particle
@@ -101,7 +101,8 @@ void Particle::create_secondary(
   bank.E = settings::run_CE ? E : g();
   bank.time = time();
 
-  bank_second_E() += bank.E;
+  if (accumulate_E)
+    bank_second_E() += bank.E;
 }
 
 void Particle::from_source(const SourceSite* src)

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -417,6 +417,7 @@ void Particle::event_revive_from_secondary()
     from_source(&secondary_bank().back());
     secondary_bank().pop_back();
     n_event() = 0;
+    bank_second_E() = 0.0;
 
     // Subtract secondary particle energy from interim pulse-height results
     if (!model::active_pulse_height_tallies.empty() &&

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -239,11 +239,10 @@ void create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx)
     }
 
     // Write fission particles to nuBank
-    p.nu_bank().emplace_back();
-    NuBank* nu_bank_entry = &p.nu_bank().back();
-    nu_bank_entry->wgt = site.wgt;
-    nu_bank_entry->E = site.E;
-    nu_bank_entry->delayed_group = site.delayed_group;
+    NuBank& nu_bank_entry = p.nu_bank().emplace_back();
+    nu_bank_entry.wgt = site.wgt;
+    nu_bank_entry.E = site.E;
+    nu_bank_entry.delayed_group = site.delayed_group;
   }
 
   // If shared fission bank was full, and no fissions could be added,

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -188,11 +188,10 @@ void create_fission_sites(Particle& p)
     }
 
     // Write fission particles to nuBank
-    p.nu_bank().emplace_back();
-    NuBank* nu_bank_entry = &p.nu_bank().back();
-    nu_bank_entry->wgt = site.wgt;
-    nu_bank_entry->E = site.E;
-    nu_bank_entry->delayed_group = site.delayed_group;
+    NuBank& nu_bank_entry = p.nu_bank().emplace_back();
+    nu_bank_entry.wgt = site.wgt;
+    nu_bank_entry.E = site.E;
+    nu_bank_entry.delayed_group = site.delayed_group;
   }
 
   // If shared fission bank was full, and no fissions could be added,

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -964,14 +964,9 @@ void score_general_ce_nonanalog(Particle& p, int i_tally, int start_index,
           // The energy deposited is the difference between the pre-collision
           // and post-collision energy...
           score = E - p.E();
-
           // ...less the energy of any secondary particles since they will be
           // transported individually later
-          const auto& bank = p.secondary_bank();
-          for (auto it = bank.end() - p.n_bank_second(); it < bank.end();
-               ++it) {
-            score -= it->E;
-          }
+          score -= p.bank_second_E();
 
           score *= p.wgt_last();
         } else {
@@ -1500,13 +1495,9 @@ void score_general_ce_analog(Particle& p, int i_tally, int start_index,
         // The energy deposited is the difference between the pre-collision and
         // post-collision energy...
         score = E - p.E();
-
         // ...less the energy of any secondary particles since they will be
         // transported individually later
-        const auto& bank = p.secondary_bank();
-        for (auto it = bank.end() - p.n_bank_second(); it < bank.end(); ++it) {
-          score -= it->E;
-        }
+        score -= p.bank_second_E();
 
         score *= p.wgt_last();
       }

--- a/src/track_output.cpp
+++ b/src/track_output.cpp
@@ -31,8 +31,8 @@ int n_tracks_written; //! Number of tracks written
 
 void add_particle_track(Particle& p)
 {
-  p.tracks().emplace_back();
-  p.tracks().back().particle = p.type();
+  auto& track = p.tracks().emplace_back();
+  track.particle = p.type();
 }
 
 void write_particle_track(Particle& p)

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -114,7 +114,7 @@ void apply_weight_windows(Particle& p)
     // Create secondaries and divide weight among all particles
     int i_split = std::round(n_split);
     for (int l = 0; l < i_split - 1; l++) {
-      p.create_secondary(weight / n_split, p.u(), p.E(), p.type());
+      p.create_secondary(weight / n_split, p.u(), p.E(), p.type(), false);
     }
     // remaining weight is applied to current particle
     p.wgt() = weight / n_split;

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -114,7 +114,7 @@ void apply_weight_windows(Particle& p)
     // Create secondaries and divide weight among all particles
     int i_split = std::round(n_split);
     for (int l = 0; l < i_split - 1; l++) {
-      p.create_secondary(weight / n_split, p.u(), p.E(), p.type(), false);
+      p.split(weight / n_split);
     }
     // remaining weight is applied to current particle
     p.wgt() = weight / n_split;


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This addresses #3207 by adjusting heating scores using the sum of secondary particle energy rather than a placeholder for how many secondaries were produced by the latest reaction. Namely, the attribute `Particle::n_bank_secondary_` is replaced with `Particle::bank_second_E_` to track how much heating scores should be decremented when secondary particles are generated and will be transported independently.

This also contains a fix for a pathway by which particles were revived from particles in the secondary bank but the original attribute was not reset correctly. This line has been added in `Particle::event_revive_from_secondary`.

The previous method was more general and I think we should keep it in mind for the future if other/additional information needs to be gathered from the latest secondaries, but updating to this method will avoid the problems we're seeing evidence of when photon transport is enabled with weight windows applied.

Fixes #3207 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] ~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~
- [ ] ~I have made corresponding changes to the documentation (if applicable)~
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
