### PR TITLE
Skip DAGMC lost particles test

### DIFF
--- a/tests/unit_tests/dagmc/test_lost_particles.py
+++ b/tests/unit_tests/dagmc/test_lost_particles.py
@@ -66,6 +66,7 @@ def broken_dagmc_model(request):
     return model
 
 
+@pytest.mark.skip(reason="Test causes CI to hang intermittently")
 def test_lost_particles(run_in_tmpdir, broken_dagmc_model):
     broken_dagmc_model.export_to_xml()
     # ensure that particles will be lost when cell intersections can't be found


### PR DESCRIPTION
# Description

As described in #3826, many CI jobs have been hanging due to `tests/unit_tests/dagmc/test_lost_particles.py`. I thought I had fixed this with an update in #3817 but we're still seeing hangs. This PR skips this test for now while we dig further into why this test is causing problems (notably, no one has been able to reproduce the behavior locally).

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)