### PR TITLE
Clip negative atom densities that result from CRAM

### DIFF
--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -583,6 +583,11 @@ class Integrator(ABC):
         `source_rates` should be the same as the initial run.
 
         .. versionadded:: 0.15.1
+    clip_negative_densities : bool, optional
+        Whether to clip negative atom densities to zero after each CRAM
+        solve. CRAM can produce small negative values. Defaults to False.
+
+        .. versionadded:: 0.15.4
 
     Attributes
     ----------
@@ -632,6 +637,7 @@ class Integrator(ABC):
             timestep_units: str = 's',
             solver: str = "cram48",
             continue_timesteps: bool = False,
+            clip_negative_densities: bool = False,
         ):
         if continue_timesteps and operator.prev_res is None:
             raise ValueError("Continuation run requires passing prev_results.")
@@ -684,6 +690,8 @@ class Integrator(ABC):
         self.timesteps = np.asarray(seconds)
         self.source_rates = np.asarray(source_rates)
 
+        self.clip_negative_densities = clip_negative_densities
+        self._warned_negative_density = False
         self.transfer_rates = None
         self.external_source_rates = None
 
@@ -736,8 +744,17 @@ class Integrator(ABC):
         results = deplete(
             self._solver, self.chain, n, rates, dt, i, matrix_func,
             self.transfer_rates, self.external_source_rates)
-        # filter-out negative atom densities (non-physical)
-        results = [np.maximum(r, 0.0) for r in results]
+        if self.clip_negative_densities:
+            for j, r in enumerate(results):
+                neg_mask = r < 0
+                if neg_mask.any():
+                    if not self._warned_negative_density:
+                        idx = np.argmin(r)
+                        nuc = self.chain.nuclides[idx].name
+                        warn(f"Clipping negative atom densities "
+                             f"(worst: {nuc} = {r[idx]:.4e})")
+                        self._warned_negative_density = True
+                    results[j] = np.maximum(r, 0.0)
         return time.time() - start, results
 
     @abstractmethod
@@ -1118,6 +1135,11 @@ class SIIntegrator(Integrator):
         `source_rates` should be the same as the initial run.
 
         .. versionadded:: 0.15.1
+    clip_negative_densities : bool, optional
+        Whether to clip negative atom densities to zero after each CRAM
+        solve. CRAM can produce small negative values. Defaults to False.
+
+        .. versionadded:: 0.15.4
 
     Attributes
     ----------
@@ -1161,12 +1183,15 @@ class SIIntegrator(Integrator):
             n_steps: int = 10,
             solver: str = "cram48",
             continue_timesteps: bool = False,
+            clip_negative_densities: bool = False,
         ):
         check_type("n_steps", n_steps, Integral)
         check_greater_than("n_steps", n_steps, 0)
         super().__init__(
             operator, timesteps, power, power_density, source_rates,
-            timestep_units=timestep_units, solver=solver, continue_timesteps=continue_timesteps)
+            timestep_units=timestep_units, solver=solver,
+            continue_timesteps=continue_timesteps,
+            clip_negative_densities=clip_negative_densities)
         self.n_steps = n_steps
 
     def _get_bos_data_from_operator(self, step_index, step_power, n_bos):

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -583,11 +583,6 @@ class Integrator(ABC):
         `source_rates` should be the same as the initial run.
 
         .. versionadded:: 0.15.1
-    clip_negative_densities : bool, optional
-        Whether to clip negative atom densities to zero after each CRAM
-        solve. CRAM can produce small negative values. Defaults to False.
-
-        .. versionadded:: 0.15.4
 
     Attributes
     ----------
@@ -637,7 +632,6 @@ class Integrator(ABC):
             timestep_units: str = 's',
             solver: str = "cram48",
             continue_timesteps: bool = False,
-            clip_negative_densities: bool = False,
         ):
         if continue_timesteps and operator.prev_res is None:
             raise ValueError("Continuation run requires passing prev_results.")
@@ -690,8 +684,6 @@ class Integrator(ABC):
         self.timesteps = np.asarray(seconds)
         self.source_rates = np.asarray(source_rates)
 
-        self.clip_negative_densities = clip_negative_densities
-        self._warned_negative_density = False
         self.transfer_rates = None
         self.external_source_rates = None
 
@@ -744,17 +736,11 @@ class Integrator(ABC):
         results = deplete(
             self._solver, self.chain, n, rates, dt, i, matrix_func,
             self.transfer_rates, self.external_source_rates)
-        if self.clip_negative_densities:
-            for j, r in enumerate(results):
-                neg_mask = r < 0
-                if neg_mask.any():
-                    if not self._warned_negative_density:
-                        idx = np.argmin(r)
-                        nuc = self.chain.nuclides[idx].name
-                        warn(f"Clipping negative atom densities "
-                             f"(worst: {nuc} = {r[idx]:.4e})")
-                        self._warned_negative_density = True
-                    results[j] = np.maximum(r, 0.0)
+
+        # Clip unphysical negative number densities
+        for r in results:
+            r.clip(min=0.0, out=r)
+
         return time.time() - start, results
 
     @abstractmethod
