### PR TITLE
fix the bug in function differentiate_mats()

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1262,8 +1262,9 @@ class Model:
                 if diff_volume_method != 'match cell':
                     cell.fill = [mat.clone() for _ in range(cell.num_instances)]
                 elif diff_volume_method == 'match cell':
-                    cell.fill = mat.clone()
-                    cell.fill.volume = cell.volume
+                    cell.fill = [mat.clone() for _ in range(cell.num_instances)]
+                    for  clone_mat in cell.fill:
+                        clone_mat.volume = cell.volume
 
         if self.materials is not None:
             self.materials = openmc.Materials(

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1259,11 +1259,9 @@ class Model:
         for cell in self.geometry.get_all_material_cells().values():
             if cell.fill in distribmats:
                 mat = cell.fill
-                if diff_volume_method != 'match cell':
-                    cell.fill = [mat.clone() for _ in range(cell.num_instances)]
-                elif diff_volume_method == 'match cell':
-                    cell.fill = [mat.clone() for _ in range(cell.num_instances)]
-                    for  clone_mat in cell.fill:
+                cell.fill = [mat.clone() for _ in range(cell.num_instances)]
+                if diff_volume_method == 'match cell':
+                    for clone_mat in cell.fill:
                         clone_mat.volume = cell.volume
 
         if self.materials is not None:

--- a/tests/unit_tests/test_deplete_coupled_operator.py
+++ b/tests/unit_tests/test_deplete_coupled_operator.py
@@ -114,7 +114,7 @@ def test_diff_volume_method_divide_equally(model_with_volumes):
     )
 
     all_cells = list(operator.model.geometry.get_all_cells().values())
-    assert all_cells[0].fill[0].volume == 51
-    assert all_cells[1].fill[0].volume == 51
+    assert all_cells[0].fill.volume == 51
+    assert all_cells[1].fill.volume == 51
     # mat2 is not depletable
     assert all_cells[2].fill.volume is None


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description
I found that [differentiate_mats](https://github.com/openmc-dev/openmc/blob/6d731934f4e0b62c3be6094c283a19730d8ce08f/openmc/model/model.py#L1264) method cannot assign the distributed material properly. When I use the ‘match cell’ method, only one material rather than a list is assigned to the repeating cell. That’s seem to be a bug.
Now it has been fix in this pr.
# Checklist

- [ √ ] I have performed a self-review of my own code
- [ √] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ √] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ √ ] I have made corresponding changes to the documentation (if applicable)
- [ √ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
