### PR TITLE
Avoid duplicate materials written to XML

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1927,8 +1927,7 @@ class Materials(cv.CheckedList):
             file.write(ET.tostring(element, encoding="unicode"))
 
         # Write the <material> elements.
-        unique_materials = sorted(set(self), key=lambda x: x.id)
-        for material in unique_materials:
+        for material in sorted(set(self), key=lambda x: x.id):
             element = material.to_xml_element(nuclides_to_ignore=nuclides_to_ignore)
             clean_indentation(element, level=level+1)
             element.tail = element.tail.strip(' ')

--- a/tests/unit_tests/test_materials.py
+++ b/tests/unit_tests/test_materials.py
@@ -62,7 +62,8 @@ def test_materials_deplete():
     # step. It then decays in the second cooling step (flux = 0)
     assert Ni59_mat_1_step_1 > 0.0 and Ni59_mat_1_step_1 > Ni59_mat_1_step_2
 
-def test_export_duplicate_materials_to_xml():
+
+def test_export_duplicate_materials_to_xml(run_in_tmpdir):
     """
     Test exporting Materials to xml with a duplicate and checking that only
     unique entities are exported.


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

[Recently](https://github.com/LIBRA-project/libra-toolbox/pull/84), we accidentally added the same `Material` object to a `Model` twice which made the simulation crash because there were duplicate IDs in the XML. Consider the following MWE:

```python
import openmc

my_mat = openmc.Material(name="my_mat")
my_mat2 = openmc.Material(name="my_mat2")

materials = openmc.Materials([my_mat, my_mat2, my_mat])

materials.export_to_xml("materials.xml")

materials_in = openmc.Materials.from_xml("materials.xml")
assert len(materials_in) == 2
```

A simple way to get rid of this is to only export unique entities to XML.

@pshriwise 

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
