### PR TITLE
Updated Docs to Not Give Specific Python Version Requirement

### DIFF
--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -515,10 +515,13 @@ to install the Python package in :ref:`"editable" mode <devguide_editable>`.
 Prerequisites
 -------------
 
-The Python API works with Python 3.8+. In addition to Python itself, the API
-relies on a number of third-party packages. All prerequisites can be installed
-using Conda_ (recommended), pip_, or through the package manager in most Linux
-distributions.
+In addition to Python itself, the OpenMC Python API relies on a number of
+third-party packages. All prerequisites can be installed using Conda_
+(recommended), pip_, or through the package manager in most Linux distributions.
+The current required Python version and up-to-date list of package dependencies
+can be found in the `pyproject.toml <https://github.com/openmc-dev/openmc/blob/develop/pyproject.toml>`_
+file in the root directory of the OpenMC repository. An overview of these
+dependencies is provided below.
 
 .. admonition:: Required
    :class: error


### PR DESCRIPTION


<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Currently the docs have a place that says the OpenMC Python API supports 3.8+, when in reality it is 3.11+.

This PR updates the docs to drop this reference and refer users instead to the pyproject.toml.



# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
