### PR TITLE
Update C++/CMake policy based on Ubuntu 22.04

### DIFF
--- a/docs/source/devguide/policies.rst
+++ b/docs/source/devguide/policies.rst
@@ -21,8 +21,8 @@ C++ code in OpenMC must conform to the most recent C++ standard that is fully
 supported in the `version of the gcc compiler
 <https://gcc.gnu.org/projects/cxx-status.html>`_ that is distributed with the
 oldest version of Ubuntu that is still within its `standard support period
-<https://ubuntu.com/about/release-cycle>`_. Ubuntu 20.04 LTS will be supported
-through April 2025 and is distributed with gcc 9.3.0, which fully supports the
+<https://ubuntu.com/about/release-cycle>`_. Ubuntu 22.04 LTS will be supported
+through April 2027 and is distributed with gcc 11.4.0, which fully supports the
 C++17 standard.
 
 --------------------
@@ -31,5 +31,5 @@ CMake Version Policy
 
 Similar to the C++ standard policy, the minimum supported version of CMake
 corresponds to whatever version is distributed with the oldest version of Ubuntu
-still within its standard support period. Ubuntu 20.04 LTS is distributed with
-CMake 3.16.
+still within its standard support period. Ubuntu 22.04 LTS is distributed with
+CMake 3.22.


### PR DESCRIPTION
# Description

This PR updates the language around the C++/CMake version policy since Ubuntu 20.04 is reached end of life. This means our minimum supported versions become gcc 11.4 and CMake 3.22 based on Ubuntu 22.04.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>