### PR TITLE
Warn users when setting undefined attributes in ```openmc.Settings```

### DIFF
--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable, Mapping, MutableSequence, Sequence
 from enum import Enum
+import inspect
 import itertools
 from math import ceil
 from numbers import Integral, Real
@@ -467,15 +468,15 @@ class Settings:
 
         for key, value in kwargs.items():
             setattr(self, key, value)
-            
-    def __setattr__(self, name, value):
+
+    def __setattr__(self, name: str, value):
         if not name.startswith('_'):
             try:
-              getattr(self, name)
+                getattr(self, name)
             except AttributeError as e:
-              msg, = traceback.format_exception_only(e)
-              msg = msg.strip().split(maxsplit=1)[-1]
-              warnings.warn(msg, stacklevel=2)
+                msg, = traceback.format_exception_only(e)
+                msg = msg.strip().split(maxsplit=1)[-1]
+                warnings.warn(msg, stacklevel=2)
         super().__setattr__(name, value)
 
     @property

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -4,6 +4,7 @@ import itertools
 from math import ceil
 from numbers import Integral, Real
 from pathlib import Path
+import traceback
 
 import lxml.etree as ET
 import warnings
@@ -466,6 +467,16 @@ class Settings:
 
         for key, value in kwargs.items():
             setattr(self, key, value)
+            
+    def __setattr__(self, name, value):
+        if not name.startswith('_'):
+            try:
+              getattr(self, name)
+            except AttributeError as e:
+              msg, = traceback.format_exception_only(e)
+              msg = msg.strip().split(maxsplit=1)[-1]
+              warnings.warn(msg, stacklevel=2)
+        super().__setattr__(name, value)
 
     @property
     def run_mode(self) -> str:

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -1,6 +1,5 @@
 from collections.abc import Iterable, Mapping, MutableSequence, Sequence
 from enum import Enum
-import inspect
 import itertools
 from math import ceil
 from numbers import Integral, Real
@@ -12,7 +11,7 @@ import warnings
 import openmc
 import openmc.checkvalue as cv
 from openmc.checkvalue import PathLike
-from openmc.stats.multivariate import MeshSpatial, Box, PolarAzimuthal, Isotropic
+from openmc.stats.multivariate import MeshSpatial
 from ._xml import clean_indentation, get_elem_list, get_text
 from .mesh import _read_meshes, RegularMesh, MeshBase
 from .source import SourceBase, MeshSource, IndependentSource


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR warn users when setting undefined attributes in ```openmc.Settings```

Fixes #3741

# Example Behavior

```
>>> import openmc
>>> s = openmc.Settings()
>>> s.particle = 5
<python-input-2>:1: UserWarning: 'Settings' object has no attribute 'particle'. Did you mean: 'particles'?
  s.particle = 5
```

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
