### PR TITLE
Apply resolve paths to path values in `config`

### DIFF
--- a/docs/source/usersguide/data.rst
+++ b/docs/source/usersguide/data.rst
@@ -30,7 +30,8 @@ responsible for specifying one or more of the following:
 Each of the above files can specified in several ways. In the Python API, a
 :ref:`runtime configuration variable <usersguide_data_runtime>`
 :data:`openmc.config` can be used to specify any of the above and is initialized
-using a set of environment variables.
+using a set of environment variables. Data configuration paths set in
+:data:`openmc.config` will be expanded to absolute paths.
 
 .. _usersguide_data_runtime:
 

--- a/openmc/config.py
+++ b/openmc/config.py
@@ -60,7 +60,7 @@ class _Config(MutableMapping):
         return repr(self._mapping)
 
     def _set_path(self, key, value):
-        self._mapping[key] = p = Path(value)
+        self._mapping[key] = p = Path(value).resolve()
         if not p.exists():
             warnings.warn(f"'{value}' does not exist.")
 

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -1,5 +1,6 @@
 from collections.abc import Mapping
 import os
+from pathlib import Path
 
 import openmc
 import pytest
@@ -33,6 +34,12 @@ def test_config_basics():
     # Can't use any key
     with pytest.raises(KeyError):
         openmc.config['🐖'] = '/like/to/eat/bacon'
+
+    # ensure relative paths are expanded into absolute
+    # paths
+    chain_path = Path('./chain.xml')
+    openmc.config['chain_file'] = chain_path
+    assert openmc.config['chain_file'] == chain_path.resolve()
 
 
 def test_config_patch():


### PR DESCRIPTION
# Description

This change expands data configuration paths in `openmc.config`.

One example where this behavior is useful is in streamlining workflows using customized/reduced decay chains. A script and bespoke decay chain can be included in a repository with a workflow script that sets the `openmc.config["chain_file"]` value with a relative path and be expected to work on many machines.

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
