### PR TITLE
Ensure n_dimension_ attribute is set for unstructured meshes.

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -666,9 +666,8 @@ class UnstructuredMesh : public Mesh {
 
 public:
   // Constructors
-  UnstructuredMesh() {};
+  UnstructuredMesh() { n_dimension_ = 3; };
   UnstructuredMesh(pugi::xml_node node);
-  UnstructuredMesh(const std::string& filename);
 
   static const std::string mesh_type;
   virtual std::string get_mesh_type() const override;

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -590,6 +590,8 @@ Position StructuredMesh::sample_element(
 
 UnstructuredMesh::UnstructuredMesh(pugi::xml_node node) : Mesh(node)
 {
+  n_dimension_ = 3;
+
   // check the mesh type
   if (check_for_node(node, "type")) {
     auto temp = get_node_value(node, "type", true, true);
@@ -2518,8 +2520,9 @@ MOABMesh::MOABMesh(pugi::xml_node node) : UnstructuredMesh(node)
   initialize();
 }
 
-MOABMesh::MOABMesh(const std::string& filename, double length_multiplier)
+MOABMesh::MOABMesh(const std::string& filename, double length_multiplier) : UnstructuredMesh()
 {
+  n_dimension_ = 3;
   filename_ = filename;
   set_length_multiplier(length_multiplier);
   initialize();
@@ -3242,6 +3245,7 @@ LibMesh::LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier)
 LibMesh::LibMesh(const std::string& filename, double length_multiplier)
   : adaptive_(false)
 {
+  n_dimension_ = 3;
   set_mesh_pointer_from_filename(filename);
   set_length_multiplier(length_multiplier);
   initialize();

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -2520,7 +2520,8 @@ MOABMesh::MOABMesh(pugi::xml_node node) : UnstructuredMesh(node)
   initialize();
 }
 
-MOABMesh::MOABMesh(const std::string& filename, double length_multiplier) : UnstructuredMesh()
+MOABMesh::MOABMesh(const std::string& filename, double length_multiplier)
+  : UnstructuredMesh()
 {
   n_dimension_ = 3;
   filename_ = filename;


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Output of libMesh tally results to exodus is failing on newer versions of libMesh. This is an error on our side as the `n_dimension_` attribute of the mesh is not being set for `UnstructuredMesh` objects. This value is propagated to the libMesh mesh object  These changes 

Tested with libMesh v1.8.2.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
