### PR TITLE
added stable and unstable nuclides to the Chain object

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -245,6 +245,10 @@ class Chain:
         Reactions that are tracked in the depletion chain
     nuclide_dict : dict of str to int
         Maps a nuclide name to an index in nuclides.
+    stable_nuclides : list of openmc.deplete.Nuclide
+        List of stable nuclides available in the chain.
+    unstable_nuclides : list of openmc.deplete.Nuclide
+        List of unstable nuclides available in the chain.
     fission_yields : None or iterable of dict
         List of effective fission yields for materials. Each dictionary
         should be of the form ``{parent: {product: yield}}`` with
@@ -257,7 +261,7 @@ class Chain:
     """
 
     def __init__(self):
-        self.nuclides = []
+        self.nuclides: List[Nuclide] = []
         self.reactions = []
         self.nuclide_dict = {}
         self._fission_yields = None
@@ -274,31 +278,17 @@ class Chain:
         return len(self.nuclides)
 
 
-    def get_stable_nuclides(self) -> List[Nuclide]:
-        """Return a list of stable nuclides in available the Chain
+    @property
+    def stable_nuclides(self) -> List[Nuclide]:
+        """List of stable nuclides available in the chain"""
+        return [nuc for nuc in self.nuclides if nuc.half_life is None]
 
-        Returns
-        -------
-        nuclides: openmc.deplete.Nuclide
-            List of stable nuclides in the chain
-        """
+    @property
+    def unstable_nuclides(self) -> List[Nuclide]:
+        """List of unstable nuclides available in the chain"""
+        return [nuc for nuc in self.nuclides if nuc.half_life is not None]
 
-        return [nuclide for nuclide in self.nuclides if nuclide.n_decay_modes == 0]
-
-
-    def get_unstable_nuclides(self) -> List[Nuclide]:
-        """Return a list of unstable nuclides in available the Chain
-
-        Returns
-        -------
-        nuclides: openmc.deplete.Nuclide
-            List of unstable nuclides in the chain
-        """
-
-        return [nuclide for nuclide in self.nuclides if nuclide.n_decay_modes != 0]
-
-
-    def add_nuclide(self, nuclide):
+    def add_nuclide(self, nuclide: Nuclide):
         """Add a nuclide to the depletion chain
 
         Parameters

--- a/tests/unit_tests/test_deplete_chain.py
+++ b/tests/unit_tests/test_deplete_chain.py
@@ -86,12 +86,12 @@ def test_from_endf(endf_chain):
         assert nuc == chain[nuc.name]
 
 
-def test_unstable_nuclides(simple_chain):
-    assert [nuc.name for nuc in simple_chain.get_unstable_nuclides()] == ["A", "B"]
+def test_unstable_nuclides(simple_chain: Chain):
+    assert [nuc.name for nuc in simple_chain.unstable_nuclides] == ["A", "B"]
 
 
-def test_stable_nuclides(simple_chain):
-    assert [nuc.name for nuc in simple_chain.get_stable_nuclides()] == ["H1", "C"]
+def test_stable_nuclides(simple_chain: Chain):
+    assert [nuc.name for nuc in simple_chain.stable_nuclides] == ["H1", "C"]
 
 
 def test_from_xml(simple_chain):


### PR DESCRIPTION
# Description

I find myself wanting to access the stable and unstable nuclides in a chain file when post processing results. Perhaps this is functionality useful for others. It doesn't save much effort but could perhaps still be useful. I tend to filter the material isotopes to see which nuclides produced are unstable, then I further filter by activation, decay heat etc when producing plots of important isotopes in activated material as a function of time.

I was not sure if it is best to return a list of Nuclides or list of strings (nuclides names) but I went for the list of nuclides as the ```Chain.Nuclies``` also returns a list of ```openmc.deplete.Nuclide```

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
