### PR TITLE
Allow Mesh.volumes property for 1D and 2D RegularMesh

### DIFF
--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -268,10 +268,11 @@ class MeshBase(IDManagerMixin, ABC):
         return string
 
     def _volume_dim_check(self):
-        if self.n_dimension != 3 or \
-           any([d == 0 for d in self.dimension]):
-            raise RuntimeError(f'Mesh {self.id} is not 3D. '
-                               'Volumes cannot be provided.')
+        if any(d == 0 for d in self.dimension):
+            raise RuntimeError(
+                f'Mesh {self.id} has a zero-size dimension. '
+                'Volumes cannot be provided.'
+            )
 
     @classmethod
     def from_hdf5(cls, group: h5py.Group):


### PR DESCRIPTION
# Description

To help with PR https://github.com/openmc-dev/openmc/pull/3877 it would be useful if we can get volumes for 1d and 2d meshes. @pshriwise is this ok to remove this defensive check so that meshes with dimensions not equal to 3 are allowed, I think this might come from a time when meshes were only 3d?

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
~ - [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable) ~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
~ - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable) ~
