### PR TITLE
Guard average molar mass and validate materials depletion inputs

### DIFF
--- a/openmc/material.py
+++ b/openmc/material.py
@@ -296,6 +296,8 @@ class Material(IDManagerMixin):
                 mass += nuc.percent
 
         # Compute and return the molar mass
+        if moles == 0.0:
+            raise ValueError("Material has no nuclides; cannot compute molar mass")
         return mass / moles
 
     @property

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -2289,7 +2289,7 @@ class Materials(cv.CheckedList):
         multigroup_fluxes: Sequence[Sequence[float]]
             Energy-dependent multigroup flux values, where each sublist corresponds
             to a specific material. Will be normalized so that it sums to 1.
-        energy_group_structures': Sequence[Sequence[float] | str]
+        energy_group_structures: Sequence[Sequence[float] | str]
             Energy group boundaries in [eV] or the name of the group structure.
         timesteps : iterable of float or iterable of tuple
             Array of timesteps. Note that values are not cumulative. The units are
@@ -2324,6 +2324,11 @@ class Materials(cv.CheckedList):
         for mat in self:
             mat.depletable = True
 
+        if len(multigroup_fluxes) != len(self):
+            raise ValueError("multigroup_fluxes length must match number of materials")
+        if len(energy_group_structures) != len(self):
+            raise ValueError("energy_group_structures length must match number of materials")
+
         chain = _get_chain(chain_file)
 
         # Create MicroXS objects for all materials
@@ -2334,6 +2339,10 @@ class Materials(cv.CheckedList):
             for material, flux, energy in zip(
                 self, multigroup_fluxes, energy_group_structures
             ):
+                if material.volume is None:
+                    raise ValueError(
+                        f"Material {material.id} has no volume; cannot deplete"
+                    )
                 temperature = material.temperature or 293.6
                 micro_xs = openmc.deplete.MicroXS.from_multigroup_flux(
                     energies=energy,

--- a/tests/unit_tests/test_materials.py
+++ b/tests/unit_tests/test_materials.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 import openmc
 from openmc.deplete import Chain
 
@@ -78,3 +80,50 @@ def test_export_duplicate_materials_to_xml(run_in_tmpdir):
 
     materials_in = openmc.Materials.from_xml("materials.xml")
     assert len(materials_in) == 2
+
+
+def test_materials_deplete_length_mismatch():
+    mats = openmc.Materials([openmc.Material()])
+
+    with pytest.raises(ValueError, match="multigroup_fluxes length"):
+        mats.deplete(
+            multigroup_fluxes=[],
+            energy_group_structures=["VITAMIN-J-42"],
+            timesteps=[1.0],
+            source_rates=1.0,
+        )
+
+    with pytest.raises(ValueError, match="energy_group_structures length"):
+        mats.deplete(
+            multigroup_fluxes=[[1.0]],
+            energy_group_structures=[],
+            timesteps=[1.0],
+            source_rates=1.0,
+        )
+
+
+def test_materials_deplete_missing_volume(monkeypatch):
+    mat = openmc.Material()
+    mat.add_nuclide("Ni58", 1.0)
+    mat.set_density("g/cm3", 7.87)
+
+    mats = openmc.Materials([mat])
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(openmc.lib, "TemporarySession", DummySession)
+
+    chain = Path(__file__).parents[1] / "chain_ni.xml"
+    with pytest.raises(ValueError, match="has no volume"):
+        mats.deplete(
+            multigroup_fluxes=[[1.0]],
+            energy_group_structures=["VITAMIN-J-42"],
+            timesteps=[1.0],
+            source_rates=1.0,
+            chain_file=chain,
+        )


### PR DESCRIPTION
# Description

- Raise a clear error if average_molar_mass is accessed before any nuclides are added. 
- Add validation for Materials.deplete input lengths and missing material volumes. 
- Fix a small docstring typo in Materials.deplete. 
- Add unit tests covering the new validation errors.

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
