### PR TITLE
stepresult.py; chunks=True

### DIFF
--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -328,13 +328,13 @@ class StepResult:
 
         handle.create_dataset("number", (1, n_stages, n_mats, n_nuc_number),
                               maxshape=(None, n_stages, n_mats, n_nuc_number),
-                              chunks=(1, 1, n_mats, n_nuc_number),
+                              chunks=True,
                               dtype='float64')
 
         if n_nuc_rxn > 0 and n_rxn > 0:
             handle.create_dataset("reaction rates", (1, n_stages, n_mats, n_nuc_rxn, n_rxn),
                                 maxshape=(None, n_stages, n_mats, n_nuc_rxn, n_rxn),
-                                chunks=(1, 1, n_mats, n_nuc_rxn, n_rxn),
+                                chunks=True,
                                 dtype='float64')
 
         handle.create_dataset("eigenvalues", (1, n_stages, 2),


### PR DESCRIPTION
Large activation calculations exceed HDF5 chunk sizes of 4GB.
Using chunks=True resolves this limitation.

see issue:
https://github.com/openmc-dev/openmc/issues/3497



# Description

Changes to chunks in stepresult.py. Enable integration and creation of depletion_result HDF5 files for large activation calculations

Fixes #3497

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
