### PR TITLE
Correct normalization of thermal elastic in non standard ENDF-6 files

### DIFF
--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -804,7 +804,7 @@ class ThermalScattering(EqualityMixin):
     @classmethod
     def from_njoy(cls, filename, filename_thermal, temperatures=None,
                   evaluation=None, evaluation_thermal=None,
-                  use_endf_data=True, **kwargs):
+                  use_endf_data=True, nonstandard_endf=True, **kwargs):
         """Generate thermal scattering data by running NJOY.
 
         Parameters
@@ -827,6 +827,10 @@ class ThermalScattering(EqualityMixin):
         use_endf_data : bool
             If the material has incoherent elastic scattering, the ENDF data
             will be used rather than the ACE data.
+        nonstandard_endf: bool
+            Divide incoherent elastic cross section by
+            number of principal atoms. This is not part of the ENDF-6
+            standard but it is how it is processed by NJOY.
         **kwargs
             Keyword arguments passed to :func:`openmc.data.njoy.make_ace_thermal`
 
@@ -853,7 +857,7 @@ class ThermalScattering(EqualityMixin):
 
             # Load ENDF data to replace incoherent elastic
             if use_endf_data:
-                data_endf = cls.from_endf(filename_thermal)
+                data_endf = cls.from_endf(filename_thermal, nonstandard_endf)
                 if data_endf.elastic is not None:
                     # Get appropriate temperatures
                     if temperatures is None:
@@ -871,7 +875,7 @@ class ThermalScattering(EqualityMixin):
         return data
 
     @classmethod
-    def from_endf(cls, ev_or_filename):
+    def from_endf(cls, ev_or_filename, nonstandard_endf):
         """Generate thermal scattering data from an ENDF file
 
         Parameters
@@ -879,6 +883,10 @@ class ThermalScattering(EqualityMixin):
         ev_or_filename : openmc.data.endf.Evaluation or str
             ENDF evaluation to read from. If given as a string, it is assumed to
             be the filename for the ENDF file.
+        nonstandard_endf: bool
+            Divide incoherent elastic cross section by
+            number of principal atoms. This is not part of the ENDF-6
+            standard but it is how it is processed by NJOY.
 
         Returns
         -------
@@ -890,56 +898,6 @@ class ThermalScattering(EqualityMixin):
             ev = ev_or_filename
         else:
             ev = endf.Evaluation(ev_or_filename)
-
-        # Read coherent/incoherent elastic data
-        elastic = None
-        if (7, 2) in ev.section:
-            # Define helper functions to avoid duplication
-            def get_coherent_elastic(file_obj):
-                # Get structure factor at first temperature
-                params, S = endf.get_tab1_record(file_obj)
-                strT = _temperature_str(params[0])
-                n_temps = params[2]
-                bragg_edges = S.x
-                xs = {strT: CoherentElastic(bragg_edges, S.y)}
-                distribution = {strT: CoherentElasticAE(xs[strT])}
-
-                # Get structure factor for subsequent temperatures
-                for _ in range(n_temps):
-                    params, S = endf.get_list_record(file_obj)
-                    strT = _temperature_str(params[0])
-                    xs[strT] = CoherentElastic(bragg_edges, S)
-                    distribution[strT] = CoherentElasticAE(xs[strT])
-                return xs, distribution
-
-            def get_incoherent_elastic(file_obj):
-                params, W = endf.get_tab1_record(file_obj)
-                bound_xs = params[0]
-                xs = {}
-                distribution = {}
-                for T, debye_waller in zip(W.x, W.y):
-                    strT = _temperature_str(T)
-                    xs[strT] = IncoherentElastic(bound_xs, debye_waller)
-                    distribution[strT] = IncoherentElasticAE(debye_waller)
-                return xs, distribution
-
-            file_obj = StringIO(ev.section[7, 2])
-            lhtr = endf.get_head_record(file_obj)[2]
-            if lhtr == 1:
-                # coherent elastic
-                xs, distribution = get_coherent_elastic(file_obj)
-            elif lhtr == 2:
-                # incoherent elastic
-                xs, distribution = get_incoherent_elastic(file_obj)
-            elif lhtr == 3:
-                # mixed coherent / incoherent elastic
-                xs_c, dist_c = get_coherent_elastic(file_obj)
-                xs_i, dist_i = get_incoherent_elastic(file_obj)
-                assert sorted(xs_c) == sorted(xs_i)
-                xs = {T: Sum([xs_c[T], xs_i[T]]) for T in xs_c}
-                distribution = {T: MixedElasticAE(dist_c[T], dist_i[T]) for T in dist_c}
-
-            elastic = ThermalScatteringReaction(xs, distribution)
 
         # Read incoherent inelastic data
         assert (7, 4) in ev.section, 'No MF=7, MT=4 found in thermal scattering'
