### PR TITLE
Small Fixes to Allow Random Ray to Work with DAGMC

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1828,6 +1828,16 @@ class Model:
         if isinstance(groups, str):
             groups = openmc.mgxs.EnergyGroups(groups)
 
+        # Determine if this is a DAGMC geometry. If so, we need to syncronize
+        # the dagmc materials with cells.
+        # TODO: Can this be done without having to init/finalize?
+        for univ in self.geometry.get_all_universes().values():
+            if isinstance(univ, openmc.DAGMCUniverse):
+                self.init_lib()
+                self.sync_dagmc_universes()
+                self.finalize_lib()
+                break
+           
         # Make sure all materials have a name, and that the name is a valid HDF5
         # dataset name
         for material in self.materials:

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1859,7 +1859,7 @@ class Model:
         # to avoid polluting the working directory with residual XML files
         with TemporaryDirectory() as tmpdir:
 
-            # Determine if this is a DAGMC geometry. If so, we need to syncronize
+            # Determine if there are DAGMC universes in the model. If so, we need to synchronize
             # the dagmc materials with cells.
             # TODO: Can this be done without having to init/finalize?
             for univ in self.geometry.get_all_universes().values():

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -306,7 +306,8 @@ class Model:
         args = _process_CLI_arguments(
             volume=False, geometry_debug=geometry_debug,
             restart_file=restart_file, threads=threads, tracks=tracks,
-            event_based=event_based)
+            event_based=event_based, path_input=directory)
+
         # Args adds the openmc_exec command in the first entry; remove it
         args = args[1:]
 
@@ -1857,13 +1858,13 @@ class Model:
         # Do all work (including MGXS generation) in a temporary directory
         # to avoid polluting the working directory with residual XML files
         with TemporaryDirectory() as tmpdir:
-            
+
             # Determine if this is a DAGMC geometry. If so, we need to syncronize
             # the dagmc materials with cells.
             # TODO: Can this be done without having to init/finalize?
             for univ in self.geometry.get_all_universes().values():
                 if isinstance(univ, openmc.DAGMCUniverse):
-                    self.init_lib(tmpdir)
+                    self.init_lib(directory=tmpdir)
                     self.sync_dagmc_universes()
                     self.finalize_lib()
                     break

--- a/src/random_ray/random_ray.cpp
+++ b/src/random_ray/random_ray.cpp
@@ -277,7 +277,7 @@ void RandomRay::event_advance_ray()
   boundary() = distance_to_boundary(*this);
   double distance = boundary().distance;
 
-  if (distance <= 0.0) {
+  if (distance < 0.0) {
     mark_as_lost("Negative transport distance detected for particle " +
                  std::to_string(id()));
     return;

--- a/src/random_ray/random_ray_simulation.cpp
+++ b/src/random_ray/random_ray_simulation.cpp
@@ -197,7 +197,7 @@ void validate_random_ray_inputs()
     }
     if (material.get_xsdata().size() > 1) {
       warning("Non-isothermal MGXS detected. Only isothermal XS data sets "
-                  "supported in random ray mode. Using lowest temperature.");
+              "supported in random ray mode. Using lowest temperature.");
     }
     for (int g = 0; g < data::mg.num_energy_groups_; g++) {
       if (material.exists_in_model) {

--- a/src/random_ray/random_ray_simulation.cpp
+++ b/src/random_ray/random_ray_simulation.cpp
@@ -196,8 +196,8 @@ void validate_random_ray_inputs()
                   "supported in random ray mode.");
     }
     if (material.get_xsdata().size() > 1) {
-      fatal_error("Non-isothermal MGXS detected. Only isothermal XS data sets "
-                  "supported in random ray mode.");
+      warning("Non-isothermal MGXS detected. Only isothermal XS data sets "
+                  "supported in random ray mode. Using lowest temperature.");
     }
     for (int g = 0; g < data::mg.num_energy_groups_; g++) {
       if (material.exists_in_model) {


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Problem

Currently there are a few small issues with running DAGMC geometries in random ray mode:

- DAGMC materials can fail to have MGXS data generated due to a lack of synchronization between the DAGMC model and the cells.
- A "negative transport distance" error can be reported, due to embedded surfaces in the DAGMC model.
- The code can hit a fatal error at launch due to a temperature data being embedded into the DAGMC model.

# Fixes

This PR makes a few small tweaks to avoid the above issues:

- The following snippet is added to the `model.convert_to_multigroup()` function:

```python
        for univ in self.geometry.get_all_universes().values():
            if isinstance(univ, openmc.DAGMCUniverse):
                self.init_lib()
                self.sync_dagmc_universes()
                self.finalize_lib()
                break
```

which ensures that all materials are registered properly. It would be nice in the future to not have to call `init_lib()` and `finalize_lib()`, so as to avoid generating all the extra `.xml` files. @pshriwise - any other options?

- Previously the random ray transport code considered a "distance to boundary" of 0.0 to be an error. We now only consider a negative number an error. This seems to fix the issues and several CAD test models are running cleanly now.

- The fatal error at launch regarding multiple temperatures being detected has been downgraded to a warning. If using the `model.convert_to_multigroup()` function, the data will be isothermal anyway, even if there are multiple temperatures in the model.  Notably, the MGXS data is always material-wise currently, so if you have the same material at multiple different temperatures in different cells, then the MC solve will be combining all those regions into one material tally. If you created different materials each with a different temperature, then they will remain different when moving to MGXS. The MGXS library is not universally isothermal over all materials, it is just isothermal for each material. In summary, we will just pick the first temperature now and warn the user about the issue.

# Results

We're now able to run some pretty cool DAGMC geometries with random ray & FW-CADIS, e.g. an unconverged stellarator:

![Screenshot 2025-04-11 at 4 18 47 PM](https://github.com/user-attachments/assets/638c5adf-66cc-4c47-b5e3-a63ff389020c)


![Screenshot 2025-04-11 at 2 58 50 PM](https://github.com/user-attachments/assets/cefd351a-bbe8-4474-8746-62dfddd138ee)

Just a few iterations of results here, so pretty noisy, but good to see DAGMC working as expected for random ray.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
