### PR TITLE
Chain Reduce. restrict_products, null check

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -1173,10 +1173,11 @@ class Chain:
                 if rx.target in all_isotopes:
                     new_nuclide.add_reaction(*rx)
                 elif rx.type == "fission":
-                    new_yields = new_nuclide.yield_data = (
-                        previous.yield_data.restrict_products(name_sort))
-                    if new_yields is not None:
-                        new_nuclide.add_reaction(*rx)
+                    if previous.yield_data is not None:
+                        new_yields = new_nuclide.yield_data = (
+                            previous.yield_data.restrict_products(name_sort))
+                        if new_yields is not None:
+                            new_nuclide.add_reaction(*rx)
                 # Maintain total destruction rates but set no target
                 else:
                     new_nuclide.add_reaction(rx.type, None, rx.Q, rx.branching_ratio)


### PR DESCRIPTION
# Issue
Chain Reduce fails with a vanilla jeff-3.3 chain:
```
Traceback (most recent call last):
  File "~/OMC-mR2S_v5.py", line 798, in <module>
    chain_reduce(model_n)
  File "~/OMC-mR2S_v5.py", line 84, in chain_reduce
    reduced_chain = chain.reduce(initial_nuclides, level=3)    # reduced to only the isotopes initially present in depletable materials and their possible progeny
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "xxx/site-packages/openmc/deplete/chain.py", line 1177, in reduce
    previous.yield_data.restrict_products(name_sort))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'restrict_products'

```


# Description

In the reduce method, when processing fission reactions, the code tries to call restrict_products() on previous.yield_data without checking if it's None first.

The issue is that some nuclides in your chain don't have fission yield data (yield_data is None), but the code assumes all fissionable nuclides have this data.

Solution:
Add a null check before calling restrict_products(). 

# Alternative 
```
elif rx.type == "fission":
    try:
        new_yields = new_nuclide.yield_data = (
            previous.yield_data.restrict_products(name_sort))
        if new_yields is not None:
            new_nuclide.add_reaction(*rx)
    except AttributeError:
        # Skip fission reactions with no yield data
        pass
```


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
