### PR TITLE
depletion: fix performance of chain matrix construction

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -629,8 +629,8 @@ class Chain:
 
         n = len(self)
 
-        # we accumulate indices and value entries for everything and create the matrix in one at
-        # the end to avoid expensive index checks scipy otherwise does.
+        # we accumulate indices and value entries for everything and create the matrix 
+        # in one step at the end to avoid expensive index checks scipy otherwise does.
         rows, cols, vals = [], [], []
         def setval(i, j, val):
             rows.append(i)


### PR DESCRIPTION
# Description

The previous construction of the chain sparse matrix was repeatedly invoking square bracket indexing which calls into the expensive `_validate_indices` func.  This was causing my full core depletion runs to take 10s of hours with ~90% of the time spent in these validate indices checks.  This avoids that and does a batch/all-at-once construction of the sparse matrix after accumulating all the indices and values.

Sorry for the quick drive-by.  I haven't really looked over your contributor guidelines or done any due diligence beyond ensuring this makes my depletion runs ~10x faster.  Figured it might be consequential enough that you'd want to at least see the issue.


# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

