### PR TITLE
Use min/max position members in C++ BoundingBox class

### DIFF
--- a/include/openmc/bounding_box.h
+++ b/include/openmc/bounding_box.h
@@ -13,12 +13,19 @@ namespace openmc {
 //==============================================================================
 
 struct BoundingBox {
-  double xmin = -INFTY;
-  double xmax = INFTY;
-  double ymin = -INFTY;
-  double ymax = INFTY;
-  double zmin = -INFTY;
-  double zmax = INFTY;
+  Position min = {-INFTY, -INFTY, -INFTY};
+  Position max = {INFTY, INFTY, INFTY};
+
+  // Constructors
+  BoundingBox() = default;
+  BoundingBox(Position min_, Position max_) : min {min_}, max {max_} {}
+
+  // Static factory methods
+  static BoundingBox infinite() { return {}; }
+  static BoundingBox inverted()
+  {
+    return {{INFTY, INFTY, INFTY}, {-INFTY, -INFTY, -INFTY}};
+  }
 
   inline BoundingBox operator&(const BoundingBox& other)
   {
@@ -35,29 +42,26 @@ struct BoundingBox {
   // intersect operator
   inline BoundingBox& operator&=(const BoundingBox& other)
   {
-    xmin = std::max(xmin, other.xmin);
-    xmax = std::min(xmax, other.xmax);
-    ymin = std::max(ymin, other.ymin);
-    ymax = std::min(ymax, other.ymax);
-    zmin = std::max(zmin, other.zmin);
-    zmax = std::min(zmax, other.zmax);
+    min.x = std::max(min.x, other.min.x);
+    min.y = std::max(min.y, other.min.y);
+    min.z = std::max(min.z, other.min.z);
+    max.x = std::min(max.x, other.max.x);
+    max.y = std::min(max.y, other.max.y);
+    max.z = std::min(max.z, other.max.z);
     return *this;
   }
 
   // union operator
   inline BoundingBox& operator|=(const BoundingBox& other)
   {
-    xmin = std::min(xmin, other.xmin);
-    xmax = std::max(xmax, other.xmax);
-    ymin = std::min(ymin, other.ymin);
-    ymax = std::max(ymax, other.ymax);
-    zmin = std::min(zmin, other.zmin);
-    zmax = std::max(zmax, other.zmax);
+    min.x = std::min(min.x, other.min.x);
+    min.y = std::min(min.y, other.min.y);
+    min.z = std::min(min.z, other.min.z);
+    max.x = std::max(max.x, other.max.x);
+    max.y = std::max(max.y, other.max.y);
+    max.z = std::max(max.z, other.max.z);
     return *this;
   }
-
-  inline Position min() const { return {xmin, ymin, zmin}; }
-  inline Position max() const { return {xmax, ymax, zmax}; }
 };
 
 } // namespace openmc

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -244,9 +244,7 @@ public:
   //! \return Bounding box of mesh
   BoundingBox bounding_box() const
   {
-    auto ll = this->lower_left();
-    auto ur = this->upper_right();
-    return {ll.x, ur.x, ll.y, ur.y, ll.z, ur.z};
+    return {this->lower_left(), this->upper_right()};
   }
 
   virtual Position lower_left() const = 0;

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1334,14 +1334,14 @@ extern "C" int openmc_cell_bounding_box(
   bbox = c->bounding_box();
 
   // set lower left corner values
-  llc[0] = bbox.xmin;
-  llc[1] = bbox.ymin;
-  llc[2] = bbox.zmin;
+  llc[0] = bbox.min.x;
+  llc[1] = bbox.min.y;
+  llc[2] = bbox.min.z;
 
   // set upper right corner values
-  urc[0] = bbox.xmax;
-  urc[1] = bbox.ymax;
-  urc[2] = bbox.zmax;
+  urc[0] = bbox.max.x;
+  urc[1] = bbox.max.y;
+  urc[2] = bbox.max.z;
 
   return 0;
 }

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -753,7 +753,7 @@ BoundingBox DAGCell::bounding_box() const
   double min[3], max[3];
   rval = dagmc_ptr_->getobb(vol, min, max);
   MB_CHK_ERR_CONT(rval);
-  return {min[0], max[0], min[1], max[1], min[2], max[2]};
+  return {{min[0], min[1], min[2]}, {max[0], max[1], max[2]}};
 }
 
 //==============================================================================

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -480,14 +480,14 @@ extern "C" int openmc_global_bounding_box(double* llc, double* urc)
   auto bbox = model::universes.at(model::root_universe)->bounding_box();
 
   // set lower left corner values
-  llc[0] = bbox.xmin;
-  llc[1] = bbox.ymin;
-  llc[2] = bbox.zmin;
+  llc[0] = bbox.min.x;
+  llc[1] = bbox.min.y;
+  llc[2] = bbox.min.z;
 
   // set upper right corner values
-  urc[0] = bbox.xmax;
-  urc[1] = bbox.ymax;
-  urc[2] = bbox.zmax;
+  urc[0] = bbox.max.x;
+  urc[1] = bbox.max.y;
+  urc[2] = bbox.max.z;
 
   return 0;
 }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -359,9 +359,10 @@ void Mesh::material_volumes(int nx, int ny, int nz, int table_size,
   std::array<int, 3> n_rays = {nx, ny, nz};
 
   // Determine effective width of rays
-  Position width((nx > 0) ? (bbox.xmax - bbox.xmin) / nx : 0.0,
-    (ny > 0) ? (bbox.ymax - bbox.ymin) / ny : 0.0,
-    (nz > 0) ? (bbox.zmax - bbox.zmin) / nz : 0.0);
+  Position width = bbox.max - bbox.min;
+  width.x = (nx > 0) ? width.x / nx : 0.0;
+  width.y = (ny > 0) ? width.y / ny : 0.0;
+  width.z = (nz > 0) ? width.z / nz : 0.0;
 
   // Set flag for mesh being contained within model
   bool out_of_model = false;
@@ -380,15 +381,15 @@ void Mesh::material_volumes(int nx, int ny, int nz, int table_size,
     for (int axis = 0; axis < 3; ++axis) {
       // Set starting position and direction
       site.r = {0.0, 0.0, 0.0};
-      site.r[axis] = bbox.min()[axis];
+      site.r[axis] = bbox.min[axis];
       site.u = {0.0, 0.0, 0.0};
       site.u[axis] = 1.0;
 
       // Determine width of rays and number of rays in other directions
       int ax1 = (axis + 1) % 3;
       int ax2 = (axis + 2) % 3;
-      double min1 = bbox.min()[ax1];
-      double min2 = bbox.min()[ax2];
+      double min1 = bbox.min[ax1];
+      double min2 = bbox.min[ax2];
       double d1 = width[ax1];
       double d2 = width[ax2];
       int n1 = n_rays[ax1];
@@ -433,7 +434,7 @@ void Mesh::material_volumes(int nx, int ny, int nz, int table_size,
           while (true) {
             // Ray trace from r_start to r_end
             Position r0 = p.r();
-            double max_distance = bbox.max()[axis] - r0[axis];
+            double max_distance = bbox.max[axis] - r0[axis];
 
             // Find the distance to the nearest boundary
             BoundaryInfo boundary = distance_to_boundary(p);
@@ -2415,14 +2416,14 @@ extern "C" int openmc_mesh_bounding_box(int32_t index, double* ll, double* ur)
   BoundingBox bbox = model::meshes[index]->bounding_box();
 
   // set lower left corner values
-  ll[0] = bbox.xmin;
-  ll[1] = bbox.ymin;
-  ll[2] = bbox.zmin;
+  ll[0] = bbox.min.x;
+  ll[1] = bbox.min.y;
+  ll[2] = bbox.min.z;
 
   // set upper right corner values
-  ur[0] = bbox.xmax;
-  ur[1] = bbox.ymax;
-  ur[2] = bbox.zmax;
+  ur[0] = bbox.max.x;
+  ur[1] = bbox.max.y;
+  ur[2] = bbox.max.z;
   return 0;
 }
 

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -251,9 +251,9 @@ void SurfaceXPlane::to_hdf5_inner(hid_t group_id) const
 BoundingBox SurfaceXPlane::bounding_box(bool pos_side) const
 {
   if (pos_side) {
-    return {x0_, INFTY, -INFTY, INFTY, -INFTY, INFTY};
+    return {{x0_, -INFTY, -INFTY}, {INFTY, INFTY, INFTY}};
   } else {
-    return {-INFTY, x0_, -INFTY, INFTY, -INFTY, INFTY};
+    return {{-INFTY, -INFTY, -INFTY}, {x0_, INFTY, INFTY}};
   }
 }
 
@@ -291,9 +291,9 @@ void SurfaceYPlane::to_hdf5_inner(hid_t group_id) const
 BoundingBox SurfaceYPlane::bounding_box(bool pos_side) const
 {
   if (pos_side) {
-    return {-INFTY, INFTY, y0_, INFTY, -INFTY, INFTY};
+    return {{-INFTY, y0_, -INFTY}, {INFTY, INFTY, INFTY}};
   } else {
-    return {-INFTY, INFTY, -INFTY, y0_, -INFTY, INFTY};
+    return {{-INFTY, -INFTY, -INFTY}, {INFTY, y0_, INFTY}};
   }
 }
 
@@ -331,9 +331,9 @@ void SurfaceZPlane::to_hdf5_inner(hid_t group_id) const
 BoundingBox SurfaceZPlane::bounding_box(bool pos_side) const
 {
   if (pos_side) {
-    return {-INFTY, INFTY, -INFTY, INFTY, z0_, INFTY};
+    return {{-INFTY, -INFTY, z0_}, {INFTY, INFTY, INFTY}};
   } else {
-    return {-INFTY, INFTY, -INFTY, INFTY, -INFTY, z0_};
+    return {{-INFTY, -INFTY, -INFTY}, {INFTY, INFTY, z0_}};
   }
 }
 
@@ -492,8 +492,8 @@ void SurfaceXCylinder::to_hdf5_inner(hid_t group_id) const
 BoundingBox SurfaceXCylinder::bounding_box(bool pos_side) const
 {
   if (!pos_side) {
-    return {-INFTY, INFTY, y0_ - radius_, y0_ + radius_, z0_ - radius_,
-      z0_ + radius_};
+    return {{-INFTY, y0_ - radius_, z0_ - radius_},
+      {INFTY, y0_ + radius_, z0_ + radius_}};
   } else {
     return {};
   }
@@ -535,8 +535,8 @@ void SurfaceYCylinder::to_hdf5_inner(hid_t group_id) const
 BoundingBox SurfaceYCylinder::bounding_box(bool pos_side) const
 {
   if (!pos_side) {
-    return {x0_ - radius_, x0_ + radius_, -INFTY, INFTY, z0_ - radius_,
-      z0_ + radius_};
+    return {{x0_ - radius_, -INFTY, z0_ - radius_},
+      {x0_ + radius_, INFTY, z0_ + radius_}};
   } else {
     return {};
   }
@@ -579,8 +579,8 @@ void SurfaceZCylinder::to_hdf5_inner(hid_t group_id) const
 BoundingBox SurfaceZCylinder::bounding_box(bool pos_side) const
 {
   if (!pos_side) {
-    return {x0_ - radius_, x0_ + radius_, y0_ - radius_, y0_ + radius_, -INFTY,
-      INFTY};
+    return {{x0_ - radius_, y0_ - radius_, -INFTY},
+      {x0_ + radius_, y0_ + radius_, INFTY}};
   } else {
     return {};
   }
@@ -657,8 +657,8 @@ void SurfaceSphere::to_hdf5_inner(hid_t group_id) const
 BoundingBox SurfaceSphere::bounding_box(bool pos_side) const
 {
   if (!pos_side) {
-    return {x0_ - radius_, x0_ + radius_, y0_ - radius_, y0_ + radius_,
-      z0_ - radius_, z0_ + radius_};
+    return {{x0_ - radius_, y0_ - radius_, z0_ - radius_},
+      {x0_ + radius_, y0_ + radius_, z0_ + radius_}};
   } else {
     return {};
   }

--- a/src/universe.cpp
+++ b/src/universe.cpp
@@ -61,7 +61,7 @@ bool Universe::find_cell(GeometryState& p) const
 
 BoundingBox Universe::bounding_box() const
 {
-  BoundingBox bbox = {INFTY, -INFTY, INFTY, -INFTY, INFTY, -INFTY};
+  BoundingBox bbox = BoundingBox::inverted();
   if (cells_.size() == 0) {
     return {};
   } else {


### PR DESCRIPTION
# Description

This PR refactors the `BoundingBox` class on the C++ side to have `min` and `max` data members of type `Position` rather than separate `xmin`, `xmax`, `ymin`, `ymax`, `zmin`, and `zmax` members. This brings it closer to the `BoundingBox` Python class. 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>