### PR TITLE
automatically finding appropriate dimension when making regular mesh from domain

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1095,7 +1095,7 @@ class RegularMesh(StructuredMesh):
     def from_domain(
         cls,
         domain: HasBoundingBox,
-        dimension: Sequence[int] = (10, 10, 10),
+        dimension: Sequence[int] | int = 1000,
         mesh_id: int | None = None,
         name: str = ''
     ):
@@ -1107,8 +1107,11 @@ class RegularMesh(StructuredMesh):
             The object passed in will be used as a template for this mesh. The
             bounding box of the property of the object passed will be used to
             set the lower_left and upper_right and of the mesh instance
-        dimension : Iterable of int
-            The number of mesh cells in each direction (x, y, z).
+        dimension : Iterable of int | int
+            The number of mesh cells in total or number of mesh cells in each
+            direction (x, y, z). If a single integer is provided, the domain
+            will will be divided into that many mesh cells with roughly equal
+            lengths in each direction (cubes).
         mesh_id : int
             Unique identifier for the mesh
         name : str
@@ -1126,6 +1129,16 @@ class RegularMesh(StructuredMesh):
         mesh = cls(mesh_id=mesh_id, name=name)
         mesh.lower_left = domain.bounding_box[0]
         mesh.upper_right = domain.bounding_box[1]
+        if isinstance(dimension, int):
+            cv.check_greater_than("dimension", dimension, 1, equality=True)
+            # If a single integer is provided, divide the domain into that many
+            # mesh cells with roughly equal lengths in each direction
+            ideal_cube_volume = domain.bounding_box.volume / dimension
+            ideal_cube_size = ideal_cube_volume ** (1 / 3)
+            dimension = [
+                max(1, int(round(side / ideal_cube_size)))
+                for side in domain.bounding_box.width
+            ]
         mesh.dimension = dimension
 
         return mesh

--- a/tests/unit_tests/test_mesh_from_domain.py
+++ b/tests/unit_tests/test_mesh_from_domain.py
@@ -147,3 +147,27 @@ def test_reg_mesh_from_geometry():
 def test_error_from_unsupported_object():
     with pytest.raises(TypeError):
         openmc.RegularMesh.from_domain("vacuum energy")
+
+
+def test_regularmesh_from_domain_error_from_small_dimensions():
+    surface = openmc.Sphere(r=20)
+    cell = openmc.Cell(region=-surface)
+    with pytest.raises(
+        ValueError, match='Unable to set "dimension" to "-2" since it is less than "1"'
+    ):
+        openmc.RegularMesh.from_domain(domain=cell, dimension=-2)
+
+
+def test_dimensions_from_domain_dimensions_from_int():
+    region = openmc.model.RectangularParallelepiped(
+        xmin=-100,
+        xmax=150,
+        ymin=-50,
+        ymax=200,
+        zmin=300,
+        zmax=400,
+        boundary_type="vacuum",
+    )
+    cell = openmc.Cell(region=-region)
+    mesh = openmc.RegularMesh.from_domain(domain=cell, dimension=1000)
+    assert mesh.dimension == (14, 14, 5)


### PR DESCRIPTION
# Description

I have been using this modified RegularMesh.from_domain locally and though it might be nice to share with others. This is a tiny quality of life improvement for users who just want n numbers of mesh voxels and don't want to think about how many subdivisions for each dimension.

The RegularMesh.from_domain function can accommodate this as it has access to the domain bounding box. So we could accept a single int for the dimension and use this to calculate the number of subdivisions needed in each direction to result in cubes across the domain.

I make use of this as I tend to just want a large number of cubes covering the geometry and I scale the magnitude of the int to my memory limits.

This is similar to the pixel argument used in openmc.plot which can take a tuple of ints for x and y or a single int for total number of pixels.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)