### PR TITLE
Feature: Add model.description

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -51,6 +51,8 @@ class Model:
         Tallies information
     plots : openmc.Plots, optional
         Plot information
+    description : str, optional
+        Description of the model
 
     Attributes
     ----------
@@ -64,6 +66,8 @@ class Model:
         Tallies information
     plots : openmc.Plots
         Plot information
+    description : str
+        Description of the model
 
     """
 
@@ -74,12 +78,15 @@ class Model:
         settings: openmc.Settings | None = None,
         tallies: openmc.Tallies | None = None,
         plots: openmc.Plots | None = None,
+        description: str | None = None
     ):
         self.geometry = openmc.Geometry() if geometry is None else geometry
         self.materials = openmc.Materials() if materials is None else materials
         self.settings = openmc.Settings() if settings is None else settings
         self.tallies = openmc.Tallies() if tallies is None else tallies
         self.plots = openmc.Plots() if plots is None else plots
+        if description is not None:
+            self.description = description
 
     @property
     def geometry(self) -> openmc.Geometry:
@@ -114,6 +121,24 @@ class Model:
     def settings(self, settings):
         check_type('settings', settings, openmc.Settings)
         self._settings = settings
+
+    @property
+    def description(self) -> str:
+        return self.settings.description
+
+    @description.setter
+    def description(self, description: str):
+        cv.check_type('description', description, str)
+        self.settings.description = description
+
+    @property
+    def description(self) -> str:
+        return self.settings.description
+
+    @description.setter
+    def description(self, description: str):
+        check_type('description', description, str)
+        self.settings.description = description
 
     @property
     def tallies(self) -> openmc.Tallies:

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -342,6 +342,8 @@ class Settings:
 
     weight_windows_file: Pathlike
         Path to a weight window file to load during simulation initialization
+    description : str
+        Description of the model
 
         .. versionadded::0.14.0
     write_initial_source : bool
@@ -370,6 +372,7 @@ class Settings:
         self._confidence_intervals = None
         self._electron_treatment = None
         self._photon_transport = None
+        self._description = None
         self._plot_seed = None
         self._ptables = None
         self._uniform_source_sampling = None
@@ -1255,6 +1258,15 @@ class Settings:
         cv.check_less_than('source_rejection_fraction', source_rejection_fraction, 1)
         self._source_rejection_fraction = source_rejection_fraction
 
+    @property
+    def description(self):
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        cv.check_type('description', description, str)
+        self._description = description
+
     def _create_run_mode_subelement(self, root):
         elem = ET.SubElement(root, "run_mode")
         elem.text = self._run_mode.value
@@ -1733,6 +1745,11 @@ class Settings:
             element = ET.SubElement(root, "source_rejection_fraction")
             element.text = str(self._source_rejection_fraction)
 
+    def _create_description_subelement(self, root):
+        if self._description is not None:
+            subelement = ET.SubElement(root, "description")
+            subelement.text = self._description
+
     def _eigenvalue_from_xml_element(self, root):
         elem = root.find('eigenvalue')
         if elem is not None:
@@ -2171,6 +2188,11 @@ class Settings:
         if text is not None:
             self.source_rejection_fraction = float(text)
 
+    def _description_from_xml_element(self, root):
+        text = get_text(root, 'description')
+        if text is not None:
+            self.description = text
+
     def to_xml_element(self, mesh_memo=None):
         """Create a 'settings' element to be written to an XML file.
 
@@ -2241,6 +2263,7 @@ class Settings:
         self._create_random_ray_subelement(element, mesh_memo)
         self._create_use_decay_photons_subelement(element)
         self._create_source_rejection_fraction_subelement(element)
+        self._create_description_subelement(element)
 
         # Clean the indentation in the file to be user-readable
         clean_indentation(element)
@@ -2352,6 +2375,7 @@ class Settings:
         settings._random_ray_from_xml_element(elem, meshes)
         settings._use_decay_photons_from_xml_element(elem)
         settings._source_rejection_fraction_from_xml_element(elem)
+        settings._description_from_xml_element(elem)
 
         return settings
 

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -372,7 +372,6 @@ class Settings:
         self._confidence_intervals = None
         self._electron_treatment = None
         self._photon_transport = None
-        self._description = None
         self._plot_seed = None
         self._ptables = None
         self._uniform_source_sampling = None
@@ -442,6 +441,8 @@ class Settings:
         self._use_decay_photons = None
 
         self._random_ray = {}
+
+        self._description = None
 
         for key, value in kwargs.items():
             setattr(self, key, value)

--- a/tests/unit_tests/test_model_description.py
+++ b/tests/unit_tests/test_model_description.py
@@ -1,0 +1,30 @@
+import openmc
+
+DESCRIPTION_TEXT = "This is a test model."
+
+
+def test_model_description():
+    """Test the description attribute on the Model class."""
+    model = openmc.Model()
+    model.description = DESCRIPTION_TEXT
+
+    # Check that the description is set on the underlying settings object
+    assert model.settings.description == DESCRIPTION_TEXT
+
+
+def test_settings_description_xml():
+    """Test the XML representation of the description in Settings."""
+    settings = openmc.Settings()
+    settings.description = DESCRIPTION_TEXT
+
+    # Generate XML element
+    elem = settings.to_xml_element()
+
+    # Check for the presence and content of the description tag
+    desc_elem = elem.find('description')
+    assert desc_elem is not None
+    assert desc_elem.text == DESCRIPTION_TEXT
+
+    # Test from_xml_element
+    new_settings = openmc.Settings.from_xml_element(elem)
+    assert new_settings.description == DESCRIPTION_TEXT


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This pull request introduces a description attribute to the Model class, allowing users to add a descriptive text to their models. This description is saved in the settings.xml output.

Key changes:

* Added description property to openmc.model.Model.
* Updated openmc.settings.Settings to include and handle the description in XML exports.
* Added documentation for the new feature.
* Included unit tests to verify the new functionality.

Fixes # 3586

# Checklist

- [x] I have performed a self-review of my own code
- [N/A] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
