### PR TITLE
Use local variable to avoid attribute lookup in form_rxn_matrix loop

### DIFF
--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -641,6 +641,9 @@ class Chain:
         if fission_yields is None:
             fission_yields = self.get_default_fission_yields()
 
+        _index_nuc = rates.index_nuc
+        _index_rx = rates.index_rx
+
         for i, nuc in enumerate(self.nuclides):
             # Loss from radioactive decay
             if nuc.half_life is not None:
@@ -671,14 +674,14 @@ class Chain:
                                 count = decay_type.count('p')
                                 setval(k, i, count * branch_val)
 
-            if nuc.name in rates.index_nuc:
+            if nuc.name in _index_nuc:
                 # Extract all reactions for this nuclide in this cell
-                nuc_ind = rates.index_nuc[nuc.name]
+                nuc_ind = _index_nuc[nuc.name]
                 nuc_rates = rates[nuc_ind, :]
 
                 for r_type, target, _, br in nuc.reactions:
                     # Extract reaction index, and then final reaction rate
-                    r_id = rates.index_rx[r_type]
+                    r_id = _index_rx[r_type]
                     path_rate = nuc_rates[r_id]
 
                     # Loss term -- make sure we only count loss once for


### PR DESCRIPTION

# Description

A tiny performance improvement that caches the  rates.index_nuc and rates.index_rx so that we can avoid looking them up within the loop

I have committed as @yrrepy as this is his idea, I am just facilitating by splitting up a otherwise large piece of work.

I think this small speed improvement makes sense on its own

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

