### PR TITLE
Vaccum detction test

### DIFF
--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 import openmc
 from openmc.utility_funcs import change_directory
-import openmc.lib
 pytestmark = pytest.mark.skipif(
     not openmc.lib._dagmc_enabled(),
     reason="DAGMC CAD geometry is not enabled.")
@@ -44,7 +43,6 @@ def model(request):
         [daguniv, daguniv]]
 
     box = openmc.model.RectangularParallelepiped(-pitch, pitch, -pitch, pitch, -5, 5)
-    box.boundary_type = "vacuum"
 
     root = openmc.Universe(cells=[openmc.Cell(region=-box, fill=lattice)])
 

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -41,6 +41,7 @@ def model(request):
         [daguniv, daguniv]]
 
     box = openmc.model.RectangularParallelepiped(-pitch, pitch, -pitch, pitch, -5, 5)
+    box.boundary_type = "vacuum"
 
     root = openmc.Universe(cells=[openmc.Cell(region=-box, fill=lattice)])
 

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -330,7 +330,7 @@ def test_dagmc_vacuum(request, run_in_tmpdir, tmpdir):
     p = tmpdir/"dagmc_a_vacuum.h5m"
     daguniv = openmc.DAGMCUniverse(p, auto_geom_ids=True).bounded_universe()
     settings = openmc.Settings()
-    settings.batches = 100
+    settings.batches = 2
     settings.inactive = 10
     settings.particles = 1000
     model = openmc.Model()

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -259,10 +259,8 @@ def test_dagmc_xml(model):
         assert all([xml_mat.id == orig_mat.id for xml_mat, orig_mat in zip(xml_mats, model_mats)])
 
 def test_dagmc_vacuum(request, run_in_tmpdir, tmpdir):
-    
     # Required initial mats.
     mats = {}
-
     mats["41"] = openmc.Material(name="41")
     mats["41"].add_nuclide("U235", 0.03)
     mats["41"].add_nuclide("U238", 0.97)
@@ -324,7 +322,7 @@ def test_dagmc_vacuum(request, run_in_tmpdir, tmpdir):
         non_zero_tal = [x for x in tally.mean.flatten() if x > 0]
         assert len(non_zero_tal) > 1
 
-    # Not a vacuum material
+    # Vacuum material
     vacuum_str = "vacuum"
     mats[vacuum_str] = openmc.Material(name=vacuum_str)
     mats[vacuum_str].add_nuclide("U235", 0.03)

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -354,9 +354,9 @@ def test_dagmc_vacuum(request, run_in_tmpdir, tmpdir):
     model.settings.source = src
 
     model.export_to_model_xml('sub_dir_vacuum/model.xml',)
-    openmc.run(cwd='sub_dir_vacuum')
+    sp_filename = openmc.run(cwd='sub_dir_vacuum')
     # Read the statepoint file.
-    sp = openmc.StatePoint("sub_dir_vacuum/statepoint.100.h5")
+    sp = openmc.StatePoint(sp_filename)
 
     # Extract the tally data as a Pandas DataFrame.
     tally_dfs = [t.get_pandas_dataframe() for t in sp.tallies.values()]

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import h5py
 import shutil
-import pandas as pd
 import lxml.etree as ET
 import numpy as np
 import pytest
@@ -262,18 +261,14 @@ def test_dagmc_vacuum(request, run_in_tmpdir, tmpdir):
     # Required initial mats.
     mats = {}
     mats["41"] = openmc.Material(name="41")
-    mats["41"].add_nuclide("U235", 0.03)
-    mats["41"].add_nuclide("U238", 0.97)
-    mats["41"].add_nuclide("O16", 2.0)
-    mats["41"].set_density("g/cm3", 10.0)
+    mats["41"].add_nuclide("U235", 1)
+    mats["41"].set_density("g/cm3", 0.03)
 
     # Not a vacuum material
     na_vacuum_str = "not_a_vacuum"
     mats[na_vacuum_str] = openmc.Material(name=na_vacuum_str)
-    mats[na_vacuum_str].add_nuclide("U235", 0.03)
-    mats[na_vacuum_str].add_nuclide("U238", 0.97)
-    mats[na_vacuum_str].add_nuclide("O16", 2.0)
-    mats[na_vacuum_str].set_density("g/cm3", 10.0)
+    mats[na_vacuum_str].add_nuclide("U235", 1)
+    mats[na_vacuum_str].set_density("g/cm3", 0.03)
 
     # Tweaking the h5m file to change the material assignment
     na_vacuum_h5 = tmpdir / f"dagmc_{na_vacuum_str}.h5m"

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import openmc
 from openmc.utility_funcs import change_directory
-
+import openmc.lib
 pytestmark = pytest.mark.skipif(
     not openmc.lib._dagmc_enabled(),
     reason="DAGMC CAD geometry is not enabled.")
