### PR TITLE
Fix apply_tally_results when std_dev is checked first

### DIFF
--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -427,8 +427,9 @@ class Tally(IDManagerMixin):
             if not self._sp_filename:
                 return None
 
-            n = self.num_realizations
+            # Make sure self.mean is read first to trigger _read_results
             nonzero = np.abs(self.mean) > 0
+            n = self.num_realizations
             self._std_dev = np.zeros_like(self.mean)
             self._std_dev[nonzero] = np.sqrt((self.sum_sq[nonzero]/n -
                                               self.mean[nonzero]**2)/(n - 1))

--- a/tests/unit_tests/test_tallies.py
+++ b/tests/unit_tests/test_tallies.py
@@ -116,4 +116,3 @@ def test_tally_application(sphere_model, run_in_tmpdir):
     assert (sp_tally.mean == tally.mean).all()
     assert (sp_tally.std_dev == tally.std_dev).all()
     assert sp_tally.nuclides == tally.nuclides
-


### PR DESCRIPTION
# Description

This PR fixes #3311, wherein `model.run(apply_tally_results=True)` results in `Tally` objects for which the `std_dev` property doesn't work if called first.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)