### PR TITLE
adding plot function to DAGMCUnvierse

### DIFF
--- a/openmc/dagmc.py
+++ b/openmc/dagmc.py
@@ -13,6 +13,7 @@ from .checkvalue import check_type, check_value
 from .surface import _BOUNDARY_TYPES
 from .bounding_box import BoundingBox
 from .utility_funcs import input_path
+from .plots import add_plot_params
 
 
 class DAGMCUniverse(openmc.UniverseBase):
@@ -565,6 +566,22 @@ class DAGMCUniverse(openmc.UniverseBase):
             else:
                 fill = mats_per_id[dag_cell.fill.id] if dag_cell.fill else None
             self.add_cell(openmc.DAGMCCell(cell_id=dag_cell_id, fill=fill))
+
+    @add_plot_params
+    def plot(self, *args, **kwargs):
+        """Display a slice plot of the DAGMCUniverse."""
+        model = openmc.Model()
+        model.geometry = openmc.Geometry(self)
+
+        for mat_name in self.material_names:
+            material = openmc.Material(name=mat_name)
+            # Placeholder nuclide to ensure material is not empty
+            material.add_nuclide('H1', 1.0)
+            # Placeholder density to ensure material is not empty
+            material.set_density('g/cc', 1.0)
+            model.materials.append(material)
+
+        return model.plot(*args, **kwargs)
 
 
 class DAGMCCell(openmc.Cell):

--- a/openmc/dagmc.py
+++ b/openmc/dagmc.py
@@ -569,7 +569,8 @@ class DAGMCUniverse(openmc.UniverseBase):
 
     @add_plot_params
     def plot(self, *args, **kwargs):
-        """Display a slice plot of the DAGMCUniverse."""
+        """Display a slice plot of the DAGMCUniverse.
+        """
         model = openmc.Model()
         model.geometry = openmc.Geometry(self)
 
@@ -577,8 +578,6 @@ class DAGMCUniverse(openmc.UniverseBase):
             material = openmc.Material(name=mat_name)
             # Placeholder nuclide to ensure material is not empty
             material.add_nuclide('H1', 1.0)
-            # Placeholder density to ensure material is not empty
-            material.set_density('g/cc', 1.0)
             model.materials.append(material)
 
         return model.plot(*args, **kwargs)

--- a/tests/unit_tests/dagmc/test_plot.py
+++ b/tests/unit_tests/dagmc/test_plot.py
@@ -7,9 +7,9 @@ pytestmark = pytest.mark.skipif(
     not openmc.lib._dagmc_enabled(), reason="DAGMC CAD geometry is not enabled."
 )
 
-def test_plotting_dagmc_geometry(request):
-    """Test plotting a DAGMC geometry with OpenMC. This is different to CSG
-    geometry plotting as the path to the DAGMC file needs handling."""
+def test_plotting_dagmc_model(request):
+    """Test plotting a DAGMC model with OpenMC. This is different to CSG
+    model plotting as the path to the DAGMC file needs handling."""
 
     dag_universe = openmc.DAGMCUniverse(request.path.parent / 'dagmc.h5m')
     csg_with_dag_inside = dag_universe.bounded_universe()
@@ -30,3 +30,11 @@ def test_plotting_dagmc_geometry(request):
     model.settings.particles = 50
 
     model.plot()
+
+
+def test_plotting_dagmc_universe(request):
+    """Test plotting a DAGMCUniverse with OpenMC. This is different to plotting
+    UniverseBase as the materials are not defined withing the DAGMCUniverse."""
+
+    dag_universe = openmc.DAGMCUniverse(request.path.parent / 'dagmc.h5m')
+    dag_universe.plot()


### PR DESCRIPTION
# Description

I noticed when we call ```.plot``` on a ```DAGMCUniverse``` it calls the inherited ```UniverseBase.plot()``` and then fails to find the materials and crashes.

This small PR adds a plot function to the ```DAGMCUniverse``` universe class that makes placeholder materials and allows users to plot a DAGMCUniverse with the appropriate material names (as found in the dagmc file)

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)