### PR TITLE
Prevent Adjoint Sources from Trending towards Infinity

### DIFF
--- a/include/openmc/constants.h
+++ b/include/openmc/constants.h
@@ -63,6 +63,11 @@ constexpr int MAX_SAMPLE {100000};
 // source region in the random ray solver
 constexpr double MIN_HITS_PER_BATCH {1.5};
 
+// The minimum flux value to be considered non-zero when computing adjoint
+// sources. Positive values below this cutoff will be treated as zero, so as to
+// prevent extremely large adjoint source terms from being generated.
+constexpr double ZERO_FLUX_CUTOFF {1e-22};
+
 // ============================================================================
 // MATH AND PHYSICAL CONSTANTS
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR adds two minor enhancements to support FW-CADIS on large fusion models like JET.

Specifically, it makes the following changes:

1. Addition of `ZERO_FLUX_CUTOFF` macro (define here as 10^-22) to ensure that global adjoint external sources (defined as 1/forward flux) do not tend towards infinity. Especially in low ray density situations, you might end up with a really small flux estimate in a small cell, and we don't want to end up having this source dominate the overall adjoint source term. We check the flux against this new macro when computing the adjoint external source terms, and just set the external source to zero. While we generally want to make weight windows that bias particles towards areas of low flux, there is a limit to what is detectable. In this case, a 22 order of magnitude flux attenuation would essentially produce particle count rates that would be well below background rates even for the strongest fission/fusion starting sources, meaning fluxes below this level become meaningless in practice.

2. When pulling data from the MGXS interface, check `Chi` for values of `NaN`. For some reason, when I generate MGXS data with the `model.convert_to_multigroup()` function on JET, some materials will end up having extremely low `sigma_f` values but will return `NaN` for `Chi`. This may be caused by a bug in the MGXS interface, but for now I simply fix the random ray interface to check for this case and set `Chi` to zero.

3. Fixed a variable capitalization to be more consistent.


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
