### PR TITLE
Avoid end of life ubuntu 20.04 in ReadTheDocs runner

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "3.12"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-24.04"
   tools:
-    python: "3.13"
+    python: "3.12"
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.12"
+    python: "3.13"
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
Tiny PR to update the OS version used in the documentation runner
This avoids the soon end of life version of Ubuntu (which I think is April 2025)
Additionally this is useful for potential future the sci kit core build which would need to apt get install packages in the read the docs runner and the apt-get commands benefit from this newer ubuntu version (22.04 would also be fine)

Fixes # (issue)
No specific issue

# Checklist

- [x] I have performed a self-review of my own code

