### PR TITLE
C++ formatting suggestions on PRs

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -44,4 +44,5 @@ jobs:
           echo "Some files failed the formatting check."
           echo "See job summary and file annotations for details."
           echo "To request inline suggestions on the next PR update, add the 'cpp-format-suggest' label to this pull request."
+          echo "This workflow can be triggered by re-running it or pushing a new commit to the pull request."
           exit 1

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -5,6 +5,12 @@ on:
   workflow_dispatch:
 
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
     branches:
       - develop
       - master
@@ -12,6 +18,9 @@ on:
 jobs:
   cpp-linter:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: cpp-linter/cpp-linter-action@v2
@@ -23,10 +32,16 @@ jobs:
           files-changed-only: true
           tidy-checks: '-*'
           version: '15' # clang-format version
+          format-review: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'cpp-format-suggest') }}
+          passive-reviews: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'cpp-format-suggest') }}
           file-annotations: true
           step-summary: true
           extensions: 'cpp,h'
 
       - name: Failure Check
         if: steps.linter.outputs.checks-failed > 0
-        run: echo "Some files failed the formatting check! See job summary and file annotations for more info" && exit 1
+        run: |
+          echo "Some files failed the formatting check."
+          echo "See job summary and file annotations for details."
+          echo "To request inline suggestions on the next PR update, add the 'cpp-format-suggest' label to this pull request."
+          exit 1

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -38,11 +38,23 @@ jobs:
           step-summary: true
           extensions: 'cpp,h'
 
+      - name: Comment with suggestion instructions
+        if: steps.linter.outputs.checks-failed > 0 && !contains(github.event.pull_request.labels.*.name, 'cpp-format-suggest')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: "C++ formatting checks failed. Add the `cpp-format-suggest` label to this PR for inline formatting suggestions on the next run."
+            });
+
       - name: Failure Check
         if: steps.linter.outputs.checks-failed > 0
         run: |
           echo "Some files failed the formatting check."
           echo "See job summary and file annotations for details."
-          echo "To request inline suggestions on the next PR update, add the 'cpp-format-suggest' label to this pull request."
-          echo "This workflow can be triggered by re-running it or pushing a new commit to the pull request."
           exit 1


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

The C++ linter check has been a hassle for a number of contributors due to differing behavior for various versions of clang-format that sometimes aren't covered by our style file.

This PR adds the option for inline suggestions from the `cpp-linter` actions in a PR when the `cpp-format-suggest` label is applied to the PR.

When the C++ formatting check fails and the label isn't present, a comment is added by the workflow with instructions on how to get inline suggestions for format fixes. By adding the `-label` event trigger to the workflow, all one has to do to get these suggestions is add the label.

I can't really demonstrate this here until it's merged but here's a PR in my fork where I've been playing around with the updated workflow: https://github.com/pshriwise/openmc/pull/33

Fixes #2746

# Checklist

- [x] ~I have performed a self-review of my own code~
- [x] ~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~
- [x] ~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~
- [x] ~I have made corresponding changes to the documentation (if applicable)~
- [x] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
