### PR TITLE
Add n_elements to the MeshBase protocol and deprecate num_mesh_cells

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -153,11 +153,17 @@ class MeshBase(IDManagerMixin, ABC):
         Unique identifier for the mesh
     name : str
         Name of the mesh
+    lower_left : Iterable of float
+        The lower-left coordinates
+    upper_right : Iterable of float
+        The upper-right coordinates
     bounding_box : openmc.BoundingBox
         Axis-aligned bounding box of the mesh as defined by the upper-right and
         lower-left coordinates.
     indices : Iterable of tuple
         An iterable of mesh indices for each mesh element, e.g. [(1, 1, 1), (2, 1, 1), ...]
+    n_elements : int
+        Number of elements in the mesh
     """
 
     next_id = 1
@@ -179,6 +185,16 @@ class MeshBase(IDManagerMixin, ABC):
             self._name = name
         else:
             self._name = ''
+            
+    @property
+    @abstractmethod
+    def lower_left(self):
+        pass
+        
+    @property
+    @abstractmethod
+    def upper_right(self):
+        pass
 
     @property
     def bounding_box(self) -> openmc.BoundingBox:
@@ -187,6 +203,11 @@ class MeshBase(IDManagerMixin, ABC):
     @property
     @abstractmethod
     def indices(self):
+        pass
+        
+    @property
+    @abstractmethod
+    def n_elements(self):
         pass
 
     def __repr__(self):
@@ -557,10 +578,19 @@ class StructuredMesh(MeshBase):
         s0 = (slice(0, -1),)*ndim + (slice(None),)
         s1 = (slice(1, None),)*ndim + (slice(None),)
         return (vertices[s0] + vertices[s1]) / 2
+    
+    @property
+    def n_elements(self):
+        return np.prod(self.dimension)
 
     @property
     def num_mesh_cells(self):
-        return np.prod(self.dimension)
+        warnings.warn(
+            "The 'num_mesh_cells' attribute is deprecated and will be removed in a future version. "
+            "Use 'n_elements' instead.",
+            FutureWarning, stacklevel=2
+        )
+        return self.n_elements
 
     def write_data_to_vtk(self,
                           filename: PathLike,
@@ -822,10 +852,10 @@ class StructuredMesh(MeshBase):
         """
         cv.check_type('data label', label, str)
 
-        if dataset.size != self.num_mesh_cells:
+        if dataset.size != self.n_elements:
             raise ValueError(
                 f"The size of the dataset '{label}' ({dataset.size}) should be"
-                f" equal to the number of mesh cells ({self.num_mesh_cells})"
+                f" equal to the number of mesh cells ({self.n_elements})"
             )
 
         # accept a flat array as-is, assuming it is in the correct order

--- a/openmc/source.py
+++ b/openmc/source.py
@@ -570,13 +570,13 @@ class MeshSource(SourceBase):
         cv.check_iterable_type('mesh sources', s, SourceBase, max_depth=3)
 
         s = np.asarray(s)
+        
+        if s.size != self.mesh.n_elements:
+            raise ValueError(
+                    f'The length of the source array ({s.size}) does not match '
+                    f'the number of mesh elements ({self.mesh.n_elements}).')
 
         if isinstance(self.mesh, StructuredMesh):
-            if s.size != self.mesh.num_mesh_cells:
-                raise ValueError(
-                    f'The length of the source array ({s.size}) does not match '
-                    f'the number of mesh elements ({self.mesh.num_mesh_cells}).')
-
             # If user gave a multidimensional array, flatten in the order
             # of the mesh indices
             if s.ndim > 1:

--- a/openmc/source.py
+++ b/openmc/source.py
@@ -570,13 +570,13 @@ class MeshSource(SourceBase):
         cv.check_iterable_type('mesh sources', s, SourceBase, max_depth=3)
 
         s = np.asarray(s)
-        
-        if s.size != self.mesh.n_elements:
-            raise ValueError(
+
+        if isinstance(self.mesh, StructuredMesh):
+            if s.size != self.mesh.n_elements:
+                raise ValueError(
                     f'The length of the source array ({s.size}) does not match '
                     f'the number of mesh elements ({self.mesh.n_elements}).')
 
-        if isinstance(self.mesh, StructuredMesh):
             # If user gave a multidimensional array, flatten in the order
             # of the mesh indices
             if s.ndim > 1:

--- a/tests/unit_tests/mesh_to_vtk/test_vtk_dims.py
+++ b/tests/unit_tests/mesh_to_vtk/test_vtk_dims.py
@@ -131,7 +131,7 @@ def test_write_data_to_vtk_size_mismatch(mesh):
     mesh : openmc.StructuredMesh
         The mesh to test
     """
-    right_size = mesh.num_mesh_cells
+    right_size = mesh.n_elements
     data = np.random.random(right_size + 1)
 
     # Error message has \ in to escape characters that are otherwise recognized
@@ -139,7 +139,7 @@ def test_write_data_to_vtk_size_mismatch(mesh):
     # string when using the match argument as that uses regular expression
     expected_error_msg = (
         fr"The size of the dataset 'label' \({len(data)}\) should be equal to "
-        fr"the number of mesh cells \({mesh.num_mesh_cells}\)"
+        fr"the number of mesh cells \({mesh.n_elements}\)"
     )
     with pytest.raises(ValueError, match=expected_error_msg):
         mesh.write_data_to_vtk(filename="out.vtk", datasets={"label": data})


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR unify mesh classes number of elements access.
It deprecated ```num_mesh_cells``` in favor of ```n_elements```.

This PR also add lower_left and upper_right to the MeshBase protocol.

Fixes #3548

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
