### PR TITLE
Add more operator overloads in the new Tensor class

### DIFF
--- a/include/openmc/tensor.h
+++ b/include/openmc/tensor.h
@@ -762,6 +762,18 @@ public:
       data_[i] += o.data_[i];
     return *this;
   }
+  Tensor& operator*=(const Tensor& o)
+  {
+    for (size_t i = 0; i < data_.size(); ++i)
+      data_[i] *= o.data_[i];
+    return *this;
+  }
+  Tensor& operator/=(const Tensor& o)
+  {
+    for (size_t i = 0; i < data_.size(); ++i)
+      data_[i] /= o.data_[i];
+    return *this;
+  }
 
   Tensor operator+(const Tensor& o) const
   {
@@ -782,6 +794,13 @@ public:
     Tensor r(shape_);
     for (size_t i = 0; i < data_.size(); ++i)
       r.data_[i] = data_[i] / o.data_[i];
+    return r;
+  }
+  Tensor operator*(const Tensor& o) const
+  {
+    Tensor r(shape_);
+    for (size_t i = 0; i < data_.size(); ++i)
+      r.data_[i] = data_[i] * o.data_[i];
     return r;
   }
 

--- a/include/openmc/tensor.h
+++ b/include/openmc/tensor.h
@@ -762,6 +762,12 @@ public:
       data_[i] += o.data_[i];
     return *this;
   }
+  Tensor& operator-=(const Tensor& o)
+  {
+    for (size_t i = 0; i < data_.size(); ++i)
+      data_[i] -= o.data_[i];
+    return *this;
+  }
   Tensor& operator*=(const Tensor& o)
   {
     for (size_t i = 0; i < data_.size(); ++i)

--- a/tests/cpp_unit_tests/test_tensor.cpp
+++ b/tests/cpp_unit_tests/test_tensor.cpp
@@ -394,9 +394,9 @@ TEST_CASE("Tensor compound arithmetic with tensor")
 
   a = {1.0, 2.0, 3.0};
   b -= a;
-  REQUIRE(a[0] == 9.0);
-  REQUIRE(a[1] == 18.0);
-  REQUIRE(a[2] == 27.0);
+  REQUIRE(b[0] == 9.0);
+  REQUIRE(b[1] == 18.0);
+  REQUIRE(b[2] == 27.0);
 
   b = {10.0, 20.0, 30.0};
   a *= b;
@@ -406,9 +406,9 @@ TEST_CASE("Tensor compound arithmetic with tensor")
 
   a = {1.0, 2.0, 3.0};
   b /= a;
-  REQUIRE(a[0] == 10.0);
-  REQUIRE(a[1] == 10.0);
-  REQUIRE(a[2] == 10.0);
+  REQUIRE(b[0] == 10.0);
+  REQUIRE(b[1] == 10.0);
+  REQUIRE(b[2] == 10.0);
 }
 
 TEST_CASE("Tensor comparison operators")

--- a/tests/cpp_unit_tests/test_tensor.cpp
+++ b/tests/cpp_unit_tests/test_tensor.cpp
@@ -350,6 +350,9 @@ TEST_CASE("Tensor element-wise arithmetic")
 
   c = a / b;
   REQUIRE(c[0] == 0.25);
+
+  c = a * b;
+  REQUIRE(c[0] == 4.0);
 }
 
 TEST_CASE("Tensor scalar arithmetic")
@@ -378,7 +381,7 @@ TEST_CASE("Tensor scalar arithmetic")
   REQUIRE(b[0] == 11.0);
 }
 
-TEST_CASE("Tensor compound addition with tensor")
+TEST_CASE("Tensor compound arithmetic with tensor")
 {
   Tensor<double> a({3}, 0.0);
   Tensor<double> b({3}, 0.0);
@@ -388,6 +391,24 @@ TEST_CASE("Tensor compound addition with tensor")
   REQUIRE(a[0] == 11.0);
   REQUIRE(a[1] == 22.0);
   REQUIRE(a[2] == 33.0);
+
+  a = {1.0, 2.0, 3.0};
+  b -= a;
+  REQUIRE(a[0] == 9.0);
+  REQUIRE(a[1] == 18.0);
+  REQUIRE(a[2] == 27.0);
+
+  b = {10.0, 20.0, 30.0};
+  a *= b;
+  REQUIRE(a[0] == 10.0);
+  REQUIRE(a[1] == 40.0);
+  REQUIRE(a[2] == 90.0);
+
+  a = {1.0, 2.0, 3.0};
+  b /= a;
+  REQUIRE(a[0] == 10.0);
+  REQUIRE(a[1] == 10.0);
+  REQUIRE(a[2] == 10.0);
 }
 
 TEST_CASE("Tensor comparison operators")


### PR DESCRIPTION
# Description

I've been working on updating Cardinal to the latest version of OpenMC after the removal of XTensor, and found that a few operator overrides are missing in the new tensor class (which saw use in Cardinal). This PR adds those operators to the new tensor class.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [ ] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [ ] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
