### PR TITLE
Update to a consistent definition of the r2 parameter for cones

### DIFF
--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -748,9 +748,9 @@ class XConeOneSided(CompositeSurface):
     z0 : float, optional
         z-coordinate of the apex. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture [:math:`\\rm cm^2`].
-        It can be interpreted as the increase in the radius squared per cm along
-        the cone's axis of revolution.
+        Parameter related to the aperture. This is the square of the radius of
+        the cone 1 cm from the apex. This can also be treated as the square of
+        the cone's slope relative to its axis of revolution. Defaults to 1.
     up : bool
         Whether to select the side of the cone that extends to infinity in the
         positive direction of the coordinate axis (the positive half-space of
@@ -802,9 +802,9 @@ class YConeOneSided(CompositeSurface):
     z0 : float, optional
         z-coordinate of the apex. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture [:math:`\\rm cm^2`].
-        It can be interpreted as the increase in the radius squared per cm along
-        the cone's axis of revolution.
+        Parameter related to the aperture. This is the square of the radius of
+        the cone 1 cm from the apex. This can also be treated as the square of
+        the cone's slope relative to its axis of revolution. Defaults to 1.
     up : bool
         Whether to select the side of the cone that extends to infinity in the
         positive direction of the coordinate axis (the positive half-space of
@@ -855,9 +855,9 @@ class ZConeOneSided(CompositeSurface):
     z0 : float, optional
         z-coordinate of the apex. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture [:math:`\\rm cm^2`].
-        It can be interpreted as the increase in the radius squared per cm along
-        the cone's axis of revolution.
+        Parameter related to the aperture. This is the square of the radius of
+        the cone 1 cm from the apex. This can also be treated as the square of
+        the cone's slope relative to its axis of revolution. Defaults to 1.
     up : bool
         Whether to select the side of the cone that extends to infinity in the
         positive direction of the coordinate axis (the positive half-space of

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -729,7 +729,7 @@ class OrthogonalBox(CompositeSurface):
 
 
 class XConeOneSided(CompositeSurface):
-    """One-sided cone parallel the x-axis
+    r"""One-sided cone parallel the x-axis
 
     A one-sided cone is composed of a normal cone surface and a "disambiguation"
     surface that eliminates the ambiguity as to which region of space is
@@ -742,17 +742,16 @@ class XConeOneSided(CompositeSurface):
     Parameters
     ----------
     x0 : float, optional
-        x-coordinate of the apex. Defaults to 0.
+        x-coordinate of the apex in [cm].
     y0 : float, optional
-        y-coordinate of the apex. Defaults to 0.
+        y-coordinate of the apex in [cm].
     z0 : float, optional
-        z-coordinate of the apex. Defaults to 0.
+        z-coordinate of the apex in [cm].
     r2 : float, optional
-        This parameter is the square of the slope of the cone. It is defined as
-        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        The square of the slope of the cone. It is defined as
+        :math:`\left(\frac{r}{h}\right)^2` for a radius, :math:`r` and an axial
         distance :math:`h` from the apex. An easy way to define this quantity is
         to take the square of the radius of the cone (in cm) 1 cm from the apex.
-        Defaults to 1.
     up : bool
         Whether to select the side of the cone that extends to infinity in the
         positive direction of the coordinate axis (the positive half-space of
@@ -785,7 +784,7 @@ class XConeOneSided(CompositeSurface):
 
 
 class YConeOneSided(CompositeSurface):
-    """One-sided cone parallel the y-axis
+    r"""One-sided cone parallel the y-axis
 
     A one-sided cone is composed of a normal cone surface and a "disambiguation"
     surface that eliminates the ambiguity as to which region of space is
@@ -798,17 +797,16 @@ class YConeOneSided(CompositeSurface):
     Parameters
     ----------
     x0 : float, optional
-        x-coordinate of the apex. Defaults to 0.
+        x-coordinate of the apex in [cm].
     y0 : float, optional
-        y-coordinate of the apex. Defaults to 0.
+        y-coordinate of the apex in [cm].
     z0 : float, optional
-        z-coordinate of the apex. Defaults to 0.
+        z-coordinate of the apex in [cm].
     r2 : float, optional
-        This parameter is the square of the slope of the cone. It is defined as
-        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        The square of the slope of the cone. It is defined as
+        :math:`\left(\frac{r}{h}\right)^2` for a radius, :math:`r` and an axial
         distance :math:`h` from the apex. An easy way to define this quantity is
         to take the square of the radius of the cone (in cm) 1 cm from the apex.
-        Defaults to 1.
     up : bool
         Whether to select the side of the cone that extends to infinity in the
         positive direction of the coordinate axis (the positive half-space of
@@ -840,7 +838,7 @@ class YConeOneSided(CompositeSurface):
 
 
 class ZConeOneSided(CompositeSurface):
-    """One-sided cone parallel the z-axis
+    r"""One-sided cone parallel the z-axis
 
     A one-sided cone is composed of a normal cone surface and a "disambiguation"
     surface that eliminates the ambiguity as to which region of space is
@@ -853,17 +851,16 @@ class ZConeOneSided(CompositeSurface):
     Parameters
     ----------
     x0 : float, optional
-        x-coordinate of the apex. Defaults to 0.
+        x-coordinate of the apex in [cm].
     y0 : float, optional
-        y-coordinate of the apex. Defaults to 0.
+        y-coordinate of the apex in [cm].
     z0 : float, optional
-        z-coordinate of the apex. Defaults to 0.
+        z-coordinate of the apex in [cm].
     r2 : float, optional
-        This parameter is the square of the slope of the cone. It is defined as
-        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        The square of the slope of the cone. It is defined as
+        :math:`\left(\frac{r}{h}\right)^2` for a radius, :math:`r` and an axial
         distance :math:`h` from the apex. An easy way to define this quantity is
         to take the square of the radius of the cone (in cm) 1 cm from the apex.
-        Defaults to 1.
     up : bool
         Whether to select the side of the cone that extends to infinity in the
         positive direction of the coordinate axis (the positive half-space of

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -748,10 +748,9 @@ class XConeOneSided(CompositeSurface):
     z0 : float, optional
         z-coordinate of the apex. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture [:math:`\\rm cm^2`]. This is the
-        square of the radius of the cone 1 cm from the apex. This can also be
-        treated as the square of the cone's slope relative to its axis of
-        revolution. Defaults to 1.
+        This parameter is the square of the slope of the cone.
+        It is defined as :math:`\left(\frac{r}{h}\right)^2` for a radius, :math:`r`, an axial distance :math:`h` from the apex.
+        An easy way to define this quantity is to take the square of the radius of the cone (in cm) 1 cm from the apex.
     up : bool
         Whether to select the side of the cone that extends to infinity in the
         positive direction of the coordinate axis (the positive half-space of

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -748,9 +748,10 @@ class XConeOneSided(CompositeSurface):
     z0 : float, optional
         z-coordinate of the apex. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture. This is the square of the radius of
-        the cone 1 cm from the apex. This can also be treated as the square of
-        the cone's slope relative to its axis of revolution. Defaults to 1.
+        Parameter related to the aperture [:math:`\\rm cm^2`]. This is the
+        square of the radius of the cone 1 cm from the apex. This can also be
+        treated as the square of the cone's slope relative to its axis of
+        revolution. Defaults to 1.
     up : bool
         Whether to select the side of the cone that extends to infinity in the
         positive direction of the coordinate axis (the positive half-space of
@@ -802,9 +803,10 @@ class YConeOneSided(CompositeSurface):
     z0 : float, optional
         z-coordinate of the apex. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture. This is the square of the radius of
-        the cone 1 cm from the apex. This can also be treated as the square of
-        the cone's slope relative to its axis of revolution. Defaults to 1.
+        Parameter related to the aperture [:math:`\\rm cm^2`]. This is the
+        square of the radius of the cone 1 cm from the apex. This can also be
+        treated as the square of the cone's slope relative to its axis of
+        revolution. Defaults to 1.
     up : bool
         Whether to select the side of the cone that extends to infinity in the
         positive direction of the coordinate axis (the positive half-space of
@@ -855,9 +857,10 @@ class ZConeOneSided(CompositeSurface):
     z0 : float, optional
         z-coordinate of the apex. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture. This is the square of the radius of
-        the cone 1 cm from the apex. This can also be treated as the square of
-        the cone's slope relative to its axis of revolution. Defaults to 1.
+        Parameter related to the aperture [:math:`\\rm cm^2`]. This is the
+        square of the radius of the cone 1 cm from the apex. This can also be
+        treated as the square of the cone's slope relative to its axis of
+        revolution. Defaults to 1.
     up : bool
         Whether to select the side of the cone that extends to infinity in the
         positive direction of the coordinate axis (the positive half-space of

--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -748,9 +748,11 @@ class XConeOneSided(CompositeSurface):
     z0 : float, optional
         z-coordinate of the apex. Defaults to 0.
     r2 : float, optional
-        This parameter is the square of the slope of the cone.
-        It is defined as :math:`\left(\frac{r}{h}\right)^2` for a radius, :math:`r`, an axial distance :math:`h` from the apex.
-        An easy way to define this quantity is to take the square of the radius of the cone (in cm) 1 cm from the apex.
+        This parameter is the square of the slope of the cone. It is defined as
+        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        distance :math:`h` from the apex. An easy way to define this quantity is
+        to take the square of the radius of the cone (in cm) 1 cm from the apex.
+        Defaults to 1.
     up : bool
         Whether to select the side of the cone that extends to infinity in the
         positive direction of the coordinate axis (the positive half-space of
@@ -802,10 +804,11 @@ class YConeOneSided(CompositeSurface):
     z0 : float, optional
         z-coordinate of the apex. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture [:math:`\\rm cm^2`]. This is the
-        square of the radius of the cone 1 cm from the apex. This can also be
-        treated as the square of the cone's slope relative to its axis of
-        revolution. Defaults to 1.
+        This parameter is the square of the slope of the cone. It is defined as
+        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        distance :math:`h` from the apex. An easy way to define this quantity is
+        to take the square of the radius of the cone (in cm) 1 cm from the apex.
+        Defaults to 1.
     up : bool
         Whether to select the side of the cone that extends to infinity in the
         positive direction of the coordinate axis (the positive half-space of
@@ -856,10 +859,11 @@ class ZConeOneSided(CompositeSurface):
     z0 : float, optional
         z-coordinate of the apex. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture [:math:`\\rm cm^2`]. This is the
-        square of the radius of the cone 1 cm from the apex. This can also be
-        treated as the square of the cone's slope relative to its axis of
-        revolution. Defaults to 1.
+        This parameter is the square of the slope of the cone. It is defined as
+        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        distance :math:`h` from the apex. An easy way to define this quantity is
+        to take the square of the radius of the cone (in cm) 1 cm from the apex.
+        Defaults to 1.
     up : bool
         Whether to select the side of the cone that extends to infinity in the
         positive direction of the coordinate axis (the positive half-space of

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1753,7 +1753,7 @@ class Sphere(QuadricMixin, Surface):
 
 
 class Cone(QuadricMixin, Surface):
-    """A conical surface parallel to the x-, y-, or z-axis.
+    r"""A conical surface parallel to the x-, y-, or z-axis.
 
     .. Note::
         This creates a double cone, which is two one-sided cones that meet at their apex.
@@ -1763,26 +1763,22 @@ class Cone(QuadricMixin, Surface):
     Parameters
     ----------
     x0 : float, optional
-        x-coordinate of the apex in [cm]. Defaults to 0.
+        x-coordinate of the apex in [cm].
     y0 : float, optional
-        y-coordinate of the apex in [cm]. Defaults to 0.
+        y-coordinate of the apex in [cm].
     z0 : float, optional
-        z-coordinate of the apex in [cm]. Defaults to 0.
+        z-coordinate of the apex in [cm].
     r2 : float, optional
-        This parameter is the square of the slope of the cone. It is defined as
-        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        The square of the slope of the cone. It is defined as
+        :math:`\left(\frac{r}{h}\right)^2` for a radius, :math:`r` and an axial
         distance :math:`h` from the apex. An easy way to define this quantity is
         to take the square of the radius of the cone (in cm) 1 cm from the apex.
-        Defaults to 1.
     dx : float, optional
         x-component of the vector representing the axis of the cone.
-        Defaults to 0.
     dy : float, optional
         y-component of the vector representing the axis of the cone.
-        Defaults to 0.
     dz : float, optional
         z-component of the vector representing the axis of the cone.
-        Defaults to 1.
     surface_id : int, optional
         Unique identifier for the surface. If not specified, an identifier will
         automatically be assigned.
@@ -1913,7 +1909,7 @@ class Cone(QuadricMixin, Surface):
 
 
 class XCone(QuadricMixin, Surface):
-    """A cone parallel to the x-axis of the form :math:`(y - y_0)^2 + (z - z_0)^2 =
+    r"""A cone parallel to the x-axis of the form :math:`(y - y_0)^2 + (z - z_0)^2 =
     r^2 (x - x_0)^2`.
 
     .. Note::
@@ -1923,17 +1919,16 @@ class XCone(QuadricMixin, Surface):
     Parameters
     ----------
     x0 : float, optional
-        x-coordinate of the apex in [cm]. Defaults to 0.
+        x-coordinate of the apex in [cm].
     y0 : float, optional
-        y-coordinate of the apex in [cm]. Defaults to 0.
+        y-coordinate of the apex in [cm].
     z0 : float, optional
-        z-coordinate of the apex in [cm]. Defaults to 0.
+        z-coordinate of the apex in [cm].
     r2 : float, optional
-        This parameter is the square of the slope of the cone. It is defined as
-        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        The square of the slope of the cone. It is defined as
+        :math:`\left(\frac{r}{h}\right)^2` for a radius, :math:`r` and an axial
         distance :math:`h` from the apex. An easy way to define this quantity is
         to take the square of the radius of the cone (in cm) 1 cm from the apex.
-        Defaults to 1.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}, optional
         Boundary condition that defines the behavior for particles hitting the
         surface. Defaults to transmissive boundary condition where particles
@@ -2016,7 +2011,7 @@ class XCone(QuadricMixin, Surface):
 
 
 class YCone(QuadricMixin, Surface):
-    """A cone parallel to the y-axis of the form :math:`(x - x_0)^2 + (z - z_0)^2 =
+    r"""A cone parallel to the y-axis of the form :math:`(x - x_0)^2 + (z - z_0)^2 =
     r^2 (y - y_0)^2`.
 
     .. Note::
@@ -2026,17 +2021,16 @@ class YCone(QuadricMixin, Surface):
     Parameters
     ----------
     x0 : float, optional
-        x-coordinate of the apex in [cm]. Defaults to 0.
+        x-coordinate of the apex in [cm].
     y0 : float, optional
-        y-coordinate of the apex in [cm]. Defaults to 0.
+        y-coordinate of the apex in [cm].
     z0 : float, optional
-        z-coordinate of the apex in [cm]. Defaults to 0.
+        z-coordinate of the apex in [cm].
     r2 : float, optional
-        This parameter is the square of the slope of the cone. It is defined as
-        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        The square of the slope of the cone. It is defined as
+        :math:`\left(\frac{r}{h}\right)^2` for a radius, :math:`r` and an axial
         distance :math:`h` from the apex. An easy way to define this quantity is
         to take the square of the radius of the cone (in cm) 1 cm from the apex.
-        Defaults to 1.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}, optional
         Boundary condition that defines the behavior for particles hitting the
         surface. Defaults to transmissive boundary condition where particles
@@ -2119,7 +2113,7 @@ class YCone(QuadricMixin, Surface):
 
 
 class ZCone(QuadricMixin, Surface):
-    """A cone parallel to the z-axis of the form :math:`(x - x_0)^2 + (y - y_0)^2 =
+    r"""A cone parallel to the z-axis of the form :math:`(x - x_0)^2 + (y - y_0)^2 =
     r^2 (z - z_0)^2`.
 
     .. Note::
@@ -2129,17 +2123,16 @@ class ZCone(QuadricMixin, Surface):
     Parameters
     ----------
     x0 : float, optional
-        x-coordinate of the apex in [cm]. Defaults to 0.
+        x-coordinate of the apex in [cm].
     y0 : float, optional
-        y-coordinate of the apex in [cm]. Defaults to 0.
+        y-coordinate of the apex in [cm].
     z0 : float, optional
-        z-coordinate of the apex in [cm]. Defaults to 0.
+        z-coordinate of the apex in [cm].
     r2 : float, optional
-        This parameter is the square of the slope of the cone. It is defined as
-        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        The square of the slope of the cone. It is defined as
+        :math:`\left(\frac{r}{h}\right)^2` for a radius, :math:`r` and an axial
         distance :math:`h` from the apex. An easy way to define this quantity is
         to take the square of the radius of the cone (in cm) 1 cm from the apex.
-        Defaults to 1.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}, optional
         Boundary condition that defines the behavior for particles hitting the
         surface. Defaults to transmissive boundary condition where particles

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1769,10 +1769,11 @@ class Cone(QuadricMixin, Surface):
     z0 : float, optional
         z-coordinate of the apex in [cm]. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture [:math:`\\rm cm^2`]. This is the
-        square of the radius of the cone 1 cm from the apex. This can also be
-        treated as the square of the cone's slope relative to its axis of
-        revolution. Defaults to 1.
+        This parameter is the square of the slope of the cone. It is defined as
+        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        distance :math:`h` from the apex. An easy way to define this quantity is
+        to take the square of the radius of the cone (in cm) 1 cm from the apex.
+        Defaults to 1.
     dx : float, optional
         x-component of the vector representing the axis of the cone.
         Defaults to 0.
@@ -1806,7 +1807,7 @@ class Cone(QuadricMixin, Surface):
     z0 : float
         z-coordinate of the apex in [cm]
     r2 : float
-        Parameter related to the aperture [:math:`\\rm cm^2`]
+        Parameter related to the aperture
     dx : float
         x-component of the vector representing the axis of the cone.
     dy : float
@@ -1928,10 +1929,11 @@ class XCone(QuadricMixin, Surface):
     z0 : float, optional
         z-coordinate of the apex in [cm]. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture [:math:`\\rm cm^2`]. This is t1he
-        square of the radius of the cone 1 cm from the apex. This can also be
-        treated as the square of the cone's slope relative to its axis of
-        revolution. Defaults to 1.
+        This parameter is the square of the slope of the cone. It is defined as
+        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        distance :math:`h` from the apex. An easy way to define this quantity is
+        to take the square of the radius of the cone (in cm) 1 cm from the apex.
+        Defaults to 1.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}, optional
         Boundary condition that defines the behavior for particles hitting the
         surface. Defaults to transmissive boundary condition where particles
@@ -1955,7 +1957,7 @@ class XCone(QuadricMixin, Surface):
     z0 : float
         z-coordinate of the apex in [cm]
     r2 : float
-        Parameter related to the aperture [:math:`\\rm cm^2`]
+        Parameter related to the aperture
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}
         Boundary condition that defines the behavior for particles hitting the
         surface.
@@ -2030,10 +2032,11 @@ class YCone(QuadricMixin, Surface):
     z0 : float, optional
         z-coordinate of the apex in [cm]. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture [:math:`\\rm cm^2`]. This is the
-        square of the radius of the cone 1 cm from the apex. This can also be
-        treated as the square of the cone's slope relative to its axis of
-        revolution. Defaults to 1.
+        This parameter is the square of the slope of the cone. It is defined as
+        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        distance :math:`h` from the apex. An easy way to define this quantity is
+        to take the square of the radius of the cone (in cm) 1 cm from the apex.
+        Defaults to 1.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}, optional
         Boundary condition that defines the behavior for particles hitting the
         surface. Defaults to transmissive boundary condition where particles
@@ -2057,7 +2060,7 @@ class YCone(QuadricMixin, Surface):
     z0 : float
         z-coordinate of the apex in [cm]
     r2 : float
-        Parameter related to the aperture [:math:`\\rm cm^2`].
+        Parameter related to the aperture
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}
         Boundary condition that defines the behavior for particles hitting the
         surface.
@@ -2132,10 +2135,11 @@ class ZCone(QuadricMixin, Surface):
     z0 : float, optional
         z-coordinate of the apex in [cm]. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture [:math:`\\rm cm^2`]. This is the
-        square of the radius of the cone 1 cm from the apex. This can also be
-        treated as the square of the cone's slope relative to its axis of
-        revolution. Defaults to 1.
+        This parameter is the square of the slope of the cone. It is defined as
+        :math:`\\left(\\frac{r}{h}\\right)^2` for a radius, :math:`r`, an axial
+        distance :math:`h` from the apex. An easy way to define this quantity is
+        to take the square of the radius of the cone (in cm) 1 cm from the apex.
+        Defaults to 1.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}, optional
         Boundary condition that defines the behavior for particles hitting the
         surface. Defaults to transmissive boundary condition where particles
@@ -2159,7 +2163,7 @@ class ZCone(QuadricMixin, Surface):
     z0 : float
         z-coordinate of the apex in [cm]
     r2 : float
-        Parameter related to the aperture [:math:`\\rm cm^2`].
+        Parameter related to the aperture.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}
         Boundary condition that defines the behavior for particles hitting the
         surface.

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1769,9 +1769,9 @@ class Cone(QuadricMixin, Surface):
     z0 : float, optional
         z-coordinate of the apex in [cm]. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture [:math:`\\rm cm^2`].
-        It can be interpreted as the increase in the radius squared per cm along
-        the cone's axis of revolution.
+        Parameter related to the aperture. This is the square of the radius of
+        the cone 1 cm from the apex. This can also be treated as the square of
+        the cone's slope relative to its axis of revolution. Defaults to 1.
     dx : float, optional
         x-component of the vector representing the axis of the cone.
         Defaults to 0.
@@ -1805,7 +1805,7 @@ class Cone(QuadricMixin, Surface):
     z0 : float
         z-coordinate of the apex in [cm]
     r2 : float
-        Parameter related to the aperature [cm^2]
+        Parameter related to the aperture
     dx : float
         x-component of the vector representing the axis of the cone.
     dy : float
@@ -1927,9 +1927,9 @@ class XCone(QuadricMixin, Surface):
     z0 : float, optional
         z-coordinate of the apex in [cm]. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture [:math:`\\rm cm^2`].
-        It can be interpreted as the increase in the radius squared per cm along
-        the cone's axis of revolution.
+        Parameter related to the aperture. This is the square of the radius of
+        the cone 1 cm from the apex. This can also be treated as the square of
+        the cone's slope relative to its axis of revolution. Defaults to 1.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}, optional
         Boundary condition that defines the behavior for particles hitting the
         surface. Defaults to transmissive boundary condition where particles
@@ -2028,9 +2028,9 @@ class YCone(QuadricMixin, Surface):
     z0 : float, optional
         z-coordinate of the apex in [cm]. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture [:math:`\\rm cm^2`].
-        It can be interpreted as the increase in the radius squared per cm along
-        the cone's axis of revolution.
+        Parameter related to the aperture. This is the square of the radius of
+        the cone 1 cm from the apex. This can also be treated as the square of
+        the cone's slope relative to its axis of revolution. Defaults to 1.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}, optional
         Boundary condition that defines the behavior for particles hitting the
         surface. Defaults to transmissive boundary condition where particles
@@ -2054,7 +2054,7 @@ class YCone(QuadricMixin, Surface):
     z0 : float
         z-coordinate of the apex in [cm]
     r2 : float
-        Parameter related to the aperature
+        Parameter related to the aperture.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}
         Boundary condition that defines the behavior for particles hitting the
         surface.
@@ -2129,9 +2129,9 @@ class ZCone(QuadricMixin, Surface):
     z0 : float, optional
         z-coordinate of the apex in [cm]. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperature [cm^2].
-        This is the square of the radius of the cone 1 cm from.
-        This can also be treated as the square of the slope of the cone relative to its axis.
+        Parameter related to the aperture. This is the square of the radius of
+        the cone 1 cm from the apex. This can also be treated as the square of
+        the cone's slope relative to its axis of revolution. Defaults to 1.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}, optional
         Boundary condition that defines the behavior for particles hitting the
         surface. Defaults to transmissive boundary condition where particles
@@ -2155,7 +2155,7 @@ class ZCone(QuadricMixin, Surface):
     z0 : float
         z-coordinate of the apex in [cm]
     r2 : float
-        Parameter related to the aperature
+        Parameter related to the aperture.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}
         Boundary condition that defines the behavior for particles hitting the
         surface.

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -1769,9 +1769,10 @@ class Cone(QuadricMixin, Surface):
     z0 : float, optional
         z-coordinate of the apex in [cm]. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture. This is the square of the radius of
-        the cone 1 cm from the apex. This can also be treated as the square of
-        the cone's slope relative to its axis of revolution. Defaults to 1.
+        Parameter related to the aperture [:math:`\\rm cm^2`]. This is the
+        square of the radius of the cone 1 cm from the apex. This can also be
+        treated as the square of the cone's slope relative to its axis of
+        revolution. Defaults to 1.
     dx : float, optional
         x-component of the vector representing the axis of the cone.
         Defaults to 0.
@@ -1805,7 +1806,7 @@ class Cone(QuadricMixin, Surface):
     z0 : float
         z-coordinate of the apex in [cm]
     r2 : float
-        Parameter related to the aperture
+        Parameter related to the aperture [:math:`\\rm cm^2`]
     dx : float
         x-component of the vector representing the axis of the cone.
     dy : float
@@ -1927,9 +1928,10 @@ class XCone(QuadricMixin, Surface):
     z0 : float, optional
         z-coordinate of the apex in [cm]. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture. This is the square of the radius of
-        the cone 1 cm from the apex. This can also be treated as the square of
-        the cone's slope relative to its axis of revolution. Defaults to 1.
+        Parameter related to the aperture [:math:`\\rm cm^2`]. This is t1he
+        square of the radius of the cone 1 cm from the apex. This can also be
+        treated as the square of the cone's slope relative to its axis of
+        revolution. Defaults to 1.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}, optional
         Boundary condition that defines the behavior for particles hitting the
         surface. Defaults to transmissive boundary condition where particles
@@ -1953,7 +1955,7 @@ class XCone(QuadricMixin, Surface):
     z0 : float
         z-coordinate of the apex in [cm]
     r2 : float
-        Parameter related to the aperature
+        Parameter related to the aperture [:math:`\\rm cm^2`]
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}
         Boundary condition that defines the behavior for particles hitting the
         surface.
