### PR TITLE
Use clang-format version 18 for CI format checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Fixes # (issue)
 # Checklist
 
 - [ ] I have performed a self-review of my own code
-- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)
+- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
 - [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
 - [ ] I have made corresponding changes to the documentation (if applicable)
 - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -31,7 +31,7 @@ jobs:
           style: file
           files-changed-only: true
           tidy-checks: '-*'
-          version: '15' # clang-format version
+          version: '18' # clang-format version
           format-review: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'cpp-format-suggest') }}
           passive-reviews: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'cpp-format-suggest') }}
           file-annotations: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ When modifying C++ public APIs, update corresponding ctypes signatures in `openm
 - **Include order**: Related header first, then C/C++ stdlib, third-party libs, local headers
 - **Comments**: C++-style (`//`) only, never C-style (`/* */`)
 - **Standard**: C++17 features allowed
-- **Formatting**: Run `clang-format` (version 15) before committing; install via `tools/dev/install-commit-hooks.sh`
+- **Formatting**: Run `clang-format` (version 18) before committing; install via `tools/dev/install-commit-hooks.sh`
 
 ### Python Style
 - **PEP8** compliant
@@ -295,4 +295,4 @@ Check for optional features:
 2. **ID conflicts**: Python objects with duplicate IDs trigger `IDWarning`, use `reset_auto_ids()` between tests
 3. **MPI builds**: Code must work with and without MPI; use `#ifdef OPENMC_MPI` guards
 4. **Path handling**: Use `pathlib.Path` in new Python code, not `os.path`
-5. **Clang-format version**: CI uses version 15; other versions may produce different formatting
+5. **Clang-format version**: CI uses version 18; other versions may produce different formatting

--- a/docs/source/devguide/styleguide.rst
+++ b/docs/source/devguide/styleguide.rst
@@ -30,7 +30,7 @@ whenever a file is saved. For example, `Visual Studio Code
 support for running clang-format.
 
 .. note::
-    OpenMC's CI uses `clang-format` version 15. A different version of `clang-format`
+    OpenMC's CI uses `clang-format` version 18. A different version of `clang-format`
     may produce different line changes and as a result fail the CI test.
 
 Miscellaneous

--- a/include/openmc/volume_calc.h
+++ b/include/openmc/volume_calc.h
@@ -34,7 +34,7 @@ public:
     vector<double> atoms;       //!< Number of atoms for each nuclide
     vector<double> uncertainty; //!< Uncertainty on number of atoms
     int iterations; //!< Number of iterations needed to obtain the results
-  };                // Results for a single domain
+  }; // Results for a single domain
 
   // Constructors
   VolumeCalculation(pugi::xml_node node);

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -365,7 +365,7 @@ Mgxs::Mgxs(const std::string& in_name, const vector<double>& mat_kTs,
           }
         }
       } // end switch
-    }   // end microscopic temperature loop
+    } // end microscopic temperature loop
 
     // Now combine the microscopic data at each relevant temperature
     // We will do this by treating the multiple temperatures of a nuclide as


### PR DESCRIPTION
# Description

This PR updates the version of clang-format used in our format check CI job to version 18, whereas it is currently using version 15. This was discussed in #2746 and #3829. Version 18 is the default in Ubuntu 24.04 but I'm open to other opinions on what we should be using. After playing around with multiple versions (18, 19, 20), they all give slightly different formatting results so it seems like there is no good way to avoid some churn, but at least with a more recent version it should be easier for people to install if needed.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
