### PR TITLE
Add a simplification step to cpp region parsing.

### DIFF
--- a/include/openmc/cell.h
+++ b/include/openmc/cell.h
@@ -106,6 +106,9 @@ private:
   //! Get a vector of the region expression in postfix notation
   vector<int32_t> generate_postfix(int32_t cell_id) const;
 
+  //! Get a vector of the region expression in infix notation
+  vector<int32_t> generate_infix(vector<int32_t> rpn) const;
+
   //! Determine if a particle is inside the cell for a simple cell (only
   //! intersection operators)
   bool contains_simple(Position r, Direction u, int32_t on_surface) const;

--- a/tests/cpp_unit_tests/CMakeLists.txt
+++ b/tests/cpp_unit_tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_NAMES
   test_math
   test_mcpl_stat_sum
   test_mesh
+  test_region
   # Add additional unit test files here
 )
 

--- a/tests/cpp_unit_tests/test_region.cpp
+++ b/tests/cpp_unit_tests/test_region.cpp
@@ -1,0 +1,11 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_vector.hpp>
+
+#include "openmc/cell.h"
+
+TEST_CASE("Test region simplification")
+{
+  auto region = openmc::Region::Region("-1 2 (-3 4) | (-5 6)", 0);
+  REQUIRE_THAT(region->str() == "(-1 2 -3 4) | (-5 6)");
+}

--- a/tests/cpp_unit_tests/test_region.cpp
+++ b/tests/cpp_unit_tests/test_region.cpp
@@ -1,11 +1,27 @@
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_floating_point.hpp>
-#include <catch2/matchers/catch_matchers_vector.hpp>
 
 #include "openmc/cell.h"
+#include "openmc/surface.h"
+
+#include <pugixml.hpp>
 
 TEST_CASE("Test region simplification")
 {
-  auto region = openmc::Region::Region("-1 2 (-3 4) | (-5 6)", 0);
-  REQUIRE_THAT(region->str() == "(-1 2 -3 4) | (-5 6)");
+  pugi::xml_document doc;
+  pugi::xml_node surf_node = doc.append_child("surface");
+  surf_node.set_name("surface");
+  surf_node.append_attribute("id") = "0";
+  surf_node.append_attribute("type") = "x-plane";
+  surf_node.append_attribute("coeffs") = "1";
+
+  for (int i = 1; i < 7; ++i) {
+    surf_node.attribute("id") = i;
+    openmc::model::surfaces.push_back(
+      std::make_unique<openmc::SurfaceXPlane>(surf_node));
+    openmc::model::surface_map[i] = i - 1;
+  }
+  auto region = openmc::Region("(-1 2 (-3 4) | (-5 6))", 0);
+  auto ref_val = " ( -1 2 -3 4 ) | ( -5 6 )";
+  auto test_val = region.str();
+  REQUIRE(test_val == ref_val);
 }


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR adds a simplification step to region parsing.
This is done to fix parsing of complicated region definitions that are written outside the python API.

Fixes #3685.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
