### PR TITLE
Enable UWUW library when building with DAGMC in CI

### DIFF
--- a/tools/ci/gha-install.py
+++ b/tools/ci/gha-install.py
@@ -31,6 +31,7 @@ def install(omp=False, mpi=False, phdf5=False, dagmc=False, libmesh=False, ncrys
 
     if dagmc:
         cmake_cmd.append('-DOPENMC_USE_DAGMC=ON')
+        cmake_cmd.append('-DOPENMC_USE_UWUW=ON')
         dagmc_path = os.environ.get('HOME') + '/DAGMC'
         cmake_cmd.append('-DCMAKE_PREFIX_PATH=' + dagmc_path)
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Since #2965 was merged the DAGMC tests in CI that use UWUW material definitions and assignments. This PR sets `OPENMC_USE_UWUW` to `ON` to remedy the problem.


# Checklist

- [x] I have performed a self-review of my own code
- [x] ~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~
- [x] ~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~
- [x] ~I have made corresponding changes to the documentation (if applicable)~
- [x] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
