### PR TITLE
Simplify code by storing coord_last the same as coord.

### DIFF
--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -290,8 +290,8 @@ public:
     }
     n_coord_ = 1;
 
-    for (auto& cell : cell_last_) {
-      cell = C_NONE;
+    for (auto& level : coord_last_) {
+      level.reset();
     }
     n_coord_last_ = 1;
   }
@@ -334,6 +334,12 @@ public:
   LocalCoord& coord(int i) { return coord_[i]; }
   const LocalCoord& coord(int i) const { return coord_[i]; }
   const vector<LocalCoord>& coord() const { return coord_; }
+  vector<LocalCoord>& coord() { return coord_; }
+
+  LocalCoord& coord_last(int i) { return coord_last_[i]; }
+  const LocalCoord& coord_last(int i) const { return coord_last_[i]; }
+  const vector<LocalCoord>& coord_last() const { return coord_last_; }
+  vector<LocalCoord>& coord_last() { return coord_last_; }
 
   // Innermost universe nesting coordinates
   LocalCoord& lowest_coord() { return coord_[n_coord_ - 1]; }
@@ -342,8 +348,12 @@ public:
   // Last coordinates on all nesting levels, before crossing a surface
   int& n_coord_last() { return n_coord_last_; }
   const int& n_coord_last() const { return n_coord_last_; }
-  int& cell_last(int i) { return cell_last_[i]; }
-  const int& cell_last(int i) const { return cell_last_[i]; }
+
+  int& cell(int i) { return coord_[i].cell(); }
+  const int& cell(int i) const { return coord_[i].cell(); }
+
+  int& cell_last(int i) { return coord_last_[i].cell(); }
+  const int& cell_last(int i) const { return coord_last_[i].cell(); }
 
   // Coordinates at birth
   Position& r_born() { return r_born_; }
@@ -355,10 +365,10 @@ public:
   const Position& r_last_current() const { return r_last_current_; }
 
   // Previous direction and spatial coordinates before a collision
-  Position& r_last() { return r_last_; }
-  const Position& r_last() const { return r_last_; }
-  Position& u_last() { return u_last_; }
-  const Position& u_last() const { return u_last_; }
+  Position& r_last() { return coord_last_[0].r(); }
+  const Position& r_last() const { return coord_last_[0].r(); }
+  Position& u_last() { return coord_last_[0].u(); }
+  const Position& u_last() const { return coord_last_[0].u(); }
 
   // Accessors for position in global coordinates
   Position& r() { return coord_[0].r(); }
@@ -415,19 +425,16 @@ public:
 private:
   int64_t id_ {-1}; //!< Unique ID
 
-  int n_coord_ {1};          //!< number of current coordinate levels
-  int cell_instance_;        //!< offset for distributed properties
-  vector<LocalCoord> coord_; //!< coordinates for all levels
-
-  int n_coord_last_ {1};  //!< number of current coordinates
-  vector<int> cell_last_; //!< coordinates for all levels
+  int n_coord_ {1};               //!< number of current coordinate levels
+  int n_coord_last_ {1};          //!< number of last coordinates
+  int cell_instance_;             //!< offset for distributed properties
+  vector<LocalCoord> coord_;      //!< coordinates for all levels
+  vector<LocalCoord> coord_last_; //!< last coordinates for all levels
 
   Position r_born_;         //!< coordinates at birth
   Position r_last_current_; //!< coordinates of the last collision or
                             //!< reflective/periodic surface crossing for
                             //!< current tallies
-  Position r_last_;         //!< previous coordinates
-  Direction u_last_;        //!< previous direction coordinates
 
   int surface_ {
     SURFACE_NONE}; //!< surface token for surface the particle is currently on

--- a/include/openmc/particle_data.h
+++ b/include/openmc/particle_data.h
@@ -311,8 +311,6 @@ public:
     r() = r_a;
     u() = u_a;
     r_last_current() = r_a;
-    r_last() = r_a;
-    u_last() = u_a;
   }
 
   // Unique ID. This is not geometric info, but the
