### PR TITLE
Do not write source_bank when it is not availabe

### DIFF
--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -339,17 +339,13 @@ extern "C" int openmc_statepoint_write(const char* filename, bool* write_source)
   bool parallel = false;
 #endif
 
-  // Write the source bank if desired and available
-  if (settings::run_mode == RunMode::EIGENVALUE &&
-      settings::solver_type == SolverType::MONTE_CARLO) {
-    if (write_source_) {
-      if (mpi::master || parallel)
-        file_id = file_open(filename_, 'a', true);
-      write_source_bank(
-        file_id, simulation::source_bank, simulation::work_index);
-      if (mpi::master || parallel)
-        file_close(file_id);
-    }
+  // Write the source bank if desired
+  if (write_source_) {
+    if (mpi::master || parallel)
+      file_id = file_open(filename_, 'a', true);
+    write_source_bank(file_id, simulation::source_bank, simulation::work_index);
+    if (mpi::master || parallel)
+      file_close(file_id);
   }
 
 #if defined(OPENMC_LIBMESH_ENABLED) || defined(OPENMC_DAGMC_ENABLED)
@@ -649,6 +645,10 @@ void write_h5_source_point(const char* filename, span<SourceSite> source_bank,
 void write_source_bank(hid_t group_id, span<SourceSite> source_bank,
   const vector<int64_t>& bank_index)
 {
+  // Skip writing source bank if it is not available
+  if (settings::run_mode != RunMode::EIGENVALUE ||
+      settings::solver_type != SolverType::MONTE_CARLO)
+    return;
   hid_t membanktype = h5banktype(true);
   hid_t filebanktype = h5banktype(false);
 

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -339,13 +339,17 @@ extern "C" int openmc_statepoint_write(const char* filename, bool* write_source)
   bool parallel = false;
 #endif
 
-  // Write the source bank if desired
-  if (write_source_) {
-    if (mpi::master || parallel)
-      file_id = file_open(filename_, 'a', true);
-    write_source_bank(file_id, simulation::source_bank, simulation::work_index);
-    if (mpi::master || parallel)
-      file_close(file_id);
+  // Write the source bank if desired and available
+  if (settings::run_mode == RunMode::EIGENVALUE &&
+      settings::solver_type == SolverType::MONTE_CARLO) {
+    if (write_source_) {
+      if (mpi::master || parallel)
+        file_id = file_open(filename_, 'a', true);
+      write_source_bank(
+        file_id, simulation::source_bank, simulation::work_index);
+      if (mpi::master || parallel)
+        file_close(file_id);
+    }
   }
 
 #if defined(OPENMC_LIBMESH_ENABLED) || defined(OPENMC_DAGMC_ENABLED)

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -460,7 +460,7 @@ def test_global_tallies(lib_run):
 def test_statepoint(lib_run):
     openmc.lib.statepoint_write('test_sp.h5')
     assert os.path.exists('test_sp.h5')
-
+        
 
 def test_source_bank(lib_run):
     source = openmc.lib.source_bank()
@@ -1122,11 +1122,48 @@ def test_sample_external_source(run_in_tmpdir, mpi_intracomm):
     openmc.lib.finalize()
 
 
+def test_statepoint_write_source_in_fixed_mode(run_in_tmpdir, mpi_intracomm):
+    model = openmc.Model()    
+    model.materials = openmc.Materials()
+
+    nitrogen = openmc.Material(name='Air')
+    nitrogen.add_nuclide('N14', 1.0, 'wo')
+    nitrogen.set_density('g/cm3', 1.205E-50)
+    nitrogen.temperature = 293
+
+    model.materials.append(nitrogen)
+
+    sphere = openmc.Sphere(r=10, boundary_type='vacuum')
+
+    cell = openmc.Cell(region = -sphere, fill=nitrogen)
+
+    root = openmc.Universe(cells=[cell])
+    
+    model.geometry = openmc.Geometry(root)
+
+    src = openmc.IndependentSource()
+    src.space = openmc.stats.Point((0,0,0))
+
+    model.settings = openmc.Settings()
+    model.settings.source = src
+    model.settings.batches = 10
+    model.settings.particles = 1000
+    model.settings.run_mode = 'fixed source'
+
+    model.export_to_xml() 
+    openmc.lib.finalize()
+    openmc.lib.init(intracomm=mpi_intracomm)
+    openmc.lib.run()
+    openmc.lib.statepoint_write(write_source=True)
+    openmc.lib.finalize()
+    
+
 def test_random_ray(random_ray_pincell_model, mpi_intracomm):
     openmc.lib.finalize()
     openmc.lib.init(intracomm=mpi_intracomm)
     openmc.lib.simulation_init()
     openmc.lib.run_random_ray()
+    openmc.lib.statepoint_write(write_source=True)
     keff = openmc.lib.keff()
 
     assert keff[0]==pytest.approx(1.3236826574065745)

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -460,7 +460,7 @@ def test_global_tallies(lib_run):
 def test_statepoint(lib_run):
     openmc.lib.statepoint_write('test_sp.h5')
     assert os.path.exists('test_sp.h5')
-        
+
 
 def test_source_bank(lib_run):
     source = openmc.lib.source_bank()


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Currently, openmc crash in cases where is tries to write the source bank to the statepoint file and it is not available.
This PR wrap the code that write the source bank to the statepoint file in a check against that.

Fixes #3380

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
