### PR TITLE
Allow already-initialized openmc.lib in TemporarySession

### DIFF
--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -352,7 +352,8 @@ class MicroXS:
         # Create 3D array for microscopic cross sections
         microxs_arr = np.zeros((len(nuclides), len(mts), 1))
 
-        def compute_microxs():
+        # Compute microscopic cross sections within a temporary session
+        with openmc.lib.TemporarySession(**init_kwargs):
             # For each nuclide and reaction, compute the flux-averaged xs
             for nuc_index, nuc in enumerate(nuclides):
                 if nuc not in nuclides_with_data:
@@ -362,13 +363,6 @@ class MicroXS:
                     microxs_arr[nuc_index, mt_index, 0] = lib_nuc.collapse_rate(
                         mt, temperature, energies, multigroup_flux
                     )
-
-        # Compute microscopic cross sections within a temporary session
-        if not openmc.lib.is_initialized:
-            with openmc.lib.TemporarySession(**init_kwargs):
-                compute_microxs()
-        else:
-            compute_microxs()
 
         return cls(microxs_arr, nuclides, reactions)
 

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -996,16 +996,13 @@ class Model:
         plot_obj.v_res = pixels[1]
         plot_obj.basis = basis
 
-        if self.is_initialized:
-            return openmc.lib.id_map(plot_obj)
-        else:
-            # Silence output by default. Also set arguments to start in volume
-            # calculation mode to avoid loading cross sections
-            init_kwargs.setdefault('output', False)
-            init_kwargs.setdefault('args', ['-c'])
+        # Silence output by default. Also set arguments to start in volume
+        # calculation mode to avoid loading cross sections
+        init_kwargs.setdefault('output', False)
+        init_kwargs.setdefault('args', ['-c'])
 
-            with openmc.lib.TemporarySession(self, **init_kwargs):
-                return openmc.lib.id_map(plot_obj)
+        with openmc.lib.TemporarySession(self, **init_kwargs):
+            return openmc.lib.id_map(plot_obj)
 
     @add_plot_params
     def plot(
@@ -1229,20 +1226,15 @@ class Model:
         """
         import openmc.lib
 
-        if self.is_initialized:
+        # Silence output by default. Also set arguments to start in volume
+        # calculation mode to avoid loading cross sections
+        init_kwargs.setdefault('output', False)
+        init_kwargs.setdefault('args', ['-c'])
+
+        with openmc.lib.TemporarySession(self, **init_kwargs):
             return openmc.lib.sample_external_source(
                 n_samples=n_samples, prn_seed=prn_seed
             )
-        else:
-            # Silence output by default. Also set arguments to start in volume
-            # calculation mode to avoid loading cross sections
-            init_kwargs.setdefault('output', False)
-            init_kwargs.setdefault('args', ['-c'])
-
-            with openmc.lib.TemporarySession(self, **init_kwargs):
-                return openmc.lib.sample_external_source(
-                    n_samples=n_samples, prn_seed=prn_seed
-                )
 
     def apply_tally_results(self, statepoint: PathLike | openmc.StatePoint):
         """Apply results from a statepoint to tally objects on the Model


### PR DESCRIPTION
# Description

Right now, if you try to enter a `with openmc.lib.TemporarySession()` block and `openmc.lib` has already been initialized, you'll get an exception. However, the more that I'm working with this class, I see that it would be beneficial to allow `TemporarySession` to be a no-op in the case where `openmc.lib` is already initialized. The major issue that I see with the current design is that it forces us to explicitly check for the initialization status anywhere we use `TemporarySession`. A good example is in microxs.py:
https://github.com/openmc-dev/openmc/blob/659e43af7de9030ef3fbfef32f0992c39a00820d/openmc/deplete/microxs.py#L355-L371

In this example, to avoid repeating a bunch of code, the body of the `with` block had to be separated out into a function that is called in two spots. If we simply allow `TemporarySession` to be a no-op when `openmc.lib` is already initilized, there is no need to have an explicit check and a separate call.

I have a few more PRs coming up that make additional use of `TemporarySession` and it would be nice to have this design issue resolved before putting those in.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)