### PR TITLE
Fix include guard in output.h

### DIFF
--- a/include/openmc/output.h
+++ b/include/openmc/output.h
@@ -62,7 +62,6 @@ void write_tallies();
 void show_time(const char* label, double secs, int indent_level = 0);
 
 } // namespace openmc
-#endif // OPENMC_OUTPUT_H
 
 //////////////////////////////////////
 // Custom formatters
@@ -89,3 +88,5 @@ struct formatter<std::array<T, 2>> {
 }; // namespace fmt
 
 } // namespace fmt
+
+#endif // OPENMC_OUTPUT_H


### PR DESCRIPTION
# Description

I recently tried doing a unity build (`cmake -DCMAKE_UNITY_BUILD=ON`) only to find that it was broken. Turns out the `#endif` on the include guard in output.h was in the wrong place so a portion of the header was getting included repeatedly in the same translation unit.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>