### PR TITLE
Release notes for 0.15.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ openmc@anl.gov.
 ## Resources
 
 - [GitHub Repository](https://github.com/openmc-dev/openmc)
-- [Documentation](http://docs.openmc.org/en/latest)
+- [Documentation](https://docs.openmc.org/en/latest)
 - [Discussion Forum](https://openmc.discourse.group)
 - [Slack Community](https://openmc.slack.com/signup) (If you don't see your
   domain listed, contact openmc@anl.gov)

--- a/docs/source/devguide/docker.rst
+++ b/docs/source/devguide/docker.rst
@@ -45,12 +45,11 @@ Now you can run the following to create a `Docker container`_ called
 This command will open an interactive shell running from within the
 Docker container where you have access to use OpenMC.
 
-.. note:: The ``docker run`` command supports many
-          `options <https://docs.docker.com/engine/reference/commandline/run/>`_
+.. note:: The ``docker run`` command supports many options_
           for spawning containers -- including `mounting volumes`_ from the
           host filesystem -- which many users will find useful.
 
-.. _Docker image: https://docs.docker.com/engine/reference/commandline/images/
+.. _Docker image: https://docs.docker.com/get-started/docker-concepts/the-basics/what-is-an-image/
 .. _Docker container: https://www.docker.com/resources/what-container
-.. _options: https://docs.docker.com/engine/reference/commandline/run/
-.. _mounting volumes: https://docs.docker.com/storage/volumes/
+.. _options: https://docs.docker.com/reference/cli/docker/container/run/
+.. _mounting volumes: https://docs.docker.com/engine/storage/volumes/

--- a/docs/source/devguide/styleguide.rst
+++ b/docs/source/devguide/styleguide.rst
@@ -47,7 +47,8 @@ is more difficult to comment out a large section of code that uses C-style
 comments.)
 
 Do not use C-style casting. Always use the C++-style casts ``static_cast``,
-``const_cast``, or ``reinterpret_cast``. (See `ES.49 <http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es49-if-you-must-use-a-cast-use-a-named-cast>`_)
+``const_cast``, or ``reinterpret_cast``. (See `ES.49
+<https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es49-if-you-must-use-a-cast-use-a-named-cast>`_)
 
 Source Files
 ------------
@@ -156,11 +157,11 @@ Prefer pathlib_ when working with filesystem paths over functions in the os_
 module or other standard-library modules. Functions that accept arguments that
 represent a filesystem path should work with both strings and Path_ objects.
 
-.. _C++ Core Guidelines: http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines
-.. _PEP8: https://www.python.org/dev/peps/pep-0008/
+.. _C++ Core Guidelines: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines
+.. _PEP8: https://peps.python.org/pep-0008/
 .. _numpydoc: https://numpydoc.readthedocs.io/en/latest/format.html
 .. _numpy: https://numpy.org/
-.. _scipy: https://www.scipy.org/
+.. _scipy: https://scipy.org/
 .. _matplotlib: https://matplotlib.org/
 .. _pandas: https://pandas.pydata.org/
 .. _h5py: https://www.h5py.org/

--- a/docs/source/devguide/user-input.rst
+++ b/docs/source/devguide/user-input.rst
@@ -55,6 +55,6 @@ developer or send a message to the `developers mailing list`_.
 
 
 .. _property attribute: https://docs.python.org/3.6/library/functions.html#property
-.. _XML Schema Part 2: http://www.w3.org/TR/xmlschema-2/
-.. _boolean: http://www.w3.org/TR/xmlschema-2/#boolean
+.. _XML Schema Part 2: https://www.w3.org/TR/xmlschema-2/
+.. _boolean: https://www.w3.org/TR/xmlschema-2/#boolean
 .. _developers mailing list: https://groups.google.com/forum/?fromgroups=#!forum/openmc-dev

--- a/docs/source/devguide/workflow.rst
+++ b/docs/source/devguide/workflow.rst
@@ -129,7 +129,7 @@ can interfere with virtual environments.
 .. _git: https://git-scm.com/
 .. _GitHub: https://github.com/
 .. _git flow: https://nvie.com/git-model
-.. _valgrind: https://www.valgrind.org/
+.. _valgrind: https://valgrind.org/
 .. _style guide: https://docs.openmc.org/en/latest/devguide/styleguide.html
 .. _pull request: https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
 .. _openmc-dev/openmc: https://github.com/openmc-dev/openmc

--- a/docs/source/methods/cross_sections.rst
+++ b/docs/source/methods/cross_sections.rst
@@ -295,8 +295,8 @@ or even isotropic scattering.
 .. _Josey: https://doi.org/10.1016/j.jcp.2015.08.013
 .. _WMP Library: https://github.com/mit-crpg/WMP_Library
 .. _MCNP: https://mcnp.lanl.gov
-.. _Serpent: https://serpent.vtt.fi/serpent/
-.. _NJOY: https://www.njoy21.io/NJOY21/
+.. _Serpent: https://serpent.vtt.fi
+.. _NJOY: https://www.njoy21.io/
 .. _ENDF/B data: https://www.nndc.bnl.gov/endf-b8.0/
 .. _Leppanen: https://doi.org/10.1016/j.anucene.2009.03.019
 .. _algorithms: http://ab-initio.mit.edu/faddeeva/

--- a/docs/source/methods/depletion.rst
+++ b/docs/source/methods/depletion.rst
@@ -114,7 +114,7 @@ The predictor method only requires one evaluation and its error converges as
 twice as expensive as the predictor method, but achieves an error of
 :math:`\mathcal{O}(h^2)`. An exhaustive description of time integration methods
 and their merits can be found in the `thesis of Colin Josey
-<http://dspace.mit.edu/handle/1721.1/7582>`_.
+<https://dspace.mit.edu/handle/1721.1/7582>`_.
 
 OpenMC does not rely on a single time integration method but rather has several
 classes that implement different algorithms. For example, the

--- a/docs/source/methods/geometry.rst
+++ b/docs/source/methods/geometry.rst
@@ -1066,5 +1066,5 @@ surface is known as in :ref:`reflection`.
 .. _constructive solid geometry: https://en.wikipedia.org/wiki/Constructive_solid_geometry
 .. _surfaces: https://en.wikipedia.org/wiki/Surface
 .. _MCNP: https://mcnp.lanl.gov
-.. _Serpent: https://serpent.vtt.fi/serpent/
+.. _Serpent: https://serpent.vtt.fi
 .. _Monte Carlo Performance benchmark: https://github.com/mit-crpg/benchmarks/tree/master/mc-performance/openmc

--- a/docs/source/methods/neutron_physics.rst
+++ b/docs/source/methods/neutron_physics.rst
@@ -1743,19 +1743,19 @@ types.
 
 .. _Watt fission spectrum: https://doi.org/10.1103/PhysRev.87.1037
 
-.. _Foderaro: http://hdl.handle.net/1721.1/1716
+.. _Foderaro: https://dspace.mit.edu/handle/1721.1/1716
 
 .. _OECD: https://www.oecd-nea.org/tools/abstract/detail/NEA-1792
 
 .. _NJOY: https://www.njoy21.io/NJOY2016/
 
-.. _PREPRO: https://www-nds.iaea.org/ndspub/endf/prepro/
+.. _PREPRO: https://www-nds.iaea.org/public/endf/prepro/
 
 .. _ENDF-6 Format: https://www.oecd-nea.org/dbdata/data/manual-endf/endf102.pdf
 
-.. _Monte Carlo Sampler: https://permalink.lanl.gov/object/tr?what=info:lanl-repo/lareport/LA-09721-MS
+.. _Monte Carlo Sampler: https://mcnp.lanl.gov/pdf_files/TechReport_1983_LANL_LA-9721-MS_EverettCashwell.pdf
 
-.. _LA-UR-14-27694: https://permalink.lanl.gov/object/tr?what=info:lanl-repo/lareport/LA-UR-14-27694
+.. _LA-UR-14-27694: https://www.osti.gov/biblio/1159204
 
 .. _MC21: https://www.osti.gov/biblio/903083
 
@@ -1763,6 +1763,4 @@ types.
 
 .. _Sutton and Brown: https://www.osti.gov/biblio/307911
 
-.. _lectures: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/la-ur-05-4983.pdf
-
-.. _MCNP Manual: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/pdf_files/la-ur-03-1987.pdf
+.. _lectures: https://mcnp.lanl.gov/pdf_files/TechReport_2005_LANL_LA-UR-05-4983_Brown.pdf

--- a/docs/source/methods/parallelization.rst
+++ b/docs/source/methods/parallelization.rst
@@ -609,17 +609,17 @@ is actually independent of the number of nodes:
 
 .. _first paper: https://doi.org/10.2307/2280232
 
-.. _work of Forrest Brown: http://hdl.handle.net/2027.42/24996
+.. _work of Forrest Brown: https://deepblue.lib.umich.edu/handle/2027.42/24996
 
 .. _Brissenden and Garlick: https://doi.org/10.1016/0306-4549(86)90095-2
 
-.. _MPICH: http://www.mpich.org
+.. _MPICH: https://www.mpich.org
 
 .. _binomial tree: https://www.mcs.anl.gov/~thakur/papers/ijhpca-coll.pdf
 
 .. _Geary: https://doi.org/10.2307/2342070
 
-.. _Barnett: http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.51.7772
+.. _Barnett: https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.51.7772
 
 .. _single-instruction multiple-data: https://en.wikipedia.org/wiki/SIMD
 

--- a/docs/source/methods/photon_physics.rst
+++ b/docs/source/methods/photon_physics.rst
@@ -1059,7 +1059,7 @@ emitted photon.
 
 .. _anomalous scattering: http://pd.chem.ucl.ac.uk/pdnn/diff1/anomscat.htm
 
-.. _Kahn's rejection method: https://mcnp.lanl.gov/pdf_files/TechReport_1956_RC_AECU-3259RM-1237-AEC_Kahn.pdf
+.. _Kahn's rejection method: https://doi.org/10.2172/4353680
 
 .. _Klein-Nishina: https://en.wikipedia.org/wiki/Klein%E2%80%93Nishina_formula
 

--- a/docs/source/methods/tallies.rst
+++ b/docs/source/methods/tallies.rst
@@ -522,4 +522,4 @@ improve the estimate of the percentile.
 
 .. _unpublished rational approximation: https://stackedboxes.org/2017/05/01/acklams-normal-quantile-function/
 
-.. _MC21: http://www.osti.gov/bridge/servlets/purl/903083-HT5p1o/903083.pdf
+.. _MC21: https://www.osti.gov/servlets/purl/903083

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -138,8 +138,8 @@ Geometry and Visualization
   *Trans. Am. Nucl. Soc.*, **114**, 391-394 (2016).
 
 - Derek M. Lax, "`Memory efficient indexing algorithm for physical properties in
-  OpenMC <http://hdl.handle.net/1721.1/97862>`_," S. M. Thesis, Massachusetts
-  Institute of Technology (2015).
+  OpenMC <https://dspace.mit.edu/handle/1721.1/97862>`_," S. M. Thesis,
+  Massachusetts Institute of Technology (2015).
 
 - Derek Lax, William Boyd, Nicholas Horelik, Benoit Forget, and Kord Smith, "A
   memory efficient algorithm for classifying unique regions in constructive
@@ -399,7 +399,8 @@ Doppler Broadening
 - Jonathan A. Walsh, Benoit Forget, Kord S. Smith, Brian C. Kiedrowski, and
   Forrest B. Brown, "`Direct, on-the-fly calculation of unresolved resonance
   region cross sections in Monte Carlo simulations
-  <http://hdl.handle.net/1721.1/108644>`_," *Proc. Joint Int. Conf. M&C+SNA+MC*,
+  <https://dspace.mit.edu/handle/1721.1/108644>`_," *Proc. Joint Int. Conf.
+  M&C+SNA+MC*,
   Nashville, Tennessee, Apr. 19--23 (2015).
 
 - Colin Josey, Benoit Forget, and Kord Smith, "`Windowed multipole sensitivity
@@ -596,7 +597,8 @@ Depletion
 
 - Matthew S. Ellis, Colin Josey, Benoit Forget, and Kord Smith, "`Spatially
   Continuous Depletion Algorithm for Monte Carlo Simulations
-  <http://hdl.handle.net/1721.1/107880>`_," *Trans. Am. Nucl. Soc.*, **115**,
+  <https://dspace.mit.edu/handle/1721.1/107880>`_," *Trans. Am. Nucl. Soc.*,
+  **115**,
   1221-1224 (2016).
 
 - Anas Gul, K. S. Chaudri, R. Khan, and M. Azeen, "`Development and verification

--- a/docs/source/pythonapi/deplete.rst
+++ b/docs/source/pythonapi/deplete.rst
@@ -26,7 +26,7 @@ provided to obtain reaction rates from cross-section data. Several classes are
 provided that implement different time-integration algorithms for depletion
 calculations, which are described in detail in Colin Josey's thesis,
 `Development and analysis of high order neutron transport-depletion coupling
-algorithms <http://hdl.handle.net/1721.1/113721>`_.
+algorithms <https://dspace.mit.edu/handle/1721.1/113721>`_.
 
 .. autosummary::
     :toctree: generated

--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -12,17 +12,17 @@ OpenMC, see :ref:`usersguide_install` in the User's Manual.
 Installing on Linux/Mac with Mamba and conda-forge
 --------------------------------------------------
 
-`Conda <https://conda.io/en/latest/>`_ is an open source package management
+`Conda <https://docs.conda.io/en/latest/>`_ is an open source package management
 system and environments management system for installing multiple versions of
 software packages and their dependencies and switching easily between them.
 `Mamba <https://mamba.readthedocs.io/en/latest/>`_ is a cross-platform package
-manager and is compatible with `conda` packages.
-OpenMC can be installed in a `conda` environment with `mamba`.
-First, `conda` should be installed with one of the following installers:
-`Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_,
-`Anaconda <https://www.anaconda.com/>`_, or `Miniforge <https://github.com/conda-forge/miniforge>`_.
-Once you have `conda` installed on your system, OpenMC can be installed via the
-`conda-forge` channel with `mamba`.
+manager and is compatible with `conda` packages. OpenMC can be installed in a
+`conda` environment with `mamba`. First, `conda` should be installed with one of
+the following installers: `Miniconda
+<https://docs.conda.io/en/latest/miniconda.html>`_, `Anaconda
+<https://www.anaconda.com/>`_, or `Miniforge
+<https://github.com/conda-forge/miniforge>`_. Once you have `conda` installed on
+your system, OpenMC can be installed via the `conda-forge` channel with `mamba`.
 
 First, add the `conda-forge` channel with:
 

--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -8,56 +8,35 @@ This quick install guide outlines the basic steps needed to install OpenMC on
 your computer. For more detailed instructions on configuring and installing
 OpenMC, see :ref:`usersguide_install` in the User's Manual.
 
---------------------------------------------------
-Installing on Linux/Mac with Mamba and conda-forge
---------------------------------------------------
+----------------------------------
+Installing on Linux/Mac with Conda
+----------------------------------
 
 `Conda <https://docs.conda.io/en/latest/>`_ is an open source package management
 system and environments management system for installing multiple versions of
 software packages and their dependencies and switching easily between them.
-`Mamba <https://mamba.readthedocs.io/en/latest/>`_ is a cross-platform package
-manager and is compatible with `conda` packages. OpenMC can be installed in a
-`conda` environment with `mamba`. First, `conda` should be installed with one of
-the following installers: `Miniconda
-<https://docs.conda.io/en/latest/miniconda.html>`_, `Anaconda
-<https://www.anaconda.com/>`_, or `Miniforge
-<https://github.com/conda-forge/miniforge>`_. Once you have `conda` installed on
-your system, OpenMC can be installed via the `conda-forge` channel with `mamba`.
+OpenMC can be installed in a `conda` environment. First, `conda` should be
+`installed <https://www.anaconda.com/docs/getting-started/getting-started>`_
+with either Anaconda Distribution or Miniconda. Once you have `conda` installed
+on your system, OpenMC can be installed via the `conda-forge` channel.
 
 First, add the `conda-forge` channel with:
 
 .. code-block:: sh
 
     conda config --add channels conda-forge
+    conda config --set channel_priority strict
 
-Then create and activate a new conda enviroment called `openmc-env` in
-which to install OpenMC.
+Then create and activate a new conda enviroment called `openmc-env` (or whatever
+you wish) with OpenMC installed.
 
 .. code-block:: sh
 
-    conda create -n openmc-env
+    conda create --name openmc-env openmc
     conda activate openmc-env
 
-Then install `mamba`, which will be used to install OpenMC.
-
-.. code-block:: sh
-
-    conda install mamba
-
-To list the versions of OpenMC that are available on the `conda-forge` channel,
-in your terminal window or an Anaconda Prompt run:
-
-.. code-block:: sh
-
-    mamba search openmc
-
-OpenMC can then be installed with:
-
-.. code-block:: sh
-
-    mamba install openmc
-
-You are now in a conda environment called `openmc-env` that has OpenMC installed.
+You are now in a conda environment called `openmc-env` that has OpenMC
+installed.
 
 -------------------------------------------
 Installing on Linux/Mac/Windows with Docker

--- a/docs/source/releasenotes/0.15.1.rst
+++ b/docs/source/releasenotes/0.15.1.rst
@@ -1,0 +1,222 @@
+====================
+What's New in 0.15.1
+====================
+
+.. currentmodule:: openmc
+
+-------
+Summary
+-------
+
+This release of OpenMC includes many bug fixes, performance improvements, and
+several notable new features. The random ray solver continues to receives many
+updates and improvements, which are listed below in more detail. A new
+:class:`~openmc.SolidRayTracePlot` class has been added that enables attractive
+3D visualization using Phong shading. Several composite surfaces have been
+introduced (which help to further expand the capabilities of the
+`openmc_mcnp_adapter <https://github.com/openmc-dev/openmc_mcnp_adapter/>`_).
+The :meth:`openmc.Mesh.material_volumes` method has been completely
+reimplemented with a new approach based on ray tracing that greatly improves
+performance and can be executed in parallel. Finally, a new
+:mod:`openmc.deplete.d1s` submodule has been added that enables Direct 1-Step
+(D1S) calculations of shutdown dose rate for fusion applications.
+
+------------------------------------
+Compatibility Notes and Deprecations
+------------------------------------
+
+The ``openmc.ProjectionPlot`` class has been renamed to
+:class:`openmc.WireframeRayTracePlot` to be in better alignment with the newly
+introduced :class:`openmc.SolidRayTracePlot` class.
+
+NCrystal has been moved from a build-time dependency to a runtime dependency,
+which means there is no longer a ``OPENMC_USE_NCRYSTAL`` CMake option. Instead,
+OpenMC will look for an installed version of NCrystal using the
+``ncrystal-config`` command.
+
+------------
+New Features
+------------
+
+- Numerous improvements have been made in the random ray solver:
+  - Calculation of Shannon entropy now works with random ray (`#3030 <https://github.com/openmc-dev/openmc/pull/3030>`_)
+  - Support for linear sources (`#3072 <https://github.com/openmc-dev/openmc/pull/3072>`_)
+  - Ability to slove for adjoint flux (`#3191 <https://github.com/openmc-dev/openmc/pull/3191>`_)
+  - Support randomized Quasi-Monte Carlo sampling (`#3268 <https://github.com/openmc-dev/openmc/pull/3268>`_)
+  - FW-CADIS weight window generation (`#3273 <https://github.com/openmc-dev/openmc/pull/3273>`_)
+  - Source region mesh subdivision(`#3333 <https://github.com/openmc-dev/openmc/pull/3333>`_)
+- Several new composite surfaces have been added:
+  - :class:`openmc.model.OrthogonalBox` (`#3118 <https://github.com/openmc-dev/openmc/pull/3118>`_)
+  - :class:`openmc.model.ConicalFrustum` (`#3151 <https://github.com/openmc-dev/openmc/pull/3151>`_)
+  - :class:`openmc.model.Vessel` (`#3168 <https://github.com/openmc-dev/openmc/pull/3168>`_)
+- The :meth:`openmc.Model.plot` method now supports plotting source sites
+  (`#2863 <https://github.com/openmc-dev/openmc/pull/2863>`_)
+- The :func:`openmc.stats.delta_function` convenience function can be used for
+  specifying distributions with a single point (`#3090
+  <https://github.com/openmc-dev/openmc/pull/3090>`_)
+- Added a :meth:`openmc,Material.get_element_atom_densities` method (`#3103
+  <https://github.com/openmc-dev/openmc/pull/3103>`_)
+- Several third-party dependencies have been removed:
+    - Cython (`#3111 <https://github.com/openmc-dev/openmc/pull/3111>`_)
+    - gsl-lite (`#3225 <https://github.com/openmc-dev/openmc/pull/3225>`_)
+- Added a new :class:`openmc.MuSurfaceFilter` class that filters tally events by
+  the cosine of angle of a surface crossing (`#2768
+  <https://github.com/openmc-dev/openmc/pull/2768>`_)
+- Introduced a :class:`openmc.ParticleList` class for manipulating a list of
+  source particles (`#3148 <https://github.com/openmc-dev/openmc/pull/3148>`_)
+- Support dose coefficients from ICRP 74 in
+  :func:`openmc.data.dose_coefficients` (`#3020
+  <https://github.com/openmc-dev/openmc/pull/3020>`_)
+- Introduced a new :attr:`openmc.Settings.uniform_source_sampling` option
+  (`#3195 <https://github.com/openmc-dev/openmc/pull/3195>`_)
+- Ability to differentiate materials in DAGMC universes (`#3056
+  <https://github.com/openmc-dev/openmc/pull/3056>`_)
+- Added methods to automatically apply results to existing Tally objects.
+  (`#2671 <https://github.com/openmc-dev/openmc/pull/2671>`_)
+- Implemented a new :class:`openmc.SolidRayTracePlot` class that can produce a
+  3D visualization based on Phong shading (`#2655
+  <https://github.com/openmc-dev/openmc/pull/2655>`_)
+- The :meth:`openmc.UnstructuredMesh.write_data_to_vtk` method now supports
+  writing a VTU file (`#3290 <https://github.com/openmc-dev/openmc/pull/3290>`_)
+- Composite surfaces now have a
+  :attr:`~openmc.CompositeSurface.component_surfaces` attribute that provides
+  the underlying primitive surfaces (`#3167
+  <https://github.com/openmc-dev/openmc/pull/3167>`_)
+- A new :mod:`openmc.deplete.d1s` submodule has been added that enables Direct
+  1-Step (D1S) calculations of shutdown dose rate for fusion applications
+  (`#3235 <https://github.com/openmc-dev/openmc/pull/3235>`_)
+
+---------------------------
+Bug Fixes and Small Changes
+---------------------------
+
+- run microxs with mpi (`#3028 <https://github.com/openmc-dev/openmc/pull/3028>`_)
+- Rely on std::filesystem for file_utils (`#3042 <https://github.com/openmc-dev/openmc/pull/3042>`_)
+- Random Ray Normalization Improvements (`#3051 <https://github.com/openmc-dev/openmc/pull/3051>`_)
+- Alternative Random Ray Volume Estimators (`#3060 <https://github.com/openmc-dev/openmc/pull/3060>`_)
+- Random Ray Testing Simplification (`#3061 <https://github.com/openmc-dev/openmc/pull/3061>`_)
+- Fix hyperlinks in `random_ray.rst` (`#3064 <https://github.com/openmc-dev/openmc/pull/3064>`_)
+- Add missing show_overlaps option to plots.xml input file documentation (`#3068 <https://github.com/openmc-dev/openmc/pull/3068>`_)
+- Remove use of pkg_resources package (`#3069 <https://github.com/openmc-dev/openmc/pull/3069>`_)
+- Add option for survival biasing source normalization (`#3070 <https://github.com/openmc-dev/openmc/pull/3070>`_)
+- Enforce sequence type when setting Setting.track (`#3071 <https://github.com/openmc-dev/openmc/pull/3071>`_)
+- Moving most of setup.py to pyproject.toml (`#3074 <https://github.com/openmc-dev/openmc/pull/3074>`_)
+- Enforce non-negative percents for material.add_nuclide to prevent unintended ao/wo flipping (`#3075 <https://github.com/openmc-dev/openmc/pull/3075>`_)
+- Include batch statistics discussion in methodology introduction (`#3076 <https://github.com/openmc-dev/openmc/pull/3076>`_)
+- Add -DCMAKE_BUILD_TYPE=Release flag for MOAB in Dockerfile (`#3077 <https://github.com/openmc-dev/openmc/pull/3077>`_)
+- Adjust decay data reader to better handle non-normalized branching ratios (`#3080 <https://github.com/openmc-dev/openmc/pull/3080>`_)
+- Correct openmc.Geometry initializer to accept iterables of openmc.Cell (`#3081 <https://github.com/openmc-dev/openmc/pull/3081>`_)
+- Replace all deprecated Python typing imports and syntax with updated forms (`#3085 <https://github.com/openmc-dev/openmc/pull/3085>`_)
+- Fix ParticleFilter to work with set inputs (`#3092 <https://github.com/openmc-dev/openmc/pull/3092>`_)
+- packages used for testing moved to tests section of pyprojects.toml (`#3094 <https://github.com/openmc-dev/openmc/pull/3094>`_)
+- removed unused which function in CI scripts (`#3095 <https://github.com/openmc-dev/openmc/pull/3095>`_)
+- Improve description of probabilities for openmc.stats.Tabular class (`#3099 <https://github.com/openmc-dev/openmc/pull/3099>`_)
+- Ensure RegularMesh repr shows value for width of the mesh (`#3100 <https://github.com/openmc-dev/openmc/pull/3100>`_)
+- Replacing endf c functions with package (`#3101 <https://github.com/openmc-dev/openmc/pull/3101>`_)
+- Fix random ray solver to correctly simulate fixed source problems with fissionable materials (`#3106 <https://github.com/openmc-dev/openmc/pull/3106>`_)
+- Improve error for nuclide temperature not found  (`#3110 <https://github.com/openmc-dev/openmc/pull/3110>`_)
+- Added error if cross sections path is a folder (`#3115 <https://github.com/openmc-dev/openmc/pull/3115>`_)
+- Implement bounding_box operation for meshes (`#3119 <https://github.com/openmc-dev/openmc/pull/3119>`_)
+- allowing varible offsets for polygon.offset (`#3120 <https://github.com/openmc-dev/openmc/pull/3120>`_)
+- Write surface source files per batch (`#3124 <https://github.com/openmc-dev/openmc/pull/3124>`_)
+- Mat ids reset (`#3125 <https://github.com/openmc-dev/openmc/pull/3125>`_)
+- Tweaking title of feature issue template (`#3127 <https://github.com/openmc-dev/openmc/pull/3127>`_)
+- Fix a typo in feature request template (`#3128 <https://github.com/openmc-dev/openmc/pull/3128>`_)
+- Update quickinstall instructions for macOS (`#3130 <https://github.com/openmc-dev/openmc/pull/3130>`_)
+- adapt the openmc-update-inputs script for surfaces (`#3131 <https://github.com/openmc-dev/openmc/pull/3131>`_)
+- Theory documentation on PCG random number generator (`#3134 <https://github.com/openmc-dev/openmc/pull/3134>`_)
+- Adding tmate action to CI for debugging (`#3138 <https://github.com/openmc-dev/openmc/pull/3138>`_)
+- Add Versioning Support from `version.txt` (`#3140 <https://github.com/openmc-dev/openmc/pull/3140>`_)
+- Correct failure due to progress bar values  (`#3143 <https://github.com/openmc-dev/openmc/pull/3143>`_)
+- Avoid writing subnormal nuclide densities to XML (`#3144 <https://github.com/openmc-dev/openmc/pull/3144>`_)
+- Immediately resolve complement operators for regions (`#3145 <https://github.com/openmc-dev/openmc/pull/3145>`_)
+- Improve Detection of libMesh Installation via `LIBMESH_ROOT` and CMake's PkgConfig (`#3149 <https://github.com/openmc-dev/openmc/pull/3149>`_)
+- Fix for UWUW Macro Conflict (`#3150 <https://github.com/openmc-dev/openmc/pull/3150>`_)
+- Consistency in treatment of paths for files specified within the Model class (`#3153 <https://github.com/openmc-dev/openmc/pull/3153>`_)
+- Improve clipping of Mixture distributions (`#3154 <https://github.com/openmc-dev/openmc/pull/3154>`_)
+- Fix check for trigger score name (`#3155 <https://github.com/openmc-dev/openmc/pull/3155>`_)
+- Prepare point query data structures on meshes when applying Weight Windows (`#3157 <https://github.com/openmc-dev/openmc/pull/3157>`_)
+- Add PointCloud spatial distribution (`#3161 <https://github.com/openmc-dev/openmc/pull/3161>`_)
+- Update fmt submodule to version 11.0.2 (`#3162 <https://github.com/openmc-dev/openmc/pull/3162>`_)
+- Move to support python 3.13 (`#3165 <https://github.com/openmc-dev/openmc/pull/3165>`_)
+- avoid zero division if source rate of previous result is zero (`#3169 <https://github.com/openmc-dev/openmc/pull/3169>`_)
+- Fix path handling for thermal ACE generation (`#3171 <https://github.com/openmc-dev/openmc/pull/3171>`_)
+- Update `fmt` Formatters for Compatibility with Versions below 11 (`#3172 <https://github.com/openmc-dev/openmc/pull/3172>`_)
+- added subfolders to txt search command in pyproject (`#3174 <https://github.com/openmc-dev/openmc/pull/3174>`_)
+- added list to doc string arg for plot_xs (`#3178 <https://github.com/openmc-dev/openmc/pull/3178>`_)
+- enable polymorphism for mix_materials (`#3180 <https://github.com/openmc-dev/openmc/pull/3180>`_)
+- Fix plot_xs type hint (`#3184 <https://github.com/openmc-dev/openmc/pull/3184>`_)
+- Enable adaptive mesh support on libMesh tallies (`#3185 <https://github.com/openmc-dev/openmc/pull/3185>`_)
+- Reset values of lattice offset tables when allocated (`#3188 <https://github.com/openmc-dev/openmc/pull/3188>`_)
+- Update surface_composite.py (`#3189 <https://github.com/openmc-dev/openmc/pull/3189>`_)
+- add export_model_xml arguments to Model.plot_geometry and Model.calculate_volumes (`#3190 <https://github.com/openmc-dev/openmc/pull/3190>`_)
+- Fixes in MicroXS.from_multigroup_flux (`#3192 <https://github.com/openmc-dev/openmc/pull/3192>`_)
+- Fix documentation typo in `boundary_type` (`#3196 <https://github.com/openmc-dev/openmc/pull/3196>`_)
+- Fix docstring for Model.plot (`#3198 <https://github.com/openmc-dev/openmc/pull/3198>`_)
+- Apply weight windows at collisions in multigroup transport mode. (`#3199 <https://github.com/openmc-dev/openmc/pull/3199>`_)
+- External sources alias sampler (`#3201 <https://github.com/openmc-dev/openmc/pull/3201>`_)
+- Add test for flux bias with weight windows in multigroup mode (`#3202 <https://github.com/openmc-dev/openmc/pull/3202>`_)
+- Fix bin index to DoF ID mapping bug in adaptive libMesh meshes (`#3206 <https://github.com/openmc-dev/openmc/pull/3206>`_)
+- Ensure libMesh::ReplicatedMesh is used for LibMesh tallies (`#3208 <https://github.com/openmc-dev/openmc/pull/3208>`_)
+- Set Model attributes only if needed (`#3209 <https://github.com/openmc-dev/openmc/pull/3209>`_)
+- adding unstrucutred mesh file suffix to docstring (`#3211 <https://github.com/openmc-dev/openmc/pull/3211>`_)
+- Write and read mesh name attribute (`#3221 <https://github.com/openmc-dev/openmc/pull/3221>`_)
+- Adjust for secondary particle energy directly in heating scores (`#3227 <https://github.com/openmc-dev/openmc/pull/3227>`_)
+- Correct normalization of thermal elastic in non standard ENDF-6 files (`#3234 <https://github.com/openmc-dev/openmc/pull/3234>`_)
+- Adding '#define _USE_MATH_DEFINES' to make M_PI declared in Intel and MSVC compilers (`#3238 <https://github.com/openmc-dev/openmc/pull/3238>`_)
+- updated link to log mapping technique (`#3241 <https://github.com/openmc-dev/openmc/pull/3241>`_)
+- Fix for erroneously non-zero tally results of photon threshold reactions (`#3242 <https://github.com/openmc-dev/openmc/pull/3242>`_)
+- Fix type comparison (`#3244 <https://github.com/openmc-dev/openmc/pull/3244>`_)
+- Enable the LegendreFilter filter to be used in photon tallies for orders greater than P0. (`#3245 <https://github.com/openmc-dev/openmc/pull/3245>`_)
+- Enable UWUW library when building with DAGMC in CI (`#3246 <https://github.com/openmc-dev/openmc/pull/3246>`_)
+- Remove top-level import of openmc.lib (`#3250 <https://github.com/openmc-dev/openmc/pull/3250>`_)
+- updated docker file to latest DAGMC (`#3251 <https://github.com/openmc-dev/openmc/pull/3251>`_)
+- Write mesh type as a dataset always (`#3253 <https://github.com/openmc-dev/openmc/pull/3253>`_)
+- Update to a consistent definition of the r2 parameter for cones (`#3254 <https://github.com/openmc-dev/openmc/pull/3254>`_)
+- Add Patrick Shriwise to technical committee (`#3255 <https://github.com/openmc-dev/openmc/pull/3255>`_)
+- Change `Zernike` documentation in polynomial.py (`#3258 <https://github.com/openmc-dev/openmc/pull/3258>`_)
+- Bug fix for Polygon 'yz' basis (`#3259 <https://github.com/openmc-dev/openmc/pull/3259>`_)
+- Add constant for invalid surface tokens. (`#3260 <https://github.com/openmc-dev/openmc/pull/3260>`_)
+- Update plots.py for PathLike to string handling error (`#3261 <https://github.com/openmc-dev/openmc/pull/3261>`_)
+- Fix bug in WeightWindowGenerator for empty energy bounds (`#3263 <https://github.com/openmc-dev/openmc/pull/3263>`_)
+- Update recognized thermal scattering materials for ENDF/B-VIII.1 (`#3267 <https://github.com/openmc-dev/openmc/pull/3267>`_)
+- simplify mechanism to detect if geometry entity is DAG (`#3269 <https://github.com/openmc-dev/openmc/pull/3269>`_)
+- Fix bug in Surface.normalize (`#3270 <https://github.com/openmc-dev/openmc/pull/3270>`_)
+- Tweak To Sphinx Install Documentation (`#3271 <https://github.com/openmc-dev/openmc/pull/3271>`_)
+- add continue feature for depletion (`#3272 <https://github.com/openmc-dev/openmc/pull/3272>`_)
+- Updates for building with NCrystal support (and fix CI) (`#3274 <https://github.com/openmc-dev/openmc/pull/3274>`_)
+- Added missing documentation (`#3275 <https://github.com/openmc-dev/openmc/pull/3275>`_)
+- fix the bug in function differentiate_mats() (`#3277 <https://github.com/openmc-dev/openmc/pull/3277>`_)
+- Fix the bug in the Material.from_xml_element function  (`#3278 <https://github.com/openmc-dev/openmc/pull/3278>`_)
+- Doc typo fix for rand ray mgxs (`#3280 <https://github.com/openmc-dev/openmc/pull/3280>`_)
+- Consolidate plotting capabilities in Model.plot (`#3282 <https://github.com/openmc-dev/openmc/pull/3282>`_)
+- adding non elastic MT number (`#3285 <https://github.com/openmc-dev/openmc/pull/3285>`_)
+- Fix Tabular.from_xml_element for histogram case (`#3287 <https://github.com/openmc-dev/openmc/pull/3287>`_)
+- Random Ray Source Region Refactor (`#3288 <https://github.com/openmc-dev/openmc/pull/3288>`_)
+- added terminal output showing compile options selected (`#3291 <https://github.com/openmc-dev/openmc/pull/3291>`_)
+- Random ray consistency changes (`#3298 <https://github.com/openmc-dev/openmc/pull/3298>`_)
+- Random Ray Explicit Void Treatment (`#3299 <https://github.com/openmc-dev/openmc/pull/3299>`_)
+- removed old command line scripts (`#3300 <https://github.com/openmc-dev/openmc/pull/3300>`_)
+- Avoid end of life ubuntu 20.04 in ReadTheDocs runner (`#3301 <https://github.com/openmc-dev/openmc/pull/3301>`_)
+- Avoid error in CI from newlines in commit message (`#3302 <https://github.com/openmc-dev/openmc/pull/3302>`_)
+- Handle reflex angles in CylinderSector (`#3303 <https://github.com/openmc-dev/openmc/pull/3303>`_)
+- Relax requirement on polar/azimuthal axis for wwinp conversion (`#3307 <https://github.com/openmc-dev/openmc/pull/3307>`_)
+- Add nuclides_to_ignore argument on Model export methods (`#3309 <https://github.com/openmc-dev/openmc/pull/3309>`_)
+- Enable overlap plotting from Python API (`#3310 <https://github.com/openmc-dev/openmc/pull/3310>`_)
+- Fix access order issues after applying tally results from `Model.run` (`#3313 <https://github.com/openmc-dev/openmc/pull/3313>`_)
+- Random Ray Void Accuracy Fix (`#3316 <https://github.com/openmc-dev/openmc/pull/3316>`_)
+- Fixes for problems encountered with version determination (`#3320 <https://github.com/openmc-dev/openmc/pull/3320>`_)
+- Clarify effect of CMAKE_BUILD_TYPE in docs (`#3321 <https://github.com/openmc-dev/openmc/pull/3321>`_)
+- Random Ray Linear Source Stability Improvement (`#3322 <https://github.com/openmc-dev/openmc/pull/3322>`_)
+- Mark a canonical URL for docs (`#3324 <https://github.com/openmc-dev/openmc/pull/3324>`_)
+- Random Ray Adjoint Source Logic Improvement (`#3325 <https://github.com/openmc-dev/openmc/pull/3325>`_)
+- Reflect multigroup MicroXS in IndependentOperator docstrings (`#3327 <https://github.com/openmc-dev/openmc/pull/3327>`_)
+- NCrystal becomes runtime rather than buildtime dependency (`#3328 <https://github.com/openmc-dev/openmc/pull/3328>`_)
+- Adding per kg as unit option on material functions (`#3329 <https://github.com/openmc-dev/openmc/pull/3329>`_)
+- Fix reading of horizontal field of view for ray-traced plots (`#3330 <https://github.com/openmc-dev/openmc/pull/3330>`_)
+- Manually fix broken links (`#3331 <https://github.com/openmc-dev/openmc/pull/3331>`_)
+- Update pugixml to v1.15 (`#3332 <https://github.com/openmc-dev/openmc/pull/3332>`_)
+- Determine nuclides correctly for DAGMC models in d1s.get_radionuclides (`#3335 <https://github.com/openmc-dev/openmc/pull/3335>`_)
+- openmc.Material.mix_materials() allows for keyword arguments (`#3336 <https://github.com/openmc-dev/openmc/pull/3336>`_)
+- Fix bug in Mesh::material_volumes for void materials (`#3337 <https://github.com/openmc-dev/openmc/pull/3337>`_)
+- added stable and unstable nuclides to the Chain object (`#3338 <https://github.com/openmc-dev/openmc/pull/3338>`_)

--- a/docs/source/releasenotes/0.15.1.rst
+++ b/docs/source/releasenotes/0.15.1.rst
@@ -9,7 +9,7 @@ Summary
 -------
 
 This release of OpenMC includes many bug fixes, performance improvements, and
-several notable new features. The random ray solver continues to receives many
+several notable new features. The random ray solver continues to receive many
 updates and improvements, which are listed below in more detail. A new
 :class:`~openmc.SolidRayTracePlot` class has been added that enables attractive
 3D visualization using Phong shading. Several composite surfaces have been
@@ -17,9 +17,11 @@ introduced (which help to further expand the capabilities of the
 `openmc_mcnp_adapter <https://github.com/openmc-dev/openmc_mcnp_adapter/>`_).
 The :meth:`openmc.Mesh.material_volumes` method has been completely
 reimplemented with a new approach based on ray tracing that greatly improves
-performance and can be executed in parallel. Finally, a new
-:mod:`openmc.deplete.d1s` submodule has been added that enables Direct 1-Step
-(D1S) calculations of shutdown dose rate for fusion applications.
+performance and can be executed in parallel. Tally results can be automatically
+applied to input :class:`~openmc.Tally` objects with :meth:`openmc.Model.run`,
+bypassing boilerplate code for collecting tally results from statepoint files.
+Finally, a new :mod:`openmc.deplete.d1s` submodule has been added that enables
+Direct 1-Step (D1S) calculations of shutdown dose rate for fusion applications.
 
 ------------------------------------
 Compatibility Notes and Deprecations
@@ -99,25 +101,25 @@ Bug Fixes and Small Changes
 - Add missing show_overlaps option to plots.xml input file documentation (`#3068 <https://github.com/openmc-dev/openmc/pull/3068>`_)
 - Remove use of pkg_resources package (`#3069 <https://github.com/openmc-dev/openmc/pull/3069>`_)
 - Add option for survival biasing source normalization (`#3070 <https://github.com/openmc-dev/openmc/pull/3070>`_)
-- Enforce sequence type when setting Setting.track (`#3071 <https://github.com/openmc-dev/openmc/pull/3071>`_)
+- Enforce sequence type when setting ``Setting.track`` (`#3071 <https://github.com/openmc-dev/openmc/pull/3071>`_)
 - Moving most of setup.py to pyproject.toml (`#3074 <https://github.com/openmc-dev/openmc/pull/3074>`_)
-- Enforce non-negative percents for material.add_nuclide to prevent unintended ao/wo flipping (`#3075 <https://github.com/openmc-dev/openmc/pull/3075>`_)
+- Enforce non-negative percents for ``material.add_nuclide`` to prevent unintended ao/wo flipping (`#3075 <https://github.com/openmc-dev/openmc/pull/3075>`_)
 - Include batch statistics discussion in methodology introduction (`#3076 <https://github.com/openmc-dev/openmc/pull/3076>`_)
 - Add -DCMAKE_BUILD_TYPE=Release flag for MOAB in Dockerfile (`#3077 <https://github.com/openmc-dev/openmc/pull/3077>`_)
 - Adjust decay data reader to better handle non-normalized branching ratios (`#3080 <https://github.com/openmc-dev/openmc/pull/3080>`_)
-- Correct openmc.Geometry initializer to accept iterables of openmc.Cell (`#3081 <https://github.com/openmc-dev/openmc/pull/3081>`_)
+- Correct openmc.Geometry initializer to accept iterables of ``openmc.Cell`` (`#3081 <https://github.com/openmc-dev/openmc/pull/3081>`_)
 - Replace all deprecated Python typing imports and syntax with updated forms (`#3085 <https://github.com/openmc-dev/openmc/pull/3085>`_)
 - Fix ParticleFilter to work with set inputs (`#3092 <https://github.com/openmc-dev/openmc/pull/3092>`_)
 - packages used for testing moved to tests section of pyprojects.toml (`#3094 <https://github.com/openmc-dev/openmc/pull/3094>`_)
 - removed unused which function in CI scripts (`#3095 <https://github.com/openmc-dev/openmc/pull/3095>`_)
-- Improve description of probabilities for openmc.stats.Tabular class (`#3099 <https://github.com/openmc-dev/openmc/pull/3099>`_)
+- Improve description of probabilities for ``openmc.stats.Tabular`` class (`#3099 <https://github.com/openmc-dev/openmc/pull/3099>`_)
 - Ensure RegularMesh repr shows value for width of the mesh (`#3100 <https://github.com/openmc-dev/openmc/pull/3100>`_)
 - Replacing endf c functions with package (`#3101 <https://github.com/openmc-dev/openmc/pull/3101>`_)
 - Fix random ray solver to correctly simulate fixed source problems with fissionable materials (`#3106 <https://github.com/openmc-dev/openmc/pull/3106>`_)
 - Improve error for nuclide temperature not found  (`#3110 <https://github.com/openmc-dev/openmc/pull/3110>`_)
 - Added error if cross sections path is a folder (`#3115 <https://github.com/openmc-dev/openmc/pull/3115>`_)
 - Implement bounding_box operation for meshes (`#3119 <https://github.com/openmc-dev/openmc/pull/3119>`_)
-- allowing varible offsets for polygon.offset (`#3120 <https://github.com/openmc-dev/openmc/pull/3120>`_)
+- allowing varible offsets for ``polygon.offset`` (`#3120 <https://github.com/openmc-dev/openmc/pull/3120>`_)
 - Write surface source files per batch (`#3124 <https://github.com/openmc-dev/openmc/pull/3124>`_)
 - Mat ids reset (`#3125 <https://github.com/openmc-dev/openmc/pull/3125>`_)
 - Tweaking title of feature issue template (`#3127 <https://github.com/openmc-dev/openmc/pull/3127>`_)
@@ -149,15 +151,15 @@ Bug Fixes and Small Changes
 - Enable adaptive mesh support on libMesh tallies (`#3185 <https://github.com/openmc-dev/openmc/pull/3185>`_)
 - Reset values of lattice offset tables when allocated (`#3188 <https://github.com/openmc-dev/openmc/pull/3188>`_)
 - Update surface_composite.py (`#3189 <https://github.com/openmc-dev/openmc/pull/3189>`_)
-- add export_model_xml arguments to Model.plot_geometry and Model.calculate_volumes (`#3190 <https://github.com/openmc-dev/openmc/pull/3190>`_)
+- add export_model_xml arguments to ``Model.plot_geometry`` and ``Model.calculate_volumes`` (`#3190 <https://github.com/openmc-dev/openmc/pull/3190>`_)
 - Fixes in MicroXS.from_multigroup_flux (`#3192 <https://github.com/openmc-dev/openmc/pull/3192>`_)
-- Fix documentation typo in `boundary_type` (`#3196 <https://github.com/openmc-dev/openmc/pull/3196>`_)
-- Fix docstring for Model.plot (`#3198 <https://github.com/openmc-dev/openmc/pull/3198>`_)
+- Fix documentation typo in ``boundary_type`` (`#3196 <https://github.com/openmc-dev/openmc/pull/3196>`_)
+- Fix docstring for ``Model.plot`` (`#3198 <https://github.com/openmc-dev/openmc/pull/3198>`_)
 - Apply weight windows at collisions in multigroup transport mode. (`#3199 <https://github.com/openmc-dev/openmc/pull/3199>`_)
 - External sources alias sampler (`#3201 <https://github.com/openmc-dev/openmc/pull/3201>`_)
 - Add test for flux bias with weight windows in multigroup mode (`#3202 <https://github.com/openmc-dev/openmc/pull/3202>`_)
 - Fix bin index to DoF ID mapping bug in adaptive libMesh meshes (`#3206 <https://github.com/openmc-dev/openmc/pull/3206>`_)
-- Ensure libMesh::ReplicatedMesh is used for LibMesh tallies (`#3208 <https://github.com/openmc-dev/openmc/pull/3208>`_)
+- Ensure ``libMesh::ReplicatedMesh`` is used for LibMesh tallies (`#3208 <https://github.com/openmc-dev/openmc/pull/3208>`_)
 - Set Model attributes only if needed (`#3209 <https://github.com/openmc-dev/openmc/pull/3209>`_)
 - adding unstrucutred mesh file suffix to docstring (`#3211 <https://github.com/openmc-dev/openmc/pull/3211>`_)
 - Write and read mesh name attribute (`#3221 <https://github.com/openmc-dev/openmc/pull/3221>`_)
@@ -169,7 +171,7 @@ Bug Fixes and Small Changes
 - Fix type comparison (`#3244 <https://github.com/openmc-dev/openmc/pull/3244>`_)
 - Enable the LegendreFilter filter to be used in photon tallies for orders greater than P0. (`#3245 <https://github.com/openmc-dev/openmc/pull/3245>`_)
 - Enable UWUW library when building with DAGMC in CI (`#3246 <https://github.com/openmc-dev/openmc/pull/3246>`_)
-- Remove top-level import of openmc.lib (`#3250 <https://github.com/openmc-dev/openmc/pull/3250>`_)
+- Remove top-level import of ``openmc.lib`` (`#3250 <https://github.com/openmc-dev/openmc/pull/3250>`_)
 - updated docker file to latest DAGMC (`#3251 <https://github.com/openmc-dev/openmc/pull/3251>`_)
 - Write mesh type as a dataset always (`#3253 <https://github.com/openmc-dev/openmc/pull/3253>`_)
 - Update to a consistent definition of the r2 parameter for cones (`#3254 <https://github.com/openmc-dev/openmc/pull/3254>`_)
@@ -181,17 +183,17 @@ Bug Fixes and Small Changes
 - Fix bug in WeightWindowGenerator for empty energy bounds (`#3263 <https://github.com/openmc-dev/openmc/pull/3263>`_)
 - Update recognized thermal scattering materials for ENDF/B-VIII.1 (`#3267 <https://github.com/openmc-dev/openmc/pull/3267>`_)
 - simplify mechanism to detect if geometry entity is DAG (`#3269 <https://github.com/openmc-dev/openmc/pull/3269>`_)
-- Fix bug in Surface.normalize (`#3270 <https://github.com/openmc-dev/openmc/pull/3270>`_)
+- Fix bug in ``Surface.normalize`` (`#3270 <https://github.com/openmc-dev/openmc/pull/3270>`_)
 - Tweak To Sphinx Install Documentation (`#3271 <https://github.com/openmc-dev/openmc/pull/3271>`_)
 - add continue feature for depletion (`#3272 <https://github.com/openmc-dev/openmc/pull/3272>`_)
 - Updates for building with NCrystal support (and fix CI) (`#3274 <https://github.com/openmc-dev/openmc/pull/3274>`_)
 - Added missing documentation (`#3275 <https://github.com/openmc-dev/openmc/pull/3275>`_)
 - fix the bug in function differentiate_mats() (`#3277 <https://github.com/openmc-dev/openmc/pull/3277>`_)
-- Fix the bug in the Material.from_xml_element function  (`#3278 <https://github.com/openmc-dev/openmc/pull/3278>`_)
+- Fix the bug in the ``Material.from_xml_element`` function  (`#3278 <https://github.com/openmc-dev/openmc/pull/3278>`_)
 - Doc typo fix for rand ray mgxs (`#3280 <https://github.com/openmc-dev/openmc/pull/3280>`_)
 - Consolidate plotting capabilities in Model.plot (`#3282 <https://github.com/openmc-dev/openmc/pull/3282>`_)
 - adding non elastic MT number (`#3285 <https://github.com/openmc-dev/openmc/pull/3285>`_)
-- Fix Tabular.from_xml_element for histogram case (`#3287 <https://github.com/openmc-dev/openmc/pull/3287>`_)
+- Fix ``Tabular.from_xml_element`` for histogram case (`#3287 <https://github.com/openmc-dev/openmc/pull/3287>`_)
 - Random Ray Source Region Refactor (`#3288 <https://github.com/openmc-dev/openmc/pull/3288>`_)
 - added terminal output showing compile options selected (`#3291 <https://github.com/openmc-dev/openmc/pull/3291>`_)
 - Random ray consistency changes (`#3298 <https://github.com/openmc-dev/openmc/pull/3298>`_)
@@ -218,5 +220,5 @@ Bug Fixes and Small Changes
 - Update pugixml to v1.15 (`#3332 <https://github.com/openmc-dev/openmc/pull/3332>`_)
 - Determine nuclides correctly for DAGMC models in d1s.get_radionuclides (`#3335 <https://github.com/openmc-dev/openmc/pull/3335>`_)
 - openmc.Material.mix_materials() allows for keyword arguments (`#3336 <https://github.com/openmc-dev/openmc/pull/3336>`_)
-- Fix bug in Mesh::material_volumes for void materials (`#3337 <https://github.com/openmc-dev/openmc/pull/3337>`_)
+- Fix bug in ``Mesh::material_volumes`` for void materials (`#3337 <https://github.com/openmc-dev/openmc/pull/3337>`_)
 - added stable and unstable nuclides to the Chain object (`#3338 <https://github.com/openmc-dev/openmc/pull/3338>`_)

--- a/docs/source/releasenotes/index.rst
+++ b/docs/source/releasenotes/index.rst
@@ -7,6 +7,7 @@ Release Notes
 .. toctree::
   :maxdepth: 1
 
+  0.15.1
   0.15.0
   0.14.0
   0.13.3

--- a/docs/source/usersguide/basics.rst
+++ b/docs/source/usersguide/basics.rst
@@ -53,7 +53,7 @@ eXtensible Markup Language (XML)
 Unlike many other Monte Carlo codes which use an arbitrary-format ASCII file
 with "cards" to specify a particular geometry, materials, and associated run
 settings, the input files for OpenMC are structured in a set of `XML
-<http://www.w3.org/XML/>`_ files. XML, which stands for eXtensible Markup
+<https://www.w3.org/XML/>`_ files. XML, which stands for eXtensible Markup
 Language, is a simple format that allows data to be exchanged efficiently
 between different programs and interfaces.
 

--- a/docs/source/usersguide/beginners.rst
+++ b/docs/source/usersguide/beginners.rst
@@ -109,8 +109,8 @@ familiar with. Whether you plan on working in Linux, macOS, or Windows, you
 should be comfortable working in a command line environment. There are many
 resources online for learning command line environments. If you are using Linux
 or Mac OS X (also Unix-derived), `this tutorial
-<http://www.ee.surrey.ac.uk/Teaching/Unix/>`_ will help you get acquainted with
-commonly-used commands.
+<https://info-ee.surrey.ac.uk/Teaching/Unix/>`_ will help you get acquainted
+with commonly-used commands.
 
 To reap the full benefits of OpenMC, you should also have basic proficiency in
 the use of `Python <https://www.python.org/>`_, as OpenMC includes a rich Python
@@ -127,8 +127,8 @@ are hosted at `GitHub`_. In order to receive updates to the code directly,
 submit `bug reports`_, and perform other development tasks, you may want to sign
 up for a free account on GitHub. Once you have an account, you can follow `these
 instructions
-<https://docs.github.com/en/github/getting-started-with-github/set-up-git>`_ on
-how to set up your computer for using GitHub.
+<https://docs.github.com/en/get-started/getting-started-with-git/set-up-git>`_
+on how to set up your computer for using GitHub.
 
 If you are new to nuclear engineering, you may want to review the NRC's `Reactor
 Concepts Manual`_. This manual describes the basics of nuclear power for
@@ -149,9 +149,9 @@ and `Volume II`_. You may also find it helpful to review the following terms:
 .. _neutron transport: https://en.wikipedia.org/wiki/Neutron_transport
 .. _discretization: https://en.wikipedia.org/wiki/Discretization
 .. _constructive solid geometry: https://en.wikipedia.org/wiki/Constructive_solid_geometry
-.. _git: http://git-scm.com/
+.. _git: https://git-scm.com/
 .. _git tutorials: https://git-scm.com/doc
-.. _Reactor Concepts Manual: http://www.tayloredge.com/periodic/trivia/ReactorConcepts.pdf
+.. _Reactor Concepts Manual: https://www.tayloredge.com/periodic/trivia/ReactorConcepts.pdf
 .. _Volume I: https://www.standards.doe.gov/standards-documents/1000/1019-bhdbk-1993-v1
 .. _Volume II: https://www.standards.doe.gov/standards-documents/1000/1019-bhdbk-1993-v2
 .. _OpenMC source code: https://github.com/openmc-dev/openmc

--- a/docs/source/usersguide/data.rst
+++ b/docs/source/usersguide/data.rst
@@ -12,9 +12,9 @@ responsible for specifying one or more of the following:
   file (commonly named ``cross_sections.xml``) contains a listing of other data
   files, in particular neutron cross sections, photon cross sections, and
   windowed multipole data. Each of those files, in turn, uses a `HDF5
-  <https://support.hdfgroup.org/documentation/index.html>`_ format (see :ref:`io_nuclear_data`). In
-  order to run transport simulations with continuous-energy cross sections, you
-  need to specify this file.
+  <https://www.hdfgroup.org/solutions/hdf5/>`_ format (see
+  :ref:`io_nuclear_data`). In order to run transport simulations with
+  continuous-energy cross sections, you need to specify this file.
 
 - **Depletion chain (XML)** -- A :ref:`depletion chain XML <io_depletion_chain>`
   file contains decay data, fission product yields, and information on what
@@ -69,7 +69,7 @@ If you want to persistently set the environment variables used to initialized
 the configuration, export them from your shell profile (``.profile`` or
 ``.bashrc`` in bash_).
 
-.. _bash: http://www.linuxfromscratch.org/blfs/view/6.3/postlfs/profile.html
+.. _bash: https://www.linuxfromscratch.org/blfs/view/6.3/postlfs/profile.html
 
 --------------------------------
 Continuous-Energy Cross Sections
@@ -290,16 +290,16 @@ calculation to be performed.  Therefore, at this point in time, OpenMC is not
 distributed with any pre-existing multigroup cross section libraries. However,
 if a multigroup library file is downloaded or generated, the path to the file
 needs to be specified as described in :ref:`usersguide_data_runtime`. For an
-example of how to create a multigroup library, see the `example notebook
-<https://nbviewer.org/github/openmc-dev/openmc-notebooks/blob/main/mgxs-part-i.ipynb>`_.
+example of how to create a multigroup library, see this `MG mode notebook
+<https://nbviewer.org/github/openmc-dev/openmc-notebooks/blob/main/mg-mode-part-i.ipynb>`_.
 
-.. _NJOY: http://www.njoy21.io/
+.. _NJOY: https://www.njoy21.io/
 .. _NNDC: https://www.nndc.bnl.gov/endf
 .. _MCNP: https://mcnp.lanl.gov
-.. _Serpent: https://serpent.vtt.fi/serpent/
+.. _Serpent: https://serpent.vtt.fi
 .. _ENDF/B: https://www.nndc.bnl.gov/endf-b7.1/acefiles.html
 .. _JEFF: https://www.oecd-nea.org/dbdata/jeff/jeff33/
-.. _TENDL: https://tendl.web.psi.ch/tendl_2017/tendl2017.html
+.. _TENDL: https://tendl.web.psi.ch/tendl_2023/tendl2023.html
 .. _Seltzer and Berger: https://doi.org/10.1016/0092-640X(86)90014-8
 .. _NIST ESTAR database: https://physics.nist.gov/PhysRefData/Star/Text/ESTAR.html
 .. _Biggs et al.: https://doi.org/10.1016/0092-640X(75)90030-3

--- a/docs/source/usersguide/decay_sources.rst
+++ b/docs/source/usersguide/decay_sources.rst
@@ -47,14 +47,14 @@ Direct 1-Step (D1S) Calculations
 ================================
 
 OpenMC also includes built-in capability for performing shutdown dose rate
-calculations using the `direct 1-step <https://10.1016/S0920-3796(01)00188-0>`_
-(D1S) method. In this method, a single coupled neutron--photon transport
-calculation is used where the prompt photon production is replaced with photons
-produced from the decay of radionuclides in an activated material. To obtain
-properly scaled results, it is also necessary to apply time correction factors.
-A normal neutron transport calculation can be extended to a D1S calculation with
-a few helper functions. First, import the ``d1s`` submodule, which is part of
-:mod:`openmc.deplete`::
+calculations using the `direct 1-step
+<https://doi.org/10.1016/S0920-3796(01)00188-0>`_ (D1S) method. In this method,
+a single coupled neutron--photon transport calculation is used where the prompt
+photon production is replaced with photons produced from the decay of
+radionuclides in an activated material. To obtain properly scaled results, it is
+also necessary to apply time correction factors. A normal neutron transport
+calculation can be extended to a D1S calculation with a few helper functions.
+First, import the ``d1s`` submodule, which is part of :mod:`openmc.deplete`::
 
     from openmc.deplete import d1s
 

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -35,21 +35,9 @@ you wish) with OpenMC installed.
     conda create --name openmc-env openmc
     conda activate openmc-env
 
-To list the versions of OpenMC that are available on the `conda-forge` channel,
-in your terminal window or an Anaconda prompt run:
-
-.. code-block:: sh
-
-    conda search openmc
-
-OpenMC can then be installed with:
-
-.. code-block:: sh
-
-    conda install openmc
-
 You are now in a conda environment called `openmc-env` that has OpenMC
 installed.
+
 -------------------------------------------
 Installing on Linux/Mac/Windows with Docker
 -------------------------------------------

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -50,15 +50,6 @@ OpenMC can then be installed with:
 
 You are now in a conda environment called `openmc-env` that has OpenMC
 installed.
-
-Similar instructions apply using `mamba` as a replacement for `conda` in the
-commands above provided it has been installed through one of its distribution
-channels (see `Mamba`_) or with:
-
-.. code-block:: sh
-
-    conda install mamba
-
 -------------------------------------------
 Installing on Linux/Mac/Windows with Docker
 -------------------------------------------

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -557,7 +557,7 @@ distributions.
       notebook
       <https://nbviewer.jupyter.org/github/openmc-dev/openmc-notebooks/blob/main/pandas-dataframes.ipynb>`_.
 
-   `h5py <http://www.h5py.org/>`_
+   `h5py <https://www.h5py.org/>`_
       h5py provides Python bindings to the HDF5 library. Since OpenMC outputs
       various HDF5 files, h5py is needed to provide access to data within these
       files from Python.

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -8,57 +8,35 @@ Installation and Configuration
 
 .. _install_conda:
 
---------------------------------------------------
-Installing on Linux/Mac with Mamba and conda-forge
---------------------------------------------------
+----------------------------------
+Installing on Linux/Mac with Conda
+----------------------------------
 
-`Conda <https://conda.io/en/latest/>`_ is an open source package management
-systems and environments management system for installing multiple versions of
+`Conda <https://docs.conda.io/en/latest/>`_ is an open source package management
+system and environments management system for installing multiple versions of
 software packages and their dependencies and switching easily between them.
-`Mamba <https://mamba.readthedocs.io/en/latest/>`_ is a cross-platform package
-manager and is compatible with `conda` packages.
-OpenMC can be installed in a `conda` environment with `mamba`.
-First, `conda` should be installed with one of the following installers:
-`Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_,
-`Anaconda <https://www.anaconda.com/>`_, or `Miniforge <https://github.com/conda-forge/miniforge>`_.
-Once you have `conda` installed on your system, OpenMC can be installed via the
-`conda-forge` channel with `mamba`.
+OpenMC can be installed in a `conda` environment. First, `conda` should be
+`installed <https://www.anaconda.com/docs/getting-started/getting-started>`_
+with either Anaconda Distribution or Miniconda. Once you have `conda` installed
+on your system, OpenMC can be installed via the `conda-forge` channel.
 
 First, add the `conda-forge` channel with:
 
 .. code-block:: sh
 
     conda config --add channels conda-forge
+    conda config --set channel_priority strict
 
-Then create and activate a new conda enviroment called `openmc-env` in
-which to install OpenMC.
+Then create and activate a new conda enviroment called `openmc-env` (or whatever
+you wish) with OpenMC installed.
 
 .. code-block:: sh
 
-    conda create -n openmc-env
+    conda create --name openmc-env openmc
     conda activate openmc-env
 
-Then install `mamba`, which will be used to install OpenMC.
-
-.. code-block:: sh
-
-    conda install mamba
-
-To list the versions of OpenMC that are available on the `conda-forge` channel,
-in your terminal window or an Anaconda Prompt run:
-
-.. code-block:: sh
-
-    mamba search openmc
-
-OpenMC can then be installed with:
-
-.. code-block:: sh
-
-    mamba install openmc
-
-You are now in a conda environment called `openmc-env` that has OpenMC installed.
-
+You are now in a conda environment called `openmc-env` that has OpenMC
+installed.
 -------------------------------------------
 Installing on Linux/Mac/Windows with Docker
 -------------------------------------------

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -35,8 +35,30 @@ you wish) with OpenMC installed.
     conda create --name openmc-env openmc
     conda activate openmc-env
 
