### PR TITLE
Add check for equal value bins in an EnergyFilter

### DIFF
--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1384,7 +1384,7 @@ class EnergyFilter(RealFilter):
     ----------
     values : Iterable of Real
         A list of values for which each successive pair constitutes a range of
-        energies in [eV] for a single bin
+        energies in [eV] for a single bin. Entries must be positive and ascending.
     filter_id : int
         Unique identifier for the filter
 

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1238,7 +1238,7 @@ class RealFilter(Filter):
             cv.check_type('filter value', v1, Real)
 
             # Make sure that each tuple has values that are increasing
-            if v1 < v0:
+            if v1 <= v0:
                 raise ValueError(f'Values {v0} and {v1} appear to be out of '
                                  'order')
 

--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -294,3 +294,21 @@ def test_tabular_from_energyfilter():
 
     tab = efilter.get_tabular(values=np.array([10, 10, 5]), interpolation='linear-linear')
     assert tab.interpolation == 'linear-linear'
+
+
+def test_energy_filter():
+
+    # testing that bins descending value raises error
+    msg = "Values 1.0 and 0.5 appear to be out of order"
+    with raises(ValueError, match=msg):
+        openmc.EnergyFilter([0.0, 1.0, 0.5])
+
+    # testing that bins with same value raises error
+    msg = "Values 0.25 and 0.25 appear to be out of order"
+    with raises(ValueError, match=msg):
+        openmc.EnergyFilter([0.0, 0.25, 0.25])
+
+    # testing that negative bins values raises error
+    msg = 'Unable to set "filter value" to "-1.2" since it is less than "0.0"'
+    with raises(ValueError, match=msg):
+        openmc.EnergyFilter([-1.2, 0.25, 0.5])


### PR DESCRIPTION
# Description

I noticed it is possible to set equal value energy bins when making an ```EnergyFilter```
```
openmc.EnergyFilter([0.0, 0.25, 0.25])
```

Perhaps I have misunderstood but maybe we should raise a value error if the user puts in bin values that are the same?

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)