### PR TITLE
Fixing compiler warning about VLA (Clang extension)

### DIFF
--- a/src/eigenvalue.cpp
+++ b/src/eigenvalue.cpp
@@ -192,9 +192,9 @@ void synchronize_bank()
   // TODO: protect for MPI_Exscan at rank 0
 
   // Allocate space for bank_position if this hasn't been done yet
-  int64_t bank_position[mpi::n_procs];
-  MPI_Allgather(
-    &start, 1, MPI_INT64_T, bank_position, 1, MPI_INT64_T, mpi::intracomm);
+  std::vector<int64_t> bank_position(mpi::n_procs);
+  MPI_Allgather(&start, 1, MPI_INT64_T, bank_position.data(), 1, MPI_INT64_T,
+    mpi::intracomm);
 #else
   start = 0;
   finish = index_temp;
@@ -289,7 +289,7 @@ void synchronize_bank()
     neighbor = mpi::n_procs - 1;
   } else {
     neighbor =
-      upper_bound_index(bank_position, bank_position + mpi::n_procs, start);
+      upper_bound_index(bank_position.begin(), bank_position.end(), start);
   }
 
   // Resize IFP receive buffers


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Variable-length arrays are a C construct. clang supports that as a non-standard extension. This changes the code to use `std::vector` instead. 

I noticed that this warning started to pop up when we migrated to clang-20.


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
