### PR TITLE
Skip tests on documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests and Coverage
 
 on:
   # allows us to run workflows manually
@@ -24,22 +24,22 @@ jobs:
   filter-changes:
     runs-on: ubuntu-22.04
     outputs:
-      status: ${{ steps.filter.outputs.source }}
+      source_changed: ${{ steps.filter.outputs.source_changed }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
       - name: Examine changed files
-        id: filter 
+        id: filter
         uses: dorny/paths-filter@v3
         with:
           filters: |
-            source: 
-              - '!docs/**' 
-              - '!*.md'
+            source_changed:
+              - '!docs/**'
+              - '!**/*.md'
           predicate-quantifier: 'every'
   main:
     needs: filter-changes
-    if: ${{ needs.filter-changes.outputs.status == 'true' }}
+    if: ${{ needs.filter-changes.outputs.source_changed == 'true' }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -223,12 +223,33 @@ jobs:
           flag-name: C++ and Python
           path-to-lcov: coverage.lcov
 
-  finish:
-    needs: main
+  coverage:
+    needs: [filter-changes, main]
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
+        if: ${{ needs.filter-changes.outputs.source_changed == 'true' }}
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+
+  ci-pass:
+    needs: [filter-changes, main, coverage]
+    name: Check CI status
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CI status
+        run: |
+          if [[ "${{ needs.filter-changes.outputs.source_changed }}" == "false" ]]; then
+            echo "Documentation-only change - CI skipped successfully"
+            exit 0
+          fi
+          if [[ "${{ needs.main.result }}" == "success" && "${{ needs.coverage.result }}" == "success" ]]; then
+            echo "CI passed"
+            exit 0
+          fi
+          echo "CI failed"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   filter-changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       source_changed: ${{ steps.filter.outputs.source_changed }}
     steps:
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Examine changed files
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # latest master commit, not released yet
         with:
           filters: |
             source_changed:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,16 @@ on:
   workflow_dispatch:
 
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'  
     branches:
       - develop
       - master
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
     branches:
       - develop
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,10 @@ on:
   workflow_dispatch:
 
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'  
     branches:
       - develop
       - master
   push:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
     branches:
       - develop
       - master
@@ -27,7 +21,26 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
+  filter-changes:
+    runs-on: ubuntu-22.04
+    outputs:
+      source_status: ${{ steps.filter.outputs.source }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+      - name: Examine changed files
+        id: filter 
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            source: 
+              - 'src/**' 
+              - 'tests/**'
+              - '.github/workflows/**' 
+              - 'tools/ci/**'
   main:
+    needs: filter-changes
+    if: ${{ needs.filter-changes.outputs.cpp_status == 'true' }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   filter-changes:
     runs-on: ubuntu-22.04
     outputs:
-      source_status: ${{ steps.filter.outputs.source }}
+      status: ${{ steps.filter.outputs.source }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
           predicate-quantifier: 'every'
   main:
     needs: filter-changes
-    if: ${{ needs.filter-changes.outputs.cpp_status == 'true' }}
+    if: ${{ needs.filter-changes.outputs.status == 'true' }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,9 @@ jobs:
         with:
           filters: |
             source: 
-              - 'src/**' 
-              - 'tests/**'
-              - '.github/workflows/**' 
-              - 'tools/ci/**'
+              - '!docs/**' 
+              - '!*.md'
+          predicate-quantifier: 'every'
   main:
     needs: filter-changes
     if: ${{ needs.filter-changes.outputs.cpp_status == 'true' }}

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -10,7 +10,26 @@ on:
       - master
 
 jobs:
+  filter-cpp-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      cpp_status: ${{ steps.filter.outputs.cpp }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+      - name: Examine changed files
+        id: filter 
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            cpp: 
+              - 'src/**/*.cpp' 
+              - 'tests/**/*.cpp'
+              - 'src/**/*.h' 
+              - 'tests/**/*.h'
   cpp-linter:
+    needs: filter-cpp-changes
+    if: ${{ needs.filter-cpp-changes.outputs.cpp_status == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -10,26 +10,7 @@ on:
       - master
 
 jobs:
-  filter-cpp-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      cpp_status: ${{ steps.filter.outputs.cpp }}
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
-      - name: Examine changed files
-        id: filter 
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            cpp: 
-              - 'src/**/*.cpp' 
-              - 'tests/**/*.cpp'
-              - 'src/**/*.h' 
-              - 'tests/**/*.h'
   cpp-linter:
-    needs: filter-cpp-changes
-    if: ${{ needs.filter-cpp-changes.outputs.cpp_status == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Currently, we run the full test suite even if a commit only changes documentation.
This PR changes that. 


# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
