### PR TITLE
All reduce to print correct number of surface source particles

### DIFF
--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -596,7 +596,8 @@ void write_source_point(std::string filename, span<SourceSite> source_bank,
   int total_surf_particles = source_bank.size();
 #ifdef OPENMC_MPI
   int num_particles = source_bank.size();
-  MPI_Allreduce(&num_particles, &total_surf_particles, 1, MPI_INT, MPI_SUM, mpi::intracomm);
+  MPI_Allreduce(
+    &num_particles, &total_surf_particles, 1, MPI_INT, MPI_SUM, mpi::intracomm);
 #endif
 
   write_message("Creating source file {}.{} with {} particles ...", filename,

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -592,8 +592,15 @@ void write_source_point(std::string filename, span<SourceSite> source_bank,
   const vector<int64_t>& bank_index, bool use_mcpl)
 {
   std::string ext = use_mcpl ? "mcpl" : "h5";
+
+  int total_surf_particles = source_bank.size();
+#ifdef OPENMC_MPI
+  int num_particles = source_bank.size();
+  MPI_Allreduce(&num_particles, &total_surf_particles, 1, MPI_INT, MPI_SUM, mpi::intracomm);
+#endif
+
   write_message("Creating source file {}.{} with {} particles ...", filename,
-    ext, source_bank.size(), 5);
+    ext, total_surf_particles, 5);
 
   // Dispatch to appropriate function based on file type
   if (use_mcpl) {


### PR DESCRIPTION
# Description

Closes #3900

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