@@ -259,8 +259,6 @@ def test_dagmc_xml(model):
 
 def test_dagmc_vacuum(model):
 
-    openmc.run()
-
     # Verify Not_A_Vacuum is not detected as a Vacuum
     mat_not_a_vacuum = openmc.Material(1, name="Not_A_Vacuum")
     mat_not_a_vacuum.add_nuclide("U235", 0.03)
@@ -276,6 +274,12 @@ def test_dagmc_vacuum(model):
     # Replacing all the materials with vacuum
     for mat in dag_univ.material_names:
         dag_univ.replace_material_assignment(mat, mat_not_a_vacuum)
+
+    current = openmc.Tally()
+    current.scores = ['current']
+    model._tallies.append(current)
+    src = openmc.IndependentSource(space=openmc.stats.Point())
+    model.settings.source = src
 
     model.export_to_xml()
     # Ensure this run as expected.

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import h5py
+import shutil
 import pandas as pd
 import lxml.etree as ET
 import numpy as np
@@ -259,7 +261,6 @@ def test_dagmc_xml(model):
 
 def test_dagmc_vacuum(request, run_in_tmpdir, tmpdir):
     
-    import shutil
     shutil.copyfile(Path(request.fspath).parent / "dagmc.h5m", tmpdir/"dagmc_not_a_vacuum.h5m")
 
     mats = {}
@@ -281,7 +282,6 @@ def test_dagmc_vacuum(request, run_in_tmpdir, tmpdir):
     mats["41"].add_nuclide("O16", 2.0)
     mats["41"].set_density("g/cm3", 10.0)
 
-    import h5py
     hf = h5py.File(tmpdir/ "dagmc_not_a_vacuum.h5m", 'r+')
     new_assignment = 'mat:not_a_vacuum'.encode('utf-8')
     hf['/tstt/tags/NAME']['values'][1] = new_assignment
@@ -291,7 +291,6 @@ def test_dagmc_vacuum(request, run_in_tmpdir, tmpdir):
     daguniv = openmc.DAGMCUniverse(p, auto_geom_ids=True).bounded_universe()
     settings = openmc.Settings()
     settings.batches = 100
-    settings.inactive = 10
     settings.particles = 1000
     model = openmc.Model()
     model.materials = openmc.Materials(mats.values())

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -258,6 +258,8 @@ def test_dagmc_xml(model):
 
 def test_dagmc_vacuum(model):
 
+    openmc.run()
+
     # Verify Not_A_Vacuum is not detected as a Vacuum
     mat_not_a_vacuum = openmc.Material(1, name="Not_A_Vacuum")
     mat_not_a_vacuum.add_nuclide("U235", 0.03)

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -288,7 +288,14 @@ def test_dagmc_vacuum(model):
     model.export_to_xml()
     # Ensure this run as expected.
     openmc.run()
+    # Read the statepoint file.
+    sp = openmc.StatePoint("statepoint.100.h5")
 
+    # Extract the tally data as a Pandas DataFrame.
+    tally_dfs = [t.get_pandas_dataframe() for t in sp.tallies.values()]
+    df = pd.concat(tally_dfs, ignore_index=True)
+    print(df)
+    
     # Verify that the vacuum is detected as a Vacuum
     mat_a_vacuum = openmc.Material(1, name="Vacuum")
     mat_a_vacuum.add_nuclide("U235", 0.03)

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -275,9 +275,13 @@ def test_dagmc_vacuum(model):
     for mat in dag_univ.material_names:
         dag_univ.replace_material_assignment(mat, mat_not_a_vacuum)
 
+
+    pitch = 1.26
+    box = openmc.SurfaceFilter(openmc.Sphere(r=pitch))
     current = openmc.Tally()
     current.scores = ['current']
-    model._tallies.append(current)
+    current.filters = [box]
+    model.tallies.append(current)
     src = openmc.IndependentSource(space=openmc.stats.Point())
     model.settings.source = src
 

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -332,7 +332,7 @@ def test_dagmc_vacuum(request, run_in_tmpdir, tmpdir):
     settings = openmc.Settings()
     settings.batches = 2
     settings.inactive = 10
-    settings.particles = 1000
+    settings.particles = 100
     model = openmc.Model()
     model.materials = openmc.Materials(mats.values())
     model.geometry = openmc.Geometry(root=daguniv)

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 import openmc
 from openmc.utility_funcs import change_directory
-import openmc.lib
 pytestmark = pytest.mark.skipif(
     not openmc.lib._dagmc_enabled(),
     reason="DAGMC CAD geometry is not enabled.")

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -295,7 +295,7 @@ def test_dagmc_vacuum(model):
 
     # Replacing all the materials with vacuum
     for mat in dag_univ.material_names:
-        dag_univ.replace_material_assignment(mat, at_a_vacuum)
+        dag_univ.replace_material_assignment(mat, mat_a_vacuum)
 
     model.export_to_xml()
     # ensure that particles will be lost when cell intersections can't be found

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -262,13 +262,13 @@ def test_dagmc_vacuum(request, run_in_tmpdir, tmpdir):
     mats = {}
     mats["41"] = openmc.Material(name="41")
     mats["41"].add_nuclide("U235", 1)
-    mats["41"].set_density("g/cm3", 0.03)
+    mats["41"].set_density("g/cm3", 1)
 
     # Not a vacuum material
     na_vacuum_str = "not_a_vacuum"
     mats[na_vacuum_str] = openmc.Material(name=na_vacuum_str)
     mats[na_vacuum_str].add_nuclide("U235", 1)
-    mats[na_vacuum_str].set_density("g/cm3", 0.03)
+    mats[na_vacuum_str].set_density("g/cm3", 1)
 
     # Tweaking the h5m file to change the material assignment
     na_vacuum_h5 = tmpdir / f"dagmc_{na_vacuum_str}.h5m"

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -257,10 +257,10 @@ def test_dagmc_xml(model):
     for xml_mats, model_mats in zip(xml_dagmc_univ._material_overrides.values(), dag_univ._material_overrides.values()):
         assert all([xml_mat.id == orig_mat.id for xml_mat, orig_mat in zip(xml_mats, model_mats)])
 
-def test_dagmc_vacuum(request, run_in_tmpdir):
+def test_dagmc_vacuum(request, run_in_tmpdir, tmpdir):
     
     import shutil
-    shutil.copyfile(Path(request.fspath).parent / "dagmc.h5m", Path(request.fspath).parent / "dagmc_not_a_vacuum.h5m")
+    shutil.copyfile(Path(request.fspath).parent / "dagmc.h5m", tmpdir/"dagmc_not_a_vacuum.h5m")
 
     mats = {}
     mats["not_a_vacuum"] = openmc.Material(1, name="not_a_vacuum")
@@ -282,12 +282,12 @@ def test_dagmc_vacuum(request, run_in_tmpdir):
     mats["41"].set_density("g/cm3", 10.0)
 
     import h5py
-    hf = h5py.File(Path(request.fspath).parent / "dagmc_not_a_vacuum.h5m", 'r+')
+    hf = h5py.File(tmpdir/ "dagmc_not_a_vacuum.h5m", 'r+')
     new_assignment = 'mat:not_a_vacuum'.encode('utf-8')
     hf['/tstt/tags/NAME']['values'][1] = new_assignment
     hf.close()
     
-    p = Path(request.fspath).parent / "dagmc_not_a_vacuum.h5m"
+    p = tmpdir/"dagmc_not_a_vacuum.h5m"
     daguniv = openmc.DAGMCUniverse(p, auto_geom_ids=True).bounded_universe()
     settings = openmc.Settings()
     settings.batches = 100
@@ -324,14 +324,13 @@ def test_dagmc_vacuum(request, run_in_tmpdir):
     # not detected as vacuum so tally should be non-zero
     assert df['mean'].loc[0] > 0
 
-    shutil.copyfile(Path(request.fspath).parent / "dagmc.h5m", Path(request.fspath).parent / "dagmc_a_vacuum.h5m")
-    hf = h5py.File(Path(request.fspath).parent / "dagmc_a_vacuum.h5m", 'r+')
+    shutil.copyfile(Path(request.fspath).parent / "dagmc.h5m", tmpdir/"dagmc_a_vacuum.h5m")
+    hf = h5py.File(tmpdir/ "dagmc_a_vacuum.h5m", 'r+')
     new_assignment = 'mat:vacuum'.encode('utf-8')
     hf['/tstt/tags/NAME']['values'][1] = new_assignment
     hf.close()
 
-    p = Path(request.fspath).parent / "dagmc_a_vacuum.h5m"
-
+    p = tmpdir/"dagmc_a_vacuum.h5m"
     daguniv = openmc.DAGMCUniverse(p, auto_geom_ids=True).bounded_universe()
     settings = openmc.Settings()
     settings.batches = 100


### PR DESCRIPTION
# Description

This is a follow up on [svalinn/DAGMC#805](https://github.com/svalinn/DAGMC/issues/805)

This ensures that a assignment named "not_a_vacuum" is not flagged as vacuum and therefore is not assigned with vacuum boundary condition.

Fixes # (issue)
This is related to #3218 

I also had to implement that a different way than initially expected.
I first thought about leveraging the #3056 PR recently merged to do this kind of test.
But, vacuum detection is perform (in the DAGMC workflow within openMC) before applying materials assignment (therefore before overriding)

This is why I implemented this by making temporary copy of the `dagmc.hm5` and modifying them. (Not that seing how simple this is we could potentially provide a method that allows to do that within `dagmc.py` ?)

I trying and failed to design this test as a fixture, I don't know why it failed it never recognised the returned `model` as a `openmc.Model` but as a function... (@pshriwise if you have any insight on this ?)

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