+To list the versions of OpenMC that are available on the `conda-forge` channel,
+in your terminal window or an Anaconda prompt run:
+
+.. code-block:: sh
+
+    conda search openmc
+
+OpenMC can then be installed with:
+
+.. code-block:: sh
+
+    conda install openmc
+
 You are now in a conda environment called `openmc-env` that has OpenMC
 installed.
+
+Similar instructions apply using `mamba` as a replacement for `conda` in the
+commands above provided it has been installed through one of its distribution
+channels (see `Mamba`_) or with:
+
+.. code-block:: sh
+
+    conda install mamba
+
 -------------------------------------------
 Installing on Linux/Mac/Windows with Docker
 -------------------------------------------
@@ -588,5 +610,6 @@ wrapper is used when installing h5py:
 
     CC=<path to mpicc> HDF5_MPI=ON HDF5_DIR=<path to HDF5> python -m pip install --no-binary=h5py h5py
 
+.. _Mamba: https://mamba.readthedocs.io/en/latest/
 .. _Conda: https://conda.io/en/latest/
 .. _pip: https://pip.pypa.io/en/stable/

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -12,7 +12,7 @@ Installation and Configuration
 Installing on Linux/Mac with Conda
 ----------------------------------
 
-`Conda <https://docs.conda.io/en/latest/>`_ is an open source package management
+`Conda`_ is an open source package management
 system and environments management system for installing multiple versions of
 software packages and their dependencies and switching easily between them.
 OpenMC can be installed in a `conda` environment. First, `conda` should be

