### PR TITLE
Update DAGMC and libMesh precompiler definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,7 +516,7 @@ elseif(OPENMC_USE_UWUW)
 endif()
 
 if(OPENMC_USE_LIBMESH)
-  target_compile_definitions(libopenmc PRIVATE LIBMESH)
+  target_compile_definitions(libopenmc PRIVATE OPENMC_LIBMESH_ENABLED)
   target_link_libraries(libopenmc PkgConfig::LIBMESH)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,7 +507,7 @@ if(OPENMC_USE_DAGMC)
   target_link_libraries(libopenmc dagmc-shared)
 
   if(OPENMC_USE_UWUW)
-    target_compile_definitions(libopenmc PRIVATE OPENMC_UWUW)
+    target_compile_definitions(libopenmc PRIVATE OPENMC_UWUW_ENABLED)
     target_link_libraries(libopenmc uwuw-shared)
   endif()
 elseif(OPENMC_USE_UWUW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,7 +503,7 @@ else()
 endif()
 
 if(OPENMC_USE_DAGMC)
-  target_compile_definitions(libopenmc PRIVATE DAGMC)
+  target_compile_definitions(libopenmc PRIVATE OPENMC_DAGMC_ENABLED)
   target_link_libraries(libopenmc dagmc-shared)
 
   if(OPENMC_USE_UWUW)

--- a/include/openmc/dagmc.h
+++ b/include/openmc/dagmc.h
@@ -20,7 +20,7 @@ void check_dagmc_root_univ();
 
 } // namespace openmc
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
 
 #include "DagMC.hpp"
 #include "dagmcmetadata.hpp"
@@ -216,6 +216,6 @@ int32_t next_cell(int32_t surf, int32_t curr_cell, int32_t univ);
 
 } // namespace openmc
 
-#endif // DAGMC
+#endif // OPENMC_DAGMC_ENABLED
 
 #endif // OPENMC_DAGMC_H

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -26,7 +26,7 @@
 #include "moab/Matrix3.hpp"
 #endif
 
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
 #include "libmesh/bounding_box.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/elem.h"
