### PR TITLE
Check for missing thread count argument for -s/--threads

### DIFF
--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -300,6 +300,11 @@ int parse_command_line(int argc, char* argv[])
         settings::run_mode = RunMode::VOLUME;
       } else if (arg == "-s" || arg == "--threads") {
         // Read number of threads
+        if (i + 1 >= argc) {
+          std::string msg {"Number of threads not specified."};
+          strcpy(openmc_err_msg, msg.c_str());
+          return OPENMC_E_INVALID_ARGUMENT;
+        }
         i += 1;
 
 #ifdef _OPENMP


### PR DESCRIPTION
Summary
Adds validation for the `-s` / `--threads` command line option to ensure a thread count argument is provided before accessing `argv[i]`.

Previously, invoking:
openmc -s
could result in an out-of-range access and exception rather than returning a clean invalid argument error.

Changes Made
- Added argument existence check before reading thread count value
- Returns `OPENMC_E_INVALID_ARGUMENT` with a descriptive error message when no thread count is specified

Issue
Fixes #3353