### PR TITLE
Fix Tabular.from_xml_element for histogram case

### DIFF
--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -1116,8 +1116,9 @@ class Tabular(Univariate):
         """
         interpolation = get_text(elem, 'interpolation')
         params = [float(x) for x in get_text(elem, 'parameters').split()]
-        x = params[:len(params)//2]
-        p = params[len(params)//2:]
+        m = (len(params) + 1)//2  # +1 for when len(params) is odd
+        x = params[:m]
+        p = params[m:]
         return cls(x, p, interpolation)
 
     def integral(self):

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -258,8 +258,12 @@ Tabular::Tabular(pugi::xml_node node)
     interp_ = Interpolation::histogram;
   }
 
-  // Read and initialize tabular distribution
+  // Read and initialize tabular distribution. If number of parameters is odd,
+  // add an extra zero for the 'p' array.
   auto params = get_node_array<double>(node, "parameters");
+  if (params.size() % 2 != 0) {
+    params.push_back(0.0);
+  }
   std::size_t n = params.size() / 2;
   const double* x = params.data();
   const double* p = x + n;

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -195,19 +195,10 @@ def test_watt():
 
 
 def test_tabular():
+    # test linear-linear sampling
     x = np.array([0.0, 5.0, 7.0, 10.0])
     p = np.array([10.0, 20.0, 5.0, 6.0])
     d = openmc.stats.Tabular(x, p, 'linear-linear')
-    elem = d.to_xml_element('distribution')
-
-    d = openmc.stats.Tabular.from_xml_element(elem)
-    assert all(d.x == x)
-    assert all(d.p == p)
-    assert d.interpolation == 'linear-linear'
-    assert len(d) == len(x)
-
-    # test linear-linear sampling
-    d = openmc.stats.Tabular(x, p)
     n_samples = 100_000
     samples = d.sample(n_samples)
     assert_sample_mean(samples, d.mean())
@@ -240,6 +231,28 @@ def test_tabular():
     # call the CDF method
     d = openmc.stats.Tabular(x, p, interpolation='linear-linear')
     d.cdf()
+
+
+def test_tabular_from_xml():
+    x = np.array([0.0, 5.0, 7.0, 10.0])
+    p = np.array([10.0, 20.0, 5.0, 6.0])
+    d = openmc.stats.Tabular(x, p, 'linear-linear')
+    elem = d.to_xml_element('distribution')
+
+    d = openmc.stats.Tabular.from_xml_element(elem)
+    assert all(d.x == x)
+    assert all(d.p == p)
+    assert d.interpolation == 'linear-linear'
+    assert len(d) == len(x)
+
+    # Make sure XML roundtrip works with len(x) == len(p) + 1
+    x = np.array([0.0, 5.0, 7.0, 10.0])
+    p = np.array([10.0, 20.0, 5.0])
+    d = openmc.stats.Tabular(x, p, 'histogram')
+    elem = d.to_xml_element('distribution')
+    d = openmc.stats.Tabular.from_xml_element(elem)
+    assert all(d.x == x)
+    assert all(d.p == p)
 
 
 def test_legendre():


### PR DESCRIPTION
# Description

Due to the change in #2981, I found that `Tabular.from_xml_element` didn't work for the case when len(x) == len(p) + 1. This PR fixes that.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)