### PR TITLE
Add constant for invalid surface tokens.

### DIFF
--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -29,13 +29,6 @@ namespace openmc {
 
 enum class Fill { MATERIAL, UNIVERSE, LATTICE };
 
-// TODO: Convert to enum
-constexpr int32_t OP_LEFT_PAREN {std::numeric_limits<int32_t>::max()};
-constexpr int32_t OP_RIGHT_PAREN {std::numeric_limits<int32_t>::max() - 1};
-constexpr int32_t OP_COMPLEMENT {std::numeric_limits<int32_t>::max() - 2};
-constexpr int32_t OP_INTERSECTION {std::numeric_limits<int32_t>::max() - 3};
-constexpr int32_t OP_UNION {std::numeric_limits<int32_t>::max() - 4};
-
 //==============================================================================
 // Global variables
 //==============================================================================

--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -29,6 +29,12 @@ namespace openmc {
 
 enum class Fill { MATERIAL, UNIVERSE, LATTICE };
 
+constexpr int32_t OP_LEFT_PAREN {std::numeric_limits<int32_t>::max()};
+constexpr int32_t OP_RIGHT_PAREN {std::numeric_limits<int32_t>::max() - 1};
+constexpr int32_t OP_COMPLEMENT {std::numeric_limits<int32_t>::max() - 2};
+constexpr int32_t OP_INTERSECTION {std::numeric_limits<int32_t>::max() - 3};
+constexpr int32_t OP_UNION {std::numeric_limits<int32_t>::max() - 4};
+
 //==============================================================================
 // Global variables
 //==============================================================================

--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -354,7 +354,6 @@ enum class GeometryType { CSG, DAG };
 // representations. This value represents no surface.
 constexpr int32_t SURFACE_NONE {0};
 
-
 } // namespace openmc
 
 #endif // OPENMC_CONSTANTS_H

--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -350,6 +350,14 @@ enum class RandomRaySourceShape { FLAT, LINEAR, LINEAR_XY };
 
 enum class GeometryType { CSG, DAG };
 
+constexpr int32_t OP_LEFT_PAREN {std::numeric_limits<int32_t>::max()};
+constexpr int32_t OP_RIGHT_PAREN {std::numeric_limits<int32_t>::max() - 1};
+constexpr int32_t OP_COMPLEMENT {std::numeric_limits<int32_t>::max() - 2};
+constexpr int32_t OP_INTERSECTION {std::numeric_limits<int32_t>::max() - 3};
+constexpr int32_t OP_UNION {std::numeric_limits<int32_t>::max() - 4};
+constexpr int32_t NO_SURFACE {std::numeric_limits<int32_t>::max() - 5};
+
+
 } // namespace openmc
 
 #endif // OPENMC_CONSTANTS_H

--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -350,12 +350,9 @@ enum class RandomRaySourceShape { FLAT, LINEAR, LINEAR_XY };
 
 enum class GeometryType { CSG, DAG };
 
