### PR TITLE
Block restriction of libMesh unstructured mesh tallies

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -4,6 +4,7 @@
 #ifndef OPENMC_MESH_H
 #define OPENMC_MESH_H
 
+#include <set>
 #include <unordered_map>
 
 #include "hdf5.h"
@@ -1043,8 +1044,9 @@ private:
 class AdaptiveLibMesh : public LibMesh {
 public:
   // Constructor
-  AdaptiveLibMesh(
-    libMesh::MeshBase& input_mesh, double length_multiplier = 1.0);
+  AdaptiveLibMesh(libMesh::MeshBase& input_mesh, double length_multiplier = 1.0,
+    const std::set<libMesh::subdomain_id_type>& block_ids =
+      std::set<libMesh::subdomain_id_type>());
 
   // Overridden methods
   int n_bins() const override;
@@ -1064,6 +1066,9 @@ protected:
 
 private:
   // Data members
+  const std::set<libMesh::subdomain_id_type>
+    block_ids_;               //!< subdomains of the mesh to tally on
+  const bool block_restrict_; //!< whether a subset of the mesh is being used
   const libMesh::dof_id_type num_active_; //!< cached number of active elements
 
   std::vector<libMesh::dof_id_type>

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -970,7 +970,7 @@ public:
 
   Position sample_element(int32_t bin, uint64_t* seed) const override;
 
-  int get_bin(Position r) const override;
+  virtual int get_bin(Position r) const override;
 
   int n_bins() const override;
 
@@ -1008,16 +1008,21 @@ public:
 
 protected:
   // Methods
-
   //! Translate a bin value to an element reference
   virtual const libMesh::Elem& get_element_from_bin(int bin) const;
 
   //! Translate an element pointer to a bin index
   virtual int get_bin_from_element(const libMesh::Elem* elem) const;
 
+  // Data members
   libMesh::MeshBase* m_; //!< pointer to libMesh MeshBase instance, always set
                          //!< during intialization
+  vector<unique_ptr<libMesh::PointLocatorBase>>
+    pl_; //!< per-thread point locators
+  libMesh::BoundingBox bbox_; //!< bounding box of the mesh
+
 private:
+  // Methods
   void initialize() override;
   void set_mesh_pointer_from_filename(const std::string& filename);
   void build_eqn_sys();
@@ -1026,8 +1031,6 @@ private:
   unique_ptr<libMesh::MeshBase> unique_m_ =
     nullptr; //!< pointer to the libMesh MeshBase instance, only used if mesh is
              //!< created inside OpenMC
-  vector<unique_ptr<libMesh::PointLocatorBase>>
-    pl_; //!< per-thread point locators
   unique_ptr<libMesh::EquationSystems>
     equation_systems_; //!< pointer to the libMesh EquationSystems
                        //!< instance
@@ -1036,7 +1039,6 @@ private:
   std::unordered_map<std::string, unsigned int>
     variable_map_; //!< mapping of variable names (tally scores) to libMesh
                    //!< variable numbers
-  libMesh::BoundingBox bbox_; //!< bounding box of the mesh
   libMesh::dof_id_type
     first_element_id_; //!< id of the first element in the mesh
 };
@@ -1057,6 +1059,8 @@ public:
     const vector<double>& std_dev) override;
 
   void write(const std::string& filename) const override;
+
+  int get_bin(Position r) const override;
 
 protected:
   // Overridden methods

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -1018,7 +1018,7 @@ protected:
   libMesh::MeshBase* m_; //!< pointer to libMesh MeshBase instance, always set
                          //!< during intialization
   vector<unique_ptr<libMesh::PointLocatorBase>>
-    pl_; //!< per-thread point locators
+    pl_;                      //!< per-thread point locators
   libMesh::BoundingBox bbox_; //!< bounding box of the mesh
 
 private:

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3485,9 +3485,6 @@ void LibMesh::initialize()
   // assuming that unstructured meshes used in OpenMC are 3D
   n_dimension_ = 3;
 
