### PR TITLE
Fix broken CI (again)

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -28,5 +28,5 @@ jobs:
           extensions: 'cpp,h'
 
       - name: Failure Check
-        if: steps.linter.outputs.checks-failed > 0
+        if: steps.linter.outputs.clang-format-checks-failed > 0
         run: echo "Some files failed the formatting check! See job summary and file annotations for more info" && exit 1


### PR DESCRIPTION
# Description
Suddenly PRs fail if they do not pass clang-tidy checks (not sure why).
This PR aim to fix that by declaring the run successfull according to the clang-format checks only.