### PR TITLE
Fix access order issues after applying tally results from `Model.run`.

### DIFF
--- a/openmc/statepoint.py
+++ b/openmc/statepoint.py
@@ -6,6 +6,7 @@ import warnings
 
 import h5py
 import numpy as np
+from pathlib import Path
 from uncertainties import ufloat
 
 import openmc
@@ -415,7 +416,7 @@ class StatePoint:
 
                     # Create Tally object and assign basic properties
                     tally = openmc.Tally(tally_id)
-                    tally._sp_filename = self._f.filename
+                    tally._sp_filename = Path(self._f.filename)
                     tally.name = group['name'][()].decode() if 'name' in group else ''
 
                     # Check if tally has multiply_density attribute

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -180,20 +180,22 @@ class Tally(IDManagerMixin):
         return '\n\t'.join(parts)
 
     @staticmethod
-    def check_results(f):
-        """A decorator to be applied to any method that might use tally results
+    def ensure_results(f):
+        """A decorator to be applied to any method that might use tally results.
+           Results will be loaded if appropriate based on the tally properties.
 
         Args:
             f function: Tally method to wrap
 
         Returns:
-            function: Wrapped function that reads tally results before calling the methodif necessary
+            function: Wrapped function that reads tally results before calling
+            the methodif necessary
         """
         @wraps(f)
-        def read(self, *args, **kwargs):
+        def read(self):
             if self._sp_filename is not None and not self.derived:
                 self._read_results()
-            return f(self, *args, **kwargs)
+            return f(self)
         return read
 
     @property
@@ -235,7 +237,7 @@ class Tally(IDManagerMixin):
         self._filters = cv.CheckedList(_FILTER_CLASSES, 'tally filters', filters)
 
     @property
-    @check_results
+    @ensure_results
     def nuclides(self):
         return self._nuclides
 
@@ -332,7 +334,7 @@ class Tally(IDManagerMixin):
                                         triggers)
 
     @property
-    @check_results
+    @ensure_results
     def num_realizations(self):
         return self._num_realizations
 
@@ -387,7 +389,7 @@ class Tally(IDManagerMixin):
         self._results_read = True
 
     @property
-    @check_results
+    @ensure_results
     def sum(self):
         if not self._sp_filename or self.derived:
             return None
@@ -403,7 +405,7 @@ class Tally(IDManagerMixin):
         self._sum = sum
 
     @property
-    @check_results
+    @ensure_results
     def sum_sq(self):
         if not self._sp_filename or self.derived:
             return None
@@ -419,7 +421,7 @@ class Tally(IDManagerMixin):
         self._sum_sq = sum_sq
 
     @property
-    @check_results
+    @ensure_results
     def mean(self):
         if self._mean is None:
             if not self._sp_filename:
@@ -438,7 +440,7 @@ class Tally(IDManagerMixin):
             return self._mean
 
     @property
-    @check_results
+    @ensure_results
     def std_dev(self):
         if self._std_dev is None:
             if not self._sp_filename:

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -959,6 +959,19 @@ class Tally(IDManagerMixin):
         else:
             self._sp_filename = Path(str(statepoint))
 
+        if self.derived:
+            return
+
+        # reset these properties to ensure that
+        # any results read after this point are from the
+        # current statepoint file
+        self._sum = None
+        self._sum_sq = None
+        self._mean = None
+        self._std_dev = None
+        self._num_realizations = 0
+        self._results_read = False
+
     @classmethod
     def from_xml_element(cls, elem, **kwargs):
         """Generate tally object from an XML element

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -421,7 +421,6 @@ class Tally(IDManagerMixin):
         self._sum_sq = sum_sq
 
     @property
-    @ensure_results
     def mean(self):
         if self._mean is None:
             if not self._sp_filename:
@@ -440,7 +439,6 @@ class Tally(IDManagerMixin):
             return self._mean
 
     @property
-    @ensure_results
     def std_dev(self):
         if self._std_dev is None:
             if not self._sp_filename:
@@ -964,9 +962,8 @@ class Tally(IDManagerMixin):
         else:
             self._sp_filename = Path(str(statepoint))
 
-        # reset these properties to ensure that
-        # any results access after this point are
-        # based on the current statepoint file
+        # reset these properties to ensure that any results access after this
+        # point are based on the current statepoint file
         self._sum = None
         self._sum_sq = None
         self._mean = None

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -191,7 +191,7 @@ class Tally(IDManagerMixin):
         """
         @wraps(f)
         def read(self, *args, **kwargs):
-            if self._sp_filename is not None:
+            if self._sp_filename is not None and not self.derived:
                 self._read_results()
             return f(self, *args, **kwargs)
         return read

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -963,8 +963,8 @@ class Tally(IDManagerMixin):
             return
 
         # reset these properties to ensure that
-        # any results read after this point are from the
-        # current statepoint file
+        # any results access after this point are
+        # based on the current statepoint file
         self._sum = None
         self._sum_sq = None
         self._mean = None

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -954,13 +954,15 @@ class Tally(IDManagerMixin):
         statepoint : openmc.PathLike or openmc.StatePoint
             Statepoint used to update tally results
         """
