### PR TITLE
Split storage optimization

### DIFF
--- a/include/openmc/particle.h
+++ b/include/openmc/particle.h
@@ -50,11 +50,11 @@ public:
   //! \return Whether a secondary particle was created
   bool create_secondary(double wgt, Direction u, double E, ParticleType type);
 
-  //! split a particle
+  //! replicate a particle
   //
-  //! creates a new particle with weight wgt
-  //! \param wgt Weight of the new particle
-  void split(double wgt);
+  //! creates replicated particles from this one
+  //! \param n_repl Number of replicas
+  void replicate(int n_repl);
 
   //! initialize from a source site
   //
@@ -63,6 +63,15 @@ public:
   //! simply as a secondary particle.
   //! \param src Source site data
   void from_source(const SourceSite* src);
+
+  //! initialize from a spendable source site
+  //
+  //! takes a particle from source site data and notifies that the site has
+  //! become spent.
+  //! \param src Source site data
+  //! \param empty_bank If false, the site does not contain remianed particle
+  //! replicas anymore
+  void from_spendable_source(SourceSite* src, bool& empty_bank);
 
   // Coarse-grained particle events
   void event_calculate_xs();

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -46,6 +46,7 @@ struct SourceSite {
   double E;
   double time {0.0};
   double wgt {1.0};
+  int n_repl {1};
   int delayed_group {0};
   int surf_id {SURFACE_NONE};
   ParticleType particle;

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -157,7 +157,7 @@ void initialize_mpi(MPI_Comm intracomm)
 
   // Create bank datatype
   SourceSite b;
-  MPI_Aint disp[11];
+  MPI_Aint disp[12];
   MPI_Get_address(&b.r, &disp[0]);
   MPI_Get_address(&b.u, &disp[1]);
   MPI_Get_address(&b.E, &disp[2]);
@@ -169,14 +169,16 @@ void initialize_mpi(MPI_Comm intracomm)
   MPI_Get_address(&b.parent_nuclide, &disp[8]);
   MPI_Get_address(&b.parent_id, &disp[9]);
   MPI_Get_address(&b.progeny_id, &disp[10]);
-  for (int i = 10; i >= 0; --i) {
+  MPI_Get_address(&b.n_repl, &disp[11]);
+  for (int i = 11; i >= 0; --i) {
     disp[i] -= disp[0];
   }
 
-  int blocks[] {3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  int blocks[] {3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
   MPI_Datatype types[] {MPI_DOUBLE, MPI_DOUBLE, MPI_DOUBLE, MPI_DOUBLE,
-    MPI_DOUBLE, MPI_INT, MPI_INT, MPI_INT, MPI_INT, MPI_LONG, MPI_LONG};
-  MPI_Type_create_struct(11, blocks, disp, types, &mpi::source_site);
+    MPI_DOUBLE, MPI_INT, MPI_INT, MPI_INT, MPI_INT, MPI_LONG, MPI_LONG,
+    MPI_INT};
+  MPI_Type_create_struct(12, blocks, disp, types, &mpi::source_site);
   MPI_Type_commit(&mpi::source_site);
 
   CollisionTrackSite bc;

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -128,14 +128,10 @@ void apply_weight_windows(Particle& p)
     n_split = std::min(n_split, max_split);
 
     p.n_split() += n_split;
-
-    // Create secondaries and divide weight among all particles
-    int i_split = std::round(n_split);
-    for (int l = 0; l < i_split - 1; l++) {
-      p.split(weight / n_split);
-    }
     // remaining weight is applied to current particle
     p.wgt() = weight / n_split;
+    // Create secondaries from current particle
+    p.replicate(std::round(n_split) - 1);
 
   } else if (weight <= weight_window.lower_weight) {
     // if the particle weight is below the window, play Russian roulette


### PR DESCRIPTION
# Description

Based on the raised by @pshriwise problem in #3492 and followed the given there accompanying technical aspects description, it is implemented in this small PR an approach of simple count of remaining particles in a bank specific to each split event instead of the current copying.

To store the counter value, it has been added a new field of the `SourceSite` struct named `n_repl` that has also been reflected in the related MPI struct.

This approach prevents excess copying and storing of particle data `n_split-2` times after each splitting event (when `n_split > 1`) that reduces both the computational cost (negligibly, but does not increase guaranteed) and used memory (as strong as the splitting/roulette technique is desirable). The last one improves the entire computational scheme stability in extreme cases.

Fixes #3492

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

