### PR TITLE
Correcting the size of the displacement list in the SourceSite MPI interface object

### DIFF
--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -157,7 +157,7 @@ void initialize_mpi(MPI_Comm intracomm)
 
   // Create bank datatype
   SourceSite b;
-  MPI_Aint disp[10];
+  MPI_Aint disp[11];
   MPI_Get_address(&b.r, &disp[0]);
   MPI_Get_address(&b.u, &disp[1]);
   MPI_Get_address(&b.E, &disp[2]);


### PR DESCRIPTION
# Description

This PR only increase the size of the MPI displacement list (disp) from 10 to 11 to be consistent with the new number of attributes (parent_nuclide added in #3235).

With this correction, openmc is no longer failing with 2 procs using openmpi on a "random" model.
Interestingly, openmc was not failing with MPICH for the same model and same running conditions.

Fixes #3352 

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