+        # derived tallies are populated with data based on combined tallies
+        # and should not be modified
+        if self.derived:
+            return
+
         if isinstance(statepoint, openmc.StatePoint):
             self._sp_filename = Path(statepoint._f.filename)
         else:
             self._sp_filename = Path(str(statepoint))
-
-        if self.derived:
-            return
 
         # reset these properties to ensure that
         # any results access after this point are

--- a/tests/regression_tests/filter_energyfun/test.py
+++ b/tests/regression_tests/filter_energyfun/test.py
@@ -167,3 +167,6 @@ class FilterEnergyFunHarness(PyAPITestHarness):
 def test_filter_energyfun(model):
     harness = FilterEnergyFunHarness('statepoint.5.h5', model)
     harness.main()
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])

--- a/tests/regression_tests/filter_energyfun/test.py
+++ b/tests/regression_tests/filter_energyfun/test.py
@@ -167,6 +167,3 @@ class FilterEnergyFunHarness(PyAPITestHarness):
 def test_filter_energyfun(model):
     harness = FilterEnergyFunHarness('statepoint.5.h5', model)
     harness.main()
-
-if __name__ == '__main__':
-    pytest.main(['-v', __file__])

--- a/tests/unit_tests/test_tallies.py
+++ b/tests/unit_tests/test_tallies.py
@@ -108,12 +108,22 @@ def test_tally_application(sphere_model, run_in_tmpdir):
 
     # run the simulation and apply results
     sp_file = sphere_model.run(apply_tally_results=True)
+    # before calling for any property requiring results (including the equivalence check below),
+    # the following internal attributes of the original should be unset
+    assert tally._mean is None
+    assert tally._std_dev is None
+    assert tally._sum is None
+    assert tally._sum_sq is None
+    assert tally._num_realizations == 0
+    # the statepoint file property should be set, however
+    assert tally._sp_filename == sp_file
+
     with openmc.StatePoint(sp_file) as sp:
-        assert tally in sp.tallies.values()
-        sp_tally = sp.tallies[tally.id]
+       assert tally in sp.tallies.values()
+       sp_tally = sp.tallies[tally.id]
 
     # at this point the tally information regarding results should be the same
-    assert (sp_tally.mean == tally.mean).all()
     assert (sp_tally.std_dev == tally.std_dev).all()
+    assert (sp_tally.mean == tally.mean).all()
     assert sp_tally.nuclides == tally.nuclides
 

--- a/tests/unit_tests/test_tallies.py
+++ b/tests/unit_tests/test_tallies.py
@@ -120,8 +120,8 @@ def test_tally_application(sphere_model, run_in_tmpdir):
     assert tally._sp_filename == sp_file
 
     with openmc.StatePoint(sp_file) as sp:
-       assert tally in sp.tallies.values()
-       sp_tally = sp.tallies[tally.id]
+        assert tally in sp.tallies.values()
+        sp_tally = sp.tallies[tally.id]
 
     # at this point the tally information regarding results should be the same
     assert (sp_tally.std_dev == tally.std_dev).all()
@@ -140,8 +140,8 @@ def test_tally_application(sphere_model, run_in_tmpdir):
     # ensure that the new results match those in
     # the latest statepoint
     with openmc.StatePoint(sp_file) as sp:
-       assert tally in sp.tallies.values()
-       sp_tally = sp.tallies[tally.id]
+        assert tally in sp.tallies.values()
+        sp_tally = sp.tallies[tally.id]
 
     # at this point the tally information regarding results should be the same
     assert (sp_tally.std_dev == tally.std_dev).all()


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Fixes #3311 

This addresses issues with access of various tally properties after `Tally.add_results` is called by implementing a decorator that ensures results are read before accessing properties of the `Tally` object that rely on statepoint data.

The tests have been updated to ensure that the state of internal attributes are correct at different points of the object's lifetime.

I also realized that the current approach to automatically applying tally results to the  "input" Python objects would only work for one invocation of `Model.run` and that subsequent runs of the model would result in stale tally results on the input `Tally` objects. This also incorporates changes that resets internal attributes in `Tally.add_results` to ensure that data accessed on the object is consistent with the current statepoint file.

One more small change is the update of the `Tally._sp_filename` attribute from a `str` to a `Path` object. I though this made sense as we do the same for other Path/Pathlike values in the API.

# Checklist

- [x] I have performed a self-review of my own code
- [X] ~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
