### PR TITLE
Fixed plotting issue by scaling source locations with axis units

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1287,8 +1287,8 @@ class Model:
             tol = plane_tolerance
             for particle in particles:
                 if (slice_value - tol < particle.r[z] < slice_value + tol):
-                    xs.append(particle.r[x])
-                    ys.append(particle.r[y])
+                    xs.append(particle.r[x] * axis_scaling_factor[axis_units])
+                    ys.append(particle.r[y] * axis_scaling_factor[axis_units])
             axes.scatter(xs, ys, **source_kwargs)
 
         return axes


### PR DESCRIPTION
This PR simply scales the location of the source scatter points so that they are in the same units as the axis

Fixes #3660

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)

I have made this script to demonstrate the issue and test the solution
```python
import openmc
import matplotlib.pyplot as plt
openmc.config['cross_sections'] = '/home/jon/nuclear_data/cross_sections.xml'
major_radius = 5.0
minor_radius = 1.0
torus = openmc.ZTorus(a=major_radius, b=minor_radius, c=minor_radius)
outer_sphere = openmc.Sphere(r=10.0, boundary_type='vacuum')
torus_cell = openmc.Cell(name='torus')
torus_cell.region = -torus & -outer_sphere
void_cell = openmc.Cell(name='void')
void_cell.region = +torus & -outer_sphere
universe = openmc.Universe(cells=[torus_cell, void_cell])
geometry = openmc.Geometry(universe)
source = openmc.IndependentSource()
source.space = openmc.stats.CylindricalIndependent(
    r=openmc.stats.Discrete([major_radius], [1.0]),  # Ring at major radius
    phi=openmc.stats.Uniform(0, 2*3.14),  # Full circle
    z=openmc.stats.Discrete([0.0], [1.0]),  # At z=0
    origin=(0.0, 0.0, 0.0)
)
settings = openmc.Settings()
settings.source = source
settings.batches = 10
settings.particles = 1000
settings.run_mode = 'fixed source'
settings.export_to_xml()
model = openmc.model.Model(geometry=geometry, settings=settings)
model.plot(
    origin=[0, 0, 0],
    width=[15, 15],
    pixels=[1000, 1000],
    basis='xy',
    color_by='cell',
    n_samples=100
)
model.plot(
    origin=[0, 0, 0],
    width=[15, 15],
    pixels=[1000, 1000],
    basis='xy',
    color_by='cell',
    axis_units='m',  # <--- note this is in meters
    n_samples=100
)
plt.show()
```