-constexpr int32_t OP_LEFT_PAREN {std::numeric_limits<int32_t>::max()};
-constexpr int32_t OP_RIGHT_PAREN {std::numeric_limits<int32_t>::max() - 1};
-constexpr int32_t OP_COMPLEMENT {std::numeric_limits<int32_t>::max() - 2};
-constexpr int32_t OP_INTERSECTION {std::numeric_limits<int32_t>::max() - 3};
-constexpr int32_t OP_UNION {std::numeric_limits<int32_t>::max() - 4};
-constexpr int32_t NO_SURFACE {std::numeric_limits<int32_t>::max() - 5};
+// a surface token cannot be zero due to the unsigned nature of zero for integer
+// representations. This value represents no surface.
+constexpr int32_t SURFACE_NONE {0};
 
 
 } // namespace openmc

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -185,10 +185,13 @@ struct CacheDataMG {
 
 struct BoundaryInfo {
   double distance {INFINITY}; //!< distance to nearest boundary
-  int surface_index {SURFACE_NONE}; //!< if boundary is surface, index in surfaces vector
+  int surface {SURFACE_NONE}; //!< surface token, non-zero if boundary is surface
   int coord_level;       //!< coordinate level after crossing boundary
   array<int, 3>
     lattice_translation {}; //!< which way lattice indices will change
+
+  // TODO: off-by-one
+  int surface_index() const { return std::abs(surface) - 1; }
 };
 
 /*
@@ -303,6 +306,7 @@ public:
   // Surface index based on the current value of the surface_ attribute
   int surface_index() const
   {
+    // TODO: off-by-one on surface indices throughout this function.
     return std::abs(surface_) - 1;
   }
 

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -347,7 +347,7 @@ private:
   Position r_last_;         //!< previous coordinates
   Direction u_last_;        //!< previous direction coordinates
 
-  int surface_ {SURFACE_NONE}; //!< index for surface particle is on
+  int surface_ {SURFACE_NONE}; //!< surface token for surface the particle is currently on
 
   BoundaryInfo boundary_; //!< Info about the next intersection
 

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -300,14 +300,14 @@ public:
   Direction& u_local() { return coord_[n_coord_ - 1].u; }
   const Direction& u_local() const { return coord_[n_coord_ - 1].u; }
 
-  // Surface that the particle is on
+  // Surface token for the surfae that the particle is currently on
   int& surface() { return surface_; }
   const int& surface() const { return surface_; }
 
   // Surface index based on the current value of the surface_ attribute
   int surface_index() const
   {
-    // TODO: off-by-one on surface indices throughout this function.
+    // TODO: off-by-one on
     return std::abs(surface_) - 1;
   }
 

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -185,8 +185,9 @@ struct CacheDataMG {
 
 struct BoundaryInfo {
   double distance {INFINITY}; //!< distance to nearest boundary
-  int surface {SURFACE_NONE}; //!< surface token, non-zero if boundary is surface
-  int coord_level;       //!< coordinate level after crossing boundary
+  int surface {
+    SURFACE_NONE}; //!< surface token, non-zero if boundary is surface
+  int coord_level; //!< coordinate level after crossing boundary
   array<int, 3>
     lattice_translation {}; //!< which way lattice indices will change
 
@@ -347,7 +348,8 @@ private:
   Position r_last_;         //!< previous coordinates
   Direction u_last_;        //!< previous direction coordinates
 
-  int surface_ {SURFACE_NONE}; //!< surface token for surface the particle is currently on
+  int surface_ {
+    SURFACE_NONE}; //!< surface token for surface the particle is currently on
 
   BoundaryInfo boundary_; //!< Info about the next intersection
 

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -300,14 +300,14 @@ public:
   Direction& u_local() { return coord_[n_coord_ - 1].u; }
   const Direction& u_local() const { return coord_[n_coord_ - 1].u; }
 
-  // Surface token for the surfae that the particle is currently on
+  // Surface token for the surface that the particle is currently on
   int& surface() { return surface_; }
   const int& surface() const { return surface_; }
 
   // Surface index based on the current value of the surface_ attribute
   int surface_index() const
   {
-    // TODO: off-by-one on
+    // TODO: off-by-one
     return std::abs(surface_) - 1;
   }
 

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -226,7 +226,7 @@ public:
   void init_from_r_u(Position r_a, Direction u_a)
   {
     clear();
-    surface() = 0;
+    surface() = NO_SURFACE;
     material() = C_NONE;
     r() = r_a;
     u() = u_a;
@@ -337,7 +337,7 @@ private:
   Position r_last_;         //!< previous coordinates
   Direction u_last_;        //!< previous direction coordinates
 
-  int surface_ {0}; //!< index for surface particle is on
+  int surface_ {NO_SURFACE}; //!< index for surface particle is on
 
   BoundaryInfo boundary_; //!< Info about the next intersection
 

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -185,7 +185,7 @@ struct CacheDataMG {
 
 struct BoundaryInfo {
   double distance {INFINITY}; //!< distance to nearest boundary
-  int surface_index {0}; //!< if boundary is surface, index in surfaces vector
+  int surface_index {SURFACE_NONE}; //!< if boundary is surface, index in surfaces vector
   int coord_level;       //!< coordinate level after crossing boundary
   array<int, 3>
     lattice_translation {}; //!< which way lattice indices will change
@@ -226,7 +226,7 @@ public:
   void init_from_r_u(Position r_a, Direction u_a)
   {
     clear();
-    surface() = NO_SURFACE;
+    surface() = SURFACE_NONE;
     material() = C_NONE;
     r() = r_a;
     u() = u_a;
@@ -300,6 +300,12 @@ public:
   int& surface() { return surface_; }
   const int& surface() const { return surface_; }
 
+  // Surface index based on the current value of the surface_ attribute
+  int surface_index() const
+  {
+    return std::abs(surface_) - 1;
+  }
+
   // Boundary information
   BoundaryInfo& boundary() { return boundary_; }
 
@@ -337,7 +343,7 @@ private:
   Position r_last_;         //!< previous coordinates
   Direction u_last_;        //!< previous direction coordinates
 
-  int surface_ {NO_SURFACE}; //!< index for surface particle is on
+  int surface_ {SURFACE_NONE}; //!< index for surface particle is on
 
   BoundaryInfo boundary_; //!< Info about the next intersection
 

--- a/src/boundary_condition.cpp
+++ b/src/boundary_condition.cpp
@@ -129,8 +129,7 @@ TranslationalPeriodicBC::TranslationalPeriodicBC(int i_surf, int j_surf)
 void TranslationalPeriodicBC::handle_particle(
   Particle& p, const Surface& surf) const
 {
-  // TODO: off-by-one on surface indices throughout this function.
-  int i_particle_surf = std::abs(p.surface()) - 1;
+  int i_particle_surf = p.surface_index();
 
   // Figure out which of the two BC surfaces were struck then find the
   // particle's new location and surface.
@@ -255,8 +254,7 @@ RotationalPeriodicBC::RotationalPeriodicBC(int i_surf, int j_surf)
 void RotationalPeriodicBC::handle_particle(
   Particle& p, const Surface& surf) const
 {
-  // TODO: off-by-one on surface indices throughout this function.
-  int i_particle_surf = std::abs(p.surface()) - 1;
+  int i_particle_surf = p.surface_index();
 
   // Figure out which of the two BC surfaces were struck to figure out if a
   // forward or backward rotation is required.  Specify the other surface as

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -847,7 +847,7 @@ void check_dagmc_root_univ()
 
 int32_t next_cell(int32_t surf, int32_t curr_cell, int32_t univ)
 {
-  auto surfp = dynamic_cast<DAGSurface*>(model::surfaces[surf - 1].get());
+  auto surfp = dynamic_cast<DAGSurface*>(model::surfaces[surf].get());
   auto cellp = dynamic_cast<DAGCell*>(model::cells[curr_cell].get());
   auto univp = static_cast<DAGUniverse*>(model::universes[univ].get());
 

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -424,7 +424,7 @@ BoundaryInfo distance_to_boundary(GeometryState& p)
           info.surface = level_surf_cross;
         } else {
           Position r_hit = r + d_surf * u;
-          Surface& surf {*model::surfaces[info.surface_index()]};
+          Surface& surf {*model::surfaces[std::abs(level_surf_cross)-1]};
           Direction norm = surf.normal(r_hit);
           if (u.dot(norm) > 0) {
             info.surface = std::abs(level_surf_cross);

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -424,7 +424,7 @@ BoundaryInfo distance_to_boundary(GeometryState& p)
           info.surface = level_surf_cross;
         } else {
           Position r_hit = r + d_surf * u;
-          Surface& surf {*model::surfaces[std::abs(level_surf_cross)-1]};
+          Surface& surf {*model::surfaces[std::abs(level_surf_cross) - 1]};
           Direction norm = surf.normal(r_hit);
           if (u.dot(norm) > 0) {
             info.surface = std::abs(level_surf_cross);

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -421,15 +421,15 @@ BoundaryInfo distance_to_boundary(GeometryState& p)
         // have to explicitly check which half-space the particle would be
         // traveling into if the surface is crossed
         if (c.is_simple() || d == INFTY) {
-          info.surface_index = level_surf_cross;
+          info.surface = level_surf_cross;
         } else {
           Position r_hit = r + d_surf * u;
-          Surface& surf {*model::surfaces[std::abs(level_surf_cross) - 1]};
+          Surface& surf {*model::surfaces[info.surface_index()]};
           Direction norm = surf.normal(r_hit);
           if (u.dot(norm) > 0) {
-            info.surface_index = std::abs(level_surf_cross);
+            info.surface = std::abs(level_surf_cross);
           } else {
-            info.surface_index = -std::abs(level_surf_cross);
+            info.surface = -std::abs(level_surf_cross);
           }
         }
 
@@ -441,7 +441,7 @@ BoundaryInfo distance_to_boundary(GeometryState& p)
     } else {
       if (d == INFINITY || (d - d_lat) / d >= FP_REL_PRECISION) {
         d = d_lat;
-        info.surface_index = 0;
+        info.surface = SURFACE_NONE;
         info.lattice_translation = level_lat_trans;
         info.coord_level = i + 1;
       }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -200,7 +200,7 @@ void print_particle(Particle& p)
   }
 
   // Display miscellaneous info.
-  if (p.surface() != 0) {
+  if (p.surface() != NO_SURFACE) {
     // Surfaces identifiers are >= 1, but indices are >= 0 so we need -1
     const Surface& surf {*model::surfaces[std::abs(p.surface()) - 1]};
     fmt::print("  Surface = {}\n", (p.surface() > 0) ? surf.id_ : -surf.id_);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -202,7 +202,7 @@ void print_particle(Particle& p)
   // Display miscellaneous info.
   if (p.surface() != SURFACE_NONE) {
     // Surfaces identifiers are >= 1, but indices are >= 0 so we need -1
-    const Surface& surf {*model::surfaces[std::abs(p.surface()) - 1]};
+    const Surface& surf {*model::surfaces[p.surface_index()]};
     fmt::print("  Surface = {}\n", (p.surface() > 0) ? surf.id_ : -surf.id_);
   }
   fmt::print("  Weight = {}\n", p.wgt());

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -200,7 +200,7 @@ void print_particle(Particle& p)
   }
 
   // Display miscellaneous info.
-  if (p.surface() != NO_SURFACE) {
+  if (p.surface() != SURFACE_NONE) {
     // Surfaces identifiers are >= 1, but indices are >= 0 so we need -1
     const Surface& surf {*model::surfaces[std::abs(p.surface()) - 1]};
     fmt::print("  Surface = {}\n", (p.surface() > 0) ? surf.id_ : -surf.id_);

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -277,7 +277,7 @@ void Particle::event_cross_surface()
   n_coord_last() = n_coord();
 
   // Set surface that particle is on and adjust coordinate levels
-  surface() = boundary().surface_index;
+  surface() = boundary().surface;
   n_coord() = boundary().coord_level;
 
   if (boundary().lattice_translation[0] != 0 ||
@@ -291,7 +291,7 @@ void Particle::event_cross_surface()
   } else {
     // Particle crosses surface
     // TODO: off-by-one
-    const auto& surf {model::surfaces[std::abs(surface()) - 1].get()};
+    const auto& surf {model::surfaces[surface_index()].get()};
     // If BC, add particle to surface source before crossing surface
     if (surf->surf_source_ && surf->bc_) {
       add_surf_source_to_bank(*this, *surf);
@@ -549,7 +549,7 @@ void Particle::cross_surface(const Surface& surf)
 #ifdef DAGMC
   // in DAGMC, we know what the next cell should be
   if (surf.geom_type() == GeometryType::DAG) {
-    int32_t i_cell = next_cell(std::abs(surface()), cell_last(n_coord() - 1),
+    int32_t i_cell = next_cell(surface_index(), cell_last(n_coord() - 1),
                        lowest_coord().universe) -
                      1;
     // save material and temp

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -108,7 +108,7 @@ void Particle::from_source(const SourceSite* src)
 {
   // Reset some attributes
   clear();
-  surface() = 0;
+  surface() = NO_SURFACE;
   cell_born() = C_NONE;
   material() = C_NONE;
   n_collision() = 0;
@@ -328,7 +328,7 @@ void Particle::event_collide()
     score_surface_tally(*this, model::active_meshsurf_tallies);
 
   // Clear surface component
-  surface() = 0;
+  surface() = NO_SURFACE;
 
   if (settings::run_CE) {
     collision(*this);
@@ -587,7 +587,7 @@ void Particle::cross_surface(const Surface& surf)
     // the particle is really traveling tangent to a surface, if we move it
     // forward a tiny bit it should fix the problem.
 
-    surface() = 0;
+    surface() = NO_SURFACE;
     n_coord() = 1;
     r() += TINY_BIT * u();
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -108,7 +108,7 @@ void Particle::from_source(const SourceSite* src)
 {
   // Reset some attributes
   clear();
-  surface() = NO_SURFACE;
+  surface() = SURFACE_NONE;
   cell_born() = C_NONE;
   material() = C_NONE;
   n_collision() = 0;
@@ -328,7 +328,7 @@ void Particle::event_collide()
     score_surface_tally(*this, model::active_meshsurf_tallies);
 
   // Clear surface component
-  surface() = NO_SURFACE;
+  surface() = SURFACE_NONE;
 
   if (settings::run_CE) {
     collision(*this);
@@ -587,7 +587,7 @@ void Particle::cross_surface(const Surface& surf)
     // the particle is really traveling tangent to a surface, if we move it
     // forward a tiny bit it should fix the problem.
 
-    surface() = NO_SURFACE;
+    surface() = SURFACE_NONE;
     n_coord() = 1;
     r() += TINY_BIT * u();
 

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -1301,7 +1301,7 @@ void ProjectionPlot::create_output() const
           while (intersection_found) {
             bool inside_cell = false;
 
-            int32_t i_surface = std::abs(p.surface()) - 1;
+            int32_t i_surface = p.surface_index();
             if (i_surface > 0 &&
                 model::surfaces[i_surface]->geom_type() == GeometryType::DAG) {
 #ifdef DAGMC
@@ -1334,13 +1334,13 @@ void ProjectionPlot::create_output() const
               this_line_segments[tid][horiz].emplace_back(
                 color_by_ == PlotColorBy::mats ? p.material()
                                                : p.lowest_coord().cell,
-                dist.distance, std::abs(dist.surface_index));
+                dist.distance, std::abs(dist.surface));
 
               // Advance particle
               for (int lev = 0; lev < p.n_coord(); ++lev) {
                 p.coord(lev).r += dist.distance * p.coord(lev).u;
               }
-              p.surface() = dist.surface_index;
+              p.surface() = dist.surface;
               p.n_coord_last() = p.n_coord();
               p.n_coord() = dist.coord_level;
               if (dist.lattice_translation[0] != 0 ||

--- a/src/tallies/filter_musurface.cpp
+++ b/src/tallies/filter_musurface.cpp
@@ -12,7 +12,7 @@ void MuSurfaceFilter::get_all_bins(
   const Particle& p, TallyEstimator estimator, FilterMatch& match) const
 {
   // Get surface normal (and make sure it is a unit vector)
-  const auto surf {model::surfaces[std::abs(p.surface()) - 1].get()};
+  const auto surf {model::surfaces[p.surface_index()].get()};
   auto n = surf->normal(p.r());
   n /= n.norm();
 

--- a/src/tallies/filter_surface.cpp
+++ b/src/tallies/filter_surface.cpp
@@ -47,7 +47,7 @@ void SurfaceFilter::set_surfaces(gsl::span<int32_t> surfaces)
 void SurfaceFilter::get_all_bins(
   const Particle& p, TallyEstimator estimator, FilterMatch& match) const
 {
-  auto search = map_.find(std::abs(p.surface()) - 1);
+  auto search = map_.find(p.surface_index());
   if (search != map_.end()) {
     match.bins_.push_back(search->second);
     if (p.surface() < 0) {


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

As I was going through some of the plotting code I noticed that through out the code we use a value of `0` for an invalid surface token. Here, token meaning a signed, off-by-one index as opposed to a signed surface ID. 

The "magic number" is a little confusing when we're constantly converting between tokens and indices into the `model::surfaces` vector. Further, we initialize `BoundaryInfo.surface_index` to `0` because this member is really a token rather than an index.

In an effort to distinguish surface token values I've added a `SURFACE_NONE` constexpr that is `0` for these cases.

I've also updated `BoundaryInfo::surface_index` attribute to `surface` in an effort to be consistent with the `GeometryState::surface_` attribute  and added `BoundaryInfo|GeometryState::surface_index` methods that convert from the token to the index for that token. This doesn't cover all of the cases where we do this conversion, but I think it generally increases clarity were `surface` indicates a token and `surface_index` an index.s

**Update**

It's worth noting that there's a fix for the surface index passed into the DAGMC `next_cell` call for projection plots. The off-by-one used to be handled in `next_cell` but the argument passed in was already adjustment, so this was happening twice. 

# Checklist

- [ ] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~ N/A
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~ N/A
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
