### PR TITLE
avoid need to set particles and batches for dagmc models when calling convert_to_multigroup

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2583,10 +2583,14 @@ class Model:
             # TODO: Can this be done without having to init/finalize?
             for univ in self.geometry.get_all_universes().values():
                 if isinstance(univ, openmc.DAGMCUniverse):
-                    # Initialize in volume calculation mode (non-transport mode)
+                    # Initialize in plotting mode (non-transport mode)
                     # This mode doesn't require
                     # valid transport settings like particles/batches
-                    self.init_lib(args=['-c'], directory=tmpdir)
+                    original_run_mode = self.settings.run_mode
+                    self.settings.run_mode = 'plot' 
+                    self.init_lib(directory=tmpdir)
+                    # Restore original run mode
+                    self.settings.run_mode = original_run_mode
                     self.sync_dagmc_universes()
                     self.finalize_lib()
                     break

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2583,11 +2583,11 @@ class Model:
             # TODO: Can this be done without having to init/finalize?
             for univ in self.geometry.get_all_universes().values():
                 if isinstance(univ, openmc.DAGMCUniverse):
-                    # Initialize in plotting mode (non-transport mode)
+                    # Initialize in stochastic volume mode (non-transport mode)
                     # This mode doesn't require
                     # valid transport settings like particles/batches
                     original_run_mode = self.settings.run_mode
-                    self.settings.run_mode = 'plot' 
+                    self.settings.run_mode = 'volume' 
                     self.init_lib(directory=tmpdir)
                     self.sync_dagmc_universes()
                     self.finalize_lib()

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2582,16 +2582,16 @@ class Model:
             # the dagmc materials with cells.
             # TODO: Can this be done without having to init/finalize?
             for univ in self.geometry.get_all_universes().values():
-              if isinstance(univ, openmc.DAGMCUniverse):
-                  # Ensure settings has valid particles/batches for init_lib validation
-                  # These values are only needed for XML export during initialization
-                  # and won't affect the actual MGXS generation which uses an internal model
-                  self.settings.particles = 1
-                  self.settings.batches = 2
-                  self.init_lib(directory=tmpdir)
-                  self.sync_dagmc_universes()
-                  self.finalize_lib()
-                  break
+                if isinstance(univ, openmc.DAGMCUniverse):
+                    # Ensure settings has valid particles/batches for init_lib validation
+                    # These values are only needed for XML export during initialization
+                    # and won't affect the actual MGXS generation which uses an internal model
+                    self.settings.particles = 1
+                    self.settings.batches = 2
+                    self.init_lib(directory=tmpdir)
+                    self.sync_dagmc_universes()
+                    self.finalize_lib()
+                    break
 
 
             # Make sure all materials have a name, and that the name is a valid HDF5

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2582,11 +2582,17 @@ class Model:
             # the dagmc materials with cells.
             # TODO: Can this be done without having to init/finalize?
             for univ in self.geometry.get_all_universes().values():
-                if isinstance(univ, openmc.DAGMCUniverse):
-                    self.init_lib(directory=tmpdir)
-                    self.sync_dagmc_universes()
-                    self.finalize_lib()
-                    break
+              if isinstance(univ, openmc.DAGMCUniverse):
+                  # Ensure settings has valid particles/batches for init_lib validation
+                  # These values are only needed for XML export during initialization
+                  # and won't affect the actual MGXS generation which uses an internal model
+                  self.settings.particles = 1
+                  self.settings.batches = 2
+                  self.init_lib(directory=tmpdir)
+                  self.sync_dagmc_universes()
+                  self.finalize_lib()
+                  break
+
 
             # Make sure all materials have a name, and that the name is a valid HDF5
             # dataset name

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2584,7 +2584,7 @@ class Model:
             for univ in self.geometry.get_all_universes().values():
                 if isinstance(univ, openmc.DAGMCUniverse):
                     # Initialize in volume calculation mode (non-transport mode)
-                    # This avoids loading cross sections and doesn't require
+                    # This mode doesn't require
                     # valid transport settings like particles/batches
                     self.init_lib(args=['-c'], directory=tmpdir)
                     self.sync_dagmc_universes()

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2589,10 +2589,10 @@ class Model:
                     original_run_mode = self.settings.run_mode
                     self.settings.run_mode = 'plot' 
                     self.init_lib(directory=tmpdir)
-                    # Restore original run mode
-                    self.settings.run_mode = original_run_mode
                     self.sync_dagmc_universes()
                     self.finalize_lib()
+                    # Restore original run mode
+                    self.settings.run_mode = original_run_mode
                     break
 
             # Make sure all materials have a name, and that the name is a valid HDF5

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2583,12 +2583,10 @@ class Model:
             # TODO: Can this be done without having to init/finalize?
             for univ in self.geometry.get_all_universes().values():
                 if isinstance(univ, openmc.DAGMCUniverse):
