### PR TITLE
Fixing crash when calling Geometry.plot when DAGMCUniverse in geometry

### DIFF
--- a/openmc/dagmc.py
+++ b/openmc/dagmc.py
@@ -571,16 +571,7 @@ class DAGMCUniverse(openmc.UniverseBase):
     def plot(self, *args, **kwargs):
         """Display a slice plot of the DAGMCUniverse.
         """
-        model = openmc.Model()
-        model.geometry = openmc.Geometry(self)
-
-        for mat_name in self.material_names:
-            material = openmc.Material(name=mat_name)
-            # Placeholder nuclide to ensure material is not empty
-            material.add_nuclide('H1', 1.0)
-            model.materials.append(material)
-
-        return model.plot(*args, **kwargs)
+        return openmc.Geometry(self).plot(*args, **kwargs)
 
 
 class DAGMCCell(openmc.Cell):

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -756,9 +756,9 @@ class Geometry:
         """
         model = openmc.Model()
         model.geometry = self
-        model.materials = openmc.Materials(list(self.get_all_materials().values()))
+        model.materials = self.get_all_materials().values()
 
-        # Adding placeholder materials for DAGMCUniverses
+        # Add placeholder materials for DAGMCUniverses
         universes = self.get_all_universes()
         for universe in universes.values():
             if isinstance(universe, openmc.DAGMCUniverse):
@@ -766,12 +766,5 @@ class Geometry:
                     mat_dag = openmc.Material(name=name)
                     mat_dag.add_nuclide('H1', 1.0)
                     model.materials.append(mat_dag)
-
-        # Determine whether any materials contains macroscopic data and if
-        # so, set energy mode accordingly
-        for mat in self.get_all_materials().values():
-            if mat._macroscopic is not None:
-                model.settings.energy_mode = 'multi-group'
-                break
 
         return model.plot(*args, **kwargs)

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -758,6 +758,7 @@ class Geometry:
         model.geometry = self
         model.materials = openmc.Materials(list(self.get_all_materials().values()))
 
+        # Adding placeholder materials for DAGMCUniverses
         universes = self.get_all_universes()
         for universe in universes.values():
             if isinstance(universe, openmc.DAGMCUniverse):

--- a/openmc/universe.py
+++ b/openmc/universe.py
@@ -337,14 +337,6 @@ class UniverseBase(ABC, IDManagerMixin):
         """
         model = openmc.Model()
         model.geometry = openmc.Geometry(self)
-
-        # Determine whether any materials contains macroscopic data and if
-        # so, set energy mode accordingly
-        for mat in self.get_all_materials().values():
-            if mat._macroscopic is not None:
-                model.settings.energy_mode = 'multi-group'
-                break
-
         return model.plot(*args, **kwargs)
 
     def get_nuclides(self):

--- a/tests/unit_tests/dagmc/test_plot.py
+++ b/tests/unit_tests/dagmc/test_plot.py
@@ -58,5 +58,4 @@ def test_plotting_geometry_filled_with_dagmc_universe(request):
     cell2 = openmc.Cell(fill=csg_material, region=+sphere1 & -sphere2)
 
     geometry = openmc.Geometry([cell1, cell2])
-
     geometry.plot()

--- a/tests/unit_tests/dagmc/test_plot.py
+++ b/tests/unit_tests/dagmc/test_plot.py
@@ -50,6 +50,7 @@ def test_plotting_geometry_filled_with_dagmc_universe(request):
     sphere1 = openmc.Sphere(r=50.0)
     sphere2 = openmc.Sphere(r=60.0, boundary_type='vacuum')
 
+    # Adding a material to the CSG Universe to check all materials are accounted for
     csg_material = openmc.Material(name='csg_material')
     csg_material.add_nuclide("H1", 1.0)
 

--- a/tests/unit_tests/dagmc/test_plot.py
+++ b/tests/unit_tests/dagmc/test_plot.py
@@ -38,3 +38,24 @@ def test_plotting_dagmc_universe(request):
 
     dag_universe = openmc.DAGMCUniverse(request.path.parent / 'dagmc.h5m')
     dag_universe.plot()
+
+
+def test_plotting_geometry_filled_with_dagmc_universe(request):
+    """Test plotting a geometry with OpenMC. This is an edge case when plotting
+    geometry as often geometry objects don't include a DAGMCUniverse. The
+    inclusion of a DAGMCUniverse requires special handling for the materials."""
+
+    dag_universe = openmc.DAGMCUniverse(request.path.parent / 'dagmc.h5m', auto_geom_ids=True)
+
+    sphere1 = openmc.Sphere(r=50.0)
+    sphere2 = openmc.Sphere(r=60.0, boundary_type='vacuum')
+
+    csg_material = openmc.Material(name='csg_material')
+    csg_material.add_nuclide("H1", 1.0)
+
+    cell1 = openmc.Cell(fill=dag_universe, region=-sphere1)
+    cell2 = openmc.Cell(fill=dag_universe, region=+sphere1 & -sphere2)
+
+    geometry = openmc.Geometry([cell1, cell2])
+
+    geometry.plot()

--- a/tests/unit_tests/dagmc/test_plot.py
+++ b/tests/unit_tests/dagmc/test_plot.py
@@ -54,7 +54,7 @@ def test_plotting_geometry_filled_with_dagmc_universe(request):
     csg_material.add_nuclide("H1", 1.0)
 
     cell1 = openmc.Cell(fill=dag_universe, region=-sphere1)
-    cell2 = openmc.Cell(fill=dag_universe, region=+sphere1 & -sphere2)
+    cell2 = openmc.Cell(fill=csg_material, region=+sphere1 & -sphere2)
 
     geometry = openmc.Geometry([cell1, cell2])
 


### PR DESCRIPTION
# Description

Currently when calling ```geometry.plot``` for a geometry that has a DAGMCUniverse within the code crashes with this error

```python
import openmc
dag_universe = openmc.DAGMCUniverse('tests/unit_tests/dagmc/dagmc.h5m', auto_geom_ids=True)
sphere1 = openmc.Sphere(r=50.0)
sphere2 = openmc.Sphere(r=60.0, boundary_type='vacuum')
cell1 = openmc.Cell(fill=dag_universe, region=-sphere1)
cell2 = openmc.Cell(region=+sphere1 & -sphere2)
geometry = openmc.Geometry([cell1, cell2])
geometry.plot()
# >           raise RuntimeError(error_msg)
# E           RuntimeError: Material with name/ID 'no-void fuel' not found for volume (cell) 3
```

This PR adapts the ```geometry.plot()``` function so that it makes placeholder materials for the DAGMC geometry, this is similar to PR #3451 which did a similar operation for DAGMCUniverse. That is useful for plotting DAGMCUniverses on their own. However, as we typically use DAGMC within a CSG Universe and filling a geometry, this function proposed in this PR would also be useful.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)