@@ -998,6 +956,57 @@ class ThermalScattering(EqualityMixin):
             if atom.func == 'SCT':
                 _, Teff = endf.get_tab1_record(file_obj)
                 data['effective_temperature'].append(Teff)
+
+        # Read coherent/incoherent elastic data
+        elastic = None
+        if (7, 2) in ev.section:
+            # Define helper functions to avoid duplication
+            def get_coherent_elastic(file_obj):
+                # Get structure factor at first temperature
+                params, S = endf.get_tab1_record(file_obj)
+                strT = _temperature_str(params[0])
+                n_temps = params[2]
+                bragg_edges = S.x
+                xs = {strT: CoherentElastic(bragg_edges, S.y)}
+                distribution = {strT: CoherentElasticAE(xs[strT])}
+
+                # Get structure factor for subsequent temperatures
+                for _ in range(n_temps):
+                    params, S = endf.get_list_record(file_obj)
+                    strT = _temperature_str(params[0])
+                    xs[strT] = CoherentElastic(bragg_edges, S)
+                    distribution[strT] = CoherentElasticAE(xs[strT])
+                return xs, distribution
+
+            def get_incoherent_elastic(file_obj, natom):
+                params, W = endf.get_tab1_record(file_obj)
+                bound_xs = params[0]/natom
+                xs = {}
+                distribution = {}
+                for T, debye_waller in zip(W.x, W.y):
+                    strT = _temperature_str(T)
+                    xs[strT] = IncoherentElastic(bound_xs, debye_waller)
+                    distribution[strT] = IncoherentElasticAE(debye_waller)
+                return xs, distribution
+
+            file_obj = StringIO(ev.section[7, 2])
+            lhtr = endf.get_head_record(file_obj)[2]
+            natom = data['M0'] if nonstandard_endf else 1
+            if lhtr == 1:
+                # coherent elastic
+                xs, distribution = get_coherent_elastic(file_obj)
+            elif lhtr == 2:
+                # incoherent elastic
+                xs, distribution = get_incoherent_elastic(file_obj, natom)
+            elif lhtr == 3:
+                # mixed coherent / incoherent elastic
+                xs_c, dist_c = get_coherent_elastic(file_obj)
+                xs_i, dist_i = get_incoherent_elastic(file_obj, natom)
+                assert sorted(xs_c) == sorted(xs_i)
+                xs = {T: Sum([xs_c[T], xs_i[T]]) for T in xs_c}
+                distribution = {T: MixedElasticAE(dist_c[T], dist_i[T]) for T in dist_c}
+
+            elastic = ThermalScatteringReaction(xs, distribution)
 
         name = ev.target['zsymam'].strip()
         instance = cls(name, awr, energy_max, kTs)

--- a/tests/unit_tests/test_data_thermal.py
+++ b/tests/unit_tests/test_data_thermal.py
@@ -41,7 +41,7 @@ def hzrh():
     """H in ZrH thermal scattering data."""
     endf_data = os.environ['OPENMC_ENDF_DATA']
     filename = os.path.join(endf_data, 'thermal_scatt', 'tsl-HinZrH.endf')