@@ -61,7 +61,7 @@ extern vector<unique_ptr<Mesh>> meshes;
 
 } // namespace model
 
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
 namespace settings {
 // used when creating new libMesh::MeshBase instances
 extern unique_ptr<libMesh::LibMeshInit> libmesh_init;
@@ -938,7 +938,7 @@ private:
 
 #endif
 
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
 
 class LibMesh : public UnstructuredMesh {
 public:

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -19,7 +19,7 @@
 #include "openmc/vector.h"
 #include "openmc/xml_interface.h"
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
 #include "moab/AdaptiveKDTree.hpp"
 #include "moab/Core.hpp"
 #include "moab/GeomUtil.hpp"
@@ -768,7 +768,7 @@ private:
   virtual void initialize() = 0;
 };
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
 
 class MOABMesh : public UnstructuredMesh {
 public:

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -8,7 +8,7 @@
 #include "openmc/tallies/filter_match.h"
 #include "openmc/vector.h"
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
 #include "DagMC.hpp"
 #endif
 
@@ -354,7 +354,7 @@ public:
   // Boundary information
   BoundaryInfo& boundary() { return boundary_; }
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
   // DagMC state variables
   moab::DagMC::RayHistory& history() { return history_; }
   Direction& last_dir() { return last_dir_; }
@@ -399,7 +399,7 @@ private:
   double sqrtkT_ {-1.0};     //!< sqrt(k_Boltzmann * temperature) in eV
   double sqrtkT_last_ {0.0}; //!< last temperature
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
   moab::DagMC::RayHistory history_;
   Direction last_dir_;
 #endif

--- a/include/openmc/universe.h
+++ b/include/openmc/universe.h
@@ -6,7 +6,7 @@
 
 namespace openmc {
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
 class DAGUniverse;
 #endif
 

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1025,7 +1025,7 @@ void populate_universes()
       model::universes.back()->cells_.push_back(index_cell);
       model::universe_map[uid] = model::universes.size() - 1;
     } else {
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
       // Skip implicit complement cells for now
       Universe* univ = model::universes[it->second].get();
       DAGUniverse* dag_univ = dynamic_cast<DAGUniverse*>(univ);

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -13,7 +13,7 @@
 #include "openmc/settings.h"
 #include "openmc/string_utils.h"
 
-#ifdef OPENMC_UWUW
+#ifdef OPENMC_UWUW_ENABLED
 #include "uwuw.hpp"
 #endif
 #include <fmt/core.h>
@@ -32,7 +32,7 @@ const bool DAGMC_ENABLED = true;
 const bool DAGMC_ENABLED = false;
 #endif
 
-#ifdef OPENMC_UWUW
+#ifdef OPENMC_UWUW_ENABLED
 const bool UWUW_ENABLED = true;
 #else
 const bool UWUW_ENABLED = false;
@@ -131,7 +131,7 @@ void DAGUniverse::set_id()
 
 void DAGUniverse::initialize()
 {
-#ifdef OPENMC_UWUW
+#ifdef OPENMC_UWUW_ENABLED
   // read uwuw materials from the .h5m file if present
   read_uwuw_materials();
 #endif
@@ -456,16 +456,16 @@ void DAGUniverse::to_hdf5(hid_t universes_group) const
 
 bool DAGUniverse::uses_uwuw() const
 {
-#ifdef OPENMC_UWUW
+#ifdef OPENMC_UWUW_ENABLED
   return uwuw_ && !uwuw_->material_library.empty();
 #else
   return false;
-#endif // OPENMC_UWUW
+#endif // OPENMC_UWUW_ENABLED
 }
 
 std::string DAGUniverse::get_uwuw_materials_xml() const
 {
-#ifdef OPENMC_UWUW
+#ifdef OPENMC_UWUW_ENABLED
   if (!uses_uwuw()) {
     throw std::runtime_error("This DAGMC Universe does not use UWUW materials");
   }
@@ -485,12 +485,12 @@ std::string DAGUniverse::get_uwuw_materials_xml() const
   return ss.str();
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif // OPENMC_UWUW
+#endif // OPENMC_UWUW_ENABLED
 }
 
 void DAGUniverse::write_uwuw_materials_xml(const std::string& outfile) const
 {
-#ifdef OPENMC_UWUW
+#ifdef OPENMC_UWUW_ENABLED
   if (!uses_uwuw()) {
     throw std::runtime_error(
       "This DAGMC universe does not use UWUW materials.");
@@ -503,7 +503,7 @@ void DAGUniverse::write_uwuw_materials_xml(const std::string& outfile) const
   mats_xml.close();
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif // OPENMC_UWUW
+#endif // OPENMC_UWUW_ENABLED
 }
 
 void DAGUniverse::legacy_assign_material(
@@ -565,7 +565,7 @@ void DAGUniverse::legacy_assign_material(
 
 void DAGUniverse::read_uwuw_materials()
 {
-#ifdef OPENMC_UWUW
+#ifdef OPENMC_UWUW_ENABLED
   // If no filename was provided, don't read UWUW materials
   if (filename_ == "")
     return;
@@ -605,13 +605,13 @@ void DAGUniverse::read_uwuw_materials()
   }
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif // OPENMC_UWUW
+#endif // OPENMC_UWUW_ENABLED
 }
 
 void DAGUniverse::uwuw_assign_material(
   moab::EntityHandle vol_handle, std::unique_ptr<DAGCell>& c) const
 {
-#ifdef OPENMC_UWUW
+#ifdef OPENMC_UWUW_ENABLED
   // lookup material in uwuw if present
   std::string uwuw_mat = dmd_ptr->volume_material_property_data_eh[vol_handle];
   if (uwuw_->material_library.count(uwuw_mat) != 0) {
@@ -627,7 +627,7 @@ void DAGUniverse::uwuw_assign_material(
   }
 #else
   fatal_error("DAGMC was not configured with UWUW.");
-#endif // OPENMC_UWUW
+#endif // OPENMC_UWUW_ENABLED
 }
 
 void DAGUniverse::override_assign_material(std::unique_ptr<DAGCell>& c) const

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -26,7 +26,7 @@
 
 namespace openmc {
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
 const bool DAGMC_ENABLED = true;
 #else
 const bool DAGMC_ENABLED = false;
@@ -40,7 +40,7 @@ const bool UWUW_ENABLED = false;
 
 } // namespace openmc
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
 
 namespace openmc {
 
@@ -926,4 +926,4 @@ int32_t next_cell(int32_t surf, int32_t curr_cell, int32_t univ);
 
 } // namespace openmc
 
-#endif // DAGMC
+#endif // OPENMC_DAGMC_ENABLED

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -166,7 +166,7 @@ int openmc_finalize()
   // Deallocate arrays
   free_memory();
 
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
   settings::libmesh_init.reset();
 #endif
 

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -38,7 +38,7 @@
 #include "openmc/vector.h"
 #include "openmc/weight_windows.h"
 
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
 #include "libmesh/libmesh.h"
 #endif
 
@@ -64,7 +64,7 @@ int openmc_init(int argc, char* argv[], const void* intracomm)
   if (err)
     return err;
 
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
   const int n_threads = num_threads();
   // initialize libMesh if it hasn't been initialized already
   // (if initialized externally, the libmesh_init object needs to be provided

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -47,7 +47,7 @@
 #include "openmc/volume_calc.h"
 #include "openmc/xml_interface.h"
 
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
 #include "libmesh/mesh_modification.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/numeric_vector.h"
@@ -63,7 +63,7 @@ namespace openmc {
 // Global variables
 //==============================================================================
 
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
 const bool LIBMESH_ENABLED = true;
 #else
 const bool LIBMESH_ENABLED = false;
@@ -80,7 +80,7 @@ vector<unique_ptr<Mesh>> meshes;
 
 } // namespace model
 
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
 namespace settings {
 unique_ptr<libMesh::LibMeshInit> libmesh_init;
 const libMesh::Parallel::Communicator* libmesh_comm {nullptr};
@@ -2141,7 +2141,7 @@ extern "C" int openmc_add_unstructured_mesh(
   }
 #endif
 
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
   if (lib_name == LibMesh::mesh_lib_type) {
     model::meshes.push_back(std::move(make_unique<LibMesh>(mesh_file)));
     valid_lib = true;
@@ -3211,7 +3211,7 @@ void MOABMesh::write(const std::string& base_filename) const
 
 #endif
 
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
 
 const std::string LibMesh::mesh_lib_type = "libmesh";
 
@@ -3556,7 +3556,7 @@ double LibMesh::volume(int bin) const
   return this->get_element_from_bin(bin).volume();
 }
 
-#endif // LIBMESH
+#endif // OPENMC_LIBMESH_ENABLED
 
 //==============================================================================
 // Non-member functions
@@ -3610,7 +3610,7 @@ void read_meshes(pugi::xml_node root)
                mesh_lib == MOABMesh::mesh_lib_type) {
       model::meshes.push_back(make_unique<MOABMesh>(node));
 #endif
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
     } else if (mesh_type == UnstructuredMesh::mesh_type &&
                mesh_lib == LibMesh::mesh_lib_type) {
       model::meshes.push_back(make_unique<LibMesh>(node));

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -53,7 +53,7 @@
 #include "libmesh/numeric_vector.h"
 #endif
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
 #include "moab/FileOptions.hpp"
 #endif
 
@@ -2134,7 +2134,7 @@ extern "C" int openmc_add_unstructured_mesh(
   std::string mesh_file(filename);
   bool valid_lib = false;
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
   if (lib_name == MOABMesh::mesh_lib_type) {
     model::meshes.push_back(std::move(make_unique<MOABMesh>(mesh_file)));
     valid_lib = true;
@@ -2509,7 +2509,7 @@ extern "C" int openmc_spherical_mesh_set_grid(int32_t index,
     index, grid_x, nx, grid_y, ny, grid_z, nz);
 }
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
 
 const std::string MOABMesh::mesh_lib_type = "moab";
 
@@ -3605,7 +3605,7 @@ void read_meshes(pugi::xml_node root)
       model::meshes.push_back(make_unique<CylindricalMesh>(node));
     } else if (mesh_type == SphericalMesh::mesh_type) {
       model::meshes.push_back(make_unique<SphericalMesh>(node));
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
     } else if (mesh_type == UnstructuredMesh::mesh_type &&
                mesh_lib == MOABMesh::mesh_lib_type) {
       model::meshes.push_back(make_unique<MOABMesh>(node));

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -323,7 +323,7 @@ void print_build_info()
 #ifdef OPENMC_MPI
   mpi = y;
 #endif
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
   dagmc = y;
 #endif
 #ifdef LIBMESH

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -326,7 +326,7 @@ void print_build_info()
 #ifdef OPENMC_DAGMC_ENABLED
   dagmc = y;
 #endif
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
   libmesh = y;
 #endif
 #ifdef OPENMC_MCPL

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -341,7 +341,7 @@ void print_build_info()
 #ifdef COVERAGEBUILD
   coverage = y;
 #endif
-#ifdef OPENMC_UWUW
+#ifdef OPENMC_UWUW_ENABLED
   uwuw = y;
 #endif
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -32,7 +32,7 @@
 #include "openmc/track_output.h"
 #include "openmc/weight_windows.h"
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
 #include "DagMC.hpp"
 #endif
 
@@ -408,7 +408,7 @@ void Particle::event_collide()
   if (!model::active_tallies.empty())
     score_collision_derivative(*this);
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
   history().reset();
 #endif
 }
@@ -473,7 +473,7 @@ void Particle::event_revive_from_secondary()
 
 void Particle::event_death()
 {
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
   history().reset();
 #endif
 
@@ -553,7 +553,7 @@ void Particle::cross_surface(const Surface& surf)
   }
 
 // if we're crossing a CSG surface, make sure the DAG history is reset
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
   if (surf.geom_type() == GeometryType::CSG)
     history().reset();
 #endif
@@ -567,7 +567,7 @@ void Particle::cross_surface(const Surface& surf)
   // ==========================================================================
   // SEARCH NEIGHBOR LISTS FOR NEXT CELL
 
-#ifdef DAGMC
+#ifdef OPENMC_DAGMC_ENABLED
   // in DAGMC, we know what the next cell should be
   if (surf.geom_type() == GeometryType::DAG) {
     int32_t i_cell = next_cell(surface_index(), cell_last(n_coord() - 1),

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -340,7 +340,7 @@ extern "C" int openmc_statepoint_write(const char* filename, bool* write_source)
       file_close(file_id);
   }
 
-#if defined(LIBMESH) || defined(OPENMC_DAGMC_ENABLED)
+#if defined(OPENMC_LIBMESH_ENABLED) || defined(OPENMC_DAGMC_ENABLED)
   // write unstructured mesh tally files
   write_unstructured_mesh_results();
 #endif

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -340,7 +340,7 @@ extern "C" int openmc_statepoint_write(const char* filename, bool* write_source)
       file_close(file_id);
   }
 
-#if defined(LIBMESH) || defined(DAGMC)
+#if defined(LIBMESH) || defined(OPENMC_DAGMC_ENABLED)
   // write unstructured mesh tally files
   write_unstructured_mesh_results();
 #endif

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -376,7 +376,7 @@ Tally::Tally(pugi::xml_node node)
     }
   }
 
-#ifdef LIBMESH
+#ifdef OPENMC_LIBMESH_ENABLED
   // ensure a tracklength tally isn't used with a libMesh filter
   for (auto i : this->filters_) {
     auto df = dynamic_cast<MeshFilter*>(model::tally_filters[i].get());

--- a/tests/regression_tests/dagmc/external/test.py
+++ b/tests/regression_tests/dagmc/external/test.py
@@ -32,7 +32,7 @@ def cpp_driver(request):
             target_link_libraries(main OpenMC::libopenmc)
             target_compile_features(main PUBLIC cxx_std_14)
             set(CMAKE_CXX_FLAGS "-pedantic-errors")
-            add_compile_definitions(DAGMC=1)
+            add_compile_definitions(OPENMC_DAGMC_ENABLED=1)
             """.format(openmc_dir)))
 
     # Create temporary build directory and change to there

--- a/tests/regression_tests/external_moab/test.py
+++ b/tests/regression_tests/external_moab/test.py
@@ -39,7 +39,7 @@ def cpp_driver(request):
             target_link_libraries(main OpenMC::libopenmc)
             target_compile_features(main PUBLIC cxx_std_14)
             set(CMAKE_CXX_FLAGS "-pedantic-errors")
-            add_compile_definitions(DAGMC=1)
+            add_compile_definitions(OPENMC_DAGMC_ENABLED=1)
             """.format(openmc_dir)))
 
     # Create temporary build directory and change to there


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

The current precompiler definitions for DAGMC and libMesh are a little too generic and are likely to clash with variable/enum names in other locations. I've updated the UWUW precompiler definition to follow the naming adopted here.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~
- [x] ~I have made corresponding changes to the documentation (if applicable)~
- [x] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
