### PR TITLE
C-API bindings for key random ray functions

### DIFF
--- a/docs/source/capi/index.rst
+++ b/docs/source/capi/index.rst
@@ -587,6 +587,10 @@ Functions
    :return: Return status (negative if an error occurs)
    :rtype: int
 
+.. c:function:: void openmc_reset_random_ray()
+
+  Reset the random ray solver
+
 .. c:function:: int openmc_remove_tally(int32_t index);
 
    Given an index of a tally, remove it from the tallies array
@@ -600,6 +604,10 @@ Functions
 
    :return: Return status (negative if an error occurs)
    :rtype: int
+
+.. c:function:: void openmc_run_random_ray()
+
+   Run a random ray simulation
 
 .. c:function:: int openmc_set_n_batches(int32_t n_batches, bool set_max_batches, bool add_statepoint_batch)
 

--- a/docs/source/capi/index.rst
+++ b/docs/source/capi/index.rst
@@ -587,10 +587,6 @@ Functions
    :return: Return status (negative if an error occurs)
    :rtype: int
 
-.. c:function:: void openmc_reset_random_ray()
-
-  Reset the random ray solver
-
 .. c:function:: int openmc_remove_tally(int32_t index);
 
    Given an index of a tally, remove it from the tallies array

--- a/docs/source/pythonapi/capi.rst
+++ b/docs/source/pythonapi/capi.rst
@@ -38,6 +38,7 @@ Functions
    property_map
    reset
    reset_timers
+   reset_random_ray
    run
    run_in_memory
    sample_external_source

--- a/docs/source/pythonapi/capi.rst
+++ b/docs/source/pythonapi/capi.rst
@@ -38,9 +38,9 @@ Functions
    property_map
    reset
    reset_timers
-   reset_random_ray
    run
    run_in_memory
+   run_random_ray
    sample_external_source
    simulation_finalize
    simulation_init

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -141,7 +141,6 @@ int openmc_reset();
 int openmc_reset_timers();
 int openmc_run();
 void openmc_run_random_ray();
-void openmc_reset_random_ray();
 int openmc_sample_external_source(size_t n, uint64_t* seed, void* sites);
 void openmc_set_seed(int64_t new_seed);
 void openmc_set_stride(uint64_t new_stride);

--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -140,6 +140,8 @@ int openmc_remove_tally(int32_t index);
 int openmc_reset();
 int openmc_reset_timers();
 int openmc_run();
+void openmc_run_random_ray();
+void openmc_reset_random_ray();
 int openmc_sample_external_source(size_t n, uint64_t* seed, void* sites);
 void openmc_set_seed(int64_t new_seed);
 void openmc_set_stride(uint64_t new_stride);

--- a/include/openmc/random_ray/random_ray_simulation.h
+++ b/include/openmc/random_ray/random_ray_simulation.h
@@ -66,9 +66,7 @@ private:
 //! Non-member functions
 //============================================================================
 
-void openmc_run_random_ray();
 void validate_random_ray_inputs();
-void openmc_reset_random_ray();
 void print_adjoint_header();
 
 } // namespace openmc

--- a/include/openmc/random_ray/random_ray_simulation.h
+++ b/include/openmc/random_ray/random_ray_simulation.h
@@ -68,6 +68,7 @@ private:
 
 void validate_random_ray_inputs();
 void print_adjoint_header();
+void openmc_finalize_random_ray();
 
 } // namespace openmc
 

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -82,8 +82,12 @@ _dll.openmc_properties_import.restype = c_int
 _dll.openmc_properties_import.errcheck = _error_handler
 _dll.openmc_run.restype = c_int
 _dll.openmc_run.errcheck = _error_handler
+_dll.openmc_run_random_ray.restype = None
+_dll.openmc_run_random_ray.errcheck = _error_handler
 _dll.openmc_reset.restype = c_int
 _dll.openmc_reset.errcheck = _error_handler
