### PR TITLE
extra checks for pixels

### DIFF
--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -22,9 +22,9 @@ import openmc._xml as xml
 from openmc.dummy_comm import DummyCommunicator
 from openmc.executor import _process_CLI_arguments
 from openmc.checkvalue import (check_type, check_value, check_greater_than,
-                               PathLike)
+                               check_length, PathLike)
 from openmc.exceptions import InvalidIDError
-from openmc.plots import add_plot_params, _check_pixels, _BASIS_INDICES, id_map_to_rgb
+from openmc.plots import add_plot_params, _BASIS_INDICES, id_map_to_rgb
 from openmc.utility_funcs import change_directory
 
 
@@ -32,6 +32,15 @@ from openmc.utility_funcs import change_directory
 class ModelModifier(Protocol):
     def __call__(self, val: float, **kwargs: Any) -> None:
         ...
+
+
+def _check_pixels(pixels: int | Sequence[int]) -> None:
+    if isinstance(pixels, Integral):
+        check_greater_than('pixels', pixels, 0)
+    else:
+        check_length('pixels', pixels, 2)
+        for p in pixels:
+            check_greater_than('pixels', p, 0)
 
 
 class Model:
@@ -1213,9 +1222,9 @@ class Model:
             Shape (v_res, h_res, 2) float64 array with [temperature, density],
             or None if include_properties=False.
         """
-        _check_pixels(pixels)
-
         import openmc.lib
+
+        _check_pixels(pixels)
 
         if width is not None and (u_span is not None or v_span is not None):
             raise ValueError("width is mutually exclusive with u_span/v_span.")

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -22,9 +22,9 @@ import openmc._xml as xml
 from openmc.dummy_comm import DummyCommunicator
 from openmc.executor import _process_CLI_arguments
 from openmc.checkvalue import (check_type, check_value, check_greater_than,
-                               check_length, PathLike)
+                               PathLike)
 from openmc.exceptions import InvalidIDError
-from openmc.plots import add_plot_params, _BASIS_INDICES, id_map_to_rgb
+from openmc.plots import add_plot_params, _check_pixels, _BASIS_INDICES, id_map_to_rgb
 from openmc.utility_funcs import change_directory
 
 
@@ -1051,12 +1051,7 @@ class Model:
         pixels: int | Sequence[int],
         basis: str
     ):
-        if isinstance(pixels, int):
-            check_greater_than('pixels', pixels, 0)
-        else:
-            check_length('pixels', pixels, 2)
-            for p in pixels:
-                check_greater_than('pixels', p, 0)
+        _check_pixels(pixels)
 
         x, y, _ = _BASIS_INDICES[basis]
 
@@ -1218,6 +1213,8 @@ class Model:
             Shape (v_res, h_res, 2) float64 array with [temperature, density],
             or None if include_properties=False.
         """
+        _check_pixels(pixels)
+
         import openmc.lib
 
         if width is not None and (u_span is not None or v_span is not None):

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -262,6 +262,15 @@ def add_plot_params(func):
     return func
 
 
+def _check_pixels(pixels):
+    if isinstance(pixels, Integral):
+        cv.check_greater_than('pixels', pixels, 0)
+    else:
+        cv.check_length('pixels', pixels, 2)
+        for p in pixels:
+            cv.check_greater_than('pixels', p, 0)
+
+
 def _get_plot_image(plot, cwd):
     from IPython.display import Image
 

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -262,7 +262,7 @@ def add_plot_params(func):
     return func
 
 
-def _check_pixels(pixels):
+def _check_pixels(pixels: int | Sequence[int]) -> None:
     if isinstance(pixels, Integral):
         cv.check_greater_than('pixels', pixels, 0)
     else:

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -262,15 +262,6 @@ def add_plot_params(func):
     return func
 
 
-def _check_pixels(pixels: int | Sequence[int]) -> None:
-    if isinstance(pixels, Integral):
-        cv.check_greater_than('pixels', pixels, 0)
-    else:
-        cv.check_length('pixels', pixels, 2)
-        for p in pixels:
-            cv.check_greater_than('pixels', p, 0)
-
-
 def _get_plot_image(plot, cwd):
     from IPython.display import Image
 
@@ -392,7 +383,7 @@ def id_map_to_rgb(
     """
     # Initialize RGB array with white background (values between 0 and 1 for matplotlib)
     img = np.ones(id_map.shape, dtype=float)
-    
+
     # Get the appropriate index based on color_by
     if color_by == 'cell':
         id_index = 0  # Cell IDs are in the first channel
@@ -400,14 +391,14 @@ def id_map_to_rgb(
         id_index = 2  # Material IDs are in the third channel
     else:
         raise ValueError("color_by must be either 'cell' or 'material'")
-    
+
     # Get all unique IDs in the plot
     unique_ids = np.unique(id_map[:, :, id_index])
-    
+
     # Generate default colors if not provided
     if colors is None:
         colors = {}
-    
+
     # Convert colors dict to use IDs as keys
     color_map = {}
     for key, color in colors.items():
@@ -415,13 +406,13 @@ def id_map_to_rgb(
             color_map[key.id] = color
         else:
             color_map[key] = color
-    
+
     # Generate random colors for IDs not in color_map
     rng = np.random.RandomState(1)
     for uid in unique_ids:
         if uid > 0 and uid not in color_map:
             color_map[uid] = rng.randint(0, 256, (3,))
-    
+
     # Apply colors to each pixel
     for uid in unique_ids:
         if uid == -1:  # Background/void
@@ -441,7 +432,7 @@ def id_map_to_rgb(
                 rgb = color
             mask = id_map[:, :, id_index] == uid
             img[mask] = np.array(rgb) / 255.0
-    
+
     return img
 
 class PlotBase(IDManagerMixin):

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -679,6 +679,8 @@ def test_model_plot_invalid_inputs():
         model.plot(pixels=(0, 100))
     with pytest.raises(ValueError):
         model.plot(pixels=(100,))
+    with pytest.raises(ValueError):
+        model.slice_data(u_span=(2, 0, 0), v_span=(0, 2, 0), pixels=-1)
 
 
 def test_model_id_map_initialization(run_in_tmpdir):


### PR DESCRIPTION
## Summary

Follow-up to #4004, I noticed this opportunity to add checks in more places and reuse some existing code for that.

- Extracts the `pixels` validation from `Model._set_plot_defaults` into a `_check_pixels` helper in `openmc/plots.py`, next to `add_plot_params`.
- Calls the helper at the top of `Model.slice_data`, which covers the oriented-slice (`u_span`/`v_span`) branch that converts `pixels` itself and never reaches `_set_plot_defaults`. The call sits before the `openmc.lib` import so invalid arguments raise without needing the compiled core.
- `_set_plot_defaults` keeps its check via the helper, so `Model.plot` remains validated even though it reaches `slice_data` later.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)