### PR TITLE
Allow newer Sphinx version and fix docbuild warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,9 +121,7 @@ pygments_style = 'tango'
 # -- Options for HTML output ---------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages
-import sphinx_rtd_theme
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_baseurl = "https://docs.openmc.org/en/stable/"
 
 html_logo = '_images/openmc_logo.png'

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -12,6 +12,7 @@ from copy import deepcopy
 from inspect import signature
 from numbers import Real, Integral
 from pathlib import Path
+from textwrap import dedent
 import time
 from typing import Optional, Union, Sequence
 from warnings import warn
@@ -526,7 +527,7 @@ class Integrator(ABC):
     r"""Abstract class for solving the time-integration for depletion
     """
 
-    _params = r"""
+    _params = dedent(r"""
     Parameters
     ----------
     operator : openmc.deplete.abc.TransportOperator
@@ -617,7 +618,7 @@ class Integrator(ABC):
 
         .. versionadded:: 0.15.3
 
-    """
+    """)
 
     def __init__(
             self,
@@ -1020,7 +1021,7 @@ class SIIntegrator(Integrator):
     the number of particles used in initial transport calculation
     """
 
-    _params = r"""
+    _params = dedent(r"""
     Parameters
     ----------
     operator : openmc.deplete.abc.TransportOperator
@@ -1108,7 +1109,7 @@ class SIIntegrator(Integrator):
 
         .. versionadded:: 0.12
 
-    """
+    """)
 
     def __init__(
             self,

--- a/openmc/deplete/integrators.py
+++ b/openmc/deplete/integrators.py
@@ -22,7 +22,6 @@ class PredictorIntegrator(Integrator):
 
     .. math::
         \mathbf{n}_{i+1} = \exp\left(h\mathbf{A}(\mathbf{n}_i) \right) \mathbf{n}_i
-
     """
     _num_stages = 1
 

--- a/openmc/mgxs/mgxs.py
+++ b/openmc/mgxs/mgxs.py
@@ -2,6 +2,7 @@ import copy
 from numbers import Integral
 import os
 import warnings
+from textwrap import dedent
 
 import h5py
 import numpy as np
@@ -164,7 +165,7 @@ class MGXS:
 
     """
 
-    _params = """
+    _params = dedent("""
     Parameters
     ----------
     domain : openmc.Material or openmc.Cell or openmc.Universe or openmc.RegularMesh
@@ -251,7 +252,7 @@ class MGXS:
 
         .. versionadded:: 0.13.1
 
-    """
+    """)
 
     # Store whether or not the number density should be removed for microscopic
     # values of this data

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable, Mapping
 from numbers import Integral, Real
 from pathlib import Path
+from textwrap import dedent
 
 import h5py
 import lxml.etree as ET
@@ -167,7 +168,8 @@ _SVG_COLORS = {
     'yellowgreen': (154, 205, 50)
 }
 
-_PLOT_PARAMS = """
+_PLOT_PARAMS = dedent("""\
+
         Parameters
         ----------
         origin : iterable of float
@@ -249,7 +251,7 @@ _PLOT_PARAMS = """
         -------
         matplotlib.axes.Axes
             Axes containing resulting image
-"""
+""")
 
 
 # Decorator for consistently adding plot parameters to docstrings (Model.plot,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,12 @@ dependencies = [
 [project.optional-dependencies]
 depletion-mpi = ["mpi4py"]
 docs = [
-    "sphinx==5.0.2",
+    "sphinx",
     "sphinxcontrib-katex",
     "sphinx-numfig",
     "jupyter",
     "sphinxcontrib-svg2pdfconverter",
-    "sphinx-rtd-theme==1.0.0"
+    "sphinx-rtd-theme"
 ]
 test = ["packaging", "pytest", "pytest-cov", "colorama", "openpyxl"]
 ci = ["cpp-coveralls", "coveralls"]


### PR DESCRIPTION
# Description

I just noticed recently that we're pinned to a relatively old version of Sphinx for building documentation. This PR removes that pin since there's no reason we can't use newer versions, and then fixes some warnings that arise with newer versions.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>