### PR TITLE
Weight Window Birth Scaling

### DIFF
--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -435,7 +435,7 @@ private:
 
   double wgt_ {1.0};
   double wgt_born_ {1.0};
-  double ww_born_ {-1.0};
+  double wgt_ww_born_ {-1.0};
   double mu_;
   double time_ {0.0};
   double time_last_ {0.0};
@@ -547,8 +547,8 @@ public:
   double wgt_born() const { return wgt_born_; }
 
   // Weight window value at birth
-  double& ww_born() { return ww_born_; }
-  const double& ww_born() const { return ww_born_; }
+  double& wgt_ww_born() { return wgt_ww_born_; }
+  const double& wgt_ww_born() const { return wgt_ww_born_; }
 
   // Statistic weight of particle at last collision
   double& wgt_last() { return wgt_last_; }

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -615,7 +615,7 @@ void initialize_history(Particle& p, int64_t index_source)
   p.write_track() = check_track_criteria(p);
 
   // Set the particle's initial weight window value.
-  p.ww_born() = -1.0;
+  p.wgt_ww_born() = -1.0;
   apply_weight_windows(p);
 
   // Display message if high verbosity or trace is on

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -76,12 +76,12 @@ void apply_weight_windows(Particle& p)
 
   // If particle has not yet had its birth weight window value set, set it to
   // the current weight window (or 1.0 if not born in a weight window).
-  if (p.ww_born() == -1.0) {
+  if (p.wgt_ww_born() == -1.0) {
     if (weight_window.is_valid()) {
-      p.ww_born() =
+      p.wgt_ww_born() =
         (weight_window.lower_weight + weight_window.upper_weight) / 2;
     } else {
-      p.ww_born() = 1.0;
+      p.wgt_ww_born() = 1.0;
     }
   }
 
@@ -91,7 +91,7 @@ void apply_weight_windows(Particle& p)
 
   // Normalize weight windows based on particle's starting weight
   // and the value of the weight window the particle was born in.
-  weight_window.scale(p.wgt_born() / p.ww_born());
+  weight_window.scale(p.wgt_born() / p.wgt_ww_born());
 
   // get the paramters
   double weight = p.wgt();


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Overview

Currently, particles starting in regions with very low weight window values may aggressively split shortly after being born. This reduces sampling efficiency as there is no reason to place such great importance on particles right at birth. 

This PR introduces two normalization factors to improve the behavior of weight windows so as to prevent aggressive splitting or rouletting right after particles are born.

# Improvement 1: Scaling by Weight Window Value at Birth

The first normalization step involves adding a new variable to the particle object (`ww_born_`) that records the weight window value of the particle when it is born. This value can then be used to divide any weight windows before they are applied to the particle. 

# Improvement 2: Scaling by Particle Birth Weight

In the context of importance sampling, particles may be sampled with very low weights leading to immediate weight window effects right after birth. Thus, the second normalization step involves multiplying weight window values by the particle's starting weight.

# Testing

To test this problem, I use a greatly simplified 2D model of JET that retains some key characteristics. Namely, it is a 40x40 meter model that has a 2.5m thick bioshield and 30cm thick borated concrete liner around a room filled with air. Inside the room, there is a large donut shape in the middle of the room that contains a 14.1 MeV plasma source (with chamber walls, steel shielding, and coolant layers around it).

Geometry:

![jetson_2d](https://github.com/user-attachments/assets/6f4328c0-4edc-41bf-a465-fac8338e6f78)

This is a great test case for weight windows, as we can see the high difficultly that analog MC has in delivering particles to all areas of the bioshield. Below, we see the analog MC flux without any weight windows, with particles only able to explore a few 10's of cm into the concrete wall.

![without_ww](https://github.com/user-attachments/assets/30505d45-4ee2-4fed-a2b9-96532398aa1d)

Below, we can see that random ray FW-CADIS generated weight windows (with 2 energy groups, on a 10cm resolution mesh) are highly effective, scoring tallies everywhere in just a few minutes on my laptop:

![with_ww](https://github.com/user-attachments/assets/1ff542b2-a32e-4943-a349-7912778ae52a)

To test the improvement that scaling delivers, I ran the problem for a target time of around 300 seconds on my laptop and studied three cases: 1) without weight windows, 2) with weight windows (no scaling), and 3) with weight windows (with scaling, as in this PR). As all the runtimes are around the same, the key figures of merit are the average relative error for all tallies (with flux tallied at 10cm mesh resolution) and the particle tracking rate.

Results summary:

|  | No Weight Windows | Regular Weight Windows | Scaled Weight Windows (This PR) |
|---|---|---|---|
| Particles/batch |                              450,000  |                                               1,000  |                                                                 45,000  |
| Batches |                                           50  |                                                       10  |                                                                            10  |
| Runtime [s] |                                        295  |                                                    338  |                                                                         386  |
| Particles/s |                                 76,151  |                                                       30  |                                                                    1,166  |
| Cells Hit [%] | 83.0 | 100.0 | 100.0 |
| Avg Relative Error [%] | 22.8 | 9.7 | 7.6 |
| Maximum Relative Error [%] | 100.0 | 99.2 | 94.6 |

The weight windows perform well both with and without the scaling. In both cases, the weight windows are able to deliver scoring particles to all regions, whereas without any weight windows very few particles migrate into the bio shield at all. The scaling strategy does show significant improvements both numerically and practically as compared to the unscaled weight window usage. For relatively equal runtimes, we get a non-trivial decrease in average relative error (form 9.7% to 7.6%) and a significant improvement in particle tracking rate from 30 particles/sec to over 1000 particles/sec. While the tracking rate by itself is somewhat meaningless, lower tracking rates create two practical problems: 1) load imbalances between threads become more significant due to threads waiting for long particle histories to complete on other threads, and 2) for a given target runtime, fewer starting particles are sampled, potentially adding noise/bias given that the starting source distribution is not as well explored.

To get an idea of why the scaling is important, we can look at the random ray FW-CADIS weight windows for the fast group on this problem:

![fast_ww](https://github.com/user-attachments/assets/3af6f9a0-08ae-4f7a-9459-46386086913f)


as can be seen above, particles in the plasma region of the problem are starting in areas with lower bound weight window values of 10^-3. Absent the new scaling technique, this means that each sampled particle is likely to immediately split into 1,000 copies. Even if the `max_split` variable is set to a lower value, the particle will still aggressively split over its first few events, such that 1,000 copies will still be made very early in its lifetime. Thus, the new scaling technique ensures that particles at least travel to the wall of the tokamak before mild splitting events begin to occur.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
