### PR TITLE
Add Arch Linux User Repository (AUR) installation instructions to documentation 

### DIFF
--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -173,7 +173,7 @@ This package provides a full-featured OpenMC stack, including:
 
 * MPI and DAGMC-enabled OpenMC build
 * User-selected nuclear data libraries
-* The `CAD_to_OpenMC <https://github.com/united-neux/CAD_to_OpenMC>` meshing tool
+* The `CAD_to_OpenMC <https://github.com/united-neux/CAD_to_OpenMC>`_ meshing tool
 * All required dependencies for the above components
 
 To install the package, you will need an AUR helper such as `yay`_ or `paru`_.

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -192,8 +192,8 @@ Alternatively, you can manually clone and build the package:
     cd openmc-git
     makepkg -si
 
-Note, `makepkg`_ uses `pacman`_ to resolve dependencies. Therefore, AUR-based 
-need to be installed separately with `yay`_ or `paru`_ before running `makepkg`_.
+Note, ``makepkg`` uses ``pacman`` to resolve dependencies. Therefore, AUR-based 
+need to be installed separately with ``yay`` or ``paru`` before running ``makepkg``.
 The PKGBUILD will automatically handle all required dependencies and build
 OpenMC with MPI and DAGMC support enabled.
 

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -160,9 +160,9 @@ feature can be used to access the installed packages.
 
 .. _install_aur:
 
-----------------------------------------
+------------------------------------
 Installing on Arch Linux via the AUR
-----------------------------------------
+------------------------------------
 
 On Arch Linux and Arch-based distributions, OpenMC can be installed from the
 `Arch User Repository (AUR) <https://aur.archlinux.org/>`_. An AUR package named
@@ -177,37 +177,30 @@ This package provides a full-featured OpenMC stack, including:
 * All required dependencies for the above components
 
 To install the package, you will need an AUR helper such as `yay`_ or `paru`_.
-For example, using ``yay``:
-
-.. code-block:: sh
+For example, using ``yay``::
 
     yay -S openmc-git
 
 
-Alternatively, you can manually clone and build the package:
-
-.. code-block:: sh
+Alternatively, you can manually clone and build the package::
 
     git clone https://aur.archlinux.org/openmc-git.git
     cd openmc-git
     makepkg -si
 
-Note, ``makepkg`` uses ``pacman`` to resolve dependencies. Therefore, AUR-based 
-dependencies need to be installed separately with ``yay`` or ``paru`` before running ``makepkg``.
-The PKGBUILD will automatically handle all required dependencies and build
-OpenMC with MPI and DAGMC support enabled.
+Note, ``makepkg`` uses ``pacman`` to resolve dependencies. Therefore, AUR-based
+dependencies need to be installed separately with ``yay`` or ``paru`` before
+running ``makepkg``. The PKGBUILD will automatically handle all required
+dependencies and build OpenMC with MPI and DAGMC support enabled.
 
 .. tip::
 
-    If there are failing checks during the build process, you can bypass them with the ``--nocheck`` flag:
-
-    .. code-block:: sh
+    If there are failing checks during the build process, you can bypass them
+    with the ``--nocheck`` flag::
 
         yay -S openmc-git --mflags "--nocheck"
 
-    Or 
-
-    .. code-block:: sh
+    Or::
 
         git clone https://aur.archlinux.org/openmc-git.git
         cd openmc-git
@@ -221,17 +214,16 @@ OpenMC with MPI and DAGMC support enabled.
 
 .. tip::
 
-    OpenMC is installed under ``/opt``. If you are installing and using it in the
-    same terminal session, you may need to reload your environment variables:
-
-    .. code-block:: sh
+    OpenMC is installed under ``/opt``. If you are installing and using it in
+    the same terminal session, you may need to reload your environment
+    variables::
 
         source /etc/profile
 
     Alternatively, start a new shell session.
 
 Once installed, the ``openmc`` executable, nuclear data libraries, and
-associated tools will be available in your system PATH.
+associated tools will be available in your system :envvar:`PATH`.
 
 .. _yay: https://github.com/Jguer/yay
 .. _paru: https://github.com/Morganamilo/paru

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -183,6 +183,7 @@ For example, using ``yay``:
 
     yay -S openmc-git
 
