### PR TITLE
Add option to determine waste disposal rating by nuclide

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1348,10 +1348,11 @@ class Material(IDManagerMixin):
         return waste._waste_classification(self, metal=metal)
 
     def waste_disposal_rating(
-            self,
-            limits: str | dict[str, float] = 'Fetter',
-            metal: bool = False,
-        ) -> float:
+        self,
+        limits: str | dict[str, float] = 'Fetter',
+        metal: bool = False,
+        by_nuclide: bool = False,
+    ) -> float | dict[str, float]:
         """Return the waste disposal rating for the material.
 
         This method returns a waste disposal rating for the material based on a
@@ -1387,18 +1388,25 @@ class Material(IDManagerMixin):
         metal : bool, optional
             Whether or not the material is in metal form (only applicable for
             NRC based limits)
+        by_nuclide : bool, optional
+            Whether to return the waste disposal rating for each nuclide in the
+            material. If True, a dictionary is returned where the keys are the
+            nuclide names and the values are the waste disposal ratings for each
+            nuclide. If False, a single float value is returned that represents
+            the overall waste disposal rating for the material.
 
         Returns
         -------
-        float
-            The waste disposal rating for the material.
+        float or dict
+            The waste disposal rating for the material or its constituent
+            nuclides.
 
         See also
         --------
         Material.waste_classification()
 
         """
-        return waste._waste_disposal_rating(self, limits, metal)
+        return waste._waste_disposal_rating(self, limits, metal, by_nuclide)
 
     def clone(self, memo: dict | None = None) -> Material:
         """Create a copy of this material with a new unique ID.

--- a/openmc/waste.py
+++ b/openmc/waste.py
@@ -77,10 +77,11 @@ def _waste_classification(mat: openmc.Material, metal: bool = True) -> str:
 
 
 def _waste_disposal_rating(
-        mat: openmc.Material,
-        limits: str | dict[str, float] = 'Fetter',
-        metal: bool = False,
-    ) -> float:
+    mat: openmc.Material,
+    limits: str | dict[str, float] = 'Fetter',
+    metal: bool = False,
+    by_nuclide: bool = False,
+) -> float | dict[str, float]:
     """Return the waste disposal rating for a material.
 
     This method returns a waste disposal rating for the material based on a set
@@ -111,11 +112,17 @@ def _waste_disposal_rating(
     metal : bool, optional
         Whether or not the material is in metal form (only applicable for NRC
         based limits)
+    by_nuclide : bool, optional
+        Whether to return the waste disposal rating for each nuclide in the
+        material. If True, a dictionary is returned where the keys are the
+        nuclide names and the values are the waste disposal ratings for each
+        nuclide. If False, a single float value is returned that represents the
+        overall waste disposal rating for the material.
 
     Returns
     -------
-    float
-        The waste disposal rating for the material.
+    float or dict
+        The waste disposal rating for the material or its constituent nuclides.
 
     """
     if limits == 'Fetter':
@@ -272,8 +279,8 @@ def _waste_disposal_rating(
 
     # Calculate the sum of the fractions of the activity of each radionuclide
     # compared to the specified limits
-    ratio = 0.0
+    ratio = {}
     for nuc, ci_m3 in mat.get_activity(units="Ci/m3", by_nuclide=True).items():
         if nuc in limits:
-            ratio += ci_m3 / limits[nuc]
-    return ratio
+            ratio[nuc] = ci_m3 / limits[nuc]
+    return ratio if by_nuclide else sum(ratio.values())

--- a/tests/unit_tests/test_waste_classification.py
+++ b/tests/unit_tests/test_waste_classification.py
@@ -96,3 +96,7 @@ def test_waste_disposal_rating():
     ci_m3 = mat.get_activity('Ci/m3')
     assert mat.waste_disposal_rating(limits={'K40': 2*ci_m3}) < 1.0
     assert mat.waste_disposal_rating(limits={'K40': 0.5*ci_m3}) > 1.0
+
+    wdr = mat.waste_disposal_rating(limits={'K40': 4*ci_m3}, by_nuclide=True)
+    assert isinstance(wdr, dict)
+    assert wdr['K40'] == pytest.approx(1/4)


### PR DESCRIPTION
# Description

This is a quick follow-up to #3366 that introduces a `by_nuclide` argument on `Material.waste_disposal_rating` so that a user can inspect which nuclides contribute most to the waste disposal rating.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)