### PR TITLE
add continue feature for depletion

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -572,6 +572,18 @@ class Integrator(ABC):
         :attr:`solver`.
 
         .. versionadded:: 0.12
+    continue_timesteps : bool, optional
+        Whether or not to treat the current solve as a continuation of a
+        previous simulation. Defaults to `False`. If `True`, the timesteps
+        provided to the `Integrator` must match exactly those that exist
+        in the `prev_results` passed to the `Opereator`. The `power`,
+        `power_density`, or `source_rates` must match as well. It
+        is the user's responsibility to make sure that the continue
+        solve uses the same method of specifying `power`, `power_density`,
+        or `source_rates`.
+
+        .. versionadded:: 0.15.1
+
     Attributes
     ----------
     operator : openmc.deplete.abc.TransportOperator
@@ -933,6 +945,17 @@ class SIIntegrator(Integrator):
         :attr:`solver`.
 
         .. versionadded:: 0.12
+    continue_timesteps : bool, optional
+        Whether or not to treat the current solve as a continuation of a
+        previous simulation. Defaults to `False`. If `True`, the timesteps
+        provided to the `Integrator` must match exactly those that exist
+        in the `prev_results` passed to the `Opereator`. The `power`,
+        `power_density`, or `source_rates` must match as well. It
+        is the user's responsibility to make sure that the continue
+        solve uses the same method of specifying `power`, `power_density`,
+        or `source_rates`.
+
+        .. versionadded:: 0.15.1
 
     Attributes
     ----------
@@ -974,13 +997,14 @@ class SIIntegrator(Integrator):
             source_rates: Optional[Sequence[float]] = None,
             timestep_units: str = 's',
             n_steps: int = 10,
-            solver: str = "cram48"
+            solver: str = "cram48",
+            continue_timesteps: bool = False,
         ):
         check_type("n_steps", n_steps, Integral)
         check_greater_than("n_steps", n_steps, 0)
         super().__init__(
             operator, timesteps, power, power_density, source_rates,
-            timestep_units=timestep_units, solver=solver)
+            timestep_units=timestep_units, solver=solver, continue_timesteps=continue_timesteps)
         self.n_steps = n_steps
 
     def _get_bos_data_from_operator(self, step_index, step_power, n_bos):

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -574,13 +574,13 @@ class Integrator(ABC):
         .. versionadded:: 0.12
     continue_timesteps : bool, optional
         Whether or not to treat the current solve as a continuation of a
-        previous simulation. Defaults to `False`. If `True`, the timesteps
-        provided to the `Integrator` must match exactly those that exist
-        in the `prev_results` passed to the `Operator`. The `power`,
-        `power_density`, or `source_rates` must match as well. It
-        is the user's responsibility to make sure that the continue
-        solve uses the same method of specifying `power`, `power_density`,
-        or `source_rates`.
+        previous simulation. Defaults to `False`. When `False`, the depletion
+        steps provided are appended to any previous steps. If `True`, the
+        timesteps provided to the `Integrator` must exacly match any that
+        exist in the `prev_results` passed to the `Operator`. The `power`,
+        `power_density`, or `source_rates` must match as well. The 
+        method of specifying `power`, `power_density`, or 
+        `source_rates` should be the same as the initial run.
 
         .. versionadded:: 0.15.1
 

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -662,7 +662,7 @@ class Integrator(ABC):
         # validate existing depletion steps are consistent with those passed to operator
         # if the timesteps retrieved from operator.prev_res.get_times match the first set
         # of time steps provided to the continue run, and the same is true for the source_rates
-        # retrieved from operator.prev_res.get_source_rates(), then run a depletion simulations
+        # retrieved from operator.prev_res.get_source_rates(), then run a depletion simulation
         # with only the new time steps and source rates provided
         if continue_timesteps:
             completed_times = operator.prev_res.get_times(time_units=timestep_units)
