### PR TITLE
Allow Path objects in MGXSLibrary.export_to_hdf5

### DIFF
--- a/tests/regression_tests/mgxs_library_ce_to_mg/test.py
+++ b/tests/regression_tests/mgxs_library_ce_to_mg/test.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import openmc
 import openmc.mgxs
@@ -54,7 +53,7 @@ class MGXSTestHarness(PyAPITestHarness):
 
         # Write modified input files
         self._model.export_to_model_xml()
-        self._model.mgxs_file.export_to_hdf5(filename = Path('mgxs.h5'))
+        self._model.mgxs_file.export_to_hdf5()
 
         # Re-run MG mode.
         if config['mpi']:


### PR DESCRIPTION
# Description

I have got quite use to passing around a ```Path``` instead of strings for a filepath. I tried to save a mgxs file using a Path today and got a type error so I thought it would be nice if this function allowed Paths to be put in as well as strings (like we do in most other places in the code).

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

