### PR TITLE
Fix caching issue when using NCrystal materials

### DIFF
--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -157,6 +157,7 @@ struct NuclideMicroXS {
   double last_E {0.0};      //!< Last evaluated energy
   double last_sqrtkT {0.0}; //!< Last temperature in sqrt(Boltzmann constant
                             //!< * temperature (eV))
+  double last_ncrystal_xs {-999.0}; //!< Last evaluated NCrystal cross section
 };
 
 //==============================================================================

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -154,10 +154,10 @@ struct NuclideMicroXS {
 
   // Energy and temperature last used to evaluate these cross sections.  If
   // these values have changed, then the cross sections must be re-evaluated.
-  double last_E {0.0};      //!< Last evaluated energy
-  double last_sqrtkT {0.0}; //!< Last temperature in sqrt(Boltzmann constant
-                            //!< * temperature (eV))
-  double last_ncrystal_xs {-999.0}; //!< Last evaluated NCrystal cross section
+  double last_E {0.0};       //!< Last evaluated energy
+  double last_sqrtkT {0.0};  //!< Last temperature in sqrt(Boltzmann constant
+                             //!< * temperature (eV))
+  double ncrystal_xs {-1.0}; //!< NCrystal cross section
 };
 
 //==============================================================================

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -500,7 +500,7 @@ def _calculate_cexs_nuclide(this, types, temperature=294., sab_name=None,
                     elif ncrystal_cfg:
                         import NCrystal
                         nc_scatter = NCrystal.createScatter(ncrystal_cfg)
-                        nc_func = nc_scatter.crossSectionNonOriented
+                        nc_func = nc_scatter.xsect
                         nc_emax = 5 # eV # this should be obtained from NCRYSTAL_MAX_ENERGY
                         energy_grid = np.union1d(np.geomspace(min(energy_grid),
                                                               1.1*nc_emax,

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -849,8 +849,10 @@ void Particle::update_neutron_xs(
 
   // If the cache doesn't match, recalculate micro xs
   if (this->E() != micro.last_E || this->sqrtkT() != micro.last_sqrtkT ||
-      i_sab != micro.index_sab || sab_frac != micro.sab_frac) {
+      i_sab != micro.index_sab || sab_frac != micro.sab_frac ||
+      ncrystal_xs != micro.last_ncrystal_xs) {
     data::nuclides[i_nuclide]->calculate_xs(i_sab, i_grid, sab_frac, *this);
+    micro.last_ncrystal_xs = ncrystal_xs;
 
     // If NCrystal is being used, update micro cross section cache
     if (ncrystal_xs >= 0.0) {

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -850,11 +850,11 @@ void Particle::update_neutron_xs(
   // If the cache doesn't match, recalculate micro xs
   if (this->E() != micro.last_E || this->sqrtkT() != micro.last_sqrtkT ||
       i_sab != micro.index_sab || sab_frac != micro.sab_frac ||
-      ncrystal_xs != micro.last_ncrystal_xs) {
+      ncrystal_xs != micro.ncrystal_xs) {
     data::nuclides[i_nuclide]->calculate_xs(i_sab, i_grid, sab_frac, *this);
-    micro.last_ncrystal_xs = ncrystal_xs;
 
     // If NCrystal is being used, update micro cross section cache
+    micro.ncrystal_xs = ncrystal_xs;
     if (ncrystal_xs >= 0.0) {
       data::nuclides[i_nuclide]->calculate_elastic_xs(*this);
       ncrystal_update_micro(ncrystal_xs, micro);


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This small but important PR fixes a caching issue affecting NCrystal materials when any of the isotopes of NCrystal materials also appear in other materials with the same temperature. It seems to be simply that the "is the cached xs still valid" check never actually took the NCrystal contribution into account.

This issue was observed by two different people recently, and was initially reported in the ncrystal issue tracker at mctools/ncrystal#243.

Fixes #3540

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
