### PR TITLE
Install MCPL using same build type as OpenMC in CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,13 @@ endif()
 #===============================================================================
 
 if (OPENMC_USE_MCPL)
+  if (NOT DEFINED MCPL_DIR)
+    execute_process(
+      COMMAND mcpl-config --show cmakedir
+      OUTPUT_VARIABLE MCPL_DIR
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  endif()
   find_package(MCPL REQUIRED)
   message(STATUS "Found MCPL: ${MCPL_DIR} (found version \"${MCPL_VERSION}\")")
 endif()

--- a/cmake/OpenMCConfig.cmake.in
+++ b/cmake/OpenMCConfig.cmake.in
@@ -30,7 +30,7 @@ if(@OPENMC_USE_OPENMP@)
 endif()
 
 if(@OPENMC_USE_MCPL@)
-  find_package(MCPL REQUIRED)
+  find_package(MCPL REQUIRED HINTS @MCPL_DIR@)
 endif()
 
 if(@OPENMC_USE_UWUW@ AND NOT ${DAGMC_BUILD_UWUW})

--- a/tools/ci/gha-install-mcpl.sh
+++ b/tools/ci/gha-install-mcpl.sh
@@ -4,4 +4,4 @@ cd $HOME
 git clone https://github.com/mctools/mcpl
 cd mcpl
 mkdir build && cd build
-cmake .. && make 2>/dev/null && sudo make install
+cmake -DCMAKE_BUILD_TYPE=Debug .. && make 2>/dev/null && sudo make install

--- a/tools/ci/gha-install-mcpl.sh
+++ b/tools/ci/gha-install-mcpl.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -ex
-cd $HOME
-git clone https://github.com/mctools/mcpl
-cd mcpl
-mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Debug .. && make 2>/dev/null && sudo make install

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -29,7 +29,7 @@ if [[ $LIBMESH = 'y' ]]; then
 fi
 
 # Install MCPL
-./tools/ci/gha-install-mcpl.sh
+pip install mcpl
 
 # For MPI configurations, make sure mpi4py and h5py are built against the
 # correct version of MPI


### PR DESCRIPTION
# Description

It looks like most recent [release of MCPL](https://github.com/mctools/mcpl/releases/tag/v2.0.0) has [broken our CI](https://github.com/openmc-dev/openmc/actions/runs/14670188177/job/41174681314) because it gets installed with a Release build and OpenMC's Debug build doesn't seem to like that. This small change here should at least get CI working, but curious to hear thoughts from @tkittel on how we should be doing this. Notably, I see that the PyPI version of MCPL might be able to suit our needs, meaning we don't need to install from source?

Also, here's my [ChatGPT transcript](https://chatgpt.com/share/680be4f1-ebe8-8004-a007-511e2c246c3c) where it explained the problem to me in more detail.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)