### PR TITLE
Lost particle track files

### DIFF
--- a/include/openmc/particle_restart.h
+++ b/include/openmc/particle_restart.h
@@ -1,9 +1,12 @@
 #ifndef OPENMC_PARTICLE_RESTART_H
 #define OPENMC_PARTICLE_RESTART_H
 
+#include "openmc/particle.h"
+
 namespace openmc {
 
 void run_particle_restart();
+void run_lost_particle_track(Particle& lost);
 
 } // namespace openmc
 

--- a/include/openmc/track_output.h
+++ b/include/openmc/track_output.h
@@ -2,6 +2,7 @@
 #define OPENMC_TRACK_OUTPUT_H
 
 #include "openmc/particle.h"
+#include <hdf5.h>
 
 namespace openmc {
 
@@ -35,6 +36,12 @@ void write_particle_track(Particle& p);
 //
 //! \param[in] p  Current particle
 void finalize_particle_track(Particle& p);
+
+// Check whether --track is calling or lost particles are calling automatically
+extern bool lost_particle_track_file_open;
+extern hid_t track_file;
+extern hid_t track_dtype;
+extern thread_local bool in_lost_track;
 
 } // namespace openmc
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -845,7 +845,10 @@ void Particle::mark_as_lost(const char* message)
   }
 
   // Print warning and write lost particle file
