### PR TITLE
Fix bug in WeightWindowGenerator for empty energy bounds

### DIFF
--- a/openmc/weight_windows.py
+++ b/openmc/weight_windows.py
@@ -897,7 +897,10 @@ class WeightWindowGenerator:
         mesh_id = int(get_text(elem, 'mesh'))
         mesh = meshes[mesh_id]
 
-        energy_bounds = [float(x) for x in get_text(elem, 'energy_bounds').split()]
+        if energy_bounds := get_text(elem, 'energy_bounds') is not None:
+            energy_bounds = [float(x) for x in energy_bounds.split()]
+        else:
+            energy_bounds = None
         particle_type = get_text(elem, 'particle_type')
 
         wwg = cls(mesh, energy_bounds, particle_type)


### PR DESCRIPTION
# Description

I recently noticed that if you have a `WeightWindowGenerator` without energy bounds specified, it does not roundtrip in XML correctly. This PR should fix that.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)