### PR TITLE
IFP creates fatal error in all run modes except eigenvalue.

### DIFF
--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -215,7 +215,7 @@ Tally::Tally(pugi::xml_node node)
                       "number of inactive cycles.");
         }
         settings::ifp_on = true;
-      } else {
+      } else if (settings::run_mode == RunMode::FIXED_SOURCE) {
         fatal_error(
           "Iterated Fission Probability can only be used in an eigenvalue "
           "calculation.");


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Currently, using IFP tallies emit fatal error even in plot or volume run modes.
This PR changes the behavior to emit fatal error only in fixed source mode.

Fixes #3679.


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
