### PR TITLE
Update conda install instructions for macOS Apple silicon

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,6 +9,7 @@ preferred-citation:
     given-names: Bryan R.
   - family-names: Nelson
     given-names: Adam G.
+    orcid: "https://orcid.org/0000-0002-3614-0676"
   - family-names: Forget
     given-names: Benoit
     orcid: "https://orcid.org/0000-0003-1459-7672"
@@ -18,16 +19,16 @@ preferred-citation:
   - family-names: Romano
     given-names: Paul K.
     orcid: "https://orcid.org/0000-0002-1147-045X"
-  date-published: 2015-08
   doi: 10.1016/j.anucene.2014.07.048
-  issn: 1873-2100
+  issn: 0306-4549
   volume: 82
   journal: Annals of Nuclear Energy
   publisher:
     name: Elsevier
   start: 90
+  end: 97
+  year: 2015
+  month: 8
   title: "OpenMC: A state-of-the-art Monte Carlo code for research and development"
   type: article
-  url: "https://www.sciencedirect.com/science/article/pii/S030645491400379X"
-  volume: 10
-
+  url: "https://doi.org/10.1016/j.anucene.2014.07.048"

--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -35,6 +35,13 @@ you wish) with OpenMC installed.
     conda create --name openmc-env openmc
     conda activate openmc-env
 
+If you are installing on macOS with an Apple silicon ARM-based processor, you
+will also need to specify the `--platform` option:
+
+.. code-block:: sh
+
+    conda create --name openmc-env --platform osx-arm64 openmc
+
 You are now in a conda environment called `openmc-env` that has OpenMC
 installed.
 

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -35,6 +35,13 @@ you wish) with OpenMC installed.
     conda create --name openmc-env openmc
     conda activate openmc-env
 
+If you are installing on macOS with an Apple silicon ARM-based processor, you
+will also need to specify the `--platform` option:
+
+.. code-block:: sh
+
+    conda create --name openmc-env --platform osx-arm64 openmc
+
 You are now in a conda environment called `openmc-env` that has OpenMC
 installed.
 


### PR DESCRIPTION
# Description

This PR updates the install instructions for conda to mention that on Apple silicon you need `--platform osx-arm64`. Also added some fixes in the CITATION.cff file that I missed out on in #3409.

Fixes #3486

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>