### PR TITLE
Vectfit

### DIFF
--- a/openmc/data/__init__.py
+++ b/openmc/data/__init__.py
@@ -33,5 +33,6 @@ from .resonance_covariance import *
 from .multipole import *
 from .grid import *
 from .function import *
+from .vectfit import *
 
 from .effective_dose.dose import dose_coefficients

--- a/openmc/data/multipole.py
+++ b/openmc/data/multipole.py
@@ -9,6 +9,8 @@ import numpy as np
 from scipy.signal import find_peaks
 
 import openmc.checkvalue as cv
+import vecfit as vf
+
 from ..exceptions import DataError
 from ..mixin import EqualityMixin
 from . import WMP_VERSION, WMP_VERSION_MAJOR
@@ -571,10 +573,6 @@ def _windowing(mp_data, n_cf, rtol=1e-3, atol=1e-5, n_win=None, spacing=None,
         format.
 
     """
-
-    # import vectfit package: https://github.com/liangjg/vectfit
-    import vectfit as vf
-
     # unpack multipole data
     name = mp_data["name"]
     awr = mp_data["AWR"]

--- a/openmc/data/vectfit.py
+++ b/openmc/data/vectfit.py
@@ -1,0 +1,63 @@
+import numpy as np
+import skrf
+from skrf.vectorFitting import VectorFitting
+
+def evaluate(s, poles, residues, polys=None):
+    """
+    Pure-NumPy version of vectfit.evaluate reproduced with scikit-rf conventions.
+    Parameters
+    ----------
+    s : (Ns,) real or complex                     # sample points (typically j*ω)
+    poles : (N,) complex
+    residues : (Nv, N) complex
+    polys : (Nv, Nc) real-valued coefficients, Nc=0/1/2 ...
+    Returns
+    -------
+    f : (Nv, Ns) real (matches the C++ behaviour)
+    """
+    s   = np.asarray(s, dtype=complex)
+    piv = 1.0 / (s[None, :] - poles[:, None])     # (N, Ns)
+
+    out = (residues @ piv).real                  # rational part
+    if polys is not None and polys.size:
+        for m, c_m in enumerate(polys.T):        # add Σ c_m s**m
+            out += c_m[:, None] * (s**m).real
+    return out
+
+def vectfit(f, s, poles_init, weight=None, n_polys=0,
+            skip_pole=False, skip_res=False):
+    """
+    Replaces vectfit.vectfit() using pure-Python scikit-rf.
+    Only the subset required by OpenMC (n_polys 0/1, no skip flags) is shown.
+    """
+    Nv, Ns = f.shape
+    nports = int(np.sqrt(Nv))           # scikit-rf expects Nv == nports**2
+    if nports**2 != Nv:
+        raise ValueError("VectorFitting needs Nv to be a perfect square.")
+
+    # 1-build an N-port Network object from the response matrix
+    S = np.zeros((Ns, nports, nports), dtype=complex)
+    for i in range(nports):
+        for j in range(nports):
+            S[:, i, j] = f[i*nports + j]          # row-major mapping
+
+    freq = skrf.Frequency.from_f(s/(2*np.pi), unit='hz')   # s=jω → f
+    nw = skrf.Network(frequency=freq, s=S, z0=50)        # 50 Ω dummy
+
+    # 2-run vector fitting
+    vf = VectorFitting(nw)
+    vf.poles = poles_init
+    vf.vector_fit(init_pole_spacing='custom',
+                  n_poles_real = np.count_nonzero(poles_init.imag == 0),
+                  n_poles_cmplx= np.count_nonzero(poles_init.imag > 0))
+
+    # 3-package results so OpenMC sees the same tuple
+    fitted = np.vstack([vf.get_model_response(i//nports, i % nports)
+                        for i in range(Nv)])
+    rmserr = np.linalg.norm(fitted - f) / np.sqrt(f.size)
+
+    # scikit-rf holds only degree-0/1 terms; stack them to look like polys
+    polys  = np.stack([vf.constant_coeff,
+                       vf.proportional_coeff], axis=1)[:, :n_polys]
+
+    return vf.poles, vf.residues, polys, fitted, rmserr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "uncertainties",
     "setuptools",
     "endf",
+    "scikit-rf"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This pull request removes the dependency on the unmaintained external `vectfit` package (https://github.com/liangjg/vectfit) used in OpenMC's windowed multipole (WMP) infrastructure. In its place, a vector fitting is introduced based on the `vectorFitting.py` module from `scikit-rf` project.

This change improves long-term maintainability and compatibility of OpenMC.

Fixes #3487

# Checklist

- [ ] I have performed a self-review of my own code  
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)  
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)  
- [ ] I have made corresponding changes to the documentation (if applicable)  
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)  
