### PR TITLE
Fix for Issue Loading MGXS Data Files with LLVM 20 or Newer

### DIFF
--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -107,7 +107,7 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
       double closest = std::numeric_limits<double>::max();
       int i_closest = 0;
       for (int i = 0; i < temps_available.size(); i++) {
-        double diff = std::fabs(temps_available[i] - T);
+        double diff = std::abs(temps_available[i] - T);
         if (diff < closest) {
           closest = diff;
           i_closest = i;

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -106,7 +106,7 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
       // auto i_closest = xt::argmin(xt::abs(temps_available - T))[0];
       double closest = std::numeric_limits<double>::max();
       int i_closest = 0;
-      for (int i = 0; i < num_temps; i++) {
+      for (int i = 0; i < temps_available.size(); i++) {
         double diff = std::fabs(temps_available[i] - T);
         if (diff < closest) {
           closest = diff;


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Currently, OpenMC crashes with errors like:

```
libc++abi: terminating due to uncaught exception of type std::bad_array_new_length: bad_array_new_length
```

when reading in `mgxs.h5` multigroup data files when using LLVM clang version 20 or newer. More info is in Issue #3367. 

# The Cause

The debugger reveals the crash is coming from this xtensor operation in mgxs.cpp:

```C++
      auto i_closest = xt::argmin(xt::abs(temps_available - T))[0];
```

Specifically, the `xt::argmin` part of the operation. This seems like a valid operation and works fine in gcc and LLVM 19 and older, but appears to break in LLVM 20 and newer. My best guess is that this is related to the relaxed template arguments issue in xtensor. It's possible this issue is fixed in xtensor 0.26.0, but that is unfortunately also the version of xtensor where they refactored the API seemingly for no reason (which I expect might get rolled back?). So, updating the xtensor version is not a good option.

# The Fix

Instead of using `xt::argmin` we just find the closest element manually with a for loop. Not as elegant but gets the job done! Note there are other areas in the code that use `xt:argmin` but perhaps they don't break as they are being used on different types where the relaxed template issue doesn't get tripped.


Fixes #3367 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
