### PR TITLE
Bug fix for Polygon 'yz' basis

### DIFF
--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -1252,11 +1252,11 @@ class Polygon(CompositeSurface):
             else:
                 op = operator.neg
                 if basis == 'xy':
-                    surf = openmc.Plane(a=dx, b=dy, d=-c)
+                    surf = openmc.Plane(a=dx, b=dy, c=0.0, d=-c)
                 elif basis == 'yz':
-                    surf = openmc.Plane(b=dx, c=dy, d=-c)
+                    surf = openmc.Plane(a=0.0, b=dx, c=dy, d=-c)
                 elif basis == 'xz':
-                    surf = openmc.Plane(a=dx, c=dy, d=-c)
+                    surf = openmc.Plane(a=dx, b=0.0, c=dy, d=-c)
                 else:
                     y0 = -c/dy
                     r2 = dy**2 / dx**2


### PR DESCRIPTION
# Description

The general plane constructor defaults to an x-plane with `a=1`. This was overlooked in the case when the Polygon basis is 'yz' and results in the wrong equation for planes in that case. This PR simply explicitly sets all kwargs in the constructor to avoid this.

Fixes # (issue)
A user raised this issue on the discourse forum here: https://openmc.discourse.group/t/polygon-yz-basis-bug/5124

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
