### PR TITLE
Adding get adjacent nuclides utility function

### DIFF
--- a/tests/unit_tests/test_data_misc.py
+++ b/tests/unit_tests/test_data_misc.py
@@ -156,6 +156,12 @@ def test_get_adjacent_nuclides():
     result = openmc.data.get_adjacent_nuclides(["Fe56"], include_input=True)
     assert "Fe56" in result
     assert len(result) == 9
+    result = openmc.data.get_adjacent_nuclides(["Fe56"], delta_z=2)
+    assert len(result) == 15
+    result = openmc.data.get_adjacent_nuclides(["Fe56"], delta_n=3)
+    assert len(result) == 21
+    result = openmc.data.get_adjacent_nuclides(["Fe56"], delta_n=2, delta_z=2)
+    assert len(result) == 25
 
     # test with multiple nuclides
     result = openmc.data.get_adjacent_nuclides(["Fe56", "Be9"])
@@ -166,8 +172,24 @@ def test_get_adjacent_nuclides():
     assert len(result) >= max(len(fe56_result), len(be9_result))
 
     # Test with adjacent nuclides that have overlapping surroundings.
-    fe56_fe57_result = openmc.data.get_adjacent_nuclides(["Fe56", "Fe57"])
+    fe56_fe57_result = openmc.data.get_adjacent_nuclides(
+        ["Fe56", "Fe57"], include_input=True
+    )
+    assert "Fe57" in fe56_fe57_result
+    assert "Fe56" in fe56_fe57_result
+    assert len(fe56_fe57_result) == 12
+    fe56_fe57_result = openmc.data.get_adjacent_nuclides(
+        ["Fe56", "Fe57"], include_input=False
+    )
+    assert "Fe57" not in fe56_fe57_result
+    assert "Fe56" not in fe56_fe57_result
+    assert len(fe56_fe57_result) == 10
     fe57_result = openmc.data.get_adjacent_nuclides(["Fe57"])
 
     # Combined result should be less than sum due to overlap (no duplicates)
     assert len(fe56_fe57_result) < len(fe56_result) + len(fe57_result)
+
+    fe56_fe57_result_extra = openmc.data.get_adjacent_nuclides(
+        ["Fe56", "Fe57"], delta_n=2, delta_z=2
+    )
+    assert len(fe56_fe57_result_extra) == 30


### PR DESCRIPTION
# Description

Adding a utility function to get the nuclides that surround the input nuclides.

I'm thinking this function can be used to help the depletion simulations avoid reading in all the nuclides in the chain file. We can quickly get the nuclides around the input nuclides and limit the depletion code to just read in these files. I think this could speed up the openmc_activator @jbae11 would you mind taking a look at this PR.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
