### PR TITLE
Clarify effect of CMAKE_BUILD_TYPE in docs

### DIFF
--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -425,13 +425,16 @@ OpenMC can be configured for debug, release, or release with debug info by setti
 the `CMAKE_BUILD_TYPE` option.
 
 Debug
-  Enable debug compiler flags with no optimization `-O0 -g`.
+  Enable debug compiler flags with no optimization. On most platforms/compilers,
+  this is equivalent to `-O0 -g`.
 
 Release
-  Disable debug and enable optimization `-O3 -DNDEBUG`.
+  Disable debug and enable optimization. On most platforms/compilers, this is
+  equivalent to `-O3 -DNDEBUG`.
 
 RelWithDebInfo
-  (Default if no type is specified.) Enable optimization and debug `-O2 -g`.
+  (Default if no type is specified.) Enable optimization and debug. On most
+  platforms/compilers, this is equivalent to `-O2 -g`.
 
 Example of configuring for Debug mode:
 


### PR DESCRIPTION
# Description

This PR clarifies the use of `CMAKE_BUILD_TYPE` with respect to what compiler flags are typically (but not always) used.

Fixes #3314.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>