### PR TITLE
added openmc.Material.mean_free_path function

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1718,6 +1718,36 @@ class Material(IDManagerMixin):
         return mat
 
 
+    def mean_free_path(self, energy: float) -> float:
+        """Calculate the mean free path of neutrons in the material at a given
+        energy.
+
+        .. versionadded:: 0.15.3
+
+        Parameters
+        ----------
+        energy : float
+            Neutron energy in eV
+
+        Returns
+        -------
+        float
+            Mean free path in cm
+
+        """
+        from openmc.plotter import _calculate_cexs_elem_mat
+
+        energy_grid, cexs = _calculate_cexs_elem_mat(
+            this=self,
+            types=["total"],
+        )
+        total_cexs = cexs[0]
+
+        interpolated_cexs = float(np.interp(energy, energy_grid, total_cexs))
+
+        return 1.0 / interpolated_cexs
+
+
 class Materials(cv.CheckedList):
     """Collection of Materials used for an OpenMC simulation.
 

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -710,3 +710,16 @@ def test_avoid_subnormal(run_in_tmpdir):
     # When read back in, the density should be zero
     mats = openmc.Materials.from_xml()
     assert mats[0].get_nuclide_atom_densities()['H2'] == 0.0
+
+
+def test_mean_free_path():
+
+    mat1 = openmc.Material()
+    mat1.add_nuclide('Si28', 1.0)
+    mat1.set_density('g/cm3', 2.32)
+    assert mat2.mean_free_path(energy=14e6) == pytest.approx(5.65, abs=1e-2)
+
+    mat2 = openmc.Material()
+    mat2.add_nuclide('Pb208', 1.0)
+    mat2.set_density('g/cm3', 11.34)
+    assert mat1.mean_free_path(energy=14e6) == pytest.approx(11.41, abs=1e-2)

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -717,9 +717,9 @@ def test_mean_free_path():
     mat1 = openmc.Material()
     mat1.add_nuclide('Si28', 1.0)
     mat1.set_density('g/cm3', 2.32)
-    assert mat2.mean_free_path(energy=14e6) == pytest.approx(5.65, abs=1e-2)
+    assert mat1.mean_free_path(energy=14e6) == pytest.approx(11.41, abs=1e-2)
 
     mat2 = openmc.Material()
     mat2.add_nuclide('Pb208', 1.0)
     mat2.set_density('g/cm3', 11.34)
-    assert mat1.mean_free_path(energy=14e6) == pytest.approx(11.41, abs=1e-2)
+    assert mat2.mean_free_path(energy=14e6) == pytest.approx(5.65, abs=1e-2)


### PR DESCRIPTION
This PR proposes that we add a ```mean_free_path``` method to the ```openmc.Material()``` class.

@jtramm this might be useful when setting the mesh sizes to a couple of mean free paths in your nice FW-CADIS workflow. Where we don't want the weight window mesh voxel sizes to be more than a few mean free paths of the material.

I would be keen to one day extend this to allow photons but I don't think the underlying ```_calculate_cexs_elem_mat``` functions support particles other than neutrons.

Example use

```python
import openmc

mat_concrete = openmc.Material(name="concrete")
mat_concrete.add_element("H", 0.168759)
mat_concrete.add_element("C", 0.001416)
mat_concrete.add_element("O", 0.562524)
mat_concrete.add_element("Na", 0.011838)
mat_concrete.add_element("Mg", 0.0014)
mat_concrete.add_element("Al", 0.021354)
mat_concrete.add_element("Si", 0.204115)
mat_concrete.add_element("K", 0.005656)
mat_concrete.add_element("Ca", 0.018674)
mat_concrete.add_element("Fe", 0.00426)
mat_concrete.set_density("g/cm3", 2.3)

print(mat_concrete.mean_free_path(energy=14e6))
>>>8.220341386874415
```

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)