### PR TITLE
Fix a bug in openmc.data.combine_distributions

### DIFF
--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -1383,19 +1383,19 @@ class Mixture(Univariate):
         others = [[],[]]
         for p,d in zip(probs,dists):
             if isinstance(d, Mixture):
-                iterator = zip(m.probability,m.distribution)
+                iterator = zip(p * m.probability, m.distribution)
             else:
                 iterator = [(p,d)]
             for prob,dist in iterator:
                 if isinstance(dist,Discrete):
                     discrete[0].append(dist)
-                    discrete[1].append(p*prob)  
+                    discrete[1].append(prob)  
                 elif isinstance(dist,Normal):
                     normal[0].append(dist)
-                    normal[1].append(p*prob)
+                    normal[1].append(prob)
                 else:
                     others[0].append(dist)
-                    others[1].append(p*prob)
+                    others[1].append(prob)
         if discrete[0]:
             others[0].append(Discrete.merge(*discrete))
             others[1].append(1.0)

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -830,6 +830,36 @@ class Normal(Univariate):
         params = get_text(elem, 'parameters').split()
         return cls(*map(float, params))
 
+    @classmethod
+    def merge(
+        cls,
+        dists: Sequence[Normal],
+        probs: Sequence[int]
+    ):
+        """Merge multiple normal distributions into a single distribution
+
+        Parameters
+        ----------
+        dists : iterable of openmc.stats.Normal
+            Normal distributions to combine
+        probs : iterable of float
+            Probability of each distribution
+
+        Returns
+        -------
+        openmc.stats.Normal
+            Combined normal distribution
+
+        """
+        if len(dists) != len(probs):
+            raise ValueError("Number of distributions and probabilities must match.")
+        means = np.array([d.mean_value for d in dists])
+        stds = np.array([d.std_dev for d in dists])
+        probs = np.asarray(probs)
+        combined_mean = np.dot(probs,means)
+        combined_std = np.sqrt(np.dot(probs**2,stds**2))
+        return cls(combined_mean, combined_std)
+
 
 def muir(e0: float, m_rat: float, kt: float):
     """Generate a Muir energy spectrum

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -1396,10 +1396,10 @@ class Mixture(Univariate):
                 else:
                     others[0].append(dist)
                     others[1].append(p*prob)
-        if discrete:
+        if discrete[0]:
             others[0].append(Discrete.merge(*discrete))
             others[1].append(1.0)
-        if normal:
+        if normal[0]:
             others[0].append(Normal.merge(*normal))
             others[1].append(1.0)
         if others[1]==[1.0]:

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -444,6 +444,15 @@ def test_normal():
     assert_sample_mean(samples, mean)
 
 
+def test_combine_normal():
+    norm1=openmc.stats.Normal(mean_value=10, std_dev=1)
+    norm2=openmc.stats.Normal(mean_value=1, std_dev=1)
+    combined=openmc.stats.combine_distributions([norm1,norm2],probs=[0.1,0.9])
+    assert isinstance(combined, openmc.stats.Normal)
+    assert combined.mean_value == pytest.approx(1.9)
+    assert combined.std_dev**2 == pytest.approx(0.82)
+
+
 def test_muir():
     mean = 10.0
     mass = 5.0


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This pr change the implementation of combine_distributions to support combination of any Univariate distributions with specified probabilities.

The new implementation knows to combine analytically discrete and normal distributions.

Fixes #3105

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
