### PR TITLE
Fixed a bug in plotting cross sections with S(a,b) data

### DIFF
--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -413,7 +413,8 @@ def _calculate_cexs_nuclide(this, types, temperature=294., sab_name=None,
 
         # Prep S(a,b) data if needed
         if sab_name:
-            sab = openmc.data.ThermalScattering.from_hdf5(sab_name)
+            sab = openmc.data.ThermalScattering.from_hdf5(
+                library.get_by_material(sab_name, data_type='thermal')['path'])
             # Obtain the nearest temperature
             if strT in sab.temperatures:
                 sabT = strT
@@ -640,14 +641,13 @@ def _calculate_cexs_elem_mat(this, types, temperature=294.,
             sab = openmc.data.ThermalScattering.from_hdf5(
                 library.get_by_material(sab_name, data_type='thermal')['path'])
             for nuc in sab.nuclides:
-                sabs[nuc] = library.get_by_material(sab_name,
-                        data_type='thermal')['path']
+                sabs[nuc] = sab_name
     else:
         if sab_name:
-            sab = openmc.data.ThermalScattering.from_hdf5(sab_name)
+            sab = openmc.data.ThermalScattering.from_hdf5(
+                library.get_by_material(sab_name, data_type='thermal')['path'])
             for nuc in sab.nuclides:
-                sabs[nuc] = library.get_by_material(sab_name,
-                        data_type='thermal')['path']
+                sabs[nuc] = sab_name
 
     # Now we can create the data sets to be plotted
     xs = {}
@@ -655,8 +655,8 @@ def _calculate_cexs_elem_mat(this, types, temperature=294.,
     for nuclide in nuclides.items():
         name = nuclide[0]
         nuc = nuclide[1]
-        sab_tab = sabs[name]
-        temp_E, temp_xs = calculate_cexs(nuc, types, T, sab_tab, cross_sections,
+        sab_name = sabs[name]
+        temp_E, temp_xs = calculate_cexs(nuc, types, T, sab_name, cross_sections,
                                          ncrystal_cfg=ncrystal_cfg
                                          )
         E.append(temp_E)


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Sab data is not accessed correctly in openmc/plotter.py.
This PR fix it.

Fixes #3557

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
