### PR TITLE
fixed a bug in MeshMaterialFilter.from_volumes

### DIFF
--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1082,7 +1082,8 @@ class MeshMaterialFilter(MeshFilter):
             A new MeshMaterialFilter instance
 
         """
-        bins = list(zip(*np.where(volumes._materials > -1)))
+        i,j = np.where(volumes._materials > -1)
+        bins = sorted(zip(i,volumes._materials[i,j]))
         return cls(mesh, bins)
 
     def __hash__(self):

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1082,8 +1082,12 @@ class MeshMaterialFilter(MeshFilter):
             A new MeshMaterialFilter instance
 
         """
-        i,j = np.where(volumes._materials > -1)
-        bins = sorted(zip(i,volumes._materials[i,j]))
+        # Get flat arrays of material IDs and element indices
+        mat_ids = volumes._materials[volumes._materials > -1]
+        elems, _ = np.where(volumes._materials > -1)
+
+        # Stack them into a 2D array of (element, material) pairs
+        bins = np.column_stack((elems, mat_ids))
         return cls(mesh, bins)
 
     def __hash__(self):

--- a/tests/unit_tests/test_filter_meshmaterial.py
+++ b/tests/unit_tests/test_filter_meshmaterial.py
@@ -36,7 +36,7 @@ def test_filter_mesh_material(run_in_tmpdir):
     # MeshMaterialFilter with corresponding bins
     vols = mesh.material_volumes(model)
     mmf = openmc.MeshMaterialFilter.from_volumes(mesh, vols)
-    expected_bins = [(0, 10), (1, 10), (1, 20), (2, 20), (2, 30), (3, 30), (3, 40), (4, 40)]
+    expected_bins = [(0, 10), (1, 10), (1, 20), (2, 20), (2, 30), (3, 40), (3, 30), (4, 40)]
     np.testing.assert_equal(mmf.bins, expected_bins)
 
     # Create two tallies, one with a mesh filter and one with mesh-material

--- a/tests/unit_tests/test_filter_meshmaterial.py
+++ b/tests/unit_tests/test_filter_meshmaterial.py
@@ -9,6 +9,7 @@ def test_filter_mesh_material(run_in_tmpdir):
     materials = []
     for i in range(4):
         mat = openmc.Material()
+        mat.id = 10*(i+1)
         mat.add_nuclide('Fe56', 1.0)
         materials.append(mat)
 
@@ -35,7 +36,7 @@ def test_filter_mesh_material(run_in_tmpdir):
     # MeshMaterialFilter with corresponding bins
     vols = mesh.material_volumes(model)
     mmf = openmc.MeshMaterialFilter.from_volumes(mesh, vols)
-    expected_bins = [(0, 1), (1, 1), (1, 2), (2, 2), (2, 3), (3, 3), (3, 4), (4, 4)]
+    expected_bins = [(0, 10), (1, 10), (1, 20), (2, 20), (2, 30), (3, 30), (3, 40), (4, 40)]
     np.testing.assert_equal(mmf.bins, expected_bins)
 
     # Create two tallies, one with a mesh filter and one with mesh-material


### PR DESCRIPTION


<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR fix a bug in MeshMaterialFilter.from_volumes when material ids are not a simple contiguous interval.

Fixes #3518

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