@@ -978,13 +978,14 @@ class SIIntegrator(Integrator):
         .. versionadded:: 0.12
     continue_timesteps : bool, optional
         Whether or not to treat the current solve as a continuation of a
-        previous simulation. Defaults to `False`. If `True`, the timesteps
+        previous simulation. Defaults to `False`. If `False`, all time
+        steps and source rates will be run in an append fashion and will run
+        after whatever time steps exist, if any. If `True`, the timesteps
         provided to the `Integrator` must match exactly those that exist
         in the `prev_results` passed to the `Opereator`. The `power`,
-        `power_density`, or `source_rates` must match as well. It
-        is the user's responsibility to make sure that the continue
-        solve uses the same method of specifying `power`, `power_density`,
-        or `source_rates`.
+        `power_density`, or `source_rates` must match as well. The 
+        method of specifying `power`, `power_density`, or 
+        `source_rates` should be the same as the initial run.
 
         .. versionadded:: 0.15.1
 

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -659,29 +659,33 @@ class Integrator(ABC):
         seconds, source_rates = _normalize_timesteps(
             timesteps, source_rates, timestep_units, operator)
 
-            # validate existing depletion steps are consistent with those passed to operator
-            if continue_timesteps:
-                completed_times = operator.prev_res.get_times(time_units=timestep_units)
-                completed_timesteps = completed_times[1:] - completed_times[:-1] # convert absolute t to dt
-                completed_source_rates = operator.prev_res.get_source_rates()
-                num_previous_steps_run = len(completed_timesteps)
-                if (np.array_equal(completed_timesteps, timesteps[:num_previous_steps_run])):
-                    seconds = seconds[num_previous_steps_run:]
-                else:
-                    raise ValueError(
-                        "You are attempting to continue a run in which the previous timesteps "
-                        "do not have the same initial timesteps as those provided to the "
-                        "Integrator. Please make sure you are using the correct timesteps."
-                    )
-                if(np.array_equal(completed_source_rates, np.asarray(source_rates)[:num_previous_steps_run] )):
-                    source_rates = source_rates[num_previous_steps_run:]
-                else:
-                    raise ValueError(
-                        "You are attempting to continue a run in which the previous results "
-                        "do not have the same initial source rates, powers, or power densities "
-                        "as those provided to the Integrator. Please make sure you are using "
-                        "the correct powers, power densities, or source rates and previous results file."
-                    ) 
+        # validate existing depletion steps are consistent with those passed to operator
+        # if the timesteps retrieved from operator.prev_res.get_times match the first set
+        # of time steps provided to the continue run, and the same is true for the source_rates
+        # retrieved from operator.prev_res.get_source_rates(), then run a depletion simulations
+        # with only the new time steps and source rates provided
+        if continue_timesteps:
+            completed_times = operator.prev_res.get_times(time_units=timestep_units)
+            completed_timesteps = completed_times[1:] - completed_times[:-1] # convert absolute t to dt
+            completed_source_rates = operator.prev_res.get_source_rates()
+            num_previous_steps_run = len(completed_timesteps)
+            if (np.array_equal(completed_timesteps, timesteps[:num_previous_steps_run])):
+                seconds = seconds[num_previous_steps_run:]
+            else:
+                raise ValueError(
+                    "You are attempting to continue a run in which the previous timesteps "
+                    "do not have the same initial timesteps as those provided to the "
+                    "Integrator. Please make sure you are using the correct timesteps."
+                )
+            if(np.array_equal(completed_source_rates, np.asarray(source_rates)[:num_previous_steps_run] )):
+                source_rates = source_rates[num_previous_steps_run:]
+            else:
+                raise ValueError(
+                    "You are attempting to continue a run in which the previous results "
+                    "do not have the same initial source rates, powers, or power densities "
+                    "as those provided to the Integrator. Please make sure you are using "
+                    "the correct powers, power densities, or source rates and previous results file."
+                ) 
         self.timesteps = np.asarray(seconds)
         self.source_rates = np.asarray(source_rates)
 

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -655,6 +655,30 @@ class Integrator(ABC):
         # Normalize timesteps and source rates
         seconds, source_rates = _normalize_timesteps(
             timesteps, source_rates, timestep_units, operator)
