### PR TITLE
Correction to surface normal determination in SolidRayTrace plots

### DIFF
--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -1873,7 +1873,8 @@ void PhongRay::on_intersection()
 
     // The crossed surface may be on a higher coordinate level than the
     // innermost local coordinates, so we check the surface's coordinate level
-    // to find the appropriate coordinate level to use for the normal calculation
+    // to find the appropriate coordinate level to use for the normal
+    // calculation
     int surf_level = boundary().coord_level() - 1;
     // ensure surface level is within bounds of current coordinate stack
     surf_level = std::max(0, std::min(surf_level, n_coord() - 1));

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -1847,7 +1847,10 @@ void PhongRay::on_intersection()
     // the normal or the diffuse lighting contribution
     reflected_ = true;
     result_color_ = plot_.colors_[hit_id];
-    Direction to_light = plot_.light_location_ - r();
+    // The ray has been advanced slightly past the boundary. Use an
+    // approximation to the actual hit point for stable normal/lighting.
+    Position r_hit = r() - TINY_BIT * u();
+    Direction to_light = plot_.light_location_ - r_hit;
     to_light /= to_light.norm();
 
     // TODO
@@ -1868,12 +1871,21 @@ void PhongRay::on_intersection()
     // Get surface pointer
     const auto& surf = model::surfaces.at(surface_index());
 
-    Direction normal = surf->normal(r_local());
+    // The crossed surface may be on a higher coordinate level than the
+    // innermost local coordinates, so we check the surface's coordinate level
+    // to find the appropriate coordinate level to use for the normal calculation
+    int surf_level = boundary().coord_level() - 1;
+    // ensure surface level is within bounds of current coordinate stack
+    surf_level = std::max(0, std::min(surf_level, n_coord() - 1));
+
+    Position r_hit_level =
+      coord(surf_level).r() - TINY_BIT * coord(surf_level).u();
+    Direction normal = surf->normal(r_hit_level);
     normal /= normal.norm();
 
-    // Need to apply translations to find the normal vector in
+    // Need to apply rotations to find the normal vector in
     // the base level universe's coordinate system.
-    for (int lev = n_coord() - 2; lev >= 0; --lev) {
+    for (int lev = surf_level - 1; lev >= 0; --lev) {
       if (coord(lev + 1).rotated()) {
         const Cell& c {*model::cells[coord(lev).cell()]};
         normal = normal.inverse_rotate(c.rotation_);


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

When determining the normal of a surface for shading, the position `Particle::r_local()` is currently being used, which represents the position at the lowest level of the geometry. This was causing some strange shading, particularly in models using lattices:

<img width="400" height="400" alt="bad_shading" src="https://github.com/user-attachments/assets/97a896d6-a1fc-47cc-ad9c-71c9f8a91667" />

Using the coordinate level of the intersected surface to get the normal results in improved shading at lower levels of the geometry.

<img width="400" height="400" alt="good_shading" src="https://github.com/user-attachments/assets/b3edf54e-19f1-4b7d-85c7-67ca47535b5e" />

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~
- [x] ~I have made corresponding changes to the documentation (if applicable)~
- [x] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
