### PR TITLE
Fixes for problems encountered with version determination

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,9 @@ build:
   os: "ubuntu-24.04"
   tools:
     python: "3.12"
-
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
 sphinx:
   configuration: docs/source/conf.py
 

--- a/cmake/Modules/GetVersionFromGit.cmake
+++ b/cmake/Modules/GetVersionFromGit.cmake
@@ -39,6 +39,11 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/.git" AND GIT_FOUND)
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
+    # If no tags are found, instruct user to fetch them
+    if(VERSION_STRING STREQUAL "")
+        message(FATAL_ERROR "No git tags found. Run 'git fetch --tags' and try again.")
+    endif()
+
     # Extract the commit hash
     execute_process(
         COMMAND git rev-parse HEAD


### PR DESCRIPTION
# Description

This PR fixes #3318 and fixes #3319.  For #3318, I've added an error message telling the user how to resolve the problem. For #3319, I've added a configuration variable that tells RTD to get the full git history so that it can determine the version properly.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)