+
+            # validate existing depletion steps are consistent with those passed to operator
+            if continue_timesteps:
+                completed_times = operator.prev_res.get_times(time_units=timestep_units)
+                completed_timesteps = completed_times[1:] - completed_times[:-1] # convert absolute t to dt
+                completed_source_rates = operator.prev_res.get_source_rates()
+                num_previous_steps_run = len(completed_timesteps)
+                if (np.array_equal(completed_timesteps, timesteps[:num_previous_steps_run])):
+                    seconds = seconds[num_previous_steps_run:]
+                else:
+                    raise ValueError(
+                        "You are attempting to continue a run in which the previous timesteps "
+                        "do not have the same initial timesteps as those provided to the "
+                        "Integrator. Please make sure you are using the correct timesteps."
+                    )
+                if(np.array_equal(completed_source_rates, np.asarray(source_rates)[:num_previous_steps_run] )):
+                    source_rates = source_rates[num_previous_steps_run:]
+                else:
+                    raise ValueError(
+                        "You are attempting to continue a run in which the previous results "
+                        "do not have the same initial source rates, powers, or power densities "
+                        "as those provided to the Integrator. Please make sure you are using "
+                        "the correct powers, power densities, or source rates and previous results file."
+                    ) 
         self.timesteps = np.asarray(seconds)
         self.source_rates = np.asarray(source_rates)
 

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -576,7 +576,7 @@ class Integrator(ABC):
         Whether or not to treat the current solve as a continuation of a
         previous simulation. Defaults to `False`. If `True`, the timesteps
         provided to the `Integrator` must match exactly those that exist
-        in the `prev_results` passed to the `Opereator`. The `power`,
+        in the `prev_results` passed to the `Operator`. The `power`,
         `power_density`, or `source_rates` must match as well. It
         is the user's responsibility to make sure that the continue
         solve uses the same method of specifying `power`, `power_density`,

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -638,6 +638,9 @@ class Integrator(ABC):
                     "this uses {}".format(
                         self.__class__.__name__, res.data.shape[0],
                         self._num_stages))
+        else:
+            # if the user specifies a continue run without a previous results, set the flag to False for them
+            continue_timesteps = False
         self.operator = operator
         self.chain = operator.chain
 

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -667,7 +667,6 @@ class Integrator(ABC):
         if continue_timesteps:
             completed_times = operator.prev_res.get_times(time_units=timestep_units)
             completed_timesteps = completed_times[1:] - completed_times[:-1] # convert absolute t to dt
-            completed_source_rates = operator.prev_res.get_source_rates()
             num_previous_steps_run = len(completed_timesteps)
             if (np.array_equal(completed_timesteps, timesteps[:num_previous_steps_run])):
                 seconds = seconds[num_previous_steps_run:]
@@ -677,6 +676,7 @@ class Integrator(ABC):
                     "do not have the same initial timesteps as those provided to the "
                     "Integrator. Please make sure you are using the correct timesteps."
                 )
+            completed_source_rates = operator.prev_res.get_source_rates()
             if(np.array_equal(completed_source_rates, np.asarray(source_rates)[:num_previous_steps_run] )):
                 source_rates = source_rates[num_previous_steps_run:]
             else:

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -613,7 +613,8 @@ class Integrator(ABC):
             power_density: Optional[Union[float, Sequence[float]]] = None,
             source_rates: Optional[Union[float, Sequence[float]]] = None,
             timestep_units: str = 's',
-            solver: str = "cram48"
+            solver: str = "cram48",
+            continue_timesteps: bool = False,
         ):
         # Check number of stages previously used
         if operator.prev_res is not None:

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -17,6 +17,10 @@ from openmc.checkvalue import PathLike
 
 __all__ = ["Results", "ResultsList"]
 
