### PR TITLE
Do not add radioactive Ta180 when calling add_element('Ta')

### DIFF
--- a/openmc/element.py
+++ b/openmc/element.py
@@ -184,8 +184,6 @@ class Element(str):
                 for nuclide in absent_nuclides:
                     if nuclide in ['O17', 'O18'] and 'O16' in mutual_nuclides:
                         abundances['O16'] += NATURAL_ABUNDANCE[nuclide]
-                    elif nuclide == 'Ta180_m1' and 'Ta180' in library_nuclides:
-                            abundances['Ta180'] = NATURAL_ABUNDANCE[nuclide]
                     elif nuclide == 'Ta180_m1' and 'Ta181' in mutual_nuclides:
                             abundances['Ta181'] += NATURAL_ABUNDANCE[nuclide]
                     elif nuclide == 'W180' and 'W182' in mutual_nuclides:

--- a/tests/unit_tests/test_element.py
+++ b/tests/unit_tests/test_element.py
@@ -45,11 +45,11 @@ def test_expand_no_isotopes():
 
 
 def test_expand_ta():
-    ref = {'Ta180': 0.01201, 'Ta181': 99.98799}
+    ref = {'Ta181': 100.0}
     element = openmc.Element('Ta')
     for isotope in element.expand(100.0, 'ao'):
         assert isotope[1] == approx(ref[isotope[0]])
-    
+
 
 def test_expand_exceptions():
     """ Test that correct exceptions are raised for invalid input """


### PR DESCRIPTION
# Description

Tantalum (Ta) has two naturally occurring isotopes, <sup>180m</sup>Ta and <sup>181</sup>Ta. The ground state <sup>180</sup>Ta is actually unstable with a 8 hr half-life. Recently, PR #3443 fixed our natural abundance data to ensure that the metastable state of 180 is given rather than the ground state. Along with that, it added logic for expanding element data to account for whether the nuclear data library has data for the metastable state or not. The problem with the logic is that in the case where no cross sections are available for the metastable, it defaults to adding the (unstable) ground state. In practical terms, this means that when running:
```python
mat = openmc.Material()
mat.add_element('Ta')
```
you may get a material that is radioactive. This would happen with ENDF/B-VII.1 and ENDF/B-VIII.0 because they do not have cross sections for the metastable state but do for the ground state. In ENDF/B-VIII.1 cross sections are given for the metastable state so it can be used correctly. However, for the older libraries, the correct thing to do is to simply omit Ta180 and only add Ta181 if the user calls `add_element('Ta')`.

It's important to note that this is not just a hypothetical problem as Ta is included in EUROFER97 reduced-activation steel. Thanks to @jihye4756 for bringing this to my attention!

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)