### PR TITLE
Avoid divide-by-zero in `from_multigroup_flux` when flux is zero

### DIFF
--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -359,17 +359,13 @@ class MicroXS:
         # Create 3D array for microscopic cross sections
         microxs_arr = np.zeros((len(nuclides), len(mts), 1))
 
-        # Normalize multigroup flux
+        # If flux is zero, safely return zero cross sections
         multigroup_flux = np.array(multigroup_flux)
-
-        flux_sum = multigroup_flux.sum()
-        if flux_sum <= 0:
-            # return zero microxs safely (no division by zero)
+        if (flux_sum := multigroup_flux.sum()) == 0.0:
             return cls(microxs_arr, nuclides, reactions)
 
-
+        # Normalize multigroup flux
         multigroup_flux /= flux_sum
-
 
         # Compute microscopic cross sections within a temporary session
         with openmc.lib.TemporarySession(**init_kwargs):

--- a/tests/unit_tests/test_deplete_microxs.py
+++ b/tests/unit_tests/test_deplete_microxs.py
@@ -111,3 +111,16 @@ def test_multigroup_flux_same():
         energies=energies, multigroup_flux=flux, chain_file=chain_file)
 
     assert microxs_4g.data == pytest.approx(microxs_2g.data)
+
+
+def test_microxs_zero_flux():
+    chain_file = Path(__file__).parents[1] / 'chain_simple.xml'
+
+    # Generate micro XS based on zero flux
+    energies = [0., 6.25e-1, 5.53e3, 8.21e5, 2.e7]
+    flux = [0.0, 0.0, 0.0, 0.0]
+    microxs = MicroXS.from_multigroup_flux(
+        energies=energies, multigroup_flux=flux, chain_file=chain_file)
+
+    # All microscopic cross sections should be zero
+    assert np.all(microxs.data == 0.0)


### PR DESCRIPTION


# Description

When trying to create a MicroXS object with the `from_multigroup_flux` function with an empty flux as argument, it silently fills the micro cross sections with nan values.

The fix ensures the microXS object contains zeros insteads of NaNs if the neutron flux sum is equal to zero

Could be related with the issue #3597 as this function is called from within `get_microxs_and_flux`

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
