### PR TITLE
Replace Ben Forget with John Tramm on technical committee

### DIFF
--- a/docs/source/devguide/contributing.rst
+++ b/docs/source/devguide/contributing.rst
@@ -111,8 +111,8 @@ The TC consists of the following individuals:
 - `Paul Romano <https://github.com/paulromano>`_
 - `Patrick Shriwise <https://github.com/pshriwise>`_
 - `Adam Nelson <https://github.com/nelsonag>`_
-- `Benoit Forget <https://github.com/bforget>`_
 - `Jonathan Shimwell <https://github.com/shimwell>`_
+- `John Tramm <https://github.com/jtramm>`_
 
 The Project Lead is Paul Romano.
 


### PR DESCRIPTION
# Description

Per the vote in #3217, this PR updates our documentation to replace @bforget on the @openmc-dev/technical-committee with @jtramm.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>