### PR TITLE
Closing the stdout file descriptor when finished

### DIFF
--- a/openmc/executor.py
+++ b/openmc/executor.py
@@ -103,6 +103,7 @@ def _run(args, output, cwd):
         # If OpenMC is finished, break loop
         line = p.stdout.readline()
         if not line and p.poll() is not None:
+            p.stdout.close()
             break
 
         lines.append(line)


### PR DESCRIPTION

# Description

Currently, since the `_run` function in the `executor.py` file uses the `stdout` of the `Popen` it creates, it can sometimes fail to close that resource when the process is finished, leading to a `ResourceWarning: unclosed file <_io.TextIOWrapper ...>` warning.
This happened to me consistently when plotting a specific model, but does not happen for all the models I try to plot. However, Python's tracemalloc option points to this particular file descriptor being left open on those rare cases, and this fix stopped the warnings on my end.

I don't think it hurts to release this resource explicitly when the process is finished and we break from the printing loop, so this is a case of a small cost in terms of lines of code for a small benefit in terms of unintended warnings.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I changed no C++ source files, so I did not have to run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] There were no corresponding changes to be made to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

If adding a test for this case is required, I can try to find a minimal working example of this warning case.