### PR TITLE
Throw an error if a spherical harmonics order larger than 10 is provided.

### DIFF
--- a/src/tallies/filter_sph_harm.cpp
+++ b/src/tallies/filter_sph_harm.cpp
@@ -25,6 +25,9 @@ void SphericalHarmonicsFilter::set_order(int order)
   if (order < 0) {
     throw std::invalid_argument {
       "Spherical harmonics order must be non-negative."};
+  } else if (order > 10) {
+    throw std::invalid_argument {"Spherical harmonics orders greater than 10 "
+                                 "are currently not supported!"};
   }
   order_ = order;
   n_bins_ = (order_ + 1) * (order_ + 1);


### PR DESCRIPTION
# Description

I was going through the spherical harmonics source code for both the [math implementation](https://github.com/openmc-dev/openmc/blob/develop/src/math_functions.cpp#L129) / [spherical harmonics filter implementation](https://github.com/openmc-dev/openmc/blob/develop/src/tallies/filter_sph_harm.cpp) and noticed that the `l > 10` moments are not tallied. To avoid possible user confusion as to why certain expansion coefficients are zero, this PR adds an exception to `SphericalHarmonicsFilter::set_order(int order)` which gets thrown if `order > 10`.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~