+_dll.openmc_reset_random_ray.restype = None
+_dll.openmc_reset_random_ray.errcheck = _error_handler
 _dll.openmc_reset_timers.restype = c_int
 _dll.openmc_reset_timers.errcheck = _error_handler
 _run_linsolver_argtypes = [_array_1d_dble, _array_1d_dble, _array_1d_dble,
@@ -458,6 +462,11 @@ def reset():
     _dll.openmc_reset()
 
 
+def reset_random_ray():
+    """Reset the random ray solver"""
+    _dll.openmc_reset_random_ray()
+
+
 def reset_timers():
     """Reset timers."""
     _dll.openmc_reset_timers()
@@ -478,6 +487,18 @@ def run(output=True):
     with quiet_dll(output):
         _dll.openmc_run()
 
+
+def run_random_ray(output=True):
+    """Run a random ray simulation
+
+    Parameters
+    ----------
+    output : bool, optional
+        Whether or not to show output. Defaults to showing output
+    """
+
+    with quiet_dll(output):
+        _dll.openmc_run_random_ray()
 
 def sample_external_source(
         n_samples: int = 1000,

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -83,11 +83,8 @@ _dll.openmc_properties_import.errcheck = _error_handler
 _dll.openmc_run.restype = c_int
 _dll.openmc_run.errcheck = _error_handler
 _dll.openmc_run_random_ray.restype = None
-_dll.openmc_run_random_ray.errcheck = _error_handler
 _dll.openmc_reset.restype = c_int
 _dll.openmc_reset.errcheck = _error_handler
-_dll.openmc_reset_random_ray.restype = None
-_dll.openmc_reset_random_ray.errcheck = _error_handler
 _dll.openmc_reset_timers.restype = c_int
 _dll.openmc_reset_timers.errcheck = _error_handler
 _run_linsolver_argtypes = [_array_1d_dble, _array_1d_dble, _array_1d_dble,
@@ -460,11 +457,6 @@ def plot_geometry(output=True):
 def reset():
     """Reset tally results"""
     _dll.openmc_reset()
-
-
-def reset_random_ray():
-    """Reset the random ray solver"""
-    _dll.openmc_reset_random_ray()
 
 
 def reset_timers():

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -122,6 +122,7 @@ int openmc_finalize()
   settings::restart_run = false;
   settings::run_CE = true;
   settings::run_mode = RunMode::UNSET;
+  settings::solver_type = SolverType::MONTE_CARLO;
   settings::source_latest = false;
   settings::source_rejection_fraction = 0.05;
   settings::source_separate = false;

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -184,7 +184,7 @@ int openmc_finalize()
   }
 #endif
 
-  openmc_reset_random_ray();
+  openmc_finalize_random_ray();
 
   return 0;
 }

--- a/src/random_ray/random_ray_simulation.cpp
+++ b/src/random_ray/random_ray_simulation.cpp
@@ -617,6 +617,17 @@ void RandomRaySimulation::print_results_random_ray(
   }
 }
 
+void openmc_finalize_random_ray()
+{
+  FlatSourceDomain::volume_estimator_ = RandomRayVolumeEstimator::HYBRID;
+  FlatSourceDomain::volume_normalized_flux_tallies_ = false;
+  FlatSourceDomain::adjoint_ = false;
+  FlatSourceDomain::mesh_domain_map_.clear();
+  RandomRay::ray_source_.reset();
+  RandomRay::source_shape_ = RandomRaySourceShape::FLAT;
+  RandomRay::sample_method_ = RandomRaySampleMethod::PRNG;
+}
+
 } // namespace openmc
 
 //==============================================================================
@@ -664,16 +675,4 @@ void openmc_run_random_ray()
     // Run adjoint simulation
     sim.simulate();
   }