@@ -1135,11 +1121,6 @@ class SIIntegrator(Integrator):
         `source_rates` should be the same as the initial run.
 
         .. versionadded:: 0.15.1
-    clip_negative_densities : bool, optional
-        Whether to clip negative atom densities to zero after each CRAM
-        solve. CRAM can produce small negative values. Defaults to False.
-
-        .. versionadded:: 0.15.4
 
     Attributes
     ----------
@@ -1183,15 +1164,12 @@ class SIIntegrator(Integrator):
             n_steps: int = 10,
             solver: str = "cram48",
             continue_timesteps: bool = False,
-            clip_negative_densities: bool = False,
         ):
         check_type("n_steps", n_steps, Integral)
         check_greater_than("n_steps", n_steps, 0)
         super().__init__(
             operator, timesteps, power, power_density, source_rates,
-            timestep_units=timestep_units, solver=solver,
-            continue_timesteps=continue_timesteps,
-            clip_negative_densities=clip_negative_densities)
+            timestep_units=timestep_units, solver=solver, continue_timesteps=continue_timesteps)
         self.n_steps = n_steps
 
     def _get_bos_data_from_operator(self, step_index, step_power, n_bos):

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -736,6 +736,8 @@ class Integrator(ABC):
         results = deplete(
             self._solver, self.chain, n, rates, dt, i, matrix_func,
             self.transfer_rates, self.external_source_rates)
+        # filter-out negative atom densities (non-physical)
+        results = [np.maximum(r, 0.0) for r in results]
         return time.time() - start, results
 
     @abstractmethod

