### PR TITLE
Fix performance regression in libMesh unstructured mesh tallies

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -1028,7 +1028,8 @@ private:
 class AdaptiveLibMesh : public LibMesh {
 public:
   // Constructor
-  AdaptiveLibMesh(libMesh::MeshBase& input_mesh, double length_multiplier = 1.0);
+  AdaptiveLibMesh(
+    libMesh::MeshBase& input_mesh, double length_multiplier = 1.0);
 
   // Overridden methods
   int n_bins() const override;
@@ -1051,8 +1052,8 @@ private:
   const libMesh::dof_id_type num_active_; //!< cached number of active elements
 
   std::vector<libMesh::dof_id_type>
-  bin_to_elem_map_; //!< mapping bin indices to dof indices for active
-                    //!< elements
+    bin_to_elem_map_; //!< mapping bin indices to dof indices for active
+                      //!< elements
   std::vector<int> elem_to_bin_map_; //!< mapping dof indices to bin indices for
                                      //!< active elements
 };

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3519,9 +3519,9 @@ double LibMesh::volume(int bin) const
   return this->get_element_from_bin(bin).volume();
 }
 
-AdaptiveLibMesh::AdaptiveLibMesh(libMesh::MeshBase& input_mesh, double length_multiplier)
-  : LibMesh(input_mesh, length_multiplier),
-    num_active_(m_->n_active_elem())
+AdaptiveLibMesh::AdaptiveLibMesh(
+  libMesh::MeshBase& input_mesh, double length_multiplier)
+  : LibMesh(input_mesh, length_multiplier), num_active_(m_->n_active_elem())
 {
   // if the mesh is adaptive elements aren't guaranteed by libMesh to be
   // contiguous in ID space, so we need to map from bin indices (defined over
@@ -3549,8 +3549,8 @@ void AdaptiveLibMesh::add_score(const std::string& var_name)
     this->id_));
 }
 
-void AdaptiveLibMesh::set_score_data(const std::string& var_name, const vector<double>& values,
-  const vector<double>& std_dev)
+void AdaptiveLibMesh::set_score_data(const std::string& var_name,
+  const vector<double>& values, const vector<double>& std_dev)
 {
   warning(fmt::format(
     "Exodus output cannot be provided as unstructured mesh {} is adaptive.",


### PR DESCRIPTION
# Description

#3185 added support for adaptive libMesh tallies initialized by an external C++ driver application (e.g. Cardinal) to support a project investigating adaptive mesh refinement applied to unstructured mesh tallies in Monte Carlo particle transport. Unfortunately, this addition also introduced a bug which yielded a massive performance penalty during tallying for users of both OpenMC and Cardinal. The crux of the issue is the function
```c++
int LibMesh::n_bins() const
{
  return m_->n_elem();
}
```
was changed to
```c++
int LibMesh::n_bins() const
{
  return m_->n_active_elem();
}
```
Without getting too deep into the weeds of how libMesh is designed and the process behind adaptive mesh refinement, the return value of `n_elem()` is cached when the libMesh mesh is constructed, while `n_active_elem()` (required for AMR) is not. This necessitates what is essentially a loop over all elements every time `n_active_elem()` is called, which in the case of transport is _every time a libMesh element accumulates a hit_ due to this function:
```c++
int LibMesh::get_bin_from_element(const libMesh::Elem* elem) const
{
  int bin =
    adaptive_ ? elem_to_bin_map_[elem->id()] : elem->id() - first_element_id_;
  if (bin >= n_bins() || bin < 0) {
    fatal_error(fmt::format("Invalid bin: {}", bin));
  }
  return bin;
}
```

## This Implementation

To fix this performance regression, I've reverted the `LibMesh` class back to it's previous state. All of the adaptivity code necessary for mesh tally AMR in Cardinal has been moved to a new class called `AdaptiveLibMesh` which inherits from `LibMesh` and overrides the few functions required to get adaptivity working. `n_active_elem()` is cached on construction to avoid any performance hits in transport. This should insulate OpenMC users from any other changes made to support the AMR project in Cardinal, such as #3553.
 
 ## Simpler Implementation
 
 If a simpler fix is desired, I can revert these changes and simply implement the cache for `n_active_elem()` in `LibMesh`. I decided to go all the way in an attempt to guard against future performance regressions.
 
 FYI @pshriwise @aprilnovak 
 
# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
