### PR TITLE
Map Compton subshell data to atomic relaxation data

### DIFF
--- a/include/openmc/photon.h
+++ b/include/openmc/photon.h
@@ -33,7 +33,6 @@ public:
 
   int index_subshell; //!< index in SUBSHELLS
   int threshold;
-  double n_electrons;
   double binding_energy;
   vector<Transition> transitions;
 };
@@ -89,6 +88,11 @@ public:
   xt::xtensor<double, 2> profile_cdf_;
   xt::xtensor<double, 1> binding_energy_;
   xt::xtensor<double, 1> electron_pdf_;
+
+  // Map subshells from Compton profile data obtained from Biggs et al,
+  // "Hartree-Fock Compton profiles for the elements" to ENDF/B atomic
+  // relaxation data
+  xt::xtensor<int, 1> subshell_map_;
 
   // Stopping power data
   double I_; // mean excitation energy

--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -165,7 +165,6 @@ PhotonInteraction::PhotonInteraction(hid_t group)
     if (attribute_exists(tgroup, "binding_energy")) {
       has_atomic_relaxation_ = true;
       read_attribute(tgroup, "binding_energy", shell.binding_energy);
-      read_attribute(tgroup, "num_electrons", shell.n_electrons);
     }
 
     // Read subshell cross section
@@ -232,6 +231,28 @@ PhotonInteraction::PhotonInteraction(hid_t group)
     read_dataset(rgroup, "pz", data::compton_profile_pz);
   }
   close_group(rgroup);
+
+  // Map Compton subshell data to atomic relaxation data by finding the
+  // subshell with the equivalent binding energy
+  if (has_atomic_relaxation_) {
+    auto is_close = [](double a, double b) {
+      return std::abs(a - b) / a < FP_REL_PRECISION;
+    };
+    subshell_map_ = xt::full_like(binding_energy_, -1);
+    for (int i = 0; i < binding_energy_.shape(0); ++i) {
+      double E_b = binding_energy_[i];
+      if (i < n_shell && is_close(E_b, shells_[i].binding_energy)) {
+        subshell_map_[i] = i;
+      } else {
+        for (int j = 0; j < n_shell; ++j) {
+          if (is_close(E_b, shells_[j].binding_energy)) {
+            subshell_map_[i] = j;
+            break;
+          }
+        }
+      }
+    }
+  }
 
   // Create Compton profile CDF
   auto n_profile = data::compton_profile_pz.size();
@@ -423,13 +444,6 @@ void PhotonInteraction::compton_scatter(double alpha, bool doppler,
         double E_out;
         this->compton_doppler(alpha, *mu, &E_out, i_shell, seed);
         *alpha_out = E_out / MASS_ELECTRON_EV;
-
-        // It's possible for the Compton profile data to have more shells than
-        // there are in the ENDF data. Make sure the shell index doesn't end up
-        // out of bounds.
-        if (*i_shell >= shells_.size()) {
-          *i_shell = -1;
-        }
       } else {
         *i_shell = -1;
       }

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -340,11 +340,11 @@ void sample_photon_reaction(Particle& p)
       p.create_secondary(p.wgt(), u, E_electron, ParticleType::electron);
     }
 
