### PR TITLE
Random Ray External Source Plotting Fix

### DIFF
--- a/src/random_ray/flat_source_domain.cpp
+++ b/src/random_ray/flat_source_domain.cpp
@@ -923,7 +923,7 @@ void FlatSourceDomain::output_to_vtk() const
         float total_external = 0.0f;
         if (fsr >= 0) {
           for (int g = 0; g < negroups_; g++) {
-            // external sources are already divided by sigma_t, so we need to
+            // External sources are already divided by sigma_t, so we need to
             // multiply it back to get the true external source.
             double sigma_t = 1.0;
             if (mat != MATERIAL_VOID) {

--- a/src/random_ray/flat_source_domain.cpp
+++ b/src/random_ray/flat_source_domain.cpp
@@ -919,10 +919,17 @@ void FlatSourceDomain::output_to_vtk() const
       std::fprintf(plot, "LOOKUP_TABLE default\n");
       for (int i = 0; i < Nx * Ny * Nz; i++) {
         int64_t fsr = voxel_indices[i];
+        int mat = source_regions_.material(fsr);
         float total_external = 0.0f;
         if (fsr >= 0) {
           for (int g = 0; g < negroups_; g++) {
-            total_external += source_regions_.external_source(fsr, g);
+            // external sources are already divided by sigma_t, so we need to
+            // multiply it back to get the true external source.
+            double sigma_t = 1.0;
+            if (mat != MATERIAL_VOID) {
+              sigma_t = sigma_t_[mat * negroups_ + g];
+            }
+            total_external += source_regions_.external_source(fsr, g) * sigma_t;
           }
         }
         total_external = convert_to_big_endian<float>(total_external);


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

In the random ray solver, the `external_source` vector for each source region is divided by `sigma_t` before storage. This is done to avoid having to perform many extra division operations over the course of the simulation. However, the random ray `output_to_vtk()` function currently plots the external source values directly, such that regions with smaller cross sections (e.g., air) tend to look like they have external source terms that are orders of magnitude larger than they are in reality.

Thus, this fix simply multiples the external source term by `sigma_t` during plotting so as to visualize the true source value. 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
