### PR TITLE
Change Dockerfile from debian:bookworm-slim to ubuntu:24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG compile_cores=1
 ARG build_dagmc=off
 ARG build_libmesh=off
 
-FROM debian:bookworm-slim AS dependencies
+FROM ubuntu:24.04 AS dependencies
 
 ARG compile_cores
 ARG build_dagmc


### PR DESCRIPTION
# Description

Currently, our GH action that builds a Docker image and publishes to Dockerhub is broken (e.g., see [this log](https://github.com/openmc-dev/openmc/actions/runs/15623926925/job/44014497371)). The log shows that it fails at the point where it is doing a source build of mpi4py. After digging into it, I figured out that this is due to an issue with the gcc 12 compiler as discussed in mpi4py/mpi4py#652. A simple fix is to use a more up-to-date version of gcc. Because our Dockerfile is based on the debian:bookworm-slim image and Debian Bookworm uses gcc 12 (and is the most recent stable release of Debian), we can achieve this by simply switching to Ubuntu 24.04.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)