### PR TITLE
Avoid storing inconsistent sum/sum_sq on summed D1S tallies

### DIFF
--- a/openmc/deplete/d1s.py
+++ b/openmc/deplete/d1s.py
@@ -150,10 +150,7 @@ def apply_time_correction(
     Returns
     -------
     openmc.Tally
-        Derived tally with time correction factors applied. When
-        ``sum_nuclides`` is True the result is a derived tally, for which
-        ``sum`` and ``sum_sq`` are None (as for any derived tally); the
-        meaningful results are ``mean`` and ``std_dev``.
+        Derived tally with time correction factors applied
 
     """
     # Make sure the tally contains a ParentNuclideFilter
@@ -197,18 +194,11 @@ def apply_time_correction(
     if sum_nuclides:
         # Sum over parent nuclides (note that when combining different bins for
         # parent nuclide, we can't work directly on sum_sq)
+        new_tally._sum = None
+        new_tally._sum_sq = None
         new_tally._mean = new_tally.mean.sum(axis=1).reshape(shape)
         new_tally._std_dev = np.linalg.norm(new_tally.std_dev, axis=1).reshape(shape)
         new_tally._derived = True
-
-        # The summed tally is derived, so Tally.sum/sum_sq return None
-        # regardless of what is stored. Leave them unset rather than keeping the
-        # per-parent-nuclide arrays, which are shaped inconsistently with the
-        # remaining filters (the ParentNuclideFilter is removed below). This
-        # also avoids two full-size array multiplies per call that are never
-        # read.
-        new_tally._sum = None
-        new_tally._sum_sq = None
 
         # Remove ParentNuclideFilter
         new_tally.filters.pop(i_filter)

--- a/openmc/deplete/d1s.py
+++ b/openmc/deplete/d1s.py
@@ -150,7 +150,10 @@ def apply_time_correction(
     Returns
     -------
     openmc.Tally
-        Derived tally with time correction factors applied
+        Derived tally with time correction factors applied. When
+        ``sum_nuclides`` is True the result is a derived tally, for which
+        ``sum`` and ``sum_sq`` are None (as for any derived tally); the
+        meaningful results are ``mean`` and ``std_dev``.
 
     """
     # Make sure the tally contains a ParentNuclideFilter
@@ -186,8 +189,6 @@ def apply_time_correction(
 
     # Apply TCF, broadcasting to the correct dimensions
     tcf.shape = (1, -1, 1, 1, 1)
-    new_tally._sum = tally_sum * tcf
-    new_tally._sum_sq = tally_sum_sq * (tcf*tcf)
     new_tally._mean = tally_mean * tcf
     new_tally._std_dev = tally_std_dev * tcf
 
@@ -200,12 +201,22 @@ def apply_time_correction(
         new_tally._std_dev = np.linalg.norm(new_tally.std_dev, axis=1).reshape(shape)
         new_tally._derived = True
 
+        # The summed tally is derived, so Tally.sum/sum_sq return None
+        # regardless of what is stored. Leave them unset rather than keeping the
+        # per-parent-nuclide arrays, which are shaped inconsistently with the
+        # remaining filters (the ParentNuclideFilter is removed below). This
+        # also avoids two full-size array multiplies per call that are never
+        # read.
+        new_tally._sum = None
+        new_tally._sum_sq = None
+
         # Remove ParentNuclideFilter
         new_tally.filters.pop(i_filter)
     else:
-        # Change shape back to (filter combinations, nuclides, scores)
-        new_tally._sum.shape = shape
-        new_tally._sum_sq.shape = shape
+        # Apply TCF and change shape back to (filter combinations, nuclides,
+        # scores)
+        new_tally._sum = (tally_sum * tcf).reshape(shape)
+        new_tally._sum_sq = (tally_sum_sq * (tcf*tcf)).reshape(shape)
         new_tally._mean.shape = shape
         new_tally._std_dev.shape = shape
 

--- a/tests/unit_tests/test_d1s.py
+++ b/tests/unit_tests/test_d1s.py
@@ -150,3 +150,7 @@ def test_apply_time_correction(run_in_tmpdir):
     result_summed.get_reshaped_data()
     result.get_pandas_dataframe()
     result_summed.get_pandas_dataframe()
+
+    # The summed tally is derived, so sum/sum_sq are None
+    assert result_summed.sum is None
+    assert result_summed.sum_sq is None


### PR DESCRIPTION
# Description

I think we are doing some compute that we don't need to when working with D1S tallies.

For sum_nuclides=True, apply_time_correction returns a derived tally with the ParentNuclideFilter removed. The previous code left _sum/_sum_sq set to per-parent-nuclide arrays shaped for the pre-removal filter set. These are unreachable through the public Tally.sum/sum_sq accessors (which return None for any derived tally) and are inconsistent with the remaining filters, so converting such a tally with Tally.sparse raises a reshape error.

Set sum/sum_sq to None for the summed result (matching the observable develop behavior) and skip the two full-size array multiplies that are never read. mean/std_dev are unchanged bit-for-bit. This fixes Tally.sparse on summed D1S tallies and speeds up the summed path for large mesh tallies by not computing the discarded arrays.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
