### PR TITLE
Optional separation of mesh-material-volume calc from get_homogenized_materials

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -367,6 +367,7 @@ class MeshBase(IDManagerMixin, ABC):
             model: openmc.Model,
             n_samples: int | tuple[int, int, int] = 10_000,
             max_materials: int = 4,
+            save_filename: PathLike | None = None,
             **kwargs
     ) -> MeshMaterialVolumes:
         """Determine volume of materials in each mesh element.
@@ -389,6 +390,9 @@ class MeshBase(IDManagerMixin, ABC):
             the x, y, and z dimensions.
         max_materials : int, optional
             Estimated maximum number of materials in any given mesh element.
+        save_filename : path-like, optional
+            If provided, the material volumes will be saved to this file using
+            the MeshMaterialVolumes.save() method.
         **kwargs : dict
             Keyword arguments passed to :func:`openmc.lib.init`
 
@@ -425,6 +429,10 @@ class MeshBase(IDManagerMixin, ABC):
         # Restore original tallies
         model.tallies = original_tallies
 
+        # Save material volumes if filename provided
+        if save_filename is not None:
+            volumes.save(save_filename)
+    
         return volumes
 
 


### PR DESCRIPTION
# Description

Enable mesh material_volumes to directly save to npz the material volumes it calculates.

When using get_homogenized_materials, the normal mesh volumes (pre-homogenization) are buried and not directly accessible, this enables getting them out.
This is useful to determine what original inventory is being activated in a large mesh R2S.

Small change enabling kwargs to material_volumes and an if statement to save this file. Builds on existing functionatlity.


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