+_SECONDS_PER_MINUTE = 60
+_SECONDS_PER_HOUR = 60*60
+_SECONDS_PER_DAY = 24*60*60
+_SECONDS_PER_JULIAN_YEAR = 365.25*24*60*60
 
 def _get_time_as(seconds: float, units: str) -> float:
     """Converts the time in seconds to time in different units
@@ -31,13 +35,13 @@ def _get_time_as(seconds: float, units: str) -> float:
 
     """
     if units == "a":
-        return seconds / (60 * 60 * 24 * 365.25)  # 365.25 due to the leap year
+        return seconds / _SECONDS_PER_JULIAN_YEAR
     if units == "d":
-        return seconds / (60 * 60 * 24)
+        return seconds / _SECONDS_PER_DAY
     elif units == "h":
-        return seconds / (60 * 60)
+        return seconds / _SECONDS_PER_HOUR
     elif units == "min":
-        return seconds / 60
+        return seconds / _SECONDS_PER_MINUTE
     else:
         return seconds
 
@@ -70,7 +74,6 @@ class Results(list):
                 for i in range(n):
                     data.append(StepResult.from_hdf5(fh, i))
         super().__init__(data)
-
 
     @classmethod
     def from_hdf5(cls, filename: PathLike):
@@ -459,6 +462,26 @@ class Results(list):
         )
 
         return _get_time_as(times, time_units)
+
+    def get_source_rates(self) -> np.ndarray:
+        """
+        .. versionadded:: 0.15.1
+
+        Returns
+        -------
+        numpy.ndarray
+            1-D vector of source rates at each point in the depletion simulation
+            with the units originally defined by the user.
+
+        """
+
+        source_rates = np.fromiter(
+            (r.source_rate[0] for r in self),
+            dtype=self[0].source_rate.dtype,
+            count=len(self),
+        )
+
+        return source_rates
 
     def get_step_where(
         self, time, time_units: str = "d", atol: float = 1e-6, rtol: float = 1e-3

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -20,7 +20,7 @@ __all__ = ["Results", "ResultsList"]
 _SECONDS_PER_MINUTE = 60
 _SECONDS_PER_HOUR = 60*60
 _SECONDS_PER_DAY = 24*60*60
-_SECONDS_PER_JULIAN_YEAR = 365.25*24*60*60
+_SECONDS_PER_JULIAN_YEAR = 365.25*24*60*60 # 365.25 due to the leap year
 
 def _get_time_as(seconds: float, units: str) -> float:
     """Converts the time in seconds to time in different units
@@ -474,11 +474,12 @@ class Results(list):
             with the units originally defined by the user.
 
         """
+        # Results duplicate the final source rate at the final simulation time
         source_rates = np.fromiter(
             (r.source_rate for r in self),
             dtype=self[0].source_rate.dtype,
             count=len(self)-1,
-        ) # Results duplicates the final source rate at the final simulation time
+        )
 
         return source_rates
 

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -477,8 +477,8 @@ class Results(list):
         source_rates = np.fromiter(
             (r.source_rate for r in self),
             dtype=self[0].source_rate.dtype,
-            count=len(self),
-        )
+            count=len(self)-1,
+        ) # Results duplicates the final source rate at the final simulation time
 
         return source_rates
 

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -20,7 +20,8 @@ __all__ = ["Results", "ResultsList"]
 _SECONDS_PER_MINUTE = 60
 _SECONDS_PER_HOUR = 60*60
 _SECONDS_PER_DAY = 24*60*60
-_SECONDS_PER_JULIAN_YEAR = 365.25*24*60*60 # 365.25 due to the leap year
+_SECONDS_PER_JULIAN_YEAR = 365.25*24*60*60  # 365.25 due to the leap year
+
 
 def _get_time_as(seconds: float, units: str) -> float:
     """Converts the time in seconds to time in different units

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -474,9 +474,8 @@ class Results(list):
             with the units originally defined by the user.
 
         """
