### PR TITLE
Check that Surface IDs are at least 1

### DIFF
--- a/openmc/mixin.py
+++ b/openmc/mixin.py
@@ -38,7 +38,7 @@ class IDManagerMixin:
     'used_ids' as they are used in the 'id' property that is supplied here.
 
     """
-    
+
     min_id = 0
 
     @property

--- a/openmc/mixin.py
+++ b/openmc/mixin.py
@@ -64,7 +64,7 @@ class IDManagerMixin:
         else:
             name = cls.__name__
             cv.check_type(f'{name} ID', uid, Integral)
-            cv.check_greater_than(f'{name} ID', uid, 0, equality=True)
+            cv.check_greater_than(f'{name} ID', uid, 0, equality=False)
             if uid in cls.used_ids:
                 msg = f'Another {name} instance already exists with id={uid}.'
                 warn(msg, IDWarning)

--- a/openmc/mixin.py
+++ b/openmc/mixin.py
@@ -38,6 +38,8 @@ class IDManagerMixin:
     'used_ids' as they are used in the 'id' property that is supplied here.
 
     """
+    
+    min_id = 0
 
     @property
     def id(self):
@@ -64,7 +66,7 @@ class IDManagerMixin:
         else:
             name = cls.__name__
             cv.check_type(f'{name} ID', uid, Integral)
-            cv.check_greater_than(f'{name} ID', uid, 0, equality=False)
+            cv.check_greater_than(f'{name} ID', uid, cls.min_id, equality=True)
             if uid in cls.used_ids:
                 msg = f'Another {name} instance already exists with id={uid}.'
                 warn(msg, IDWarning)

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -150,7 +150,7 @@ class Surface(IDManagerMixin, ABC):
         Type of the surface
 
     """
-    
+
     min_id = 1
     next_id = 1
     used_ids = set()

--- a/openmc/surface.py
+++ b/openmc/surface.py
@@ -150,7 +150,8 @@ class Surface(IDManagerMixin, ABC):
         Type of the surface
 
     """
-
+    
+    min_id = 1
     next_id = 1
     used_ids = set()
     _atol = 1.e-12

--- a/tests/unit_tests/test_cell.py
+++ b/tests/unit_tests/test_cell.py
@@ -19,10 +19,12 @@ def test_contains():
     c = openmc.Cell()
     assert (10.0, -4., 2.0) in c
 
+
 def test_id():
     openmc.Cell(cell_id=0)
     with pytest.raises(ValueError):
-        openmc.Cell(cell_id=-1) 
+        openmc.Cell(cell_id=-1)
+
 
 def test_repr(cell_with_lattice):
     cells, mats, univ, lattice = cell_with_lattice

--- a/tests/unit_tests/test_cell.py
+++ b/tests/unit_tests/test_cell.py
@@ -19,6 +19,10 @@ def test_contains():
     c = openmc.Cell()
     assert (10.0, -4., 2.0) in c
 
+def test_id():
+    openmc.Cell(cell_id=0)
+    with pytest.raises(ValueError):
+        openmc.Cell(cell_id=-1) 
 
 def test_repr(cell_with_lattice):
     cells, mats, univ, lattice = cell_with_lattice

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -76,6 +76,11 @@ def test_add_components():
         m.add_components({1.0: 'H1'}, percent_type = 'wo')
     with pytest.raises(ValueError):
         m.add_components({'H1': 1.0}, percent_type = 'oa')
+        
+def test_id():
+    openmc.Material(material_id=0)
+    with pytest.raises(ValueError):
+        openmc.Material(material_id=-1)        
 
 def test_nuclides_to_ignore(run_in_tmpdir):
     """Test nuclides_to_ignore when exporting a material to XML"""

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -76,11 +76,13 @@ def test_add_components():
         m.add_components({1.0: 'H1'}, percent_type = 'wo')
     with pytest.raises(ValueError):
         m.add_components({'H1': 1.0}, percent_type = 'oa')
-        
+
+
 def test_id():
     openmc.Material(material_id=0)
     with pytest.raises(ValueError):
-        openmc.Material(material_id=-1)        
+        openmc.Material(material_id=-1)
+
 
 def test_nuclides_to_ignore(run_in_tmpdir):
     """Test nuclides_to_ignore when exporting a material to XML"""

--- a/tests/unit_tests/test_surface.py
+++ b/tests/unit_tests/test_surface.py
@@ -8,11 +8,11 @@ import pytest
 
 
 def test_id():
-    for i in range(-10,1):
+    for i in range(-10, 1):
         with pytest.raises(ValueError):
             openmc.Plane(a=1, b=2, c=-1, d=3, surface_id=i)
-    
-    
+
+
 def assert_infinite_bb(s):
     ll, ur = (-s).bounding_box
     assert np.all(np.isinf(ll))

--- a/tests/unit_tests/test_surface.py
+++ b/tests/unit_tests/test_surface.py
@@ -7,6 +7,12 @@ import openmc
 import pytest
 
 
+def test_id():
+    for i in range(-10,1):
+        with pytest.raises(ValueError):
+            openmc.Plane(a=1, b=2, c=-1, d=3, surface_id=i)
+    
+    
 def assert_infinite_bb(s):
     ll, ur = (-s).bounding_box
     assert np.all(np.isinf(ll))

--- a/tests/unit_tests/test_universe.py
+++ b/tests/unit_tests/test_universe.py
@@ -48,10 +48,12 @@ def test_bounding_box():
     u = openmc.Universe()
     assert_unbounded(u)
 
+
 def test_id():
     openmc.Universe(universe_id=0)
     with pytest.raises(ValueError):
-        openmc.Universe(universe_id=-1)        
+        openmc.Universe(universe_id=-1)
+
 
 def test_plot(run_in_tmpdir, sphere_model):
 

--- a/tests/unit_tests/test_universe.py
+++ b/tests/unit_tests/test_universe.py
@@ -48,6 +48,10 @@ def test_bounding_box():
     u = openmc.Universe()
     assert_unbounded(u)
 
+def test_id():
+    openmc.Universe(universe_id=0)
+    with pytest.raises(ValueError):
+        openmc.Universe(universe_id=-1)        
 
 def test_plot(run_in_tmpdir, sphere_model):
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

A user got unexpected behavior when he used surface id 0.
This PR enforce surface ids to be at least 1.

Fixes #3770

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
