### PR TITLE
Install parallel h5py with no build isolation

### DIFF
--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -14,6 +14,7 @@
 #include "openmc/material.h"
 #include "openmc/mesh.h"
 #include "openmc/message_passing.h"
+#include "openmc/mgxs_interface.h"
 #include "openmc/nuclide.h"
 #include "openmc/photon.h"
 #include "openmc/plot.h"
@@ -163,6 +164,7 @@ int openmc_finalize()
   data::energy_min = {0.0, 0.0, 0.0, 0.0};
   data::temperature_min = 0.0;
   data::temperature_max = INFTY;
+  data::mg = {};
   model::root_universe = -1;
   model::plotter_seed = 1;
   openmc::openmc_set_seed(DEFAULT_SEED);

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -36,6 +36,9 @@ pip install mcpl
 if [[ $MPI == 'y' ]]; then
     pip install --no-binary=mpi4py mpi4py
 
+    # h5py install with setuptools 81 currently fails
+    pip install 'setuptools<81'
+
     export CC=mpicc
     export HDF5_MPI=ON
     export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -39,8 +39,8 @@ if [[ $MPI == 'y' ]]; then
     export CC=mpicc
     export HDF5_MPI=ON
     export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich
-    # h5py install with setuptools 81 currently fails
-    pip install 'setuptools<81' Cython packaging pkgconfig
+    # Install h5py without build isolation to pick up already installed mpi4py
+    pip install Cython pkgconfig
     pip install --no-build-isolation --no-binary=h5py h5py
 fi
 

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -36,13 +36,12 @@ pip install mcpl
 if [[ $MPI == 'y' ]]; then
     pip install --no-binary=mpi4py mpi4py
 
-    # h5py install with setuptools 81 currently fails
-    pip install 'setuptools<81'
-
     export CC=mpicc
     export HDF5_MPI=ON
     export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich
-    pip install --no-binary=h5py h5py
+    # h5py install with setuptools 81 currently fails
+    pip install 'setuptools<81'
+    pip install --no-build-isolation --no-binary=h5py h5py
 fi
 
 # Build and install OpenMC executable

--- a/tools/ci/gha-install.sh
+++ b/tools/ci/gha-install.sh
@@ -40,7 +40,7 @@ if [[ $MPI == 'y' ]]; then
     export HDF5_MPI=ON
     export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich
     # h5py install with setuptools 81 currently fails
-    pip install 'setuptools<81'
+    pip install 'setuptools<81' Cython packaging pkgconfig
     pip install --no-build-isolation --no-binary=h5py h5py
 fi
 


### PR DESCRIPTION
# Description

This PR pins setuptools<81 when building parallel h5py from source in CI to avoid compatibility issues with mpi4py 3.1.4, which is pulled in as a dependency and fails to build with [setuptools 81](https://setuptools.pypa.io/en/stable/history.html#v81-0-0)+ because it removed a `dry-run` parameter that mpi4py used.

EDIT: I found that when using `--no-build-isolation`, the version of setuptools doesn't matter anymore because mpi4py is already installed. Also filed an issue with h5py that explains the root cause of the issue: h5py/h5py#2797

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>