### PR TITLE
using reduce chain level to remove need for reduce chain

### DIFF
--- a/openmc/deplete/coupled_operator.py
+++ b/openmc/deplete/coupled_operator.py
@@ -153,7 +153,7 @@ class CoupledOperator(OpenMCOperator):
         :class:`~openmc.deplete.helpers.FluxCollapseHelper` class for all
         options.
 
-        .. versionadded:: 0.12
+        .. versionadded:: 0.12.1
     reduce_chain_level : int, optional
         Depth of the search when reducing the depletion chain. The default
         value of ``None`` implies no limit on the depth.

--- a/openmc/deplete/coupled_operator.py
+++ b/openmc/deplete/coupled_operator.py
@@ -153,16 +153,10 @@ class CoupledOperator(OpenMCOperator):
         :class:`~openmc.deplete.helpers.FluxCollapseHelper` class for all
         options.
 
-        .. versionadded:: 0.12.1
-    reduce_chain : bool, optional
-        If True, use :meth:`openmc.deplete.Chain.reduce` to reduce the
-        depletion chain up to ``reduce_chain_level``.
-
         .. versionadded:: 0.12
     reduce_chain_level : int, optional
-        Depth of the search when reducing the depletion chain. Only used
-        if ``reduce_chain`` evaluates to true. The default value of
-        ``None`` implies no limit on the depth.
+        Depth of the search when reducing the depletion chain. The default
+        value of ``None`` implies no limit on the depth.
 
         .. versionadded:: 0.12
     diff_volume_method : str
@@ -214,7 +208,7 @@ class CoupledOperator(OpenMCOperator):
                  normalization_mode="fission-q", fission_q=None,
                  fission_yield_mode="constant", fission_yield_opts=None,
                  reaction_rate_mode="direct", reaction_rate_opts=None,
-                 reduce_chain=False, reduce_chain_level=None):
+                 reduce_chain_level=None):
 
         # check for old call to constructor
         if isinstance(model, openmc.Geometry):
@@ -270,7 +264,6 @@ class CoupledOperator(OpenMCOperator):
             diff_volume_method=diff_volume_method,
             fission_q=fission_q,
             helper_kwargs=helper_kwargs,
-            reduce_chain=reduce_chain,
             reduce_chain_level=reduce_chain_level)
 
     def _differentiate_burnable_mats(self):

--- a/openmc/deplete/independent_operator.py
+++ b/openmc/deplete/independent_operator.py
@@ -66,13 +66,9 @@ class IndependentOperator(OpenMCOperator):
         Dictionary of nuclides and their fission Q values [eV]. If not given,
         values will be pulled from the ``chain_file``. Only applicable if
         ``"normalization_mode" == "fission-q"``.
-    reduce_chain : bool, optional
-        If True, use :meth:`openmc.deplete.Chain.reduce` to reduce the depletion
-        chain up to ``reduce_chain_level``.
     reduce_chain_level : int, optional
-        Depth of the search when reducing the depletion chain. Only used if
-        ``reduce_chain`` evaluates to true. The default value of ``None``
-        implies no limit on the depth.
+        Depth of the search when reducing the depletion chain. The default
+        value of ``None`` implies no limit on the depth.
     fission_yield_opts : dict of str to option, optional
         Optional arguments to pass to the
         :class:`openmc.deplete.helpers.FissionYieldHelper` object. Will be
@@ -119,7 +115,6 @@ class IndependentOperator(OpenMCOperator):
                  normalization_mode='fission-q',
                  fission_q=None,
                  prev_results=None,
-                 reduce_chain=False,
                  reduce_chain_level=None,
                  fission_yield_opts=None):
         # Validate micro-xs parameters
@@ -157,7 +152,6 @@ class IndependentOperator(OpenMCOperator):
             prev_results=prev_results,
             fission_q=fission_q,
             helper_kwargs=helper_kwargs,
