### PR TITLE
Write particle states as separate lines in track VTK files.

### DIFF
--- a/openmc/tracks.py
+++ b/openmc/tracks.py
@@ -296,16 +296,16 @@ class Tracks(list):
                 for state in pt.states:
                     points.InsertNextPoint(state['r'])
 
-            # Create VTK line and assign points to line.
-            n = pt.states.size
-            line = vtk.vtkPolyLine()
-            line.GetPointIds().SetNumberOfIds(n)
-            for i in range(n):
-                line.GetPointIds().SetId(i, point_offset + i)
-            point_offset += n
+                # Create VTK line and assign points to line.
+                n = pt.states.size
+                line = vtk.vtkPolyLine()
+                line.GetPointIds().SetNumberOfIds(n)
+                for i in range(n):
+                    line.GetPointIds().SetId(i, point_offset + i)
+                point_offset += n
 
-            # Add line to cell array
-            cells.InsertNextCell(line)
+                # Add line to cell array
+                cells.InsertNextCell(line)
 
         data = vtk.vtkPolyData()
         data.SetPoints(points)


### PR DESCRIPTION
… the whole track

<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR modifies track to VTK writing such that particle states are written as separate `vtkPolyLine`'s.

Below are track representations from #3622 before and after this change.

<img width="1644" height="1043" alt="image" src="https://github.com/user-attachments/assets/9047e225-1d66-44ec-ab89-070450830ab8" />


<img width="1644" height="1043" alt="image" src="https://github.com/user-attachments/assets/79026e73-70a4-4eda-af90-8b7e7ac55529" />

Fixes #3625 

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) ~on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~


<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
