### PR TITLE
Update find_package calls in OpenMCConfig.cmake

### DIFF
--- a/cmake/OpenMCConfig.cmake.in
+++ b/cmake/OpenMCConfig.cmake.in
@@ -1,9 +1,12 @@
 get_filename_component(OpenMC_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 
-find_package(fmt REQUIRED HINTS ${OpenMC_CMAKE_DIR}/../fmt)
-find_package(pugixml REQUIRED HINTS ${OpenMC_CMAKE_DIR}/../pugixml)
-find_package(xtl REQUIRED HINTS ${OpenMC_CMAKE_DIR}/../xtl)
-find_package(xtensor REQUIRED HINTS ${OpenMC_CMAKE_DIR}/../xtensor)
+# Compute the install prefix from this file's location
+get_filename_component(_OPENMC_PREFIX "${OpenMC_CMAKE_DIR}/../../.." ABSOLUTE)
+
+find_package(fmt CONFIG REQUIRED HINTS ${_OPENMC_PREFIX})
+find_package(pugixml CONFIG REQUIRED HINTS ${_OPENMC_PREFIX})
+find_package(xtl CONFIG REQUIRED HINTS ${_OPENMC_PREFIX})
+find_package(xtensor CONFIG REQUIRED HINTS ${_OPENMC_PREFIX})
 if(@OPENMC_USE_DAGMC@)
   find_package(DAGMC REQUIRED HINTS @DAGMC_DIR@)
 endif()

--- a/openmc/deplete/transfer_rates.py
+++ b/openmc/deplete/transfer_rates.py
@@ -366,7 +366,7 @@ class ExternalSourceRates(ExternalRates):
         rate : float
             External source rate in units of mass per time. A positive or
             negative value corresponds to a feed or removal rate, respectively.
-        units : {'g/s', 'g/min', 'g/h', 'g/d', 'g/a'}
+        rate_units : {'g/s', 'g/min', 'g/h', 'g/d', 'g/a'}
             Units for values specified in the `rate` argument. 's' for seconds,
             'min' for minutes, 'h' for hours, 'a' for Julian years.
         timesteps : list of int, optional

--- a/tests/regression_tests/unstructured_mesh/test.py
+++ b/tests/regression_tests/unstructured_mesh/test.py
@@ -256,7 +256,7 @@ for i, (lib, estimator, ext_geom, holes) in enumerate(product(*param_values)):
 def test_unstructured_mesh_tets(model, test_opts):
     # skip the test if the library is not enabled
     if test_opts['library'] == 'moab' and not openmc.lib._dagmc_enabled():
-        pytest.skip("DAGMC (and MOAB) mesh not enbaled in this build.")
+        pytest.skip("DAGMC (and MOAB) mesh not enabled in this build.")
 
     if test_opts['library'] == 'libmesh' and not openmc.lib._libmesh_enabled():
         pytest.skip("LibMesh is not enabled in this build.")

--- a/tests/unit_tests/dagmc/test_plot.py
+++ b/tests/unit_tests/dagmc/test_plot.py
@@ -64,5 +64,8 @@ def test_plotting_geometry_filled_with_dagmc_universe(request):
     cell2 = openmc.Cell(fill=csg_material, region=+sphere1 & -sphere2)
 
     geometry = openmc.Geometry([cell1, cell2])
-
     geometry.plot()
+
+    # Close plot to avoid warning
+    import matplotlib.pyplot as plt
+    plt.close()

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -650,6 +650,10 @@ def test_model_plot():
     test_mask = (image_data == white) | (image_data == red)
     assert np.all(test_mask), "Colors other than white or red found in overlap plot image"
 
+    # Close plots to avoid warning
+    import matplotlib.pyplot as plt
+    plt.close('all')
+
 
 def test_model_id_map_initialization(run_in_tmpdir):
     model = openmc.examples.pwr_assembly()

--- a/tests/unit_tests/test_region.py
+++ b/tests/unit_tests/test_region.py
@@ -248,6 +248,10 @@ def test_plot():
     c_before = openmc.Cell()
     region.plot()
 
+    # Close plot to avoid warning
+    import matplotlib.pyplot as plt
+    plt.close()
+
     # Ensure that calling plot doesn't affect cell ID space
     c_after = openmc.Cell()
     assert c_after.id - 1 == c_before.id

--- a/tests/unit_tests/test_universe.py
+++ b/tests/unit_tests/test_universe.py
@@ -99,6 +99,10 @@ def test_plot(run_in_tmpdir, sphere_model):
             pixels=100,
         )
 
+    # Close plots to avoid warning
+    import matplotlib.pyplot as plt
+    plt.close('all')
+
 
 def test_get_nuclides(uo2):
     c = openmc.Cell(fill=uo2)

--- a/tests/unit_tests/weightwindows/test_wwinp_reader.py
+++ b/tests/unit_tests/weightwindows/test_wwinp_reader.py
@@ -140,4 +140,4 @@ def test_wwinp_reader_failures(wwinp_data, request):
     filename, expected_failure = wwinp_data
 
     with pytest.raises(expected_failure):
-        _ = openmc.wwinp_to_wws(request.node.path.parent / filename)
+        _ = openmc.WeightWindowsList.from_wwinp(request.node.path.parent / filename)


### PR DESCRIPTION
# Description

I noticed recently that installs of xtensor/xtl go into a different directory than the one that is indicated by the HINT in OpenMCConfig.cmake.in. Namely, currently it assumes that the xtensor/xtl cmake files get installed in `lib/cmake/xtensor` and `lib/cmake/xtensor`, whereas it is actually getting installed to `share/cmake/xtensor` and `share/cmake/xtl`. Both of them seem to be common locations for installing `*.cmake` files, so it's hard to say what is "correct". In this PR, I've updated the find_package calls to instead give a HINT to the prefix where OpenMC was installed, which by CMake search rules will include both `lib/cmake` and `share/cmake`. It seems we've just been getting lucky in CI because everything is installed to /usr/local, which is found by other means.

A few other miscellaneous fixes in this PR:
- Fix a few typos
- Close matplotlib figures in tests to avoid a warning
- Fix a deprecated use of `wwinp_to_wws` in one test

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)