--- a/docs/source/usersguide/parallel.rst
+++ b/docs/source/usersguide/parallel.rst
@@ -101,5 +101,5 @@ performance on a machine when running in parallel:
      settings = openmc.Settings()
      settings.output = {'tallies': False}
 
-.. _Haswell-EP: http://www.anandtech.com/show/8423/intel-xeon-e5-version-3-up-to-18-haswell-ep-cores-/4
+.. _Haswell-EP: https://www.anandtech.com/show/8423/intel-xeon-e5-version-3-up-to-18-haswell-ep-cores-/4
 .. _bound: https://github.com/pmodels/mpich/blob/main/doc/wiki/how_to/Using_the_Hydra_Process_Manager.md#process-core-binding

--- a/include/openmc/random_dist.h
+++ b/include/openmc/random_dist.h
@@ -64,8 +64,8 @@ extern "C" double watt_spectrum(double a, double b, uint64_t* seed);
 //! Samples from a normal distribution with a given mean and standard deviation
 //! The PDF is defined as s(x) = (1/2*sigma*sqrt(2) * e-((mu-x)/2*sigma)^2
 //! Its sampled according to
-//! http://www-pdg.lbl.gov/2009/reviews/rpp2009-rev-monte-carlo-techniques.pdf
-//! section 33.4.4
+//! https://pdg.lbl.gov/2023/reviews/rpp2023-rev-monte-carlo-techniques.pdf
+//! section 42.4.4
 //!
 //! \param mean mean of the Gaussian distribution
 //! \param std_dev standard deviation of the Gaussian distribution

