### PR TITLE
Fix for erroneously non-zero tally results of photon threshold reactions

### DIFF
--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -337,7 +337,6 @@ PhotonInteraction::PhotonInteraction(hid_t group)
   pair_production_total_ = xt::where(
     pair_production_total_ > 0.0, xt::log(pair_production_total_), -900.0);
   heating_ = xt::where(heating_ > 0.0, xt::log(heating_), -900.0);
-
 }
 
 PhotonInteraction::~PhotonInteraction()

--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -330,13 +330,14 @@ PhotonInteraction::PhotonInteraction(hid_t group)
   // Take logarithm of energies and cross sections since they are log-log
   // interpolated
   energy_ = xt::log(energy_);
-  coherent_ = xt::where(coherent_ > 0.0, xt::log(coherent_), -500.0);
-  incoherent_ = xt::where(incoherent_ > 0.0, xt::log(incoherent_), -500.0);
+  coherent_ = xt::where(coherent_ > 0.0, xt::log(coherent_), -900.0);
+  incoherent_ = xt::where(incoherent_ > 0.0, xt::log(incoherent_), -900.0);
   photoelectric_total_ = xt::where(
-    photoelectric_total_ > 0.0, xt::log(photoelectric_total_), -500.0);
+    photoelectric_total_ > 0.0, xt::log(photoelectric_total_), -900.0);
   pair_production_total_ = xt::where(
-    pair_production_total_ > 0.0, xt::log(pair_production_total_), -500.0);
-  heating_ = xt::where(heating_ > 0.0, xt::log(heating_), -500.0);
+    pair_production_total_ > 0.0, xt::log(pair_production_total_), -900.0);
+  heating_ = xt::where(heating_ > 0.0, xt::log(heating_), -900.0);
+
 }
 
 PhotonInteraction::~PhotonInteraction()

--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -328,15 +328,19 @@ PhotonInteraction::PhotonInteraction(hid_t group)
   }
 
   // Take logarithm of energies and cross sections since they are log-log
-  // interpolated
+  // interpolated. Note that cross section libraries converted from ACE files
+  // represent zero as exp(-500) to avoid log-log interpolation errors. For
+  // values below exp(-499) we store the log as -900, for which exp(-900)
+  // evaluates to zero.
+  double limit = std::exp(-499.0);
   energy_ = xt::log(energy_);
-  coherent_ = xt::where(coherent_ > 0.0, xt::log(coherent_), -900.0);
-  incoherent_ = xt::where(incoherent_ > 0.0, xt::log(incoherent_), -900.0);
+  coherent_ = xt::where(coherent_ > limit, xt::log(coherent_), -900.0);
+  incoherent_ = xt::where(incoherent_ > limit, xt::log(incoherent_), -900.0);
   photoelectric_total_ = xt::where(
-    photoelectric_total_ > 0.0, xt::log(photoelectric_total_), -900.0);
+    photoelectric_total_ > limit, xt::log(photoelectric_total_), -900.0);
   pair_production_total_ = xt::where(
-    pair_production_total_ > 0.0, xt::log(pair_production_total_), -900.0);
-  heating_ = xt::where(heating_ > 0.0, xt::log(heating_), -900.0);
+    pair_production_total_ > limit, xt::log(pair_production_total_), -900.0);
+  heating_ = xt::where(heating_ > limit, xt::log(heating_), -900.0);
 }
 
 PhotonInteraction::~PhotonInteraction()


### PR DESCRIPTION
# Description

When pushing photons through a model I noticed that threshold reaction tallies (e.g., pair-production) had small, but non-zero, values for energy bins below the threshold.

This can be observed in the attached `orig_tallies.out` which was produced by running the attached `model.xml` file. 

The cause of the issue is the line where the log of the xs arrays are taken since they are all log-log interpolated. Here, an `xt::where` call is used to set all zero-values to -500 instead of taking the logarithm. However, when interpolation is applied e is raised to the power of -500, which results in ~7E-218. 

If this -500 is replaced with -900, then a correct value of 0 results. This fix is applied here. The result can be
 seen in `new_tallies.out` within the zip.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
