### PR TITLE
Tally 32-bit Overflow Fix

### DIFF
--- a/include/openmc/random_ray/source_region.h
+++ b/include/openmc/random_ray/source_region.h
@@ -690,7 +690,7 @@ private:
   // Private Methods
 
   // Helper function for indexing
-  inline int index(int64_t sr, int g) const { return sr * negroups_ + g; }
+  inline int64_t index(int64_t sr, int g) const { return sr * negroups_ + g; }
 };
 
 } // namespace openmc

--- a/include/openmc/random_ray/source_region.h
+++ b/include/openmc/random_ray/source_region.h
@@ -51,10 +51,10 @@ inline void hash_combine(size_t& seed, const size_t v)
 // every iteration.
 struct TallyTask {
   int tally_idx;
-  int filter_idx;
+  int64_t filter_idx;
   int score_idx;
   int score_type;
-  TallyTask(int tally_idx, int filter_idx, int score_idx, int score_type)
+  TallyTask(int tally_idx, int64_t filter_idx, int score_idx, int score_type)
     : tally_idx(tally_idx), filter_idx(filter_idx), score_idx(score_idx),
       score_type(score_type)
   {}

--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -97,9 +97,9 @@ public:
   //! Given already-set filters, set the stride lengths
   void set_strides();
 
-  int32_t strides(int i) const { return strides_[i]; }
+  int64_t strides(int i) const { return strides_[i]; }
 
-  int32_t n_filter_bins() const { return n_filter_bins_; }
+  int64_t n_filter_bins() const { return n_filter_bins_; }
 
   bool multiply_density() const { return multiply_density_; }
 
@@ -184,9 +184,9 @@ private:
   vector<int32_t> filters_; //!< Filter indices in global filters array
 
   //! Index strides assigned to each filter to support 1D indexing.
-  vector<int32_t> strides_;
+  vector<int64_t> strides_;
 
-  int32_t n_filter_bins_ {0};
+  int64_t n_filter_bins_ {0};
 
   //! Whether to multiply by atom density for reaction rates
   bool multiply_density_ {true};

--- a/include/openmc/tallies/tally_scoring.h
+++ b/include/openmc/tallies/tally_scoring.h
@@ -41,7 +41,7 @@ public:
 
   FilterBinIter& operator++();
 
-  int index_ {1};
+  int64_t index_ {1};
   double weight_ {1.};
 
   vector<FilterMatch>& filter_matches_;

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3,10 +3,10 @@
 #include <cassert>
 #include <cstdint>        // for uint64_t
 #include <cstring>        // for memcpy
-#include <limits>
 #define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
 #include <cmath>          // for ceil
 #include <cstddef>        // for size_t
+#include <limits>
 #include <numeric>        // for accumulate
 #include <string>
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cstdint>        // for uint64_t
 #include <cstring>        // for memcpy
+#include <limits>
 #define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
 #include <cmath>          // for ceil
 #include <cstddef>        // for size_t
@@ -1080,13 +1081,26 @@ int StructuredMesh::get_bin(Position r) const
 
 int StructuredMesh::n_bins() const
 {
-  return std::accumulate(
-    shape_.begin(), shape_.begin() + n_dimension_, 1, std::multiplies<>());
+  // Bin indices are stored as 32-bit ints in the tally system.
+  int64_t n = 1;
+  for (int i = 0; i < n_dimension_; ++i)
+    n *= shape_[i];
+  if (n > std::numeric_limits<int>::max()) {
+    fatal_error(fmt::format(
+      "Mesh {} has too many bins ({}) for 32-bit tally indexing", id_, n));
+  }
+  return static_cast<int>(n);
 }
 
 int StructuredMesh::n_surface_bins() const
 {
-  return 4 * n_dimension_ * n_bins();
+  // Surface bin indices are stored as 32-bit ints in the tally system.
+  int64_t n = static_cast<int64_t>(n_bins()) * 4 * n_dimension_;
+  if (n > std::numeric_limits<int>::max()) {
+    fatal_error(fmt::format(
+      "Mesh {} has too many surface bins ({}) for tally indexing", id_, n));
+  }
+  return static_cast<int>(n);
 }
 
 tensor::Tensor<double> StructuredMesh::count_sites(

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -7,7 +7,7 @@
 #include <cmath>          // for ceil
 #include <cstddef>        // for size_t
 #include <limits>
-#include <numeric>        // for accumulate
+#include <numeric> // for accumulate
 #include <string>
 
 #ifdef _MSC_VER

--- a/src/random_ray/flat_source_domain.cpp
+++ b/src/random_ray/flat_source_domain.cpp
@@ -724,7 +724,7 @@ void FlatSourceDomain::random_ray_tally()
     for (int i = 0; i < model::tallies.size(); i++) {
       Tally& tally {*model::tallies[i]};
 #pragma omp parallel for
-      for (int bin = 0; bin < tally.n_filter_bins(); bin++) {
+      for (int64_t bin = 0; bin < tally.n_filter_bins(); bin++) {
         for (int score_idx = 0; score_idx < tally.n_scores(); score_idx++) {
           auto score_type = tally.scores_[score_idx];
           if (score_type == SCORE_FLUX) {

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -887,7 +887,7 @@ void Tally::accumulate()
     if (higher_moments_) {
 #pragma omp parallel for
       // filter bins (specific cell, energy bins)
-      for (int i = 0; i < results_.shape(0); ++i) {
+      for (int64_t i = 0; i < results_.shape(0); ++i) {
         // score bins (flux, total reaction rate, fission reaction rate, etc.)
         for (int j = 0; j < results_.shape(1); ++j) {
           double val = results_(i, j, TallyResult::VALUE) * norm;
@@ -902,7 +902,7 @@ void Tally::accumulate()
     } else {
 #pragma omp parallel for
       // filter bins (specific cell, energy bins)
-      for (int i = 0; i < results_.shape(0); ++i) {
+      for (int64_t i = 0; i < results_.shape(0); ++i) {
         // score bins (flux, total reaction rate, fission reaction rate, etc.)
         for (int j = 0; j < results_.shape(1); ++j) {
           double val = results_(i, j, TallyResult::VALUE) * norm;

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -512,7 +512,7 @@ void Tally::set_strides()
   // longest stride.
   auto n = filters_.size();
   strides_.resize(n, 0);
-  int stride = 1;
+  int64_t stride = 1;
   for (int i = n - 1; i >= 0; --i) {
     strides_[i] = stride;
     stride *= model::tally_filters[filters_[i]]->n_bins();

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -578,8 +578,8 @@ double get_nuclide_xs(const Particle& p, int i_nuclide, int score_bin)
 //! collision estimator.
 
 void score_general_ce_nonanalog(Particle& p, int i_tally, int start_index,
-  int64_t filter_index, double filter_weight, int i_nuclide, double atom_density,
-  double flux)
+  int64_t filter_index, double filter_weight, int i_nuclide,
+  double atom_density, double flux)
 {
   Tally& tally {*model::tallies[i_tally]};
 
@@ -1112,8 +1112,8 @@ void score_general_ce_nonanalog(Particle& p, int i_tally, int start_index,
 //! is not used for analog tallies.
 
 void score_general_ce_analog(Particle& p, int i_tally, int start_index,
-  int64_t filter_index, double filter_weight, int i_nuclide, double atom_density,
-  double flux)
+  int64_t filter_index, double filter_weight, int i_nuclide,
+  double atom_density, double flux)
 {
   Tally& tally {*model::tallies[i_tally]};
 
@@ -1615,8 +1615,8 @@ void score_general_ce_analog(Particle& p, int i_tally, int start_index,
 //! argument is really just used for filter weights.
 
 void score_general_mg(Particle& p, int i_tally, int start_index,
-  int64_t filter_index, double filter_weight, int i_nuclide, double atom_density,
-  double flux)
+  int64_t filter_index, double filter_weight, int i_nuclide,
+  double atom_density, double flux)
 {
   auto& tally {*model::tallies[i_tally]};
 

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -578,7 +578,7 @@ double get_nuclide_xs(const Particle& p, int i_nuclide, int score_bin)
 //! collision estimator.
 
 void score_general_ce_nonanalog(Particle& p, int i_tally, int start_index,
-  int filter_index, double filter_weight, int i_nuclide, double atom_density,
+  int64_t filter_index, double filter_weight, int i_nuclide, double atom_density,
   double flux)
 {
   Tally& tally {*model::tallies[i_tally]};
@@ -1112,7 +1112,7 @@ void score_general_ce_nonanalog(Particle& p, int i_tally, int start_index,
 //! is not used for analog tallies.
 
 void score_general_ce_analog(Particle& p, int i_tally, int start_index,
-  int filter_index, double filter_weight, int i_nuclide, double atom_density,
+  int64_t filter_index, double filter_weight, int i_nuclide, double atom_density,
   double flux)
 {
   Tally& tally {*model::tallies[i_tally]};
@@ -1615,7 +1615,7 @@ void score_general_ce_analog(Particle& p, int i_tally, int start_index,
 //! argument is really just used for filter weights.
 
 void score_general_mg(Particle& p, int i_tally, int start_index,
-  int filter_index, double filter_weight, int i_nuclide, double atom_density,
+  int64_t filter_index, double filter_weight, int i_nuclide, double atom_density,
   double flux)
 {
   auto& tally {*model::tallies[i_tally]};

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -158,7 +158,7 @@ void score_fission_delayed_dg(int i_tally, int d_bin, double score,
   dg_match.bins_[i_bin] = d_bin;
 
   // Determine the filter scoring index
-  auto filter_index = 0;
+  int64_t filter_index = 0;
   double filter_weight = 1.;
   for (auto i = 0; i < tally.filters().size(); ++i) {
     auto i_filt = tally.filters(i);
@@ -449,7 +449,7 @@ void score_fission_eout(Particle& p, int i_tally, int i_score, int score_bin)
         (score_bin == SCORE_PROMPT_NU_FISSION && g == 0)) {
 
       // Find the filter scoring index for this filter combination
-      int filter_index = 0;
+      int64_t filter_index = 0;
       double filter_weight = 1.0;
       for (auto j = 0; j < tally.filters().size(); ++j) {
         auto i_filt = tally.filters(j);
@@ -497,7 +497,7 @@ void score_fission_eout(Particle& p, int i_tally, int i_score, int score_bin)
       } else {
 
         // Find the filter index and weight for this filter combination
-        int filter_index = 0;
+        int64_t filter_index = 0;
         double filter_weight = 1.;
         for (auto j = 0; j < tally.filters().size(); ++j) {
           auto i_filt = tally.filters(j);

--- a/src/tallies/trigger.cpp
+++ b/src/tallies/trigger.cpp
@@ -28,7 +28,7 @@ KTrigger keff_trigger;
 //==============================================================================
 
 std::pair<double, double> get_tally_uncertainty(
-  int i_tally, int score_index, int filter_index)
+  int i_tally, int score_index, int64_t filter_index)
 {
   const auto& tally {model::tallies[i_tally]};
 
@@ -71,7 +71,7 @@ void check_tally_triggers(double& ratio, int& tally_id, int& score)
         continue;
 
       const auto& results = t.results_;
-      for (auto filter_index = 0; filter_index < results.shape(0);
+      for (int64_t filter_index = 0; filter_index < results.shape(0);
            ++filter_index) {
         // Compute the tally uncertainty metrics.
         auto uncert_pair =

--- a/tests/cpp_unit_tests/test_tally.cpp
+++ b/tests/cpp_unit_tests/test_tally.cpp
@@ -1,3 +1,4 @@
+#include "openmc/tallies/filter_energy.h"
 #include "openmc/tallies/tally.h"
 #include <catch2/catch_test_macros.hpp>
 
@@ -52,4 +53,28 @@ TEST_CASE("Test add/set_filter")
   REQUIRE(tally->filters().size() == 1);
   REQUIRE(model::filter_map[cell_filter->id()] == tally->filters(0));
 
+}
+
+// Regression test for 64-bit tally filter-bin counts (mesh x groups > 2^31).
+TEST_CASE("Tally filter-bin count does not overflow 32 bits")
+{
+  // Two energy filters whose bin counts multiply to 2.5e9, above INT32_MAX.
+  constexpr int64_t bins_per_filter = 50000;
+
+  // Only the bin count matters here, so the edge values are an arbitrary ramp.
+  std::vector<double> edges(bins_per_filter + 1);
+  for (int64_t i = 0; i < bins_per_filter + 1; ++i)
+    edges[i] = static_cast<double>(i);
+
+  Tally* tally = Tally::create();
+  for (int i = 0; i < 2; ++i) {
+    Filter* filter = Filter::create("energy");
+    dynamic_cast<EnergyFilter*>(filter)->set_bins(edges);
+    tally->add_filter(filter);
+  }
+  tally->set_strides();
+
+  // set_strides() previously accumulated this product in a 32-bit int.
+  REQUIRE(tally->n_filter_bins() == bins_per_filter * bins_per_filter);
+  REQUIRE(tally->n_filter_bins() > 2147483647);
 }

--- a/tests/cpp_unit_tests/test_tally.cpp
+++ b/tests/cpp_unit_tests/test_tally.cpp
@@ -52,7 +52,6 @@ TEST_CASE("Test add/set_filter")
   tally->set_filters(filters);
   REQUIRE(tally->filters().size() == 1);
   REQUIRE(model::filter_map[cell_filter->id()] == tally->filters(0));
-
 }
 
 // Regression test for 64-bit tally filter-bin counts (mesh x groups > 2^31).

--- a/tests/cpp_unit_tests/test_tally.cpp
+++ b/tests/cpp_unit_tests/test_tally.cpp
@@ -47,7 +47,8 @@ TEST_CASE("Test add/set_filter")
   REQUIRE(model::filter_map[cell_filter->id()] == tally->filters(0));
   REQUIRE(model::filter_map[particle_filter->id()] == tally->filters(1));
 
-  // set filters with a duplicate filter, should only add the filter to the tally once
+  // set filters with a duplicate filter, should only add the filter to the
+  // tally once
   filters = {cell_filter, cell_filter};
   tally->set_filters(filters);
   REQUIRE(tally->filters().size() == 1);


### PR DESCRIPTION
# Fix 32-bit integer overflow in tally filter-bin indexing

## Problem

A tally with more than 2³¹ (~2.15 billion) filter bins aborts during initialization:

```
terminate called after throwing an instance of 'std::length_error'
  what():  cannot create std::vector larger than max_size()
```

(`Tally::init_results` → `tensor::Tensor<double>` constructor → `std::vector(__n = 18446744068490538100)`.)

This is reachable from ordinary random-ray FW-CADIS runs. The weight-window flux tally
carries one bin per mesh element per energy group, so a 97,860,906-element mesh at 70
groups produces 6,850,263,420 filter bins. The same model at 4 groups (391M bins) runs
fine; the crash appears only once the bin count crosses 2³¹.

I hit this bug from a real world use case with the JET model, where I was creating 70 group weight windows on a (513, 638, 299) resolution mesh. To be clear: the error stems from the normal OpenMC tallying machinery on a mesh of that size with that many energy bins, the error is not coming from the random ray machinery. As such, the error could be hit from normal Monte Carlo usage as well if a large mesh + significant number of energy filter bins are used.

## Root cause

`Tally::n_filter_bins_` and `strides_` are `int32_t`, and `Tally::set_strides()`
accumulates the product of the per-filter bin counts in a plain `int`. At 6.85e9 bins
this overflows and wraps to `-1,739,671,172`. `Tally::init_results()` then forms
`static_cast<size_t>(n_filter_bins_) * n_scores * 3`; the negative value sign-extends to
a huge `size_t` (× 3 = `18446744068490538100`), which exceeds `vector::max_size()` and
throws.

The same 32-bit width is used at every step that later consumes the flat filter index,
so widening only the allocation would still mis-score above 2³¹ bins:

- `FilterBinIter::index_` — the accumulated flat filter index;
- `TallyTask::filter_idx` — the random-ray per-element stored index;
- the local `filter_index` accumulators and the `filter_index` parameters of
  `score_general_ce_nonanalog` / `score_general_ce_analog` / `score_general_mg`.

Separately, random ray's `SourceRegionContainer::index()` computes `sr * negroups_ + g`
in 64-bit (since `sr` is `int64_t`) but returned `int`, truncating the flux-array offset
past ~30.7M source regions at 70 groups.

The bin *count* overflows one layer lower too: `StructuredMesh::n_bins()` and
`n_surface_bins()` compute their counts in `int` (the latter is `4 * n_dim * n_bins`, i.e.
~12x the element count in 3D), so a single very large mesh produces a negative count that
reaches `init_results()` as the same `length_error`. A surface-current tally hits this
first, near ~179M 3D cells.

## Fix

Widen the bin count and the flat result index to `int64_t` along the whole chain:

- **Sizing/allocation:** `Tally::n_filter_bins_`, `strides_`, their accessors, and the
  `set_strides()` accumulator.
- **Scoring index:** `FilterBinIter::index_`; `TallyTask::filter_idx` (member +
  constructor); the CE/MG `filter_index` accumulators and `score_general_*` parameters;
  the random-ray flux-tally volume-normalization loop counter.
- **Random-ray flux index:** `SourceRegionContainer::index()` return type.

`tensor::Tensor` already computes its size and offsets in `size_t`, so it is unchanged.
The result index is now 64-bit end-to-end on both the random-ray and the CE/MG scoring
paths.

**Mesh bin-count guard.** The widening above does not lift the limit on a *single* mesh:
`Filter::n_bins_` and the per-event `FilterMatch::bins_` remain `int`, so one mesh or filter
past 2³¹ bins is still unsupported. `StructuredMesh::n_bins()` / `n_surface_bins()` now
compute their counts in `int64_t` and raise a clear `fatal_error` (naming the mesh and
count) when the value exceeds `int`, instead of silently overflowing into the same
`length_error`. This makes the 32-bit boundary safe and explicit rather than lifting it.
(Unstructured MOAB/LibMesh counts are left as-is.)

## Why a guard instead of widening everything?

We widened the indexing chain, so the obvious question is why not also widen
`Filter::n_bins_` and `FilterMatch::bins_` and support a single mesh or filter past 2³¹ bins
outright, instead of leaving a guarded limit.

Not because that case is unrealistic — a multi-billion-element structured mesh is perfectly
reasonable (e.g. ITER-scale shielding), the mesh itself is cheap to store, and the tally
memory (tens of GB) sits comfortably on a compute node. The reason is that lifting the limit
is a substantially larger, separable change than the two remaining type flips it looks like:

- **It is the entire mesh bin-index type, not two members.** A mesh only ever *emits* a
  >2³¹ index if the mesh layer itself computes one in 64-bit: `get_bin()`,
  `get_bin_from_indices()`, `get_indices()`, `bins_crossed()` / `surface_bins_crossed()`,
  and the internal `for (int ... < n_bins())` loops — across `RegularMesh`,
  `RectilinearMesh`, `CylindricalMesh`, and `SphericalMesh`. Only then do `Filter::n_bins_`
  and the per-event `FilterMatch::bins_` (`vector<int>`) matter.
- **It reaches into I/O and the public API.** The statepoint HDF5 layout, the C API
  (`openmc_mesh_*`), and the Python bindings all assume 32-bit bin indices, so it carries
  format and compatibility surface, not just internal types.
- **It is on the hot path and should be measured.** `FilterMatch::bins_` is written and read
  on every scored event; widening it is a (likely small, but unmeasured) cost on *every*
  simulation, so it warrants a benchmark rather than an assumption.
- **It can only be validated at scale.** Proving a multi-billion-bin tally scores correctly
  end-to-end needs a big-memory integration test, not the kilobyte unit test that covers the
  arithmetic in this PR.

So this PR fixes the crash and makes indexing correct up to the 2³¹-per-filter boundary, and
the guard ensures **nothing past that boundary is left as a silent bug**: an over-limit tally
now stops immediately with a clear message instead of corrupting indices or dying with a
cryptic `length_error`. Lifting the boundary outright — full 64-bit mesh and filter
indexing — can be done in the future if and when the need arrises. At that point, hopefully the performance CI can be used to reveal any performance regressions caused by that change.

## Testing

The PR adds a Catch2 case to `tests/cpp_unit_tests/test_tally.cpp` (run with `ctest`;
the file is already in `TEST_NAMES`, so no `CMakeLists.txt` change is needed). It builds
a `Tally` with two energy filters of 50,000 bins each, whose bin counts multiply to
2.5e9 (above `INT32_MAX`), then calls `Tally::set_strides()` directly (it is public and
is what `init_results()` relies on) and asserts the count is the exact 64-bit product:

```cpp
constexpr int64_t bins_per_filter = 50000; // two filters -> 2.5e9 > 2^31
...
REQUIRE(tally->n_filter_bins() == bins_per_filter * bins_per_filter);
REQUIRE(tally->n_filter_bins() > 2147483647);
```

This pins exactly the `set_strides()` / `n_filter_bins_` arithmetic that overflowed,
runs in milliseconds on ~1 MB, and fails on the old `int32_t` code (the product wraps
negative). The large `results_` allocation in `init_results()` is intentionally not
exercised; the defect is in the index arithmetic, not in the size of the results array.

# Does the Fix Work?

The JET model has previously been running fine for weight window generation with random ray but I had been limiting my testing to 4 groups. I have been doing some parameter sensitivity studies and was trying to do 70 groups -- that's when I hit this issue. I can confirm that the fix does indeed work and I'm able to apply the 70 group energy mesh on that mesh now.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
