### PR TITLE
not printing nuclides with 0 percent to terminal (option 1)

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -157,8 +157,9 @@ class Material(IDManagerMixin):
         string += '{: <16}\n'.format('\tNuclides')
 
         for nuclide, percent, percent_type in self._nuclides:
-            string += '{: <16}'.format('\t{}'.format(nuclide))
-            string += f'=\t{percent: <12} [{percent_type}]\n'
+            if percent > 0.:
+                string += '{: <16}'.format('\t{}'.format(nuclide))
+                string += f'=\t{percent: <12} [{percent_type}]\n'
 
         if self._macroscopic is not None:
             string += '{: <16}\n'.format('\tMacroscopic Data')


### PR DESCRIPTION
# Description

This PR is one option for solving #3446 by not printing materials with 0.0 percent to the terminal. This approach changes the __repl__ so that it skips these materials

Fixes # (issue)

#3446

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
