### PR TITLE
Add nuclides_to_ignore argument on Model export methods

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -441,7 +441,8 @@ class Model:
                 depletion_operator.cleanup_when_done = True
                 depletion_operator.finalize()
 
-    def export_to_xml(self, directory='.', remove_surfs=False):
+    def export_to_xml(self, directory: PathLike = '.', remove_surfs: bool = False,
+                      nuclides_to_ignore: Iterable[str] | None = None):
         """Export model to separate XML files.
 
         Parameters
@@ -454,6 +455,9 @@ class Model:
             exporting.
 
             .. versionadded:: 0.13.1
+        nuclides_to_ignore : list of str
+            Nuclides to ignore when exporting to XML.
+
         """
         # Create directory if required
         d = Path(directory)
@@ -467,18 +471,19 @@ class Model:
         # for all materials in the geometry and use that to automatically build
         # a collection.
         if self.materials:
-            self.materials.export_to_xml(d)
+            self.materials.export_to_xml(d, nuclides_to_ignore=nuclides_to_ignore)
         else:
             materials = openmc.Materials(self.geometry.get_all_materials()
                                          .values())
-            materials.export_to_xml(d)
+            materials.export_to_xml(d, nuclides_to_ignore=nuclides_to_ignore)
 
         if self.tallies:
             self.tallies.export_to_xml(d)
         if self.plots:
             self.plots.export_to_xml(d)
 
-    def export_to_model_xml(self, path='model.xml', remove_surfs=False):
+    def export_to_model_xml(self, path: PathLike = 'model.xml', remove_surfs: bool = False,
+                            nuclides_to_ignore: Iterable[str] | None = None):
         """Export model to a single XML file.
 
         .. versionadded:: 0.13.3
@@ -491,6 +496,8 @@ class Model:
         remove_surfs : bool
             Whether or not to remove redundant surfaces from the geometry when
             exporting.
+        nuclides_to_ignore : list of str
+            Nuclides to ignore when exporting to XML.
 
         """
         xml_path = Path(path)
@@ -536,7 +543,8 @@ class Model:
             fh.write("<model>\n")
             # Write the materials collection to the open XML file first.
             # This will write the XML header also
-            materials._write_xml(fh, False, level=1)
+            materials._write_xml(fh, False, level=1,
+                                 nuclides_to_ignore=nuclides_to_ignore)
             # Write remaining elements as a tree
             fh.write(ET.tostring(geometry_element, encoding="unicode"))
             fh.write(ET.tostring(settings_element, encoding="unicode"))

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -593,6 +593,24 @@ def test_single_xml_exec(run_in_tmpdir):
     pincell_model.run(path='subdir')
 
 
+def test_nuclides_to_ignore(run_in_tmpdir, pin_model_attributes):
+    """Test nuclides_to_ignore when exporting a model XML"""
+    materials, geometry, settings = pin_model_attributes[:3]
+    model = openmc.Model(geometry=geometry, settings=settings)
+
+    # grab one of the nuclides present in this model as a test
+    test_nuclide = list(materials[0].get_nuclides())[0]
+
+    # exclude the test nuclide from the XML file during export
+    model.export_to_model_xml(nuclides_to_ignore=[test_nuclide])
+
+    # ensure that the nuclide doesn't appear after reading in
+    # the resulting XML model
+    xml_model = openmc.Model.from_model_xml()
+    for material in xml_model.materials:
+        assert test_nuclide not in material.get_nuclides()
+
+
 def test_model_plot():
     # plots the geometry with source location and checks the resulting
     # matplotlib includes the correct coordinates for the scatter plot for all


### PR DESCRIPTION
# Description

#2616 added the ability to specify a list of nuclides to ignore when exporting a materials.xml file. However, at present it's not possible to specify this when using `Model.export_to_model_xml` or `Model.export_to_xml`. This PR simply adds this argument to those methods.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)