### PR TITLE
using id_map in model.plot for more efficient plotting

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1131,8 +1131,8 @@ class Model:
             RGB image array with shape (v_pixels, h_pixels, 3) with values
             in range [0, 1] for matplotlib
         """
-        # Initialize RGB array (values between 0 and 1 for matplotlib)
-        img = np.zeros(id_map.shape, dtype=float)
+        # Initialize RGB array with white background (values between 0 and 1 for matplotlib)
+        img = np.ones(id_map.shape, dtype=float)
         
         # Get the appropriate index based on color_by
         if color_by == 'cell':

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -1104,7 +1104,6 @@ class Model:
         with openmc.lib.TemporarySession(self, **init_kwargs):
             return openmc.lib.id_map(plot_obj)
 
-
     @add_plot_params
     def plot(
         self,

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from numbers import Integral, Real
 from pathlib import Path
 from textwrap import dedent
@@ -354,6 +354,84 @@ def voxel_to_vtk(voxel_file: PathLike, output: PathLike = 'plot.vti'):
 
     return output
 
+
+def id_map_to_rgb(
+    id_map: np.ndarray,
+    color_by: str = 'cell',
+    colors: dict | None = None,
+    overlap_color: Sequence[int] | str = (255, 0, 0)
+) -> np.ndarray:
+    """Convert ID map array to RGB image array.
+
+    Parameters
+    ----------
+    id_map : numpy.ndarray
+        Array with shape (v_pixels, h_pixels, 3) containing cell IDs,
+        cell instances, and material IDs
+    color_by : {'cell', 'material'}
+        Whether to color by cell or material
+    colors : dict, optional
+        Dictionary mapping cells/materials to colors
+    overlap_color : sequence of int or str, optional
+        Color to use for overlaps. Defaults to red (255, 0, 0).
+
+    Returns
+    -------
+    numpy.ndarray
+        RGB image array with shape (v_pixels, h_pixels, 3) with values
+        in range [0, 1] for matplotlib
+    """
+    # Initialize RGB array with white background (values between 0 and 1 for matplotlib)
+    img = np.ones(id_map.shape, dtype=float)
+    
+    # Get the appropriate index based on color_by
+    if color_by == 'cell':
+        id_index = 0  # Cell IDs are in the first channel
+    else:  # material
+        id_index = 2  # Material IDs are in the third channel
+    
+    # Get all unique IDs in the plot
+    unique_ids = np.unique(id_map[:, :, id_index])
+    
+    # Generate default colors if not provided
+    if colors is None:
+        colors = {}
+    
+    # Convert colors dict to use IDs as keys
+    color_map = {}
+    for key, color in colors.items():
+        if isinstance(key, (openmc.Cell, openmc.Material)):
+            color_map[key.id] = color
+        else:
+            color_map[key] = color
+    
+    # Generate random colors for IDs not in color_map
+    rng = np.random.RandomState(1)
+    for uid in unique_ids:
+        if uid > 0 and uid not in color_map:
+            color_map[uid] = rng.randint(0, 256, (3,))
+    
+    # Apply colors to each pixel
+    for uid in unique_ids:
+        if uid == -1:  # Background/void
+            continue
+        elif uid == -3:  # Overlap (only present if color_overlaps was True)
+            if isinstance(overlap_color, str):
+                rgb = _SVG_COLORS[overlap_color.lower()]
+            else:
+                rgb = overlap_color
+            mask = id_map[:, :, id_index] == uid
+            img[mask] = np.array(rgb) / 255.0
+        elif uid in color_map:
+            color = color_map[uid]
+            if isinstance(color, str):
+                rgb = _SVG_COLORS[color.lower()]
+            else:
+                rgb = color
+            mask = id_map[:, :, id_index] == uid
+            img[mask] = np.array(rgb) / 255.0
+    
+    return img
 
 class PlotBase(IDManagerMixin):
     """

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -387,8 +387,10 @@ def id_map_to_rgb(
     # Get the appropriate index based on color_by
     if color_by == 'cell':
         id_index = 0  # Cell IDs are in the first channel
-    else:  # material
+    elif color_by == 'material':
         id_index = 2  # Material IDs are in the third channel
+    else:
+        raise ValueError("color_by must be either 'cell' or 'material'")
     
     # Get all unique IDs in the plot
     unique_ids = np.unique(id_map[:, :, id_index])

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -998,7 +998,8 @@ def test_keff_search(run_in_tmpdir):
     assert result.total_batches == sum(result.batches)
     assert result.total_batches > 0
 
-# def test_id_map_to_rgb():
+
+def test_id_map_to_rgb():
     """Test conversion of ID map to RGB image array."""
     # Create a simple model
     mat = openmc.Material()

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -7,6 +7,7 @@ import pytest
 
 import openmc
 import openmc.lib
+from openmc.plots import id_map_to_rgb
 
 
 @pytest.fixture(scope='function')
@@ -997,13 +998,13 @@ def test_keff_search(run_in_tmpdir):
     assert result.total_batches == sum(result.batches)
     assert result.total_batches > 0
 
-def test_id_map_to_rgb():
+# def test_id_map_to_rgb():
     """Test conversion of ID map to RGB image array."""
     # Create a simple model
     mat = openmc.Material()
     mat.set_density('g/cm3', 1.0)
     mat.add_nuclide('Li7', 1.0)
-    
+
     sphere = openmc.Sphere(r=5.0, boundary_type='vacuum')
     cell = openmc.Cell(fill=mat, region=-sphere)
     geometry = openmc.Geometry([cell])
@@ -1015,23 +1016,23 @@ def test_id_map_to_rgb():
     id_data = np.zeros((10, 10, 3), dtype=np.int32)
     id_data[:, :, 0] = cell.id  # Cell IDs
     id_data[:, :, 2] = mat.id   # Material IDs
-    
+
     # Test color_by with default colors
     for color_by in ['cell', 'material']:
-        rgb = model._id_map_to_rgb(id_data, color_by=color_by)
+        rgb = id_map_to_rgb(id_data, color_by=color_by)
         assert rgb.shape == (10, 10, 3)
         assert rgb.dtype == float
         assert np.all((rgb >= 0) & (rgb <= 1))  # RGB values in [0, 1]
 
     # Test with custom colors
     colors = {cell.id: (255, 0, 0)}  # Red
-    rgb_custom = model._id_map_to_rgb(id_data, color_by='cell', colors=colors)
+    rgb_custom = id_map_to_rgb(id_data, color_by='cell', colors=colors)
     assert np.allclose(rgb_custom, [1.0, 0.0, 0.0])  # All pixels should be red
 
     # Test with overlaps
     id_data_overlap = id_data.copy()
     id_data_overlap[5:, 5:, 0] = -3  # Mark some pixels as overlaps
-    rgb_overlap = model._id_map_to_rgb(
+    rgb_overlap = id_map_to_rgb(
         id_data_overlap, overlap_color=(0, 255, 0)
     )
     # Check that overlap region is green

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -1032,7 +1032,7 @@ def test_id_map_to_rgb():
     id_data_overlap = id_data.copy()
     id_data_overlap[5:, 5:, 0] = -3  # Mark some pixels as overlaps
     rgb_overlap = model._id_map_to_rgb(
-        id_data_overlap, show_overlaps=True, overlap_color=(0, 255, 0)
+        id_data_overlap, overlap_color=(0, 255, 0)
     )
     # Check that overlap region is green
     assert np.allclose(rgb_overlap[5:, 5:], [0.0, 1.0, 0.0])

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -996,3 +996,43 @@ def test_keff_search(run_in_tmpdir):
     # Check that total_batches property works
     assert result.total_batches == sum(result.batches)
     assert result.total_batches > 0
+
+def test_id_map_to_rgb():
+    """Test conversion of ID map to RGB image array."""
+    # Create a simple model
+    mat = openmc.Material()
+    mat.set_density('g/cm3', 1.0)
+    mat.add_nuclide('Li7', 1.0)
+    
+    sphere = openmc.Sphere(r=5.0, boundary_type='vacuum')
+    cell = openmc.Cell(fill=mat, region=-sphere)
+    geometry = openmc.Geometry([cell])
+    settings = openmc.Settings(
+        batches=10, particles=100, run_mode='fixed source'
+    )
+    model = openmc.Model(geometry, settings=settings)
+
+    id_data = np.zeros((10, 10, 3), dtype=np.int32)
+    id_data[:, :, 0] = cell.id  # Cell IDs
+    id_data[:, :, 2] = mat.id   # Material IDs
+    
+    # Test color_by with default colors
+    for color_by in ['cell', 'material']:
+        rgb = model._id_map_to_rgb(id_data, color_by=color_by)
+        assert rgb.shape == (10, 10, 3)
+        assert rgb.dtype == float
+        assert np.all((rgb >= 0) & (rgb <= 1))  # RGB values in [0, 1]
+
+    # Test with custom colors
+    colors = {cell.id: (255, 0, 0)}  # Red
+    rgb_custom = model._id_map_to_rgb(id_data, color_by='cell', colors=colors)
+    assert np.allclose(rgb_custom, [1.0, 0.0, 0.0])  # All pixels should be red
+
+    # Test with overlaps
+    id_data_overlap = id_data.copy()
+    id_data_overlap[5:, 5:, 0] = -3  # Mark some pixels as overlaps
+    rgb_overlap = model._id_map_to_rgb(
+        id_data_overlap, show_overlaps=True, overlap_color=(0, 255, 0)
+    )
+    # Check that overlap region is green
+    assert np.allclose(rgb_overlap[5:, 5:], [0.0, 1.0, 0.0])


### PR DESCRIPTION
# Description

This PR makes use of the ```model.id_map``` when plotting. This avoids writing the png/ppm file and then reading the image back in with ```mpimg.imread```. I believe this is therefore more efficient than the current model.plot. Initially it looks like a lot of changes but many changes are just removing indentation which is no longer needed as the temp dir is not needed as we don't write files anymore.

I also split out some logic for converting id_maps to RGB maps which I could then test separately.

Previous PRs that made this possible
Following on from the excellent id_map PR #3481 that  @pshriwise we recently added the ability to include overlaps in the id_map with #3669


Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)