--- a/openmc/data/ace.py
+++ b/openmc/data/ace.py
@@ -9,9 +9,9 @@ unresolved resonance region, and tabulated data in the fast region. After the
 ENDF data has been reconstructed and Doppler-broadened, the ACER module
 generates ACE-format cross sections.
 
-.. _MCNP: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/
-.. _NJOY: http://t2.lanl.gov/codes.shtml
-.. _ENDF: http://www.nndc.bnl.gov/endf
+.. _MCNP: https://mcnp.lanl.gov/
+.. _NJOY: https://www.njoy21.io/
+.. _ENDF: https://www.nndc.bnl.gov/endf-library/
 
 """
 

--- a/openmc/data/endf.py
+++ b/openmc/data/endf.py
@@ -1,9 +1,9 @@
 """Module for parsing and manipulating data from ENDF evaluations.
 
-All the classes and functions in this module are based on document
-ENDF-102 titled "Data Formats and Procedures for the Evaluated Nuclear
-Data File ENDF-6". The latest version from June 2009 can be found at
-http://www-nds.iaea.org/ndspub/documents/endf/endf102/endf102.pdf
+All the classes and functions in this module are based on document ENDF-102
+titled "Data Formats and Procedures for the Evaluated Nuclear Data File ENDF-6".
+The version from September 2023 can be found at
+https://www.nndc.bnl.gov/endfdocs/ENDF-102-2023.pdf
 
 """
 import io

--- a/openmc/data/fission_energy.py
+++ b/openmc/data/fission_energy.py
@@ -44,7 +44,7 @@ class FissionEnergyRelease(EqualityMixin):
     ----------
     [1] D. G. Madland, "Total prompt energy release in the neutron-induced
     fission of ^235U, ^238U, and ^239Pu", Nuclear Physics A 772:113--137 (2006).
-    <http://dx.doi.org/10.1016/j.nuclphysa.2006.03.013>
+    <https://doi.org/10.1016/j.nuclphysa.2006.03.013>
 
     Attributes
     ----------

--- a/openmc/deplete/integrators.py
+++ b/openmc/deplete/integrators.py
@@ -446,7 +446,7 @@ class SICELIIntegrator(SIIntegrator):
     <https://doi.org/10.1137/05063042>`_.
 
     Detailed algorithm can be found in section 3.2 in `Colin Josey's thesis
-    <http://hdl.handle.net/1721.1/113721>`_.
+    <https://dspace.mit.edu/handle/1721.1/113721>`_.
     """
     _num_stages = 2
 
