### PR TITLE
Constrain version of gcovr in CI to be <8.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ test = [
     "colorama",
     "openpyxl",
 ]
-ci = ["coverage>=7.4", "gcovr>=7.2"]
+ci = ["coverage>=7.4", "gcovr>=7.2,<8.5"]
 vtk = ["vtk"]
 
 [project.urls]


### PR DESCRIPTION
# Description

There's a [new version of gcovr](https://gcovr.com/en/stable/changelog.html#january-2026) that appears to have broken our CI. While we look into why this is and how to get it working with the new version, for now I've put a constraint on the installed version in CI to get it passing again.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>