### PR TITLE
Add random ray info to statepoint file

### DIFF
--- a/include/openmc/random_ray/random_ray.h
+++ b/include/openmc/random_ray/random_ray.h
@@ -46,10 +46,20 @@ public:
   // Static data members
   static double distance_inactive_;          // Inactive (dead zone) ray length
   static double distance_active_;            // Active ray length
+  static double avg_miss_rate;               // Average ray miss rate per
+                                             // iteration for reporting
   static unique_ptr<Source> ray_source_;     // Starting source for ray sampling
   static RandomRaySourceShape source_shape_; // Flag for linear source
   static bool mesh_subdivision_enabled_;     // Flag for mesh subdivision
   static RandomRaySampleMethod sample_method_; // Flag for sampling method
+  static int64_t n_source_regions;             // Total number of source regions
+  static int64_t
+    n_external_source_regions; // Total number of source regions with
+                               // non-zero external source terms
+  static uint64_t total_geometric_intersections; // Tracks the total number of
+                                                 // geometric intersections by
+                                                 // all rays for reporting
+  static int negroups_;                          // Number of energy groups
 
   //----------------------------------------------------------------------------
   // Public data members
@@ -65,7 +75,6 @@ private:
   vector<int> mesh_bins_;
   vector<double> mesh_fractional_lengths_;
 
-  int negroups_;
   FlatSourceDomain* domain_ {nullptr}; // pointer to domain that has flat source
                                        // data needed for ray transport
   double distance_travelled_ {0};

--- a/include/openmc/random_ray/random_ray_simulation.h
+++ b/include/openmc/random_ray/random_ray_simulation.h
@@ -30,9 +30,11 @@ public:
   void output_simulation_results() const;
   void instability_check(
     int64_t n_hits, double k_eff, double& avg_miss_rate) const;
-  void print_results_random_ray(uint64_t total_geometric_intersections,
-    double avg_miss_rate, int negroups, int64_t n_source_regions,
-    int64_t n_external_source_regions) const;
+  void print_results_random_ray() const;
+  int64_t total_geometric_intersections() const
+  {
+    return total_geometric_intersections_;
+  }
 
   //----------------------------------------------------------------------------
   // Accessors
@@ -67,6 +69,10 @@ private:
 void openmc_run_random_ray();
 void validate_random_ray_inputs();
 void openmc_reset_random_ray();
+
+//! Write data related to randaom ray to statepoint
+//! \param[in] group HDF5 group
+void write_random_ray_hdf5(hid_t group);
 
 } // namespace openmc
 

--- a/openmc/statepoint.py
+++ b/openmc/statepoint.py
@@ -31,6 +31,10 @@ class StatePoint:
 
     Attributes
     ----------
+    adjoint_mode : bool
+        Indicate whether random ray solve was in adjoint mode
+    avg_miss_rate : float
+        The random ray average source region miss rate per iteration 
     cmfd_on : bool
         Indicate whether CMFD is active
     cmfd_balance : numpy.ndarray
@@ -52,6 +56,10 @@ class StatePoint:
         Number of batches simulated
     date_and_time : datetime.datetime
         Date and time at which statepoint was written
+    distance_active : float
+        Active distance for each ray in Random ray
+    distance_inactive : float
+        Inactive distance for each ray in Random ray
     entropy : numpy.ndarray
         Shannon entropy of fission source at each batch
     filters : dict
@@ -82,12 +90,20 @@ class StatePoint:
         Dictionary whose keys are mesh IDs and whose values are MeshBase objects
     n_batches : int
         Number of batches
+    n_external_source_regions : int
+        Number of external source regions in random ray simulation
+    n_geometric_intersections : int
+        Total number of geometric intersections in random ray simulation
     n_inactive : int
         Number of inactive batches
+    n_integrations : int
+        Total number of integrations in random ray simulation
     n_particles : int
         Number of particles per generation
     n_realizations : int
         Number of tally realizations
+    n_source_regions : int
+        Number of source regions in random ray simulation
     path : str
         Working directory for simulation
     photon_transport : bool
@@ -97,8 +113,14 @@ class StatePoint:
     runtime : dict
         Dictionary whose keys are strings describing various runtime metrics
         and whose values are time values in seconds.
+    sample_method : str
+        Random ray sample method, e.g. 'prng' or 'halton'
     seed : int
         Pseudorandom number generator seed
+    solver_type : str
+        Transport method, e.g. 'monte carlo' or 'random ray'
+    source_shape : str
+        Random ray source region approximation, e.g. 'flat' or 'linear'
     stride : int
         Number of random numbers allocated for each particle history
     source : numpy.ndarray of compound datatype
@@ -120,6 +142,8 @@ class StatePoint:
         TallyDerivative objects
     version: tuple of Integral
         Version of OpenMC
+    volume_estimator  : str
+        Random ray source region volume estimatation method, e.g. 'naive'
     summary : None or openmc.Summary
         A summary object if the statepoint has been linked with a summary file
 
