### PR TITLE
Allow `StepResult.get_material` to accept integer material ID

### DIFF
--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -204,7 +204,7 @@ class StepResult:
 
         Parameters
         ----------
-        mat_id : str | int
+        mat_id : str or int
             Material ID as a string or integer
 
         Returns
@@ -218,9 +218,9 @@ class StepResult:
             If specified material ID is not found in the StepResult
 
         """
-        # To avoid crash when calling the mat_id as an int, which is common elsewhere
+        # Coerce to str since internal dictionaries use str keys
         mat_id = str(mat_id)
-        
+
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', openmc.IDWarning)
             material = openmc.Material(material_id=int(mat_id))

--- a/openmc/deplete/stepresult.py
+++ b/openmc/deplete/stepresult.py
@@ -12,8 +12,9 @@ import h5py
 import numpy as np
 
 import openmc
-from openmc.mpi import comm, MPI
 from openmc.checkvalue import PathLike
+from openmc.mpi import MPI, comm
+
 from .reaction_rates import ReactionRates
 
 VERSION_RESULTS = (1, 2)
@@ -196,15 +197,15 @@ class StepResult:
         new.rates = self.rates[ranges]
         return new
 
-    def get_material(self, mat_id):
+    def get_material(self, mat_id: str | int) -> openmc.Material:
         """Return material object for given depleted composition
 
         .. versionadded:: 0.13.2
 
         Parameters
         ----------
-        mat_id : str
-            Material ID as a string
+        mat_id : str | int
+            Material ID as a string or integer
 
         Returns
         -------
@@ -217,6 +218,9 @@ class StepResult:
             If specified material ID is not found in the StepResult
 
         """
+        # To avoid crash when calling the mat_id as an int, which is common elsewhere
+        mat_id = str(mat_id)
+        
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', openmc.IDWarning)
             material = openmc.Material(material_id=int(mat_id))

--- a/tests/unit_tests/test_deplete_resultslist.py
+++ b/tests/unit_tests/test_deplete_resultslist.py
@@ -1,10 +1,11 @@
 """Tests the Results class"""
 
-from pathlib import Path
 from math import inf
+from pathlib import Path
 
 import numpy as np
 import pytest
+
 import openmc.deplete
 
 
@@ -221,3 +222,11 @@ def test_stepresult_get_material(res):
     densities = mat1.get_nuclide_atom_densities()
     assert densities['Xe135'] == pytest.approx(1e-14)
     assert densities['U234'] == pytest.approx(1.00506e-05)
+
+
+def test_stepresult_get_material_mat_id_as_int(res):
+    # Get material at first timestep using int mat_id
+    step_result = res[0]
+    mat1 = step_result.get_material(1)
+    assert mat1.id == 1
+    assert mat1.volume == step_result.volume["1"]


### PR DESCRIPTION
# Description

The `StepResult.get_material` method uses `str` for `mat_id`. Usually we pass `int` as ids. Now the function has been updated to work both with strings and integers. 

A test has been added.

Fixes #3869

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

