### PR TITLE
Avoid multiprocessing Pool when running depletion tests with MPI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,12 +29,29 @@ def run_in_tmpdir(tmpdir):
         yield
     finally:
         orig.chdir()
-        
+
 @pytest.fixture(scope="module")
 def endf_data():
-    return os.environ['OPENMC_ENDF_DATA']        
+    return os.environ['OPENMC_ENDF_DATA']
 
 @pytest.fixture(scope='session', autouse=True)
 def resolve_paths():
     with openmc.config.patch('resolve_paths', False):
         yield
+
+
+@pytest.fixture(scope='session', autouse=True)
+def disable_depletion_multiprocessing_under_mpi():
+    """Fork-based depletion multiprocessing may deadlock if MPI is active."""
+    if not regression_config['mpi']:
+        yield
+        return
+
+    from openmc.deplete import pool
+
+    original_setting = pool.USE_MULTIPROCESSING
+    pool.USE_MULTIPROCESSING = False
+    try:
+        yield
+    finally:
+        pool.USE_MULTIPROCESSING = original_setting

--- a/tests/regression_tests/deplete_no_transport/test.py
+++ b/tests/regression_tests/deplete_no_transport/test.py
@@ -76,6 +76,8 @@ def test_against_self(run_in_tmpdir,
     dt = [360]  # single step
 
     # Perform simulation using the predictor algorithm
+    if config['mpi'] and multiproc:
+        pytest.skip("Multiprocessing depletion is disabled when MPI is enabled.")
     openmc.deplete.pool.USE_MULTIPROCESSING = multiproc
     openmc.deplete.PredictorIntegrator(op,
                                        dt,
@@ -135,6 +137,8 @@ def test_against_coupled(run_in_tmpdir,
     dt = [dt]  # single step
 
     # Perform simulation using the predictor algorithm
+    if config['mpi'] and multiproc:
+        pytest.skip("Multiprocessing depletion is disabled when MPI is enabled.")
     openmc.deplete.pool.USE_MULTIPROCESSING = multiproc
     openmc.deplete.PredictorIntegrator(
         op, dt, power=174, timestep_units=time_units).integrate()

--- a/tests/regression_tests/deplete_with_transport/test.py
+++ b/tests/regression_tests/deplete_with_transport/test.py
@@ -65,6 +65,8 @@ def test_full(run_in_tmpdir, problem, multiproc):
     power = 2.337e15*4*JOULE_PER_EV*1e6  # MeV/second cm from CASMO
 
     # Perform simulation using the predictor algorithm
+    if config['mpi'] and multiproc:
+        pytest.skip("Multiprocessing depletion is disabled when MPI is enabled.")
     openmc.deplete.pool.USE_MULTIPROCESSING = multiproc
     openmc.deplete.PredictorIntegrator(op, dt, power).integrate()
 


### PR DESCRIPTION
# Description

I've noticed that a [common failure mode](https://github.com/openmc-dev/openmc/actions/workflows/ci.yml?query=is%3Acancelled) for CI is that one of the MPI configurations will seemingly hang, and after the job goes for 6 hours, it hits the GHA time limit and is then cancelled. Looking at logs, this usually happens when running a depletion-related test. I suspect this has to do with the fact that depletion uses multiprocessing, and in conjunction with MPI/mpi4py, it can cause deadlocking. The solution I've implemented here is to avoid the use of multiprocessing for depletion when the MPI configuration is active. Hopefully this should mitigate those CI runs hanging and hitting the 6 hour time limit :crossed_fingers: 

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>