### PR TITLE
Limit Random Ray Weight Window Generation to Final Batch

### DIFF
--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -400,8 +400,11 @@ void finalize_batch()
   simulation::time_tallies.stop();
 
   // update weight windows if needed
-  for (const auto& wwg : variance_reduction::weight_windows_generators) {
-    wwg->update();
+  if (settings::solver_type != SolverType::RANDOM_RAY ||
+      simulation::current_batch == settings::n_batches) {
+    for (const auto& wwg : variance_reduction::weight_windows_generators) {
+      wwg->update();
+    }
   }
 
   // Reset global tally results


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Currently OpenMC refreshes weight window parameters at the end of every batch, so as to support iterative MAGIC weight window generation with Monte Carlo. However, as the random ray solver does not need to use the weight window information during its simulation, it is more optimal to put off calculation of weight window parameters until the end of the program when fluxes are fully converged.

This PR adds a simple check to restrict weight window updates until the last batch when in random ray mode. Note that the same weight windows will still be output at the end, as previously we were just overwriting the weight window values every iteration.

# Impact

On the JETSON 2D model (a simplified 2D version of JET), this PR reduces the overall weight window generation time from 3.9 seconds down to 0.23 seconds (a 17x speedup) when run on my laptop. The impact is going to be even larger when run on bigger machines, as I don't think the weight window updating time is parallelized (which is left as a TODO item for now).

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
