### PR TITLE
Remove top-level import of openmc.lib

### DIFF
--- a/tests/test_matplotlib_import.py
+++ b/tests/test_matplotlib_import.py
@@ -1,12 +1,6 @@
 import sys
 import openmc
 
-
 def test_matplotlib_presence():
     """Checks that matplotlib remains a deferred import"""
     assert 'matplotlib' not in sys.modules
-
-
-def test_openmc_lib_presence():
-    """Checks that openmc.lib remains a deferred import"""
-    assert 'openmc.lib' not in sys.modules


### PR DESCRIPTION
# Description

The recent merging of #3056 added a top-level import of openmc.lib, which shouldn't be there. It has been our practice to keep imports of openmc.lib within functions to not be loaded by default if someone runs `import openmc`. This PR removes the top-level import.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>