### PR TITLE
adding name to materials in depletion_results

### DIFF
--- a/include/openmc/position.h
+++ b/include/openmc/position.h
@@ -5,6 +5,8 @@
 #include <iostream>
 #include <stdexcept> // for out_of_range
 
+#include <fmt/format.h>
+
 #include "openmc/array.h"
 #include "openmc/vector.h"
 
@@ -161,5 +163,19 @@ std::ostream& operator<<(std::ostream& os, Position a);
 using Direction = Position;
 
 } // namespace openmc
+
+//==============================================================================
+// fmt formatter for Position
+//==============================================================================
+
+template<>
+struct fmt::formatter<openmc::Position> {
+  constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
+
+  template<typename FormatContext>
+  auto format(const openmc::Position& p, FormatContext& ctx) const {
+    return fmt::format_to(ctx.out(), "({}, {}, {})", p.x, p.y, p.z);
+  }
+};
 
 #endif // OPENMC_POSITION_H

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -190,7 +190,7 @@ class TransportOperator(ABC):
 
     @abstractmethod
     def get_results_info(self):
-        """Returns volume list, cell lists, and nuc lists.
+        """Returns volume list, cell lists, nuc lists, and material names.
 
         Returns
         -------
@@ -203,6 +203,8 @@ class TransportOperator(ABC):
             simulation.
         full_burn_list : list of int
             All burnable materials in the geometry.
+        mat_to_name : dict of str to str
+            Mapping of material ID to material name
         """
 
     def finalize(self):

--- a/openmc/deplete/operator.py
+++ b/openmc/deplete/operator.py
@@ -219,7 +219,7 @@ class Operator(TransportOperator):
 
         # Clear out OpenMC, create task lists, distribute
         openmc.reset_auto_ids()
-        self.burnable_mats, volume, nuclides = self._get_burnable_mats()
+        self.burnable_mats, volume, nuclides, self.mat_to_name = self._get_burnable_mats()
         self.local_mats = _distribute(self.burnable_mats)
 
         # Generate map from local materials => material index
@@ -387,7 +387,7 @@ class Operator(TransportOperator):
                                  for i in range(cell.num_instances)]
 
     def _get_burnable_mats(self):
-        """Determine depletable materials, volumes, and nuclides
+        """Determine depletable materials, volumes, nuclides, and names
 
         Returns
         -------
@@ -397,12 +397,15 @@ class Operator(TransportOperator):
             Volume of each material in [cm^3]
         nuclides : list of str
             Nuclides in order of how they'll appear in the simulation.
+        mat_name : OrderedDict of str to str
+            Name of each material (empty string if not set)
 
         """
 
         burnable_mats = set()
         model_nuclides = set()
         volume = OrderedDict()
+        mat_name = OrderedDict()
 
         self.heavy_metal = 0.0
 
@@ -416,6 +419,7 @@ class Operator(TransportOperator):
                     raise RuntimeError("Volume not specified for depletable "
                                        "material with ID={}.".format(mat.id))
                 volume[str(mat.id)] = mat.volume
+                mat_name[str(mat.id)] = mat.name if mat.name else ""
                 self.heavy_metal += mat.fissionable_mass
 
         # Make sure there are burnable materials
@@ -433,7 +437,7 @@ class Operator(TransportOperator):
             if nuc not in nuclides:
                 nuclides.append(nuc)
 
-        return burnable_mats, volume, nuclides
+        return burnable_mats, volume, nuclides, mat_name
 
     def _extract_number(self, local_mats, volume, nuclides, prev_res=None):
         """Construct AtomNumber using geometry
@@ -782,7 +786,7 @@ class Operator(TransportOperator):
         return nuclides
 
     def get_results_info(self):
-        """Returns volume list, material lists, and nuc lists.
+        """Returns volume list, material lists, nuc lists, and material names.
 
         Returns
         -------
@@ -794,6 +798,8 @@ class Operator(TransportOperator):
             A list of all material IDs to be burned.  Used for sorting the simulation.
         full_burn_list : list
             List of all burnable material IDs
+        mat_to_name : dict of str to str
+            Mapping of material ID to material name
 
         """
         nuc_list = self.number.burnable_nuclides
