### PR TITLE
Optimize Mapping of Random Ray Source Regions to Tallies

### DIFF
--- a/include/openmc/random_ray/flat_source_domain.h
+++ b/include/openmc/random_ray/flat_source_domain.h
@@ -34,7 +34,7 @@ public:
 
   int64_t add_source_to_scalar_flux();
   virtual void batch_reset();
-  void convert_source_regions_to_tallies();
+  void convert_source_regions_to_tallies(int64_t start_sr_id);
   void reset_tally_volumes();
   void random_ray_tally();
   virtual void accumulate_iteration_flux();

--- a/src/random_ray/flat_source_domain.cpp
+++ b/src/random_ray/flat_source_domain.cpp
@@ -473,7 +473,7 @@ void FlatSourceDomain::convert_source_regions_to_tallies(int64_t start_sr_id)
       // Loop over all active tallies. This logic is essentially identical
       // to what happens when scanning for applicable tallies during
       // MC transport.
-      for (auto i_tally : model::active_tallies) {
+      for (int i_tally = 0; i_tally < model::tallies.size(); i_tally++) {
         Tally& tally {*model::tallies[i_tally]};
 
         // Initialize an iterator over valid filter bin combinations.

--- a/src/random_ray/flat_source_domain.cpp
+++ b/src/random_ray/flat_source_domain.cpp
@@ -421,7 +421,12 @@ double FlatSourceDomain::compute_k_eff(double k_eff_old) const
 // be passed back to the caller to alert them that this function doesn't
 // need to be called for the remainder of the simulation.
 
-void FlatSourceDomain::convert_source_regions_to_tallies()
+// It takes as an argument the starting index in the source region array,
+// and it will operate from that index until the end of the array. This
+// is useful as it can be called for both explicit user source regions or
+// when a source region mesh is overlaid.
+
+void FlatSourceDomain::convert_source_regions_to_tallies(int64_t start_sr_id)
 {
   openmc::simulation::time_tallies.start();
 
@@ -430,7 +435,7 @@ void FlatSourceDomain::convert_source_regions_to_tallies()
 
 // Attempt to generate mapping for all source regions
 #pragma omp parallel for
-  for (int64_t sr = 0; sr < n_source_regions(); sr++) {
+  for (int64_t sr = start_sr_id; sr < n_source_regions(); sr++) {
 
     // If this source region has not been hit by a ray yet, then
     // we aren't going to be able to map it, so skip it.
@@ -1525,6 +1530,9 @@ void FlatSourceDomain::finalize_discovered_source_regions()
     // order due to shared memory threading.
     std::sort(keys.begin(), keys.end());
 
+    // Remember the index of the first new source region
+    int64_t start_sr_id = source_regions_.n_source_regions();
+
     // Append the source regions in the sorted key order.
     for (const auto& key : keys) {
       const SourceRegion& sr = discovered_source_regions_[key];
@@ -1532,9 +1540,8 @@ void FlatSourceDomain::finalize_discovered_source_regions()
       source_regions_.push_back(sr);
     }
 
-    // If any new source regions were discovered, we need to update the
-    // tally mapping between source regions and tally bins.
-    mapped_all_tallies_ = false;
+    // Map all new source regions to tallies
+    convert_source_regions_to_tallies(start_sr_id);
   }
 
   discovered_source_regions_.clear();

--- a/src/random_ray/random_ray_simulation.cpp
+++ b/src/random_ray/random_ray_simulation.cpp
@@ -508,8 +508,9 @@ void RandomRaySimulation::simulate()
         domain_->accumulate_iteration_flux();
 
         // Generate mapping between source regions and tallies
-        if (!domain_->mapped_all_tallies_) {
-          domain_->convert_source_regions_to_tallies();
+        if (!domain_->mapped_all_tallies_ &&
+            !RandomRay::mesh_subdivision_enabled_) {
+          domain_->convert_source_regions_to_tallies(0);
         }
 
         // Use above mapping to contribute FSR flux data to appropriate

--- a/src/random_ray/source_region.cpp
+++ b/src/random_ray/source_region.cpp
@@ -276,10 +276,6 @@ void SourceRegionContainer::adjoint_reset()
     MomentArray {0.0, 0.0, 0.0});
   std::fill(flux_moments_t_.begin(), flux_moments_t_.end(),
     MomentArray {0.0, 0.0, 0.0});
-
-  for (auto& task_set : tally_task_) {
-    task_set.clear();
-  }
 }
 
 } // namespace openmc

--- a/src/random_ray/source_region.cpp
+++ b/src/random_ray/source_region.cpp
@@ -259,15 +259,11 @@ void SourceRegionContainer::adjoint_reset()
     MomentMatrix {0.0, 0.0, 0.0, 0.0, 0.0, 0.0});
   std::fill(mom_matrix_t_.begin(), mom_matrix_t_.end(),
     MomentMatrix {0.0, 0.0, 0.0, 0.0, 0.0, 0.0});
-  for (auto& task_set : volume_task_) {
-    task_set.clear();
-  }
   std::fill(scalar_flux_old_.begin(), scalar_flux_old_.end(), 0.0);
   std::fill(scalar_flux_new_.begin(), scalar_flux_new_.end(), 0.0);
   std::fill(scalar_flux_final_.begin(), scalar_flux_final_.end(), 0.0);
   std::fill(source_.begin(), source_.end(), 0.0f);
   std::fill(external_source_.begin(), external_source_.end(), 0.0f);
-
   std::fill(source_gradients_.begin(), source_gradients_.end(),
     MomentArray {0.0, 0.0, 0.0});
   std::fill(flux_moments_old_.begin(), flux_moments_old_.end(),


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Currently in OpenMC, at the end of a batch, if a new source region is discovered during transport then a search of all known source regions is done to relate them to any spatial tally filters. Source regions that have already been mapped to tallies will exit this process early, saving time. However, the exit process happens after a `Particle` object is allocated and searched for with `exhaustive_find_cell()`, making this mapping test become quite expensive. 

The present PR changes the behavior such that source regions are only mapped to tallies once. When mesh overlay is being used, this process occurs at the time when newly discovered source regions are moved out of the dynamic thread safe source region container into the permanent known source region container.

I had also thought about just adding in another data variable to the source region itself to use as a flag to indicate if it has been mapped to tallies yet or not. This would greatly speed up the exit process and save a lot of time. However, on large problems like JET we can easily have over 100 million source regions, so it's not a great design pattern to loop over all 100 million just to find one that needs mapping. Thus, the optimization proposed in this PR seems like the better long term route.

Note that this PR should not change any results from the code -- the same tallies will still be scored, but we are just reducing wasted effort.

# Impact

I tested this new optimization out on a short run of the JET model on a large CPU node. The impacts are significant. Without this PR, tallying takes 55.78 seconds during the adjoint phase of the simulation. With this PR, tallying only takes 0.98 seconds (a 57x speedup for this section of the code). 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
