### PR TITLE
Improve libMesh tally performance

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3641,6 +3641,7 @@ void LibMesh::initialize()
   for (int i = 0; i < num_threads(); i++) {
     pl_.emplace_back(m_->sub_point_locator());
     pl_.back()->set_contains_point_tol(FP_COINCIDENT);
+    pl_.back()->unset_close_to_point_tol();
     pl_.back()->enable_out_of_mesh_mode();
   }
 


### PR DESCRIPTION
# Description

I had been noticing a fairly substantial performance penalty when using libMesh unstructured mesh tallies and a mesh that only covers a portion of the domain. The performance penalty scaled with the number of elements in the mesh (so long as the mesh did not fully cover the domain), and would disappear if the mesh fully covered the problem. After perusing the libMesh doxygen for the point locators, namely the [accessor function](https://mooseframework.inl.gov/docs/doxygen/libmesh/classlibMesh_1_1PointLocatorTree.html#a800d292542988fd1d97199d6bb34f92e), I discovered that libMesh will perform a linear search over all mesh elements in the event that an element containing a point was not found after querying spatial trees. This behaviour can be ~~fixed~~ slightly improved by calling `PointLocatorBase::unset_close_to_point_tol()`, which sets `_use_close_to_point_tol = false` and disables the linear search.

After some more testing this only results in a slight increase in performance for these problems, and only for wrapped applications that were setting the flag behind the scenes (e.g. MOOSE). 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [ ] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [ ] ~~I have made corresponding changes to the documentation (if applicable)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
