### PR TITLE
Fix extremely large yields from Bremsstrahlung

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -640,7 +640,7 @@ void Material::init_bremsstrahlung()
     // Allocate arrays for TTB data
     ttb->pdf = xt::zeros<double>({n_e, n_e});
     ttb->cdf = xt::zeros<double>({n_e, n_e});
-    ttb->yield = xt::empty<double>({n_e});
+    ttb->yield = xt::zeros<double>({n_e});
 
     // Allocate temporary arrays
     xt::xtensor<double, 1> stopping_power_collision({n_e}, 0.0);


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

My work on #2919 has been delayed for quite a while, because I noticed that when using photon transport on Windows, the memory would increase without bound. I am not super well versed with debugging tools on Windows, but was finally able to find the time to learn a bit about it, and find the error.

It turns out that the number of secondary photons being produced from Bremsstrahlung could occasionally be on the order of 10^8, very quickly leaking to a bad_alloc. The reason for this was the `yield` array was being initialized with `xt::empty`, which does not initialize the values, and on Windows, this means you get an array with random bits in it. When setting the yields for each energy, the loop that begins at line 772 skips the first energy. Therefore, if that first entry was initialized with a random yield of 10^8 for example, we could produce that many secondaries at some collisions. My fix was simply to initialize the yields array with `xt::zeros`, so that it starts at a physically valid value, and is then translated correctly at the end of the function to -500, facilitating log-log interpolation. Making this change allowed photon transport calculations to actually run on Windows without memory problems.

I do not believe that this was posing real problems on Linux systems, as I think GCC and Clang ensure new allocations are zeroed out first.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
