### PR TITLE
small typo - spelling of Debian

### DIFF
--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -221,7 +221,7 @@ Prerequisites
       OpenMC's built-in plotting capabilities use the libpng library to produce
       compressed PNG files. In the absence of this library, OpenMC will fallback
       to writing PPM files, which are uncompressed and only supported by select
-      image viewers. libpng can be installed on Ddebian derivates with::
+      image viewers. libpng can be installed on Debian derivates with::
 
           sudo apt install libpng-dev
 


### PR DESCRIPTION
# Description

This is just a tiny correction of a typo in the "install" manual. The word "Debian" was written with a double leading "d".

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)