### PR TITLE
Fix the bug in the Material.from_xml_element function 

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1582,7 +1582,7 @@ class Material(IDManagerMixin):
 
         if 'volume' in elem.attrib:
             mat.volume = float(elem.get('volume'))
-        mat.depletable = bool(elem.get('depletable'))
+        mat.depletable = elem.get('depletable')=="ture"
 
         # Get each nuclide
         for nuclide in elem.findall('nuclide'):

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1582,7 +1582,6 @@ class Material(IDManagerMixin):
 
         if 'volume' in elem.attrib:
             mat.volume = float(elem.get('volume'))
-        mat.depletable = elem.get('depletable')=="ture"
 
         # Get each nuclide
         for nuclide in elem.findall('nuclide'):
@@ -1591,6 +1590,9 @@ class Material(IDManagerMixin):
                 mat.add_nuclide(name, float(nuclide.attrib['ao']))
             elif 'wo' in nuclide.attrib:
                 mat.add_nuclide(name, float(nuclide.attrib['wo']), 'wo')
+
+        # Get depletable attribute
+        mat.depletable = elem.get('depletable') in ('true', '1')
 
         # Get each S(a,b) table
         for sab in elem.findall('sab'):


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description
Fixed the error in the Material.from_xml_element function that occurred while reading the depletable attribute from the XML file.

In the original function, the script performed a forced boolean conversion on the depletable attribute in the XML, but since the value of the depletable attribute is usually a string, regardless of what the value of the depletable attribute is, it will ultimately be converted to True (even if depletable=“false” is set). This is clearly a bug. Now this bug has been fixed in this PR.



# Checklist

- [√] I have performed a self-review of my own code

- [√] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
