### PR TITLE
Add Ball spatial distribution

### DIFF
--- a/docs/source/pythonapi/stats.rst
+++ b/docs/source/pythonapi/stats.rst
@@ -56,6 +56,7 @@ Spatial Distributions
    openmc.stats.CartesianIndependent
    openmc.stats.CylindricalIndependent
    openmc.stats.SphericalIndependent
+   openmc.stats.Ball
    openmc.stats.Box
    openmc.stats.Point
    openmc.stats.MeshSpatial

--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -182,6 +182,28 @@ private:
 };
 
 //==============================================================================
+//! Uniform distribution of points over a ball
+//==============================================================================
+
+class SpatialBall : public SpatialDistribution {
+public:
+  explicit SpatialBall(pugi::xml_node node);
+
+  //! Sample a position from the distribution
+  //! \param seed Pseudorandom number seed pointer
+  //! \return Sampled position
+  Position sample(uint64_t* seed) const override;
+
+  // Properties
+  Position origin() const { return origin_; }
+  double radius() const { return radius_; }
+
+private:
+  Position origin_; //!< Origin coordinates of ball
+  double radius_;   //!< Radius of ball
+};
+
+//==============================================================================
 //! Distribution at a single point
 //==============================================================================
 

--- a/openmc/stats/multivariate.py
+++ b/openmc/stats/multivariate.py
@@ -281,6 +281,8 @@ class Spatial(ABC):
             return MeshSpatial.from_xml_element(elem, meshes)
         elif distribution == 'cloud':
             return PointCloud.from_xml_element(elem)
+        elif distribution == 'ball':
+            return Ball.from_xml_element(elem)
 
 
 class CartesianIndependent(Spatial):

--- a/openmc/stats/multivariate.py
+++ b/openmc/stats/multivariate.py
@@ -984,6 +984,91 @@ class Box(Spatial):
         upper_right = params[len(params)//2:]
         return cls(lower_left, upper_right, only_fissionable)
 
+class Ball(Spatial):
+    """Uniform distribution of coordinates in a closed ball.
+
+    Parameters
+    ----------
+    origin : Iterable of float
+        Origin coordinates of ball
+    radius : float
+        Radius of ball
+
+    Attributes
+    ----------
+    origin : Iterable of float
+        Origin coordinates of ball
+    radius : float
+        Radius of ball
+
+    """
+
+    def __init__(
+        self,
+        origin: Sequence[float],
+        radius: float,
+    ):
+        self.origin = origin
+        self.radius = radius
+
+    @property
+    def origin(self):
+        return self._origin
+
+    @origin.setter
+    def origin(self, origin):
+        cv.check_type('origin coordinates', origin, Iterable, Real)
+        cv.check_length('origin coordinates', origin, 3)
+        self._origin = origin
+
+    @property
+    def radius(self):
+        return self._radius
+
+    @radius.setter
+    def radius(self, radius):
+        cv.check_type('radius', radius, Real)
+        self._radius = radius
+
+    def to_xml_element(self):
+        """Return XML representation of the ball distribution
+
+
+        Returns
+        -------
+        element : lxml.etree._Element
+            XML element containing ball distribution data
+
+        """
+        element = ET.Element('space')
+        element.set("type", "ball")
+        params = ET.SubElement(element, "parameters")
+        params.text = ' '.join(map(str, self.origin)) + ' ' + \
+                      str(self.radius)
+        return element
+
+    @classmethod
+    def from_xml_element(cls, elem: ET.Element):
+        """Generate ball distribution from an XML element
+
+        Parameters
+        ----------
+        elem : lxml.etree._Element
+
+            XML element
+
+        Returns
+        -------
+        openmc.stats.Ball
+            Ball distribution generated from XML element
+
+
+        """
+        params = [float(x) for x in get_text(elem, 'parameters').split()]
+        origin = params[:-1]
+        radius = params[-1]
+        return cls(origin, radius)
+
 
 class Point(Spatial):
     """Delta function in three dimensions.

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -1,8 +1,6 @@
 #include "openmc/distribution_spatial.h"
 
-#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
-#include <cmath>          // for M_PI
-
+#include "openmc/constants.h"
 #include "openmc/error.h"
 #include "openmc/mesh.h"
 #include "openmc/random_lcg.h"
@@ -390,11 +388,11 @@ SpatialBall::SpatialBall(pugi::xml_node node)
 Position SpatialBall::sample(uint64_t* seed) const
 {
   double u = 2.0 * prn(seed) - 1.0;
-  double phi = 2 * M_PI * prn(seed);
-  double r = std::cbrt(prn(seed));
+  double phi = 2 * PI * prn(seed);
+  double r = radius_ * std::cbrt(prn(seed));
   Position xi {std::cos(phi) * std::sqrt(1 - u * u),
     std::sin(phi) * std::sqrt(1 - u * u), u};
-  return origin_ + xi * (radius_ * r);
+  return origin_ + xi * r;
 }
 
 //==============================================================================

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -1,8 +1,10 @@
 #include "openmc/distribution_spatial.h"
 
+#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers 
+#include <cmath> // for M_PI
+
 #include "openmc/error.h"
 #include "openmc/mesh.h"
-#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers 
 #include "openmc/random_lcg.h"
 #include "openmc/search.h"
 #include "openmc/xml_interface.h"

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -2,6 +2,7 @@
 
 #include "openmc/error.h"
 #include "openmc/mesh.h"
+#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers 
 #include "openmc/random_lcg.h"
 #include "openmc/search.h"
 #include "openmc/xml_interface.h"
@@ -386,9 +387,8 @@ SpatialBall::SpatialBall(pugi::xml_node node)
 
 Position SpatialBall::sample(uint64_t* seed) const
 {
-  const double pi = 3.14159265358979323846264338327950288419716939937510582;
   double u = 2.0 * prn(seed) - 1.0;
-  double phi = 2 * pi * prn(seed);
+  double phi = 2 * M_PI * prn(seed);
   double r = std::cbrt(prn(seed));
   Position xi {std::cos(phi) * std::sqrt(1 - u * u),
     std::sin(phi) * std::sqrt(1 - u * u), u};

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -1,7 +1,7 @@
 #include "openmc/distribution_spatial.h"
 
-#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers 
-#include <cmath> // for M_PI
+#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
+#include <cmath>          // for M_PI
 
 #include "openmc/error.h"
 #include "openmc/mesh.h"


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This pr implements openmc.stats.Ball, a uniform spatial distribution in a shape of a ball.
 
This class is usefull when a problem is spherically symmetric.
In a follow up pr, I plan to use this class in random ray for spherically symmetric problems.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
