### PR TITLE
Support endf.Material in `from_endf` methods

### DIFF
--- a/openmc/data/angle_distribution.py
+++ b/openmc/data/angle_distribution.py
@@ -10,8 +10,8 @@ from openmc.mixin import EqualityMixin
 from openmc.stats import Univariate, Tabular, Uniform, Legendre
 from .function import INTERPOLATION_SCHEME
 from .data import EV_PER_MEV
-from .endf import get_head_record, get_cont_record, get_tab1_record, \
-    get_list_record, get_tab2_record
+from .endf import as_evaluation, get_head_record, get_cont_record, \
+    get_tab1_record, get_list_record, get_tab2_record
 
 
 class AngleDistribution(EqualityMixin):
@@ -213,7 +213,7 @@ class AngleDistribution(EqualityMixin):
 
         Parameters
         ----------
-        ev : openmc.data.endf.Evaluation
+        ev : openmc.data.endf.Evaluation or endf.Material
             ENDF evaluation
         mt : int
             The MT value of the reaction to get angular distributions for
@@ -224,6 +224,7 @@ class AngleDistribution(EqualityMixin):
             Angular distribution
 
         """
+        ev = as_evaluation(ev)
         file_obj = StringIO(ev.section[4, mt])
 
         # Read HEAD record

--- a/openmc/data/decay.py
+++ b/openmc/data/decay.py
@@ -14,7 +14,8 @@ from openmc.mixin import EqualityMixin
 from openmc.stats import Discrete, Tabular, Univariate, combine_distributions
 from .data import gnds_name, zam
 from .function import INTERPOLATION_SCHEME
-from .endf import Evaluation, get_head_record, get_list_record, get_tab1_record
+from .endf import (
+    as_evaluation, get_head_record, get_list_record, get_tab1_record)
 
 
 # Gives name and (change in A, change in Z) resulting from decay
@@ -75,7 +76,7 @@ class FissionProductYields(EqualityMixin):
 
     Parameters
     ----------
-    ev_or_filename : str of openmc.data.endf.Evaluation
+    ev_or_filename : str, openmc.data.endf.Evaluation, or endf.Material
         ENDF fission product yield evaluation to read from. If given as a
         string, it is assumed to be the filename for the ENDF file.
 
@@ -133,11 +134,7 @@ class FissionProductYields(EqualityMixin):
 
             return energies, data
 
-        # Get evaluation if str is passed
-        if isinstance(ev_or_filename, Evaluation):
-            ev = ev_or_filename
-        else:
-            ev = Evaluation(ev_or_filename)
+        ev = as_evaluation(ev_or_filename)
 
         # Assign basic nuclide properties
         self.nuclide = {
@@ -164,7 +161,7 @@ class FissionProductYields(EqualityMixin):
 
         Parameters
         ----------
-        ev_or_filename : str or openmc.data.endf.Evaluation
+        ev_or_filename : str, openmc.data.endf.Evaluation, or endf.Material
             ENDF fission product yield evaluation to read from. If given as a
             string, it is assumed to be the filename for the ENDF file.
 
@@ -292,7 +289,7 @@ class Decay(EqualityMixin):
 
     Parameters
     ----------
-    ev_or_filename : str of openmc.data.endf.Evaluation
+    ev_or_filename : str, openmc.data.endf.Evaluation, or endf.Material
         ENDF radioactive decay data evaluation to read from. If given as a
         string, it is assumed to be the filename for the ENDF file.
 
@@ -323,11 +320,7 @@ class Decay(EqualityMixin):
 
     """
     def __init__(self, ev_or_filename):
-        # Get evaluation if str is passed
-        if isinstance(ev_or_filename, Evaluation):
-            ev = ev_or_filename
-        else:
-            ev = Evaluation(ev_or_filename)
+        ev = as_evaluation(ev_or_filename)
 
         file_obj = StringIO(ev.section[8, 457])
 
@@ -486,7 +479,7 @@ class Decay(EqualityMixin):
 
         Parameters
         ----------
