### PR TITLE
Improve radial crossing checks in SphericalMesh and CylindricalMesh

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1901,10 +1901,11 @@ double CylindricalMesh::find_r_crossing(
 
   D = std::sqrt(D);
 
-  // the solution -p - D is always smaller as -p + D : Check this one first
-  if (xt::isclose(R, r0, RADIAL_MESH_TOL, RADIAL_MESH_TOL))
+  // Particle is already on the shell surface; avoid spurious crossing
+  if (std::abs(R - r0) <= RADIAL_MESH_TOL * (1.0 + std::abs(r0)))
     return INFTY;
 
+  // Check -p - D first because it is always smaller as -p + D
   if (-p - D > l)
     return -p - D;
   if (-p + D > l)
@@ -2181,12 +2182,13 @@ double SphericalMesh::find_r_crossing(
   double R = r.norm();
   double D = p * p - (R - r0) * (R + r0);
 
-  if (xt::isclose(R, r0, RADIAL_MESH_TOL, RADIAL_MESH_TOL))
+  // Particle is already on the shell surface; avoid spurious crossing
+  if (std::abs(R - r0) <= RADIAL_MESH_TOL * (1.0 + std::abs(r0)))
     return INFTY;
 
   if (D >= 0.0) {
     D = std::sqrt(D);
-    // the solution -p - D is always smaller as -p + D : Check this one first
+    // Check -p - D first because it is always smaller as -p + D
     if (-p - D > l)
       return -p - D;
     if (-p + D > l)

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1893,8 +1893,8 @@ double CylindricalMesh::find_r_crossing(
   const double inv_denominator = 1.0 / denominator;
 
   const double p = (u.x * r.x + u.y * r.y) * inv_denominator;
-  double c = r.x * r.x + r.y * r.y - r0 * r0;
-  double D = p * p - c * inv_denominator;
+  double R = std::sqrt(r.x * r.x + r.y * r.y);
+  double D = p * p - (R - r0) * (R + r0) * inv_denominator;
 
   if (D < 0.0)
     return INFTY;
@@ -1902,7 +1902,7 @@ double CylindricalMesh::find_r_crossing(
   D = std::sqrt(D);
 
   // the solution -p - D is always smaller as -p + D : Check this one first
-  if (std::abs(c) <= RADIAL_MESH_TOL)
+  if (xt::isclose(R, r0, RADIAL_MESH_TOL, RADIAL_MESH_TOL))
     return INFTY;
 
   if (-p - D > l)
@@ -2178,10 +2178,10 @@ double SphericalMesh::find_r_crossing(
   if (r0 == 0.0)
     return INFTY;
   const double p = r.dot(u);
-  double c = r.dot(r) - r0 * r0;
-  double D = p * p - c;
+  double R = r.norm();
+  double D = p * p - (R - r0) * (R + r0);
 
-  if (std::abs(c) <= RADIAL_MESH_TOL)
+  if (xt::isclose(R, r0, RADIAL_MESH_TOL, RADIAL_MESH_TOL))
     return INFTY;
 
   if (D >= 0.0) {


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Currently the check of next radial boundary in SphericalMesh and CylindricalMesh is somewhat flaky.
This PR make it more robust.



Fixes https://openmc.discourse.group/t/heating-and-flux-score-affecting-each-other

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
