### PR TITLE
Turn on weight windows if `weight_windows_file` is specified

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1247,6 +1247,7 @@ void read_settings_xml(pugi::xml_node root)
   // read weight windows from file
   if (check_for_node(root, "weight_windows_file")) {
     weight_windows_file = get_node_value(root, "weight_windows_file");
+    weight_windows_on = true;
   }
 
   // read settings for weight windows value, this will override


### PR DESCRIPTION
# Description

When a user specifies `settings.weight_windows`, OpenMC automatically will turn weight windows on. However, when they specify `settings.weight_windows_file`, it doesn't automatically turn weight windows on. This PR changes the behavior so that weight windows are automatically enabled if `settings.weight_windows_file` is specified.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)