### PR TITLE
Fix missing volume checks in material activity/decay heat

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1418,6 +1418,9 @@ class Material(IDManagerMixin):
         if volume is None:
             volume = self.volume
 
+        if units in {'Bq', 'Ci'} and volume is None:
+            raise ValueError(f"Volume must be set in order to compute activity in '{units}'.")
+
         if units == 'Bq':
             multiplier = volume
         elif units == 'Bq/cm3':
@@ -1474,6 +1477,8 @@ class Material(IDManagerMixin):
 
         if units == 'W':
             multiplier = volume if volume is not None else self.volume
+            if multiplier is None:
+                raise ValueError("Volume must be set in order to compute total decay heat.")
         elif units == 'W/cm3':
             multiplier = 1
         elif units == 'W/m3':

--- a/tests/unit_tests/test_material.py
+++ b/tests/unit_tests/test_material.py
@@ -561,6 +561,10 @@ def test_get_activity():
     m1.add_element("Fe", 0.7)
     m1.add_element("Li", 0.3)
     m1.set_density('g/cm3', 1.5)
+    with pytest.raises(ValueError, match="Volume must be set"):
+        m1.get_activity(units='Bq')
+    with pytest.raises(ValueError, match="Volume must be set"):
+        m1.get_activity(units='Ci')
     # activity in Bq/cc and Bq/g should not require volume setting
     assert m1.get_activity(units='Bq/cm3') == 0
     assert m1.get_activity(units='Bq/g') == 0
@@ -619,6 +623,8 @@ def test_get_decay_heat():
     m1.add_nuclide("U235", 0.2)
     m1.add_nuclide("U238", 0.8)
     m1.set_density('g/cm3', 10.5)
+    with pytest.raises(ValueError, match="Volume must be set"):
+        m1.get_decay_heat(units='W')
     # decay heat in W/cc and W/g should not require volume setting
     assert m1.get_decay_heat(units='W/cm3') == 0
     assert m1.get_decay_heat(units='W/g') == 0


### PR DESCRIPTION
### Summary

This PR adds explicit validation for Material.volume in total activity (Bq, Ci) and decay heat (W) calculations.

Previously, calling get_activity() or get_decay_heat() without setting a material volume could result in unclear or misleading runtime errors (e.g., TypeError or downstream failures).

This change introduces a clear and early ValueError when volume is not defined, improving error clarity and robustness of the material depletion/decay interface.

### Changes
- Added explicit check for Material.volume before computing:
       -- total activity
       -- total decay heat
- Raise ValueError with a descriptive message if volume is not set
- Ensures failure occurs at the correct abstraction level (input validation instead of downstream numerical failure)

### Testing 
pytest tests/unit_tests/test_material.py -k "get_activity or get_decay_heat"

### Result
2 passed, 35 deselected

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
