### PR TITLE
Fix `None` values appearing in cross section data generated with `Model.autoconvert`

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2052,7 +2052,8 @@ class Model:
             # Unpack the isothermal XSData objects and build a single XSData object per material.
             mgxs_sets = []
             for m in range(len(self.materials)):
-                mgxs_sets.append(openmc.XSdata(self.materials[m].name, groups))
+                mgxs_sets.append(openmc.XSdata(self.materials[m].name, groups,
+                                               temperatures=temperatures))
                 mgxs_sets[-1].order = 0
                 for temperature in temperatures:
                     mgxs_sets[-1].add_temperature_data(raw_mgxs_sets[temperature][m])
@@ -2333,7 +2334,7 @@ class Model:
             # Unpack the isothermal XSData objects and build a single XSData object per material.
             mgxs_sets = []
             for mat in self.materials:
-                mgxs_sets.append(openmc.XSdata(mat.name, groups))
+                mgxs_sets.append(openmc.XSdata(mat.name, groups, temperatures=temperatures))
                 mgxs_sets[-1].order = 0
                 for temperature in temperatures:
                     mgxs_sets[-1].add_temperature_data(raw_mgxs_sets[temperature][mat.name])
@@ -2500,7 +2501,7 @@ class Model:
             # Unpack the isothermal XSData objects and build a single XSData object per material.
             mgxs_sets = []
             for mat in self.materials:
-                mgxs_sets.append(openmc.XSdata(mat.name, groups))
+                mgxs_sets.append(openmc.XSdata(mat.name, groups, temperatures=temperatures))
                 mgxs_sets[-1].order = 0
                 for temperature in temperatures:
                     mgxs_sets[-1].add_temperature_data(raw_mgxs_sets[temperature][mat.name])


### PR DESCRIPTION
# Description

When generating isothermal multi-group cross sections with the autoconvert function, `None` values would show up in the temperature data if 294 isn't included as a data point. This quick PR fixes this error by initializing the XSdata container with the provided temperature points.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] ~~I have made corresponding changes to the documentation (if applicable)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~

