### PR TITLE
Allow Mesh.from_domain to use bounding boxes directly

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1179,7 +1179,7 @@ class RegularMesh(StructuredMesh):
     @classmethod
     def from_domain(
         cls,
-        domain: HasBoundingBox,
+        domain: HasBoundingBox | BoundingBox,
         dimension: Sequence[int] | int = 1000,
         mesh_id: int | None = None,
         name: str = ''
@@ -1188,10 +1188,12 @@ class RegularMesh(StructuredMesh):
 
         Parameters
         ----------
-        domain : HasBoundingBox
+        domain : HasBoundingBox | openmc.BoundingBox
             The object passed in will be used as a template for this mesh. The
             bounding box of the property of the object passed will be used to
-            set the lower_left and upper_right and of the mesh instance
+            set the lower_left and upper_right and of the mesh instance.
+            Alternatively, a :class:`openmc.BoundingBox` can be passed
+            directly.
         dimension : Iterable of int | int
             The number of mesh cells in total or number of mesh cells in each
             direction (x, y, z). If a single integer is provided, the domain
@@ -1208,21 +1210,26 @@ class RegularMesh(StructuredMesh):
             RegularMesh instance
 
         """
-        if not hasattr(domain, 'bounding_box'):
-            raise TypeError("Domain must have a bounding_box property")
+        if isinstance(domain, BoundingBox):
+            bb = domain
+        elif hasattr(domain, 'bounding_box'):
+            bb = domain.bounding_box
+        else:
+            raise TypeError("Domain must be a BoundingBox or have a "
+                            "bounding_box property")
 
         mesh = cls(mesh_id=mesh_id, name=name)
-        mesh.lower_left = domain.bounding_box[0]
-        mesh.upper_right = domain.bounding_box[1]
+        mesh.lower_left = bb[0]
+        mesh.upper_right = bb[1]
         if isinstance(dimension, int):
             cv.check_greater_than("dimension", dimension, 1, equality=True)
             # If a single integer is provided, divide the domain into that many
             # mesh cells with roughly equal lengths in each direction
-            ideal_cube_volume = domain.bounding_box.volume / dimension
+            ideal_cube_volume = bb.volume / dimension
             ideal_cube_size = ideal_cube_volume ** (1 / 3)
             dimension = [
                 max(1, int(round(side / ideal_cube_size)))
-                for side in domain.bounding_box.width
+                for side in bb.width
             ]
         mesh.dimension = dimension
 
@@ -1887,7 +1894,7 @@ class CylindricalMesh(StructuredMesh):
     @classmethod
     def from_domain(
         cls,
-        domain: HasBoundingBox,
+        domain: HasBoundingBox | BoundingBox,
         dimension: Sequence[int] = (10, 10, 10),
         mesh_id: int | None = None,
         phi_grid_bounds: Sequence[float] = (0.0, 2*pi),
@@ -1898,10 +1905,11 @@ class CylindricalMesh(StructuredMesh):
 
         Parameters
         ----------
-        domain : HasBoundingBox
+        domain : HasBoundingBox | openmc.BoundingBox
             The object passed in will be used as a template for this mesh. The
             bounding box of the property of the object passed will be used to
-            set the r_grid, z_grid ranges.
+            set the r_grid, z_grid ranges. Alternatively, a
+            :class:`openmc.BoundingBox` can be passed directly.
         dimension : Iterable of int
             The number of equally spaced mesh cells in each direction (r_grid,
             phi_grid, z_grid)
@@ -1922,11 +1930,13 @@ class CylindricalMesh(StructuredMesh):
             CylindricalMesh instance
 
         """
-        if not hasattr(domain, 'bounding_box'):
-            raise TypeError("Domain must have a bounding_box property")
-
-        # loaded once to avoid recalculating bounding box
-        cached_bb = domain.bounding_box
+        if isinstance(domain, BoundingBox):
+            cached_bb = domain
+        elif hasattr(domain, 'bounding_box'):
+            cached_bb = domain.bounding_box
+        else:
+            raise TypeError("Domain must be a BoundingBox or have a "
+                            "bounding_box property")
 
         if enclose_domain:
             outer_radius = 0.5 * np.linalg.norm(cached_bb.width[:2])
@@ -2269,7 +2279,7 @@ class SphericalMesh(StructuredMesh):
     @classmethod
     def from_domain(
         cls,
-        domain: HasBoundingBox,
+        domain: HasBoundingBox | BoundingBox,
         dimension: Sequence[int] = (10, 10, 10),
         mesh_id: int | None = None,
         phi_grid_bounds: Sequence[float] = (0.0, 2*pi),
@@ -2281,10 +2291,11 @@ class SphericalMesh(StructuredMesh):
 
         Parameters
         ----------
-        domain : HasBoundingBox
+        domain : HasBoundingBox | openmc.BoundingBox
             The object passed in will be used as a template for this mesh. The
             bounding box of the property of the object passed will be used to
-            set the r_grid, phi_grid, and theta_grid ranges.
+            set the r_grid, phi_grid, and theta_grid ranges. Alternatively, a
+            :class:`openmc.BoundingBox` can be passed directly.
         dimension : Iterable of int
             The number of equally spaced mesh cells in each direction (r_grid,
             phi_grid, theta_grid). Spacing is in angular space (radians) for
@@ -2309,11 +2320,13 @@ class SphericalMesh(StructuredMesh):
             SphericalMesh instance
 
         """
-        if not hasattr(domain, 'bounding_box'):
-            raise TypeError("Domain must have a bounding_box property")
-
-        # loaded once to avoid recalculating bounding box
-        cached_bb = domain.bounding_box
+        if isinstance(domain, BoundingBox):
+            cached_bb = domain
+        elif hasattr(domain, 'bounding_box'):
+            cached_bb = domain.bounding_box
+        else:
+            raise TypeError("Domain must be a BoundingBox or have a "
+                            "bounding_box property")
 
         if enclose_domain:
             outer_radius = 0.5 * np.linalg.norm(cached_bb.width)

--- a/tests/unit_tests/test_mesh_from_domain.py
+++ b/tests/unit_tests/test_mesh_from_domain.py
@@ -16,6 +16,17 @@ def test_reg_mesh_from_cell():
     assert np.array_equal(mesh.upper_right, cell.bounding_box[1])
 
 
+def test_reg_mesh_from_bounding_box():
+    """Tests a RegularMesh can be made from a BoundingBox directly."""
+    bb = openmc.BoundingBox([-8, -7, -5], [12, 13, 15])
+
+    mesh = openmc.RegularMesh.from_domain(domain=bb, dimension=[7, 11, 13])
+    assert isinstance(mesh, openmc.RegularMesh)
+    assert np.array_equal(mesh.dimension, (7, 11, 13))
+    assert np.array_equal(mesh.lower_left, bb[0])
+    assert np.array_equal(mesh.upper_right, bb[1])
+
+
 def test_cylindrical_mesh_from_cell():
     """Tests a CylindricalMesh can be made from a Cell and the specified
     dimensions are propagated through."""


### PR DESCRIPTION
# Description

I'm keen to be able to make regular meshes from bounding boxes in addition to domains that have bounding boxes. This is because I have bounding boxes for single components in DAGMC geometries and want a mesh just for that component (.e.g TF coil magnet).

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)