@@ -349,10 +347,8 @@ public:
   int& n_coord_last() { return n_coord_last_; }
   const int& n_coord_last() const { return n_coord_last_; }
 
-  int& cell(int i) { return coord_[i].cell(); }
   const int& cell(int i) const { return coord_[i].cell(); }
 
-  int& cell_last(int i) { return coord_last_[i].cell(); }
   const int& cell_last(int i) const { return coord_last_[i].cell(); }
 
   // Coordinates at birth
@@ -365,9 +361,7 @@ public:
   const Position& r_last_current() const { return r_last_current_; }
 
   // Previous direction and spatial coordinates before a collision
-  Position& r_last() { return coord_last_[0].r(); }
   const Position& r_last() const { return coord_last_[0].r(); }
-  Position& u_last() { return coord_last_[0].u(); }
   const Position& u_last() const { return coord_last_[0].u(); }
 
   // Accessors for position in global coordinates

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -530,10 +530,8 @@ void Mesh::material_volumes(int nx, int ny, int nz, int table_size,
           if (p.cell_born() == C_NONE)
             p.cell_born() = p.lowest_coord().cell();
 
-          // Initialize last cells from current cell
-          for (int j = 0; j < p.n_coord(); ++j) {
-            p.cell_last(j) = p.coord(j).cell();
-          }
+          // Initialize last coords from current coords
+          p.coord_last() = p.coord();
           p.n_coord_last() = p.n_coord();
 
           while (true) {
@@ -594,9 +592,7 @@ void Mesh::material_volumes(int nx, int ny, int nz, int table_size,
               break;
 
             // cross next geometric surface
-            for (int j = 0; j < p.n_coord(); ++j) {
-              p.cell_last(j) = p.coord(j).cell();
-            }
+            p.coord_last() = p.coord();
             p.n_coord_last() = p.n_coord();
 
             // Set surface that particle is on and adjust coordinate levels

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -139,8 +139,6 @@ void Particle::from_source(const SourceSite* src)
   u() = src->u;
   r_born() = src->r;
   r_last_current() = src->r;
-  r_last() = src->r;
-  u_last() = src->u;
   if (settings::run_CE) {
     E() = src->E;
     g() = 0;
@@ -170,8 +168,6 @@ void Particle::event_calculate_xs()
   // Store pre-collision particle properties
   wgt_last() = wgt();
   E_last() = E();
-  u_last() = u();
-  r_last() = r();
   time_last() = time();
 
   // Reset event variables
@@ -193,10 +189,8 @@ void Particle::event_calculate_xs()
     if (cell_born() == C_NONE)
       cell_born() = lowest_coord().cell();
 
-    // Initialize last cells from current cell
-    for (int j = 0; j < n_coord(); ++j) {
-      cell_last(j) = coord(j).cell();
-    }
+    // Initialize last coords from current coords
+    coord_last() = coord();
     n_coord_last() = n_coord();
   }
 
@@ -292,10 +286,8 @@ void Particle::event_advance()
 
 void Particle::event_cross_surface()
 {
-  // Saving previous cell data
-  for (int j = 0; j < n_coord(); ++j) {
-    cell_last(j) = coord(j).cell();
-  }
+  // Saving previous coord data
+  coord_last() = coord();
   n_coord_last() = n_coord();
 
   // Set surface that particle is on and adjust coordinate levels
@@ -466,10 +458,8 @@ void Particle::event_revive_from_secondary()
         if (cell_born() == C_NONE)
           cell_born() = lowest_coord().cell();
 
-        // Initialize last cells from current cell
-        for (int j = 0; j < n_coord(); ++j) {
-          cell_last(j) = coord(j).cell();
-        }
+        // Initialize last coords from current coords
+        coord_last() = coord();
         n_coord_last() = n_coord();
       }
       pht_secondary_particles();

--- a/src/particle_data.cpp
+++ b/src/particle_data.cpp
@@ -52,7 +52,7 @@ GeometryState::GeometryState()
 {
   // Create and clear coordinate levels
   coord_.resize(model::n_coord_levels);
-  cell_last_.resize(model::n_coord_levels);
+  coord_last_.resize(model::n_coord_levels);
   clear();
 }
 

--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -72,8 +72,6 @@ void read_particle_restart(Particle& p, RunMode& previous_run_mode)
   // Set particle last attributes
   p.wgt_last() = p.wgt();
   p.r_last_current() = p.r();
-  p.r_last() = p.r();
-  p.u_last() = p.u();
   p.E_last() = p.E();
   p.g_last() = p.g();
   p.time_last() = p.time();

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -1766,11 +1766,8 @@ void Ray::trace()
       coord(lev).r() += boundary().distance() * coord(lev).u();
     }
     surface() = boundary().surface();
-    // Initialize last cells from the current cell, because the cell() variable
-    // does not contain the data for the case of a single-segment ray
-    for (int j = 0; j < n_coord(); ++j) {
-      cell_last(j) = coord(j).cell();
-    }
+    // Initialize last coords from the current coords
+    coord_last() = coord();
     n_coord_last() = n_coord();
     n_coord() = boundary().coord_level();
     if (boundary().lattice_translation()[0] != 0 ||

--- a/src/random_ray/flat_source_domain.cpp
+++ b/src/random_ray/flat_source_domain.cpp
@@ -447,7 +447,6 @@ void FlatSourceDomain::convert_source_regions_to_tallies(int64_t start_sr_id)
     // the spatial location of the source region
     Particle p;
     p.r() = source_regions_.position(sr);
-    p.r_last() = source_regions_.position(sr);
     p.u() = {1.0, 0.0, 0.0};
     bool found = exhaustive_find_cell(p);
 
@@ -819,7 +818,6 @@ void FlatSourceDomain::output_to_vtk() const
           sample.x = ll.x + x_delta / 2.0 + x * x_delta;
           Particle p;
           p.r() = sample;
-          p.r_last() = sample;
           p.E() = 1.0;
           p.E_last() = 1.0;
           p.u() = {1.0, 0.0, 0.0};
@@ -1093,7 +1091,6 @@ void FlatSourceDomain::convert_external_sources()
       auto sp = dynamic_cast<SpatialPoint*>(is->space());
       GeometryState gs;
       gs.r() = sp->r();
-      gs.r_last() = sp->r();
       gs.u() = {1.0, 0.0, 0.0};
       bool found = exhaustive_find_cell(gs);
       if (!found) {

--- a/src/tallies/filter_cell.cpp
+++ b/src/tallies/filter_cell.cpp
@@ -49,7 +49,7 @@ void CellFilter::get_all_bins(
   const Particle& p, TallyEstimator estimator, FilterMatch& match) const
 {
   for (int i = 0; i < p.n_coord(); i++) {
-    auto search = map_.find(p.coord(i).cell());
+    auto search = map_.find(p.cell(i));
     if (search != map_.end()) {
       match.bins_.push_back(search->second);
       match.weights_.push_back(1.0);

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -2487,7 +2487,7 @@ void score_timed_tracklength_tally(Particle& p, double total_distance)
 
   // save particle last state
   auto time_last = p.time_last();
-  auto r_last = p.r_last();
+  auto coord_last = p.coord_last();
 
   // move particle back
   p.move_distance(-total_distance);
@@ -2503,7 +2503,7 @@ void score_timed_tracklength_tally(Particle& p, double total_distance)
 
     // Save particle last state for tracklength tallies
     p.time_last() = p.time();
-    p.r_last() = p.r();
+    p.coord_last() = p.coord();
 
     // Advance particle in space and time
     p.move_distance(distance);
@@ -2519,7 +2519,7 @@ void score_timed_tracklength_tally(Particle& p, double total_distance)
   }
 
   p.time_last() = time_last;
-  p.r_last() = r_last;
+  p.coord_last() = coord_last;
 }
 
 void score_tracklength_tally(Particle& p, double distance)


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Currently particle data stores data about the last coord data in various variables.
This PR unify this access by using coord_last.


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