@@ -2028,9 +2030,10 @@ class YCone(QuadricMixin, Surface):
     z0 : float, optional
         z-coordinate of the apex in [cm]. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture. This is the square of the radius of
-        the cone 1 cm from the apex. This can also be treated as the square of
-        the cone's slope relative to its axis of revolution. Defaults to 1.
+        Parameter related to the aperture [:math:`\\rm cm^2`]. This is the
+        square of the radius of the cone 1 cm from the apex. This can also be
+        treated as the square of the cone's slope relative to its axis of
+        revolution. Defaults to 1.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}, optional
         Boundary condition that defines the behavior for particles hitting the
         surface. Defaults to transmissive boundary condition where particles
@@ -2054,7 +2057,7 @@ class YCone(QuadricMixin, Surface):
     z0 : float
         z-coordinate of the apex in [cm]
     r2 : float
-        Parameter related to the aperture.
+        Parameter related to the aperture [:math:`\\rm cm^2`].
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}
         Boundary condition that defines the behavior for particles hitting the
         surface.
@@ -2129,9 +2132,10 @@ class ZCone(QuadricMixin, Surface):
     z0 : float, optional
         z-coordinate of the apex in [cm]. Defaults to 0.
     r2 : float, optional
-        Parameter related to the aperture. This is the square of the radius of
-        the cone 1 cm from the apex. This can also be treated as the square of
-        the cone's slope relative to its axis of revolution. Defaults to 1.
+        Parameter related to the aperture [:math:`\\rm cm^2`]. This is the
+        square of the radius of the cone 1 cm from the apex. This can also be
+        treated as the square of the cone's slope relative to its axis of
+        revolution. Defaults to 1.
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}, optional
         Boundary condition that defines the behavior for particles hitting the
         surface. Defaults to transmissive boundary condition where particles
@@ -2155,7 +2159,7 @@ class ZCone(QuadricMixin, Surface):
     z0 : float
         z-coordinate of the apex in [cm]
     r2 : float
-        Parameter related to the aperture.
+        Parameter related to the aperture [:math:`\\rm cm^2`].
     boundary_type : {'transmission', 'vacuum', 'reflective', 'white'}
         Boundary condition that defines the behavior for particles hitting the
         surface.


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Updating documentation for the cone `r2` parameter for consistency after @NybergWISC pointed out some issues in one of the old doc strings that remained and noted possible confusion about units. Removing units (for now, depends on the discussion below) because the value is, as described in the doc strings, the square of the slope. If one's interpretation of the definition of the `r2` parameter is that it's always relative to 1 cm from the apex, then I could see how this would have units one `cm^2` also. Happy to go with a consensus on this.

@MicahGale you made some improvements here most recently. Can you take a look and provide some thoughts?

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~ N/A
- [x] ~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~ N/A
- [x] ~I have made corresponding changes to the documentation (if applicable)~ N/A
- [x] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~ N/A
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
