### PR TITLE
Apply Max Number of Events Check to Random Rays

### DIFF
--- a/src/random_ray/random_ray.cpp
+++ b/src/random_ray/random_ray.cpp
@@ -267,8 +267,8 @@ uint64_t RandomRay::transport_history_based_single_ray()
     event_cross_surface();
     // If ray has too many events, display warning and kill it
     if (n_event() >= settings::max_particle_events) {
-      warning(
-        "Ray " + std::to_string(id()) + " underwent maximum number of events, terminating ray.");
+      warning("Ray " + std::to_string(id()) +
+              " underwent maximum number of events, terminating ray.");
       wgt() = 0.0;
     }
   }

--- a/src/random_ray/random_ray.cpp
+++ b/src/random_ray/random_ray.cpp
@@ -268,7 +268,7 @@ uint64_t RandomRay::transport_history_based_single_ray()
     // If ray has too many events, display warning and kill it
     if (n_event() >= settings::max_particle_events) {
       warning(
-        "Ray " + std::to_string(id()) + " underwent maximum number of events.");
+        "Ray " + std::to_string(id()) + " underwent maximum number of events, terminating ray.");
       wgt() = 0.0;
     }
   }

--- a/src/random_ray/random_ray.cpp
+++ b/src/random_ray/random_ray.cpp
@@ -265,6 +265,12 @@ uint64_t RandomRay::transport_history_based_single_ray()
     if (!alive())
       break;
     event_cross_surface();
+    // If ray has too many events, display warning and kill it
+    if (n_event() >= settings::max_particle_events) {
+      warning(
+        "Ray " + std::to_string(id()) + " underwent maximum number of events.");
+      wgt() = 0.0;
+    }
   }
 
   return n_event();


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

OpenMC's MC solver currently checks the number of events a particle has executed and kills it if it exceeds the `settings::max_particle_events` threshold. On the JET model, I'm noticing some rays are occasionally getting stuck in infinite (or at least near infinite) loops in the ray tracer, so this check seems useful. The infinite loop issue in JET could be caused by a problem with the geometry definition itself (as the model is highly complex), but nonetheless it seems useful to ensure infinite loops don't occur.

This PR adds an identical check to the random ray transport loop to ensure rays don't get stuck in an infinite loop. With the fix in place, JET runs cleanly for random ray, though with the occasional lost ray (about 1 out of every 2 million rays are lost due to the infinite loop check triggering). 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