-}
-
-void openmc_reset_random_ray()
-{
-  openmc::FlatSourceDomain::volume_estimator_ =
-    openmc::RandomRayVolumeEstimator::HYBRID;
-  openmc::FlatSourceDomain::volume_normalized_flux_tallies_ = false;
-  openmc::FlatSourceDomain::adjoint_ = false;
-  openmc::FlatSourceDomain::mesh_domain_map_.clear();
-  openmc::RandomRay::ray_source_.reset();
-  openmc::RandomRay::source_shape_ = openmc::RandomRaySourceShape::FLAT;
-  openmc::RandomRay::sample_method_ = openmc::RandomRaySampleMethod::PRNG;
 }

--- a/src/random_ray/random_ray_simulation.cpp
+++ b/src/random_ray/random_ray_simulation.cpp
@@ -668,7 +668,8 @@ void openmc_run_random_ray()
 
 void openmc_reset_random_ray()
 {
-  openmc::FlatSourceDomain::volume_estimator_ = openmc::RandomRayVolumeEstimator::HYBRID;
+  openmc::FlatSourceDomain::volume_estimator_ =
+    openmc::RandomRayVolumeEstimator::HYBRID;
   openmc::FlatSourceDomain::volume_normalized_flux_tallies_ = false;
   openmc::FlatSourceDomain::adjoint_ = false;
   openmc::FlatSourceDomain::mesh_domain_map_.clear();

--- a/src/random_ray/random_ray_simulation.cpp
+++ b/src/random_ray/random_ray_simulation.cpp
@@ -1,5 +1,6 @@
 #include "openmc/random_ray/random_ray_simulation.h"
 
+#include "openmc/capi.h"
 #include "openmc/eigenvalue.h"
 #include "openmc/geometry.h"
 #include "openmc/message_passing.h"
@@ -21,49 +22,6 @@ namespace openmc {
 //==============================================================================
 // Non-member functions
 //==============================================================================
-
-void openmc_run_random_ray()
-{
-  //////////////////////////////////////////////////////////
-  // Run forward simulation
-  //////////////////////////////////////////////////////////
-
-  if (mpi::master) {
-    if (FlatSourceDomain::adjoint_) {
-      FlatSourceDomain::adjoint_ = false;
-      openmc::print_adjoint_header();
-      FlatSourceDomain::adjoint_ = true;
-    }
-  }
-
-  // Initialize OpenMC general data structures
-  openmc_simulation_init();
-
-  // Validate that inputs meet requirements for random ray mode
-  if (mpi::master)
-    validate_random_ray_inputs();
-
-  // Initialize Random Ray Simulation Object
-  RandomRaySimulation sim;
-
-  // Initialize fixed sources, if present
-  sim.apply_fixed_sources_and_mesh_domains();
-
-  // Run initial random ray simulation
-  sim.simulate();
-
-  //////////////////////////////////////////////////////////
-  // Run adjoint simulation (if enabled)
-  //////////////////////////////////////////////////////////
-
-  if (sim.adjoint_needed_) {
-    // Setup for adjoint simulation
-    sim.prepare_adjoint_simulation();
-
-    // Run adjoint simulation
-    sim.simulate();
-  }
-}
 
 // Enforces restrictions on inputs in random ray mode.  While there are
 // many features that don't make sense in random ray mode, and are therefore
@@ -281,17 +239,6 @@ void validate_random_ray_inputs()
       "quality FW-CADIS weight windows. We recommend you use flat source mode "
       "when generating weight windows with an overlaid mesh tally.");
   }
-}
-
-void openmc_reset_random_ray()
-{
-  FlatSourceDomain::volume_estimator_ = RandomRayVolumeEstimator::HYBRID;
-  FlatSourceDomain::volume_normalized_flux_tallies_ = false;
-  FlatSourceDomain::adjoint_ = false;
-  FlatSourceDomain::mesh_domain_map_.clear();
-  RandomRay::ray_source_.reset();
-  RandomRay::source_shape_ = RandomRaySourceShape::FLAT;
-  RandomRay::sample_method_ = RandomRaySampleMethod::PRNG;
 }
 
 void print_adjoint_header()
