### PR TITLE
Use mesh from weight window hdf5 file

### DIFF
--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -1480,7 +1480,7 @@ extern "C" int openmc_weight_windows_import(const char* filename)
   file_close(ww_file);
 
   if (mpi::master) {
-    write_message(fmt::format("Imported {} weight window and {} meshe", 
+    write_message(fmt::format("Imported {} weight window and {} mesh", 
                               ww_names.size(), meshes_loaded), 5);
   }
 


### PR DESCRIPTION
# Description

Currently, OpenMC cannot use the mesh that is on the weight windows HDF5 file.

This creates all number of frustrations. The handling of the weight window mesh in general is super awkward.
OpenMC tries to find any mesh matching the ww.h5 mesh ID already existing in the problem, but some methods strip out tallies (deplete.get_microxs_and_flux) and suddenly the mesh filter that might be useful is gone.
One way that worked for me was bootstrapping in an entropy mesh.

settings.weight_windows.mesh doesn't seem to work with ww.h5s


This change enables OpenMC to get the mesh from the ww.h5 directly during execution and use it for the weight window.
To me, this also just feels cleaner, less error prone and more straightforward.

This is vibe coded with Claude. I have shepherded it and verified that it works.
Right now only compatible with rectilinear mesh (verified) and ostensibly with a regular mesh (not verified).

Fixes (in a way) #3549

An Alternative:
Have the Python API get the mesh from the ww.h5 and export that as a mesh to <settings>.



# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