@@ -807,4 +813,4 @@ class Operator(TransportOperator):
         volume_list = comm.allgather(volume)
         volume = {k: v for d in volume_list for k, v in d.items()}
 
-        return volume, nuc_list, burn_list, self.burnable_mats
+        return volume, nuc_list, burn_list, self.burnable_mats, self.mat_to_name

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -37,6 +37,8 @@ class Results:
         The reaction rates for each substep.
     volume : OrderedDict of str to float
         Dictionary mapping mat id to volume.
+    mat_to_name : OrderedDict of str to str
+        Dictionary mapping mat id to material name.
     mat_to_ind : OrderedDict of str to int
         A dictionary mapping mat ID as string to index.
     nuc_to_ind : OrderedDict of str to int
@@ -60,6 +62,7 @@ class Results:
         self.source_rate = None
         self.rates = None
         self.volume = None
+        self.mat_to_name = None
         self.proc_time = None
 
         self.mat_to_ind = None
@@ -130,7 +133,8 @@ class Results:
     def n_stages(self):
         return self.data.shape[0]
 
-    def allocate(self, volume, nuc_list, burn_list, full_burn_list, stages):
+    def allocate(self, volume, nuc_list, burn_list, full_burn_list, stages,
+                 mat_to_name=None):
         """Allocates memory of Results.
 
         Parameters
@@ -145,12 +149,15 @@ class Results:
             List of all burnable material IDs
         stages : int
             Number of stages in simulation.
+        mat_to_name : dict of str to str, optional
+            Mapping of material ID to material name
 
         """
         self.volume = copy.deepcopy(volume)
         self.nuc_to_ind = {nuc: i for i, nuc in enumerate(nuc_list)}
         self.mat_to_ind = {mat: i for i, mat in enumerate(burn_list)}
         self.mat_to_hdf5_ind = {mat: i for i, mat in enumerate(full_burn_list)}
+        self.mat_to_name = copy.deepcopy(mat_to_name) if mat_to_name else {}
 
         # Create storage array
         self.data = np.zeros((stages, self.n_mat, self.n_nuc))
@@ -178,7 +185,7 @@ class Results:
 
         # Direct transfer
         direct_attrs = ("time", "k", "source_rate", "nuc_to_ind",
-                        "mat_to_hdf5_ind", "proc_time")
+                        "mat_to_hdf5_ind", "mat_to_name", "proc_time")
         for attr in direct_attrs:
             setattr(new, attr, getattr(self, attr))
         # Get applicable slice of data
@@ -255,6 +262,8 @@ class Results:
             mat_single_group = mat_group.create_group(mat)
             mat_single_group.attrs["index"] = self.mat_to_hdf5_ind[mat]
             mat_single_group.attrs["volume"] = self.volume[mat]
+            if self.mat_to_name and mat in self.mat_to_name:
+                mat_single_group.attrs["name"] = self.mat_to_name[mat]
 
         nuc_group = handle.create_group("nuclides")
 
@@ -416,6 +425,7 @@ class Results:
         # Reconstruct dictionaries
         results.volume = OrderedDict()
         results.mat_to_ind = OrderedDict()
+        results.mat_to_name = OrderedDict()
         results.nuc_to_ind = OrderedDict()
         rxn_nuc_to_ind = OrderedDict()
         rxn_to_ind = OrderedDict()
@@ -426,6 +436,10 @@ class Results:
 
             results.volume[mat] = vol
             results.mat_to_ind[mat] = ind
+            if "name" in mat_handle.attrs:
+                results.mat_to_name[mat] = mat_handle.attrs["name"]
+            else:
+                results.mat_to_name[mat] = ""
 
         for nuc, nuc_handle in handle["/nuclides"].items():
             ind_atom = nuc_handle.attrs["atom number index"]
