### PR TITLE
Default to chain half life if it exists

### DIFF
--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from math import sqrt, log
 from warnings import warn
 
+
 # Isotopic abundances from Meija J, Coplen T B, et al, "Isotopic compositions
 # of the elements 2013 (IUPAC Technical Report)", Pure. Appl. Chem. 88 (3),
 # pp. 293-306 (2013). The "representative isotopic abundance" values from
@@ -382,6 +383,12 @@ def half_life(isotope):
         Half-life of isotope in [s]
 
     """
+    from openmc.deplete.chain import _get_chain
+    
+    chain = _get_chain()
+    if isotope in chain:
+        return chain[isotope].half_life
+    
     global _HALF_LIFE
     if not _HALF_LIFE:
         # Load ENDF/B-VIII.0 data from JSON file


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description
Currently, half lifes in openmc are set in some constant json file.
This PR change the logic of half life to return half life stored in chain file for any isotope defined in that chain file.

Fixes #3529

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
