### PR TITLE
Add two MPI barriers in R2S workflow

### DIFF
--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -177,8 +177,9 @@ def get_microxs_and_flux(
         if not openmc.lib.is_initialized:
             run_kwargs.setdefault('cwd', temp_dir)
 
-        # Run transport simulation
+        # Run transport simulation and synchronize
         statepoint_path = model.run(**run_kwargs)
+        comm.barrier()
 
         if comm.rank == 0:
             # Move the statepoint file if it is being saved to a specific path

--- a/openmc/deplete/r2s.py
+++ b/openmc/deplete/r2s.py
@@ -392,6 +392,7 @@ class R2SManager:
         )
         output_path = output_dir / 'depletion_results.h5'
         integrator.integrate(final_step=False, path=output_path)
+        comm.barrier()
 
         # Get depletion results
         self.results['depletion_results'] = Results(output_path)

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 from random import getrandbits
 from tempfile import TemporaryDirectory
+import traceback as tb
 
 import numpy as np
 from numpy.ctypeslib import as_array
@@ -699,6 +700,15 @@ class TemporarySession:
         """Finalize the OpenMC library and clean up temporary directory."""
         if self.already_initialized:
             return
+
+        # If an exception occurred, abort all ranks immediately
+        if exc_type is not None:
+            # Print exception info on the rank that failed
+            tb.print_exception(exc_type, exc_value, traceback)
+            sys.stdout.flush()
+
+            # Abort all MPI processes
+            self.comm.Abort(1)
 
         try:
             finalize()


### PR DESCRIPTION
# Description

After the merging of #3632, I was still running into some issues running R2S calculations in parallel and found two issues, both of which are fixed here:

1. Within a `TemporarySession`, if one rank throws an exception, it goes to `__exit__` and then the job hangs because one rank is stuck in a MPI barrier there while other ranks are stuck in a different barrier. I've added logic to check for an exception and both display it and abort the job gracefully.
2. The exceptions I was seeing were due to file synchronization issues that are addressed by added MPI barriers 1) after the neutron transport step is done to ensure all ranks see the same statepoint file and, 2) after the depletion integrator is finished to ensure all ranks see the same depletion results file.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)