### PR TITLE
Update plots.py for PathLike to string handling error

### DIFF
--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -250,9 +250,10 @@ def voxel_to_vtk(voxel_file: PathLike, output: PathLike = 'plot.vti'):
         writer.SetInputData(grid)
     else:
         writer.SetInput(grid)
-    if not output.name.endswith(".vti"):
+    output = str(output)
+    if not output.endswith(".vti"):
         output += ".vti"
-    writer.SetFileName(str(output))
+    writer.SetFileName(output)
     writer.Write()
 
     return output

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -250,7 +250,7 @@ def voxel_to_vtk(voxel_file: PathLike, output: PathLike = 'plot.vti'):
         writer.SetInputData(grid)
     else:
         writer.SetInput(grid)
-    if not output.endswith(".vti"):
+    if not output.name.endswith(".vti"):
         output += ".vti"
     writer.SetFileName(str(output))
     writer.Write()

--- a/tests/unit_tests/test_plots.py
+++ b/tests/unit_tests/test_plots.py
@@ -90,7 +90,7 @@ def test_voxel_plot(run_in_tmpdir):
     assert Path('test_voxel_plot.vti').is_file()
 
     vox_plot.filename = 'h5_voxel_plot'
-    vox_plot.to_vtk('another_test_voxel_plot.vti')
+    vox_plot.to_vtk(Path('another_test_voxel_plot.vti'))
 
     assert Path('h5_voxel_plot.h5').is_file()
     assert Path('another_test_voxel_plot.vti').is_file()


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Handles issue when passing PathLike objects to `voxel_to_vtk` where a `str` method was being called on a PathLike. This PR adds the `.name` modifier to treat the PathLike as a string instead.

No issue reported for this yet

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
