### PR TITLE
fix a bug in borated_water temperature assignment

### DIFF
--- a/openmc/model/funcs.py
+++ b/openmc/model/funcs.py
@@ -39,8 +39,8 @@ def borated_water(boron_ppm, temperature=293., pressure=0.1013, temp_unit='K',
     press_unit : {'MPa', 'psi'}
         The units used for the `pressure` argument.
     density : float
-        Water density in [g / cm^3].  If specified, this value overrides the
-        temperature and pressure arguments.
+        Water density in [g / cm^3].  If specified, this value overrides 
+        the value that is computed from the temperature and pressure arguments.
     **kwargs
         All keyword arguments are passed to the created Material object.
 

--- a/openmc/model/funcs.py
+++ b/openmc/model/funcs.py
@@ -95,10 +95,7 @@ def borated_water(boron_ppm, temperature=293., pressure=0.1013, temp_unit='K',
     frac_B = boron_ppm * 1e-6 / M_B
 
     # Build the material.
-    if density is None:
-        out = openmc.Material(temperature=T, **kwargs)
-    else:
-        out = openmc.Material(**kwargs)
+    out = openmc.Material(temperature=T, **kwargs)
     out.add_element('H', frac_H, 'ao')
     out.add_element('O', frac_O, 'ao')
     out.add_element('B', frac_B, 'ao')

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -481,6 +481,7 @@ def test_borated_water():
     # Test the density override
     m = openmc.model.borated_water(975, 566.5, 15.51, density=0.9)
     assert m.density == pytest.approx(0.9, 1e-3)
+    assert m.temperature == pytest.approx(566.5)
 
 
 def test_from_xml(run_in_tmpdir):


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

function borated_water does not set temperature when density is given as an input number.

Fixes #3661 

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