-        ev_or_filename : str or openmc.data.endf.Evaluation
+        ev_or_filename : str, openmc.data.endf.Evaluation, or endf.Material
             ENDF radioactive decay data evaluation to read from. If given as a
             string, it is assumed to be the filename for the ENDF file.
 
@@ -649,5 +642,3 @@ def decay_energy(nuclide: str):
             warn(f"Chain file '{chain_file}' does not have any decay energy.")
 
     return _DECAY_ENERGY.get(nuclide, 0.0)
-
-

--- a/openmc/data/endf.py
+++ b/openmc/data/endf.py
@@ -12,7 +12,12 @@ import re
 
 from .data import gnds_name
 from .function import Tabulated1D
-from endf.material import _LIBRARY, _SUBLIBRARY, get_materials as get_evaluations
+from endf.material import (
+    Material,
+    _LIBRARY,
+    _SUBLIBRARY,
+    get_materials as get_evaluations,
+)
 from endf.incident_neutron import SUM_RULES
 from endf.records import (
     float_endf,
@@ -44,7 +49,7 @@ class Evaluation:
 
     Parameters
     ----------
-    filename_or_obj : str or file-like
+    filename_or_obj : str, file-like, or endf.Material
         Path to ENDF file to read or an open file positioned at the start of an
         ENDF material
 
@@ -64,17 +69,25 @@ class Evaluation:
 
     """
     def __init__(self, filename_or_obj):
+        self.section = {}
+        self.info = {}
+        self.target = {}
+        self.projectile = {}
+        self.reaction_list = []
+
+        if isinstance(filename_or_obj, Material):
+            self.section = dict(filename_or_obj.section_text)
+            self.section_data = filename_or_obj.section_data
+            self.material = filename_or_obj.MAT
+            self._read_header()
+            return
+
         if isinstance(filename_or_obj, (str, PurePath)):
             fh = open(str(filename_or_obj), 'r')
             need_to_close = True
         else:
             fh = filename_or_obj
             need_to_close = False
-        self.section = {}
-        self.info = {}
-        self.target = {}
-        self.projectile = {}
-        self.reaction_list = []
 
         # Skip TPID record. Evaluators sometimes put in TPID records that are
         # ill-formated because they lack MF/MT values or put them in the wrong
@@ -199,3 +212,10 @@ class Evaluation:
                          self.target['mass_number'],
                          self.target['isomeric_state'])
 
+
+def as_evaluation(ev_or_filename):
+    """Return an object supporting OpenMC's legacy Evaluation interface."""
+    if isinstance(ev_or_filename, Evaluation):
+        return ev_or_filename
+    else:
+        return Evaluation(ev_or_filename)

--- a/openmc/data/fission_energy.py
+++ b/openmc/data/fission_energy.py
@@ -5,7 +5,8 @@ from io import StringIO
 import openmc.checkvalue as cv
 from openmc.mixin import EqualityMixin
 from .data import EV_PER_MEV
-from .endf import get_cont_record, get_list_record, get_tab1_record, Evaluation
+from .endf import (
+    as_evaluation, get_cont_record, get_list_record, get_tab1_record)
 from .function import Function1D, Tabulated1D, Polynomial, sum_functions
 
 
@@ -195,7 +196,7 @@ class FissionEnergyRelease(EqualityMixin):
 
         Parameters
         ----------
-        ev : openmc.data.endf.Evaluation
+        ev : openmc.data.endf.Evaluation or endf.Material
             ENDF evaluation
         incident_neutron : openmc.data.IncidentNeutron
             Corresponding incident neutron dataset
@@ -206,7 +207,7 @@ class FissionEnergyRelease(EqualityMixin):
             Fission energy release data
 
         """
-        cv.check_type('evaluation', ev, Evaluation)
+        ev = as_evaluation(ev)
 
         # Check to make sure this ENDF file matches the expected isomer.
         if ev.target['atomic_number'] != incident_neutron.atomic_number:

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -13,7 +13,8 @@ from . import HDF5_VERSION, HDF5_VERSION_MAJOR
 from .ace import Library, Table, get_table, get_metadata
 from .data import ATOMIC_SYMBOL, K_BOLTZMANN, EV_PER_MEV, gnds_name
 from .endf import (
-    Evaluation, SUM_RULES, get_head_record, get_tab1_record, get_evaluations)
+    Evaluation, SUM_RULES, as_evaluation, get_head_record, get_tab1_record,
+    get_evaluations)
 from .fission_energy import FissionEnergyRelease
 from .function import Tabulated1D, Sum, ResonancesWithBackground
 from .njoy import make_ace, make_pendf
@@ -652,7 +653,7 @@ class IncidentNeutron(EqualityMixin):
 
         Parameters
         ----------
-        ev_or_filename : openmc.data.endf.Evaluation or str
+        ev_or_filename : openmc.data.endf.Evaluation, endf.Material, or str
             ENDF evaluation to read from. If given as a string, it is assumed to
             be the filename for the ENDF file.
 
@@ -666,10 +667,7 @@ class IncidentNeutron(EqualityMixin):
             Incident neutron continuous-energy data
 
         """
-        if isinstance(ev_or_filename, Evaluation):
-            ev = ev_or_filename
-        else:
-            ev = Evaluation(ev_or_filename)
+        ev = as_evaluation(ev_or_filename)
 
         atomic_number = ev.target['atomic_number']
         mass_number = ev.target['mass_number']

--- a/openmc/data/photon.py
+++ b/openmc/data/photon.py
@@ -15,7 +15,8 @@ from openmc.mixin import EqualityMixin
 from . import HDF5_VERSION, HDF5_VERSION_MAJOR
 from .ace import Table, get_metadata, get_table
 from .data import ATOMIC_SYMBOL, EV_PER_MEV
-from .endf import Evaluation, get_head_record, get_tab1_record, get_list_record
+from .endf import (
+    as_evaluation, get_head_record, get_tab1_record, get_list_record)
 from .function import Tabulated1D
 
 
@@ -272,7 +273,7 @@ class AtomicRelaxation(EqualityMixin):
 
         Parameters
         ----------
-        ev_or_filename : str or openmc.data.endf.Evaluation
+        ev_or_filename : str, openmc.data.endf.Evaluation, or endf.Material
             ENDF atomic relaxation evaluation to read from. If given as a
             string, it is assumed to be the filename for the ENDF file.
 
@@ -282,10 +283,7 @@ class AtomicRelaxation(EqualityMixin):
             Atomic relaxation data
 
         """
-        if isinstance(ev_or_filename, Evaluation):
-            ev = ev_or_filename
-        else:
-            ev = Evaluation(ev_or_filename)
+        ev = as_evaluation(ev_or_filename)
 
         # Atomic relaxation data is always MF=28, MT=533
         if (28, 533) not in ev.section:
@@ -606,10 +604,10 @@ class IncidentPhoton(EqualityMixin):
 
         Parameters
         ----------
-        photoatomic : str or openmc.data.endf.Evaluation
+        photoatomic : str, openmc.data.endf.Evaluation, or endf.Material
             ENDF photoatomic data evaluation to read from. If given as a string,
             it is assumed to be the filename for the ENDF file.
-        relaxation : str or openmc.data.endf.Evaluation, optional
+        relaxation : str, openmc.data.endf.Evaluation, or endf.Material, optional
             ENDF atomic relaxation data evaluation to read from. If given as a
             string, it is assumed to be the filename for the ENDF file.
 
@@ -619,10 +617,7 @@ class IncidentPhoton(EqualityMixin):
             Photon interaction data
 
         """
-        if isinstance(photoatomic, Evaluation):
-            ev = photoatomic
-        else:
-            ev = Evaluation(photoatomic)
+        ev = as_evaluation(photoatomic)
 
         Z = ev.target['atomic_number']
         data = cls(Z)
@@ -1071,7 +1066,7 @@ class PhotonReaction(EqualityMixin):
 
         Parameters
         ----------
-        ev : openmc.data.endf.Evaluation
+        ev : openmc.data.endf.Evaluation or endf.Material
             ENDF photo-atomic interaction data evaluation
         mt : int
             The MT value of the reaction to get data for
@@ -1082,6 +1077,7 @@ class PhotonReaction(EqualityMixin):
             Photon reaction data
 
         """
+        ev = as_evaluation(ev)
         rx = cls(mt)
 
         # Read photon cross section

--- a/openmc/data/reaction.py
+++ b/openmc/data/reaction.py
@@ -13,8 +13,8 @@ from .angle_distribution import AngleDistribution
 from .angle_energy import AngleEnergy
 from .correlated import CorrelatedAngleEnergy
 from .data import ATOMIC_SYMBOL, K_BOLTZMANN, EV_PER_MEV
-from .endf import get_head_record, get_tab1_record, get_list_record, \
-    get_tab2_record, get_cont_record
+from .endf import as_evaluation, get_head_record, get_tab1_record, \
+    get_list_record, get_tab2_record, get_cont_record
 from .energy_distribution import EnergyDistribution, LevelInelastic, \
     DiscretePhoton
 from .function import Tabulated1D, Polynomial
@@ -1151,7 +1151,7 @@ class Reaction(EqualityMixin):
 
         Parameters
         ----------
-        ev : openmc.data.endf.Evaluation
+        ev : openmc.data.endf.Evaluation or endf.Material
             ENDF evaluation
         mt : int
             The MT value of the reaction to get data for
@@ -1162,6 +1162,7 @@ class Reaction(EqualityMixin):
             Reaction data
 
         """
+        ev = as_evaluation(ev)
         rx = Reaction(mt)
 
         # Integrated cross section

--- a/openmc/data/resonance.py
+++ b/openmc/data/resonance.py
@@ -7,7 +7,9 @@ import pandas as pd
 
 import openmc.checkvalue as cv
 from .data import NEUTRON_MASS
-from .endf import get_head_record, get_cont_record, get_tab1_record, get_list_record
+from .endf import (
+    as_evaluation, get_head_record, get_cont_record, get_tab1_record,
+    get_list_record)
 try:
     from .reconstruct import wave_number, penetration_shift, reconstruct_mlbw, \
         reconstruct_slbw, reconstruct_rm
@@ -77,7 +79,7 @@ class Resonances:
 
         Parameters
         ----------
-        ev : openmc.data.endf.Evaluation
+        ev : openmc.data.endf.Evaluation or endf.Material
             ENDF evaluation
 
         Returns
@@ -86,6 +88,7 @@ class Resonances:
             Resonance data
 
         """
+        ev = as_evaluation(ev)
         file_obj = io.StringIO(ev.section[2, 151])
 
         # Determine whether discrete or continuous representation

--- a/openmc/data/resonance_covariance.py
+++ b/openmc/data/resonance_covariance.py
@@ -74,7 +74,7 @@ class ResonanceCovariances(Resonances):
 
         Parameters
         ----------
-        ev : openmc.data.endf.Evaluation
+        ev : openmc.data.endf.Evaluation or endf.Material
             ENDF evaluation
         resonances : openmc.data.Resonance object
             openmc.data.Resonanance object generated from the same evaluation
@@ -86,6 +86,7 @@ class ResonanceCovariances(Resonances):
             Resonance covariance data
 
         """
+        ev = endf.as_evaluation(ev)
         file_obj = io.StringIO(ev.section[32, 151])
 
         # Determine whether discrete or continuous representation

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -1042,7 +1042,7 @@ class ThermalScattering(EqualityMixin):
 
         Parameters
         ----------
-        ev_or_filename : openmc.data.endf.Evaluation or str
+        ev_or_filename : openmc.data.endf.Evaluation, endf.Material, or str
             ENDF evaluation to read from. If given as a string, it is assumed to
             be the filename for the ENDF file.
         divide_incoherent_elastic : bool
@@ -1056,10 +1056,7 @@ class ThermalScattering(EqualityMixin):
             Thermal scattering data
 
         """
-        if isinstance(ev_or_filename, endf.Evaluation):
-            ev = ev_or_filename
-        else:
-            ev = endf.Evaluation(ev_or_filename)
+        ev = endf.as_evaluation(ev_or_filename)
 
         # Read incoherent inelastic data
         assert (7, 4) in ev.section, 'No MF=7, MT=4 found in thermal scattering'

--- a/openmc/deplete/chain.py
+++ b/openmc/deplete/chain.py
@@ -319,16 +319,16 @@ class Chain:
 
         String arguments in ``decay_files``, ``fpy_files``, and
         ``neutron_files`` will be treated as file names to be read.
-        Alternatively, :class:`openmc.data.endf.Evaluation` instances
-        can be included in these arguments.
+        Alternatively, :class:`openmc.data.endf.Evaluation` or
+        ``endf.Material`` instances can be included in these arguments.
 
         Parameters
         ----------
-        decay_files : list of str or openmc.data.endf.Evaluation
+        decay_files : list of str, openmc.data.endf.Evaluation, or endf.Material
             List of ENDF decay sub-library files
-        fpy_files : list of str or openmc.data.endf.Evaluation
+        fpy_files : list of str, openmc.data.endf.Evaluation, or endf.Material
             List of ENDF neutron-induced fission product yield sub-library files
-        neutron_files : list of str or openmc.data.endf.Evaluation
+        neutron_files : list of str, openmc.data.endf.Evaluation, or endf.Material
             List of ENDF neutron reaction sub-library files
         reactions : iterable of str, optional
             Transmutation reactions to include in the depletion chain, e.g.,
@@ -363,7 +363,7 @@ class Chain:
             print('Processing neutron sub-library files...')
         reactions = {}
         for f in neutron_files:
-            evaluation = openmc.data.endf.Evaluation(f)
+            evaluation = openmc.data.endf.as_evaluation(f)
             name = evaluation.gnds_name
             reactions[name] = {}
             for mf, mt, nc, mod in evaluation.reaction_list:

--- a/tests/unit_tests/test_data_decay.py
+++ b/tests/unit_tests/test_data_decay.py
@@ -100,6 +100,28 @@ def test_fpy(u235_yields):
     ufloat_close(thermal['I135'], ufloat(0.0292737, 0.000819663))
 
 
+def test_decay_from_endf_material(endf_data):
+    filename = os.path.join(endf_data, 'decay', 'dec-041_Nb_090.endf')
+    material = openmc.data.endf.get_evaluations(filename)[0]
+
+    data = openmc.data.Decay.from_endf(material)
+
+    assert data.nuclide['name'] == 'Nb90'
+    assert not data.nuclide['stable']
+    assert len(data.modes) == 2
+
+
+def test_fpy_from_endf_material(endf_data):
+    filename = os.path.join(endf_data, 'nfy', 'nfy-092_U_235.endf')
+    material = openmc.data.endf.get_evaluations(filename)[0]
+
+    data = openmc.data.FissionProductYields.from_endf(material)
+
+    assert data.nuclide['name'] == 'U235'
+    assert data.energies == pytest.approx([0.0253, 500.e3, 1.4e7])
+    assert 'I135' in data.cumulative[0]
+
+
 def test_sources(ba137m, nb90):
     # Running .sources twice should give same objects
     sources = ba137m.sources

--- a/tests/unit_tests/test_data_neutron.py
+++ b/tests/unit_tests/test_data_neutron.py
@@ -133,6 +133,28 @@ def test_attributes(pu239):
     assert pu239.atomic_weight_ratio == pytest.approx(236.9986)
 
 
+def test_from_endf_material(endf_data):
+    filename = os.path.join(endf_data, 'neutrons', 'n-001_H_001.endf')
+    material = openmc.data.endf.get_evaluations(filename)[0]
+
+    data = openmc.data.IncidentNeutron.from_endf(material)
+
+    assert data.name == 'H1'
+    assert data.atomic_number == 1
+    assert data.mass_number == 1
+    assert 2 in data.reactions
+
+
+def test_fission_energy_from_endf_material(endf_data):
+    filename = os.path.join(endf_data, 'neutrons', 'n-092_U_235.endf')
+    material = openmc.data.endf.get_evaluations(filename)[0]
+    neutron = openmc.data.IncidentNeutron.from_endf(material)
+
+    data = openmc.data.FissionEnergyRelease.from_endf(material, neutron)
+
+    assert data.fragments(0.0) > 0.0
+
+
 def test_fission_energy(pu239):
     fer = pu239.fission_energy
     assert isinstance(fer, openmc.data.FissionEnergyRelease)

--- a/tests/unit_tests/test_data_photon.py
+++ b/tests/unit_tests/test_data_photon.py
@@ -149,3 +149,27 @@ def test_photodat_only(run_in_tmpdir, endf_data):
     photoatomic_file = endf_dir / 'photoat' / 'photoat-001_H_000.endf'
     data = openmc.data.IncidentPhoton.from_endf(photoatomic_file)
     data.export_to_hdf5('tmp.h5', 'w')
+
+
+def test_from_endf_material(endf_data):
+    endf_dir = Path(endf_data)
+    photoatomic_file = endf_dir / 'photoat' / 'photoat-001_H_000.endf'
+    relaxation_file = endf_dir / 'atomic_relax' / 'atom-001_H_000.endf'
+    photoatomic = openmc.data.endf.get_evaluations(photoatomic_file)[0]
+    relaxation = openmc.data.endf.get_evaluations(relaxation_file)[0]
+
+    data = openmc.data.IncidentPhoton.from_endf(photoatomic, relaxation)
+
+    assert data.atomic_number == 1
+    assert 502 in data.reactions
+    assert data.atomic_relaxation.binding_energy['K'] == pytest.approx(13.61)
+
+
+def test_atomic_relaxation_from_endf_material(endf_data):
+    filename = Path(endf_data) / 'atomic_relax' / 'atom-001_H_000.endf'
+    material = openmc.data.endf.get_evaluations(filename)[0]
+
+    data = openmc.data.AtomicRelaxation.from_endf(material)
+
+    assert data.binding_energy['K'] == pytest.approx(13.61)
+    assert data.num_electrons['K'] == pytest.approx(1.0)

--- a/tests/unit_tests/test_data_thermal.py
+++ b/tests/unit_tests/test_data_thermal.py
@@ -148,6 +148,18 @@ def test_h2o_endf(endf_data):
                                 '600K', '650K', '800K']
 
 
+def test_from_endf_material(endf_data):
+    filename = os.path.join(endf_data, 'thermal_scatt', 'tsl-HinH2O.endf')
+    material = openmc.data.endf.get_evaluations(filename)[0]
+
+    h2o = openmc.data.ThermalScattering.from_endf(
+        material, divide_incoherent_elastic=True)
+
+    assert not h2o.elastic
+    assert h2o.atomic_weight_ratio == pytest.approx(0.99917)
+    assert h2o.temperatures[0] == '294K'
+
+
 def test_hzrh_attributes(hzrh):
     assert hzrh.atomic_weight_ratio == pytest.approx(0.99917)
     assert hzrh.energy_max == pytest.approx(1.9734)

--- a/tests/unit_tests/test_endf.py
+++ b/tests/unit_tests/test_endf.py
@@ -2,6 +2,17 @@ from openmc.data import endf
 from pytest import approx
 
 
+def test_evaluation_from_material(endf_data):
+    filename = f'{endf_data}/neutrons/n-001_H_001.endf'
+    material = endf.get_evaluations(filename)[0]
+    evaluation = endf.Evaluation(material)
+
+    assert evaluation.material == material.MAT
+    assert evaluation.gnds_name == 'H1'
+    assert evaluation.section == material.section_text
+    assert evaluation.reaction_list == material[1, 451]['section_list']
+
+
 def test_float_endf():
     assert endf.float_endf('+3.2146') == approx(3.2146)
     assert endf.float_endf('.12345') == approx(0.12345)


### PR DESCRIPTION
# Description

This PR updates the various `from_endf` methods on classes within openmc.data to function properly when passed an `endf.Material` object (which effectively replaces the `Evaluation` class from OpenMC). This is meant to be an alternative to the solution proposed in paulromano/endf-python#40.

Let me know what you think @shimwell!

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)