### PR TITLE
Enable overlap plotting from Python API

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -856,7 +856,7 @@ class Model:
         axis_units: str = 'cm',
         outline: bool | str = False,
         show_overlaps: bool = False,
-        overlap_color: bool = None,
+        overlap_color: Sequence[int] | str | None = None,
         n_samples: int | None = None,
         plane_tolerance: float = 1.,
         legend_kwargs: dict | None = None,

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -855,6 +855,8 @@ class Model:
         legend: bool = False,
         axis_units: str = 'cm',
         outline: bool | str = False,
+        show_overlaps: bool = False,
+        overlap_color: bool = None,
         n_samples: int | None = None,
         plane_tolerance: float = 1.,
         legend_kwargs: dict | None = None,
@@ -933,6 +935,9 @@ class Model:
             plot.pixels = pixels
             plot.basis = basis
             plot.color_by = color_by
+            plot.show_overlaps = show_overlaps
+            if overlap_color is not None:
+                plot.overlap_color = overlap_color
             if colors is not None:
                 plot.colors = colors
             self.plots.append(plot)

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -210,15 +210,20 @@ _PLOT_PARAMS = """
             Whether a legend showing material or cell names should be drawn
 
             .. versionadded:: 0.14.0
+        axis_units : {'km', 'm', 'cm', 'mm'}
+            Units used on the plot axis
+
+            .. versionadded:: 0.14.0
         outline : bool or str
             Whether outlines between color boundaries should be drawn. If set to
             'only', only outlines will be drawn.
 
             .. versionadded:: 0.14.0
-        axis_units : {'km', 'm', 'cm', 'mm'}
-            Units used on the plot axis
-
-            .. versionadded:: 0.14.0
+        show_overlaps: bool
+            Indicate whether or not overlapping regions are shown.
+            Default is False.
+        overlap_color: Iterable of int or str
+            Color to apply to overlapping regions. Default is red.
         n_samples : int, optional
             The number of source particles to sample and add to plot. Defaults
             to None which doesn't plot any particles on the plot.
@@ -226,11 +231,6 @@ _PLOT_PARAMS = """
             When plotting a plane the source locations within the plane +/-
             the plane_tolerance will be included and those outside of the
             plane_tolerance will not be shown
-        show_overlaps: bool
-            Indicate whether or not overlapping regions are shown.
-            Default is False.
-        overlap_color: Iterable of int or str
-            Color to apply to overlapping regions. Default is red.
         legend_kwargs : dict
             Keyword arguments passed to :func:`matplotlib.pyplot.legend`.
 

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -226,6 +226,11 @@ _PLOT_PARAMS = """
             When plotting a plane the source locations within the plane +/-
             the plane_tolerance will be included and those outside of the
             plane_tolerance will not be shown
+        show_overlaps: bool
+            Indicate whether or not overlapping regions are shown.
+            Default is False.
+        overlap_color: Iterable of int or str
+            Color to apply to overlapping regions. Default is red.
         legend_kwargs : dict
             Keyword arguments passed to :func:`matplotlib.pyplot.legend`.
 

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -629,8 +629,5 @@ def test_model_plot():
     axes_image = axes.get_images()[0]
     image_data = axes_image.get_array()
     # ensure that all of the data in the image data is either white or red
-    try:
-        test_mask = (image_data == white) | (image_data == red)
-        assert np.all(test_mask)
-    except AssertionError as e:
-        raise AssertionError("Colors other than white or red found in overlap plot image") from e
+    test_mask = (image_data == white) | (image_data == red)
+    assert np.all(test_mask), "Colors other than white or red found in overlap plot image"

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -625,13 +625,14 @@ def test_model_plot():
 
     # modify model to include another cell that overlaps the original cell entirely
     model.geometry.root_universe.add_cell(openmc.Cell(region=-surface))
-    axes = model.plot(n_samples=1, plane_tolerance=0.1, basis="xz", pixels=(5,5), show_overlaps=True)
-    image = axes.get_images()[0]
+    axes = model.plot(show_overlaps=True)
     white = np.array((1.0, 1.0, 1.0))
     red = np.array((1.0, 0.0, 0.0))
+    axes_image = axes.get_images()[0]
+    image_data = axes_image.get_array()
     # ensure that all of the data in the image data is either white or red
     try:
-        test_mask = np.isclose(image.get_array(), white) | np.isclose(image.get_array(), red)
+        test_mask = (image_data == white) | (image_data == red)
         assert np.all(test_mask)
     except AssertionError as e:
         raise AssertionError("Colors other than white or red found in overlap plot image") from e

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -8,8 +8,6 @@ import pytest
 import openmc
 import openmc.lib
 
-from matplotlib import pyplot as plt
-
 
 @pytest.fixture(scope='function')
 def pin_model_attributes():


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This adds `show_overlaps` and `overlap_color` arguments to the `Model.plot` method to allow overlap plotting from the Python API. 

I've added a test here for a model with an overlap. The image data is interrogated to ensure that the overlap appears correctly.

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