-    // TODO: Compton subshell data does not match atomic relaxation data
-    // Allow electrons to fill orbital and produce auger electrons
-    // and fluorescent photons
-    if (i_shell >= 0) {
-      element.atomic_relaxation(i_shell, p);
+    // Allow electrons to fill orbital and produce auger electrons and
+    // fluorescent photons. Since Compton subshell data does not match atomic
+    // relaxation data, use the mapping between the data to find the subshell
+    if (i_shell >= 0 && element.subshell_map_[i_shell] >= 0) {
+      element.atomic_relaxation(element.subshell_map_[i_shell], p);
     }
 
     phi += PI;


### PR DESCRIPTION
# Description

A known issue in our Compton scattering model is that the subshell data from [Biggs et al.](https://doi.org/10.1016/0092-640X(75)90030-3) doesn't match the ENDF/B atomic relaxation data (which often has more subshells). As a result, we are sometimes ejecting an electron in Compton scattering and filling a different vacancy in atomic relaxation. I think one reasonable solution is to create a mapping of the Compton to relaxation subshells based on the binding energy. While the number of electrons still won't always match, this isn't used in atomic relaxation, so I think it's ok.

<details>
  <summary> For completeness, this is a summary of all the subshells that are mismatched and remapped </summary>

| Compton subshell index | Mapped AR subshell index | Compton binding energy | Mapped AR binding energy | Unmapped AR binding energy |
| ------ | ------ | ------ | ------ | ------ |
| V |
| 3 | 4 | 76.42 | 76.42 | 524.54 |
| 4 | 5 | 50.65 | 50.65 | 76.42 |
| 5 | 7 | 9.61 | 9.61 | 50.65 |
| 6 | 9 | 6.63 | 6.63 | 49.79 |
| Na |
| 3 | 4 | 5.15 | 5.15 | 36.22 |
| Sc |
| 3 | 4 | 60.91 | 60.91 | 408.86 |
| 4 | 5 | 39.60 | 39.60 | 60.91 |
| 5 | 7 | 7.08 | 7.08 | 39.60 |
| 6 | 9 | 5.90 | 5.90 | 39.06 |
| Nd |
| 14 | 16 | 44.80 | 44.80 | 8.32 |
| 15 | 17 | 28.12 | 28.12 | 7.85 |
| 16 | 18 | 24.88 | 24.88 | 44.80 |
| 17 | 18 | 24.88 | 24.88 | 28.12 |
| 18 | 19 | 4.96 | 4.96 | 24.88 |
| S |
| 3 | 4 | 20.95 | 20.95 | 171.40 |
| 4 | 5 | 10.34 | 10.34 | 20.95 |
| K |
| 3 | 4 | 40.50 | 40.50 | 298.64 |
| 4 | 5 | 23.75 | 23.75 | 40.50 |
| 5 | 7 | 4.22 | 4.22 | 23.75 |
| Al |
| 3 | 4 | 10.16 | 10.16 | 80.73 |
| 4 | 5 | 4.88 | 4.88 | 10.16 |
| Sm |
| 14 | 16 | 47.74 | 47.74 | 9.37 |
| 15 | 17 | 29.79 | 29.79 | 8.75 |
| 16 | 18 | 26.02 | 26.02 | 47.74 |
| 17 | 19 | 5.09 | 5.09 | 29.79 |
| 18 | 19 | 5.09 | 5.09 | 26.02 |
| Ir |
| 21 | 20 | 6.79 | 6.79 | OOB |
| Pm |
| 14 | 16 | 46.27 | 46.27 | 8.88 |
| 15 | 17 | 28.96 | 28.96 | 8.35 |
| 16 | 18 | 25.46 | 25.46 | 46.27 |
| 17 | 19 | 5.03 | 5.03 | 28.96 |
| 18 | 19 | 5.03 | 5.03 | 25.46 |
| Si |
| 3 | 4 | 13.63 | 13.63 | 107.98 |
| 4 | 5 | 6.55 | 6.55 | 13.63 |
| Cl |
| 3 | 4 | 24.84 | 24.84 | 207.70 |
| 4 | 5 | 12.42 | 12.42 | 24.84 |
| Zn |
| 3 | 4 | 137.43 | 137.43 | 1026.00 |
| 4 | 6 | 90.59 | 90.59 | 137.43 |
| 5 | 7 | 16.85 | 16.85 | 93.74 |
| 6 | 9 | 8.61 | 8.61 | 90.59 |
| Mn |
| 3 | 4 | 92.58 | 92.58 | 652.22 |
| 4 | 5 | 62.09 | 62.09 | 92.58 |
| 5 | 7 | 11.85 | 11.85 | 62.09 |
| 6 | 9 | 7.25 | 7.25 | 60.78 |
| Cu |
| 3 | 4 | 121.26 | 121.26 | 937.49 |
| 4 | 5 | 80.50 | 80.50 | 121.26 |
| 5 | 8 | 9.80 | 9.80 | 80.50 |
| 6 | 9 | 7.11 | 7.11 | 77.86 |
| Ti |
| 3 | 4 | 68.61 | 68.61 | 465.24 |
| 4 | 5 | 45.10 | 45.10 | 68.61 |
| 5 | 7 | 8.39 | 8.39 | 45.10 |
| 6 | 9 | 6.28 | 6.28 | 44.42 |
| Ni |
| 3 | 4 | 118.64 | 118.64 | 867.02 |
| 4 | 5 | 80.48 | 80.48 | 118.64 |
| 5 | 8 | 14.66 | 14.66 | 80.48 |
| 6 | 9 | 8.09 | 8.09 | 78.21 |
| Ar |
| 3 | 4 | 28.92 | 28.92 | 247.09 |
| 4 | 5 | 14.62 | 14.62 | 28.92 |
| Cr |
| 3 | 4 | 79.19 | 79.19 | 580.81 |
| 4 | 5 | 51.25 | 51.25 | 79.19 |
| 5 | 7 | 6.46 | 6.46 | 51.25 |
| 6 | 9 | 5.96 | 5.96 | 50.20 |
| Br |
| 3 | 4 | 251.49 | 251.49 | 1553.60 |
| 4 | 5 | 191.82 | 191.82 | 251.49 |
| 5 | 8 | 78.45 | 78.45 | 191.82 |
| 6 | 9 | 24.18 | 24.18 | 184.78 |
| 7 | 10 | 11.59 | 11.59 | 79.59 |
| Pr |
| 14 | 16 | 43.30 | 43.30 | 7.65 |
| 15 | 17 | 27.26 | 27.26 | 7.24 |
| 16 | 18 | 24.26 | 24.26 | 43.30 |
| 17 | 19 | 4.89 | 4.89 | 27.26 |
| 18 | 19 | 4.89 | 4.89 | 24.26 |
| Co |
| 3 | 4 | 109.69 | 109.69 | 792.29 |
| 4 | 5 | 74.17 | 74.17 | 109.69 |
| 5 | 7 | 13.93 | 13.93 | 74.17 |
| 6 | 9 | 7.81 | 7.81 | 72.26 |
| As |
| 3 | 4 | 202.02 | 202.02 | 1328.30 |
| 4 | 5 | 148.95 | 148.95 | 202.02 |
| 5 | 8 | 50.55 | 50.55 | 148.95 |
| 6 | 9 | 17.86 | 17.86 | 143.78 |
| 7 | 10 | 8.12 | 8.12 | 51.32 |
| Ge |
| 3 | 4 | 179.25 | 179.25 | 1222.80 |
| 4 | 5 | 129.38 | 129.38 | 179.25 |
| 5 | 8 | 38.19 | 38.19 | 129.38 |
| 6 | 9 | 14.78 | 14.78 | 124.98 |
| 7 | 10 | 6.50 | 6.50 | 38.82 |
| Mg |
| 3 | 4 | 6.89 | 6.89 | 56.24 |
| Fe |
| 3 | 4 | 101.01 | 101.01 | 720.69 |
| 4 | 5 | 68.04 | 68.04 | 101.01 |
| 5 | 7 | 12.91 | 12.91 | 68.04 |
| 6 | 9 | 7.53 | 7.53 | 66.45 |
| Se |
| 3 | 4 | 226.10 | 226.10 | 1438.60 |
| 4 | 5 | 169.77 | 169.77 | 226.10 |
| 5 | 8 | 63.97 | 63.97 | 169.77 |
| 6 | 9 | 20.99 | 20.99 | 163.71 |
| 7 | 10 | 9.82 | 9.82 | 64.91 |
| Ga |
| 3 | 4 | 157.75 | 157.75 | 1122.00 |
| 4 | 5 | 111.01 | 111.01 | 157.75 |
| 5 | 9 | 11.69 | 11.69 | 111.01 |
| 6 | 10 | 5.00 | 5.00 | 107.28 |
| 7 | 11 | 4.88 | 4.88 | 27.37 |
| P |
| 3 | 4 | 17.21 | 17.21 | 138.18 |
| 4 | 5 | 8.38 | 8.38 | 17.21 |
| Ca |
| 3 | 4 | 53.16 | 53.16 | 355.20 |
| 4 | 5 | 34.01 | 34.01 | 53.16 |
| 5 | 7 | 5.45 | 5.45 | 34.01 |

</details>

Fixes #1942 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
