### PR TITLE
Fix S2 Random Ray Casting Issue

### DIFF
--- a/src/random_ray/random_ray.cpp
+++ b/src/random_ray/random_ray.cpp
@@ -895,7 +895,7 @@ SourceSite RandomRay::sample_s2()
   site.r = space->sample(current_seed()).first;
 
   // Sample either left or right for S2 (flashlight) transport.
-  site.u = {prn(current_seed()) < 0.5 ? -1 : 1, 0.0, 0.0};
+  site.u = {prn(current_seed()) < 0.5 ? -1.0 : 1.0, 0.0, 0.0};
 
   return site;
 }


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

When compiled with LLVM 20.1.2, OpenMC currently gives a compile time error:

```
/Users/jtramm/openmc/src/random_ray/random_ray.cpp:898:13: error: non-constant-expression cannot be narrowed from type 'int' to 'double' in initializer list [-Wc++11-narrowing]
  898 |   site.u = {prn(current_seed()) < 0.5 ? -1 : 1, 0.0, 0.0};
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jtramm/openmc/src/random_ray/random_ray.cpp:898:13: note: insert an explicit cast to silence this issue
  898 |   site.u = {prn(current_seed()) < 0.5 ? -1 : 1, 0.0, 0.0};
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |             static_cast<double>(              )

```

due to the recent S2 capabilities added in #3811. My guess is that gcc is less strict about the casting than LLVM on this type of thing.

Anyway, the fix is easy enough - just make things 1.0 instead of 1.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
