### PR TITLE
closing mgxs h5py file with context manager

### DIFF
--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -2554,20 +2554,20 @@ class MGXSLibrary:
                              "must be set")
 
         check_type('filename', filename, (str, PathLike))
-        file = h5py.File(filename, 'r')
+        with h5py.File(filename, 'r') as file:
 
-        # Check filetype and version
-        check_filetype_version(file, _FILETYPE_MGXS_LIBRARY,
-                               _VERSION_MGXS_LIBRARY)
+            # Check filetype and version
+            check_filetype_version(file, _FILETYPE_MGXS_LIBRARY,
+                                _VERSION_MGXS_LIBRARY)
 
-        group_structure = file.attrs['group structure']
-        num_delayed_groups = file.attrs['delayed_groups']
-        energy_groups = openmc.mgxs.EnergyGroups(group_structure)
-        data = cls(energy_groups, num_delayed_groups)
+            group_structure = file.attrs['group structure']
+            num_delayed_groups = file.attrs['delayed_groups']
+            energy_groups = openmc.mgxs.EnergyGroups(group_structure)
+            data = cls(energy_groups, num_delayed_groups)
 
-        for group_name, group in file.items():
-            data.add_xsdata(openmc.XSdata.from_hdf5(group, group_name,
-                                                    energy_groups,
-                                                    num_delayed_groups))
+            for group_name, group in file.items():
+                data.add_xsdata(openmc.XSdata.from_hdf5(group, group_name,
+                                                        energy_groups,
+                                                        num_delayed_groups))
 
         return data

--- a/openmc/mgxs_library.py
+++ b/openmc/mgxs_library.py
@@ -2558,7 +2558,7 @@ class MGXSLibrary:
 
             # Check filetype and version
             check_filetype_version(file, _FILETYPE_MGXS_LIBRARY,
-                                _VERSION_MGXS_LIBRARY)
+                                   _VERSION_MGXS_LIBRARY)
 
             group_structure = file.attrs['group structure']
             num_delayed_groups = file.attrs['delayed_groups']


### PR DESCRIPTION
# Description

Spotted another place where we don't close a hdf5 file, this time it is a mgxs hdf5 file so I've added another context manager to close the file automatically.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
