### PR TITLE
Bump up tolerance for flaky activation test

### DIFF
--- a/tests/unit_tests/test_deplete_activation.py
+++ b/tests/unit_tests/test_deplete_activation.py
@@ -45,7 +45,7 @@ ENERGIES = np.logspace(log10(1e-5), log10(2e7), 100)
 
 @pytest.mark.parametrize("reaction_rate_mode,reaction_rate_opts,tolerance", [
     ("direct", {}, 1e-5),
-    ("flux", {'energies': ENERGIES}, 0.01),
+    ("flux", {'energies': ENERGIES}, 0.1),
     ("flux", {'energies': ENERGIES, 'reactions': ['(n,gamma)']}, 1e-5),
     ("flux", {'energies': ENERGIES, 'reactions': ['(n,gamma)'], 'nuclides': ['W186', 'H3']}, 1e-2),
 ])
@@ -61,11 +61,10 @@ def test_activation(run_in_tmpdir, model, reaction_rate_mode, reaction_rate_opts
     w186 = openmc.deplete.Nuclide('W186')
     w186.add_reaction('(n,gamma)', None, 0.0, 1.0)
     chain.add_nuclide(w186)
-    chain.export_to_xml('test_chain.xml')
 
     # Create transport operator
     op = openmc.deplete.CoupledOperator(
-        model, 'test_chain.xml',
+        model, chain,
         normalization_mode="source-rate",
         reaction_rate_mode=reaction_rate_mode,
         reaction_rate_opts=reaction_rate_opts,


### PR DESCRIPTION
# Description

I've noticed quite a few random failures in CI lately of one of the cases in `test_activation`, where the reaction rate is estimated by tallying a 100-group flux and then collapsing it with cross sections. It is expected that you don't get the exactly right answer because it doesn't account for energy self-shielding within the groups, which is why the test is occasionally failing. This PR bumps up the tolerance for that case which should mitigate the random failures.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)