-            reduce_chain=reduce_chain,
             reduce_chain_level=reduce_chain_level)
 
     @classmethod
@@ -170,7 +164,6 @@ class IndependentOperator(OpenMCOperator):
                       normalization_mode='fission-q',
                       fission_q=None,
                       prev_results=None,
-                      reduce_chain=False,
                       reduce_chain_level=None,
                       fission_yield_opts=None):
         """
@@ -206,13 +199,9 @@ class IndependentOperator(OpenMCOperator):
             applicable if ``"normalization_mode" == "fission-q"``.
         prev_results : Results, optional
             Results from a previous depletion calculation.
-        reduce_chain : bool, optional
-            If True, use :meth:`openmc.deplete.Chain.reduce` to reduce the
-            depletion chain up to ``reduce_chain_level``. Default is False.
         reduce_chain_level : int, optional
-            Depth of the search when reducing the depletion chain. Only used
-            if ``reduce_chain`` evaluates to true. The default value of
-            ``None`` implies no limit on the depth.
+            Depth of the search when reducing the depletion chain. The default
+            value of ``None`` implies no limit on the depth.
         fission_yield_opts : dict of str to option, optional
             Optional arguments to pass to the
             :class:`openmc.deplete.helpers.FissionYieldHelper` class. Will be
@@ -232,7 +221,6 @@ class IndependentOperator(OpenMCOperator):
                    normalization_mode=normalization_mode,
                    fission_q=fission_q,
                    prev_results=prev_results,
-                   reduce_chain=reduce_chain,
                    reduce_chain_level=reduce_chain_level,
                    fission_yield_opts=fission_yield_opts)
 

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -127,7 +127,7 @@ class OpenMCOperator(TransportOperator):
         self.diff_volume_method = diff_volume_method
 
         # Reduce the chain to only those nuclides present
-        if bool(reduce_chain_level):
+        if reduce_chain_level is not None:
             init_nuclides = set()
             for material in self.materials:
                 if not material.depletable:

--- a/openmc/deplete/openmc_operator.py
+++ b/openmc/deplete/openmc_operator.py
@@ -121,8 +121,8 @@ class OpenMCOperator(TransportOperator):
 
         check_value('diff volume method', diff_volume_method,
                     {'divide equally', 'match cell'})
-        check_type('reduce_chain_level', reduce_chain_level, [None, int])
         if reduce_chain_level:
+            check_type('reduce_chain_level', reduce_chain_level, int)
             check_greater_than('reduce_chain_level', reduce_chain_level, 0)
         self.diff_volume_method = diff_volume_method
 

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -448,7 +448,7 @@ def test_deplete(run_in_tmpdir, pin_model_attributes, mpi_intracomm):
     # In this test we first run without pre-initializing the shared library
     # data and then compare. Then we repeat with the C API already initialized
     # and make sure we get the same answer
-    test_model.deplete([1e6], 'predictor', final_step=False,
+    test_model.deplete(timesteps=[1e6], method='predictor', final_step=False,
                        operator_kwargs=op_kwargs,
                        power=1., output=False)
     # Get the new Xe136 and U235 atom densities
@@ -482,7 +482,7 @@ def test_deplete(run_in_tmpdir, pin_model_attributes, mpi_intracomm):
 
     # Now we can re-run with the pre-initialized API
     test_model.init_lib(output=False, intracomm=mpi_intracomm)
-    test_model.deplete([1e6], 'predictor', final_step=False,
+    test_model.deplete(timesteps=[1e6], method='predictor', final_step=False,
                        operator_kwargs=op_kwargs,
                        power=1., output=False)
     # Get the new Xe136 and U235 atom densities


### PR DESCRIPTION
# Description

This PR makes the depletion operators a tiny bit simpler for the user to use by automating the behaviour of the ```reduce_chain``` argument.

I think we don't need reduce_chain argument as all it does is tell the function if the reduce_chain_level has been set.

We can directly detect if the reduce_chain_level has been set using bool

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)