### PR TITLE
openmc.Tally creation from constructor

### DIFF
--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -50,6 +50,18 @@ class Tally(IDManagerMixin):
         will automatically be assigned
     name : str, optional
         Name of the tally. If not specified, the name is the empty string.
+    scores : list of str, optional
+        List of scores, e.g. ['flux', 'fission']
+    filters : list of openmc.Filter, optional
+        List of filters for the tally
+    nuclides : list of str, optional
+        List of nuclides to score results for
+    estimator : {'analog', 'tracklength', 'collision'}, optional
+        Type of estimator for the tally
+    triggers : list of openmc.Trigger, optional
+        List of tally triggers
+    derivative : openmc.TallyDerivative, optional
+        A material perturbation derivative to apply to all scores in the tally
 
     Attributes
     ----------
@@ -124,7 +136,9 @@ class Tally(IDManagerMixin):
     next_id = 1
     used_ids = set()
 
-    def __init__(self, tally_id=None, name=''):
+    def __init__(self, tally_id=None, name='', scores=None, filters=None,
+                 nuclides=None, estimator=None, triggers=None,
+                 derivative=None):
         # Initialize Tally class attributes
         self.id = tally_id
         self.name = name
@@ -154,6 +168,19 @@ class Tally(IDManagerMixin):
 
         self._sp_filename = None
         self._results_read = False
+
+        if filters is not None:
+            self.filters = filters
+        if nuclides is not None:
+            self.nuclides = nuclides
+        if scores is not None:
+            self.scores = scores
+        if estimator is not None:
+            self.estimator = estimator
+        if triggers is not None:
+            self.triggers = triggers
+        if derivative is not None:
+            self.derivative = derivative
 
     def __eq__(self, other):
         if other.id != self.id:

--- a/tests/unit_tests/test_tally.py
+++ b/tests/unit_tests/test_tally.py
@@ -1,0 +1,19 @@
+import openmc
+
+
+def test_tally_init_args():
+    """Test that Tally constructor kwargs are applied correctly."""
+    filter = openmc.EnergyFilter([0.0, 1.0, 20.0e6])
+    tally = openmc.Tally(
+        name='my tally',
+        scores=['flux', 'fission'],
+        filters=[filter],
+        nuclides=['U235'],
+        estimator='tracklength',
+    )
+
+    assert tally.name == 'my tally'
+    assert tally.scores == ['flux', 'fission']
+    assert tally.filters == [filter]
+    assert tally.nuclides == ['U235']
+    assert tally.estimator == 'tracklength'


### PR DESCRIPTION
# Description

Just a small PR to allow ```openmc.Tally()``` objects to be made from the constructor.

This PR allows us to set tally attributes like this
 ```openmc.Tally(scores=['flux'], name='tally-flux, tally_id=2)```

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

