### PR TITLE
Set upper and lower interpolation bounds for MGXS data.

### DIFF
--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -14,6 +14,7 @@
 #include "openmc/error.h"
 #include "openmc/math_functions.h"
 #include "openmc/mgxs_interface.h"
+#include "openmc/nuclide.h"
 #include "openmc/random_lcg.h"
 #include "openmc/settings.h"
 #include "openmc/string_utils.h"
@@ -84,6 +85,13 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
   }
   delete[] dset_names;
   std::sort(temps_available.begin(), temps_available.end());
+
+  // Set the global upper and lower interpolation bounds to avoid errors involving
+  // C-API functions.
+  for (int i = 0; i < num_temps; ++i) {
+    data::temperature_min = std::min(data::temperature_min, temps_available[i]);
+    data::temperature_max = std::max(data::temperature_max, temps_available[i]);
+  }
 
   // If only one temperature is available, lets just use nearest temperature
   // interpolation

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -88,8 +88,10 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
 
   // Set the global upper and lower interpolation bounds to avoid errors
   // involving C-API functions.
-  data::temperature_min = std::min(data::temperature_min, *temps_available.begin());
-  data::temperature_max = std::max(data::temperature_max, *temps_available.end());
+  data::temperature_min =
+    std::min(data::temperature_min, *temps_available.begin());
+  data::temperature_max =
+    std::max(data::temperature_max, *temps_available.end());
 
   // If only one temperature is available, lets just use nearest temperature
   // interpolation

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -89,9 +89,9 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
   // Set the global upper and lower interpolation bounds to avoid errors
   // involving C-API functions.
   data::temperature_min =
-    std::min(data::temperature_min, *temps_available.begin());
+    std::min(data::temperature_min, temps_available.front());
   data::temperature_max =
-    std::max(data::temperature_max, *temps_available.end());
+    std::max(data::temperature_max, temps_available.back());
 
   // If only one temperature is available, lets just use nearest temperature
   // interpolation

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -86,8 +86,8 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
   delete[] dset_names;
   std::sort(temps_available.begin(), temps_available.end());
 
-  // Set the global upper and lower interpolation bounds to avoid errors involving
-  // C-API functions.
+  // Set the global upper and lower interpolation bounds to avoid errors
+  // involving C-API functions.
   for (int i = 0; i < num_temps; ++i) {
     data::temperature_min = std::min(data::temperature_min, temps_available[i]);
     data::temperature_max = std::max(data::temperature_max, temps_available[i]);
@@ -381,7 +381,7 @@ Mgxs::Mgxs(const std::string& in_name, const vector<double>& mat_kTs,
           }
         }
       } // end switch
-    }   // end microscopic temperature loop
+    } // end microscopic temperature loop
 
     // Now combine the microscopic data at each relevant temperature
     // We will do this by treating the multiple temperatures of a nuclide as

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -88,10 +88,8 @@ void Mgxs::metadata_from_hdf5(hid_t xs_id, const vector<double>& temperature,
 
   // Set the global upper and lower interpolation bounds to avoid errors
   // involving C-API functions.
-  for (int i = 0; i < num_temps; ++i) {
-    data::temperature_min = std::min(data::temperature_min, temps_available[i]);
-    data::temperature_max = std::max(data::temperature_max, temps_available[i]);
-  }
+  data::temperature_min = std::min(data::temperature_min, *temps_available.begin());
+  data::temperature_max = std::max(data::temperature_max, *temps_available.end());
 
   // If only one temperature is available, lets just use nearest temperature
   // interpolation
@@ -381,7 +379,7 @@ Mgxs::Mgxs(const std::string& in_name, const vector<double>& mat_kTs,
           }
         }
       } // end switch
-    } // end microscopic temperature loop
+    }   // end microscopic temperature loop
 
     // Now combine the microscopic data at each relevant temperature
     // We will do this by treating the multiple temperatures of a nuclide as


### PR DESCRIPTION
# Description

When running OpenMC with the C/C++ API in multi-group mode, an error will get thrown when cell temperatures are set with `openmc_cell_set_temperature(...)`:
```
Temperature of 600 K is below minimum temperature at which data is available of 1.7976931348623157e+308 K.
```
The error is caused by `data::temperature_min` and `data::temperature_max` not being set when loading multi-group cross sections. This PR adds a code block to compute the minimum and maximum values, which fixes a longstanding bug in Cardinal.

Combining this fix with some changes in Cardinal (clearing and reloading MGXS after temperatures are set) part of the fix for #2402

FYI @meltawila, @aprilnovak 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [ ] ~~I have made corresponding changes to the documentation (if applicable)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~