### PR TITLE
Store slice overlap indices in cell ID field

### DIFF
--- a/openmc/lib/plot.py
+++ b/openmc/lib/plot.py
@@ -265,22 +265,40 @@ _dll.openmc_slice_data_overlap_info.errcheck = _error_handler
 
 
 # Python wrappings for overlap functions
-def slice_data_overlap_count():
+def slice_data_overlap_count() -> int:
+    """Return the number of unique overlaps from the last slice plot.
+
+    Returns
+    -------
+    int
+        Number of unique overlapping cell pairs detected by the most recent
+        :func:`slice_data` call with overlap checking enabled.
+    """
     count = c_size_t()
     _dll.openmc_slice_data_overlap_count(count)
     return count.value
 
 
-def slice_data_overlap_info():
+def slice_data_overlap_info() -> np.ndarray:
+    """Return identifying information for overlaps from the last slice plot.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape ``(n, 3)`` with int32 dtype, where ``n`` is the number
+        of unique overlaps detected by the most recent :func:`slice_data` call
+        with overlap checking enabled. Each row contains ``[universe_id,
+        cell1_id, cell2_id]``.
+    """
     n = slice_data_overlap_count()
-    overlap_info = np.empty(n * 3, dtype=np.int32)
+    overlap_info = np.empty((n, 3), dtype=np.int32)
 
     if n > 0:
         _dll.openmc_slice_data_overlap_info(
             n,
             overlap_info.ctypes.data_as(POINTER(c_int32)),
         )
-    return overlap_info, n
+    return overlap_info
 
 
 _dll.openmc_get_plot_index.argtypes = [c_int32, POINTER(c_int32)]

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -156,12 +156,12 @@ void RasterData::set_value(size_t y, size_t x, const Particle& p, int level,
 
 void RasterData::set_overlap(size_t y, size_t x, int overlap_idx)
 {
-  // Set cell, instance, and material to OVERLAP, but preserve filter bin
-  id_data_(y, x, 0) = OVERLAP;
+  // Set cell, instance, and material to OVERLAP, but preserve filter bin for
+  // tally plotting. Cell encodes the overlap index as a negative number so that
+  // it can be used to look up overlap information in the plotter.
+  id_data_(y, x, 0) = OVERLAP - overlap_idx - 1;
   id_data_(y, x, 1) = OVERLAP;
-  id_data_(y, x, 2) = OVERLAP - overlap_idx - 1;
-  // Note: id_data_(y, x, 3) is NOT overwritten - preserves filter bin for tally
-  // plotting
+  id_data_(y, x, 2) = OVERLAP;
 
   property_data_(y, x, 0) = OVERLAP;
   property_data_(y, x, 1) = OVERLAP;

--- a/tests/unit_tests/test_slice_data_overlap_info.py
+++ b/tests/unit_tests/test_slice_data_overlap_info.py
@@ -55,12 +55,13 @@ def test_overlaps_enabled(overlap_model):
     # Run a single slice with overlap detection enabled and check all
     # expected properties in one pass.
     geom_data = run_slice()
-    overlap_info, n = openmc.lib.slice_data_overlap_info()
-    mat_ids = geom_data[:, :, 2]
+    overlap_info = openmc.lib.slice_data_overlap_info()
+    n = overlap_info.shape[0]
+    cell_ids = geom_data[:, :, 0]
 
-    # mat_ids should contain values more negative than _OVERLAP; RasterData
+    # cell_ids should contain values more negative than _OVERLAP; RasterData
     # encodes each unique overlap as OVERLAP - overlap_idx - 1 into slot 2.
-    assert np.any(mat_ids < _OVERLAP)
+    assert np.any(cell_ids < _OVERLAP)
 
     # overlap_keys should have 2 entries for the two distinct overlapping
     # cylinder pairs in this model.
@@ -68,9 +69,9 @@ def test_overlaps_enabled(overlap_model):
 
     # Each entry is a (universe_id, cell1_id, cell2_id) triple; verify values.
     for i in range(n):
-        universe_id = int(overlap_info[i * 3])
-        cell1_id = int(overlap_info[i * 3 + 1])
-        cell2_id = int(overlap_info[i * 3 + 2])
+        universe_id = int(overlap_info[i, 0])
+        cell1_id = int(overlap_info[i, 1])
+        cell2_id = int(overlap_info[i, 2])
         assert universe_id == 1
         assert cell1_id in {1, 2, 3}
         assert cell2_id in {1, 2, 3}
@@ -81,7 +82,8 @@ def test_overlaps_disabled(overlap_model):
     # With show_overlaps=False, set_overlap is never called and overlap_keys
     # is never written to, so the image and map should both be clean.
     geom_data = run_slice(show_overlaps=False)
-    _, n = openmc.lib.slice_data_overlap_info()
+    overlap_info = openmc.lib.slice_data_overlap_info()
+    n = overlap_info.shape[0]
 
     assert not np.any(geom_data[:, :, 2] < _OVERLAP)
     assert n == 0


### PR DESCRIPTION
# Description

This updates slice plot overlap handling so the encoded overlap index is stored in the cell ID field rather than the material ID field. The Python overlap helper function also now returns a shaped (n, 3) array of overlap metadata and includes docstrings/type annotations.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)