### PR TITLE
Add incident proton data class 

### DIFF
--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -324,7 +324,7 @@ def atomic_mass(isotope):
         # isotopes of their element (e.g. C0), calculate the atomic mass as
         # the sum of the atomic mass times the natural abundance of the isotopes
         # that make up the element.
-        for element in ['C', 'Zn', 'Pt', 'Os', 'Tl', 'V']:
+        for element in ['C', 'Zn', 'Pt', 'Os', 'Tl']:
             isotope_zero = element.lower() + '0'
             _ATOMIC_MASS[isotope_zero] = 0.
             for iso, abundance in isotopes(element):


### PR DESCRIPTION
I'm adding incident proton data class for the library conversion from ACE to HDF5. In the code implementation, it is almost a replication of the incident neutron data class with a modification in file name suffix (1001.00h). 

In addition, I added a function to include stopping power or traverse range just in case they are needed for the transport purpose. 

Feel free to let me know if you have any comments. 

<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Please include a summary of the change and which issue is fixed if applicable. Please also include relevant motivation and context.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
