### PR TITLE
Fix type comparison

### DIFF
--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -737,7 +737,7 @@ WeightWindowsGenerator::WeightWindowsGenerator(pugi::xml_node node)
   int32_t mesh_idx = model::mesh_map[mesh_id];
   max_realizations_ = std::stoi(get_node_value(node, "max_realizations"));
 
-  int active_batches = settings::n_batches - settings::n_inactive;
+  int32_t active_batches = settings::n_batches - settings::n_inactive;
   if (max_realizations_ > active_batches) {
     auto msg =
       fmt::format("The maximum number of specified tally realizations ({}) is "


### PR DESCRIPTION
There is a type inconsistency in an if statement where the variables coming from the settings namespace are of type int but are compared to a type int32_t and thus the comparison fails, i.e. `int(9) > int32_t(9)`, either the following code changes are needed, or max_realisations should be changed to be int. 