### PR TITLE
Allow groups to be passed as sequence of floats in `convert_to_multigroup`

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2520,7 +2520,7 @@ class Model:
     def convert_to_multigroup(
         self,
         method: str = "material_wise",
-        groups: str | List[float] = "CASMO-2",
+        groups: str | Iterable[float] = "CASMO-2",
         nparticles: int = 2000,
         overwrite_mgxs_library: bool = False,
         mgxs_path: PathLike = "mgxs.h5",
@@ -2538,7 +2538,7 @@ class Model:
         ----------
         method : {"material_wise", "stochastic_slab", "infinite_medium"}, optional
             Method to generate the MGXS.
-        groups : str or list[float], optional
+        groups : str or Iterable[float], optional
             Energy group structure for the MGXS. Can be either:
             - A string name of a predefined group structure (e.g., "CASMO-2", "CASMO-16")
               from :data:`openmc.mgxs.GROUP_STRUCTURES`. Defaults to "CASMO-2".
@@ -2582,7 +2582,7 @@ class Model:
         """
         if isinstance(groups, str):
             groups = openmc.mgxs.EnergyGroups(groups)
-        elif isinstance(groups, (list, tuple)):
+        elif isinstance(groups, Iterable):
             groups = openmc.mgxs.EnergyGroups(groups)
         else:
             raise TypeError("groups must be a string or list of floats")

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2520,7 +2520,7 @@ class Model:
     def convert_to_multigroup(
         self,
         method: str = "material_wise",
-        groups: str | Iterable[float] = "CASMO-2",
+        groups: str | Sequence[float] | openmc.mgxs.EnergyGroups = "CASMO-2",
         nparticles: int = 2000,
         overwrite_mgxs_library: bool = False,
         mgxs_path: PathLike = "mgxs.h5",
@@ -2538,12 +2538,13 @@ class Model:
         ----------
         method : {"material_wise", "stochastic_slab", "infinite_medium"}, optional
             Method to generate the MGXS.
-        groups : str or Iterable[float], optional
-            Energy group structure for the MGXS. Can be either:
-            - A string name of a predefined group structure (e.g., "CASMO-2", "CASMO-16")
-              from :data:`openmc.mgxs.GROUP_STRUCTURES`. Defaults to "CASMO-2".
-            - A list of floats specifying energy bin boundaries in eV, in ascending order.
-              For example, ``[0.0, 1e6]`` creates a single energy group from 0 to 1e6 eV.
+        groups : openmc.mgxs.EnergyGroups, str, or sequence of float, optional
+            Energy group structure for the MGXS. Can be an
+            :class:`openmc.mgxs.EnergyGroups` object, a string name of a
+            predefined group structure from :data:`openmc.mgxs.GROUP_STRUCTURES`
+            (e.g., ``"CASMO-2"``), or a sequence of floats specifying energy
+            bin boundaries in eV (e.g., ``[0.0, 1e6]`` for a single group).
+            Defaults to ``"CASMO-2"``.
         nparticles : int, optional
             Number of particles to simulate per batch when generating MGXS.
         overwrite_mgxs_library : bool, optional
@@ -2580,12 +2581,9 @@ class Model:
             Valid entries for temperature_settings are the same as the valid
             entries in openmc.Settings.temperature_settings.
         """
-        if isinstance(groups, str):
+        if not isinstance(groups, openmc.mgxs.EnergyGroups):
             groups = openmc.mgxs.EnergyGroups(groups)
-        elif isinstance(groups, Iterable):
-            groups = openmc.mgxs.EnergyGroups(groups)
-        else:
-            raise TypeError("groups must be a string or list of floats")
+
         # Do all work (including MGXS generation) in a temporary directory
         # to avoid polluting the working directory with residual XML files
         with TemporaryDirectory() as tmpdir:

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2543,7 +2543,7 @@ class Model:
             - A string name of a predefined group structure (e.g., "CASMO-2", "CASMO-16")
               from :data:`openmc.mgxs.GROUP_STRUCTURES`. Defaults to "CASMO-2".
             - A list of floats specifying energy bin boundaries in eV, in ascending order.
-              For example, ``[0.0, 100e6]`` creates a single energy group from 0 to 100 MeV.
+              For example, ``[0.0, 1e6]`` creates a single energy group from 0 to 1e6 eV.
         nparticles : int, optional
             Number of particles to simulate per batch when generating MGXS.
         overwrite_mgxs_library : bool, optional

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2582,7 +2582,10 @@ class Model:
         """
         if isinstance(groups, str):
             groups = openmc.mgxs.EnergyGroups(groups)
-
+        elif isinstance(groups, (list, tuple)):
+            groups = openmc.mgxs.EnergyGroups(groups)
+        else:
+            raise TypeError("groups must be a string or list of floats")
         # Do all work (including MGXS generation) in a temporary directory
         # to avoid polluting the working directory with residual XML files
         with TemporaryDirectory() as tmpdir:

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2520,7 +2520,7 @@ class Model:
     def convert_to_multigroup(
         self,
         method: str = "material_wise",
-        groups: str = "CASMO-2",
+        groups: str | List[float] = "CASMO-2",
         nparticles: int = 2000,
         overwrite_mgxs_library: bool = False,
         mgxs_path: PathLike = "mgxs.h5",
@@ -2538,9 +2538,12 @@ class Model:
         ----------
         method : {"material_wise", "stochastic_slab", "infinite_medium"}, optional
             Method to generate the MGXS.
-        groups : openmc.mgxs.EnergyGroups or str, optional
-            Energy group structure for the MGXS or the name of the group
-            structure (based on keys from openmc.mgxs.GROUP_STRUCTURES).
+        groups : str or list[float], optional
+            Energy group structure for the MGXS. Can be either:
+            - A string name of a predefined group structure (e.g., "CASMO-2", "CASMO-16")
+              from :data:`openmc.mgxs.GROUP_STRUCTURES`. Defaults to "CASMO-2".
+            - A list of floats specifying energy bin boundaries in eV, in ascending order.
+              For example, ``[0.0, 100e6]`` creates a single energy group from 0 to 100 MeV.
         nparticles : int, optional
             Number of particles to simulate per batch when generating MGXS.
         overwrite_mgxs_library : bool, optional


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed if applicable. Please also include relevant motivation and context.

Fixes #3524

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
