### PR TITLE
Pin NJOY version in CI to 2016.78

### DIFF
--- a/tools/ci/gha-install-njoy.sh
+++ b/tools/ci/gha-install-njoy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 cd $HOME
-git clone https://github.com/njoy/NJOY2016
+git clone -b 2016.78 https://github.com/njoy/NJOY2016
 cd NJOY2016
 mkdir build && cd build
 cmake -Dstatic=on .. && make 2>/dev/null && sudo make install


### PR DESCRIPTION
# Description

Looks like a recent release of NJOY caused the `make install` command to break (https://github.com/njoy/NJOY2016/issues/397), which causes gha-install-njoy.sh to fail. This PR pins to the previous release to get our CI passing while we determine what is going on with the new release.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>