### PR TITLE
making use of endf.get_evaluations

### DIFF
--- a/openmc/data/endf.py
+++ b/openmc/data/endf.py
@@ -12,7 +12,7 @@ import re
 
 from .data import gnds_name
 from .function import Tabulated1D
-from endf.material import _LIBRARY, _SUBLIBRARY
+from endf.material import _LIBRARY, _SUBLIBRARY, get_materials as get_evaluations
 from endf.incident_neutron import SUM_RULES
 from endf.records import (
     float_endf,
@@ -37,32 +37,6 @@ def get_tab1_record(file_obj):
     """
     params, tab = _get_tab1_record(file_obj)
     return params, Tabulated1D(tab.x, tab.y, tab.breakpoints, tab.interpolation)
-
-
-def get_evaluations(filename):
-    """Return a list of all evaluations within an ENDF file.
-
-    Parameters
-    ----------
-    filename : str
-        Path to ENDF-6 formatted file
-
-    Returns
-    -------
-    list
-        A list of :class:`openmc.data.endf.Evaluation` instances.
-
-    """
-    evaluations = []
-    with open(str(filename), 'r') as fh:
-        while True:
-            pos = fh.tell()
-            line = fh.readline()
-            if line[66:70] == '  -1':
-                break
-            fh.seek(pos)
-            evaluations.append(Evaluation(fh))
-    return evaluations
 
 
 class Evaluation:

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -805,7 +805,7 @@ class IncidentNeutron(EqualityMixin):
             # Helper function to get a cross section from an ENDF file on a
             # given energy grid
             def get_file3_xs(ev, mt, E):
-                file_obj = StringIO(ev.section[3, mt])
+                file_obj = StringIO(ev.section_text[3, mt])
                 get_head_record(file_obj)
                 _, xs = get_tab1_record(file_obj)
                 return xs(E)

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -805,9 +805,7 @@ class IncidentNeutron(EqualityMixin):
             # Helper function to get a cross section from an ENDF file on a
             # given energy grid
             def get_file3_xs(ev, mt, E):
-                file_obj = StringIO(ev.section_text[3, mt])
-                get_head_record(file_obj)
-                _, xs = get_tab1_record(file_obj)
+                xs = ev.section_data[3, mt]['sigma']
                 return xs(E)
 
             heating_local = Reaction(901)


### PR DESCRIPTION
# Description

making use of endf.get_evaluations from the endf-python package made by paul. this continue the theme of saving a few lines and reducing duplication. endf-python is already a dependency.

let me know if these PR are too small just for future reference.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code

- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)