@@ -671,3 +618,61 @@ void RandomRaySimulation::print_results_random_ray(
 }
 
 } // namespace openmc
+
+//==============================================================================
+// C API functions
+//==============================================================================
+
+void openmc_run_random_ray()
+{
+  //////////////////////////////////////////////////////////
+  // Run forward simulation
+  //////////////////////////////////////////////////////////
+
+  if (openmc::mpi::master) {
+    if (openmc::FlatSourceDomain::adjoint_) {
+      openmc::FlatSourceDomain::adjoint_ = false;
+      openmc::print_adjoint_header();
+      openmc::FlatSourceDomain::adjoint_ = true;
+    }
+  }
+
+  // Initialize OpenMC general data structures
+  openmc_simulation_init();
+
+  // Validate that inputs meet requirements for random ray mode
+  if (openmc::mpi::master)
+    openmc::validate_random_ray_inputs();
+
+  // Initialize Random Ray Simulation Object
+  openmc::RandomRaySimulation sim;
+
+  // Initialize fixed sources, if present
+  sim.apply_fixed_sources_and_mesh_domains();
+
+  // Run initial random ray simulation
+  sim.simulate();
+
+  //////////////////////////////////////////////////////////
+  // Run adjoint simulation (if enabled)
+  //////////////////////////////////////////////////////////
+
+  if (sim.adjoint_needed_) {
+    // Setup for adjoint simulation
+    sim.prepare_adjoint_simulation();
+
+    // Run adjoint simulation
+    sim.simulate();
+  }
+}
+
+void openmc_reset_random_ray()
+{
+  openmc::FlatSourceDomain::volume_estimator_ = openmc::RandomRayVolumeEstimator::HYBRID;
+  openmc::FlatSourceDomain::volume_normalized_flux_tallies_ = false;
+  openmc::FlatSourceDomain::adjoint_ = false;
+  openmc::FlatSourceDomain::mesh_domain_map_.clear();
+  openmc::RandomRay::ray_source_.reset();
+  openmc::RandomRay::source_shape_ = openmc::RandomRaySourceShape::FLAT;
+  openmc::RandomRay::sample_method_ = openmc::RandomRaySampleMethod::PRNG;
+}

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -5,6 +5,7 @@ import os
 import numpy as np
 import pytest
 import openmc
+from openmc.examples import random_ray_pin_cell
 import openmc.exceptions as exc
 import openmc.lib
 
@@ -82,6 +83,19 @@ def uo2_trigger_model():
         model.export_to_xml()
         yield
 
+
+@pytest.fixture(scope='module')
+def random_ray_pincell_model():
+    """Set up a random ray model to test with and delete files when done"""
+    openmc.reset_auto_ids()
+    # Write XML and MGXS files in tmpdir
+    with cdtemp():
+        model = random_ray_pin_cell()
+        model.settings.batches = 200
+        model.settings.inactive = 50
+        model.settings.particles = 50
+        model.export_to_xml()
+        yield
 
 @pytest.fixture(scope='module')
 def lib_init(pincell_model, mpi_intracomm):
@@ -1051,4 +1065,16 @@ def test_sample_external_source(run_in_tmpdir, mpi_intracomm):
     # Make sure sampling works in volume calculation mode
     openmc.lib.init(["-c"])
     openmc.lib.sample_external_source(100)
+    openmc.lib.finalize()
+
+
+def test_random_ray(random_ray_pincell_model, mpi_intracomm):
+    openmc.lib.finalize()
+    openmc.lib.init(intracomm=mpi_intracomm)
+    openmc.lib.simulation_init()
+    openmc.lib.run_random_ray()
+    keff = openmc.lib.keff()
+
+    assert keff[0]==pytest.approx(1.3236826574065745)
+
     openmc.lib.finalize()


### PR DESCRIPTION
# Description

This brief PR adds the random ray run function  to the C-API, with inclusions in the `openmc.lib` Python bindings. This provides a frontend for wrapper applications which want to expose the random ray solver for multiphysics.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
