### PR TITLE
FIX: Remove setuptools from run dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ When modifying C++ public APIs, update corresponding ctypes signatures in `openm
 - **Docstrings**: numpydoc format for all public functions/methods
 - **Type hints**: Use sparingly, primarily for complex signatures
 - **Path handling**: Use `pathlib.Path` for filesystem operations, accept `str | os.PathLike` in function arguments
-- **Dependencies**: Core dependencies only (numpy, scipy, h5py, pandas, matplotlib, lxml, ipython, uncertainties, setuptools, endf). Other packages must be optional
+- **Dependencies**: Core dependencies only (numpy, scipy, h5py, pandas, matplotlib, lxml, ipython, uncertainties, endf). Other packages must be optional
 - **Python version**: Minimum 3.11 (as of Nov 2025)
 
 ### ID Management Pattern (Python)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "pandas",
     "lxml",
     "uncertainties",
-    "setuptools",
     "endf",
 ]
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

`setuptools` is not used at runtime and should not be required as a runtime dependency. It is a build time dependency only to provide a build-backend.

Relevant for https://github.com/conda-forge/openmc-feedstock/pull/85.

https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md didn't explicitly say that all PRs need to have a motivating issue first, but if that is expected I can open an Issue.

# Checklist

- [x] I have performed a self-review of my own code
- [N/A] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [N/A] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [N/A] I have made corresponding changes to the documentation (if applicable)
- [N/A] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
