### PR TITLE
Open dagmc model file within a context manager

### DIFF
--- a/openmc/dagmc.py
+++ b/openmc/dagmc.py
@@ -223,9 +223,8 @@ class DAGMCUniverse(openmc.UniverseBase):
 
     @property
     def material_names(self):
-        dagmc_file_contents = h5py.File(self.filename)
-        material_tags_hex = dagmc_file_contents['/tstt/tags/NAME'].get(
-            'values')
+        with h5py.File(self.filename) as dagmc_file_contents:
+            material_tags_hex = dagmc_file_contents['/tstt/tags/NAME'].get('values')
         material_tags_ascii = []
         for tag in material_tags_hex:
             candidate_tag = tag.tobytes().decode().replace('\x00', '')

--- a/openmc/dagmc.py
+++ b/openmc/dagmc.py
@@ -223,20 +223,19 @@ class DAGMCUniverse(openmc.UniverseBase):
 
     @property
     def material_names(self):
+        material_tags_ascii = []
         with h5py.File(self.filename) as dagmc_file_contents:
             material_tags_hex = dagmc_file_contents['/tstt/tags/NAME'].get('values')
-        material_tags_ascii = []
-        for tag in material_tags_hex:
-            candidate_tag = tag.tobytes().decode().replace('\x00', '')
-            # tags might be for temperature or reflective surfaces
-            if candidate_tag.startswith('mat:'):
-                # if name ends with _comp remove it, it is not parsed
-                if candidate_tag.endswith('_comp'):
-                   candidate_tag = candidate_tag[:-5]
-                # removes first 4 characters as openmc.Material name should be
-                # set without the 'mat:' part of the tag
-                material_tags_ascii.append(candidate_tag[4:])
-
+            for tag in material_tags_hex:
+                candidate_tag = tag.tobytes().decode().replace('\x00', '')
+                # tags might be for temperature or reflective surfaces
+                if candidate_tag.startswith('mat:'):
+                    # if name ends with _comp remove it, it is not parsed
+                    if candidate_tag.endswith('_comp'):
+                       candidate_tag = candidate_tag[:-5]
+                    # removes first 4 characters as openmc.Material name should be
+                    # set without the 'mat:' part of the tag
+                    material_tags_ascii.append(candidate_tag[4:])
         return sorted(set(material_tags_ascii))
 
     def _n_geom_elements(self, geom_type):


### PR DESCRIPTION
# Description

when getting the material names from a DAGMC file it  appears that we don't close the file afterwards.

This PR change the code to use a context manager which automatically closes the file for us.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
