### PR TITLE
Fix typo in DAGMC lost particle test

### DIFF
--- a/tests/unit_tests/dagmc/test_lost_particles.py
+++ b/tests/unit_tests/dagmc/test_lost_particles.py
@@ -62,7 +62,7 @@ def broken_dagmc_model(request):
     return model
 
 
-def test_lost_particles(broken_dagmc_model):
+def test_lost_particles(run_in_tmpdir, broken_dagmc_model):
     broken_dagmc_model.export_to_xml()
     # ensure that particles will be lost when cell intersections can't be found
     # due to the removed triangles in this model


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Fixes a typo in the DAGMC lost particle test caught by @paulromano. 

This was causing the first case (in which lost particles should be reported when the DAGMC universe is used to fill a CSG cell) to be executed twice. 

This fix ensures that the case where the DAGMC universe is used as the root universe is also checked.

A comment was also expanded to better explain the intent of the test.

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~I have run [clang-format]~(https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~I have made corresponding changes to the documentation (if applicable)~
- [x] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
