### PR TITLE
Add description attribute to Model

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -60,6 +60,8 @@ class Model:
         Tallies information
     plots : openmc.Plots, optional
         Plot information
+    description : str, optional
+        A description of the model
 
     Attributes
     ----------
@@ -73,6 +75,8 @@ class Model:
         Tallies information
     plots : openmc.Plots
         Plot information
+    description : str
+        A description of the model
 
     """
 
@@ -83,12 +87,14 @@ class Model:
         settings: openmc.Settings | None = None,
         tallies: openmc.Tallies | None = None,
         plots: openmc.Plots | None = None,
+        description: str = '',
     ):
         self.geometry = openmc.Geometry() if geometry is None else geometry
         self.materials = openmc.Materials() if materials is None else materials
         self.settings = openmc.Settings() if settings is None else settings
         self.tallies = openmc.Tallies() if tallies is None else tallies
         self.plots = openmc.Plots() if plots is None else plots
+        self.description = description
 
     @property
     def geometry(self) -> openmc.Geometry:
@@ -155,6 +161,15 @@ class Model:
             del self._plots[:]
             for plot in plots:
                 self._plots.append(plot)
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        check_type('description', description, str)
+        self._description = description
 
     @property
     def bounding_box(self) -> openmc.BoundingBox:
@@ -364,6 +379,10 @@ class Model:
         root = tree.getroot()
 
         model = cls()
+
+        desc_elem = root.find('description')
+        if desc_elem is not None and desc_elem.text:
+            model.description = desc_elem.text
 
         meshes = {}
         model.settings = openmc.Settings.from_xml_element(
@@ -701,6 +720,8 @@ class Model:
             # write the XML header
             fh.write("<?xml version='1.0' encoding='utf-8'?>\n")
             fh.write("<model>\n")
+            if self.description:
+                fh.write(f"  <description>{self.description}</description>\n")
             # Write the materials collection to the open XML file first.
             # This will write the XML header also
             materials._write_xml(fh, False, level=1,

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -721,7 +721,11 @@ class Model:
             fh.write("<?xml version='1.0' encoding='utf-8'?>\n")
             fh.write("<model>\n")
             if self.description:
-                fh.write(f"  <description>{self.description}</description>\n")
+                description_element = ET.Element('description')
+                description_element.text = self.description
+                fh.write("  ")
+                fh.write(ET.tostring(description_element, encoding="unicode"))
+                fh.write("\n")
             # Write the materials collection to the open XML file first.
             # This will write the XML header also
             materials._write_xml(fh, False, level=1,

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -572,6 +572,24 @@ def test_model_xml(run_in_tmpdir):
     new_model.export_to_xml()
 
 
+def test_model_description(run_in_tmpdir):
+    model = openmc.examples.pwr_pin_cell()
+    model.description = "PWR pin cell test model"
+    model.export_to_model_xml()
+
+    reloaded = openmc.Model.from_model_xml()
+    assert reloaded.description == "PWR pin cell test model"
+
+    # Verify that an empty description is not written to XML
+    model2 = openmc.examples.pwr_pin_cell()
+    model2.export_to_model_xml('model_no_desc.xml')
+    with open('model_no_desc.xml') as f:
+        assert '<description>' not in f.read()
+
+    reloaded2 = openmc.Model.from_model_xml('model_no_desc.xml')
+    assert reloaded2.description == ''
+
+
 def test_single_xml_exec(run_in_tmpdir):
 
     pincell_model = openmc.examples.pwr_pin_cell()

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -574,11 +574,11 @@ def test_model_xml(run_in_tmpdir):
 
 def test_model_description(run_in_tmpdir):
     model = openmc.examples.pwr_pin_cell()
-    model.description = "PWR pin cell test model"
+    model.description = "PWR fuel & water <test model>"
     model.export_to_model_xml()
 
     reloaded = openmc.Model.from_model_xml()
-    assert reloaded.description == "PWR pin cell test model"
+    assert reloaded.description == "PWR fuel & water <test model>"
 
     # Verify that an empty description is not written to XML
     model2 = openmc.examples.pwr_pin_cell()


### PR DESCRIPTION
Closes #3586.

Adds a `description` property to `Model` that allows users to attach
a free-text description to a model instance.

- The description is written as a `<description>` element in model XML
  and read back via `from_model_xml`.
- An empty description (the default) is omitted from the output.
- Type-checked via `check_type`.

Tests cover round-trip serialization, empty-description omission, and
empty round-trip.