### PR TITLE
Speed up Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV LIBMESH_INSTALL_DIR=$HOME/LIBMESH
 ENV NJOY_REPO='https://github.com/njoy/NJOY2016'
 
 # Setup environment variables for Docker image
-ENV LD_LIBRARY_PATH=${DAGMC_INSTALL_DIR}/lib:$LD_LIBRARY_PATH \
+ENV LD_LIBRARY_PATH=${DAGMC_INSTALL_DIR}/lib:${LD_LIBRARY_PATH:-} \
     OPENMC_ENDF_DATA=/root/endf-b-vii.1 \
     DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,7 @@ RUN if [ "$build_dagmc" = "on" ]; then \
                       -DBUILD_SHARED_LIBS=OFF \
                       -DENABLE_FORTRAN=OFF \
                       -DENABLE_BLASLAPACK=OFF \
+                      -DENABLE_TESTING=OFF \
         && make 2>/dev/null -j${compile_cores} install \
         && cmake ../moab \
                     -DENABLE_PYMOAB=ON \
@@ -132,6 +133,7 @@ RUN if [ "$build_dagmc" = "on" ]; then \
                        -DDOUBLE_DOWN_DIR=${DD_INSTALL_DIR} \
                        -DCMAKE_PREFIX_PATH=${DD_INSTALL_DIR}/lib \
                        -DBUILD_STATIC_LIBS=OFF \
+                       -DBUILD_TESTS=OFF \
         && make 2>/dev/null -j${compile_cores} install \
         && rm -rf ${DAGMC_INSTALL_DIR}/DAGMC ${DAGMC_INSTALL_DIR}/build ; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update -y && \
     apt-get install -y \
         python3-pip python-is-python3 wget git build-essential cmake \
         mpich libmpich-dev libhdf5-serial-dev libhdf5-mpich-dev \
-        libpng-dev libpugixml-dev libfmt-dev python3-venv && \
+        libpng-dev libpugixml-dev libfmt-dev libcatch2-dev python3-venv && \
     apt-get autoremove
 
 # create virtual enviroment to avoid externally managed environment error

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update -y && \
     apt-get install -y \
         python3-pip python-is-python3 wget git build-essential cmake \
         mpich libmpich-dev libhdf5-serial-dev libhdf5-mpich-dev \
-        libpng-dev libpugixml-dev libfmt-dev libcatch2-dev python3-venv && \
+        libpng-dev libpugixml-dev libfmt-dev catch2 python3-venv && \
     apt-get autoremove
 
 # create virtual enviroment to avoid externally managed environment error

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update -y && \
     apt-get install -y \
         python3-pip python-is-python3 wget git build-essential cmake \
         mpich libmpich-dev libhdf5-serial-dev libhdf5-mpich-dev \
-        libpng-dev python3-venv && \
+        libpng-dev libpugixml-dev libfmt-dev python3-venv && \
     apt-get autoremove
 
 # create virtual enviroment to avoid externally managed environment error

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,6 @@ ARG build_libmesh
 # Set default value of HOME to /root
 ENV HOME=/root
 
-# Embree variables
-ENV EMBREE_TAG='v4.3.1'
-ENV EMBREE_REPO='https://github.com/embree/embree'
-ENV EMBREE_INSTALL_DIR=$HOME/EMBREE/
-
 # MOAB variables
 ENV MOAB_TAG='5.5.1'
 ENV MOAB_REPO='https://bitbucket.org/fathomteam/moab/'
@@ -94,20 +89,10 @@ RUN cd $HOME \
 
 RUN if [ "$build_dagmc" = "on" ]; then \
         # Install addition packages required for DAGMC
-        apt-get -y install libeigen3-dev libnetcdf-dev libtbb-dev libglfw3-dev \
+        apt-get -y install \
+            libeigen3-dev libnetcdf-dev libtbb-dev libglfw3-dev libembree-dev \
         && pip install --upgrade numpy \
         && pip install --no-cache-dir setuptools cython \
-        # Clone and install EMBREE
-        && mkdir -p $HOME/EMBREE && cd $HOME/EMBREE \
-        && git clone --single-branch -b ${EMBREE_TAG} --depth 1 ${EMBREE_REPO} \
-        && mkdir build && cd build \
-        && cmake ../embree \
-                    -DCMAKE_INSTALL_PREFIX=${EMBREE_INSTALL_DIR} \
-                    -DEMBREE_MAX_ISA=NONE \
-                    -DEMBREE_ISA_SSE42=ON \
-                    -DEMBREE_ISPC_SUPPORT=OFF \
-        && make 2>/dev/null -j${compile_cores} install \
-        && rm -rf ${EMBREE_INSTALL_DIR}/build ${EMBREE_INSTALL_DIR}/embree ; \
         # Clone and install MOAB
         mkdir -p $HOME/MOAB && cd $HOME/MOAB \
         && git clone  --single-branch -b ${MOAB_TAG} --depth 1 ${MOAB_REPO} \
@@ -133,7 +118,7 @@ RUN if [ "$build_dagmc" = "on" ]; then \
         && mkdir build && cd build \
         && cmake ../double-down -DCMAKE_INSTALL_PREFIX=${DD_INSTALL_DIR} \
                              -DMOAB_DIR=/usr/local \
-                             -DEMBREE_DIR=${EMBREE_INSTALL_DIR} \
+                             -DEMBREE_DIR=/usr \
         && make 2>/dev/null -j${compile_cores} install \
         && rm -rf ${DD_INSTALL_DIR}/build ${DD_INSTALL_DIR}/double-down ; \
         # Clone and install DAGMC

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN if [ "$build_dagmc" = "on" ]; then \
         && pip install --upgrade numpy \
         && pip install --no-cache-dir setuptools cython \
         # Clone and install MOAB
-        mkdir -p $HOME/MOAB && cd $HOME/MOAB \
+        && mkdir -p $HOME/MOAB && cd $HOME/MOAB \
         && git clone  --single-branch -b ${MOAB_TAG} --depth 1 ${MOAB_REPO} \
         && mkdir build && cd build \
         && cmake ../moab -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
# Description

This PR makes a few updates to our Dockerfile to speed up build times:
- Instead of building Embree from source it uses the apt package
- Similarly, pugixml, libfmt, and Catch2 are installed from apt
- Avoids building tests for MOAB and DAGMC

The Embree change alone should shave off 15-20 min of build time.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 15) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>