### PR TITLE
Hotfix: Remove errant openmc.Settings.random_ray check and removed of not useful warning in MG mode

### DIFF
--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1174,7 +1174,6 @@ class Settings:
                             raise ValueError(
                                 f'Invalid domain type: {type(domain)}. Expected '
                                 'openmc.Material, openmc.Cell, or openmc.Universe.')
-                cv.check_type('adjoint', value, bool)
             elif key == 'sample_method':
                 cv.check_value('sample method', value,
                                ('prng', 'halton'))

--- a/src/scattdata.cpp
+++ b/src/scattdata.cpp
@@ -37,20 +37,10 @@ void ScattData::base_init(int order, const xt::xtensor<int, 1>& in_gmin,
     mult[gin] = in_mult[gin];
 
     // Make sure the multiplicity does not have 0s
-    unsigned long int num_converted = 0;
     for (int go = 0; go < mult[gin].size(); go++) {
       if (mult[gin][go] == 0.) {
-        num_converted += 1;
         mult[gin][go] = 1.;
       }
-    }
-
-    if (num_converted > 0) {
-      // Raise a warning to the user if we did have to do the conversion
-      std::string msg =
-        std::to_string(num_converted) +
-        " entries in the Multiplicity Matrix were changed from 0 to 1";
-      warning(msg);
     }
 
     // Make sure the energy is normalized


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR does makes two trivial changes.
1. The new random ray ``openmc.settings.random_ray["source_region_meshes"]`` attribute type checking was erroneously requiring ``openmc.settings.random_ray["adjoint"]`` to be present during the type checking stage, likely due to an errant copy-paste. This single-line check is removed.
2. During MG mode's initialization, the multiplicity matrix elements that were 0 were replaced with 1. A warning was printed to screen for each incoming group of each MGXS' multiplicity matrix. The original intent behind that warning was to help teach users that this unique-to-openmc cross section type expects values of unity, even when there is no group-to-group transfer. However, (1) it doesnt really matter what the value of the multiplicity matrix entry is when there is no group-to-group transfer represented by that group, and (2) even the MGXS API creates values with 0s in the multiplicity matrix, and so this warning is shown alot, especially during initialization of fine-group libraries. So, this PR removes this warning as it is functionally useless to the user.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable) N/A
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable) N/A
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