-  if (length_multiplier_ > 0.0) {
-    libMesh::MeshTools::Modification::scale(*m_, length_multiplier_);
-  }
   // if OpenMC is managing the libMesh::MeshBase instance, prepare the mesh.
   // Otherwise assume that it is prepared by its owning application
   if (unique_m_) {
@@ -3537,7 +3534,11 @@ Position LibMesh::centroid(int bin) const
 {
   const auto& elem = this->get_element_from_bin(bin);
   auto centroid = elem.vertex_average();
-  return {centroid(0), centroid(1), centroid(2)};
+  if (length_multiplier_ > 0.0) {
+    return length_multiplier_ * Position(centroid(0), centroid(1), centroid(2));
+  } else {
+    return {centroid(0), centroid(1), centroid(2)};
+  }
 }
 
 int LibMesh::n_vertices() const
@@ -3548,7 +3549,11 @@ int LibMesh::n_vertices() const
 Position LibMesh::vertex(int vertex_id) const
 {
   const auto node_ref = m_->node_ref(vertex_id);
-  return {node_ref(0), node_ref(1), node_ref(2)};
+  if (length_multiplier_ > 0.0) {
+    return length_multiplier_ * Position(node_ref(0), node_ref(1), node_ref(2));
+  } else {
+    return {node_ref(0), node_ref(1), node_ref(2)};
+  }
 }
 
 std::vector<int> LibMesh::connectivity(int elem_id) const
@@ -3689,6 +3694,11 @@ int LibMesh::get_bin(Position r) const
   // look-up a tet using the point locator
   libMesh::Point p(r.x, r.y, r.z);
 
+  if (length_multiplier_ > 0.0) {
+    // Scale the point down
+    p /= length_multiplier_;
+  }
+
   // quick rejection check
   if (!bbox_.contains_point(p)) {
     return -1;
@@ -3722,7 +3732,7 @@ const libMesh::Elem& LibMesh::get_element_from_bin(int bin) const
 
 double LibMesh::volume(int bin) const
 {
-  return this->get_element_from_bin(bin).volume();
+  return this->get_element_from_bin(bin).volume() * length_multiplier_ * length_multiplier_ * length_multiplier_;
 }
 
 AdaptiveLibMesh::AdaptiveLibMesh(libMesh::MeshBase& input_mesh,
@@ -3746,9 +3756,7 @@ AdaptiveLibMesh::AdaptiveLibMesh(libMesh::MeshBase& input_mesh,
                  : m_->active_elements_begin();
   auto end = block_restrict_ ? m_->active_subdomain_set_elements_end(block_ids_)
                              : m_->active_elements_end();
-  for (auto it = begin; it != end; it++) {
-    auto elem = *it;
-
+  for (const auto & elem : libMesh::as_range(begin, end)) {
     bin_to_elem_map_.push_back(elem->id());
     elem_to_bin_map_[elem->id()] = bin_to_elem_map_.size() - 1;
   }
@@ -3779,6 +3787,27 @@ void AdaptiveLibMesh::write(const std::string& filename) const
   warning(fmt::format(
     "Exodus output cannot be provided as unstructured mesh {} is adaptive.",
     this->id_));
+}
+
+int AdaptiveLibMesh::get_bin(Position r) const
+{
+  // look-up a tet using the point locator
+  libMesh::Point p(r.x, r.y, r.z);
+
+  if (length_multiplier_ > 0.0) {
+    // Scale the point down
+    p /= length_multiplier_;
+  }
+
+  // quick rejection check
+  if (!bbox_.contains_point(p)) {
+    return -1;
+  }
+
+  const auto& point_locator = pl_.at(thread_num());
+
+  const auto elem_ptr = (*point_locator)(p, &block_ids_);
+  return elem_ptr ? get_bin_from_element(elem_ptr) : -1;
 }
 
 int AdaptiveLibMesh::get_bin_from_element(const libMesh::Elem* elem) const

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3725,17 +3725,28 @@ double LibMesh::volume(int bin) const
   return this->get_element_from_bin(bin).volume();
 }
 
-AdaptiveLibMesh::AdaptiveLibMesh(
-  libMesh::MeshBase& input_mesh, double length_multiplier)
-  : LibMesh(input_mesh, length_multiplier), num_active_(m_->n_active_elem())
+AdaptiveLibMesh::AdaptiveLibMesh(libMesh::MeshBase& input_mesh,
+  double length_multiplier,
+  const std::set<libMesh::subdomain_id_type>& block_ids)
+  : LibMesh(input_mesh, length_multiplier), block_ids_(block_ids),
+    block_restrict_(!block_ids_.empty()),
+    num_active_(
+      block_restrict_
+        ? std::distance(m_->active_subdomain_set_elements_begin(block_ids_),
+            m_->active_subdomain_set_elements_end(block_ids_))
+        : m_->n_active_elem())
 {
   // if the mesh is adaptive elements aren't guaranteed by libMesh to be
   // contiguous in ID space, so we need to map from bin indices (defined over
   // active elements) to global dof ids
   bin_to_elem_map_.reserve(num_active_);
   elem_to_bin_map_.resize(m_->n_elem(), -1);
-  for (auto it = m_->active_elements_begin(); it != m_->active_elements_end();
-       it++) {
+  auto begin = block_restrict_
+                 ? m_->active_subdomain_set_elements_begin(block_ids_)
+                 : m_->active_elements_begin();
+  auto end = block_restrict_ ? m_->active_subdomain_set_elements_end(block_ids_)
+                             : m_->active_elements_end();
+  for (auto it = begin; it != end; it++) {
     auto elem = *it;
 
     bin_to_elem_map_.push_back(elem->id());

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3732,7 +3732,8 @@ const libMesh::Elem& LibMesh::get_element_from_bin(int bin) const
 
 double LibMesh::volume(int bin) const
 {
-  return this->get_element_from_bin(bin).volume() * length_multiplier_ * length_multiplier_ * length_multiplier_;
+  return this->get_element_from_bin(bin).volume() * length_multiplier_ *
+         length_multiplier_ * length_multiplier_;
 }
 
 AdaptiveLibMesh::AdaptiveLibMesh(libMesh::MeshBase& input_mesh,
@@ -3756,7 +3757,7 @@ AdaptiveLibMesh::AdaptiveLibMesh(libMesh::MeshBase& input_mesh,
                  : m_->active_elements_begin();
   auto end = block_restrict_ ? m_->active_subdomain_set_elements_end(block_ids_)
                              : m_->active_elements_end();
-  for (const auto & elem : libMesh::as_range(begin, end)) {
+  for (const auto& elem : libMesh::as_range(begin, end)) {
     bin_to_elem_map_.push_back(elem->id());
     elem_to_bin_map_[elem->id()] = bin_to_elem_map_.size() - 1;
   }


### PR DESCRIPTION
# Description

libMesh meshes support the use of subdomains of elements known as "blocks". Often times in multi-physics applications (such as Cardinal) users will mesh their entire geometries, but only need to compute specific physics over a subset of the blocks in the mesh. Presently, OpenMC does not support the specification of block restriction for libMesh unstructured mesh tallies, and tallying on the entire geometry can be quite compute-intensive (especially for scores like kappa-fission which are defined over a single block). To get around this in Cardinal we've been creating a clone of the full libMesh mesh which only contains the elements belonging to the blocks the user wishes to tally on. This is a rather memory-intensive workaround, which becomes quite expensive when scaling up to large problems.

This PR implements a more elegant solution which uses the infrastructure in `AdaptiveLibMesh`. The forward and inverse mapping between bins and elements is redefined to work for adaptive meshes and block restriction such that tallying is only performed on the requested subdomains.

In addition to the above, this PR also changes how libMesh scaling works. The previous approach scaled all of the nodes in the libMesh mesh ahead of time. This works when OpenMC runs as a standalone application, however it causes problems when the mesh is managed by an external application which may assume that the mesh doesn't change after initialization.  In the case of Cardinal, MOOSE assumes that the mesh is not modified after setup and scaling the mesh in-place causes failures with other MOOSE systems. An alternative has been implemented here which uses the inverse scaling transformation to scale down sample points into mesh-space, instead of using the transformation to scale up the mesh. 

If preferred, I can separate these two Cardinal-motivated changes into different PR's. Just thought I'd lump them together since the scaling change is rather small.

cc'ing @aprilnovak 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