@@ -305,6 +329,83 @@ class StatePoint:
             return None
 
     @property
+    def source_shape(self):
+        if self.solver_type == 'random ray':
+            return self._f['source_shape'][()].decode()
+        else:
+            return None
+
+    @property
+    def sample_method(self):
+        if self.solver_type == 'random ray':
+            return self._f['sample_method'][()].decode()
+        else:
+            return None
+
+    @property
+    def volume_estimator(self):
+        if self.solver_type == 'random ray':
+            return self._f['volume_estimator'][()].decode()
+        else:
+            return None
+
+    @property
+    def distance_active(self):
+        if self.solver_type == 'random ray':
+            return self._f['distance_active'][()]
+        else:
+            return None
+
+    @property
+    def distance_inactive(self):
+        if self.solver_type == 'random ray':
+            return self._f['distance_inactive'][()]
+        else:
+            return None
+
+    @property
+    def adjoint_mode(self):
+        if self.solver_type == 'random ray':
+            return True if self._f['adjoint_mode'][()] else False
+        else:
+            return None
+
+    @property
+    def avg_miss_rate(self):
+        if self.solver_type == 'random ray':
+            return self._f['avg_miss_rate'][()]
+        else:
+            return None
+
+    @property
+    def n_source_regions(self):
+        if self.solver_type == 'random ray':
+            return self._f['n_source_regions'][()]
+        else:
+            return None
+
+    @property
+    def n_external_source_regions(self):
+        if self.solver_type == 'random ray':
+            return self._f['n_external_source_regions'][()]
+        else:
+            return None
+
+    @property
+    def n_geometric_intersections(self):
+        if self.solver_type == 'random ray':
+            return self._f['n_geometric_intersections'][()]
+        else:
+            return None
+
+    @property
+    def n_integrations(self):
+        if self.solver_type == 'random ray':
+            return self._f['n_integrations'][()]
+        else:
+            return None
+
+    @property
     def meshes(self):
         if not self._meshes_read:
             mesh_group = self._f['tallies/meshes']
@@ -344,6 +445,10 @@ class StatePoint:
     @property
     def photon_transport(self):
         return self._f.attrs['photon_transport'] > 0
+
+    @property
+    def solver_type(self):
+        return self._f['solver_type'][()].decode()
 
     @property
     def run_mode(self):

--- a/src/random_ray/random_ray.cpp
+++ b/src/random_ray/random_ray.cpp
@@ -235,16 +235,21 @@ vector<double> rhalton(int dim, uint64_t* seed, int64_t skip = 0)
 // Static Variable Declarations
 double RandomRay::distance_inactive_;
 double RandomRay::distance_active_;
+double RandomRay::avg_miss_rate;
 unique_ptr<Source> RandomRay::ray_source_;
 RandomRaySourceShape RandomRay::source_shape_ {RandomRaySourceShape::FLAT};
 bool RandomRay::mesh_subdivision_enabled_ {false};
 RandomRaySampleMethod RandomRay::sample_method_ {RandomRaySampleMethod::PRNG};
+int64_t RandomRay::n_source_regions;
+int64_t RandomRay::n_external_source_regions;
+uint64_t RandomRay::total_geometric_intersections;
+int RandomRay::negroups_;
 
 RandomRay::RandomRay()
   : angular_flux_(data::mg.num_energy_groups_),
-    delta_psi_(data::mg.num_energy_groups_),
-    negroups_(data::mg.num_energy_groups_)
+    delta_psi_(data::mg.num_energy_groups_)
 {
+  negroups_ = data::mg.num_energy_groups_;
   if (source_shape_ == RandomRaySourceShape::LINEAR ||
       source_shape_ == RandomRaySourceShape::LINEAR_XY) {
     delta_moments_.resize(negroups_);

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -21,6 +21,7 @@
 #include "openmc/mgxs_interface.h"
 #include "openmc/nuclide.h"
 #include "openmc/output.h"
+#include "openmc/random_ray/random_ray_simulation.h"
 #include "openmc/settings.h"
 #include "openmc/simulation.h"
 #include "openmc/tallies/derivative.h"
@@ -118,6 +119,16 @@ extern "C" int openmc_statepoint_write(const char* filename, bool* write_source)
     // Write out information for eigenvalue run
     if (settings::run_mode == RunMode::EIGENVALUE)
       write_eigenvalue_hdf5(file_id);
+
+    switch (settings::solver_type) {
+    case SolverType::RANDOM_RAY:
+      write_dataset(file_id, "solver_type", "random ray");
+      write_random_ray_hdf5(file_id);
+      break;
+    default:
+      write_dataset(file_id, "solver_type", "monte carlo");
+      break;
+    }
 
     hid_t tallies_group = create_group(file_id, "tallies");
 


### PR DESCRIPTION
# Description

This PR adds some of the basic random ray simulation parameters and summary information to the statepoint file. I tried to copy similar additions but please let me know if things could be organized differently/better!

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
