### PR TITLE
Write mesh type as a dataset always

### DIFF
--- a/docs/source/io_formats/statepoint.rst
+++ b/docs/source/io_formats/statepoint.rst
@@ -73,9 +73,9 @@ The current version of the statepoint file format is 18.1.
 **/tallies/meshes/mesh <uid>/**
 
 :Attributes: - **id** (*int*) -- ID of the mesh
-             - **type** (*char[]*) -- Type of mesh.
 
 :Datasets: - **name** (*char[]*) -- Name of the mesh.
+           - **type** (*char[]*) -- Type of mesh.
            - **dimension** (*int*) -- Number of mesh cells in each dimension.
            - **Regular Mesh Only:**
               - **lower_left** (*double[]*) -- Coordinates of lower-left corner of

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -99,7 +99,7 @@ class MeshBase(IDManagerMixin, ABC):
             Instance of a MeshBase subclass
 
         """
-        mesh_type = 'regular' if 'type' not in group.attrs else group.attrs['type'].decode()
+        mesh_type = 'regular' if 'type' not in group.keys() else group['type'][()].decode()
         mesh_id = int(group.name.split('/')[-1].lstrip('mesh '))
         mesh_name = '' if not 'name' in group else group['name'][()].decode()
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -245,7 +245,7 @@ void Mesh::to_hdf5(hid_t group) const
   hid_t mesh_group = create_group(group, group_name.c_str());
 
   // Write mesh type
-  write_attribute(mesh_group, "type", this->get_mesh_type());
+  write_dataset(mesh_group, "type", this->get_mesh_type());
 
   // Write mesh ID
   write_attribute(mesh_group, "id", id_);
@@ -307,7 +307,6 @@ Position StructuredMesh::sample_element(
 
 UnstructuredMesh::UnstructuredMesh(pugi::xml_node node) : Mesh(node)
 {
-
   // check the mesh type
   if (check_for_node(node, "type")) {
     auto temp = get_node_value(node, "type", true, true);
@@ -969,7 +968,6 @@ std::pair<vector<double>, vector<double>> RegularMesh::plot(
 
 void RegularMesh::to_hdf5_inner(hid_t mesh_group) const
 {
-  write_dataset(mesh_group, "type", "regular");
   write_dataset(mesh_group, "dimension", get_x_shape());
   write_dataset(mesh_group, "lower_left", lower_left_);
   write_dataset(mesh_group, "upper_right", upper_right_);
@@ -1155,7 +1153,6 @@ std::pair<vector<double>, vector<double>> RectilinearMesh::plot(
 
 void RectilinearMesh::to_hdf5_inner(hid_t mesh_group) const
 {
-  write_dataset(mesh_group, "type", "rectilinear");
   write_dataset(mesh_group, "x_grid", grid_[0]);
   write_dataset(mesh_group, "y_grid", grid_[1]);
   write_dataset(mesh_group, "z_grid", grid_[2]);
@@ -1430,7 +1427,6 @@ std::pair<vector<double>, vector<double>> CylindricalMesh::plot(
 
 void CylindricalMesh::to_hdf5_inner(hid_t mesh_group) const
 {
-  write_dataset(mesh_group, "type", "cylindrical");
   write_dataset(mesh_group, "r_grid", grid_[0]);
   write_dataset(mesh_group, "phi_grid", grid_[1]);
   write_dataset(mesh_group, "z_grid", grid_[2]);
@@ -1742,7 +1738,6 @@ std::pair<vector<double>, vector<double>> SphericalMesh::plot(
 
 void SphericalMesh::to_hdf5_inner(hid_t mesh_group) const
 {
-  write_dataset(mesh_group, "type", SphericalMesh::mesh_type);
   write_dataset(mesh_group, "r_grid", grid_[0]);
   write_dataset(mesh_group, "theta_grid", grid_[1]);
   write_dataset(mesh_group, "phi_grid", grid_[2]);


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

As described in #3249, a change that writes the mesh type as an attribute instead of a data set in the statepoint files along with a corresponding update in the `Mesh.from_hdf5` method caused a compatibility issue with statepoint files generated before #3221.

Some of the concrete mesh implementations were also writing the type as a dataset, which is why this wasn't caught in CI. These changes return the mesh type to a dataset, now written only from the `Mesh::to_hdf5` method. The `Mesh.from_hdf5` method has also been updated accordingly along with the documentation.

I'm open to thoughts on how to test this, but none that are straightforward come to mind immediately.

Thanks for the quick notice @shimwell! 

Fixes #3249 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
