### PR TITLE
This fixes compile isuees found with GCC 16.1.1 and FMT version

### DIFF
--- a/include/openmc/error.h
+++ b/include/openmc/error.h
@@ -64,14 +64,14 @@ void write_message(
   int level, const std::string& message, const Params&... fmt_args)
 {
   if (settings::verbosity >= level) {
-    write_message(fmt::format(message, fmt_args...));
+    write_message(fmt::format(fmt::runtime(message), fmt_args...));
   }
 }
 
 template<typename... Params>
 void write_message(const std::string& message, const Params&... fmt_args)
 {
-  write_message(fmt::format(message, fmt_args...));
+  write_message(fmt::format(fmt::runtime(message), fmt_args...));
 }
 
 #ifdef OPENMC_MPI

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -264,7 +264,7 @@ MeshSpatial::MeshSpatial(pugi::xml_node node)
 
   if (get_node_value(node, "type", true, true) != "mesh") {
     fatal_error(fmt::format(
-      "Incorrect spatial type '{}' for a MeshSpatial distribution"));
+			    fmt::runtime("Incorrect spatial type '{}' for a MeshSpatial distribution")));
   }
 
   // No in-tet distributions implemented, could include distributions for the

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -262,9 +262,11 @@ std::pair<Position, double> SphericalIndependent::sample(uint64_t* seed) const
 MeshSpatial::MeshSpatial(pugi::xml_node node)
 {
 
-  if (get_node_value(node, "type", true, true) != "mesh") {
-    fatal_error(fmt::format(
-			    fmt::runtime("Incorrect spatial type '{}' for a MeshSpatial distribution")));
+  auto spatial_type = get_node_value(node, "type", true, true);
+  if (spatial_type != "mesh") {
+    fatal_error(
+      fmt::format("Incorrect spatial type '{}' for a MeshSpatial distribution",
+        spatial_type));
   }
 
   // No in-tet distributions implemented, could include distributions for the

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -836,8 +836,8 @@ WeightWindowsGenerator::WeightWindowsGenerator(pugi::xml_node node)
                             "specified for weight window generation",
       ratio_));
   if (ratio_ <= 1.0)
-    fatal_error(fmt::format("Invalid weight window ratio '{}' (<= 1.0) "
-                            "specified for weight window generation"));
+    fatal_error(fmt::format(fmt::runtime("Invalid weight window ratio '{}' (<= 1.0) "
+					 "specified for weight window generation")));
 
   // create a matching weight windows object
   auto wws = WeightWindows::create();

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -836,8 +836,9 @@ WeightWindowsGenerator::WeightWindowsGenerator(pugi::xml_node node)
                             "specified for weight window generation",
       ratio_));
   if (ratio_ <= 1.0)
-    fatal_error(fmt::format(fmt::runtime("Invalid weight window ratio '{}' (<= 1.0) "
-					 "specified for weight window generation")));
+    fatal_error(fmt::format("Invalid weight window ratio '{}' (<= 1.0) "
+                            "specified for weight window generation",
+      ratio_));
 
   // create a matching weight windows object
   auto wws = WeightWindows::create();


### PR DESCRIPTION
# Description

When building with GCC 16.1.1 and the version of the FMT library we submodule into OpenMC I was getting compile failures of the form;

```
/home/adavis/opt/openmc/include/openmc/error.h:67:30: error: call to consteval function ‘fmt::v11::basic_format_string<char, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>((* & message))’ is not a constant expression
   67 |     write_message(fmt::format(message, fmt_args...));
      |                   ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/16/string:58,
                 from /home/adavis/opt/openmc/include/openmc/particle.h:8:
/home/adavis/opt/openmc/include/openmc/error.h:67:30:   in ‘constexpr’ expansion of ‘fmt::v11::basic_format_string<char, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>((* & message))’
/home/adavis/opt/openmc/vendor/fmt/include/fmt/base.h:2873:69:   in ‘constexpr’ expansion of ‘((fmt::v11::basic_format_string<char, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>*)this)->fmt::v11::basic_format_string<char, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>::str_.fmt::v11::basic_string_view<char>::basic_string_view<std::__cxx11::basic_string<char> >((* & s))’
 2873 |   FMT_CONSTEVAL FMT_ALWAYS_INLINE basic_format_string(const S& s) : str_(s) {
      |                                                                     ^~~~~~~
/home/adavis/opt/openmc/vendor/fmt/include/fmt/base.h:549:21:   in ‘constexpr’ expansion of ‘(& s)->std::__cxx11::basic_string<char>::data()’
  549 |       : data_(s.data()), size_(s.size()) {}
      |               ~~~~~~^~
/usr/include/c++/16/bits/basic_string.h:2911:23:   in ‘constexpr’ expansion of ‘((const std::__cxx11::basic_string<char>*)this)->std::__cxx11::basic_string<char>::_M_data()’
 2911 |       { return _M_data(); }
      |                ~~~~~~~^~
/usr/include/c++/16/bits/basic_string.h:238:16: error: ‘*(const std::__cxx11::basic_string<char>*)this’ is not a constant expression
  238 |       { return _M_dataplus._M_p; }

```
I've wrapped runtime variable messages with `fmt::runtime` to avoid the consteval problem, and thus deal with the issue.
