### PR TITLE
Add release notes for 0.15.2

### DIFF
--- a/docs/source/releasenotes/0.15.2.rst
+++ b/docs/source/releasenotes/0.15.2.rst
@@ -1,0 +1,20 @@
+====================
+What's New in 0.15.2
+====================
+
+.. currentmodule:: openmc
+
+-------
+Summary
+-------
+
+This is a hotfix release to fix an MPI-related bug that was inadvertently
+introduced in the prior release.
+
+---------------------------
+Bug Fixes and Small Changes
+---------------------------
+
+- Remove errant ``openmc.Settings.random_ray`` check and removed of not useful warning in MG mode (`#3344 <https://github.com/openmc-dev/openmc/pull/3344>`_)
+- Throw an error if a spherical harmonics order larger than 10 is provided. (`#3354 <https://github.com/openmc-dev/openmc/pull/3354>`_)
+- Correcting the size of the displacement list in the SourceSite MPI interface object (`#3356 <https://github.com/openmc-dev/openmc/pull/3356>`_)

--- a/docs/source/releasenotes/index.rst
+++ b/docs/source/releasenotes/index.rst
@@ -7,6 +7,7 @@ Release Notes
 .. toctree::
   :maxdepth: 1
 
+  0.15.2
   0.15.1
   0.15.0
   0.14.0


### PR DESCRIPTION
# Description

Since #3356 is an important MPI-related fix, I'd like to do a hotfix release (0.15.2). This PR simply adds release notes and once it's merged, I'll go ahead and tag a new release.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>