### PR TITLE
Move distrib (mat, temp, dens) from XML attribute to subelement for better compatibility with very large instance lists

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -636,8 +636,11 @@ class Cell(IDManagerMixin):
             element.set("material", str(self.fill.id))
 
         elif self.fill_type == 'distribmat':
-            element.set("material", ' '.join(['void' if m is None else str(m.id)
-                                              for m in self.fill]))
+            material_subelement= ET.SubElement(element, "material")
+            matlist_str = " ".join(
+                ["void" if m is None else str(m.id) for m in self.fill]
+            )
+            material_subelement.text = matlist_str
 
         elif self.fill_type in ('universe', 'lattice'):
             element.set("fill", str(self.fill.id))
@@ -677,14 +680,15 @@ class Cell(IDManagerMixin):
 
         if self.temperature is not None:
             if isinstance(self.temperature, Iterable):
-                element.set("temperature", ' '.join(
-                    str(t) for t in self.temperature))
+                temperature_subelement= ET.SubElement(element, "temperature")
+                temperature_subelement.text = ' '.join(str(t) for t in self.temperature)
             else:
                 element.set("temperature", str(self.temperature))
 
         if self.density is not None:
             if isinstance(self.density, Iterable):
-                element.set("density", ' '.join(str(t) for t in self.density))
+                density_subelement= ET.SubElement(element, "density")
+                density_subelement.text =  ' '.join(str(d) for d in self.density)
             else:
                 element.set("density", str(self.density))
 

--- a/tests/regression_tests/distribmat/inputs_true.dat
+++ b/tests/regression_tests/distribmat/inputs_true.dat
@@ -17,7 +17,9 @@
   </materials>
   <geometry>
     <cell id="1" material="1" universe="1"/>
-    <cell id="11" material="2 void 3 2" region="-1" universe="11"/>
+    <cell id="11" region="-1" universe="11">
+      <material>2 void 3 2</material>
+    </cell>
     <cell id="12" material="1" region="1" universe="11"/>
     <cell id="101" fill="101" region="2 -3 4 -5" universe="0"/>
     <lattice id="101">

--- a/tests/regression_tests/lattice_distribmat/True/inputs_true.dat
+++ b/tests/regression_tests/lattice_distribmat/True/inputs_true.dat
@@ -47,8 +47,12 @@
     </material>
   </materials>
   <geometry>
-    <cell id="8" material="1 2 3 4" region="-6" universe="8"/>
-    <cell id="9" material="5 6 7 8" region="6" universe="8"/>
+    <cell id="8" region="-6" universe="8">
+      <material>1 2 3 4</material>
+    </cell>
+    <cell id="9" region="6" universe="8">
+      <material>5 6 7 8</material>
+    </cell>
     <cell id="10" fill="9" region="7 -8 10 -12" universe="13"/>
     <cell id="11" fill="10" region="7 -8 12 -16" universe="13"/>
     <cell id="12" fill="11" region="8 -22 10 -12" universe="13"/>

--- a/tests/regression_tests/lattice_distribrho/inputs_true.dat
+++ b/tests/regression_tests/lattice_distribrho/inputs_true.dat
@@ -14,7 +14,9 @@
     </material>
   </materials>
   <geometry>
-    <cell id="1" material="1" region="-1" density="10.0 20.0 10.0 20.0" universe="1"/>
+    <cell id="1" material="1" region="-1" universe="1">
+      <density>10.0 20.0 10.0 20.0</density>
+    </cell>
     <cell id="2" material="2" region="1" universe="1"/>
     <cell id="3" fill="2" region="2 -3 4 -5" universe="3"/>
     <lattice id="2">

--- a/tests/regression_tests/multipole/inputs_true.dat
+++ b/tests/regression_tests/multipole/inputs_true.dat
@@ -14,7 +14,9 @@
   </materials>
   <geometry>
     <cell id="1" material="1" universe="1"/>
-    <cell id="11" material="2" region="-1" temperature="500 700 0 800" universe="11"/>
+    <cell id="11" material="2" region="-1" universe="11">
+      <temperature>500 700 0 800</temperature>
+    </cell>
     <cell id="12" material="1" region="1" universe="11"/>
     <cell id="101" fill="101" region="2 -3 4 -5" universe="0"/>
     <lattice id="101">

--- a/tests/regression_tests/random_ray_cell_density/eigen/inputs_true.dat
+++ b/tests/regression_tests/random_ray_cell_density/eigen/inputs_true.dat
@@ -12,9 +12,15 @@
     </material>
   </materials>
   <geometry>
-    <cell id="1" name="fuel inner a" material="1" region="-2" density="2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0" universe="1"/>
-    <cell id="2" name="fuel inner b" material="1" region="2 -3" density="2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0" universe="1"/>
-    <cell id="3" name="fuel inner c" material="1" region="3 -1" density="2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0" universe="1"/>
+    <cell id="1" name="fuel inner a" material="1" region="-2" universe="1">
+      <density>2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</density>
+    </cell>
+    <cell id="2" name="fuel inner b" material="1" region="2 -3" universe="1">
+      <density>2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</density>
+    </cell>
+    <cell id="3" name="fuel inner c" material="1" region="3 -1" universe="1">
+      <density>2.0 2.0 2.0 2.0 2.0 2.0 2.0 2.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0</density>
+    </cell>
     <cell id="4" name="moderator inner a" material="2" region="1 -4" universe="1"/>
     <cell id="5" name="moderator outer b" material="2" region="4 -5" universe="1"/>
     <cell id="6" name="moderator outer c" material="2" region="5" universe="1"/>


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->
# Description
Fixes #3744. I'm currently working on modeling a TRISO microreactor with north of 400 million cell instances. Things were working when they all shared the same material, but now that I'm depleting them, I have a zoning script that assigns a material instance list to the `openmc.Cell.fill` of my fuel sphere. It turns out there's a hard-coded limit for the number of values in an attribute of `10,000,000` (and my list has ~40x more values), which is leading to some issues.

I'm able to export a `model.xml`, however trying to load this file in a separate script/python terminal leads to an error.  When I try to run depletion with that model, we suspect that it might only be loading the first `10,000,000` materials and temperatures via some `gdb` inspection. There is not a similar limit for XML sub-elements, as far as we know. Either way, for very large instance lists, it probably makes more sense to have them be sub-elements and for smaller ones, there's no harm in having it be a sub-element. Thankfully the existing XML code is set up to check or both attributes or sub-elements if the other is not found.

I did some basic testing with one of the distribcell tests and added distrib temperatures. The new way of doing it worked in the plotter (see below) and the XML appeared as I'd expect
```
<model>
...
  <geometry>
...
    <cell id="11" region="-1" universe="11">
      <material>2 2 3 2</material>
      <temperature>700 733 766 800</temperature>
    </cell>
...
  </geometry>
...
</model>
```
<img width="500" height="447" alt="plotter_cell_view" src="https://github.com/user-attachments/assets/22004295-b8c5-446f-86a8-f66384ef3bf4" />
<img width="500" height="431" alt="plotter_mat_view" src="https://github.com/user-attachments/assets/a5b9e0b2-5965-473f-b9c8-69cd6f3d258e" />
<img width="500" height="399" alt="plotter_temp_view" src="https://github.com/user-attachments/assets/9b5f1726-a522-4f8b-93fc-2a34b23d7449" />


The tests are going to need to be updated, but I'll give that a go tomorrow. Ideally the `inputs_true.dat` get modified and produce identical `results_true.dat`.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->