-    return openmc.data.ThermalScattering.from_endf(filename)
+    return openmc.data.ThermalScattering.from_endf(filename, nonstandard_endf=True)
 
 
 @pytest.fixture(scope='module')
@@ -64,7 +64,7 @@ def sio2():
     """SiO2 thermal scattering data."""
     endf_data = os.environ['OPENMC_ENDF_DATA']
     filename = os.path.join(endf_data, 'thermal_scatt', 'tsl-SiO2.endf')
-    return openmc.data.ThermalScattering.from_endf(filename)
+    return openmc.data.ThermalScattering.from_endf(filename, nonstandard_endf=True)
 
 
 def test_h2o_attributes(h2o):

--- a/tests/unit_tests/test_data_thermal.py
+++ b/tests/unit_tests/test_data_thermal.py
@@ -144,7 +144,7 @@ def test_continuous_dist(h2o_njoy):
 def test_h2o_endf():
     endf_data = os.environ['OPENMC_ENDF_DATA']
     filename = os.path.join(endf_data, 'thermal_scatt', 'tsl-HinH2O.endf')
-    h2o = openmc.data.ThermalScattering.from_endf(filename)
+    h2o = openmc.data.ThermalScattering.from_endf(filename, nonstandard_endf=True)
     assert not h2o.elastic
     assert h2o.atomic_weight_ratio == pytest.approx(0.99917)
     assert h2o.energy_max == pytest.approx(3.99993)

--- a/tests/unit_tests/test_data_thermal.py
+++ b/tests/unit_tests/test_data_thermal.py
@@ -41,7 +41,7 @@ def hzrh():
     """H in ZrH thermal scattering data."""
     endf_data = os.environ['OPENMC_ENDF_DATA']
     filename = os.path.join(endf_data, 'thermal_scatt', 'tsl-HinZrH.endf')
-    return openmc.data.ThermalScattering.from_endf(filename, nonstandard_endf=True)
+    return openmc.data.ThermalScattering.from_endf(filename, divide_incoherent_elastic=True)
 
 
 @pytest.fixture(scope='module')
@@ -64,7 +64,7 @@ def sio2():
     """SiO2 thermal scattering data."""
     endf_data = os.environ['OPENMC_ENDF_DATA']
     filename = os.path.join(endf_data, 'thermal_scatt', 'tsl-SiO2.endf')
-    return openmc.data.ThermalScattering.from_endf(filename, nonstandard_endf=True)
+    return openmc.data.ThermalScattering.from_endf(filename, divide_incoherent_elastic=True)
 
 
 def test_h2o_attributes(h2o):
@@ -144,7 +144,7 @@ def test_continuous_dist(h2o_njoy):
 def test_h2o_endf():
     endf_data = os.environ['OPENMC_ENDF_DATA']
     filename = os.path.join(endf_data, 'thermal_scatt', 'tsl-HinH2O.endf')
-    h2o = openmc.data.ThermalScattering.from_endf(filename, nonstandard_endf=True)
+    h2o = openmc.data.ThermalScattering.from_endf(filename, divide_incoherent_elastic=True)
     assert not h2o.elastic
     assert h2o.atomic_weight_ratio == pytest.approx(0.99917)
     assert h2o.energy_max == pytest.approx(3.99993)


### PR DESCRIPTION
This PR attempts to solve the problem in #3233.

Maybe there is a more elegant solution, but we need to get the right normalization.

In any case, if this is adopted we should change the calls to `openmc.data.ThermalScattering.from_njoy()` in [data](https://github.com/openmc-dev/data/blob/4c10c210e8ce3bc703ba633d7c8985e11c799bf0/utils.py#L29) to flag the libraries that need to be treated differently.