### PR TITLE
added test to check dagmc name is in xml

### DIFF
--- a/openmc/dagmc.py
+++ b/openmc/dagmc.py
@@ -302,6 +302,8 @@ class DAGMCUniverse(openmc.UniverseBase):
         dagmc_element = ET.Element('dagmc_universe')
         dagmc_element.set('id', str(self.id))
 
+        if self.name:
+            dagmc_element.set('name', self.name)
         if self.auto_geom_ids:
             dagmc_element.set('auto_geom_ids', 'true')
         if self.auto_mat_ids:

--- a/tests/unit_tests/dagmc/test_model.py
+++ b/tests/unit_tests/dagmc/test_model.py
@@ -31,7 +31,7 @@ def model(request):
 
     p = Path(request.fspath).parent / "dagmc.h5m"
 
-    daguniv = openmc.DAGMCUniverse(p, auto_geom_ids=True)
+    daguniv = openmc.DAGMCUniverse(p, name='simple-dagmc', auto_geom_ids=True)
 
     lattice = openmc.RectLattice()
     lattice.dimension = [2, 2]
@@ -232,6 +232,7 @@ def test_dagmc_xml(model):
     dagmc_ele = root.find('dagmc_universe')
 
     assert dagmc_ele.get('id') == str(dag_univ.id)
+    assert dagmc_ele.get('name') == str(dag_univ.name)
     assert dagmc_ele.get('filename') == str(dag_univ.filename)
     assert dagmc_ele.get('auto_geom_ids') == str(dag_univ.auto_geom_ids).lower()
 


### PR DESCRIPTION
# Description

This PR adds a missing dagmc attribute to the xml export string. Currently the DAGMCUniverse name is not being exported to xml. First commit added the test to show the name is missing and the tests failed, 2nd commit added the name to the xml export and passes the test

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

