### PR TITLE
Read additional information for DAGMC cells from `openmc.lib`

### DIFF
--- a/openmc/dagmc.py
+++ b/openmc/dagmc.py
@@ -575,8 +575,6 @@ class DAGMCUniverse(openmc.UniverseBase):
                 else:
                     cell.temperature = dag_cell.get_temperature()
 
-                cell.bounding_box = dag_cell.bounding_box
-
                 self.add_cell(cell)
 
 
@@ -619,12 +617,7 @@ class DAGMCCell(openmc.Cell):
 
     @property
     def bounding_box(self):
-        return self._bounding_box
-
-    @bounding_box.setter
-    def bounding_box(self, box):
-        cv.check_type('bounding box', box, BoundingBox)
-        self._bounding_box = box
+        return BoundingBox.infinite()
 
     @openmc.Cell.temperature.setter
     def temperature(self, val):

--- a/openmc/dagmc.py
+++ b/openmc/dagmc.py
@@ -557,14 +557,27 @@ class DAGMCUniverse(openmc.UniverseBase):
                 f"the number of cells in the Python universe."
             )
 
-        mats_per_id = {mat.id: mat for mat in mats}
-        for dag_cell_id in dagmc_cell_ids:
-            dag_cell = openmc.lib.cells[dag_cell_id]
-            if isinstance(dag_cell.fill, Iterable):
-                fill = [mats_per_id[mat.id] for mat in dag_cell.fill if mat]
-            else:
-                fill = mats_per_id[dag_cell.fill.id] if dag_cell.fill else None
-            self.add_cell(openmc.DAGMCCell(cell_id=dag_cell_id, fill=fill))
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=UserWarning)
+
+            mats_per_id = {mat.id: mat for mat in mats}
+            for dag_cell_id in dagmc_cell_ids:
+                dag_cell = openmc.lib.cells[dag_cell_id]
+                if isinstance(dag_cell.fill, Iterable):
+                    fill = [mats_per_id[mat.id] for mat in dag_cell.fill if mat]
+                else:
+                    fill = mats_per_id[dag_cell.fill.id] if dag_cell.fill else None
+                cell = openmc.DAGMCCell(cell_id=int(dag_cell_id), fill=fill)
+
+                n_instances = dag_cell.num_instances
+                if n_instances > 1:
+                    cell.temperature = [dag_cell.get_temperature(i) for i in range(n_instances)]
+                else:
+                    cell.temperature = dag_cell.get_temperature()
+
+                cell.bounding_box = dag_cell.bounding_box
+
+                self.add_cell(cell)
 
 
 class DAGMCCell(openmc.Cell):
@@ -590,6 +603,9 @@ class DAGMCCell(openmc.Cell):
     """
     def __init__(self, cell_id=None, name='', fill=None):
         super().__init__(cell_id, name, fill, None)
+        # unlike CSG cells, the bounding boxes of DAGMC cells are retrieved from
+        # the C API and are stored on the object
+        self._bounding_box = None
 
     @property
     def DAG_parent_universe(self):
@@ -601,8 +617,19 @@ class DAGMCCell(openmc.Cell):
         """Set the parent universe of the cell."""
         self._parent_universe = universe.id
 
+    @property
     def bounding_box(self):
-        return BoundingBox.infinite()
+        return self._bounding_box
+
+    @bounding_box.setter
+    def bounding_box(self, box):
+        cv.check_type('bounding box', box, BoundingBox)
+        self._bounding_box = box
+
+    @openmc.Cell.temperature.setter
+    def temperature(self, val):
+        warnings.warn('Changed to temperatures on DAGMCCell\'s will not be reflected in transport')
+        openmc.Cell.temperature.fset(self, val)
 
     def get_all_cells(self, memo=None):
         return {}

--- a/openmc/dagmc.py
+++ b/openmc/dagmc.py
@@ -601,9 +601,6 @@ class DAGMCCell(openmc.Cell):
     """
     def __init__(self, cell_id=None, name='', fill=None):
         super().__init__(cell_id, name, fill, None)
-        # unlike CSG cells, the bounding boxes of DAGMC cells are retrieved from
-        # the C API and are stored on the object
-        self._bounding_box = None
 
     @property
     def DAG_parent_universe(self):

--- a/openmc/dagmc.py
+++ b/openmc/dagmc.py
@@ -628,7 +628,7 @@ class DAGMCCell(openmc.Cell):
 
     @openmc.Cell.temperature.setter
     def temperature(self, val):
-        warnings.warn('Changed to temperatures on DAGMCCell\'s will not be reflected in transport')
+        warnings.warn('Changes to temperatures on DAGMCCell\'s will not be reflected in transport')
         openmc.Cell.temperature.fset(self, val)
 
     def get_all_cells(self, memo=None):

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -14,6 +14,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture()
 def model(request):
+    openmc.reset_auto_ids()
     pitch = 1.26
 
     mats = {}
@@ -80,12 +81,6 @@ def test_temperature_read(model):
                 assert t == 300.0
             else:
                 assert t == pytest.approx(293.6)
-
-
-def test_finite_bounding_boxes(model):
-    for cell in model.geometry.get_all_material_cells().values():
-        assert all(np.isfinite(cell.bounding_box.lower_left))
-        assert all(np.isfinite(cell.bounding_box.upper_right))
 
 
 def test_cell_temperature_warning(model):

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -88,6 +88,12 @@ def test_finite_bounding_boxes(model):
         assert all(np.isfinite(cell.bounding_box.upper_right))
 
 
+def test_cell_temperature_warning(model):
+    c = list(model.geometry.get_all_material_cells().values())[0]
+    with pytest.warns(UserWarning):
+        c.temperature = 800
+
+
 def test_dagmc_replace_material_assignment(model):
     mats = {}
 


### PR DESCRIPTION
…penmc.lib

# Description

This PR adds temperature reading (no overrides... yet) to DAGMC universes and bounding box information from `openmc.lib`. The latter may be useful for efficient sampling of volumetric sources over a given cell.

As described in #3398, it also 

  - sets `DAGMCCell` IDs as `int` instead of `np.int32` for consistency. 
  - changes `DAGMCCell.bounding_box` from a method to a property.

Fixes #3398

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
