### PR TITLE
added option to write metadata to hdf5 file

### DIFF
--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -351,7 +351,13 @@ class IncidentNeutron(EqualityMixin):
         else:
             return [mt] if mt in self else []
 
-    def export_to_hdf5(self, path, mode='a', libver='earliest'):
+    def export_to_hdf5(
+        self,
+        path: cv.PathLike,
+        mode: str = 'a',
+        libver: str = 'earliest',
+        metadata: str | None = None
+    ):
         """Export incident neutron data to an HDF5 file.
 
         Parameters
@@ -364,6 +370,8 @@ class IncidentNeutron(EqualityMixin):
         libver : {'earliest', 'latest'}
             Compatibility mode for the HDF5 file. 'latest' will produce files
             that are less backwards compatible but have performance benefits.
+        metadata : Optional str
+            A string of metadata to include in the HDF5 file as an attribute.
 
         """
         # If data come from ENDF, don't allow exporting to HDF5
@@ -375,6 +383,8 @@ class IncidentNeutron(EqualityMixin):
         with h5py.File(str(path), mode, libver=libver) as f:
             f.attrs['filetype'] = np.bytes_('data_neutron')
             f.attrs['version'] = np.array(HDF5_VERSION)
+            if metadata is not None:
+                f.attrs['metadata'] = np.bytes_(metadata)
 
             # Write basic data
             g = f.create_group(self.name)

--- a/openmc/data/photon.py
+++ b/openmc/data/photon.py
@@ -749,7 +749,13 @@ class IncidentPhoton(EqualityMixin):
 
         return data
 
-    def export_to_hdf5(self, path, mode='a', libver='earliest'):
+    def export_to_hdf5(
+        self,
+        path: cv.PathLike,
+        mode: str = 'a',
+        libver: str = 'earliest',
+        metadata: str | None = None
+    ):
         """Export incident photon data to an HDF5 file.
 
         Parameters
@@ -762,6 +768,8 @@ class IncidentPhoton(EqualityMixin):
         libver : {'earliest', 'latest'}
             Compatibility mode for the HDF5 file. 'latest' will produce files
             that are less backwards compatible but have performance benefits.
+        metadata : Optional str
+            A string of metadata to include in the HDF5 file as an attribute.
 
         """
         with h5py.File(str(path), mode, libver=libver) as f:
@@ -769,6 +777,8 @@ class IncidentPhoton(EqualityMixin):
             f.attrs['filetype'] = np.bytes_('data_photon')
             if 'version' not in f.attrs:
                 f.attrs['version'] = np.array(HDF5_VERSION)
+            if metadata is not None:
+                f.attrs['metadata'] = np.bytes_(metadata)
 
             group = f.create_group(self.name)
             group.attrs['Z'] = Z = self.atomic_number


### PR DESCRIPTION
# Description

While chatting with @RemDelaporteMathurin this [issue](https://github.com/openmc-dev/data/issues/54) where it would be useful to know information on the nuclear data surfaced again as part of the [LIBRA project](https://github.com/LIBRA-project/libra-toolbox/pull/46#issuecomment-2581162041)

This PR would allow additional strings to be added to the hdf5 file when exporting it to hdf5, so we could add things like ```FENDL 3.2c``` or ```made with openmc version 0.15.0```


Fixes # (issue)
[issue](https://github.com/openmc-dev/data/issues/54) 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