-
         source_rates = np.fromiter(
-            (r.source_rate[0] for r in self),
+            (r.source_rate for r in self),
             dtype=self[0].source_rate.dtype,
             count=len(self),
         )

--- a/tests/unit_tests/test_deplete_continue.py
+++ b/tests/unit_tests/test_deplete_continue.py
@@ -20,16 +20,27 @@ def test_continue(run_in_tmpdir, scheme):
 
     operator = dummy_operator.DummyOperator()
 
-    # take first step
-    bundle.solver(operator, [0.75], 1.0).integrate()
+    # initial depletion
+    bundle.solver(operator, [1.0, 2.0], [1.0, 2.0]).integrate()
 
-    # restart
-    prev_res = openmc.deplete.Results(
-        operator.output_dir / "depletion_results.h5")
+    # set up continue run
+    prev_res = openmc.deplete.Results(operator.output_dir / "depletion_results.h5")
     operator = dummy_operator.DummyOperator(prev_res)
 
     # if continue run happens, test passes
-    bundle.solver(operator, [0.75, 0.75], [1.0, 1.0], continue_timesteps=True).integrate()
+    bundle.solver(operator, [1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0], continue_timesteps=True).integrate()
+
+@pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
+def test_continue_for_null_previous(run_in_tmpdir, scheme):
+    """Test to ensure that a continue run works even if there are no previous results"""
+    # set up the problem
+
+    bundle = dummy_operator.SCHEMES[scheme]
+
+    operator = dummy_operator.DummyOperator()
+
+    # initial depletion
+    bundle.solver(operator, [1.0, 2.0], [1.0, 2.0], continue_timesteps=True).integrate()
 
 @pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
 def test_mismatched_initial_times(run_in_tmpdir, scheme):
@@ -45,20 +56,19 @@ def test_mismatched_initial_times(run_in_tmpdir, scheme):
     bundle.solver(operator, [0.75, 0.75], [1.0, 1.0]).integrate()
 
     # restart
-    prev_res = openmc.deplete.Results(
-        operator.output_dir / "depletion_results.h5")
+    prev_res = openmc.deplete.Results(operator.output_dir / "depletion_results.h5")
     operator = dummy_operator.DummyOperator(prev_res)
 
     with pytest.raises(
         ValueError,
-        match = "You are attempting to continue a run in which the previous "
-                "results do not have the same initial steps as those provided "
-                "to the Integrator. Please make sure you are using the correct "
-                "timesteps, powers or power densities, and previous results file.",
+        match="You are attempting to continue a run in which the previous timesteps "
+        "do not have the same initial timesteps as those provided to the "
+        "Integrator. Please make sure you are using the correct timesteps.",
     ):
         bundle.solver(
             operator, [0.75, 0.5, 0.75], [1.0, 1.0, 1.0], continue_timesteps=True
         ).integrate()
+
 
 @pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
 def test_mismatched_initial_source_rates(run_in_tmpdir, scheme):
@@ -74,16 +84,15 @@ def test_mismatched_initial_source_rates(run_in_tmpdir, scheme):
     bundle.solver(operator, [0.75, 0.75], [1.0, 1.0]).integrate()
 
     # restart
