### PR TITLE
Handle reflex angles in CylinderSector

### DIFF
--- a/openmc/model/surface_composite.py
+++ b/openmc/model/surface_composite.py
@@ -131,6 +131,11 @@ class CylinderSector(CompositeSurface):
         if theta2 <= theta1:
             raise ValueError('theta2 must be greater than theta1.')
 
+        # Determine whether the angle between theta1 and theta2 is a reflex
+        # angle, in which case we need to use a union between the planar
+        # half-spaces
+        self._reflex = (theta2 - theta1 > 180.0)
+
         phi1 = pi / 180 * theta1
         phi2 = pi / 180 * theta2
 
@@ -165,6 +170,9 @@ class CylinderSector(CompositeSurface):
                                                **kwargs)
         self.plane2 = openmc.Plane.from_points(p1, p2_plane2, p3_plane2,
                                                **kwargs)
+        if axis == 'y':
+            self.plane1.flip_normal()
+            self.plane2.flip_normal()
 
     @classmethod
     def from_theta_alpha(cls,
@@ -219,16 +227,10 @@ class CylinderSector(CompositeSurface):
         return cls(r1, r2, theta1, theta2, center=center, axis=axis, **kwargs)
 
     def __neg__(self):
-        if isinstance(self.inner_cyl, openmc.YCylinder):
-            return -self.outer_cyl & +self.inner_cyl & +self.plane1 & -self.plane2
+        if self._reflex:
+            return -self.outer_cyl & +self.inner_cyl & (-self.plane1 | +self.plane2)
         else:
             return -self.outer_cyl & +self.inner_cyl & -self.plane1 & +self.plane2
-
-    def __pos__(self):
-        if isinstance(self.inner_cyl, openmc.YCylinder):
-            return +self.outer_cyl | -self.inner_cyl | -self.plane1 | +self.plane2
-        else:
-            return +self.outer_cyl | -self.inner_cyl | +self.plane1 | -self.plane2
 
 
 class IsogonalOctagon(CompositeSurface):

--- a/tests/unit_tests/test_surface_composite.py
+++ b/tests/unit_tests/test_surface_composite.py
@@ -207,6 +207,19 @@ def test_cylinder_sector(axis, indices, center):
     assert point_neg[indices] in -s
     assert point_neg[indices] not in +s
 
+    # Check __contains__ for sector with reflex angle
+    s_reflex = openmc.model.CylinderSector(
+        r1, r2, 0., 270., center=center, axis=axis.lower())
+    points = [
+        np.array([c1 + r1 + d, c2 + 0.01, 0.]),
+        np.array([c1, c2 + r1 + d, 0.]),
+        np.array([c1 - r1 - d, c2, 0.]),
+        np.array([c1 - 0.01, c2 - r1 - d, 0.])
+    ]
+    for point_neg in points:
+        assert point_neg[indices] in -s_reflex
+        assert point_neg[indices] not in +s_reflex
+
     # translate method
     t = uniform(-5.0, 5.0)
     s_t = s.translate((t, t, t))


### PR DESCRIPTION
# Description

This PR fixes #3293 and is an alternative solution to that proposed in #3296. First, thanks @nplinden for identifying the issue and proposing a solution. As I was looking over your PR, I realized there was a simpler solution, which is to simply use a `|` operator instead of `&` between the planar halfspaces if the angle is greater than 180°. I made a few other improvements in the implementation while I was at it:

- Removed `__pos__`, which is no longer needed for composite surfaces (the default inherited from `CompositeSurface` works fine)
- Flipped the normal on the planes when axis='y', which avoids the need for a check on the type in `__neg__`

@nplinden Please give this a try and let me know if it works for you.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)