### PR TITLE
Make sure output is treated consistently in R2SManager

### DIFF
--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -233,7 +233,8 @@ def get_microxs_and_flux(
             model.export_to_model_xml()
         comm.barrier()
         # Reinitialize with tallies
-        openmc.lib.init(intracomm=comm)
+        output = run_kwargs.get('output', True) if run_kwargs else True
+        openmc.lib.init(intracomm=comm, output=output)
 
     with TemporaryDirectory() as temp_dir:
         # Indicate to run in temporary directory unless being executed through

--- a/openmc/deplete/r2s.py
+++ b/openmc/deplete/r2s.py
@@ -347,7 +347,7 @@ class R2SManager:
 
         # Run neutron transport and get fluxes and micros. Run via openmc.lib to
         # maintain a consistent parallelism strategy with the activation step.
-        with TemporarySession():
+        with TemporarySession(output=False):
             self.results['fluxes'], self.results['micros'] = get_microxs_and_flux(
                 self.neutron_model, domains, **micro_kwargs)
 


### PR DESCRIPTION
# Description

Small PR here to fix unwanted output behavior when carrying out R2S runs with `R2SManager`:
- Before, an initialization of an empty OpenMC model (from `openmc.lib.TemporarySession`) was shown. This is fixed by passing `output=False` to `TemporarySession`
- The actual initialization of the neutron transport model was always shown regardless of the output option specified in `run_kwargs`. Now it is handled consistently: if the user calls `manager.run(run_kwargs={'output': True})` they will see output and if they call `manager.run(run_kwargs={'output': False})` they will not see output.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>