### PR TITLE
Fix mcpl dependency in test

### DIFF
--- a/tests/unit_tests/test_collision_track.py
+++ b/tests/unit_tests/test_collision_track.py
@@ -5,6 +5,7 @@ import openmc
 import pytest
 import h5py
 import numpy as np
+import shutil
 
 from tests.testing_harness import CollisionTrackTestHarness as ctt
 

--- a/tests/unit_tests/test_collision_track.py
+++ b/tests/unit_tests/test_collision_track.py
@@ -109,6 +109,7 @@ def test_particle_location(run_in_tmpdir, model):
                 assert False
 
 
+@pytest.mark.skipif(shutil.which("mcpl-config") is None, reason="MCPL is not available.")
 def test_format_similarity(run_in_tmpdir, model):
     model.settings.collision_track = {"max_collisions": 200, "reactions": ['elastic'],
                                       "cell_ids": [1, 2], "mcpl": False}


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

A test that depends on mcpl was not marked correctly. 




# Checklist 

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
