### PR TITLE
Random Ray Geometry Debug Mode Fix

### DIFF
--- a/src/random_ray/random_ray.cpp
+++ b/src/random_ray/random_ray.cpp
@@ -278,6 +278,10 @@ uint64_t RandomRay::transport_history_based_single_ray()
 // Transports ray across a single source region
 void RandomRay::event_advance_ray()
 {
+  // If geometry debug mode is on, check for cell overlaps
+  if (settings::check_overlaps)
+    check_cell_overlap(*this);
+
   // Find the distance to the nearest boundary
   boundary() = distance_to_boundary(*this);
   double distance = boundary().distance();
@@ -287,9 +291,6 @@ void RandomRay::event_advance_ray()
                  std::to_string(id()));
     return;
   }
-
-  if (settings::check_overlaps)
-    check_cell_overlap(*this);
 
   if (is_active_) {
     // If the ray is in the active length, need to check if it has


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

When run in geometry debug mode (`openmc -g`), the Monte Carlo solver will check for any overlapping cells whenever performing a cross section lookup. As the random ray solver doesn't call this function, no overlap checks are ever performed.

This PR simply adds the same overlapping check logic after each ray tracing step is performed in the random ray solver.

I have tested this fix on a random ray input deck featuring a cell overlap (thanks @shimwell!) and it works as expected.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
