### PR TITLE
Adding checks to geometry.plot to avoid material name overlaps

### DIFF
--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -769,7 +769,7 @@ class Geometry:
                 continue
             for name in universe.material_names:
                 # if this name is already present in the model, skip it
-                # (this can happen if the same material is used in multiple
+                # (this can happen if the same material name is used in multiple
                 # universes)
                 if name in all_material_names:
                     continue

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -748,27 +748,6 @@ class Geometry:
         clone.root_universe = self.root_universe.clone()
         return clone
 
-    # @add_plot_params
-    # def plot(self, *args, **kwargs):
-    #     """Display a slice plot of the geometry.
-
-    #     .. versionadded:: 0.14.0
-    #     """
-    #     model = openmc.Model()
-    #     model.geometry = self
-    #     model.materials = self.get_all_materials().values()
-
-    #     # Add placeholder materials for DAGMCUniverses
-    #     universes = self.get_all_universes()
-    #     for universe in universes.values():
-    #         if isinstance(universe, openmc.DAGMCUniverse):
-    #             for name in universe.material_names:
-    #                 mat_dag = openmc.Material(name=name)
-    #                 mat_dag.add_nuclide('H1', 1.0)
-    #                 model.materials.append(mat_dag)
-
-    #     return model.plot(*args, **kwargs)
-
 
     @add_plot_params
     def plot(self, *args, **kwargs):

--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -748,7 +748,6 @@ class Geometry:
         clone.root_universe = self.root_universe.clone()
         return clone
 
-
     @add_plot_params
     def plot(self, *args, **kwargs):
         """Display a slice plot of the geometry.

--- a/tests/unit_tests/dagmc/test_plot.py
+++ b/tests/unit_tests/dagmc/test_plot.py
@@ -48,14 +48,21 @@ def test_plotting_geometry_filled_with_dagmc_universe(request):
     dag_universe = openmc.DAGMCUniverse(request.path.parent / 'dagmc.h5m', auto_geom_ids=True)
 
     sphere1 = openmc.Sphere(r=50.0)
-    sphere2 = openmc.Sphere(r=60.0, boundary_type='vacuum')
+    sphere2 = openmc.Sphere(r=60.0)
+    sphere2 = openmc.Sphere(r=70.0, boundary_type='vacuum')
 
-    # Adding a material to the CSG Universe to check all materials are accounted for
+    # Adding a material to the CSG Universe to check universe materials are accounted for
     csg_material = openmc.Material(name='csg_material')
+    csg_material.add_nuclide("H1", 1.0)
+
+    # Adding a material with the same name as a dagmc material to check that
+    # the plot can handel two materials with the same name from different universes
+    csg_material = openmc.Material(name=dag_universe.material_names[0])
     csg_material.add_nuclide("H1", 1.0)
 
     cell1 = openmc.Cell(fill=dag_universe, region=-sphere1)
     cell2 = openmc.Cell(fill=csg_material, region=+sphere1 & -sphere2)
 
     geometry = openmc.Geometry([cell1, cell2])
+
     geometry.plot()


### PR DESCRIPTION
## Description

When plotting a geometry that has both a Universe and DAGMCUniverse it is possible to have material names in the Universe that are the same as material names in the DAGMCUniverse. This can cause a RuntimeError when using geometry.plot.

```
RuntimeError: More than one material found with name '41'. Please ensure materials have unique names if using this property to assign materials.
```

Many thanks to @pshriwise for spotting this oversight I made in PR #3455 

I believe this PR fixes the error and the logic works for multiple combinations of different types of Universes and different ordering of the universes.

I have also add to the test to include names from the dagmc model in the CSG Universe

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)