### PR TITLE
Enable the LegendreFilter filter to be used in photon tallies for orders greater than P0.

### DIFF
--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -337,7 +337,6 @@ PhotonInteraction::PhotonInteraction(hid_t group)
   pair_production_total_ = xt::where(
     pair_production_total_ > 0.0, xt::log(pair_production_total_), -900.0);
   heating_ = xt::where(heating_ > 0.0, xt::log(heating_), -900.0);
-
 }
 
 PhotonInteraction::~PhotonInteraction()

--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -330,13 +330,14 @@ PhotonInteraction::PhotonInteraction(hid_t group)
   // Take logarithm of energies and cross sections since they are log-log
   // interpolated
   energy_ = xt::log(energy_);
-  coherent_ = xt::where(coherent_ > 0.0, xt::log(coherent_), -500.0);
-  incoherent_ = xt::where(incoherent_ > 0.0, xt::log(incoherent_), -500.0);
+  coherent_ = xt::where(coherent_ > 0.0, xt::log(coherent_), -900.0);
+  incoherent_ = xt::where(incoherent_ > 0.0, xt::log(incoherent_), -900.0);
   photoelectric_total_ = xt::where(
-    photoelectric_total_ > 0.0, xt::log(photoelectric_total_), -500.0);
+    photoelectric_total_ > 0.0, xt::log(photoelectric_total_), -900.0);
   pair_production_total_ = xt::where(
-    pair_production_total_ > 0.0, xt::log(pair_production_total_), -500.0);
-  heating_ = xt::where(heating_ > 0.0, xt::log(heating_), -500.0);
+    pair_production_total_ > 0.0, xt::log(pair_production_total_), -900.0);
+  heating_ = xt::where(heating_ > 0.0, xt::log(heating_), -900.0);
+
 }
 
 PhotonInteraction::~PhotonInteraction()

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -293,8 +293,8 @@ void sample_photon_reaction(Particle& p)
   // Coherent (Rayleigh) scattering
   prob += micro.coherent;
   if (prob > cutoff) {
-    double mu = element.rayleigh_scatter(alpha, p.current_seed());
-    p.u() = rotate_angle(p.u(), mu, nullptr, p.current_seed());
+    p.mu() = element.rayleigh_scatter(alpha, p.current_seed());
+    p.u() = rotate_angle(p.u(), p.mu(), nullptr, p.current_seed());
     p.event() = TallyEvent::SCATTER;
     p.event_mt() = COHERENT;
     return;
@@ -303,10 +303,10 @@ void sample_photon_reaction(Particle& p)
   // Incoherent (Compton) scattering
   prob += micro.incoherent;
   if (prob > cutoff) {
-    double alpha_out, mu;
+    double alpha_out;
     int i_shell;
     element.compton_scatter(
-      alpha, true, &alpha_out, &mu, &i_shell, p.current_seed());
+      alpha, true, &alpha_out, &p.mu(), &i_shell, p.current_seed());
 
     // Determine binding energy of shell. The binding energy is 0.0 if
     // doppler broadening is not used.
@@ -322,9 +322,9 @@ void sample_photon_reaction(Particle& p)
     double E_electron = (alpha - alpha_out) * MASS_ELECTRON_EV - e_b;
     int electron = static_cast<int>(ParticleType::electron);
     if (E_electron >= settings::energy_cutoff[electron]) {
-      double mu_electron = (alpha - alpha_out * mu) /
+      double mu_electron = (alpha - alpha_out * p.mu()) /
                            std::sqrt(alpha * alpha + alpha_out * alpha_out -
-                                     2.0 * alpha * alpha_out * mu);
+                                     2.0 * alpha * alpha_out * p.mu());
       Direction u = rotate_angle(p.u(), mu_electron, &phi, p.current_seed());
       p.create_secondary(p.wgt(), u, E_electron, ParticleType::electron);
     }
@@ -338,7 +338,7 @@ void sample_photon_reaction(Particle& p)
 
     phi += PI;
     p.E() = alpha_out * MASS_ELECTRON_EV;
-    p.u() = rotate_angle(p.u(), mu, &phi, p.current_seed());
+    p.u() = rotate_angle(p.u(), p.mu(), &phi, p.current_seed());
     p.event() = TallyEvent::SCATTER;
     p.event_mt() = INCOHERENT;
     return;


### PR DESCRIPTION
# Description

As noted in #3243 , the LegendreFilter does not work for photon scores. The change was quite simple as a local variable, `mu`, was used for the change-in-angle during scattering kinematics and never stored on `p.mu`. This PR corrects this. Results can be seen in the attached .zip which contains the model.xml, the original tallies.out, and a new tallies.out created from the code in this PR. Note the model and original tallies.out is the same as in #3242.
[photon_mu.zip](https://github.com/user-attachments/files/18326054/photon_mu.zip)

Note, this PR is baselined off of #3242 and that should be merged first.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

