### PR TITLE
Speedup CI and Improve Reproducibility Across Compilers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,7 @@ def test_my_feature():
     harness.main()
 ```
 
-**Workflow**: Create `test.py` and `__init__.py` in `tests/regression_tests/my_test/`, run `pytest --update` to generate reference files (`inputs_true.dat`, `results_true.dat`, etc.), then verify with `pytest` without `--update`. Test results should be generated with `-DOPENMC_STRICT_FP=on` to ensure reproducibility across platforms and optimization levels.
+**Workflow**: Create `test.py` and `__init__.py` in `tests/regression_tests/my_test/`, run `pytest --update` to generate reference files (`inputs_true.dat`, `results_true.dat`, etc.), then verify with `pytest` without `--update`. Test results should be generated with `-DOPENMC_ENABLE_STRICT_FP=on` to ensure reproducibility across platforms and optimization levels.
 
 **Critical**: When modifying OpenMC code, regenerate affected test references with `pytest --update` and commit updated reference files.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,7 @@ def test_my_feature():
     harness.main()
 ```
 
-**Workflow**: Create `test.py` and `__init__.py` in `tests/regression_tests/my_test/`, run `pytest --update` to generate reference files (`inputs_true.dat`, `results_true.dat`, etc.), then verify with `pytest` without `--update`. Test results should be generated with a debug build (`-DCMAKE_BUILD_TYPE=Debug`)
+**Workflow**: Create `test.py` and `__init__.py` in `tests/regression_tests/my_test/`, run `pytest --update` to generate reference files (`inputs_true.dat`, `results_true.dat`, etc.), then verify with `pytest` without `--update`. Test results should be generated with `-DOPENMC_STRICT_FP=on` to ensure reproducibility across platforms and optimization levels.
 
 **Critical**: When modifying OpenMC code, regenerate affected test references with `pytest --update` and commit updated reference files.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ option(OPENMC_USE_LIBMESH     "Enable support for libMesh unstructured mesh tall
 option(OPENMC_USE_MPI         "Enable MPI"                                           OFF)
 option(OPENMC_USE_UWUW        "Enable UWUW"                                          OFF)
 option(OPENMC_FORCE_VENDORED_LIBS "Explicitly use submodules defined in 'vendor'"    OFF)
-option(OPENMC_ENABLE_FMA_CONTRACTION "Enable FMA contraction"                        OFF)
+option(OPENMC_ENABLE_FMA_CONTRACTION "Enable floating point FMA contraction"         OFF)
 
 message(STATUS "OPENMC_USE_OPENMP ${OPENMC_USE_OPENMP}")
 message(STATUS "OPENMC_BUILD_TESTS ${OPENMC_BUILD_TESTS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ option(OPENMC_USE_LIBMESH     "Enable support for libMesh unstructured mesh tall
 option(OPENMC_USE_MPI         "Enable MPI"                                           OFF)
 option(OPENMC_USE_UWUW        "Enable UWUW"                                          OFF)
 option(OPENMC_FORCE_VENDORED_LIBS "Explicitly use submodules defined in 'vendor'"    OFF)
+option(OPENMC_ENABLE_FMA_CONTRACTION "Enable FMA contraction"                        OFF)
 
 message(STATUS "OPENMC_USE_OPENMP ${OPENMC_USE_OPENMP}")
 message(STATUS "OPENMC_BUILD_TESTS ${OPENMC_BUILD_TESTS}")
@@ -48,6 +49,7 @@ message(STATUS "OPENMC_USE_LIBMESH ${OPENMC_USE_LIBMESH}")
 message(STATUS "OPENMC_USE_MPI ${OPENMC_USE_MPI}")
 message(STATUS "OPENMC_USE_UWUW ${OPENMC_USE_UWUW}")
 message(STATUS "OPENMC_FORCE_VENDORED_LIBS ${OPENMC_FORCE_VENDORED_LIBS}")
+message(STATUS "OPENMC_ENABLE_FMA_CONTRACTION ${OPENMC_ENABLE_FMA_CONTRACTION}")
 
 # Warnings for deprecated options
 foreach(OLD_OPT IN ITEMS "openmp" "profile" "coverage" "dagmc" "libmesh")
@@ -205,6 +207,19 @@ endif()
 if(OPENMC_ENABLE_COVERAGE)
   list(APPEND cxxflags --coverage)
   list(APPEND ldflags --coverage)
+endif()
+
+# FMA contraction is typically enabled by default at most compiler optimization
+# levels. Explicitly turning off FMA contraction greatly improves cross-system
+# and cross-compiler bit-wise reproducibility, as different compilers have
+# different policies for deciding which operations to contract to FMA
+# instructions. This is important for consistency in regression testing. A user
+# may wish to run with default FMA contraction policies to (potentially) improve
+# performance on floating point heavy workloads, though at the cost of
+# simulations potentially giving different results with different compilers and
+# systems.
+if(NOT OPENMC_ENABLE_FMA_CONTRACTION)
+  list(APPEND cxxflags -ffp-contract=off)
 endif()
 
 # Show flags being used

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,23 @@ endif()
 # Set compile/link flags based on which compiler is being used
 #===============================================================================
 
+# FMA contraction is typically enabled by default at most compiler optimization
+# levels. Explicitly turning off FMA contraction greatly improves cross-system
+# and cross-compiler bit-wise reproducibility, as different compilers have
+# different policies for deciding which operations to contract to FMA
+# instructions. This is important for consistency in regression testing. A user
+# may wish to run with default FMA contraction policies to (potentially) improve
+# performance on floating point heavy workloads, though at the cost of
+# simulations potentially giving different results with different compilers and
+# systems.
+if(NOT OPENMC_ENABLE_FMA_CONTRACTION)
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag(-ffp-contract=off COMPILER_SUPPORTS_FP_CONTRACT)
+  if(COMPILER_SUPPORTS_FP_CONTRACT)
+    list(APPEND cxxflags -ffp-contract=off)
+  endif()
+endif()
+
 # Skip for Visual Studio which has its own configurations through GUI
 if(NOT MSVC)
 
@@ -219,19 +236,6 @@ endif()
 if(OPENMC_ENABLE_COVERAGE)
   list(APPEND cxxflags --coverage)
   list(APPEND ldflags --coverage)
-endif()
-
-# FMA contraction is typically enabled by default at most compiler optimization
-# levels. Explicitly turning off FMA contraction greatly improves cross-system
-# and cross-compiler bit-wise reproducibility, as different compilers have
-# different policies for deciding which operations to contract to FMA
-# instructions. This is important for consistency in regression testing. A user
-# may wish to run with default FMA contraction policies to (potentially) improve
-# performance on floating point heavy workloads, though at the cost of
-# simulations potentially giving different results with different compilers and
-# systems.
-if(NOT OPENMC_ENABLE_FMA_CONTRACTION)
-  list(APPEND cxxflags -ffp-contract=off)
 endif()
 
 # Show flags being used

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ option(OPENMC_USE_LIBMESH     "Enable support for libMesh unstructured mesh tall
 option(OPENMC_USE_MPI         "Enable MPI"                                           OFF)
 option(OPENMC_USE_UWUW        "Enable UWUW"                                          OFF)
 option(OPENMC_FORCE_VENDORED_LIBS "Explicitly use submodules defined in 'vendor'"    OFF)
-option(OPENMC_STRICT_FP "Set strict floating point flags (improves test portability)"OFF)
+option(OPENMC_ENABLE_STRICT_FP "Enable strict FP flags to improve test portability"  OFF)
 
 message(STATUS "OPENMC_USE_OPENMP ${OPENMC_USE_OPENMP}")
 message(STATUS "OPENMC_BUILD_TESTS ${OPENMC_BUILD_TESTS}")
@@ -49,7 +49,7 @@ message(STATUS "OPENMC_USE_LIBMESH ${OPENMC_USE_LIBMESH}")
 message(STATUS "OPENMC_USE_MPI ${OPENMC_USE_MPI}")
 message(STATUS "OPENMC_USE_UWUW ${OPENMC_USE_UWUW}")
 message(STATUS "OPENMC_FORCE_VENDORED_LIBS ${OPENMC_FORCE_VENDORED_LIBS}")
-message(STATUS "OPENMC_STRICT_FP ${OPENMC_STRICT_FP}")
+message(STATUS "OPENMC_ENABLE_STRICT_FP ${OPENMC_ENABLE_STRICT_FP}")
 
 # Warnings for deprecated options
 foreach(OLD_OPT IN ITEMS "openmp" "profile" "coverage" "dagmc" "libmesh")
@@ -97,7 +97,7 @@ endif()
 # RelWithDebInfo, which disables C/C++ assert() statements.
 #===============================================================================
 
-if(OPENMC_STRICT_FP)
+if(OPENMC_ENABLE_STRICT_FP)
   foreach(FLAG_VAR CMAKE_CXX_FLAGS_RELWITHDEBINFO CMAKE_C_FLAGS_RELWITHDEBINFO)
     string(REPLACE "-DNDEBUG" "" ${FLAG_VAR} "${${FLAG_VAR}}")
     string(REPLACE "/DNDEBUG" "" ${FLAG_VAR} "${${FLAG_VAR}}")
@@ -208,7 +208,7 @@ endif()
 # Set compile/link flags based on which compiler is being used
 #===============================================================================
 
-# When OPENMC_STRICT_FP is enabled, disable compiler optimizations that change
+# When OPENMC_ENABLE_STRICT_FP is enabled, disable compiler optimizations that change
 # floating-point results relative to -O0, improving cross-platform and
 # cross-optimization-level reproducibility for regression testing:
 #   -ffp-contract=off    Prevents FMA contraction (fused multiply-add changes rounding)
@@ -216,7 +216,7 @@ endif()
 #                        with builtin versions that may differ from libm
 # By default (OFF), the compiler is free to use all optimizations for best
 # performance.
-if(OPENMC_STRICT_FP)
+if(OPENMC_ENABLE_STRICT_FP)
   include(CheckCXXCompilerFlag)
   check_cxx_compiler_flag(-ffp-contract=off SUPPORTS_FP_CONTRACT_OFF)
   if(SUPPORTS_FP_CONTRACT_OFF)
@@ -590,8 +590,8 @@ endif()
 if (OPENMC_ENABLE_COVERAGE)
   target_compile_definitions(libopenmc PRIVATE COVERAGEBUILD)
 endif()
-if (OPENMC_STRICT_FP)
-  target_compile_definitions(libopenmc PRIVATE OPENMC_STRICT_FP_BUILD)
+if (OPENMC_ENABLE_STRICT_FP)
+  target_compile_definitions(libopenmc PRIVATE OPENMC_ENABLE_STRICT_FP_BUILD)
 endif()
 
 #===============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,16 +92,17 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 #===============================================================================
-# Remove NDEBUG from RelWithDebInfo flags so that assert() remains active in
-# the default build mode. CMake normally adds -DNDEBUG for both Release and
-# RelWithDebInfo, which disables C/C++ assert() statements. We keep NDEBUG
-# in Release mode for users who want maximum performance.
+# When STRICT_FP is enabled, remove NDEBUG from RelWithDebInfo flags so that
+# assert() remains active. CMake normally adds -DNDEBUG for both Release and
+# RelWithDebInfo, which disables C/C++ assert() statements.
 #===============================================================================
 
-foreach(FLAG_VAR CMAKE_CXX_FLAGS_RELWITHDEBINFO CMAKE_C_FLAGS_RELWITHDEBINFO)
-  string(REPLACE "-DNDEBUG" "" ${FLAG_VAR} "${${FLAG_VAR}}")
-  string(REPLACE "/DNDEBUG" "" ${FLAG_VAR} "${${FLAG_VAR}}")
-endforeach()
+if(OPENMC_STRICT_FP)
+  foreach(FLAG_VAR CMAKE_CXX_FLAGS_RELWITHDEBINFO CMAKE_C_FLAGS_RELWITHDEBINFO)
+    string(REPLACE "-DNDEBUG" "" ${FLAG_VAR} "${${FLAG_VAR}}")
+    string(REPLACE "/DNDEBUG" "" ${FLAG_VAR} "${${FLAG_VAR}}")
+  endforeach()
+endif()
 
 #===============================================================================
 # OpenMP for shared-memory parallelism (and GPU support some day!)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,6 @@ endif()
 # floating-point results relative to -O0, improving cross-platform and
 # cross-optimization-level reproducibility for regression testing:
 #   -ffp-contract=off    Prevents FMA contraction (fused multiply-add changes rounding)
-#   -fno-tree-vectorize  Prevents auto-vectorization (changes summation order)
 #   -fno-builtin         Prevents replacing math function calls (pow, exp, log, etc.)
 #                        with builtin versions that may differ from libm
 # By default (OFF), the compiler is free to use all optimizations for best
@@ -221,10 +220,6 @@ if(OPENMC_STRICT_FP)
   check_cxx_compiler_flag(-ffp-contract=off SUPPORTS_FP_CONTRACT_OFF)
   if(SUPPORTS_FP_CONTRACT_OFF)
     list(APPEND cxxflags -ffp-contract=off)
-  endif()
-  check_cxx_compiler_flag(-fno-tree-vectorize SUPPORTS_NO_TREE_VECTORIZE)
-  if(SUPPORTS_NO_TREE_VECTORIZE)
-    list(APPEND cxxflags -fno-tree-vectorize)
   endif()
   check_cxx_compiler_flag(-fno-builtin SUPPORTS_NO_BUILTIN)
   if(SUPPORTS_NO_BUILTIN)
@@ -593,6 +588,9 @@ if (OPENMC_ENABLE_PROFILE)
 endif()
 if (OPENMC_ENABLE_COVERAGE)
   target_compile_definitions(libopenmc PRIVATE COVERAGEBUILD)
+endif()
+if (OPENMC_STRICT_FP)
+  target_compile_definitions(libopenmc PRIVATE OPENMC_STRICT_FP_BUILD)
 endif()
 
 #===============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,7 +591,7 @@ if (OPENMC_ENABLE_COVERAGE)
   target_compile_definitions(libopenmc PRIVATE COVERAGEBUILD)
 endif()
 if (OPENMC_ENABLE_STRICT_FP)
-  target_compile_definitions(libopenmc PRIVATE OPENMC_ENABLE_STRICT_FP_BUILD)
+  target_compile_definitions(libopenmc PRIVATE OPENMC_ENABLE_STRICT_FP)
 endif()
 
 #===============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,14 +207,15 @@ endif()
 # Set compile/link flags based on which compiler is being used
 #===============================================================================
 
-# When OPENMC_STRICT_FP is enabled, disable FMA contraction and
-# auto-vectorization to improve cross-system and cross-compiler floating-point
-# reproducibility. FMA contraction fuses multiply-add into a single instruction
-# with different rounding behavior, and auto-vectorization changes summation
-# order in reductions (e.g., AVX uses 256-bit vectors on x86 vs. 128-bit NEON
-# on ARM). Both cause bit-level differences across platforms. Disabling these
-# is important for consistency in regression testing. By default (OFF), the
-# compiler is free to use FMA and vectorization for best performance.
+# When OPENMC_STRICT_FP is enabled, disable compiler optimizations that change
+# floating-point results relative to -O0, improving cross-platform and
+# cross-optimization-level reproducibility for regression testing:
+#   -ffp-contract=off    Prevents FMA contraction (fused multiply-add changes rounding)
+#   -fno-tree-vectorize  Prevents auto-vectorization (changes summation order)
+#   -fno-builtin         Prevents replacing math function calls (pow, exp, log, etc.)
+#                        with builtin versions that may differ from libm
+# By default (OFF), the compiler is free to use all optimizations for best
+# performance.
 if(OPENMC_STRICT_FP)
   include(CheckCXXCompilerFlag)
   check_cxx_compiler_flag(-ffp-contract=off SUPPORTS_FP_CONTRACT_OFF)
@@ -224,6 +225,10 @@ if(OPENMC_STRICT_FP)
   check_cxx_compiler_flag(-fno-tree-vectorize SUPPORTS_NO_TREE_VECTORIZE)
   if(SUPPORTS_NO_TREE_VECTORIZE)
     list(APPEND cxxflags -fno-tree-vectorize)
+  endif()
+  check_cxx_compiler_flag(-fno-builtin SUPPORTS_NO_BUILTIN)
+  if(SUPPORTS_NO_BUILTIN)
+    list(APPEND cxxflags -fno-builtin)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,18 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 #===============================================================================
+# Remove NDEBUG from RelWithDebInfo flags so that assert() remains active in
+# the default build mode. CMake normally adds -DNDEBUG for both Release and
+# RelWithDebInfo, which disables C/C++ assert() statements. We keep NDEBUG
+# in Release mode for users who want maximum performance.
+#===============================================================================
+
+foreach(FLAG_VAR CMAKE_CXX_FLAGS_RELWITHDEBINFO CMAKE_C_FLAGS_RELWITHDEBINFO)
+  string(REPLACE "-DNDEBUG" "" ${FLAG_VAR} "${${FLAG_VAR}}")
+  string(REPLACE "/DNDEBUG" "" ${FLAG_VAR} "${${FLAG_VAR}}")
+endforeach()
+
+#===============================================================================
 # OpenMP for shared-memory parallelism (and GPU support some day!)
 #===============================================================================
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ option(OPENMC_USE_LIBMESH     "Enable support for libMesh unstructured mesh tall
 option(OPENMC_USE_MPI         "Enable MPI"                                           OFF)
 option(OPENMC_USE_UWUW        "Enable UWUW"                                          OFF)
 option(OPENMC_FORCE_VENDORED_LIBS "Explicitly use submodules defined in 'vendor'"    OFF)
-option(OPENMC_ENABLE_FMA_CONTRACTION "Enable floating point FMA contraction"         OFF)
+option(OPENMC_STRICT_FP "Set strict floating point flags (improves test portability)"OFF)
 
 message(STATUS "OPENMC_USE_OPENMP ${OPENMC_USE_OPENMP}")
 message(STATUS "OPENMC_BUILD_TESTS ${OPENMC_BUILD_TESTS}")
@@ -49,7 +49,7 @@ message(STATUS "OPENMC_USE_LIBMESH ${OPENMC_USE_LIBMESH}")
 message(STATUS "OPENMC_USE_MPI ${OPENMC_USE_MPI}")
 message(STATUS "OPENMC_USE_UWUW ${OPENMC_USE_UWUW}")
 message(STATUS "OPENMC_FORCE_VENDORED_LIBS ${OPENMC_FORCE_VENDORED_LIBS}")
-message(STATUS "OPENMC_ENABLE_FMA_CONTRACTION ${OPENMC_ENABLE_FMA_CONTRACTION}")
+message(STATUS "OPENMC_STRICT_FP ${OPENMC_STRICT_FP}")
 
 # Warnings for deprecated options
 foreach(OLD_OPT IN ITEMS "openmp" "profile" "coverage" "dagmc" "libmesh")
@@ -207,20 +207,23 @@ endif()
 # Set compile/link flags based on which compiler is being used
 #===============================================================================
 
-# FMA contraction is typically enabled by default at most compiler optimization
-# levels. Explicitly turning off FMA contraction greatly improves cross-system
-# and cross-compiler bit-wise reproducibility, as different compilers have
-# different policies for deciding which operations to contract to FMA
-# instructions. This is important for consistency in regression testing. A user
-# may wish to run with default FMA contraction policies to (potentially) improve
-# performance on floating point heavy workloads, though at the cost of
-# simulations potentially giving different results with different compilers and
-# systems.
-if(NOT OPENMC_ENABLE_FMA_CONTRACTION)
+# When OPENMC_STRICT_FP is enabled, disable FMA contraction and
+# auto-vectorization to improve cross-system and cross-compiler floating-point
+# reproducibility. FMA contraction fuses multiply-add into a single instruction
+# with different rounding behavior, and auto-vectorization changes summation
+# order in reductions (e.g., AVX uses 256-bit vectors on x86 vs. 128-bit NEON
+# on ARM). Both cause bit-level differences across platforms. Disabling these
+# is important for consistency in regression testing. By default (OFF), the
+# compiler is free to use FMA and vectorization for best performance.
+if(OPENMC_STRICT_FP)
   include(CheckCXXCompilerFlag)
-  check_cxx_compiler_flag(-ffp-contract=off COMPILER_SUPPORTS_FP_CONTRACT)
-  if(COMPILER_SUPPORTS_FP_CONTRACT)
+  check_cxx_compiler_flag(-ffp-contract=off SUPPORTS_FP_CONTRACT_OFF)
+  if(SUPPORTS_FP_CONTRACT_OFF)
     list(APPEND cxxflags -ffp-contract=off)
+  endif()
+  check_cxx_compiler_flag(-fno-tree-vectorize SUPPORTS_NO_TREE_VECTORIZE)
+  if(SUPPORTS_NO_TREE_VECTORIZE)
+    list(APPEND cxxflags -fno-tree-vectorize)
   endif()
 endif()
 

--- a/docs/source/devguide/tests.rst
+++ b/docs/source/devguide/tests.rst
@@ -37,6 +37,9 @@ Prerequisites
 - Some tests require `NJOY <https://www.njoy21.io/NJOY2016>`_ to preprocess
   cross section data. The test suite assumes that you have an ``njoy``
   executable available on your :envvar:`PATH`.
+- OpenMC should be compiled with ``-DOPENMC_ENABLE_STRICT_FP=on`` to ensure
+  reproducible floating-point results across platforms and optimization levels.
+  Without this flag, regression tests may not match reference values.
 
 Running Tests
 -------------
@@ -67,7 +70,7 @@ make sure you have satisfied all the prerequisites above. After you have done
 that, consider the following:
 
 - When building OpenMC, make sure you run CMake with
-  ``-DOPENMC_STRICT_FP=on``. This prevents the compiler from applying
+  ``-DOPENMC_ENABLE_STRICT_FP=on``. This prevents the compiler from applying
   floating-point optimizations (such as replacing math library calls with
   builtins or contracting multiply-add into FMA instructions) that can produce
   bit-level differences across platforms and optimization levels. Any

--- a/docs/source/devguide/tests.rst
+++ b/docs/source/devguide/tests.rst
@@ -67,9 +67,11 @@ make sure you have satisfied all the prerequisites above. After you have done
 that, consider the following:
 
 - When building OpenMC, make sure you run CMake with
-  ``-DCMAKE_BUILD_TYPE=Debug``. Building with a release build will result in
-  some test failures due to differences in which compiler optimizations are
-  used.
+  ``-DOPENMC_STRICT_FP=on``. This prevents the compiler from applying
+  floating-point optimizations (such as replacing math library calls with
+  builtins or contracting multiply-add into FMA instructions) that can produce
+  bit-level differences across platforms and optimization levels. Any
+  ``CMAKE_BUILD_TYPE`` can be used.
 - Because tallies involve the sum of many floating point numbers, the
   non-associativity of floating point numbers can result in different answers
   especially when the number of threads is high (different order of operations).

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -384,14 +384,15 @@ OPENMC_USE_MPI
   <https://cmake.org/cmake/help/latest/module/FindMPI.html>`_.
 
 OPENMC_STRICT_FP
-  Disables floating-point FMA contraction and compiler auto-vectorization to
-  improve cross-system and cross-compiler reproducibility. FMA contraction fuses
-  multiply-add into a single instruction with different rounding, and
-  auto-vectorization changes summation order in reductions (e.g., 256-bit AVX on
-  x86 vs. 128-bit NEON on ARM), both of which cause bit-level differences across
-  platforms. This option is used in CI for regression testing. By default (off),
-  the compiler is free to use FMA and vectorization for best performance.
-  (Default: off)
+  Disables compiler optimizations that change floating-point results relative to
+  unoptimized builds, improving cross-platform and cross-optimization-level
+  reproducibility. This disables FMA contraction (``-ffp-contract=off``),
+  auto-vectorization (``-fno-tree-vectorize``), and compiler builtin replacements
+  of math functions like ``pow``, ``exp``, ``log`` (``-fno-builtin``). Without
+  this flag, these optimizations can produce bit-level differences across
+  platforms, compilers, and optimization levels. This option is used in CI for
+  regression testing. By default (off), the compiler is free to use all
+  optimizations for best performance. (Default: off)
 
 OPENMC_FORCE_VENDORED_LIBS
   Forces OpenMC to use the submodules located in the vendor directory, as

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -383,15 +383,19 @@ OPENMC_USE_MPI
   options, please see the `FindMPI.cmake documentation
   <https://cmake.org/cmake/help/latest/module/FindMPI.html>`_.
 
+.. _cmake_strict_fp:
+
 OPENMC_STRICT_FP
   Disables compiler optimizations that change floating-point results relative to
   unoptimized builds, improving cross-platform and cross-optimization-level
   reproducibility. This disables FMA contraction (``-ffp-contract=off``) and
   compiler builtin replacements of math functions like ``pow``, ``exp``, ``log``
-  (``-fno-builtin``). Without this flag, these optimizations can produce
-  bit-level differences across platforms, compilers, and optimization levels.
-  This option should be used when running the test suite. By default (off), the
-  compiler is free to use all optimizations for best performance. (Default: off)
+  (``-fno-builtin``). It also keeps C/C++ assertions active by removing the
+  ``-DNDEBUG`` flag from ``RelWithDebInfo`` builds. Without this flag, these
+  optimizations can produce bit-level differences across platforms, compilers,
+  and optimization levels. This option should be used when running the test
+  suite. By default (off), the compiler is free to use all optimizations for
+  best performance. (Default: off)
 
 OPENMC_FORCE_VENDORED_LIBS
   Forces OpenMC to use the submodules located in the vendor directory, as
@@ -425,7 +429,8 @@ Release
 
 RelWithDebInfo
   (Default if no type is specified.) Enable optimization and debug. On most
-  platforms/compilers, this is equivalent to `-O2 -g`. OpenMC removes the
+  platforms/compilers, this is equivalent to `-O2 -g`. When
+  :ref:`OPENMC_STRICT_FP <cmake_strict_fp>` is enabled, OpenMC removes the
   ``-DNDEBUG`` flag that CMake normally adds for this build type, so that
   C/C++ assertions remain active.
 

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -383,6 +383,15 @@ OPENMC_USE_MPI
   options, please see the `FindMPI.cmake documentation
   <https://cmake.org/cmake/help/latest/module/FindMPI.html>`_.
 
+OPENMC_ENABLE_FMA_CONTRACTION
+  Enables floating-point fused multiply-add (FMA) contraction. FMA contraction
+  is turned off by default to improve cross-system and cross-compiler bitwise
+  reproducibility, since different compilers have different policies for
+  deciding which operations to contract to FMA instructions. Turning FMA
+  contraction on may improve performance for floating-point heavy workloads,
+  but simulations may give different results with different compilers and
+  systems. (Default: off)
+
 OPENMC_FORCE_VENDORED_LIBS
   Forces OpenMC to use the submodules located in the vendor directory, as
   opposed to searching the system for already installed versions of those
@@ -415,7 +424,9 @@ Release
 
 RelWithDebInfo
   (Default if no type is specified.) Enable optimization and debug. On most
-  platforms/compilers, this is equivalent to `-O2 -g`.
+  platforms/compilers, this is equivalent to `-O2 -g`. OpenMC removes the
+  ``-DNDEBUG`` flag that CMake normally adds for this build type, so that
+  C/C++ assertions remain active.
 
 Example of configuring for Debug mode:
 

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -383,14 +383,15 @@ OPENMC_USE_MPI
   options, please see the `FindMPI.cmake documentation
   <https://cmake.org/cmake/help/latest/module/FindMPI.html>`_.
 
-OPENMC_ENABLE_FMA_CONTRACTION
-  Enables floating-point fused multiply-add (FMA) contraction. FMA contraction
-  is turned off by default to improve cross-system and cross-compiler bitwise
-  reproducibility, since different compilers have different policies for
-  deciding which operations to contract to FMA instructions. Turning FMA
-  contraction on may improve performance for floating-point heavy workloads,
-  but simulations may give different results with different compilers and
-  systems. (Default: off)
+OPENMC_STRICT_FP
+  Disables floating-point FMA contraction and compiler auto-vectorization to
+  improve cross-system and cross-compiler reproducibility. FMA contraction fuses
+  multiply-add into a single instruction with different rounding, and
+  auto-vectorization changes summation order in reductions (e.g., 256-bit AVX on
+  x86 vs. 128-bit NEON on ARM), both of which cause bit-level differences across
+  platforms. This option is used in CI for regression testing. By default (off),
+  the compiler is free to use FMA and vectorization for best performance.
+  (Default: off)
 
 OPENMC_FORCE_VENDORED_LIBS
   Forces OpenMC to use the submodules located in the vendor directory, as

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -386,13 +386,12 @@ OPENMC_USE_MPI
 OPENMC_STRICT_FP
   Disables compiler optimizations that change floating-point results relative to
   unoptimized builds, improving cross-platform and cross-optimization-level
-  reproducibility. This disables FMA contraction (``-ffp-contract=off``),
-  auto-vectorization (``-fno-tree-vectorize``), and compiler builtin replacements
-  of math functions like ``pow``, ``exp``, ``log`` (``-fno-builtin``). Without
-  this flag, these optimizations can produce bit-level differences across
-  platforms, compilers, and optimization levels. This option is used in CI for
-  regression testing. By default (off), the compiler is free to use all
-  optimizations for best performance. (Default: off)
+  reproducibility. This disables FMA contraction (``-ffp-contract=off``) and
+  compiler builtin replacements of math functions like ``pow``, ``exp``, ``log``
+  (``-fno-builtin``). Without this flag, these optimizations can produce
+  bit-level differences across platforms, compilers, and optimization levels.
+  This option should be used when running the test suite. By default (off), the
+  compiler is free to use all optimizations for best performance. (Default: off)
 
 OPENMC_FORCE_VENDORED_LIBS
   Forces OpenMC to use the submodules located in the vendor directory, as

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -385,7 +385,7 @@ OPENMC_USE_MPI
 
 .. _cmake_strict_fp:
 
-OPENMC_STRICT_FP
+OPENMC_ENABLE_STRICT_FP
   Disables compiler optimizations that change floating-point results relative to
   unoptimized builds, improving cross-platform and cross-optimization-level
   reproducibility. This disables FMA contraction (``-ffp-contract=off``) and
@@ -430,7 +430,7 @@ Release
 RelWithDebInfo
   (Default if no type is specified.) Enable optimization and debug. On most
   platforms/compilers, this is equivalent to `-O2 -g`. When
-  :ref:`OPENMC_STRICT_FP <cmake_strict_fp>` is enabled, OpenMC removes the
+  :ref:`OPENMC_ENABLE_STRICT_FP <cmake_strict_fp>` is enabled, OpenMC removes the
   ``-DNDEBUG`` flag that CMake normally adds for this build type, so that
   C/C++ assertions remain active.
 

--- a/include/openmc/output.h
+++ b/include/openmc/output.h
@@ -10,6 +10,8 @@
 
 namespace openmc {
 
+extern "C" const bool STRICT_FP_ENABLED;
+
 //! \brief Display the main title banner as well as information about the
 //! program developers, version, and date/time which the problem was run.
 void title();

--- a/openmc/lib/__init__.py
+++ b/openmc/lib/__init__.py
@@ -49,6 +49,9 @@ def _libmesh_enabled():
 def _uwuw_enabled():
     return c_bool.in_dll(_dll, "UWUW_ENABLED").value
 
+def _strict_fp_enabled():
+    return c_bool.in_dll(_dll, "STRICT_FP_ENABLED").value
+
 
 from .error import *
 from .core import *

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -44,7 +44,7 @@
 
 namespace openmc {
 
-#ifdef OPENMC_ENABLE_STRICT_FP_BUILD
+#ifdef OPENMC_ENABLE_STRICT_FP
 const bool STRICT_FP_ENABLED = true;
 #else
 const bool STRICT_FP_ENABLED = false;
@@ -323,7 +323,6 @@ void print_build_info()
   std::string coverage(n);
   std::string mcpl(n);
   std::string uwuw(n);
-  std::string strict_fp(n);
 
 #ifdef PHDF5
   phdf5 = y;
@@ -352,9 +351,6 @@ void print_build_info()
 #ifdef OPENMC_UWUW_ENABLED
   uwuw = y;
 #endif
-#ifdef OPENMC_ENABLE_STRICT_FP_BUILD
-  strict_fp = y;
-#endif
 
   // Wraps macro variables in quotes
 #define STRINGIFY(x) STRINGIFY2(x)
@@ -373,7 +369,7 @@ void print_build_info()
     fmt::print("Coverage testing:      {}\n", coverage);
     fmt::print("Profiling flags:       {}\n", profiling);
     fmt::print("UWUW support:          {}\n", uwuw);
-    fmt::print("Strict FP:             {}\n", strict_fp);
+    fmt::print("Strict FP:             {}\n", STRICT_FP_ENABLED ? y : n);
   }
 }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -44,7 +44,7 @@
 
 namespace openmc {
 
-#ifdef OPENMC_STRICT_FP_BUILD
+#ifdef OPENMC_ENABLE_STRICT_FP_BUILD
 const bool STRICT_FP_ENABLED = true;
 #else
 const bool STRICT_FP_ENABLED = false;
@@ -352,7 +352,7 @@ void print_build_info()
 #ifdef OPENMC_UWUW_ENABLED
   uwuw = y;
 #endif
-#ifdef OPENMC_STRICT_FP_BUILD
+#ifdef OPENMC_ENABLE_STRICT_FP_BUILD
   strict_fp = y;
 #endif
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -44,6 +44,12 @@
 
 namespace openmc {
 
+#ifdef OPENMC_STRICT_FP_BUILD
+const bool STRICT_FP_ENABLED = true;
+#else
+const bool STRICT_FP_ENABLED = false;
+#endif
+
 //==============================================================================
 
 void title()
@@ -317,6 +323,7 @@ void print_build_info()
   std::string coverage(n);
   std::string mcpl(n);
   std::string uwuw(n);
+  std::string strict_fp(n);
 
 #ifdef PHDF5
   phdf5 = y;
@@ -345,6 +352,9 @@ void print_build_info()
 #ifdef OPENMC_UWUW_ENABLED
   uwuw = y;
 #endif
+#ifdef OPENMC_STRICT_FP_BUILD
+  strict_fp = y;
+#endif
 
   // Wraps macro variables in quotes
 #define STRINGIFY(x) STRINGIFY2(x)
@@ -363,6 +373,7 @@ void print_build_info()
     fmt::print("Coverage testing:      {}\n", coverage);
     fmt::print("Profiling flags:       {}\n", profiling);
     fmt::print("UWUW support:          {}\n", uwuw);
+    fmt::print("Strict FP:             {}\n", strict_fp);
   }
 }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -323,6 +323,7 @@ void print_build_info()
   std::string coverage(n);
   std::string mcpl(n);
   std::string uwuw(n);
+  std::string strict_fp(n);
 
 #ifdef PHDF5
   phdf5 = y;
@@ -351,6 +352,9 @@ void print_build_info()
 #ifdef OPENMC_UWUW_ENABLED
   uwuw = y;
 #endif
+#ifdef OPENMC_ENABLE_STRICT_FP
+  strict_fp = y;
+#endif
 
   // Wraps macro variables in quotes
 #define STRINGIFY(x) STRINGIFY2(x)
@@ -369,7 +373,7 @@ void print_build_info()
     fmt::print("Coverage testing:      {}\n", coverage);
     fmt::print("Profiling flags:       {}\n", profiling);
     fmt::print("UWUW support:          {}\n", uwuw);
-    fmt::print("Strict FP:             {}\n", STRICT_FP_ENABLED ? y : n);
+    fmt::print("Strict FP:             {}\n", strict_fp);
   }
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,50 @@
 import os
+import hashlib
 import pytest
 import openmc
+import openmc.lib
 
 from tests.regression_tests import config as regression_config
+
+# MD5 hash of the official NNDC HDF5 cross_sections.xml file.
+# Generated via: md5sum /path/to/nndc_hdf5/cross_sections.xml
+_NNDC_XS_MD5 = "2d00773012eda670bc9f95d96a31c989"
+
+# Collected during pytest_configure, displayed at start and end of session
+_environment_warnings = []
+
+
+def _check_build_environment():
+    """Check STRICT_FP and cross section data, collecting any warnings."""
+    if not openmc.lib._strict_fp_enabled():
+        _environment_warnings.append(
+            "OpenMC was NOT built with -DOPENMC_STRICT_FP=on. "
+            "Regression test results may not match reference values due to "
+            "compiler floating-point optimizations. Rebuild with "
+            "-DOPENMC_STRICT_FP=on for reproducible results."
+        )
+
+    xs_path = os.environ.get("OPENMC_CROSS_SECTIONS")
+    if not xs_path:
+        _environment_warnings.append(
+            "OPENMC_CROSS_SECTIONS environment variable is not set. "
+            "Regression tests require the NNDC HDF5 cross section data."
+        )
+    elif not os.path.isfile(xs_path):
+        _environment_warnings.append(
+            f"OPENMC_CROSS_SECTIONS ({xs_path}) is not a valid file path. "
+            "Regression tests require the NNDC HDF5 cross section data."
+        )
+    else:
+        with open(xs_path, "rb") as f:
+            md5 = hashlib.md5(f.read()).hexdigest()
+        if md5 != _NNDC_XS_MD5:
+            _environment_warnings.append(
+                f"OPENMC_CROSS_SECTIONS ({xs_path}) does not match the "
+                "official NNDC HDF5 dataset. Regression tests expect the "
+                "NNDC data; results may differ with other cross section "
+                "libraries."
+            )
 
 
 def pytest_addoption(parser):
@@ -20,6 +62,28 @@ def pytest_configure(config):
     for opt in opts:
         if config.getoption(opt) is not None:
             regression_config[opt] = config.getoption(opt)
+
+    _check_build_environment()
+
+
+def _print_environment_warnings(terminalreporter):
+    """Print environment warnings as a visible section."""
+    if _environment_warnings:
+        terminalreporter.section("OpenMC Environment Warnings")
+        for msg in _environment_warnings:
+            terminalreporter.line(f"WARNING: {msg}", yellow=True)
+        terminalreporter.line("")
+
+
+def pytest_sessionstart(session):
+    """Print environment warnings at the start of the test session."""
+    _print_environment_warnings(session.config.pluginmanager.get_plugin(
+        "terminalreporter"))
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Reprint environment warnings at the end so they aren't missed."""
+    _print_environment_warnings(terminalreporter)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,10 @@ def _check_build_environment():
     """Check STRICT_FP and cross section data, collecting any warnings."""
     if not openmc.lib._strict_fp_enabled():
         _environment_warnings.append(
-            "OpenMC was NOT built with -DOPENMC_STRICT_FP=on. "
+            "OpenMC was NOT built with -DOPENMC_ENABLE_STRICT_FP=on. "
             "Regression test results may not match reference values due to "
             "compiler floating-point optimizations. Rebuild with "
-            "-DOPENMC_STRICT_FP=on for reproducible results."
+            "-DOPENMC_ENABLE_STRICT_FP=on for reproducible results."
         )
 
     xs_path = os.environ.get("OPENMC_CROSS_SECTIONS")

--- a/tools/ci/gha-install.py
+++ b/tools/ci/gha-install.py
@@ -9,8 +9,8 @@ def install(omp=False, mpi=False, phdf5=False, dagmc=False, libmesh=False):
     os.mkdir('build')
     os.chdir('build')
 
-    # Build in debug mode by default with support for MCPL
-    cmake_cmd = ['cmake', '-DCMAKE_BUILD_TYPE=Debug', '-DOPENMC_USE_MCPL=on']
+    # Build in RelWithDebInfo mode by default with support for MCPL
+    cmake_cmd = ['cmake', '-DCMAKE_BUILD_TYPE=RelWithDebInfo', '-DOPENMC_USE_MCPL=on']
 
     # Turn off OpenMP if specified
     if not omp:

--- a/tools/ci/gha-install.py
+++ b/tools/ci/gha-install.py
@@ -43,6 +43,9 @@ def install(omp=False, mpi=False, phdf5=False, dagmc=False, libmesh=False):
     # Build in coverage mode for coverage testing
     cmake_cmd.append('-DOPENMC_ENABLE_COVERAGE=on')
 
+    # Enable strict FP for cross-platform reproducibility in CI
+    cmake_cmd.append('-DOPENMC_STRICT_FP=on')
+
     # Build and install
     cmake_cmd.append('..')
     print(' '.join(cmake_cmd))

--- a/tools/ci/gha-install.py
+++ b/tools/ci/gha-install.py
@@ -44,7 +44,7 @@ def install(omp=False, mpi=False, phdf5=False, dagmc=False, libmesh=False):
     cmake_cmd.append('-DOPENMC_ENABLE_COVERAGE=on')
 
     # Enable strict FP for cross-platform reproducibility in CI
-    cmake_cmd.append('-DOPENMC_STRICT_FP=on')
+    cmake_cmd.append('-DOPENMC_ENABLE_STRICT_FP=on')
 
     # Build and install
     cmake_cmd.append('..')


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# The Problem with FMAs

As discussed in much more depth in Issue #3820 - our regression tests are not currently perfectly portable between different compilers and systems. 

In this PR, we specifically address Item (3) identified in Issue #3820: Differences in compiler FMA contraction.

To refresh our memories from the #3820 writeup, operations like:

```C++
  for (int i = 0; i < nuclide_.size(); ++i) {
    int i_nuc = nuclide_[i];
    double awr = settings::run_CE ? data::nuclides[i_nuc]->awr_ : 1.0;
    int z = settings::run_CE ? data::nuclides[i_nuc]->Z_ : 0.0;
    density_gpcc_ += atom_density_(i) * awr * MASS_NEUTRON / N_AVOGADRO;  # Potential FMA
    charge_density_ += atom_density_(i) * z; # Potential FMA
  }
```

Will change results depending on the approach to FMA contraction that the compiler is taking. I.e., whether or not to combine multiple operations into one FMA operation or leave them as is - resulting in different rounding. Thus, before we've even sampled the first particle, our underlying material/XS data is a little different. It won't take long before you get macro-scale particle divergence.

# The Fix

I've found that this problem tends to produce differences between older and new versions of gcc, as well as gcc vs. clang. This is partly due to differences in how the two compilers go about making choices of what to contract, and partially due to differences in their default flags. Thankfully, there are flags that can offer a little more explicit control over FMA contraction globally.

Choices for this are:

- -ffp-contract=off
- -ffp-contract=on (default for clang)
- -ffp-contract=fast (default for gcc)

For a linux image, I had claude run all the tests across a variety of different gcc/clang versions and with each of the different flags (plus default where no flag was provided). The results are below:

### Number of Regression Test Failures

| Compiler | `default` | `-ffp-contract=off` | `-ffp-contract=on` | `-ffp-contract=fast` |
|----------|:---------:|:-------------------:|:-------------------:|:--------------------:|
| gcc-11   | **49** | **0** | **0** | **49** |
| gcc-13   | **49** | **0** | **0** | **49** |
| gcc-14   | **49** | **0** | **47** | **49** |
| clang-14 | **47** | **0** | **47** | **49** |
| clang-18 | **47** | **0** | **47** | **49** |

Notably, this comparison is against the current expected results in OpenMC (i.e., what the CI has). It shows that by default, none of the gcc or clang versions on this linux image (a fairly default ubuntu 24.04) give the same result as the CI. Setting things to `-ffp-contract=on` helps for gcc but not clang. So: the only viable options are `-ffp-contract=off` or `-ffp-contract=fast`.

On the one hand, going with `fast` seems attractive as this guarantees FMAs are used the most aggressively, giving slightly higher precision due to reduced rounding and potentially better runtime performance. The downsides to `-ffp-contract=fast` are:

1) pytest crashes out (looks like a seg fault?) on `cmfd_feed_ng`, so that would need to be tracked down as it prevents the rest of the tests from running, and

2) different compilers/versions may still have different internal rules/logic they follow for deciding on FMA utilization. Some compilers may be able to deduce that an FMA can be used to combine disjoint lines whereas another might not be advanced enough to realize that, such that we may still get differences.

In this light, I'm proposing in this PR to have OpenMC specify `-ffp-contract=off` by default. I don't think this will have any significant impact on performance as most simulations are typically memory/latency bound, such that the difference between 1 FMA vs. two regular FP operations would not be observable. If a user has a really floating-point intensive workload they are interested in, they can now compile with `OPENMC_ENABLE_FMA_CONTRACTION=ON` to easily test out if they get a performance benefit or not. Additionally, in the case where clear use cases are identified where the flag is making a performance impact, we can always do some analysis on the hot kernels and add in a few `std::fma()` operations manually to explicitly use FMAs. When explicit FMA intrinsics or `std::fma()` are used, then the flag won't override that, so behavior would be consistent. An added benefit to `-ffp-contract=off` is that it appears to match the behavior of the compiler that the CI uses (I believe a fairly old version of gcc?).

I'm open to other ideas though. I'm curious if anyone has in mind a use case where the potential for instruction count savings via FMA would actually be useful.

# Bad news for MacOS

The bad news here is that item (2) listed in the writeup for Issue #3820 still causes FP differences between linux (GNU glibc) and MacOS (Apple System math library). This PR fixes the FMA issues, but I still get 18 failures (down from 48) on macOS which are likely attributed to differences in transcendental operations (e.g., `exp()`) between the library implementations. Fixing that will be left for another PR.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
