### PR TITLE
material.add_component allows individual percent_type for each entry 

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -586,12 +586,15 @@ class Material(IDManagerMixin):
         ----------
         components : dict of str to float or dict
             Dictionary mapping element or nuclide names to their atom or weight
-            percent. To specify enrichment of an element, the entry of
-            ``components`` for that element must instead be a dictionary
-            containing the keyword arguments as well as a value for
-            ``'percent'``
+            percent. To specify additional customization the dictionary value
+            can be a dictionary with keys that are passed to add_element or
+            add_nuclide. This allows percent_type to be specified for components,
+            and also enrichment, enrichment_target, and percent to be specified
+            for elements.
         percent_type : {'ao', 'wo'}
-            'ao' for atom percent and 'wo' for weight percent
+            'ao' for atom percent and 'wo' for weight percent applied to all
+            elements / nuclides in the components dictionary which don't have
+            a specified percent_type. Defaults to 'ao'
 
         Examples
         --------
@@ -599,7 +602,8 @@ class Material(IDManagerMixin):
         >>> components  = {'Li': {'percent': 1.0,
         >>>                       'enrichment': 60.0,
         >>>                       'enrichment_target': 'Li7'},
-        >>>                'Fl': 1.0,
+        >>>                'Fl': {'percent': 1.0,
+        >>>                       'percent_type': 'wo'},
         >>>                'Be6': 0.5}
         >>> mat.add_components(components)
 
@@ -616,7 +620,8 @@ class Material(IDManagerMixin):
                     raise ValueError("An entry in the dictionary does not have "
                                      "a required key: 'percent'")
 
-            params['percent_type'] = percent_type
+            if 'percent_type' not in params.keys():
+                params['percent_type'] = percent_type
 
             # check if nuclide
             if not component.isalpha():

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -42,12 +42,20 @@ def test_add_components():
                         'enrichment': 4.5},
                   'Li': {'percent': 1.0,
                          'enrichment': 60.0,
-                         'enrichment_target': 'Li7'},
+                         'enrichment_target': 'Li7',
+                         'percent_type': 'wo'},
                   'H': {'percent': 1.0,
                         'enrichment': 50.0,
                         'enrichment_target': 'H2',
                         'enrichment_type': 'wo'}}
     m.add_components(components)
+
+    for nuc in m.nuclides:
+        if nuc.name in ['Li6', 'Li7']:
+            assert nuc.percent_type == 'wo'
+        else:
+            assert nuc.percent_type == 'ao'
+
     with pytest.raises(ValueError):
         m.add_components({'U': {'percent': 1.0,
                                 'enrichment': 100.0}})


### PR DESCRIPTION
I would be keen to make this small change to the ```material.add_components()``` method.

Currently we can't add components with different percent_types as all the entries in component have to be either 'ao' or 'wo'.

While we can add percent_type to the dictionary for each component it gets overwritten by the main ```percent_type``` for the add_component function. This PR allows the customization of component dictionaries to take priority over the main ```percent_type``` and thus allows one to make a material with a mix of 'ao' and 'wo' using add_component

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

