### PR TITLE
Xtensor

### DIFF
--- a/include/openmc/bremsstrahlung.h
+++ b/include/openmc/bremsstrahlung.h
@@ -3,7 +3,7 @@
 
 #include "openmc/particle.h"
 
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 namespace openmc {
 

--- a/include/openmc/distribution_energy.h
+++ b/include/openmc/distribution_energy.h
@@ -5,7 +5,7 @@
 #define OPENMC_DISTRIBUTION_ENERGY_H
 
 #include "hdf5.h"
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include "openmc/constants.h"
 #include "openmc/endf.h"

--- a/include/openmc/eigenvalue.h
+++ b/include/openmc/eigenvalue.h
@@ -6,7 +6,7 @@
 
 #include <cstdint> // for int64_t
 
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 #include <hdf5.h>
 
 #include "openmc/array.h"

--- a/include/openmc/hdf5_interface.h
+++ b/include/openmc/hdf5_interface.h
@@ -11,8 +11,8 @@
 
 #include "hdf5.h"
 #include "hdf5_hl.h"
-#include "xtensor/xadapt.hpp"
-#include "xtensor/xarray.hpp"
+#include "xtensor/containers/xadapt.hpp"
+#include "xtensor/containers/xarray.hpp"
 
 #include "openmc/array.h"
 #include "openmc/error.h"

--- a/include/openmc/material.h
+++ b/include/openmc/material.h
@@ -6,7 +6,7 @@
 
 #include "openmc/span.h"
 #include "pugixml.hpp"
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 #include <hdf5.h>
 
 #include "openmc/bremsstrahlung.h"

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -9,7 +9,7 @@
 
 #include "hdf5.h"
 #include "pugixml.hpp"
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include "openmc/bounding_box.h"
 #include "openmc/error.h"

--- a/include/openmc/mgxs.h
+++ b/include/openmc/mgxs.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include "openmc/constants.h"
 #include "openmc/hdf5_interface.h"

--- a/include/openmc/photon.h
+++ b/include/openmc/photon.h
@@ -6,7 +6,7 @@
 #include "openmc/particle.h"
 #include "openmc/vector.h"
 
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 #include <hdf5.h>
 
 #include <string>

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -7,7 +7,7 @@
 #include <unordered_set>
 
 #include "pugixml.hpp"
-#include "xtensor/xarray.hpp"
+#include "xtensor/containers/xarray.hpp"
 
 #include "hdf5.h"
 #include "openmc/cell.h"

--- a/include/openmc/scattdata.h
+++ b/include/openmc/scattdata.h
@@ -4,7 +4,7 @@
 #ifndef OPENMC_SCATTDATA_H
 #define OPENMC_SCATTDATA_H
 
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include "openmc/constants.h"
 #include "openmc/vector.h"

--- a/include/openmc/secondary_correlated.h
+++ b/include/openmc/secondary_correlated.h
@@ -5,7 +5,7 @@
 #define OPENMC_SECONDARY_CORRELATED_H
 
 #include "hdf5.h"
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include "openmc/angle_energy.h"
 #include "openmc/distribution.h"

--- a/include/openmc/secondary_kalbach.h
+++ b/include/openmc/secondary_kalbach.h
@@ -5,7 +5,7 @@
 #define OPENMC_SECONDARY_KALBACH_H
 
 #include "hdf5.h"
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include "openmc/angle_energy.h"
 #include "openmc/constants.h"

--- a/include/openmc/secondary_thermal.h
+++ b/include/openmc/secondary_thermal.h
@@ -9,7 +9,7 @@
 #include "openmc/secondary_correlated.h"
 #include "openmc/vector.h"
 
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 #include <hdf5.h>
 
 namespace openmc {

--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -9,8 +9,8 @@
 #include "openmc/vector.h"
 
 #include "pugixml.hpp"
-#include "xtensor/xfixed.hpp"
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xfixed.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include <string>
 #include <unordered_map>

--- a/include/openmc/thermal.h
+++ b/include/openmc/thermal.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <unordered_map>
 
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include "openmc/angle_energy.h"
 #include "openmc/endf.h"

--- a/include/openmc/urr.h
+++ b/include/openmc/urr.h
@@ -3,7 +3,7 @@
 #ifndef OPENMC_URR_H
 #define OPENMC_URR_H
 
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include "openmc/constants.h"
 #include "openmc/hdf5_interface.h"

--- a/include/openmc/volume_calc.h
+++ b/include/openmc/volume_calc.h
@@ -13,7 +13,7 @@
 #include "openmc/vector.h"
 
 #include "pugixml.hpp"
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 #ifdef _OPENMP
 #include <omp.h>
 #endif

--- a/include/openmc/wmp.h
+++ b/include/openmc/wmp.h
@@ -2,7 +2,7 @@
 #define OPENMC_WMP_H
 
 #include "hdf5.h"
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include <complex>
 #include <string>

--- a/include/openmc/xml_interface.h
+++ b/include/openmc/xml_interface.h
@@ -6,8 +6,8 @@
 #include <string>
 
 #include "pugixml.hpp"
-#include "xtensor/xadapt.hpp"
-#include "xtensor/xarray.hpp"
+#include "xtensor/containers/xadapt.hpp"
+#include "xtensor/containers/xarray.hpp"
 
 #include "openmc/position.h"
 #include "openmc/vector.h"

--- a/include/openmc/xsdata.h
+++ b/include/openmc/xsdata.h
@@ -4,7 +4,7 @@
 #ifndef OPENMC_XSDATA_H
 #define OPENMC_XSDATA_H
 
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include "openmc/hdf5_interface.h"
 #include "openmc/memory.h"

--- a/src/bremsstrahlung.cpp
+++ b/src/bremsstrahlung.cpp
@@ -6,7 +6,7 @@
 #include "openmc/search.h"
 #include "openmc/settings.h"
 
-#include "xtensor/xmath.hpp"
+#include "xtensor/core/xmath.hpp"
 
 namespace openmc {
 

--- a/src/cmfd_solver.cpp
+++ b/src/cmfd_solver.cpp
@@ -5,7 +5,7 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include "openmc/bank.h"
 #include "openmc/capi.h"

--- a/src/distribution_angle.cpp
+++ b/src/distribution_angle.cpp
@@ -2,8 +2,8 @@
 
 #include <cmath> // for abs, copysign
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "openmc/endf.h"
 #include "openmc/hdf5_interface.h"

--- a/src/distribution_energy.cpp
+++ b/src/distribution_energy.cpp
@@ -4,7 +4,7 @@
 #include <cstddef>   // for size_t
 #include <iterator>  // for back_inserter
 
-#include "xtensor/xview.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "openmc/endf.h"
 #include "openmc/hdf5_interface.h"

--- a/src/eigenvalue.cpp
+++ b/src/eigenvalue.cpp
@@ -1,9 +1,9 @@
 #include "openmc/eigenvalue.h"
 
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xmath.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/core/xmath.hpp"
+#include "xtensor/containers/xtensor.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "openmc/array.h"
 #include "openmc/bank.h"

--- a/src/endf.cpp
+++ b/src/endf.cpp
@@ -5,8 +5,8 @@
 #include <iterator>  // for back_inserter
 #include <stdexcept> // for runtime_error
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "openmc/array.h"
 #include "openmc/constants.h"

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -30,7 +30,7 @@
 #include "openmc/volume_calc.h"
 #include "openmc/weight_windows.h"
 
-#include "xtensor/xview.hpp"
+#include "xtensor/views/xview.hpp"
 
 namespace openmc {
 

--- a/src/hdf5_interface.cpp
+++ b/src/hdf5_interface.cpp
@@ -4,8 +4,8 @@
 #include <stdexcept>
 #include <string>
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/containers/xtensor.hpp"
 #include <fmt/core.h>
 
 #include "hdf5.h"

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -8,9 +8,9 @@
 #include <string>
 #include <unordered_set>
 
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xoperation.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/core/xoperation.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "openmc/capi.h"
 #include "openmc/container_util.h"

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -16,13 +16,13 @@
 #include "mpi.h"
 #endif
 
-#include "xtensor/xadapt.hpp"
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xeval.hpp"
-#include "xtensor/xmath.hpp"
-#include "xtensor/xsort.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xadapt.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/core/xeval.hpp"
+#include "xtensor/core/xmath.hpp"
+#include "xtensor/misc/xsort.hpp"
+#include "xtensor/containers/xtensor.hpp"
+#include "xtensor/views/xview.hpp"
 #include <fmt/core.h> // for fmt
 
 #include "openmc/capi.h"

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -5,10 +5,10 @@
 #include <cstdlib>
 #include <sstream>
 
-#include "xtensor/xadapt.hpp"
-#include "xtensor/xmath.hpp"
-#include "xtensor/xsort.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xadapt.hpp"
+#include "xtensor/core/xmath.hpp"
+#include "xtensor/misc/xsort.hpp"
+#include "xtensor/views/xview.hpp"
 #include <fmt/core.h>
 
 #include "openmc/error.h"

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -17,8 +17,8 @@
 
 #include <fmt/core.h>
 
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include <algorithm> // for sort, min_element
 #include <cassert>

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -17,7 +17,7 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
-#include "xtensor/xview.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "openmc/capi.h"
 #include "openmc/cell.h"

--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -13,11 +13,11 @@
 #include "openmc/search.h"
 #include "openmc/settings.h"
 
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xmath.hpp"
-#include "xtensor/xoperation.hpp"
-#include "xtensor/xslice.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/core/xmath.hpp"
+#include "xtensor/core/xoperation.hpp"
+#include "xtensor/views/xslice.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include <cmath>
 #include <fmt/core.h>

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -32,7 +32,7 @@
 
 #include <algorithm> // for max, min, max_element
 #include <cmath>     // for sqrt, exp, log, abs, copysign
-#include <xtensor/xview.hpp>
+#include <xtensor/views/xview.hpp>
 
 namespace openmc {
 

--- a/src/physics_mg.cpp
+++ b/src/physics_mg.cpp
@@ -2,7 +2,7 @@
 
 #include <stdexcept>
 
-#include "xtensor/xarray.hpp"
+#include "xtensor/containers/xarray.hpp"
 #include <fmt/core.h>
 
 #include "openmc/bank.h"

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -7,8 +7,8 @@
 #include <fstream>
 #include <sstream>
 
-#include "xtensor/xmanipulation.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/misc/xmanipulation.hpp"
+#include "xtensor/views/xview.hpp"
 #include <fmt/core.h>
 #include <fmt/ostream.h>
 #ifdef USE_LIBPNG

--- a/src/scattdata.cpp
+++ b/src/scattdata.cpp
@@ -4,8 +4,8 @@
 #include <cmath>
 #include <numeric>
 
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "openmc/constants.h"
 #include "openmc/error.h"

--- a/src/secondary_correlated.cpp
+++ b/src/secondary_correlated.cpp
@@ -5,8 +5,8 @@
 #include <cstddef>  // for size_t
 #include <iterator> // for back_inserter
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "openmc/endf.h"
 #include "openmc/hdf5_interface.h"

--- a/src/secondary_kalbach.cpp
+++ b/src/secondary_kalbach.cpp
@@ -5,8 +5,8 @@
 #include <cstddef>   // for size_t
 #include <iterator>  // for back_inserter
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "openmc/hdf5_interface.h"
 #include "openmc/math_functions.h"

--- a/src/secondary_thermal.cpp
+++ b/src/secondary_thermal.cpp
@@ -5,7 +5,7 @@
 #include "openmc/random_lcg.h"
 #include "openmc/search.h"
 
-#include "xtensor/xview.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include <cassert>
 #include <cmath> // for log, exp

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -30,7 +30,7 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
-#include "xtensor/xview.hpp"
+#include "xtensor/views/xview.hpp"
 
 #ifdef OPENMC_MPI
 #include <mpi.h>

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -10,7 +10,7 @@
 #include <dlfcn.h> // for dlopen, dlsym, dlclose, dlerror
 #endif
 
-#include "xtensor/xadapt.hpp"
+#include "xtensor/containers/xadapt.hpp"
 #include <fmt/core.h>
 
 #include "openmc/bank.h"

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -4,8 +4,8 @@
 #include <cstdint> // for int64_t
 #include <string>
 
-#include "xtensor/xbuilder.hpp" // for empty_like
-#include "xtensor/xview.hpp"
+#include "xtensor/generators/xbuilder.hpp" // for empty_like
+#include "xtensor/views/xview.hpp"
 #include <fmt/core.h>
 
 #include "openmc/bank.h"

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -35,9 +35,9 @@
 #include "openmc/tallies/filter_time.h"
 #include "openmc/xml_interface.h"
 
-#include "xtensor/xadapt.hpp"
-#include "xtensor/xbuilder.hpp" // for empty_like
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xadapt.hpp"
+#include "xtensor/generators/xbuilder.hpp" // for empty_like
+#include "xtensor/views/xview.hpp"
 #include <fmt/core.h>
 
 #include <algorithm> // for max, set_union

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -3,12 +3,12 @@
 #include <algorithm> // for sort, move, min, max, find
 #include <cmath>     // for round, sqrt, abs
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xmath.hpp"
-#include "xtensor/xsort.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/core/xmath.hpp"
+#include "xtensor/misc/xsort.hpp"
+#include "xtensor/containers/xtensor.hpp"
+#include "xtensor/views/xview.hpp"
 #include <fmt/core.h>
 
 #include "openmc/constants.h"

--- a/src/track_output.cpp
+++ b/src/track_output.cpp
@@ -8,7 +8,7 @@
 #include "openmc/simulation.h"
 #include "openmc/vector.h"
 
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xtensor.hpp"
 #include <fmt/core.h>
 #include <hdf5.h>
 

--- a/src/volume_calc.cpp
+++ b/src/volume_calc.cpp
@@ -17,8 +17,8 @@
 #include "openmc/timer.h"
 #include "openmc/xml_interface.h"
 
-#include "xtensor/xadapt.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xadapt.hpp"
+#include "xtensor/views/xview.hpp"
 #include <fmt/core.h>
 
 #include <algorithm> // for copy

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -6,12 +6,12 @@
 #include <set>
 #include <string>
 
-#include "xtensor/xdynamic_view.hpp"
-#include "xtensor/xindex_view.hpp"
-#include "xtensor/xio.hpp"
-#include "xtensor/xmasked_view.hpp"
-#include "xtensor/xnoalias.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/views/xdynamic_view.hpp"
+#include "xtensor/views/xindex_view.hpp"
+#include "xtensor/io/xio.hpp"
+#include "xtensor/views/xmasked_view.hpp"
+#include "xtensor/core/xnoalias.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "openmc/error.h"
 #include "openmc/file_utils.h"

--- a/src/xsdata.cpp
+++ b/src/xsdata.cpp
@@ -5,10 +5,10 @@
 #include <cstdlib>
 #include <numeric>
 
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xindex_view.hpp"
-#include "xtensor/xmath.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/views/xindex_view.hpp"
+#include "xtensor/core/xmath.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "openmc/constants.h"
 #include "openmc/error.h"


### PR DESCRIPTION
# Description

Update OpenMC to xtensor v 0.26. Confirms this works with clang 19.1.7. This is necessary for many Cardinal users who rely on MOOSE's conda environment, which uses clang by default.

Fixes # 3183

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
