### PR TITLE
Introduce `openmc.lib.TemporarySession` context manager

### DIFF
--- a/docs/source/pythonapi/capi.rst
+++ b/docs/source/pythonapi/capi.rst
@@ -89,6 +89,7 @@ Classes
    SphericalMesh
    SurfaceFilter
    Tally
+   TemporarySession
    UniverseFilter
    UnstructuredMesh
    WeightFilter

--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -215,7 +215,6 @@ class MicroXS:
         temperature: float = 293.6,
         nuclides: Sequence[str] | None = None,
         reactions: Sequence[str] | None = None,
-        session: openmc.lib.TemporarySession | None = None,
         **init_kwargs: dict,
     ) -> MicroXS:
         """Generated microscopic cross sections from a known flux.

--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -224,10 +224,9 @@ class MicroXS:
         sections available. MicroXS entry will be 0 if the nuclide cross section
         is not found.
 
-        For repeated calls to this method, it is recommended to create a context
-        manager using the :class:`openmc.lib.TemporarySession` class and pass it
-        to the `session` argument to avoid re-initializing OpenMC and loading
-        cross sections each time.
+        It is recommended to make repeated calls to this method within a context
+        manager using the :class:`openmc.lib.TemporarySession` class to avoid
+        re-initializing OpenMC and loading cross sections each time.
 
         .. versionadded:: 0.15.0
 
@@ -248,9 +247,6 @@ class MicroXS:
         reactions : list of str, optional
             Reactions to get cross sections for. If not specified, all neutron
             reactions listed in the depletion chain file are used.
-        session : TemporaryLibSession, optional
-            A temporary OpenMC shared library session. If not provided, a new
-            session will be created.
         **init_kwargs : dict
             Keyword arguments passed to :func:`openmc.lib.init`
 
@@ -307,7 +303,7 @@ class MicroXS:
                     )
 
         # Compute microscopic cross sections within a temporary session
-        if session is None:
+        if not openmc.lib.is_initialized:
             with openmc.lib.TemporarySession(**init_kwargs):
                 compute_microxs()
         else:

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -4,7 +4,9 @@ from ctypes import (c_bool, c_int, c_int32, c_int64, c_double, c_char_p,
                     c_uint64, c_size_t)
 import sys
 import os
+from pathlib import Path
 from random import getrandbits
+from tempfile import TemporaryDirectory
 
 import numpy as np
 from numpy.ctypeslib import as_array
@@ -615,6 +617,63 @@ def run_in_memory(**kwargs):
         yield
     finally:
         finalize()
+
+
+class TemporarySession:
+    """Context manager for running via openmc.lib in a temporary directory.
+
+    This class is useful for accessing functionality from openmc.lib without
+    polluting your current working directory with OpenMC files. It is used
+    internally as a persistent session to avoid loading cross sections multiple
+    times.
+
+    Parameters
+    ----------
+    model : openmc.Model, optional
+        OpenMC model to use for the session. If None, a minimal working model is
+        created.
+    **init_kwargs
+        Keyword arguments to pass to :func:`openmc.lib.init`.
+
+    Attributes
+    ----------
+    model : openmc.Model
+        The OpenMC model used for the session.
+
+    """
+    def __init__(self, model=None, **init_kwargs):
+        self.init_kwargs = init_kwargs
+        if model is None:
+            surf = openmc.Sphere(boundary_type="vacuum")
+            cell = openmc.Cell(region=-surf)
+            model = openmc.Model()
+            model.geometry = openmc.Geometry([cell])
+            model.settings = openmc.Settings(
+                particles=1, batches=1, output={'summary': False})
+        self.model = model
+
+    def __enter__(self):
+        """Initialize the OpenMC library in a temporary directory."""
+        # Store original working directory
+        self.orig_dir = Path.cwd()
+
+        # Set up temporary directory
+        self.tmp_dir = TemporaryDirectory()
+        working_dir = Path(self.tmp_dir.name)
+        working_dir.mkdir(parents=True, exist_ok=True)
+        os.chdir(working_dir)
+
+        # Export model and initialize OpenMC
+        self.model.export_to_model_xml()
+        openmc.lib.init(**self.init_kwargs)
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Finalize the OpenMC library and clean up temporary directory."""
+        openmc.lib.finalize()
+        os.chdir(self.orig_dir)
+        self.tmp_dir.cleanup()
 
 
 class _DLLGlobal:

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -654,6 +654,10 @@ class TemporarySession:
 
     def __enter__(self):
         """Initialize the OpenMC library in a temporary directory."""
+        # Make sure OpenMC is not already initialized
+        if openmc.lib.is_initialized:
+            raise RuntimeError("openmc.lib is already initialized.")
+
         # Store original working directory
         self.orig_dir = Path.cwd()
 
