### PR TITLE
Mark a canonical URL for docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -127,6 +127,7 @@ pygments_style = 'tango'
 import sphinx_rtd_theme
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_baseurl = "https://docs.openmc.org/en/stable/"
 
 html_logo = '_images/openmc_logo.png'
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR fixes an SEO error I suspect that `docs.openmc.org` is having (which should be confirmed with Google search console). The error is that no pages are marked as "canonical", which is the page that a search engine will display as the default. This would prevent older versions showing up in search results instead of "stable".

This is a quick fix that just tells sphinx/rtd which URL is canonical. You can confirm this works by checking the source [the RTD build](https://openmc--3324.org.readthedocs.build/en/3324/) which shows:

``` html
<!DOCTYPE html>
<html class="writer-html5" lang="en" >
<head>
...
    <link rel="canonical" href="https://docs.openmc.org/en/stable/index.html" />
...
```

Fixes #3323.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] ~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] ~I have made corresponding changes to the documentation (if applicable)~
- [ ] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
