### PR TITLE
Fix two docstrings that should have r prefix

### DIFF
--- a/openmc/data/dose/mass_attenuation.py
+++ b/openmc/data/dose/mass_attenuation.py
@@ -62,7 +62,7 @@ _MUEN_TABLES = {
 def mass_energy_absorption_coefficient(
     material: str, data_source: str = "nist126"
 ) -> Tabulated1D:
-    """Return the mass energy-absorption coefficient as a function of energy.
+    r"""Return the mass energy-absorption coefficient as a function of energy.
 
     The mass energy-absorption coefficient, :math:`\mu_\text{en}/\rho`, is
     defined as the fraction of incident photon energy absorbed in a material per
@@ -108,7 +108,7 @@ _MASS_ATTENUATION: dict[int, object] = {}
 
 
 def mass_attenuation_coefficient(element):
-    """Return the photon mass attenuation coefficient as a function of energy.
+    r"""Return the photon mass attenuation coefficient as a function of energy.
 
     The mass energy-absorption coefficient, :math:`\mu_\text{en}/\rho`, is
     defined as the fraction of incident photon energy absorbed in a material per


### PR DESCRIPTION
# Description

Two new docstrings from the merge of #3700 have latex notation with slash characters that produce warnings because the docstrings do not have the `r` prefix (raw string). This PR fixes that to remove these warnings.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>