### PR TITLE
Fix for Weight Window Scaling Bug

### DIFF
--- a/include/openmc/weight_windows.h
+++ b/include/openmc/weight_windows.h
@@ -71,6 +71,7 @@ struct WeightWindow {
   {
     lower_weight *= factor;
     upper_weight *= factor;
+    survival_weight *= factor;
   }
 };
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR fixes a bug in the weight window scaling logic. Currently, weight windows are scaled up/down in two areas in response to certain conditions being met. In the case of birth weight scaling (PR #3459), this is done to ensure that weight windows are scaled so as to be responsive to the weight window value of where the particle was sampled, such that rouletting/splitting does not happen immediately at birth. 

I was noticing some significant bias in tallies in the JET problem when weight windows were enabled vs. just analog MC. This was being caused by the scaling function only scaling the lower and upper weight window bounds, rather than the survival weight as well. In effect, when particles would be in a weight window zone that triggered the rouletting routine, the routine would have a survival weight that would be far below the actual particle weight. This means the particles would always pass the roulette successfully and have their weights cut down to the unscaled survival weight, leading to a significant overall net loss of weight from the simulation.

This fix simply ensures the survival weight also gets scaled, such that rouletting happens in the expected manner.

Below is the data for a specific detector tally in JET (the A1 TLD which is quite close to the tokamak, allowing for it to be possible to get some tallies scores on with just analog MC).

|  | Flux |
|---|---|
| Experimental | 2.98E-09 |
| MCNP - Weight Windows | 2.35E-09 |
| OpenMC - Analog | 2.82E-09 |
| OpenMC - Weight Windows (current branch) | 1.45e-09 |
| OpenMC - Weight Windows (this PR) | 2.01E-09 |

Notably, the difference between the analog and WW cases is still larger than expected. There is a lot of uncertainty with the analog case, however, so it's unclear if this is real bias or just noise. Even if there is another bug in the weight window logic somewhere else still causing bias, the current fix is still necessary.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