-  warning(message);
+#pragma omp critical(PrintErrorMessage)
+  {
+    warning(message);
+  }
   if (settings::max_write_lost_particles < 0 ||
       simulation::n_lost_particles < settings::max_write_lost_particles) {
     write_restart();
@@ -863,18 +866,18 @@ void Particle::mark_as_lost(const char* message)
   auto n = simulation::current_batch * settings::gen_per_batch *
            simulation::work_per_rank;
 
-  // Abort the simulation if the maximum number of lost particles has been
-  // reached
-  if (simulation::n_lost_particles >= settings::max_lost_particles &&
-      simulation::n_lost_particles >= settings::rel_max_lost_particles * n) {
-#pragma omp critical(FinalizeParticleTrack)
-    {
+// Abort the simulation if the maximum number of lost particles reached
+#pragma omp critical(FatalLostParticle)
+  {
+    if (simulation::n_lost_particles >= settings::max_lost_particles &&
+        simulation::n_lost_particles >= settings::rel_max_lost_particles * n) {
+      // close track file
       if (lost_particle_track_file_open) {
         close_track_file();
         lost_particle_track_file_open = false;
       }
+      fatal_error("Maximum number of lost particles has been reached.");
     }
-    fatal_error("Maximum number of lost particles has been reached.");
   }
 }
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -891,8 +891,8 @@ void Particle::write_restart() const
     return;
 
   // Set up file name
-  auto filename = fmt::format("{}particle_{}_{}.h5",
-    settings::path_output, simulation::current_batch, id());
+  auto filename = fmt::format("{}particle_{}_{}.h5", settings::path_output,
+    simulation::current_batch, id());
 
 #pragma omp critical(WriteParticleRestart)
   {

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -867,15 +867,18 @@ void Particle::mark_as_lost(const char* message)
            simulation::work_per_rank;
 
 // Abort the simulation if the maximum number of lost particles reached
-#pragma omp critical(FatalLostParticle)
+#pragma omp critical(TrackFile)
   {
     if (simulation::n_lost_particles >= settings::max_lost_particles &&
         simulation::n_lost_particles >= settings::rel_max_lost_particles * n) {
       // close track file
-      if (lost_particle_track_file_open) {
-        close_track_file();
-        lost_particle_track_file_open = false;
+      if (track_file >= 0) {
+            H5Tclose(track_dtype);
+            file_close(track_file);
+            track_file = -1;
+            track_dtype = -1;
       }
+      lost_particle_track_file_open = false;
       fatal_error("Maximum number of lost particles has been reached.");
     }
   }

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -20,6 +20,7 @@
 #include "openmc/mgxs_interface.h"
 #include "openmc/nuclide.h"
 #include "openmc/particle_data.h"
+#include "openmc/particle_restart.h"
 #include "openmc/photon.h"
 #include "openmc/physics.h"
 #include "openmc/physics_mg.h"
@@ -33,7 +34,6 @@
 #include "openmc/tallies/tally_scoring.h"
 #include "openmc/track_output.h"
 #include "openmc/weight_windows.h"
-#include "openmc/particle_restart.h"
 
 #ifdef OPENMC_DAGMC_ENABLED
 #include "DagMC.hpp"
@@ -849,7 +849,8 @@ void Particle::mark_as_lost(const char* message)
   if (settings::max_write_lost_particles < 0 ||
       simulation::n_lost_particles < settings::max_write_lost_particles) {
     write_restart();
-    if (settings::run_mode != RunMode::PARTICLE && !settings::write_all_tracks) {
+    if (settings::run_mode != RunMode::PARTICLE &&
+        !settings::write_all_tracks) {
       run_lost_particle_track(*this);
     }
   }
@@ -866,14 +867,14 @@ void Particle::mark_as_lost(const char* message)
   // reached
   if (simulation::n_lost_particles >= settings::max_lost_particles &&
       simulation::n_lost_particles >= settings::rel_max_lost_particles * n) {
-  #pragma omp critical(FinalizeParticleTrack)
+#pragma omp critical(FinalizeParticleTrack)
     {
       if (lost_particle_track_file_open) {
         close_track_file();
         lost_particle_track_file_open = false;
       }
     }
-      fatal_error("Maximum number of lost particles has been reached.");
+    fatal_error("Maximum number of lost particles has been reached.");
   }
 }
 
@@ -884,8 +885,8 @@ void Particle::write_restart() const
     return;
 
   // Set up file name
-  auto filename = fmt::format("{}batch_{}_particle_{}.h5", settings::path_output,
-    simulation::current_batch, id());
+  auto filename = fmt::format("{}batch_{}_particle_{}.h5",
+    settings::path_output, simulation::current_batch, id());
 
 #pragma omp critical(WriteParticleRestart)
   {

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -871,12 +871,12 @@ void Particle::mark_as_lost(const char* message)
   {
     if (simulation::n_lost_particles >= settings::max_lost_particles &&
         simulation::n_lost_particles >= settings::rel_max_lost_particles * n) {
-      // close track file
+      // close track file manually
       if (track_file >= 0) {
-            H5Tclose(track_dtype);
-            file_close(track_file);
-            track_file = -1;
-            track_dtype = -1;
+        H5Tclose(track_dtype);
+        file_close(track_file);
+        track_file = -1;
+        track_dtype = -1;
       }
       lost_particle_track_file_open = false;
       fatal_error("Maximum number of lost particles has been reached.");

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -33,6 +33,7 @@
 #include "openmc/tallies/tally_scoring.h"
 #include "openmc/track_output.h"
 #include "openmc/weight_windows.h"
+#include "openmc/particle_restart.h"
 
 #ifdef OPENMC_DAGMC_ENABLED
 #include "DagMC.hpp"
@@ -837,11 +838,20 @@ void Particle::cross_periodic_bc(
 
 void Particle::mark_as_lost(const char* message)
 {
+  // Skip if we are already replaying a lost particle
+  if (in_lost_track) {
+    wgt() = 0.0;
+    return;
+  }
+
   // Print warning and write lost particle file
   warning(message);
   if (settings::max_write_lost_particles < 0 ||
       simulation::n_lost_particles < settings::max_write_lost_particles) {
     write_restart();
+    if (settings::run_mode != RunMode::PARTICLE && !settings::write_all_tracks) {
+      run_lost_particle_track(*this);
+    }
   }
   // Increment number of lost particles
   wgt() = 0.0;
@@ -856,7 +866,14 @@ void Particle::mark_as_lost(const char* message)
   // reached
   if (simulation::n_lost_particles >= settings::max_lost_particles &&
       simulation::n_lost_particles >= settings::rel_max_lost_particles * n) {
-    fatal_error("Maximum number of lost particles has been reached.");
+  #pragma omp critical(FinalizeParticleTrack)
+    {
+      if (lost_particle_track_file_open) {
+        close_track_file();
+        lost_particle_track_file_open = false;
+      }
+    }
+      fatal_error("Maximum number of lost particles has been reached.");
   }
 }
 
@@ -867,7 +884,7 @@ void Particle::write_restart() const
     return;
 
   // Set up file name
-  auto filename = fmt::format("{}particle_{}_{}.h5", settings::path_output,
+  auto filename = fmt::format("{}batch_{}_particle_{}.h5", settings::path_output,
     simulation::current_batch, id());
 
 #pragma omp critical(WriteParticleRestart)

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -891,7 +891,7 @@ void Particle::write_restart() const
     return;
 
   // Set up file name
-  auto filename = fmt::format("{}batch_{}_particle_{}.h5",
+  auto filename = fmt::format("{}particle_{}_{}.h5",
     settings::path_output, simulation::current_batch, id());
 
 #pragma omp critical(WriteParticleRestart)

--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -11,10 +11,10 @@
 #include "openmc/random_lcg.h"
 #include "openmc/settings.h"
 #include "openmc/simulation.h"
+#include "openmc/source.h"
 #include "openmc/tallies/derivative.h"
 #include "openmc/tallies/tally.h"
 #include "openmc/track_output.h"
-#include "openmc/source.h"
 
 #include <algorithm> // for copy
 #include <stdexcept>
@@ -161,8 +161,8 @@ void run_lost_particle_track(Particle& lost)
   if (settings::run_mode == RunMode::EIGENVALUE) {
     site = simulation::source_bank[i];
   } else if (settings::run_mode == RunMode::FIXED_SOURCE &&
-              settings::use_shared_secondary_bank &&
-              i < simulation::shared_secondary_bank_read.size()) {
+             settings::use_shared_secondary_bank &&
+             i < simulation::shared_secondary_bank_read.size()) {
     site = simulation::shared_secondary_bank_read[i];
   } else if (settings::run_mode == RunMode::FIXED_SOURCE) {
     int64_t id = compute_transport_seed(compute_particle_id(i + 1));

--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -145,9 +145,9 @@ void run_lost_particle_track(Particle& lost)
     return;
   in_lost_track = true;
 
-#pragma omp critical(LostParticleTrack)
+#pragma omp critical(TrackFile)
   {
-    if (!lost_particle_track_file_open) {
+    if (track_file < 0 && !lost_particle_track_file_open) {
       open_track_file();
       lost_particle_track_file_open = true;
     }

--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -7,7 +7,6 @@
 #include "openmc/mgxs_interface.h"
 #include "openmc/nuclide.h"
 #include "openmc/output.h"
-#include "openmc/particle.h"
 #include "openmc/photon.h"
 #include "openmc/random_lcg.h"
 #include "openmc/settings.h"
@@ -15,6 +14,7 @@
 #include "openmc/tallies/derivative.h"
 #include "openmc/tallies/tally.h"
 #include "openmc/track_output.h"
+#include "openmc/source.h"
 
 #include <algorithm> // for copy
 #include <stdexcept>
@@ -137,6 +137,59 @@ void run_particle_restart()
   if (settings::write_all_tracks) {
     close_track_file();
   }
+}
+
+void run_lost_particle_track(Particle& lost)
+{
+  if (in_lost_track)
+    return;
+  in_lost_track = true;
+
+#pragma omp critical(LostParticleTrack)
+  {
+    if (!lost_particle_track_file_open) {
+      open_track_file();
+      lost_particle_track_file_open = true;
+    }
+  }
+
+  Particle p;
+  p.id() = lost.id();
+
+  int64_t i = lost.current_work();
+  SourceSite site;
+  if (settings::run_mode == RunMode::EIGENVALUE) {
+    site = simulation::source_bank[i];
+  } else if (settings::run_mode == RunMode::FIXED_SOURCE &&
+              settings::use_shared_secondary_bank &&
+              i < simulation::shared_secondary_bank_read.size()) {
+    site = simulation::shared_secondary_bank_read[i];
+  } else if (settings::run_mode == RunMode::FIXED_SOURCE) {
+    int64_t id = compute_transport_seed(compute_particle_id(i + 1));
+    uint64_t seed = init_seed(id, STREAM_SOURCE);
+    site = sample_external_source(&seed);
+  }
+
+  p.wgt() = site.wgt;
+  p.E() = site.E;
+  p.r() = site.r;
+  p.u() = site.u;
+  p.time() = site.time;
+  p.type() = lost.type();
+
+  int64_t particle_seed = compute_transport_seed(p.id());
+  init_particle_seeds(particle_seed, p.seeds());
+
+  if (settings::run_CE) {
+    p.invalidate_neutron_xs();
+  }
+
+  p.write_track() = true;
+  add_particle_track(p);
+  transport_history_based_single_particle(p);
+  // finalize_particle_track called internally by transport, don't call again
+
+  in_lost_track = false;
 }
 
 } // namespace openmc

--- a/src/particle_restart.cpp
+++ b/src/particle_restart.cpp
@@ -139,6 +139,7 @@ void run_particle_restart()
   }
 }
 
+// Function for automatically creating tracks file for lost particles
 void run_lost_particle_track(Particle& lost)
 {
   if (in_lost_track)

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -80,6 +80,11 @@ int openmc_simulation_init()
   if (simulation::initialized)
     return 0;
 
+  // Reset lost particle track file state for new simulation
+  lost_particle_track_file_open = false;
+  in_lost_track = false;
+  simulation::n_lost_particles = 0;
+
   // Initialize nuclear data (energy limits, log grid)
   if (settings::run_CE) {
     initialize_data();

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -188,6 +188,10 @@ int openmc_simulation_finalize()
   if (!settings::track_identifiers.empty() || settings::write_all_tracks) {
     close_track_file();
   }
+  if (lost_particle_track_file_open) {
+    close_track_file();
+    lost_particle_track_file_open = false;
+  }
 
   // Increment total number of generations
   simulation::total_gen += simulation::current_batch * settings::gen_per_batch;

--- a/src/track_output.cpp
+++ b/src/track_output.cpp
@@ -23,7 +23,7 @@ namespace openmc {
 
 hid_t track_file {-1};  //! HDF5 identifier for track file
 hid_t track_dtype {-1}; //! HDF5 identifier for track datatype
-int n_tracks_written; //! Number of tracks written
+int n_tracks_written;   //! Number of tracks written
 bool lost_particle_track_file_open {false};
 thread_local bool in_lost_track {false};
 
@@ -51,7 +51,7 @@ void open_track_file()
     track_file = -1;
     track_dtype = -1;
   }
-  
+
   // Open file and write filetype/version -- when MPI is enabled and there is
   // more than one rank, each rank writes its own file
 #ifdef OPENMC_MPI
@@ -92,16 +92,16 @@ void open_track_file()
 
 void close_track_file()
 {
-  #pragma omp critical(TrackFile)  
-    {
-        if (track_file >= 0) {       
-            H5Tclose(track_dtype);
-            file_close(track_file);
-            track_file = -1;
-            track_dtype = -1;
-            n_tracks_written = 0;
-        }
+#pragma omp critical(TrackFile)
+  {
+    if (track_file >= 0) {
+      H5Tclose(track_dtype);
+      file_close(track_file);
+      track_file = -1;
+      track_dtype = -1;
+      n_tracks_written = 0;
     }
+  }
 }
 
 bool check_track_criteria(const Particle& p)
@@ -143,6 +143,8 @@ void finalize_particle_track(Particle& p)
   }
   offsets.push_back(offset);
 
+  // Thread safe by ensuring opening and closing of HDF5 file is not
+  // simultaneous
 #pragma omp critical(TrackFile)
   {
     // Guard against writing to a closed file
@@ -151,10 +153,11 @@ void finalize_particle_track(Particle& p)
 
       // Create name for dataset
       std::string dset_name = fmt::format("track_{}_{}_{}",
-          simulation::current_batch, simulation::current_gen, p.id());
+        simulation::current_batch, simulation::current_gen, p.id());
 
+      // In case ID already exists (no duplicates in HDF5)
       if (H5Lexists(track_file, dset_name.c_str(), H5P_DEFAULT) > 0) {
-          dset_name = fmt::format("{}_{}", dset_name, track_index++);
+        dset_name = fmt::format("{}_{}", dset_name, track_index++);
       }
 
       // Write array of TrackState to file

--- a/src/track_output.cpp
+++ b/src/track_output.cpp
@@ -44,6 +44,14 @@ void write_particle_track(Particle& p)
 
 void open_track_file()
 {
+  // Close existing file handle if still open from a previous run
+  if (track_file >= 0) {
+    H5Tclose(track_dtype);
+    file_close(track_file);
+    track_file = -1;
+    track_dtype = -1;
+  }
+  
   // Open file and write filetype/version -- when MPI is enabled and there is
   // more than one rank, each rank writes its own file
 #ifdef OPENMC_MPI
@@ -84,15 +92,16 @@ void open_track_file()
 
 void close_track_file()
 {
-  H5Tclose(track_dtype);
-  file_close(track_file);
-
-  // Reset initial states after close for thread safety
-  track_file = -1;
-  track_dtype = -1;
-
-  // Reset number of tracks written
-  n_tracks_written = 0;
+  #pragma omp critical(TrackFile)  
+    {
+        if (track_file >= 0) {       
+            H5Tclose(track_dtype);
+            file_close(track_file);
+            track_file = -1;
+            track_dtype = -1;
+            n_tracks_written = 0;
+        }
+    }
 }
 
 bool check_track_criteria(const Particle& p)
@@ -134,13 +143,19 @@ void finalize_particle_track(Particle& p)
   }
   offsets.push_back(offset);
 
-#pragma omp critical(FinalizeParticleTrack)
+#pragma omp critical(TrackFile)
   {
     // Guard against writing to a closed file
     if (track_file >= 0) {
+      static int track_index = 0;
+
       // Create name for dataset
       std::string dset_name = fmt::format("track_{}_{}_{}",
-        simulation::current_batch, simulation::current_gen, p.id());
+          simulation::current_batch, simulation::current_gen, p.id());
+
+      if (H5Lexists(track_file, dset_name.c_str(), H5P_DEFAULT) > 0) {
+          dset_name = fmt::format("{}_{}", dset_name, track_index++);
+      }
 
       // Write array of TrackState to file
       hsize_t dims[] {static_cast<hsize_t>(tracks.size())};

--- a/src/track_output.cpp
+++ b/src/track_output.cpp
@@ -21,8 +21,8 @@ namespace openmc {
 // Global variables
 //==============================================================================
 
-hid_t track_file {-1};     //! HDF5 identifier for track file
-hid_t track_dtype {-1};    //! HDF5 identifier for track datatype
+hid_t track_file {-1};  //! HDF5 identifier for track file
+hid_t track_dtype {-1}; //! HDF5 identifier for track datatype
 int n_tracks_written; //! Number of tracks written
 bool lost_particle_track_file_open {false};
 thread_local bool in_lost_track {false};
@@ -159,8 +159,8 @@ void finalize_particle_track(Particle& p)
       H5Sclose(dspace);
     }
   }
-    // Clear particle tracks
-    p.tracks().clear();
+  // Clear particle tracks
+  p.tracks().clear();
 }
 
 } // namespace openmc

--- a/src/track_output.cpp
+++ b/src/track_output.cpp
@@ -10,7 +10,7 @@
 
 #include "openmc/tensor.h"
 #include <fmt/core.h>
-#include <hdf5.h>
+// #include <hdf5.h>
 
 #include <cstddef> // for size_t
 #include <string>
@@ -21,9 +21,11 @@ namespace openmc {
 // Global variables
 //==============================================================================
 
-hid_t track_file;     //! HDF5 identifier for track file
-hid_t track_dtype;    //! HDF5 identifier for track datatype
+hid_t track_file {-1};     //! HDF5 identifier for track file
+hid_t track_dtype {-1};    //! HDF5 identifier for track datatype
 int n_tracks_written; //! Number of tracks written
+bool lost_particle_track_file_open {false};
+thread_local bool in_lost_track {false};
 
 //==============================================================================
 // Non-member functions
@@ -85,6 +87,10 @@ void close_track_file()
   H5Tclose(track_dtype);
   file_close(track_file);
 
+  // Reset initial states after close for thread safety
+  track_file = -1;
+  track_dtype = -1;
+
   // Reset number of tracks written
   n_tracks_written = 0;
 }
@@ -130,29 +136,31 @@ void finalize_particle_track(Particle& p)
 
 #pragma omp critical(FinalizeParticleTrack)
   {
-    // Create name for dataset
-    std::string dset_name = fmt::format("track_{}_{}_{}",
-      simulation::current_batch, simulation::current_gen, p.id());
+    // Guard against writing to a closed file
+    if (track_file >= 0) {
+      // Create name for dataset
+      std::string dset_name = fmt::format("track_{}_{}_{}",
+        simulation::current_batch, simulation::current_gen, p.id());
 
-    // Write array of TrackState to file
-    hsize_t dims[] {static_cast<hsize_t>(tracks.size())};
-    hid_t dspace = H5Screate_simple(1, dims, nullptr);
-    hid_t dset = H5Dcreate(track_file, dset_name.c_str(), track_dtype, dspace,
-      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    H5Dwrite(dset, track_dtype, H5S_ALL, H5S_ALL, H5P_DEFAULT, tracks.data());
+      // Write array of TrackState to file
+      hsize_t dims[] {static_cast<hsize_t>(tracks.size())};
+      hid_t dspace = H5Screate_simple(1, dims, nullptr);
+      hid_t dset = H5Dcreate(track_file, dset_name.c_str(), track_dtype, dspace,
+        H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      H5Dwrite(dset, track_dtype, H5S_ALL, H5S_ALL, H5P_DEFAULT, tracks.data());
 
-    // Write attributes
-    write_attribute(dset, "n_particles", p.tracks().size());
-    write_attribute(dset, "offsets", offsets);
-    write_attribute(dset, "particles", particles);
+      // Write attributes
+      write_attribute(dset, "n_particles", p.tracks().size());
+      write_attribute(dset, "offsets", offsets);
+      write_attribute(dset, "particles", particles);
 
-    // Free resources
-    H5Dclose(dset);
-    H5Sclose(dspace);
+      // Free resources
+      H5Dclose(dset);
+      H5Sclose(dspace);
+    }
   }
-
-  // Clear particle tracks
-  p.tracks().clear();
+    // Clear particle tracks
+    p.tracks().clear();
 }
 
 } // namespace openmc


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

When a particle is lost during transport, OpenMC now (with this PR) automatically replays it from its original source site with tracking enabled, writing the full track history to tracks.h5 without requiring a manual -r/-t restart. Previously, diagnosing a lost particle required identifying it from the warning output, then re-running with the restart file — this change eliminates that step entirely. If there are multiple lost particles, each is written to separate parts of one tracks.h5 file to avoid clogging up the directory.

- Added run_lost_particle_track() in particle_restart.cpp which reconstructs and replays the lost particle from the source bank with write_track = true
- Added in_lost_track thread-local flag to prevent infinite recursion if the replayed particle is also lost
- Added lost_particle_track_file_open flag to manage a separate track file lifecycle from the normal --track workflow
- Wrapped warning() and track file abort logic in appropriate #pragma omp critical blocks for thread safety
- Guarded all HDF5 file operations with >= 0 checks after initializing track_file and track_dtype to -1
- Added dataset name deduplication via H5Lexists to prevent HDF5 errors if multiple lost particles share an ID
- Reset all track state variables on simulation_init and ensured proper file closure on simulation_finalize

This will also later support functionality in the plotter to help visualize particle failures in the geometry.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
