### PR TITLE
Modify the plotter ray tracing for its utilization in estimators

### DIFF
--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -502,11 +502,11 @@ private:
 class Ray : public GeometryState {
 
 public:
-  // Initialize from location and diretion
+  // Initialize from location and direction
   Ray(Position r, Direction u) { init_from_r_u(r, u); }
 
   // Initialize from known geometry state
-  Ray(GeometryState& p) : GeometryState(p) {};
+  Ray(const GeometryState& p) : GeometryState(p) {}
 
   // Called at every surface intersection within the model
   virtual void on_intersection() = 0;

--- a/include/openmc/plot.h
+++ b/include/openmc/plot.h
@@ -502,7 +502,11 @@ private:
 class Ray : public GeometryState {
 
 public:
+  // Initialize from location and diretion
   Ray(Position r, Direction u) { init_from_r_u(r, u); }
+
+  // Initialize from known geometry state
+  Ray(GeometryState& p) : GeometryState(p) {};
 
   // Called at every surface intersection within the model
   virtual void on_intersection() = 0;

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -1413,9 +1413,9 @@ ImageData WireframeRayTracePlot::create_image() const
         if (wireframe_thickness_ == 1)
           data(horiz, vert) = wireframe_color_;
         for (int i = -wireframe_thickness_ / 2; i < wireframe_thickness_ / 2;
-          ++i)
+             ++i)
           for (int j = -wireframe_thickness_ / 2; j < wireframe_thickness_ / 2;
-            ++j)
+               ++j)
             if (i * i + j * j < wireframe_thickness_ * wireframe_thickness_) {
 
               // Check if wireframe pixel is out of bounds

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -1413,9 +1413,9 @@ ImageData WireframeRayTracePlot::create_image() const
         if (wireframe_thickness_ == 1)
           data(horiz, vert) = wireframe_color_;
         for (int i = -wireframe_thickness_ / 2; i < wireframe_thickness_ / 2;
-             ++i)
+          ++i)
           for (int j = -wireframe_thickness_ / 2; j < wireframe_thickness_ / 2;
-               ++j)
+            ++j)
             if (i * i + j * j < wireframe_thickness_ * wireframe_thickness_) {
 
               // Check if wireframe pixel is out of bounds
@@ -1667,9 +1667,19 @@ void Ray::trace()
   // After phase one is done, we can starting tracing from cell to cell within
   // the model. This step can use neighbor lists to accelerate the ray tracing.
 
-  // Attempt to initialize the particle. We may have to enter a loop to move
-  // it up to the edge of the model.
-  bool inside_cell = exhaustive_find_cell(*this, settings::verbosity >= 10);
+  bool inside_cell;
+  // Check for location if the particle is already known
+  if (lowest_coord().cell() == C_NONE) {
+    // The geometry position of the particle is either unknown or outside of the
+    // edge of the model.
+    // Attempt to initialize the particle. We may have to
+    // enter a loop to move it up to the edge of the model.
+    inside_cell = exhaustive_find_cell(*this, settings::verbosity >= 10);
+  } else {
+    // Avaliability of the cell means that the particle is located inside the
+    // edge.
+    inside_cell = true;
+  }
 
   // Advance to the boundary of the model
   while (!inside_cell) {
@@ -1750,6 +1760,11 @@ void Ray::trace()
       coord(lev).r() += boundary().distance() * coord(lev).u();
     }
     surface() = boundary().surface();
+    // Initialize last cells from the current cell, because the cell() variable
+    // does not contain the data for the case of a single-segment ray
+    for (int j = 0; j < n_coord(); ++j) {
+      cell_last(j) = coord(j).cell();
+    }
     n_coord_last() = n_coord();
     n_coord() = boundary().coord_level();
     if (boundary().lattice_translation()[0] != 0 ||

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -1672,7 +1672,7 @@ void Ray::trace()
   if (lowest_coord().cell() == C_NONE) {
     // The geometry position of the particle is either unknown or outside of the
     // edge of the model.
-    if (p.lowest_coord().universe() == C_NONE) {
+    if (lowest_coord().universe() == C_NONE) {
       // Attempt to initialize the particle. We may have to
       // enter a loop to move it up to the edge of the model.
       inside_cell = exhaustive_find_cell(*this, settings::verbosity >= 10);

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -1682,7 +1682,7 @@ void Ray::trace()
       inside_cell = false;
     }
   } else {
-    // Avaliability of the cell means that the particle is located inside the
+    // Availability of the cell means that the particle is located inside the
     // edge.
     inside_cell = true;
   }

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -1672,9 +1672,15 @@ void Ray::trace()
   if (lowest_coord().cell() == C_NONE) {
     // The geometry position of the particle is either unknown or outside of the
     // edge of the model.
-    // Attempt to initialize the particle. We may have to
-    // enter a loop to move it up to the edge of the model.
-    inside_cell = exhaustive_find_cell(*this, settings::verbosity >= 10);
+    if (p.lowest_coord().universe() == C_NONE) {
+      // Attempt to initialize the particle. We may have to
+      // enter a loop to move it up to the edge of the model.
+      inside_cell = exhaustive_find_cell(*this, settings::verbosity >= 10);
+    } else {
+      // It has been already calculated that the current position is outside of
+      // the edge of the model.
+      inside_cell = false;
+    }
   } else {
     // Avaliability of the cell means that the particle is located inside the
     // edge.


### PR DESCRIPTION
# Description

A minor modification of the `Ray::trace()` routine is proposed for its optimization for utilizing in particle transport applications, which allows:
 * To start tracing from a known cell without recalculation of the initial geometry state;
 * To keep `cell_last` for the permanent availability of the traced cell entity.

## Details
The `Ray::trace()` routine provides a concise interface for geometry-related computations, and it is currently used for plotting purposes only. However, such a routine is also needed for estimators, which require the computation of track/optical distances. Such encapsulation of the geometrical functionality dramatically simplifies the implementation of many efficient techniques, especially for shielding problems. The currently relevant examples of possible usage are:
 * The track-length family of estimators (see #3645 for details of the implementation);
 * Point estimator (it could be used in #3109).

## Testing
The principle of the `Ray` class usage for such purposes was proved in #3645. Now, I have run the volume calculation tests for this version of the `Ray` class with the ray tracing volume estimator.
_UPD. 19.02.26. The bidirectional ray tracing has been used for the volume calculation of the spherical geometry from #3645 inside the bounding box. It covers all four cases of the ray origin location: the combinations of known/unknown cell and inside/outside of the edge of the model._

Here, no tests were added due to the seeming excessiveness of the creation of a new artificial problem. However, if the tests are desired right in this PR, please let me know. I would be glad if someone could specify what tests exactly are needed then.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->