### PR TITLE
Fix Dockerfile DAGMC build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,7 @@ RUN if [ "$build_dagmc" = "on" ]; then \
         # Install addition packages required for DAGMC
         apt-get -y install libeigen3-dev libnetcdf-dev libtbb-dev libglfw3-dev \
         && pip install --upgrade numpy \
+        && pip install --no-cache-dir setuptools cython \
         # Clone and install EMBREE
         && mkdir -p $HOME/EMBREE && cd $HOME/EMBREE \
         && git clone --single-branch -b ${EMBREE_TAG} --depth 1 ${EMBREE_REPO} \


### PR DESCRIPTION
# Description

After #3442 was merged, our Docker builds started working again but the DAGMC option is still broken. The explanation is as follows: the MOAB → PyMOAB step of the DAGMC tool-chain aborts during its CMake configure phase because the Python virtual-environment that the Dockerfile creates is missing `setuptools` (and therefore also has no Cython).
The relevant lines in the [log](https://github.com/openmc-dev/openmc/actions/runs/15836355163/job/44640650549) are:
```
ModuleNotFoundError: No module named 'setuptools'
...
CMake Error at pymoab/CMakeLists.txt:26 (MESSAGE): Python setuptools module is missing. 
```
Because the `find_package(Cython)` call follows immediately after this test, CMake then also reports that Cython cannot be found, so configuration terminates and the entire job fails.

The fix here is to make sure that setuptools and Cython are installed in the virtual environment.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>