### PR TITLE
Update OSX install instructions to point to x64 platform

### DIFF
--- a/docs/source/quickinstall.rst
+++ b/docs/source/quickinstall.rst
@@ -40,7 +40,7 @@ will also need to specify the `--platform` option:
 
 .. code-block:: sh
 
-    conda create --name openmc-env --platform osx-arm64 openmc
+    conda create --name openmc-env --platform osx-64 openmc
 
 You are now in a conda environment called `openmc-env` that has OpenMC
 installed.

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -40,7 +40,7 @@ will also need to specify the `--platform` option:
 
 .. code-block:: sh
 
-    conda create --name openmc-env --platform osx-arm64 openmc
+    conda create --name openmc-env --platform osx-64 openmc
 
 You are now in a conda environment called `openmc-env` that has OpenMC
 installed.


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR corrects the conda command for installing OpenMC on Mac machines by pointing the platform to osx-64 (Intel) instead of osx-arm64

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
