### PR TITLE
openmc.Material.mix_materials() allows for **kwargs

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1463,7 +1463,7 @@ class Material(IDManagerMixin):
 
     @classmethod
     def mix_materials(cls, materials, fracs: Iterable[float],
-                      percent_type: str = 'ao', name: str | None = None) -> Material:
+                      percent_type: str = 'ao', **kwargs) -> Material:
         """Mix materials together based on atom, weight, or volume fractions
 
         .. versionadded:: 0.12
@@ -1478,10 +1478,8 @@ class Material(IDManagerMixin):
             Type of percentage, must be one of 'ao', 'wo', or 'vo', to signify atom
             percent (molar percent), weight percent, or volume percent,
             optional. Defaults to 'ao'
-        name : str
-            The name for the new material, optional. Defaults to concatenated
-            names of input materials with percentages indicated inside
-            parentheses.
+        **kwargs
+            Keyword arguments passed to :class:`openmc.Material`
 
         Returns
         -------
@@ -1540,10 +1538,10 @@ class Material(IDManagerMixin):
                                     openmc.data.AVOGADRO
 
         # Create the new material with the desired name
-        if name is None:
-            name = '-'.join([f'{m.name}({f})' for m, f in
+        if cls.name is None:
+            cls.name = '-'.join([f'{m.name}({f})' for m, f in
                              zip(materials, fracs)])
-        new_mat = cls(name=name)
+        new_mat = cls(**kwargs)
 
         # Compute atom fractions of nuclides and add them to the new material
         tot_nuclides_per_cc = np.sum([dens for dens in nuclides_per_cc.values()])

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1538,9 +1538,10 @@ class Material(IDManagerMixin):
                                     openmc.data.AVOGADRO
 
         # Create the new material with the desired name
-        if cls.name is None:
-            cls.name = '-'.join([f'{m.name}({f})' for m, f in
+        if "name" not in kwargs:
+            kwargs["name"] = '-'.join([f'{m.name}({f})' for m, f in
                              zip(materials, fracs)])
+
         new_mat = cls(**kwargs)
 
         # Compute atom fractions of nuclides and add them to the new material

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -533,8 +533,8 @@ def test_mix_materials():
     dens4 = 1. / (f0 / m1dens + f1 / m2dens)
     dens5 = f0*m1dens + f1*m2dens
     m3 = openmc.Material.mix_materials([m1, m2], [f0, f1], percent_type='ao')
-    m4 = openmc.Material.mix_materials([m1, m2], [f0, f1], percent_type='wo')
-    m5 = openmc.Material.mix_materials([m1, m2], [f0, f1], percent_type='vo')
+    m4 = openmc.Material.mix_materials([m1, m2], [f0, f1], percent_type='wo', material_id=999)
+    m5 = openmc.Material.mix_materials([m1, m2], [f0, f1], percent_type='vo', name='m5')
     assert m3.density == pytest.approx(dens3)
     assert m4.density == pytest.approx(dens4)
     assert m5.density == pytest.approx(dens5)

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -538,6 +538,8 @@ def test_mix_materials():
     assert m3.density == pytest.approx(dens3)
     assert m4.density == pytest.approx(dens4)
     assert m5.density == pytest.approx(dens5)
+    assert m4.id == 999
+    assert m5.name == 'm5'
 
 
 def test_get_activity():


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Please include a summary of the change and which issue is fixed if applicable. Please also include relevant motivation and context.

Fixes # (issue)

Currently the classmethod `openmc.Materials.mix_materials(...)` allows for direct specification of the material `name` in its arguments but not the `material_id` or other arguments. This PR opts for a more generic `**kwargs` still keeping the default construction of material `name` that was implemented in the classmethod.

Fixes # (issue)
```python
def mix_materials(cls, materials, fracs: typing.Iterable[float],
                      percent_type: str = 'ao', name: Optional[str] = None) -> Material:
```
becomes:

```python
def mix_materials(cls, materials, fracs: Iterable[float],
                      percent_type: str = 'ao', **kwargs) -> Material:
```


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
