### PR TITLE
Change `Zernike` documentation in polynomial.py

### DIFF
--- a/openmc/polynomial.py
+++ b/openmc/polynomial.py
@@ -92,7 +92,7 @@ class Zernike(Polynomial):
     Parameters
     ----------
     coef : Iterable of float
-        A list of coefficients of each term in radial only Zernike polynomials
+        A list of coefficients of each term in Zernike polynomials
     radius : float
         Domain of Zernike polynomials to be applied on. Default is 1.
 


### PR DESCRIPTION
# Description

This is a small change to the documentation for the `Zernike` class. The description for `coef` was the same as the `RadialZernike` class. This is only a change in the documentation there is no functionality changed.

# Fixes no existing issue.

# Motivation

I was looking at the source code for polynomial.Zernike and noticed a mistake in the documentation.

# Checklist

- [ :heavy_check_mark: ] I have performed a self-review of my own code
- [ :heavy_check_mark: ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ :heavy_check_mark: ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ :heavy_check_mark: ] I have made corresponding changes to the documentation (if applicable)
- [ :heavy_check_mark: ] I have added tests that prove my fix is effective or that my feature works (if applicable)
