### PR TITLE
Use non-deprecated methods for getting libMesh node points

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3670,7 +3670,7 @@ Position LibMesh::sample_element(int32_t bin, uint64_t* seed) const
   // Get tet vertex coordinates from LibMesh
   std::array<Position, 4> tet_verts;
   for (int i = 0; i < elem.n_nodes(); i++) {
-    auto node_ref = elem.node_ref(i);
+    const auto& node_ref = elem.node_ref(i);
     tet_verts[i] = {node_ref(0), node_ref(1), node_ref(2)};
   }
   // Samples position within tet using Barycentric coordinates
@@ -3700,7 +3700,7 @@ int LibMesh::n_vertices() const
 
 Position LibMesh::vertex(int vertex_id) const
 {
-  const auto node_ref = m_->node_ref(vertex_id);
+  const auto& node_ref = m_->node_ref(vertex_id);
   if (length_multiplier_ > 0.0) {
     return length_multiplier_ * Position(node_ref(0), node_ref(1), node_ref(2));
   } else {


### PR DESCRIPTION
# Description

The "copy" constructor for Node (see https://github.com/libMesh/libmesh/blob/cc84387bbd96e12d2d12986402ec8bba282fc0c4/include/geom/node.h#L76) is deprecated. 

Builds with current libmesh with `--disable-deprecated` will fail to compile. Get a reference to the node and use `operator()` (from parent `Point`) instead.

See these build failures from Salamander (with cardinal and libmesh `--disable-deprecated`):

```
/tmp/build/salamander/cardinal/contrib/openmc/src/mesh.cpp: In member function 'virtual openmc::Position openmc::LibMesh::sample_element(int32_t, uint64_t*) const':
/tmp/build/salamander/cardinal/contrib/openmc/src/mesh.cpp:3673:36: error: use of deleted function 'libMesh::Node::Node(const libMesh::Node&)'
 3673 |     auto node_ref = elem.node_ref(i);
      |                                    ^
In file included from /tmp/build/salamander/moose/libmesh/installed/include/libmesh/elem.h:29,
                 from /tmp/build/salamander/moose/libmesh/installed/include/libmesh/dof_map.h:36,
                 from /tmp/build/salamander/cardinal/contrib/openmc/include/openmc/mesh.h:32,
                 from /tmp/build/salamander/cardinal/contrib/openmc/src/mesh.cpp:1:
/tmp/build/salamander/moose/libmesh/installed/include/libmesh/node.h:79:3: note: declared here
   79 |   Node (const Node & n) = delete;
      |   ^~~~
/tmp/build/salamander/cardinal/contrib/openmc/src/mesh.cpp: In member function 'virtual openmc::Position openmc::LibMesh::vertex(int) const':
/tmp/build/salamander/cardinal/contrib/openmc/src/mesh.cpp:3703:47: error: use of deleted function 'libMesh::Node::Node(const libMesh::Node&)'
 3703 |   const auto node_ref = m_->node_ref(vertex_id);
      |                                               ^
/tmp/build/salamander/moose/libmesh/installed/include/libmesh/node.h:79:3: note: declared here
   79 |   Node (const Node & n) = delete;
      |   ^~~~
```

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