--- a/tests/dummy_operator.py
+++ b/tests/dummy_operator.py
@@ -24,7 +24,7 @@ DepletionSolutionTuple = namedtuple(
 
 predictor_solution = DepletionSolutionTuple(
     PredictorIntegrator, np.array([1.0, 2.46847546272295, 4.11525874568034]),
-    np.array([1.0, 0.986431226850467, -0.0581692232513460]))
+    np.array([1.0, 0.986431226850467, 0.0]))
 
 
 cecm_solution = DepletionSolutionTuple(

--- a/tests/unit_tests/test_deplete_cram.py
+++ b/tests/unit_tests/test_deplete_cram.py
@@ -48,6 +48,8 @@ def test_timed_deplete_clips_negatives():
     integrator.chain = MagicMock()
     integrator.transfer_rates = None
     integrator.external_source_rates = None
+    integrator.clip_negative_densities = True
+    integrator._warned_negative_density = False
 
     fake_results = [
         np.array([1.0e10, -1.0e-35, 0.0, -1.0e-47, 5.0e8]),

--- a/tests/unit_tests/test_deplete_cram.py
+++ b/tests/unit_tests/test_deplete_cram.py
@@ -3,13 +3,10 @@
 Compares a few Mathematica matrix exponentials to CRAM16/CRAM48.
 """
 
-from unittest.mock import patch, MagicMock
-
 from pytest import approx
 import numpy as np
 import scipy.sparse as sp
 from openmc.deplete.cram import CRAM16, CRAM48
-from openmc.deplete.abc import Integrator
 
 
 def test_CRAM16():
@@ -38,34 +35,3 @@ def test_CRAM48():
     z0 = np.array((0.904837418035960, 0.576799023327476))
 
     assert z == approx(z0)
-
-
-def test_timed_deplete_clips_negatives():
-    """Verify _timed_deplete clips negative atom densities to zero."""
-    integrator = MagicMock(spec=Integrator)
-    integrator._timed_deplete = Integrator._timed_deplete.__get__(integrator)
-    integrator._solver = MagicMock()
-    integrator.chain = MagicMock()
-    integrator.transfer_rates = None
-    integrator.external_source_rates = None
-    integrator.clip_negative_densities = True
-    integrator._warned_negative_density = False
-
-    fake_results = [
-        np.array([1.0e10, -1.0e-35, 0.0, -1.0e-47, 5.0e8]),
-        np.array([-1.0e-20, 3.0e12, -1.0e-40]),
-    ]
-    with patch('openmc.deplete.abc.deplete', return_value=fake_results):
-        _, results = integrator._timed_deplete(None, None, 1.0)
-
-    for r in results:
-        assert np.all(r >= 0.0), f"Negative values found: {r[r < 0]}"
-    # Positive values unchanged
-    assert results[0][0] == 1.0e10
-    assert results[0][4] == 5.0e8
-    assert results[1][1] == 3.0e12
-    # Negatives clipped to zero
-    assert results[0][1] == 0.0
-    assert results[0][3] == 0.0
-    assert results[1][0] == 0.0
-    assert results[1][2] == 0.0

--- a/tests/unit_tests/test_deplete_cram.py
+++ b/tests/unit_tests/test_deplete_cram.py
@@ -3,10 +3,13 @@
 Compares a few Mathematica matrix exponentials to CRAM16/CRAM48.
 """
 
+from unittest.mock import patch, MagicMock
+
 from pytest import approx
 import numpy as np
 import scipy.sparse as sp
 from openmc.deplete.cram import CRAM16, CRAM48
+from openmc.deplete.abc import Integrator
 
 
 def test_CRAM16():
@@ -35,3 +38,32 @@ def test_CRAM48():
     z0 = np.array((0.904837418035960, 0.576799023327476))
 
     assert z == approx(z0)
+
+
+def test_timed_deplete_clips_negatives():
+    """Verify _timed_deplete clips negative atom densities to zero."""
+    integrator = MagicMock(spec=Integrator)
+    integrator._timed_deplete = Integrator._timed_deplete.__get__(integrator)
+    integrator._solver = MagicMock()
+    integrator.chain = MagicMock()
+    integrator.transfer_rates = None
+    integrator.external_source_rates = None
+
+    fake_results = [
+        np.array([1.0e10, -1.0e-35, 0.0, -1.0e-47, 5.0e8]),
+        np.array([-1.0e-20, 3.0e12, -1.0e-40]),
+    ]
+    with patch('openmc.deplete.abc.deplete', return_value=fake_results):
+        _, results = integrator._timed_deplete(None, None, 1.0)
+
+    for r in results:
+        assert np.all(r >= 0.0), f"Negative values found: {r[r < 0]}"
+    # Positive values unchanged
+    assert results[0][0] == 1.0e10
+    assert results[0][4] == 5.0e8
+    assert results[1][1] == 3.0e12
+    # Negatives clipped to zero
+    assert results[0][1] == 0.0
+    assert results[0][3] == 0.0
+    assert results[1][0] == 0.0
+    assert results[1][2] == 0.0


### PR DESCRIPTION
# Description

CRAM does not guarantee positivity of nuclide concentrations.
When atom densities get very low, the solver can start to oscillate about zero.

This PR addresses that by clipping to zero any negative value that the solver produces. This then propagates to the next step and the depletion_results.h5 file.
No impact is expected on Bateman solutions as this behaviour arises when concentrations are already infinitesimally low.

The new behaviour is made opt-in with `clip_negative_densities=True`

The attached sample script demonstrates the negative solutions.
[demo.py](https://github.com/user-attachments/files/26000964/demo.py)

**No clipping:**
```
[openmc.deplete] t=0.0 s, dt=1.0 s, source=100000000000000.0
[openmc.deplete] t=1.0 s, dt=43200.0 s, source=0.0
/home/perry/py313/lib64/python3.13/site-packages/uncertainties/core.py:1024: UserWarning: Using UFloat objects with std_dev==0 may give unexpected results.
  warn("Using UFloat objects with std_dev==0 may give unexpected results.")
[openmc.deplete] t=43201.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=86401.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=129601.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=172801.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=216001.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=259201.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=302401.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=345601.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=388801.0 s, dt=43200.0 s, source=0.0

WITHOUT clipping — Co62 oscillates around zero:
  step  1 (t=   0h):   5.79e+12
  step  2 (t=  12h):  -1.25e-34  *** NEGATIVE ***
  step  3 (t=  24h):   2.70e-81
  step  4 (t=  36h): -5.85e-128  *** NEGATIVE ***
  step  5 (t=  48h):  1.26e-174
  step  6 (t=  60h): -2.73e-221  *** NEGATIVE ***
  step  7 (t=  72h):  5.91e-268
  step  8 (t=  84h): -1.28e-314  *** NEGATIVE ***
  step  9 (t=  96h):   0.00e+00
  step 10 (t= 108h):   0.00e+00
  step 11 (t= 120h):   0.00e+00

4 negative values out of 12 steps (without clipping)
```


**With Clipping**
```
[openmc.deplete] t=0.0 s, dt=1.0 s, source=100000000000000.0
[openmc.deplete] t=1.0 s, dt=43200.0 s, source=0.0
/home/perry/py313/lib64/python3.13/site-packages/openmc/deplete/abc.py:754: UserWarning: Clipping negative atom densities (worst: Co62 = -1.2509e-34)
  warn(f"Clipping negative atom densities "
[openmc.deplete] t=43201.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=86401.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=129601.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=172801.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=216001.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=259201.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=302401.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=345601.0 s, dt=43200.0 s, source=0.0
[openmc.deplete] t=388801.0 s, dt=43200.0 s, source=0.0

WITH clipping — negatives clipped to zero:
  step  1 (t=   0h):   5.79e+12
  step  2 (t=  12h):   0.00e+00
  step  3 (t=  24h):   0.00e+00
  step  4 (t=  36h):   0.00e+00
  step  5 (t=  48h):   0.00e+00
  step  6 (t=  60h):   0.00e+00
  step  7 (t=  72h):   0.00e+00
  step  8 (t=  84h):   0.00e+00
  step  9 (t=  96h):   0.00e+00
  step 10 (t= 108h):   0.00e+00
  step 11 (t= 120h):   0.00e+00
```
# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)