### PR TITLE
Tweak To Sphinx Install Documentation

### DIFF
--- a/docs/source/devguide/docbuild.rst
+++ b/docs/source/devguide/docbuild.rst
@@ -12,7 +12,7 @@ Python API. That is, from the root directory of the OpenMC repository:
 
 .. code-block:: sh
 
-    python -m pip install .[docs]
+    python -m pip install ".[docs]"
 
 -----------------------------------
 Building Documentation as a Webpage


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

The current command in the docs for how to install the Sphinx python dependencies works on linux, but requires the addition of some quotes to work on MacOS. This PR adds those quotes so those wanting to build the docs on Mac don't get stuck. The quotes should work fine on linux as well.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
