### PR TITLE
Fix cell data parsing

### DIFF
--- a/openmc/cell.py
+++ b/openmc/cell.py
@@ -747,15 +747,6 @@ class Cell(IDManagerMixin):
             c.region = Region.from_expression(region, surfaces)
 
         # Check for other attributes
-        temperature = get_elem_list(elem, 'temperature', float)
-        if temperature is not None:
-            if len(temperature) > 1:
-                c.temperature = temperature
-            else:
-                c.temperature = temperature[0]
-        density = get_elem_list(elem, 'density', float)
-        if density is not None:
-            c.density = density if len(density) > 1 else density[0]
         v = get_text(elem, 'volume')
         if v is not None:
             c.volume = float(v)
@@ -764,6 +755,8 @@ class Cell(IDManagerMixin):
             if values is not None:
                 if key == 'rotation' and len(values) == 9:
                     values = np.array(values).reshape(3, 3)
+                elif len(values) == 1:
+                    values = values[0]
                 setattr(c, key, values)
 
         # Add this cell to appropriate universe

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -286,7 +286,7 @@ def test_import_properties(run_in_tmpdir, mpi_intracomm):
         'with_properties/settings.xml'
     )
     cell = model_with_properties.geometry.get_all_cells()[1]
-    assert cell.temperature == [600.0]
+    assert cell.temperature == 600.0
     assert cell.density == [pytest.approx(10.0, 1e-5)]
     assert cell.fill.get_mass_density() == pytest.approx(5.0)
 

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -266,7 +266,7 @@ def test_import_properties(run_in_tmpdir, mpi_intracomm):
     # First python
     cell = model.geometry.get_all_cells()[1]
     assert cell.temperature == 600.0
-    assert cell.density == [pytest.approx(10.0, 1e-5)]
+    assert cell.density == pytest.approx(10.0, 1e-5)
     assert cell.fill.get_mass_density() == pytest.approx(5.0)
     # Now C
     assert openmc.lib.cells[1].get_temperature() == 600.
@@ -287,7 +287,7 @@ def test_import_properties(run_in_tmpdir, mpi_intracomm):
     )
     cell = model_with_properties.geometry.get_all_cells()[1]
     assert cell.temperature == 600.0
-    assert cell.density == [pytest.approx(10.0, 1e-5)]
+    assert cell.density == pytest.approx(10.0, 1e-5)
     assert cell.fill.get_mass_density() == pytest.approx(5.0)
 
 

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -265,7 +265,7 @@ def test_import_properties(run_in_tmpdir, mpi_intracomm):
     # Check to see that values are assigned to the C and python representations
     # First python
     cell = model.geometry.get_all_cells()[1]
-    assert cell.temperature == [600.0]
+    assert cell.temperature == 600.0
     assert cell.density == [pytest.approx(10.0, 1e-5)]
     assert cell.fill.get_mass_density() == pytest.approx(5.0)
     # Now C


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Currently, some cell attributes are parsed twice.
This PR remove redundant lines and fix behavior when the attributes has length 1.



# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
