### PR TITLE
Change plotting docstring to specify integer RGB values

### DIFF
--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -197,13 +197,13 @@ _PLOT_PARAMS = dedent("""\
             Assigns colors to specific materials or cells. Keys are instances of
             :class:`Cell` or :class:`Material` and values are RGB 3-tuples, RGBA
             4-tuples, or strings indicating SVG color names. Red, green, blue,
-            and alpha should all be floats in the range [0.0, 1.0], for example:
+            and alpha should all be integers in the range [0, 255], for example:
 
             .. code-block:: python
 
                 # Make water blue
                 water = openmc.Cell(fill=h2o)
-                universe.plot(..., colors={water: (0., 0., 1.))
+                universe.plot(..., colors={water: (0, 0, 255))
         seed : int
             Seed for the random number generator
         openmc_exec : str


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description
Fixes the docstring in `_PLOT_PARAMS` to specify RGB values as integers in the range [0, 255].

Fixes #3866

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
