### PR TITLE
Enable nuclide filters with get_decay_photon_energy

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -353,13 +353,17 @@ class Material(IDManagerMixin):
                 dists.append(source_per_atom)
                 probs.append(1e24 * atoms_per_bcm * multiplier)
 
+        # If no photon sources, exit early
         if not dists:
             return None
 
+        # Get combined distribution, clip low-intensity values in discrete spectra
         combined = openmc.data.combine_distributions(dists, probs)
         if isinstance(combined, (Discrete, Mixture)):
             combined.clip(clip_tolerance, inplace=True)
 
+        # If clipping resulted in a single distribution within a mixture, pick
+        # out that single distribution
         if isinstance(combined, Mixture) and len(combined.distribution) == 1:
             combined = combined.distribution[0]
 


### PR DESCRIPTION
Added parameters to include or exclude specific nuclides in decay photon calculations.


# Description

Often in R2S neutronic analysis it is useful to isolate the source of shutdown dose (delayed gammas). This is often accomplished by turning on and off the photons produced from various radionuclides.

This implements that, a photon source can be built that excludes the chosen nuclides. Alternatively, one can list the nuclides of interest that a decay photon source will be built for.
Both are optional, and the filter options are mutually exclusive of each other.

# Alternatives

The parents could be omitted during activation.
The radionuclide could be filtered out during activation or removed from the depletion_results.h5 or from the material.

This just seems the most apt location, leaving other steps in the workflow intact. 
(re-executing a whole activation is tedious, editing the results file is cumbersome, etc, etc)


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