@@ -472,13 +486,14 @@ class Results:
 
         """
         # Get indexing terms
-        vol_dict, nuc_list, burn_list, full_burn_list = op.get_results_info()
+        vol_dict, nuc_list, burn_list, full_burn_list, mat_to_name = op.get_results_info()
 
         stages = len(x)
 
         # Create results
         results = Results()
-        results.allocate(vol_dict, nuc_list, burn_list, full_burn_list, stages)
+        results.allocate(vol_dict, nuc_list, burn_list, full_burn_list, stages,
+                         mat_to_name)
 
         n_mat = len(burn_list)
 

--- a/tests/dummy_operator.py
+++ b/tests/dummy_operator.py
@@ -228,7 +228,7 @@ class DummyOperator(TransportOperator):
         return [np.array((1.0, 1.0))]
 
     def get_results_info(self):
-        """Returns volume list, cell lists, and nuc lists.
+        """Returns volume list, cell lists, nuc lists, and material names.
 
         Returns
         -------
@@ -241,6 +241,9 @@ class DummyOperator(TransportOperator):
             simulation.
         full_burn_list : OrderedDict of str to int
             Maps cell name to index in global geometry.
+        mat_to_name : dict of str to str
+            Mapping of material ID to material name
 
         """
-        return self.volume, self.nuc_list, self.local_mats, self.burnable_mats
+        mat_to_name = {mat: "" for mat in self.burnable_mats}
+        return self.volume, self.nuc_list, self.local_mats, self.burnable_mats, mat_to_name

--- a/tests/unit_tests/test_deplete_integrator.py
+++ b/tests/unit_tests/test_deplete_integrator.py
@@ -60,8 +60,9 @@ def test_results_save(run_in_tmpdir):
     burn_list = full_burn_list[2*comm.rank: 2*comm.rank + 2]
     nuc_list = ["na", "nb"]
 
+    mat_to_name = {mat: "" for mat in full_burn_list}
     op.get_results_info.return_value = (
-        vol_dict, nuc_list, burn_list, full_burn_list)
+        vol_dict, nuc_list, burn_list, full_burn_list, mat_to_name)
 
     # Construct x
     x1 = []


### PR DESCRIPTION
# Description

When running a depletion simulation and then loading up the materials from a depletion_results.h5 file the material names are lost.

This makes depletion with DAGMC workflows a bit tricky as one typically knows the material name and not the ID in DAGMC workflows (this stems from material tags in the DAGMC file).

Anyway it would be super useful for me if we can preserve the material name when writing the depletion_results.h5 file so that I can easily find materials once again. 

I have added tests but also manually tested with this script

```python
"""Minimal OpenMC depletion example to test material name preservation."""

import openmc
import openmc.deplete
from pathlib import Path
openmc.config['cross_sections'] = Path.home() / 'nuclear_data'/ 'endf-b8.0-hdf5/' / 'cross_sections.xml'
openmc.config['chain_file'] = Path.home() / 'nuclear_data' / 'chain-endf-b8.0.xml'
fuel = openmc.Material(name="My Fuel Material", material_id=1)
fuel.add_nuclide("Fe56", 1)
fuel.set_density("g/cm3", 10.0)
fuel.depletable = True
fuel.volume = 4/3 * 3.14159 * 10**3  # sphere volume
materials = openmc.Materials()
sphere = openmc.Sphere(r=10, boundary_type="vacuum")
cell = openmc.Cell(fill=fuel, region=-sphere)
geometry = openmc.Geometry([cell])
settings = openmc.Settings()
settings.batches = 10
settings.run_mode  = 'fixed source'
settings.particles = 1000
settings.source = openmc.Source(
    space=openmc.stats.Point((0, 0, 0)),
    energy=openmc.stats.Discrete([14.0e6], [1.0])
)
model = openmc.Model(geometry, materials, settings)
model.deplete(
    method="predictor", 
    operator_kwargs={
        "normalization_mode": "source-rate",
        "chain_file": openmc.config['chain_file'],
        "reduce_chain_level": 5,
    },
    timesteps=[1,1,1,1],
    source_rates=[1e20,0,0,0],
)
results = openmc.deplete.Results("depletion_results.h5")
step = results[-1]
material = step.get_material('1')
assert material.name =="My Fuel Material"
print(material.name)
```

Fixes # (issue)

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
