### PR TITLE
Add flag to CMakeLists to use submodules instead of searching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ option(OPENMC_USE_LIBMESH     "Enable support for libMesh unstructured mesh tall
 option(OPENMC_USE_MPI         "Enable MPI"                                           OFF)
 option(OPENMC_USE_MCPL        "Enable MCPL"                                          OFF)
 option(OPENMC_USE_UWUW        "Enable UWUW"                                          OFF)
-option(OPENMC_USE_VENDOR      "Explicitly use submodules defined in '/vendor'"       OFF)
+option(OPENMC_FORCE_VENDORED_LIBS "Explicitly use submodules defined in 'vendor'"    OFF)
 
 message(STATUS "OPENMC_USE_OPENMP ${OPENMC_USE_OPENMP}")
 message(STATUS "OPENMC_BUILD_TESTS ${OPENMC_BUILD_TESTS}")
@@ -49,7 +49,7 @@ message(STATUS "OPENMC_USE_LIBMESH ${OPENMC_USE_LIBMESH}")
 message(STATUS "OPENMC_USE_MPI ${OPENMC_USE_MPI}")
 message(STATUS "OPENMC_USE_MCPL ${OPENMC_USE_MCPL}")
 message(STATUS "OPENMC_USE_UWUW ${OPENMC_USE_UWUW}")
-message(STATUS "OPENMC_USE_VENDOR ${OPENMC_USE_VENDOR}")
+message(STATUS "OPENMC_FORCE_VENDORED_LIBS ${OPENMC_FORCE_VENDORED_LIBS}")
 
 # Warnings for deprecated options
 foreach(OLD_OPT IN ITEMS "openmp" "profile" "coverage" "dagmc" "libmesh")
@@ -257,10 +257,11 @@ endif()
 #===============================================================================
 # pugixml library
 #===============================================================================
-if (OPENMC_USE_VENDOR)
+
+if(OPENMC_FORCE_VENDORED_LIBS)
   add_subdirectory(vendor/pugixml)
   set_target_properties(pugixml PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
-else ()
+else()
   find_package_write_status(pugixml)
   if (NOT pugixml_FOUND)
     add_subdirectory(vendor/pugixml)
@@ -268,14 +269,14 @@ else ()
   endif()
 endif()
 
-
 #===============================================================================
 # {fmt} library
 #===============================================================================
-if (OPENMC_USE_VENDOR)
+
+if(OPENMC_FORCE_VENDORED_LIBS)
   set(FMT_INSTALL ON CACHE BOOL "Generate the install target.")
   add_subdirectory(vendor/fmt)
-else ()
+else()
   find_package_write_status(fmt)
   if (NOT fmt_FOUND)
     set(FMT_INSTALL ON CACHE BOOL "Generate the install target.")
@@ -283,16 +284,15 @@ else ()
   endif()
 endif()
 
-
-
 #===============================================================================
 # xtensor header-only library
 #===============================================================================
-if (OPENMC_USE_VENDOR)
+
+if(OPENMC_FORCE_VENDORED_LIBS)
   add_subdirectory(vendor/xtl)
   set(xtl_DIR ${CMAKE_CURRENT_BINARY_DIR}/vendor/xtl)
   add_subdirectory(vendor/xtensor)
-else ()
+else()
   find_package_write_status(xtensor)
   if (NOT xtensor_FOUND)
     add_subdirectory(vendor/xtl)
@@ -301,16 +301,14 @@ else ()
   endif()
 endif()
 
-
-
 #===============================================================================
 # Catch2 library
 #===============================================================================
 
 if(OPENMC_BUILD_TESTS)
-  if (OPENMC_USE_VENDOR)
+  if (OPENMC_FORCE_VENDORED_LIBS)
     add_subdirectory(vendor/Catch2)
-  else ()
+  else()
     find_package_write_status(Catch2)
     if (NOT Catch2_FOUND)
       add_subdirectory(vendor/Catch2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ option(OPENMC_USE_LIBMESH     "Enable support for libMesh unstructured mesh tall
 option(OPENMC_USE_MPI         "Enable MPI"                                           OFF)
 option(OPENMC_USE_MCPL        "Enable MCPL"                                          OFF)
 option(OPENMC_USE_UWUW        "Enable UWUW"                                          OFF)
+option(OPENMC_USE_VENDOR      "Explicitly use submodules defined in '/vendor'"       OFF)
 
 message(STATUS "OPENMC_USE_OPENMP ${OPENMC_USE_OPENMP}")
 message(STATUS "OPENMC_BUILD_TESTS ${OPENMC_BUILD_TESTS}")
@@ -48,6 +49,7 @@ message(STATUS "OPENMC_USE_LIBMESH ${OPENMC_USE_LIBMESH}")
 message(STATUS "OPENMC_USE_MPI ${OPENMC_USE_MPI}")
 message(STATUS "OPENMC_USE_MCPL ${OPENMC_USE_MCPL}")
 message(STATUS "OPENMC_USE_UWUW ${OPENMC_USE_UWUW}")
+message(STATUS "OPENMC_USE_VENDOR ${OPENMC_USE_VENDOR}")
 
 # Warnings for deprecated options
 foreach(OLD_OPT IN ITEMS "openmp" "profile" "coverage" "dagmc" "libmesh")
@@ -255,42 +257,64 @@ endif()
 #===============================================================================
 # pugixml library
 #===============================================================================
-
-find_package_write_status(pugixml)
-if (NOT pugixml_FOUND)
+if (OPENMC_USE_VENDOR)
   add_subdirectory(vendor/pugixml)
   set_target_properties(pugixml PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
+else ()
+  find_package_write_status(pugixml)
+  if (NOT pugixml_FOUND)
+    add_subdirectory(vendor/pugixml)
+    set_target_properties(pugixml PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
+  endif()
 endif()
+
 
 #===============================================================================
 # {fmt} library
 #===============================================================================
-
-find_package_write_status(fmt)
-if (NOT fmt_FOUND)
+if (OPENMC_USE_VENDOR)
   set(FMT_INSTALL ON CACHE BOOL "Generate the install target.")
   add_subdirectory(vendor/fmt)
+else ()
+  find_package_write_status(fmt)
+  if (NOT fmt_FOUND)
+    set(FMT_INSTALL ON CACHE BOOL "Generate the install target.")
+    add_subdirectory(vendor/fmt)
+  endif()
 endif()
+
+
 
 #===============================================================================
 # xtensor header-only library
 #===============================================================================
-
-find_package_write_status(xtensor)
-if (NOT xtensor_FOUND)
+if (OPENMC_USE_VENDOR)
   add_subdirectory(vendor/xtl)
   set(xtl_DIR ${CMAKE_CURRENT_BINARY_DIR}/vendor/xtl)
   add_subdirectory(vendor/xtensor)
+else ()
+  find_package_write_status(xtensor)
+  if (NOT xtensor_FOUND)
+    add_subdirectory(vendor/xtl)
+    set(xtl_DIR ${CMAKE_CURRENT_BINARY_DIR}/vendor/xtl)
+    add_subdirectory(vendor/xtensor)
+  endif()
 endif()
+
+
 
 #===============================================================================
 # Catch2 library
 #===============================================================================
 
 if(OPENMC_BUILD_TESTS)
-  find_package_write_status(Catch2)
-  if (NOT Catch2_FOUND)
+  if (OPENMC_USE_VENDOR)
     add_subdirectory(vendor/Catch2)
+  else ()
+    find_package_write_status(Catch2)
+    if (NOT Catch2_FOUND)
+      add_subdirectory(vendor/Catch2)
+    endif()
   endif()
 endif()
 

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -380,6 +380,11 @@ OPENMC_USE_MPI
   options, please see the `FindMPI.cmake documentation
   <https://cmake.org/cmake/help/latest/module/FindMPI.html>`_.
 
+OPENMC_USE_VENDOR
+  Forces OpenMC to use the submodules located in the vendor directory, as
+  opposed to searching the system for already installed versions of those
+  modules.
+
 To set any of these options (e.g., turning on profiling), the following form
 should be used:
 

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -380,7 +380,7 @@ OPENMC_USE_MPI
   options, please see the `FindMPI.cmake documentation
   <https://cmake.org/cmake/help/latest/module/FindMPI.html>`_.
 
-OPENMC_USE_VENDOR
+OPENMC_FORCE_VENDORED_LIBS
   Forces OpenMC to use the submodules located in the vendor directory, as
   opposed to searching the system for already installed versions of those
   modules.


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description
This PR adds a flag to the `CMakeLists.txt` to force OpenMC to use the submodules in `vendor/` as opposed to search the user's system for the submodules. The search causes problems when building Cardinal (see [this discussion post](https://github.com/neams-th-coe/cardinal/discussions/1101)), which are fixed when forcing OpenMC to use the submodules in `vendor/`. 

This flag is default off, and does not change the existing default behavior when building. 

@aprilnovak 

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
