### PR TITLE
Doc typo fix for rand ray mgxs

### DIFF
--- a/docs/source/usersguide/random_ray.rst
+++ b/docs/source/usersguide/random_ray.rst
@@ -531,7 +531,6 @@ a statepoint file (e.g., ``statepoint.100.h5``) file and summary file (e.g.,
 ``summary.h5``) that resulted from running our previous example::
 
   import openmc
-  import openmc.mgxs as mgxs
 
   summary = openmc.Summary('summary.h5')
   geom = summary.geometry
@@ -540,7 +539,7 @@ a statepoint file (e.g., ``statepoint.100.h5``) file and summary file (e.g.,
   statepoint_filename = 'statepoint.100.h5'
   sp = openmc.StatePoint(statepoint_filename)
 
-  groups = mgxs.EnergyGroups(mgxs.GROUP_STRUCTURES['CASMO-2'])
+  groups = openmc.mgxs.EnergyGroups(openmc.mgxs.GROUP_STRUCTURES['CASMO-2'])
   mgxs_lib = openmc.mgxs.Library(geom)
   mgxs_lib.energy_groups = groups
   mgxs_lib.correction = None

--- a/docs/source/usersguide/random_ray.rst
+++ b/docs/source/usersguide/random_ray.rst
@@ -487,7 +487,7 @@ two group energy decomposition::
   mgxs_lib = openmc.mgxs.Library(geometry)
 
   # Pick energy group structure
-  groups = mgxs.EnergyGroups(mgxs.GROUP_STRUCTURES['CASMO-2'])
+  groups = openmc.mgxs.EnergyGroups(openmc.mgxs.GROUP_STRUCTURES['CASMO-2'])
   mgxs_lib.energy_groups = groups
 
   # Disable transport correction
@@ -501,7 +501,7 @@ two group energy decomposition::
   mgxs_lib.domain_type = "material"
 
   # Specify the cell domains over which to compute multi-group cross sections
-  mgxs_lib.domains = geom.get_all_materials().values()
+  mgxs_lib.domains = geometry.get_all_materials().values()
 
   # Do not compute cross sections on a nuclide-by-nuclide basis
   mgxs_lib.by_nuclide = False

--- a/docs/source/usersguide/random_ray.rst
+++ b/docs/source/usersguide/random_ray.rst
@@ -111,7 +111,7 @@ detector from the core. In this case, rays sampled in the moderator region and
 heading toward the detector will begin life with a highly scattered thermal
 spectrum and will have an inaccurate fast spectrum. If the dead zone length is
 only 20 cm, we might imagine such rays writing to the detector tally within
-their active lengths, despite their innaccurate estimate of the uncollided fast
+their active lengths, despite their inaccurate estimate of the uncollided fast
 angular flux. Thus, an inactive length of 100--200 cm would ensure that any such
 rays would still be within their inactive regions, and only rays that have
 actually traversed through the core (and thus have an accurate representation of


### PR DESCRIPTION
While working through the random ray examples I noticed a couple of the imports caused errors when copy pasting and running the example code.

specifically the example starts with ```geometry``` by later uses ``geom``` and the script mixes the use of mgxs, sometimes it imports as ```openmc.mgxs``` other times it imports as ```mgxs```

This PR updates the example so it runs when copy pasted

# Description

Please include a summary of the change and which issue is fixed if applicable. Please also include relevant motivation and context.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)

