### PR TITLE
Parallelize transpose of scattering matrix for random ray adjoints

### DIFF
--- a/src/random_ray/flat_source_domain.cpp
+++ b/src/random_ray/flat_source_domain.cpp
@@ -1277,6 +1277,7 @@ void FlatSourceDomain::set_adjoint_sources()
 void FlatSourceDomain::transpose_scattering_matrix()
 {
   // Transpose the inner two dimensions for each material
+#pragma omp parallel for
   for (int m = 0; m < n_materials_; ++m) {
     int material_offset = m * negroups_ * negroups_;
     for (int i = 0; i < negroups_; ++i) {


### PR DESCRIPTION
# Description

I noticed we use #pragma in the cpp code base and I was wondering if we can also do a pragma here. 

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)