### PR TITLE
Revert "fix broken CI"

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cpp-linter/cpp-linter-action@v2.16.0
+      - uses: cpp-linter/cpp-linter-action@v2
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts openmc-dev/openmc#3551

Apparently the issue we had was temporary and is resolved in https://github.com/cpp-linter/cpp-linter-action/issues/319.

So that PR is no longer necessary.

Moreover the change in version introduced new bugs in my testing...