-                    # Ensure settings has valid particles/batches for init_lib validation
-                    # These values are only needed for XML export during initialization
-                    # and won't affect the actual MGXS generation which uses an internal model
-                    self.settings.particles = 1
-                    self.settings.batches = 2
-                    self.init_lib(directory=tmpdir)
+                    # Initialize in volume calculation mode (non-transport mode)
+                    # This avoids loading cross sections and doesn't require
+                    # valid transport settings like particles/batches
+                    self.init_lib(args=['-c'], directory=tmpdir)
                     self.sync_dagmc_universes()
                     self.finalize_lib()
                     break

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2593,7 +2593,6 @@ class Model:
                     self.finalize_lib()
                     break
 
-
             # Make sure all materials have a name, and that the name is a valid HDF5
             # dataset name
             for material in self.materials:

--- a/tests/unit_tests/dagmc/test_convert_to_multigroup.py
+++ b/tests/unit_tests/dagmc/test_convert_to_multigroup.py
@@ -1,0 +1,43 @@
+"""Test that convert_to_multigroup works with DAGMC models without requiring
+particles/batches to be set beforehand.
+"""
+
+from pathlib import Path
+import pytest
+import openmc
+import openmc.lib
+
+pytestmark = pytest.mark.skipif(
+    not openmc.lib._dagmc_enabled(),
+    reason="DAGMC CAD geometry is not enabled.")
+
+
+def test_convert_to_multigroup_without_particles_batches(run_in_tmpdir):
+    """Test that convert_to_multigroup works with DAGMC model without
+    setting particles/batches beforehand."""
+
+    mat = openmc.Material(name="mat")
+    mat.add_nuclide("Fe56", 1.0)
+    mat.set_density("g/cm3", 7.0)
+
+    # Use minimal tetrahedral DAGMC file
+    dagmc_file = Path(__file__).parent / "dagmc_tetrahedral_no_graveyard.h5m"
+    dagmc_univ = openmc.DAGMCUniverse(dagmc_file, auto_geom_ids=True)
+
+    # Create model WITHOUT setting particles or batches
+    model = openmc.Model()
+    model.materials = openmc.Materials([mat])
+    model.geometry = openmc.Geometry(dagmc_univ)
+    model.settings = openmc.Settings()  # Note: no particles or batches set!
+
+    # This should work without requiring particles/batches to be set
+    # convert_to_multigroup handles initialization internally using non-transport mode
+    model.convert_to_multigroup(
+        method='material_wise',
+        groups='CASMO-2',
+        nparticles=10,
+        overwrite_mgxs_library=True
+    )
+
+    # Verify the model was converted successfully
+    assert model.settings.energy_mode == 'multi-group'

--- a/tests/unit_tests/dagmc/test_convert_to_multigroup.py
+++ b/tests/unit_tests/dagmc/test_convert_to_multigroup.py
@@ -15,7 +15,8 @@ pytestmark = pytest.mark.skipif(
 def test_convert_to_multigroup_without_particles_batches(run_in_tmpdir):
     """Test that convert_to_multigroup works with DAGMC model without
     setting particles/batches beforehand."""
-
+    openmc.reset_auto_ids()
+    
     mat = openmc.Material(name="mat")
     mat.add_nuclide("Fe56", 1.0)
     mat.set_density("g/cm3", 7.0)

--- a/tests/unit_tests/dagmc/test_convert_to_multigroup.py
+++ b/tests/unit_tests/dagmc/test_convert_to_multigroup.py
@@ -23,12 +23,21 @@ def test_convert_to_multigroup_without_particles_batches(run_in_tmpdir):
     # Use minimal tetrahedral DAGMC file
     dagmc_file = Path(__file__).parent / "dagmc_tetrahedral_no_graveyard.h5m"
     dagmc_univ = openmc.DAGMCUniverse(dagmc_file, auto_geom_ids=True)
+    bound_dagmc_univ = dagmc_univ.bounded_universe(padding_distance=1)
 
     # Create model WITHOUT setting particles or batches
     model = openmc.Model()
     model.materials = openmc.Materials([mat])
-    model.geometry = openmc.Geometry(dagmc_univ)
+    model.geometry = openmc.Geometry(bound_dagmc_univ)
     model.settings = openmc.Settings()  # Note: no particles or batches set!
+
+    model.settings.run_mode = 'fixed source'
+    
+    # Create a point source
+    my_source = openmc.IndependentSource()
+    my_source.space = openmc.stats.Point((0.25, 0.25, 0.25))
+    my_source.energy = openmc.stats.delta_function(14e6)
+    model.settings.source = my_source
 
     # This should work without requiring particles/batches to be set
     # convert_to_multigroup handles initialization internally using non-transport mode


### PR DESCRIPTION
# Description

If we call convert_to_multigroup with a dagmc model currently and the settings have no particles or batches then it fails validation.

IMO we shouldn't need to set particles or batches before calling convert_to_multigroup as convert_to_multigroup has an argument for nparticles and decides internally the batches particles split.

This PR just sets the batches and particles to a valid, this will help it pass validation but it does not actually get used in simulation

If we ask user to set particles and batches on the model.settings then this could be a bit confusing as they are not used by convert_to_multigroup

What do people think is this an acceptable hack?

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)