-    prev_res = openmc.deplete.Results(
-        operator.output_dir / "depletion_results.h5")
+    prev_res = openmc.deplete.Results(operator.output_dir / "depletion_results.h5")
     operator = dummy_operator.DummyOperator(prev_res)
 
     with pytest.raises(
         ValueError,
-        match = "You are attempting to continue a run in which the previous "
-                "results do not have the same initial steps as those provided "
-                "to the Integrator. Please make sure you are using the correct "
-                "timesteps, powers or power densities, and previous results file.",
+        match="You are attempting to continue a run in which the previous results "
+        "do not have the same initial source rates, powers, or power densities "
+        "as those provided to the Integrator. Please make sure you are using "
+        "the correct powers, power densities, or source rates and previous results file.",
     ):
         bundle.solver(
             operator, [0.75, 0.75, 0.75], [1.0, 2.0, 1.0], continue_timesteps=True

--- a/tests/unit_tests/test_deplete_continue.py
+++ b/tests/unit_tests/test_deplete_continue.py
@@ -1,6 +1,6 @@
 """Unit tests for openmc.deplete continue run capability.
 
-These tests run in two steps: first a normal run and then a continue run based on the prev_results
+These tests run in two steps: first a normal run and then a continue run using the previous results
 """
 
 import pytest
@@ -9,14 +9,12 @@ import openmc.deplete
 
 from tests import dummy_operator
 
+
 @pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
 def test_continue(run_in_tmpdir, scheme):
     """Test to ensure that a properly defined continue run works"""
-
     # set up the problem
-
     bundle = dummy_operator.SCHEMES[scheme]
-
     operator = dummy_operator.DummyOperator()
 
     # initial depletion
@@ -29,26 +27,23 @@ def test_continue(run_in_tmpdir, scheme):
     # if continue run happens, test passes
     bundle.solver(operator, [1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0], continue_timesteps=True).integrate()
 
+
 @pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
 def test_continue_for_null_previous(run_in_tmpdir, scheme):
     """Test to ensure that a continue run works even if there are no previous results"""
     # set up the problem
-
     bundle = dummy_operator.SCHEMES[scheme]
-
     operator = dummy_operator.DummyOperator()
 
     # initial depletion
     bundle.solver(operator, [1.0, 2.0], [1.0, 2.0], continue_timesteps=True).integrate()
 
+
 @pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
 def test_mismatched_initial_times(run_in_tmpdir, scheme):
     """Test to ensure that a continue run with different initial steps is properly caught"""
-
     # set up the problem
-
     bundle = dummy_operator.SCHEMES[scheme]
-
     operator = dummy_operator.DummyOperator()
 
     # perform initial steps
@@ -72,11 +67,8 @@ def test_mismatched_initial_times(run_in_tmpdir, scheme):
 @pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
 def test_mismatched_initial_source_rates(run_in_tmpdir, scheme):
     """Test to ensure that a continue run with different initial steps is properly caught"""
-
     # set up the problem
-
     bundle = dummy_operator.SCHEMES[scheme]
-
     operator = dummy_operator.DummyOperator()
 
     # perform initial steps

--- a/tests/unit_tests/test_deplete_continue.py
+++ b/tests/unit_tests/test_deplete_continue.py
@@ -52,7 +52,7 @@ def test_mismatched_initial_times(run_in_tmpdir, scheme):
 
     operator = dummy_operator.DummyOperator()
 
-    # take first step
+    # perform initial steps
     bundle.solver(operator, [0.75, 0.75], [1.0, 1.0]).integrate()
 
     # restart
@@ -80,7 +80,7 @@ def test_mismatched_initial_source_rates(run_in_tmpdir, scheme):
 
     operator = dummy_operator.DummyOperator()
 
-    # take first step
+    # perform initial steps
     bundle.solver(operator, [0.75, 0.75], [1.0, 1.0]).integrate()
 
     # restart

--- a/tests/unit_tests/test_deplete_continue.py
+++ b/tests/unit_tests/test_deplete_continue.py
@@ -4,17 +4,15 @@ These tests run in two steps: first a normal run and then a continue run using t
 """
 
 import pytest
-
 import openmc.deplete
 
 from tests import dummy_operator
 
 
-@pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
-def test_continue(run_in_tmpdir, scheme):
+def test_continue(run_in_tmpdir):
     """Test to ensure that a properly defined continue run works"""
     # set up the problem
-    bundle = dummy_operator.SCHEMES[scheme]
+    bundle = dummy_operator.SCHEMES['predictor']
     operator = dummy_operator.DummyOperator()
 
     # initial depletion
@@ -25,25 +23,14 @@ def test_continue(run_in_tmpdir, scheme):
     operator = dummy_operator.DummyOperator(prev_res)
 
     # if continue run happens, test passes
-    bundle.solver(operator, [1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0], continue_timesteps=True).integrate()
+    bundle.solver(operator, [1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0],
+                  continue_timesteps=True).integrate()
 
 
-@pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
-def test_continue_for_null_previous(run_in_tmpdir, scheme):
-    """Test to ensure that a continue run works even if there are no previous results"""
-    # set up the problem
-    bundle = dummy_operator.SCHEMES[scheme]
-    operator = dummy_operator.DummyOperator()
-
-    # initial depletion
-    bundle.solver(operator, [1.0, 2.0], [1.0, 2.0], continue_timesteps=True).integrate()
-
-
-@pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
-def test_mismatched_initial_times(run_in_tmpdir, scheme):
+def test_mismatched_initial_times(run_in_tmpdir):
     """Test to ensure that a continue run with different initial steps is properly caught"""
     # set up the problem
-    bundle = dummy_operator.SCHEMES[scheme]
+    bundle = dummy_operator.SCHEMES['predictor']
     operator = dummy_operator.DummyOperator()
 
     # perform initial steps
@@ -64,11 +51,10 @@ def test_mismatched_initial_times(run_in_tmpdir, scheme):
         ).integrate()
 
 
-@pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
-def test_mismatched_initial_source_rates(run_in_tmpdir, scheme):
+def test_mismatched_initial_source_rates(run_in_tmpdir):
     """Test to ensure that a continue run with different initial steps is properly caught"""
     # set up the problem
-    bundle = dummy_operator.SCHEMES[scheme]
+    bundle = dummy_operator.SCHEMES['predictor']
     operator = dummy_operator.DummyOperator()
 
     # perform initial steps

--- a/tests/unit_tests/test_deplete_continue.py
+++ b/tests/unit_tests/test_deplete_continue.py
@@ -9,7 +9,6 @@ import openmc.deplete
 
 from tests import dummy_operator
 
-# test that the continue timesteps works when the second integrate call contains all previous timesteps
 @pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
 def test_continue(run_in_tmpdir, scheme):
     """Test to ensure that a properly defined continue run works"""

--- a/tests/unit_tests/test_deplete_continue.py
+++ b/tests/unit_tests/test_deplete_continue.py
@@ -12,6 +12,8 @@ from tests import dummy_operator
 # test that the continue timesteps works when the second integrate call contains all previous timesteps
 @pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
 def test_continue(run_in_tmpdir, scheme):
+    """Test to ensure that a properly defined continue run works"""
+
     # set up the problem
 
     bundle = dummy_operator.SCHEMES[scheme]
@@ -27,7 +29,7 @@ def test_continue(run_in_tmpdir, scheme):
     operator = dummy_operator.DummyOperator(prev_res)
 
     # if continue run happens, test passes
-    bundle.solver(operator, [0.75, 0.75], [1.0, 1.0], continue_timesteps = True).integrate()
+    bundle.solver(operator, [0.75, 0.75], [1.0, 1.0], continue_timesteps=True).integrate()
 
 @pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
 def test_mismatched_initial_times(run_in_tmpdir, scheme):
@@ -49,7 +51,10 @@ def test_mismatched_initial_times(run_in_tmpdir, scheme):
 
     with pytest.raises(
         ValueError,
-        match="You are attempting to continue a run in which the previous results do not have the same initial steps as those provided to the Integrator. Please make sure you are using the correct timesteps, powers or power densities, and previous results file.",
+        match = "You are attempting to continue a run in which the previous "
+                "results do not have the same initial steps as those provided "
+                "to the Integrator. Please make sure you are using the correct "
+                "timesteps, powers or power densities, and previous results file.",
     ):
         bundle.solver(
             operator, [0.75, 0.5, 0.75], [1.0, 1.0, 1.0], continue_timesteps=True
@@ -75,7 +80,10 @@ def test_mismatched_initial_source_rates(run_in_tmpdir, scheme):
 
     with pytest.raises(
         ValueError,
-        match="You are attempting to continue a run in which the previous results do not have the same initial steps as those provided to the Integrator. Please make sure you are using the correct timesteps, powers or power densities, and previous results file.",
+        match = "You are attempting to continue a run in which the previous "
+                "results do not have the same initial steps as those provided "
+                "to the Integrator. Please make sure you are using the correct "
+                "timesteps, powers or power densities, and previous results file.",
     ):
         bundle.solver(
             operator, [0.75, 0.75, 0.75], [1.0, 2.0, 1.0], continue_timesteps=True

--- a/tests/unit_tests/test_deplete_continue.py
+++ b/tests/unit_tests/test_deplete_continue.py
@@ -1,0 +1,53 @@
+"""Unit tests for openmc.deplete continue run capability.
+
+These tests run in two steps: first a normal run and then a continue run based on the prev_results
+"""
+
+import pytest
+
+import openmc.deplete
+
+from tests import dummy_operator
+
+# test that the continue timesteps works when the second integrate call contains all previous timesteps
+@pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
+def test_continue(run_in_tmpdir, scheme):
+    # set up the problem
+
+    bundle = dummy_operator.SCHEMES[scheme]
+
+    operator = dummy_operator.DummyOperator()
+
+    # take first step
+    bundle.solver(operator, [0.75], 1.0).integrate()
+
+    # restart
+    prev_res = openmc.deplete.Results(
+        operator.output_dir / "depletion_results.h5")
+    operator = dummy_operator.DummyOperator(prev_res)
+
+    # if continue run happens, test passes
+    bundle.solver(operator, [0.75, 0.75], [1.0, 1.0], continue_timesteps = True).integrate()
+
+@pytest.mark.parametrize("scheme", dummy_operator.SCHEMES)
+def test_mismatched_initial_steps(run_in_tmpdir, scheme):
+    """Test to ensure that a continue run with different initial steps is properly caught"""
+
+    # set up the problem
+
+    bundle = dummy_operator.SCHEMES[scheme]
+
+    operator = dummy_operator.DummyOperator()
+
+    # take first step
+    bundle.solver(operator, [0.75, 0.75], [1.0,1.0]).integrate()
+
+    # restart
+    prev_res = openmc.deplete.Results(
+        operator.output_dir / "depletion_results.h5")
+    operator = dummy_operator.DummyOperator(prev_res)
+
+    # continue run with different previous step should cause a ValueError
+    # note the first step matches but the second does not while the third is a new step
+    with pytest.raises(ValueError):
+        bundle.solver(operator, [0.75, 0.5, 0.75], [1.0, 2.0, 1.0], continue_timesteps = True).integrate()


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description
This PR closes #2871. To summarize the motivation, I'd like depletion restarts to be a bit easier for users. If you set up a depletion simulation that doesn't end up getting run all the way (think hitting max wall time on an HPC or some other interrupt), the burden then falls to the user to correctly determine what time steps were **not** run and to create a new script that picks up where the other one left off. In my own experience, it is easy to make a mistake and re-run a simulation that is not what I desired.

All we do here is add a `continue_timesteps` flag (default to `False`) that adds a new logic block to the `Integrator` class. It would be useful in the above case and requires users to provide the `Integrator` with a set of `timesteps` and one of `power`/`power_density`/`source_rate` that matches what already exists in a `prev_results` passed to the `Opperator`.

With this flag, the depletion restart python script can now be exactly the same as the initial script, just with a `continue_timesteps = True` flag and a `prev_results` object loaded from a `depletion_statepoint.h5` passed to the `Operator`.  It could contain more timesteps at the end too, but the only requirement is that the data matches what is in the `Operator` provided to the `Integrator` for all the existing steps in the results.

This PR does not eliminate any of the existing capability of the depletion API, so all the old use cases/syntax for restarts remain. The flag is optional and defaults to `False` so no one will need to update past scripts with this change.

# Checklist
- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
