### PR TITLE
Handle Missing Tags in Versioning by Setting Default to 0

### DIFF
--- a/cmake/Modules/GetVersionFromGit.cmake
+++ b/cmake/Modules/GetVersionFromGit.cmake
@@ -43,7 +43,11 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/.git" AND GIT_FOUND)
     # If no tags are found, set version to 0 and show a warning
     if(VERSION_STRING STREQUAL "")
         set(VERSION_STRING "0.0.0")
-        message(WARNING "No git tags found. Version set to 0. Run 'git fetch --tags' to ensure proper versioning.")
+        message(WARNING 
+            "No git tags found. Version set to 0.0.0.\n"
+            "Run 'git fetch --tags' to ensure proper versioning.\n"
+            "For more information, see OpenMC developer documentation."
+        )
     endif()
 
     # Extract the commit hash

--- a/cmake/Modules/GetVersionFromGit.cmake
+++ b/cmake/Modules/GetVersionFromGit.cmake
@@ -37,11 +37,13 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/.git" AND GIT_FOUND)
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         OUTPUT_VARIABLE VERSION_STRING
         OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
     )
 
-    # If no tags are found, instruct user to fetch them
+    # If no tags are found, set version to 0 and show a warning
     if(VERSION_STRING STREQUAL "")
-        message(FATAL_ERROR "No git tags found. Run 'git fetch --tags' and try again.")
+        set(VERSION_STRING "0.0.0")
+        message(WARNING "No git tags found. Version set to 0. Run 'git fetch --tags' to ensure proper versioning.")
     endif()
 
     # Extract the commit hash

--- a/docs/source/devguide/workflow.rst
+++ b/docs/source/devguide/workflow.rst
@@ -91,6 +91,30 @@ features and bug fixes. The general steps for contributing are as follows:
 6. After the pull request has been thoroughly vetted, it is merged back into the
    *develop* branch of openmc-dev/openmc.
 
+Setting Up Upstream Tracking (Required for Versioning)
+------------------------------------------------------
+
+By default, your fork **does not** include tags from the upstream OpenMC repository.  
+OpenMC relies on `git describe --tags` for versioning, and missing tags can lead  
+to incorrect version detection (e.g., ``0.0.0``). To ensure proper versioning, follow these steps:
+
+1. **Add the Upstream Repository**  
+   This allows you to fetch updates from the main OpenMC repository.
+
+   .. code-block:: sh
+
+       git remote add upstream https://github.com/openmc-dev/openmc.git
+
+2. **Fetch and Push Tags**  
+   Retrieve tags from the upstream repository and update your fork:
+
+   .. code-block:: sh
+
+       git fetch --tags upstream
+       git push --tags origin
+
+This ensures that both your **local** and **remote** fork have the correct versioning information.
+
 Private Development
 -------------------
 

--- a/docs/source/devguide/workflow.rst
+++ b/docs/source/devguide/workflow.rst
@@ -96,7 +96,7 @@ Setting Up Upstream Tracking (Required for Versioning)
 
 By default, your fork **does not** include tags from the upstream OpenMC repository.  
 OpenMC relies on `git describe --tags` for versioning, and missing tags can lead  
-to incorrect version detection (e.g., ``0.0.0``). To ensure proper versioning, follow these steps:
+to incorrect version detection (i.e., ``0.0.0``). To ensure proper versioning, follow these steps:
 
 1. **Add the Upstream Repository**  
    This allows you to fetch updates from the main OpenMC repository.

--- a/docs/source/devguide/workflow.rst
+++ b/docs/source/devguide/workflow.rst
@@ -95,7 +95,7 @@ Setting Up Upstream Tracking (Required for Versioning)
 ------------------------------------------------------
 
 By default, your fork **does not** include tags from the upstream OpenMC repository.  
-OpenMC relies on `git describe --tags` for versioning, and missing tags can lead  
+OpenMC relies on `git describe --tags` for versioning in source builds, and missing tags can lead  
 to incorrect version detection (i.e., ``0.0.0``). To ensure proper versioning, follow these steps:
 
 1. **Add the Upstream Repository**  


### PR DESCRIPTION
### Problem

When forking and cloning OpenMC, all tags are not always present in the resulting clone. This causes issues with CMake's git-based versioning pathway:

1. **Failure case**: If `git` is available but no tags exist, version detection fails.

2. **Incorrect versioning**: The git SHA is correct, but the displayed version is incorrect.

### Solution

- Updated `GetVersionFromGit.cmake` to follow the `setuptools_scm` convention.

- If no git tags are found, the version defaults to `0.0.0` instead of failing.

- A **warning message** is displayed, instructing users to run `git fetch --tags`.

### Notes

Users who wish to fetch tags can do so manually:
 
```sh
git fetch --tags
```

### Ready for Review

Tagging @pshriwise and @MicahGale for feedback.  
