### PR TITLE
Scale the weight window cutoff with the window normalization

### DIFF
--- a/include/openmc/weight_windows.h
+++ b/include/openmc/weight_windows.h
@@ -61,6 +61,9 @@ struct WeightWindow {
     lower_weight *= factor;
     upper_weight *= factor;
     survival_weight *= factor;
+    // The cutoff is scaled with the window bounds so that it sits at the same
+    // relative depth below the window in any normalization frame
+    weight_cutoff *= factor;
   }
 };
 


### PR DESCRIPTION
`WeightWindow::scale` multiplies the lower, upper, and survival weights by a factor, but left
`weight_cutoff` unchanged. After a renormalization the cutoff therefore no longer sat at the same
relative depth below the window. This scales `weight_cutoff` by the same factor so it keeps its relative
position in any normalization frame.

One line change. Split out of #3968 for focused review. A dedicated regression test is awkward to isolate
(it only bites when `scale()` is called with a factor, i.e. via `ww_factor`); happy to add one if a
reviewer wants it.
