### PR TITLE
Random Ray Misc Memory Error Fixes

### DIFF
--- a/src/random_ray/flat_source_domain.cpp
+++ b/src/random_ray/flat_source_domain.cpp
@@ -206,9 +206,11 @@ void FlatSourceDomain::set_flux_to_flux_plus_source(
   int material = source_regions_.material(sr);
   if (material == MATERIAL_VOID) {
     source_regions_.scalar_flux_new(sr, g) /= volume;
-    source_regions_.scalar_flux_new(sr, g) +=
-      0.5f * source_regions_.external_source(sr, g) *
-      source_regions_.volume_sq(sr);
+    if (settings::run_mode == RunMode::FIXED_SOURCE) {
+      source_regions_.scalar_flux_new(sr, g) +=
+        0.5f * source_regions_.external_source(sr, g) *
+        source_regions_.volume_sq(sr);
+    }
   } else {
     double sigma_t = sigma_t_[source_regions_.material(sr) * negroups_ + g];
     source_regions_.scalar_flux_new(sr, g) /= (sigma_t * volume);

--- a/src/random_ray/random_ray.cpp
+++ b/src/random_ray/random_ray.cpp
@@ -518,8 +518,10 @@ void RandomRay::attenuate_flux_flat_source_void(
   }
 
   // Add source to incoming angular flux, assuming void region
-  for (int g = 0; g < negroups_; g++) {
-    angular_flux_[g] += srh.external_source(g) * distance;
+  if (settings::run_mode == RunMode::FIXED_SOURCE) {
+    for (int g = 0; g < negroups_; g++) {
+      angular_flux_[g] += srh.external_source(g) * distance;
+    }
   }
 }
 
@@ -688,7 +690,12 @@ void RandomRay::attenuate_flux_linear_source_void(
   // transport through a void region is greatly simplified. Here we
   // compute the updated flux moments.
   for (int g = 0; g < negroups_; g++) {
-    float spatial_source = srh.external_source(g);
+    float spatial_source;
+    if (settings::run_mode == RunMode::FIXED_SOURCE) {
+      spatial_source = srh.external_source(g);
+    } else {
+      spatial_source = 0.f;
+    }
     float new_delta_psi = (angular_flux_[g] - spatial_source) * distance;
     float h1 = 0.5f;
     h1 = h1 * angular_flux_[g];
@@ -750,8 +757,10 @@ void RandomRay::attenuate_flux_linear_source_void(
   }
 
   // Add source to incoming angular flux, assuming void region
-  for (int g = 0; g < negroups_; g++) {
-    angular_flux_[g] += srh.external_source(g) * distance;
+  if (settings::run_mode == RunMode::FIXED_SOURCE) {
+    for (int g = 0; g < negroups_; g++) {
+      angular_flux_[g] += srh.external_source(g) * distance;
+    }
   }
 }
 
@@ -782,9 +791,7 @@ void RandomRay::initialize_ray(uint64_t ray_id, FlatSourceDomain* domain)
     fatal_error("Unknown sample method for random ray transport.");
   }
 
-  site.E = lower_bound_index(
-    data::mg.rev_energy_bins_.begin(), data::mg.rev_energy_bins_.end(), site.E);
-  site.E = negroups_ - site.E - 1.;
+  site.E = 0.0;
   this->from_source(&site);
 
   // Locate ray

--- a/src/random_ray/random_ray.cpp
+++ b/src/random_ray/random_ray.cpp
@@ -690,11 +690,9 @@ void RandomRay::attenuate_flux_linear_source_void(
   // transport through a void region is greatly simplified. Here we
   // compute the updated flux moments.
   for (int g = 0; g < negroups_; g++) {
-    float spatial_source;
+    float spatial_source = 0.f;
     if (settings::run_mode == RunMode::FIXED_SOURCE) {
       spatial_source = srh.external_source(g);
-    } else {
-      spatial_source = 0.f;
     }
     float new_delta_psi = (angular_flux_[g] - spatial_source) * distance;
     float h1 = 0.5f;

--- a/src/random_ray/source_region.cpp
+++ b/src/random_ray/source_region.cpp
@@ -217,7 +217,11 @@ SourceRegionHandle SourceRegionContainer::get_source_region_handle(int64_t sr)
   handle.scalar_flux_old_ = &scalar_flux_old(sr, 0);
   handle.scalar_flux_new_ = &scalar_flux_new(sr, 0);
   handle.source_ = &source(sr, 0);
-  handle.external_source_ = &external_source(sr, 0);
+  if (settings::run_mode == RunMode::FIXED_SOURCE) {
+    handle.external_source_ = &external_source(sr, 0);
+  } else {
+    handle.external_source_ = nullptr;
+  }
   handle.scalar_flux_final_ = &scalar_flux_final(sr, 0);
   handle.tally_task_ = &tally_task(sr, 0);
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

@HunterBelanger was doing some testing with OpenMC on windows and identified several memory errors in the random ray solver.

The first has to do with the sample site energy field being uninitialized when in random ray mode, as we skip this step as the ray implicitly represents all energy groups rather than a single energy level as in MC. We can simply set `site.e = 0.0` to fix the issue.

The second issue is more subtle, and had to do with accessing of the `external_source()` portions of source regions when in eigenvalue mode. Currently we do not allocate this data for source regions when in eigenvalue mode, but were still accessing it anyway in a few locations. Surprisingly I hadn't seen any seg faults to date with this (and it passed through `valgrind --tool=memcheck` cleanly), but seems to be a pretty clear error. I've added checks now in a few spots to ensure we are only touching this field if we are in fixed source mode.

Thanks @HunterBelanger for identifying these issues and for coming up with the fix for the first one!

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