@@ -671,9 +675,11 @@ class TemporarySession:
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Finalize the OpenMC library and clean up temporary directory."""
-        openmc.lib.finalize()
-        os.chdir(self.orig_dir)
-        self.tmp_dir.cleanup()
+        try:
+            openmc.lib.finalize()
+        finally:
+            os.chdir(self.orig_dir)
+            self.tmp_dir.cleanup()
 
 
 class _DLLGlobal:

--- a/openmc/lib/nuclide.py
+++ b/openmc/lib/nuclide.py
@@ -40,8 +40,14 @@ def load_nuclide(name):
     name : str
         Name of the nuclide, e.g. 'U235'
 
+    Returns
+    -------
+    Nuclide
+        The class:`Nuclide` that was just loaded.
+
     """
     _dll.openmc_load_nuclide(name.encode(), None, 0)
+    return nuclides[name]
 
 
 class Nuclide(_FortranObject):

--- a/openmc/weight_windows.py
+++ b/openmc/weight_windows.py
@@ -1041,10 +1041,6 @@ class WeightWindowsList(list):
         # Get absolute path before moving to temporary directory
         path = Path(path).resolve()
 
-        with change_directory(tmpdir=True):
-            # Write the model to an XML file
-            model.export_to_model_xml()
-
-            # Load the model with openmc.lib and then export it to an HDF5 file
-            with openmc.lib.run_in_memory(**init_kwargs):
-                openmc.lib.export_weight_windows(path)
+        # Load the model with openmc.lib and then export it to an HDF5 file
+        with openmc.lib.TemporarySession(model, **init_kwargs):
+            openmc.lib.export_weight_windows(path)

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -1114,7 +1114,7 @@ extern "C" size_t nuclides_size()
 extern "C" int openmc_load_nuclide(const char* name, const double* temps, int n)
 {
   if (data::nuclide_map.find(name) == data::nuclide_map.end() ||
-      data::nuclide_map.at(name) >= data::elements.size()) {
+      data::nuclide_map.at(name) >= data::nuclides.size()) {
     LibraryKey key {Library::Type::neutron, name};
     const auto& it = data::library_map.find(key);
     if (it == data::library_map.end()) {
@@ -1215,7 +1215,6 @@ extern "C" int openmc_nuclide_collapse_rate(int index, int MT,
     *xs = data::nuclides[index]->collapse_rate(
       MT, temperature, {energy, energy + n + 1}, {flux, flux + n});
   } catch (const std::out_of_range& e) {
-    fmt::print("Caught error\n");
     set_errmsg(e.what());
     return OPENMC_E_OUT_OF_BOUNDS;
   }

--- a/tests/unit_tests/test_deplete_chain.py
+++ b/tests/unit_tests/test_deplete_chain.py
@@ -310,8 +310,7 @@ def test_capture_branch_infer_ground():
     # Create nuclide to be added into the chain
     xe136m = nuclide.Nuclide("Xe136_m1")
 
-    chain.nuclides.append(xe136m)
-    chain.nuclide_dict[xe136m.name] = len(chain.nuclides) - 1
+    chain.add_nuclide(xe136m)
 
     chain.set_branch_ratios(infer_br, "(n,gamma)")
 
@@ -327,8 +326,7 @@ def test_capture_branch_no_rxn():
 
     u5m = nuclide.Nuclide("U235_m1")
 
-    chain.nuclides.append(u5m)
-    chain.nuclide_dict[u5m.name] = len(chain.nuclides) - 1
+    chain.add_nuclide(u5m)
 
     with pytest.raises(AttributeError, match="U234"):
         chain.set_branch_ratios(u4br)


### PR DESCRIPTION
# Description

We have an increasing number of use cases where want to use functionality from the OpenMC shared library without actually running OpenMC itself. This usually involves creating a temporary directory, exporting a Model to XML, initializing the OpenMC shared library via `openmc.lib.init`, and then calling the function(s) of interest from openmc.lib. Examples of this include:
- `MicroXS.from_multigroup_flux`
- `WeightWindowsList.export_to_hdf5`
- `Mesh.material_volumes`

This PR introduces a new `openmc.lib.TemporarySession` context manager class that makes this process a little easier by combining the first few steps together (moving to a temp dir, exporting XML, calling `openmc.lib.init`). So the first line of code under the `with` statement can be a call to something from `openmc.lib`. I've updated each of the methods above to use the new `TemporarySession` class.

## Use for `MicroXS`

For some depletion/activation workflows, the user may want to make repeated calls to `MicroXS.from_multigroup_flux`. Right now, this will cause `openmc.lib.init` to get called (hence loading cross sections) each time, which may result in long execution times. I've added a new `session` argument on `from_multigroup_flux` that allows one to use the same temporary session so that `openmc.lib` only needs to be initialized once. So it might look like:
```Python
with openmc.lib.TemporarySession() as session:
    for mat in long_list_of_materials:
        micros = MicroXS.from_multigroup_flux(energy, flux, nuclides=mat.get_nuclides(), session=session)
```

## Chain caching

In the above example, another issue with repeated calls to `MicroXS.from_multigroup_flux` is that a chain file will get loaded from XML each time. Thanks to PR #3436 by @shimwell, this could be avoided by creating a `Chain` object and then passing it to the `chain_file` argument. In this PR, I've also made things a little bit smoother by caching `Chain` instances behind the scenes so that a user can just set `openmc.config['chain_file']` instead of having to pass around the Chain object.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)