### PR TITLE
Fix bug in Surface.normalize

### DIFF
--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -309,7 +309,7 @@ class Surface(IDManagerMixin, ABC):
             coeffs = self._get_base_coeffs()
         coeffs = np.asarray(coeffs)
         nonzeros = ~np.isclose(coeffs, 0., rtol=0., atol=self._atol)
-        norm_factor = np.abs(coeffs[nonzeros][0])
+        norm_factor = coeffs[nonzeros][0]
         return tuple([c/norm_factor for c in coeffs])
 
     def is_equal(self, other):

--- a/tests/unit_tests/test_surface.py
+++ b/tests/unit_tests/test_surface.py
@@ -753,3 +753,16 @@ def test_ztorus():
     assert isinstance(sr, openmc.YTorus)
     sr = s.rotate((0., 90., 0.))
     assert isinstance(sr, openmc.XTorus)
+
+
+def test_normalize():
+    """Test that equivalent planes give same normalized coefficients"""
+    p1 = openmc.Plane(a=0.0, b=1.0, c=0.0, d=1.0)
+    p2 = openmc.Plane(a=0.0, b=2.0, c=0.0, d=2.0)
+    assert p1.normalize() == p2.normalize()
+
+    p2 = openmc.Plane(a=0.0, b=-1.0, c=0.0, d=-1.0)
+    assert p1.normalize() == p2.normalize()
+
+    p2 = openmc.YPlane(1.0)
+    assert p1.normalize() == p2.normalize()


### PR DESCRIPTION
# Description

This PR fixes a bug in the `Surface.normalize` method. This method works by dividing the set of base coefficients by the first non-zero coefficient. However, currently it takes the absolute value which means that two otherwise equivalent surfaces can return different values, for example, `Plane(a=1, d=1)` and `Plane(a=-1, d=-1)`.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)