### PR TITLE
Change to `from_geometry` allowing for creating bounded plots from infnite geometry

### DIFF
--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -682,7 +682,7 @@ class Plot(PlotBase):
         return string
 
     @classmethod
-    def from_geometry(cls, geometry, basis='xy', slice_coord=0.):
+    def from_geometry(cls, geometry, basis='xy', slice_coord=0., width=None, origin=None):
         """Return plot that encompasses a geometry.
 
         Parameters
@@ -716,14 +716,14 @@ class Plot(PlotBase):
         lower_left = lower_left[np.array(pick_index)]
         upper_right = upper_right[np.array(pick_index)]
 
-        if np.any(np.isinf((lower_left, upper_right))):
+        if width is None and np.any(np.isinf((lower_left, upper_right))):
             raise ValueError('The geometry does not appear to be bounded '
                              f'in the {basis} plane.')
 
         plot = cls()
-        plot.origin = np.insert((lower_left + upper_right)/2,
+        plot.origin = origin if origin is not None else np.insert((lower_left + upper_right)/2,
                                 slice_index, slice_coord)
-        plot.width = upper_right - lower_left
+        plot.width = width if width is not None else upper_right - lower_left
         plot.basis = basis
         return plot
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Infinite bound geometry can't be imported straight into a plot. This is to allow for bounding of infinite geometry into a plot object on import, easing the creation of plots from infinitely bound geometry.

Fixes #3262 

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
