### PR TITLE
Making use of ```SUM_RULES``` in ```endf``` package

### DIFF
--- a/openmc/data/endf.py
+++ b/openmc/data/endf.py
@@ -12,6 +12,7 @@ import re
 
 from .data import gnds_name
 from .function import Tabulated1D
+from endf.incident_neutron import SUM_RULES
 from endf.records import (
     float_endf,
     py_float_endf,
@@ -62,24 +63,6 @@ _SUBLIBRARY = {
     20030: 'Incident-helion (3He) data',
     20040: 'Incident-alpha data'
 }
-
-SUM_RULES = {1: [2, 3],
-             3: [4, 5, 11, 16, 17, 22, 23, 24, 25, 27, 28, 29, 30, 32, 33, 34, 35,
-                 36, 37, 41, 42, 44, 45, 152, 153, 154, 156, 157, 158, 159, 160,
-                 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172,
-                 173, 174, 175, 176, 177, 178, 179, 180, 181, 183, 184, 185,
-                 186, 187, 188, 189, 190, 194, 195, 196, 198, 199, 200],
-             4: list(range(50, 92)),
-             16: list(range(875, 892)),
-             18: [19, 20, 21, 38],
-             27: [18, 101],
-             101: [102, 103, 104, 105, 106, 107, 108, 109, 111, 112, 113, 114,
-                   115, 116, 117, 155, 182, 191, 192, 193, 197],
-             103: list(range(600, 650)),
-             104: list(range(650, 700)),
-             105: list(range(700, 750)),
-             106: list(range(750, 800)),
-             107: list(range(800, 850))}
 
 
 def get_evaluations(filename):


### PR DESCRIPTION
# Description

Continuing the quest to reduce the amount of duplicate code in openmc and endf package. This one looks like an easy win, we can make use of the SUM_RULES in the endf package and save a few more lines

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
