### PR TITLE
Speed up depletion with transfer rates

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -807,37 +807,29 @@ class Chain:
         # Use DOK as intermediate representation
         n = len(self)
         matrix = dok_array((n, n))
+        
+        check_type("mats", mats, (tuple, str))
+        if not isinstance(mats, str):
+            check_type("mats", mats, tuple, str)
+            check_length("mats", mats, 2, 2)
+        
+        # Build transfer terms (nuclide transfer only)
+        if isinstance(mats, str):
+            mat = mats
+            dest_mat = None
+            components = tr_rates.get_components(mat, current_timestep)
+        # Build transfer terms (transfer from one material into another)
+        elif isinstance(mats, tuple):
+            dest_mat, mat = mats
+            components = tr_rates.get_components(mat, current_timestep, dest_mat)    
 
         for i, nuc in enumerate(self.nuclides):
             elm = re.split(r'\d+', nuc.name)[0]
-            # Build transfer terms (nuclide transfer only)
-            if isinstance(mats, str):
-                mat = mats
-                components = tr_rates.get_components(mat, current_timestep)
-                if not components:
-                    break
-                if elm in components:
-                    matrix[i, i] = sum(
-                        tr_rates.get_external_rate(mat, elm, current_timestep))
-                elif nuc.name in components:
-                    matrix[i, i] = sum(
-                        tr_rates.get_external_rate(mat, nuc.name, current_timestep))
-                else:
-                    matrix[i, i] = 0.0
-
-            # Build transfer terms (transfer from one material into another)
-            elif isinstance(mats, tuple):
-                dest_mat, mat = mats
-                components = tr_rates.get_components(mat, current_timestep, dest_mat)
-                if elm in components:
-                    matrix[i, i] = tr_rates.get_external_rate(
-                        mat, elm, current_timestep, dest_mat)[0]
-                elif nuc.name in components:
-                    matrix[i, i] = tr_rates.get_external_rate(
-                        mat, nuc.name, current_timestep, dest_mat)[0]
-                else:
-                    matrix[i, i] = 0.0
-
+            if elm in components:
+                matrix[i, i] = sum(tr_rates.get_external_rate(mat, elm, current_timestep, dest_mat))
+            elif nuc.name in components:
+                matrix[i, i] = sum(tr_rates.get_external_rate(mat, nuc.name, current_timestep, dest_mat))
+                
         # Return CSC instead of DOK
         return matrix.tocsc()
 

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -812,16 +812,13 @@ class Chain:
         if not isinstance(mats, str):
             check_type("mats", mats, tuple, str)
             check_length("mats", mats, 2, 2)
-        
-        # Build transfer terms (nuclide transfer only)
-        if isinstance(mats, str):
+            dest_mat, mat = mats
+        else:
             mat = mats
             dest_mat = None
-            components = tr_rates.get_components(mat, current_timestep)
-        # Build transfer terms (transfer from one material into another)
-        elif isinstance(mats, tuple):
-            dest_mat, mat = mats
-            components = tr_rates.get_components(mat, current_timestep, dest_mat)    
+        
+        # Build transfer term 
+        components = tr_rates.get_components(mat, current_timestep, dest_mat)
 
         for i, nuc in enumerate(self.nuclides):
             elm = re.split(r'\d+', nuc.name)[0]
@@ -861,14 +858,13 @@ class Chain:
         # Use DOK as intermediate representation
         n = len(self)
         vector = dok_array((n, 1))
+        components = ext_source_rates.get_components(mat, current_timestep)
 
         for i, nuc in enumerate(self.nuclides):
             # Build source term vector
-            if nuc.name in ext_source_rates.get_components(mat, current_timestep):
+            if nuc.name in components:
                 vector[i] = sum(ext_source_rates.get_external_rate(
                     mat, nuc.name, current_timestep))
-            else:
-                vector[i] = 0.0
 
         # Return CSC instead of DOK
         return vector.tocsc()

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -826,9 +826,12 @@ class Chain:
         for i, nuc in enumerate(self.nuclides):
             elm = re.split(r'\d+', nuc.name)[0]
             if elm in components:
-                matrix[i, i] = sum(tr_rates.get_external_rate(mat, elm, current_timestep, dest_mat))
+                key = elm
             elif nuc.name in components:
-                matrix[i, i] = sum(tr_rates.get_external_rate(mat, nuc.name, current_timestep, dest_mat))
+                key = nuc.name
+            else:
+                continue
+            matrix[i, i] = sum(tr_rates.get_external_rate(mat, key, current_timestep, dest_mat))
                 
         # Return CSC instead of DOK
         return matrix.tocsc()

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -18,7 +18,7 @@ from typing import List
 
 import lxml.etree as ET
 
-from openmc.checkvalue import check_type, check_greater_than, PathLike
+from openmc.checkvalue import check_type, check_length, check_greater_than, PathLike
 from openmc.data import gnds_name, zam
 from openmc.exceptions import DataError
 from .nuclide import FissionYieldDistribution, Nuclide


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR simplify ```form_rr_term``` to speed up problems with external transfer rates.

Fixes https://openmc.discourse.group/t/depletion-with-transfer-rates-is-extremely-slow-culprit-successfully-found/6237.

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
