### PR TITLE
Adding '#define _USE_MATH_DEFINES' to make M_PI declared in Intel and MSVC compilers

### DIFF
--- a/src/external/quartic_solver.cpp
+++ b/src/external/quartic_solver.cpp
@@ -1,5 +1,5 @@
-#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
 #include <algorithm>
+#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
 #include <cmath>
 #include <complex>
 #include <cstdlib>

--- a/src/external/quartic_solver.cpp
+++ b/src/external/quartic_solver.cpp
@@ -1,3 +1,4 @@
+#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
 #include <algorithm>
 #include <cmath>
 #include <complex>

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1,5 +1,6 @@
 #include "openmc/mesh.h"
 #include <algorithm> // for copy, equal, min, min_element
+#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
 #include <cmath>     // for ceil
 #include <cstddef>   // for size_t
 #include <gsl/gsl-lite.hpp>

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1,8 +1,8 @@
 #include "openmc/mesh.h"
-#include <algorithm> // for copy, equal, min, min_element
+#include <algorithm>      // for copy, equal, min, min_element
 #define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
-#include <cmath>     // for ceil
-#include <cstddef>   // for size_t
+#include <cmath>          // for ceil
+#include <cstddef>        // for size_t
 #include <gsl/gsl-lite.hpp>
 #include <string>
 

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -1,8 +1,8 @@
-#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
-
 #include "openmc/plot.h"
 
 #include <algorithm>
+#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
+#include <cmath>
 #include <cstdio>
 #include <fstream>
 #include <sstream>

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -1,3 +1,5 @@
+#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
+
 #include "openmc/plot.h"
 
 #include <algorithm>


### PR DESCRIPTION
the `M_PI` used in `mesh.cpp`, `plot.cpp`, and `quartic_solver.cpp` is undeclared in Intel and MSVC compilers. To make it declared in these compilers `#define _USE_MATH_DEFINES` must be added before `#include <cmath>`.