### PR TITLE
`SpatialBox` can be constructed via ctor with parameters

### DIFF
--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -167,6 +167,7 @@ private:
 class SpatialBox : public SpatialDistribution {
 public:
   explicit SpatialBox(pugi::xml_node node, bool fission = false);
+  SpatialBox(Position lower_left, Position upper_right, bool fission = false);
 
   //! Sample a position from the distribution
   //! \param seed Pseudorandom number seed pointer

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -426,6 +426,11 @@ SpatialBox::SpatialBox(pugi::xml_node node, bool fission)
   upper_right_ = Position {params[3], params[4], params[5]};
 }
 
+SpatialBox::SpatialBox(Position lower_left, Position upper_right, bool fission)
+  : lower_left_(lower_left), upper_right_(upper_right),
+    only_fissionable_(fission)
+{}
+
 std::pair<Position, double> SpatialBox::sample(uint64_t* seed) const
 {
   Position xi {prn(seed), prn(seed), prn(seed)};

--- a/tests/cpp_unit_tests/test_distribution.cpp
+++ b/tests/cpp_unit_tests/test_distribution.cpp
@@ -1,4 +1,6 @@
 #include "openmc/distribution.h"
+#include "openmc/distribution_spatial.h"
+#include "openmc/position.h"
 #include "openmc/random_lcg.h"
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
@@ -78,4 +80,15 @@ TEST_CASE("Test alias sampling method for pugixml constructor")
       dist.prob()[i], Catch::Matchers::WithinAbs(correct_prob[i], 1e-12));
     REQUIRE(dist.alias()[i] == correct_alias[i]);
   }
+}
+
+TEST_CASE("Test construction of SpatialBox with parameters")
+{
+  openmc::Position ll {-1, -2, -3};
+  openmc::Position ur {30, 15, 5};
+  openmc::SpatialBox box(ll, ur);
+
+  REQUIRE(box.lower_left() == openmc::Position {-1, -2, -3});
+  REQUIRE(box.upper_right() == openmc::Position {30, 15, 5});
+  REQUIRE_FALSE(box.only_fissionable());
 }


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

`SpatialBox` can be constructed from a C++ code via a constructor that takes `lower_left`, `upper_right`, and `fission` parameters. Before this change, `SpatialBox` was constructible only by supplying an XML node.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
