### PR TITLE
Allowing model.id_map to return overlap ID values

### DIFF
--- a/openmc/lib/plot.py
+++ b/openmc/lib/plot.py
@@ -52,7 +52,7 @@ class _PlotBase(Structure):
 
     C-Type Attributes
     -----------------
-    origin : openmc.lib.plot._Position
+    origin_ : openmc.lib.plot._Position
         A position defining the origin of the plot.
     width_ : openmc.lib.plot._Position
         The width of the plot along the x, y, and z axes, respectively
@@ -60,6 +60,8 @@ class _PlotBase(Structure):
         The axes basis of the plot view.
     pixels_ : c_size_t[3]
         The resolution of the plot in the horizontal and vertical dimensions
+    color_overlaps_ : c_bool
+        Whether to assign unique IDs (-3) to overlapping regions.
     level_ : c_int
         The universe level for the plot view
 
@@ -186,14 +188,6 @@ class _PlotBase(Structure):
     @color_overlaps.setter
     def color_overlaps(self, color_overlaps):
         self.color_overlaps_ = color_overlaps
-
-    @property
-    def color_overlaps(self):
-        return self.color_overlaps_
-
-    @color_overlaps.setter
-    def color_overlaps(self, val):
-        self.color_overlaps_ = val
 
     def __repr__(self):
         out_str = ["-----",

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1037,6 +1037,7 @@ class Model:
         width: Sequence[float] | None = None,
         pixels: int | Sequence[int] = 40000,
         basis: str = 'xy',
+        color_overlaps: bool = False,
         **init_kwargs
     ) -> np.ndarray:
         """Generate an ID map for domains based on the plot parameters
@@ -1065,6 +1066,10 @@ class Model:
             total and the image aspect ratio based on the width argument.
         basis : {'xy', 'yz', 'xz'}, optional
             Basis of the plot.
+        color_overlaps : bool, optional
+            Whether to assign unique IDs (-3) to overlapping regions. If False,
+            overlapping regions will be assigned the ID of the lowest-numbered
+            cell that occupies that region. Defaults to False.
         **init_kwargs
             Keyword arguments passed to :meth:`Model.init_lib`.
 
@@ -1089,6 +1094,7 @@ class Model:
         plot_obj.h_res = pixels[0]
         plot_obj.v_res = pixels[1]
         plot_obj.basis = basis
+        plot_obj.color_overlaps = color_overlaps
 
         # Silence output by default. Also set arguments to start in volume
         # calculation mode to avoid loading cross sections

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -902,6 +902,32 @@ def test_id_map_aligned_model():
     assert tr_material == 5, f"Expected material ID 5 at top-right corner, got {tr_material}"
 
 
+def test_id_map_model_with_overlaps():
+    """Test id_map with a model that has overlaps and color_overlaps option"""
+    surface1 = openmc.Sphere(r=50, boundary_type="vacuum")
+    surface2 = openmc.Sphere(r=30)
+    cell1 = openmc.Cell(region=-surface1)
+    cell2 = openmc.Cell(region=-surface2)
+    geometry = openmc.Geometry([cell1, cell2])
+    settings = openmc.Settings()
+    model = openmc.Model(geometry=geometry, settings=settings)
+    id_slice = model.id_map(
+        pixels=(10, 10),
+        basis='xy',
+        origin=(0, 0, 0),
+        width=(100, 100),
+    )
+    assert -3 not in id_slice  # -3 indicates overlap region
+    id_slice = model.id_map(
+        pixels=(10, 10),
+        basis='xy',
+        origin=(0, 0, 0),
+        width=(100, 100),
+        color_overlaps=True,  # enables id_map to return -3 for overlaps
+    )
+    assert -3 in id_slice
+
+
 def test_setter_from_list():
     mat = openmc.Material()
     model = openmc.Model(materials=[mat])


### PR DESCRIPTION
This small PR adds the option to use the ```color_overlaps``` argument when calling the ```id_map``` function. It looks like this argument is well supported upto the openmc.lib layer and then not in the final user facing ```id_map``` function. It would be useful for me to find overlaps using this function.

I also added a simple test to check -3 (which is the overlap ID number) appears in the returned numpy array only when the flag is used. I set the default to fault to preserve current behaviour

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
