### PR TITLE
Ensure photon cross sections are loaded when FileSource contains photons

### DIFF
--- a/src/source.cpp
+++ b/src/source.cpp
@@ -523,9 +523,16 @@ void FileSource::load_sites_from_file(const std::string& path)
     file_close(file_id);
   }
 
-  // Make sure particles in source file have valid types
+  // Make sure particles in source file have valid types. If any particle is a
+  // photon, electron, or positron, enable photon transport so that the
+  // appropriate cross sections are loaded.
   for (const auto& site : this->sites_) {
     validate_particle_type(site.particle, "FileSource");
+    if (site.particle == ParticleType::photon() ||
+        site.particle == ParticleType::electron() ||
+        site.particle == ParticleType::positron()) {
+      settings::photon_transport = true;
+    }
   }
 }
 

--- a/tests/unit_tests/test_source_file.py
+++ b/tests/unit_tests/test_source_file.py
@@ -145,3 +145,27 @@ def test_source_file_transport(run_in_tmpdir):
 
     # Try running OpenMC
     model.run()
+
+
+def test_source_file_photon_transport(run_in_tmpdir):
+    # Create a source file containing a photon. Note that photon_transport is
+    # not explicitly enabled in the settings -- it should be turned on
+    # automatically because the source file contains a photon.
+    particle = openmc.SourceParticle(E=1.0e6, particle='photon')
+    openmc.write_source_file([particle], 'photon_source.h5')
+
+    # Create simple model to use the photon source file
+    model = openmc.Model()
+    al = openmc.Material()
+    al.add_element('Al', 1.0)
+    al.set_density('g/cm3', 2.7)
+    sph = openmc.Sphere(r=10.0, boundary_type='vacuum')
+    cell = openmc.Cell(fill=al, region=-sph)
+    model.geometry = openmc.Geometry([cell])
+    model.settings.source = openmc.FileSource(path='photon_source.h5')
+    model.settings.particles = 10
+    model.settings.batches = 3
+    model.settings.run_mode = 'fixed source'
+
+    # Running OpenMC should succeed
+    model.run()


### PR DESCRIPTION
# Description

If an OpenMC model uses a `FileSource` that has photons and/or electrons/positrons but `settings.photon_transport` hasn't been set to true, the model will run but segfault because photon cross sections were never loaded. This PR fixes that and adds a test to confirm that it works as intended.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)