### PR TITLE
Fix for numpy 2.5.0

### DIFF
--- a/tests/regression_tests/mg_temperature/build_2g.py
+++ b/tests/regression_tests/mg_temperature/build_2g.py
@@ -227,7 +227,7 @@ def analytical_solution_2g_therm(xsmin, xsmax=None, wgt=1.0):
     L = np.array([sa[0] + ss12, 0.0, -ss12, sa[1]]).reshape(2, 2)
     Q = np.array([nsf[0], nsf[1], 0.0, 0.0]).reshape(2, 2)
     arr = np.linalg.inv(L).dot(Q)
-    return np.amax(np.linalg.eigvals(arr))
+    return np.amax(np.linalg.eigvals(arr).real)
 
 
 def build_inf_model(xsnames, xslibname, temperature, tempmethod='nearest'):


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR fix a problem with numpy 2.5.0 compatibility.

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
