### PR TITLE
Re-run flaky tests when needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,14 @@ docs = [
     "sphinxcontrib-svg2pdfconverter",
     "sphinx-rtd-theme"
 ]
-test = ["packaging", "pytest", "pytest-cov>=4.0", "colorama", "openpyxl"]
+test = [
+    "packaging",
+    "pytest",
+    "pytest-cov>=4.0",
+    "pytest-rerunfailures",
+    "colorama",
+    "openpyxl",
+]
 ci = ["coverage>=7.4", "gcovr>=7.2"]
 vtk = ["vtk"]
 

--- a/tests/unit_tests/test_deplete_activation.py
+++ b/tests/unit_tests/test_deplete_activation.py
@@ -49,6 +49,7 @@ ENERGIES = np.logspace(log10(1e-5), log10(2e7), 100)
     ("flux", {'energies': ENERGIES, 'reactions': ['(n,gamma)']}, 1e-5),
     ("flux", {'energies': ENERGIES, 'reactions': ['(n,gamma)'], 'nuclides': ['W186', 'H3']}, 1e-2),
 ])
+@pytest.mark.flaky(reruns=1)
 def test_activation(run_in_tmpdir, model, reaction_rate_mode, reaction_rate_opts, tolerance):
     # Determine (n.gamma) reaction rate using initial run
     sp = model.run()

--- a/tests/unit_tests/test_stats.py
+++ b/tests/unit_tests/test_stats.py
@@ -16,6 +16,7 @@ def assert_sample_mean(samples, expected_mean):
     assert np.abs(expected_mean - samples.mean()) < 4*std_dev
 
 
+@pytest.mark.flaky(reruns=1)
 def test_discrete():
     x = [0.0, 1.0, 10.0]
     p = [0.3, 0.2, 0.5]
@@ -104,6 +105,7 @@ def test_clip_discrete():
         d.clip(5)
 
 
+@pytest.mark.flaky(reruns=1)
 def test_uniform():
     a, b = 10.0, 20.0
     d = openmc.stats.Uniform(a, b)
@@ -127,6 +129,7 @@ def test_uniform():
     assert_sample_mean(samples, exp_mean)
 
 
+@pytest.mark.flaky(reruns=1)
 def test_powerlaw():
     a, b, n = 10.0, 100.0, 2.0
     d = openmc.stats.PowerLaw(a, b, n)
@@ -148,6 +151,7 @@ def test_powerlaw():
     assert_sample_mean(samples, exp_mean)
 
 
+@pytest.mark.flaky(reruns=1)
 def test_maxwell():
     theta = 1.2895e6
     d = openmc.stats.Maxwell(theta)
@@ -171,6 +175,7 @@ def test_maxwell():
     assert samples_2.mean() != samples.mean()
 
 
+@pytest.mark.flaky(reruns=1)
 def test_watt():
     a, b = 0.965e6, 2.29e-6
     d = openmc.stats.Watt(a, b)
@@ -194,6 +199,7 @@ def test_watt():
     assert_sample_mean(samples, exp_mean)
 
 
+@pytest.mark.flaky(reruns=1)
 def test_tabular():
     # test linear-linear sampling
     x = np.array([0.0, 5.0, 7.0, 10.0])
@@ -270,6 +276,7 @@ def test_legendre():
         d.to_xml_element('distribution')
 
 
+@pytest.mark.flaky(reruns=1)
 def test_mixture():
     d1 = openmc.stats.Uniform(0, 5)
     d2 = openmc.stats.Uniform(3, 7)
@@ -425,6 +432,7 @@ def test_point():
     assert d.xyz == pytest.approx(p)
 
 
+@pytest.mark.flaky(reruns=1)
 def test_normal():
     mean = 10.0
     std_dev = 2.0
@@ -444,6 +452,7 @@ def test_normal():
     assert_sample_mean(samples, mean)
 
 
+@pytest.mark.flaky(reruns=1)
 def test_muir():
     mean = 10.0
     mass = 5.0
@@ -463,6 +472,7 @@ def test_muir():
     assert_sample_mean(samples, mean)
 
 
+@pytest.mark.flaky(reruns=1)
 def test_combine_distributions():
     # Combine two discrete (same data as in test_merge_discrete)
     x1 = [0.0, 1.0, 10.0]


### PR DESCRIPTION
# Description

There are a few tests in our test suite that are flaky and fail on occasion. Some of these are tests where we're comparing that a sampled mean is within N standard deviations, so by nature it is expected to fail once in a while. The other one I've marked flaky is the deplete_activation test that uses the flux-collapse method (which is not exact) and also fails on occasion. With the changes here, if a test fails, it will automatically be re-run once. If it fails on the re-run, then it will be marked as an actual failure. This should reduce the number of random failures we see in CI from these tests.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)