### PR TITLE
Avoid error in CI from newlines in commit message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,10 @@ jobs:
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             BRANCH_SHA=$(git rev-list --parents -n 1 HEAD | rev | cut -d" " -f 1 | rev)
           fi
-          COMMIT_MESSAGE=$(git log $BRANCH_SHA -1 --pretty=%B)
+          COMMIT_MESSAGE=$(git log $BRANCH_SHA -1 --pretty=%B | tr '\n' ' ')
           echo ${COMMIT_MESSAGE}
           echo "COMMIT_MESSAGE=${COMMIT_MESSAGE}" >> $GITHUB_ENV
-          
+
       - name: Apt dependencies
         shell: bash
         run: |
@@ -170,7 +170,7 @@ jobs:
         if: ${{ contains(env.COMMIT_MESSAGE, '[gha-debug]') }}
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 10
-      
+
       - name: after_success
         shell: bash
         run: |


### PR DESCRIPTION
# Description

After #3290 was merged, I noticed that the CI on develop failed due to logic that was added in #3138 for checking the commit message for "[gha-debug]". The problem happens when the commit message contains newline characters, so this PR replaces newline characters with spaces before checking for "[gha-debug]".

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>