### PR TITLE
Fix: `materials`, `plots`, and `tallies` cannot be passed as lists

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -100,6 +100,8 @@ class Model:
         if isinstance(materials, openmc.Materials):
             self._materials = materials
         else:
+            if not hasattr(self, '_materials'):
+                self._materials = openmc.Materials()
             del self._materials[:]
             for mat in materials:
                 self._materials.append(mat)
@@ -123,6 +125,8 @@ class Model:
         if isinstance(tallies, openmc.Tallies):
             self._tallies = tallies
         else:
+            if not hasattr(self, '_tallies'):
+                self._tallies = openmc.Tallies()
             del self._tallies[:]
             for tally in tallies:
                 self._tallies.append(tally)
@@ -137,6 +141,8 @@ class Model:
         if isinstance(plots, openmc.Plots):
             self._plots = plots
         else:
+            if not hasattr(self, '_plots'):
+                self._plots = openmc.Plots()
             del self._plots[:]
             for plot in plots:
                 self._plots.append(plot)

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -70,7 +70,7 @@ class Model:
     def __init__(
         self,
         geometry: openmc.Geometry | None = None,
-        materials: openmc.Materials = None,
+        materials: openmc.Materials | None = None,
         settings: openmc.Settings | None = None,
         tallies: openmc.Tallies | None = None,
         plots: openmc.Plots | None = None,
@@ -82,7 +82,7 @@ class Model:
         self.plots = openmc.Plots() if plots is None else plots
 
     @property
-    def geometry(self) -> openmc.Geometry | None:
+    def geometry(self) -> openmc.Geometry:
         return self._geometry
 
     @geometry.setter
@@ -91,7 +91,7 @@ class Model:
         self._geometry = geometry
 
     @property
-    def materials(self) -> openmc.Materials | None:
+    def materials(self) -> openmc.Materials:
         return self._materials
 
     @materials.setter
@@ -107,7 +107,7 @@ class Model:
                 self._materials.append(mat)
 
     @property
-    def settings(self) -> openmc.Settings | None:
+    def settings(self) -> openmc.Settings:
         return self._settings
 
     @settings.setter
@@ -116,7 +116,7 @@ class Model:
         self._settings = settings
 
     @property
-    def tallies(self) -> openmc.Tallies | None:
+    def tallies(self) -> openmc.Tallies:
         return self._tallies
 
     @tallies.setter
@@ -132,7 +132,7 @@ class Model:
                 self._tallies.append(tally)
 
     @property
-    def plots(self) -> openmc.Plots | None:
+    def plots(self) -> openmc.Plots:
         return self._plots
 
     @plots.setter

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -893,11 +893,15 @@ def test_id_map_aligned_model():
     assert tr_instance == 3, f"Expected cell instance 3 at top-right corner, got {tr_instance}"
     assert tr_material == 5, f"Expected material ID 5 at top-right corner, got {tr_material}"
 
-def test_materials_setter_from_list():
-    lithium = openmc.Material(name="lithium")
-    lithium.set_density("g/cc", 0.534)
-    lithium.add_element("Li", 1.0)
+def test_setter_from_list():
+    mat = openmc.Material()
+    model = openmc.Model(materials=[mat])
+    assert isinstance(model.materials, openmc.Materials)
 
-    my_model = openmc.Model(materials=[lithium])
+    tally = openmc.Tally()
+    model = openmc.Model(tallies=[tally])
+    assert isinstance(model.tallies, openmc.Tallies)
 
-    assert isinstance(my_model.materials, openmc.Materials)
+    plot = openmc.Plot()
+    model = openmc.Model(plots=[plot])
+    assert isinstance(model.plots, openmc.Plots)

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -892,3 +892,12 @@ def test_id_map_aligned_model():
     assert tr_cell == 20, f"Expected cell ID 20 at top-right corner, got {tr_cell}"
     assert tr_instance == 3, f"Expected cell instance 3 at top-right corner, got {tr_instance}"
     assert tr_material == 5, f"Expected material ID 5 at top-right corner, got {tr_material}"
+
+def test_materials_setter_from_list():
+    lithium = openmc.Material(name="lithium")
+    lithium.set_density("g/cc", 0.534)
+    lithium.add_element("Li", 1.0)
+
+    my_model = openmc.Model(materials=[lithium])
+
+    assert isinstance(my_model.materials, openmc.Materials)


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This small PR makes sure the `_materials`, `_tallies`, and `_plots` attributes are properly initialised even when users pass lists instead of OpenMC objects. To reproduce the bug, run the following MWE:

```python
import openmc

lithium = openmc.Material(name="lithium")
lithium.set_density("g/cc", 0.534)
lithium.add_element("Li", 1.0)

my_model = openmc.Model(materials=[lithium])
```

Results in:

```
Traceback (most recent call last):
  File "/home/remidm/mwe.py", line 7, in <module>
    my_model = openmc.Model(materials=[lithium])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/remidm/anaconda3/envs/festim-v2-review-env/lib/python3.12/site-packages/openmc/model/model.py", line 70, in __init__
    self.materials = openmc.Materials() if materials is None else materials
    ^^^^^^^^^^^^^^
  File "/home/remidm/anaconda3/envs/festim-v2-review-env/lib/python3.12/site-packages/openmc/model/model.py", line 94, in materials
    del self._materials[:]
        ^^^^^^^^^^^^^^^
AttributeError: 'Model' object has no attribute '_materials'. Did you mean: 'materials'?
```

I also added a small test to make sure the fix is effective.


# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
