### PR TITLE
corrected tally name in D1S example

### DIFF
--- a/docs/source/usersguide/decay_sources.rst
+++ b/docs/source/usersguide/decay_sources.rst
@@ -88,5 +88,5 @@ relevant tallies. This can be done with the aid of the
         dose_tally = sp.get_tally(name='dose tally')
 
     # Apply time correction factors
-    tally = d1s.apply_time_correction(tally, factors, time_index)
+    tally = d1s.apply_time_correction(dose_tally, factors, time_index)
 


### PR DESCRIPTION
# Description

I think there is a small typo on this page of the docs
https://docs.openmc.org/en/stable/usersguide/decay_sources.html

The tally name is different on two lines of the example. This PR changes the variable name so it is the same 

on a similar topic, the ```time_index``` argument for the ```d1s.apply_time_correction``` function is unclear to me, it defaults to ```-1``` which is a bit unclear to me, is anyone able to flesh out that doc string? 


Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

