### PR TITLE
added terminal output showing compile options selected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ message(STATUS "OPENMC_USE_LIBMESH ${OPENMC_USE_LIBMESH}")
 message(STATUS "OPENMC_USE_MPI ${OPENMC_USE_MPI}")
 message(STATUS "OPENMC_USE_MCPL ${OPENMC_USE_MCPL}")
 message(STATUS "OPENMC_USE_NCRYSTAL ${OPENMC_USE_NCRYSTAL}")
-message(STATUS "OPENMC_USE_UWUW ${OPENMC_USE_UWUW}")OFF)
+message(STATUS "OPENMC_USE_UWUW ${OPENMC_USE_UWUW}")
 
 # Warnings for deprecated options
 foreach(OLD_OPT IN ITEMS "openmp" "profile" "coverage" "dagmc" "libmesh")


### PR DESCRIPTION
## Description

This PR adds a small amount of information to the user so that they can see which options were used to compile openmc

this is useful for CI when building different options

currently cmake .. outputs 

```
-- Configuring DAGMC 3.2.4
-- Found DAGMC: /home/jon/code_development/DAGMC/lib/cmake/dagmc (version 3.2.4)
-- HDF5 C compiler wrapper is unable to compile a minimal HDF5 program.
-- HDF5 Libraries: /usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.so
-- OpenMC C++ flags: 
-- OpenMC Linker flags: 
-- Submodule update
-- Found pugixml: /usr/local/lib/cmake/pugixml (version 1.10)
-- Found fmt: /usr/local/lib/cmake/fmt (version 11.0.2)
-- Found xtensor: /usr/local/share/cmake/xtensor (version 0.25.0)
-- Found gsl-lite: /usr/local/lib/cmake/gsl-lite (version 0.36.1)
-- Did not find Catch2, will use submodule instead
-- Configuring done (0.1s)
-- Generating done (0.0s)
-- Build files have been written to: /home/jon/openmc_fork/build
```

This PR would add a little info to the start and the cmake .. terminal output would look like this
```
-- OPENMC_USE_OPENMP ON
-- OPENMC_BUILD_TESTS ON
-- OPENMC_ENABLE_PROFILE OFF
-- OPENMC_ENABLE_COVERAGE OFF
-- OPENMC_USE_DAGMC ON
-- OPENMC_USE_LIBMESH OFF
-- OPENMC_USE_MPI OFF
-- OPENMC_USE_MCPL OFF
-- OPENMC_USE_NCRYSTAL OFF
-- OPENMC_USE_UWUW OFF
-- Configuring DAGMC 3.2.4
-- Found DAGMC: /home/jon/code_development/DAGMC/lib/cmake/dagmc (version 3.2.4)
-- HDF5 C compiler wrapper is unable to compile a minimal HDF5 program.
-- HDF5 Libraries: /usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.so
-- OpenMC C++ flags: 
-- OpenMC Linker flags: 
-- Submodule update
-- Found pugixml: /usr/local/lib/cmake/pugixml (version 1.10)
-- Found fmt: /usr/local/lib/cmake/fmt (version 11.0.2)
-- Found xtensor: /usr/local/share/cmake/xtensor (version 0.25.0)
-- Found gsl-lite: /usr/local/lib/cmake/gsl-lite (version 0.36.1)
-- Did not find Catch2, will use submodule instead
-- Configuring done (0.1s)
-- Generating done (0.0s)
-- Build files have been written to: /home/jon/openmc_fork/build

```


Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)

