### PR TITLE
Add a command-line argument for output verbosity

### DIFF
--- a/docs/source/usersguide/scripts.rst
+++ b/docs/source/usersguide/scripts.rst
@@ -48,6 +48,7 @@ flags:
                        restart file
 -s, --threads N        Run with *N* OpenMP threads
 -t, --track            Write tracks for all particles (up to max_tracks)
+-q, --verbosity V      Set the output verbosity to *V*
 -v, --version          Show version information
 -h, --help             Show help message
 

--- a/man/man1/openmc.1
+++ b/man/man1/openmc.1
@@ -39,6 +39,9 @@ Use \fIN\fP OpenMP threads.
 .B "\-t\fR, \fP\-\-track"
 Write tracks for all particles (up to max_tracks).
 .TP
+.BI \-q " V" "\fR,\fP \-\-verbosity" " V"
+Set the output verbosity to \fIV\fP.
+.TP
 .B "\-v\fR, \fP\-\-version"
 Show version information.
 .TP

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -142,7 +142,7 @@ int openmc_finalize()
   settings::uniform_source_sampling = false;
   settings::ufs_on = false;
   settings::urr_ptables_on = true;
-  settings::verbosity = 7;
+  settings::verbosity = -1;
   settings::weight_cutoff = 0.25;
   settings::weight_survive = 1.0;
   settings::weight_windows_file.clear();

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -230,8 +230,7 @@ int parse_command_line(int argc, char* argv[])
         i += 1;
         settings::verbosity = std::stoi(argv[i]);
         if (settings::verbosity > 10 || settings::verbosity < 1) {
-          auto msg =
-            fmt::format("Invalid verbosity: {}.", settings::verbosity);
+          auto msg = fmt::format("Invalid verbosity: {}.", settings::verbosity);
           strcpy(openmc_err_msg, msg.c_str());
           return OPENMC_E_INVALID_ARGUMENT;
         }

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -226,6 +226,16 @@ int parse_command_line(int argc, char* argv[])
         i += 1;
         settings::n_particles = std::stoll(argv[i]);
 
+      } else if (arg == "-q" || arg == "--verbosity") {
+        i += 1;
+        settings::verbosity = std::stoi(argv[i]);
+        if (settings::verbosity > 10 || settings::verbosity < 1) {
+          auto msg =
+            fmt::format("Invalid verbosity: {}.", settings::verbosity);
+          strcpy(openmc_err_msg, msg.c_str());
+          return OPENMC_E_INVALID_ARGUMENT;
+        }
+
       } else if (arg == "-e" || arg == "--event") {
         settings::event_based = true;
       } else if (arg == "-r" || arg == "--restart") {
@@ -376,8 +386,10 @@ bool read_model_xml()
   auto settings_root = root.child("settings");
 
   // Verbosity
-  if (check_for_node(settings_root, "verbosity")) {
+  if (check_for_node(settings_root, "verbosity") && settings::verbosity == -1) {
     settings::verbosity = std::stoi(get_node_value(settings_root, "verbosity"));
+  } else if (settings::verbosity == -1) {
+    settings::verbosity = 7;
   }
 
   // To this point, we haven't displayed any output since we didn't know what

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -281,6 +281,7 @@ void print_usage()
       "  -t, --track            Write tracks for all particles (up to "
       "max_tracks)\n"
       "  -e, --event            Run using event-based parallelism\n"
+      "  -q, --verbosity        Output verbosity\n"
       "  -v, --version          Show version information\n"
       "  -h, --help             Show this message\n");
   }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -398,8 +398,7 @@ void read_settings_xml()
   // Verbosity
   if (check_for_node(root, "verbosity") && verbosity == -1) {
     verbosity = std::stoi(get_node_value(root, "verbosity"));
-  } else if (verbosity == -1)
-  {
+  } else if (verbosity == -1) {
     verbosity = 7;
   }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -145,7 +145,7 @@ int trace_gen;
 int64_t trace_particle;
 vector<array<int, 3>> track_identifiers;
 int trigger_batch_interval {1};
-int verbosity {7};
+int verbosity {-1};
 double weight_cutoff {0.25};
 double weight_survive {1.0};
 
@@ -396,8 +396,11 @@ void read_settings_xml()
   xml_node root = doc.document_element();
 
   // Verbosity
-  if (check_for_node(root, "verbosity")) {
+  if (check_for_node(root, "verbosity") && verbosity == -1) {
     verbosity = std::stoi(get_node_value(root, "verbosity"));
+  } else if (verbosity == -1)
+  {
+    verbosity = 7;
   }
 
   // To this point, we haven't displayed any output since we didn't know what


### PR DESCRIPTION
# Description

This PR adds a command line argument to set the verbosity of an OpenMC simulation: `-q` /  `--verbosity`. The bounds are error checked to ensure the result is a valid verbosity flag in [1, 10]. If a verbosity is specified, the value from `settings.xml` / `model.xml` is overriden. 

I couldn't find any examples of places where the command line arguments are getting regression / unit tested. I'd be more then happy to add a test for this new argument if someone could point me to an example in OpenMC's regression suite!

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~