@@ -512,7 +512,7 @@ class SILEQIIntegrator(SIIntegrator):
     <https://doi.org/10.1137/05063042>`_.
 
     Detailed algorithm can be found in Section 3.2 in `Colin Josey's thesis
-    <http://hdl.handle.net/1721.1/113721>`_.
+    <https://dspace.mit.edu/handle/1721.1/113721>`_.
     """
     _num_stages = 2
 

--- a/openmc/examples.py
+++ b/openmc/examples.py
@@ -11,8 +11,9 @@ def pwr_pin_cell() -> openmc.Model:
 
     This model is a single fuel pin with 2.4 w/o enriched UO2 corresponding to a
     beginning-of-cycle condition and borated water. The specifications are from
-    the `BEAVRS <https://crpg.mit.edu/research/beavrs>`_ benchmark. Note that the
-    number of particles/batches is initially set very low for testing purposes.
+    the `BEAVRS <https://crpg.mit.edu/research/beavrs>`_ benchmark. Note that
+    the number of particles/batches is initially set very low for testing
+    purposes.
 
     Returns
     -------

--- a/openmc/mgxs/__init__.py
+++ b/openmc/mgxs/__init__.py
@@ -14,7 +14,7 @@ GROUP_STRUCTURES = {}
 - "SHEM-361_" designed for LWR analysis to eliminate self-shielding calculations
   of thermal resonances ([HFA2005]_, [SAN2007]_, [HEB2008]_)
 - "SCALE-X" (where X is 44 which is designed for criticality analysis
-  and 252 is designed for thermal reactors) for the SCALE code suite 
+  and 252 is designed for thermal reactors) for the SCALE code suite
   ([ZAL1999]_ and [REARDEN2013]_)
 - "MPACT-X" (where X is 51 (PWR), 60 (BWR), 69 (Magnox)) from the MPACT_ reactor
   physics code ([KIM2019]_ and [KIM2020]_)
@@ -28,12 +28,12 @@ GROUP_STRUCTURES = {}
 .. _SCALE252: https://oecd-nea.org/science/wpncs/amct/workingarea/meeting2013/EGAMCT2013_08.pdf
 .. _MPACT: https://vera.ornl.gov/mpact/
 .. _XMAS-172: https://www-nds.iaea.org/wimsd/energy.htm
-.. _SHEM-361: https://www.polymtl.ca/merlin/downloads/FP214.pdf
+.. _SHEM-361: http://merlin.polymtl.ca/downloads/FP214.pdf
 .. _activation: https://fispact.ukaea.uk/wiki/Keyword:GETXS
 .. _VITAMIN-J-42: https://www.oecd-nea.org/dbdata/nds_jefreports/jefreport-10.pdf
 .. _CCFE-709: https://fispact.ukaea.uk/wiki/CCFE-709_group_structure
 .. _UKAEA-1102: https://fispact.ukaea.uk/wiki/UKAEA-1102_group_structure
-.. _ECCO-1968: http://serpent.vtt.fi/mediawiki/index.php/ECCO_1968-group_structure
+.. _ECCO-1968: https://serpent.vtt.fi/mediawiki/index.php/ECCO_1968-group_structure
 .. [SAR1990] Sartori, E., OECD/NEA Data Bank: Standard Energy Group Structures
    of Cross Section Libraries for Reactor Shielding, Reactor Cell and Fusion
    Neutronics Applications: VITAMIN-J, ECCO-33, ECCO-2000 and XMAS JEF/DOC-315

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -1502,7 +1502,7 @@ class Tally(IDManagerMixin):
                 df.columns = pd.MultiIndex.from_tuples(columns)
 
         # Modify the df.to_string method so that it prints formatted strings.
-        # Credit to http://stackoverflow.com/users/3657742/chrisb for this trick
+        # Credit to https://stackoverflow.com/users/3657742/chrisb for this trick
         df.to_string = partial(df.to_string, float_format=float_format.format)
 
         return df

--- a/src/math_functions.cpp
+++ b/src/math_functions.cpp
@@ -650,7 +650,7 @@ void calc_zn(int n, double rho, double phi, double zn[])
   // ===========================================================================
   // Determine vector of sin(n*phi) and cos(n*phi). This takes advantage of the
   // following recurrence relations so that only a single sin/cos have to be
-  // evaluated (http://mathworld.wolfram.com/Multiple-AngleFormulas.html)
+  // evaluated (https://mathworld.wolfram.com/Multiple-AngleFormulas.html)
   //
   // sin(nx) = 2 cos(x) sin((n-1)x) - sin((n-2)x)
   // cos(nx) = 2 cos(x) cos((n-1)x) - cos((n-2)x)

--- a/tools/dev/generate_release_notes.py
+++ b/tools/dev/generate_release_notes.py
@@ -1,0 +1,17 @@
+import argparse
+import re
+import subprocess
+
+parser = argparse.ArgumentParser()
+parser.add_argument('tag')
+args = parser.parse_args()
+
+proc = subprocess.run(["git", "log", "--format=%s", f"{args.tag}.."], capture_output=True, text=True)
+data = []
+for line in proc.stdout.rstrip().split('\n'):
+    m = re.match(r'(.*) \(\#(\d+)\)', line)
+    if m is not None:
+        data.append(m.groups())
+    
+for comment, num in sorted(data, key=lambda x: int(x[1])):
+    print(f'- {comment} (`#{num} <https://github.com/openmc-dev/openmc/pull/{num}>`_)')


### PR DESCRIPTION
# Description

This is the final PR for version 0.15.1 and includes the following changes:
- Add release notes
- Update various links throughout the codebase
- Adds a script to ease the generation of release notes

One thing it does not include is a bumping of the version number, which is now handled automatically thanks to #3140. Once this is merged, I'll tag the release.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>