### PR TITLE
more helpful error message for dose_coefficients

### DIFF
--- a/openmc/data/effective_dose/dose.py
+++ b/openmc/data/effective_dose/dose.py
@@ -84,7 +84,7 @@ def dose_coefficients(particle, geometry='AP', data_source='icrp116'):
     if (data_source, particle) not in _FILES:
         available_particles = sorted({p for (ds, p) in _FILES if ds == data_source})
         msg = (
-            f"'{particle}' has no dose data in data source '{data_source}'. "
+            f"'{particle}' has no dose data in data source {data_source}. "
             f"Available particles for {data_source} are: {available_particles}"
         )
         raise ValueError(msg)

--- a/tests/unit_tests/test_data_dose.py
+++ b/tests/unit_tests/test_data_dose.py
@@ -41,3 +41,23 @@ def test_dose_coefficients():
         dose_coefficients('neutron', 'ZZ')
     with raises(ValueError):
         dose_coefficients('neutron', data_source='icrp7000')
+    with raises(ValueError) as excinfo:
+        dose_coefficients("photons", data_source="icrp116")
+    expected_particles = [
+        "electron",
+        "helium",
+        "mu+",
+        "mu-",
+        "neutron",
+        "photon",
+        "photon kerma",
+        "pi+",
+        "pi-",
+        "positron",
+        "proton",
+    ]
+    expected_msg = (
+        "'photons' has no dose data in data source icrp116. "
+        f"Available particles for icrp116 are: {expected_particles}"
+    )
+    assert str(excinfo.value) == expected_msg


### PR DESCRIPTION
# Description

I was just trying to get dose coefficients for 'gamma', 'gammas', 'photons' and had to peak at the source code to realise the keyword to use was 'photon'.

I thought it might be worth adding to the error message to help future users

So now if the particle is not found it lets the user know the acceptable particles

Current error message
```
ValueError: photons has no dose data in data source icrp116.
```

Error message introduced by this PR
```
ValueError: 'photons' has no dose data in data source 'icrp116'. Available particles for icrp116 are: ['electron', 'helium', 'mu+', 'mu-', 'neutron', 'photon', 'photon kerma', 'pi+', 'pi-', 'positron', 'proton']
```

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x]  I have added tests that prove my fix is effective or that my feature works (if applicable)