+
 Alternatively, you can manually clone and build the package:
 
 .. code-block:: sh
@@ -191,8 +192,26 @@ Alternatively, you can manually clone and build the package:
     cd openmc-git
     makepkg -si
 
+Note, `makepkg`_ uses `pacman`_ to resolve dependencies. Therefore, AUR-based 
+need to be installed separately with `yay`_ or `paru`_ before running `makepkg`_.
 The PKGBUILD will automatically handle all required dependencies and build
 OpenMC with MPI and DAGMC support enabled.
+
+.. tip::
+
+    If there are failing checks during the build process, you can bypass them with the ``--nocheck`` flag:
+
+    .. code-block:: sh
+
+        yay -S openmc-git --mflags "--nocheck"
+
+    Or 
+
+    .. code-block:: sh
+
+        git clone https://aur.archlinux.org/openmc-git.git
+        cd openmc-git
+        makepkg -si --nocheck
 
 .. note::
 

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -158,6 +158,64 @@ feature can be used to access the installed packages.
 .. _Spack: https://spack.readthedocs.io/en/latest/
 .. _setup guide: https://spack.readthedocs.io/en/latest/getting_started.html
 
+.. _install_aur:
+
+----------------------------------------
+Installing on Arch Linux via the AUR
+----------------------------------------
+
+On Arch Linux and Arch-based distributions, OpenMC can be installed from the
+`Arch User Repository (AUR) <https://aur.archlinux.org/>`_. An AUR package named
+``openmc-git`` is available, which builds OpenMC directly from the latest
+development sources.
+
+This package provides a full-featured OpenMC stack, including:
+
+* MPI and DAGMC-enabled OpenMC build
+* User-selected nuclear data libraries
+* The `CAD_to_OpenMC <https://github.com/united-neux/CAD_to_OpenMC>` meshing tool
+* All required dependencies for the above components
+
+To install the package, you will need an AUR helper such as `yay`_ or `paru`_.
+For example, using ``yay``:
+
+.. code-block:: sh
+
+    yay -S openmc-git
+
+Alternatively, you can manually clone and build the package:
+
+.. code-block:: sh
+
+    git clone https://aur.archlinux.org/openmc-git.git
+    cd openmc-git
+    makepkg -si
+
+The PKGBUILD will automatically handle all required dependencies and build
+OpenMC with MPI and DAGMC support enabled.
+
+.. note::
+
+    The ``openmc-git`` package tracks the latest development version from the
+    upstream repository. As such, it may include new features and bug fixes, but
+    could also introduce instability compared to official releases.
+
+.. tip::
+
+    OpenMC is installed under ``/opt``. If you are installing and using it in the
+    same terminal session, you may need to reload your environment variables:
+
+    .. code-block:: sh
+
+        source /etc/profile
+
+    Alternatively, start a new shell session.
+
+Once installed, the ``openmc`` executable, nuclear data libraries, and
+associated tools will be available in your system PATH.
+
+.. _yay: https://github.com/Jguer/yay
+.. _paru: https://github.com/Morganamilo/paru
 
 .. _install_source:
 

--- a/docs/source/usersguide/install.rst
+++ b/docs/source/usersguide/install.rst
@@ -193,7 +193,7 @@ Alternatively, you can manually clone and build the package:
     makepkg -si
 
 Note, ``makepkg`` uses ``pacman`` to resolve dependencies. Therefore, AUR-based 
-need to be installed separately with ``yay`` or ``paru`` before running ``makepkg``.
+dependencies need to be installed separately with ``yay`` or ``paru`` before running ``makepkg``.
 The PKGBUILD will automatically handle all required dependencies and build
 OpenMC with MPI and DAGMC support enabled.
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR adds an installation option to the User's Guide for Arch Linux and other Arch-based distro users through the [Arch Linux User Repository (AUR)](https://aur.archlinux.org/). 

The goal here is to provide a one-step, Arch-flavored installation option that delivers a fully featured stack including:
- DAGMC and MPI enabled version of OpenMC which tracks the `develop` branch
- User-selected nuclear data installed to `/opt`
- `CAD_to_OpenMC` meshing tool 
# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
