### PR TITLE
Performance optimizations for shared secondary bank

### DIFF
--- a/include/openmc/shared_array.h
+++ b/include/openmc/shared_array.h
@@ -114,6 +114,32 @@ public:
     data_[size_++] = value;
   }
 
+  //! Increase the size of the container by count elements without assigning
+  //! values to the new elements. Existing elements are preserved if the
+  //! container needs to grow. This does not perform any thread safety checks.
+  //
+  //! \param count The number of elements to append
+  //! \return The starting index of the appended range
+  int64_t extend_uninitialized(int64_t count)
+  {
+    int64_t offset = size_;
+    int64_t new_size = size_ + count;
+    if (new_size > capacity_) {
+      int64_t new_capacity = capacity_ == 0 ? 8 : capacity_;
+      while (new_capacity < new_size) {
+        new_capacity *= 2;
+      }
+      unique_ptr<T[]> new_data = make_unique<T[]>(new_capacity);
+      if (size_ > 0) {
+        std::copy_n(data_.get(), size_, new_data.get());
+      }
+      data_ = std::move(new_data);
+      capacity_ = new_capacity;
+    }
+    size_ = new_size;
+    return offset;
+  }
+
   //! Return the number of elements in the container
   int64_t size() { return size_; }
   int64_t size() const { return size_; }

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -12,6 +12,7 @@
 #include "openmc/material.h"
 #include "openmc/message_passing.h"
 #include "openmc/nuclide.h"
+#include "openmc/openmp_interface.h"
 #include "openmc/output.h"
 #include "openmc/particle.h"
 #include "openmc/photon.h"
@@ -353,6 +354,53 @@ vector<int64_t> work_index;
 int64_t simulation_tracks_completed {0};
 
 } // namespace simulation
+
+namespace {
+
+void collect_history_secondary_banks(vector<vector<SourceSite>>& thread_banks)
+{
+  int64_t total = 0;
+  for (const auto& bank : thread_banks) {
+    total += bank.size();
+  }
+
+  simulation::shared_secondary_bank_write = SharedArray<SourceSite>(total);
+
+  int64_t offset = 0;
+  for (const auto& bank : thread_banks) {
+    if (!bank.empty()) {
+      std::copy(bank.cbegin(), bank.cend(),
+        simulation::shared_secondary_bank_write.data() + offset);
+    }
+    offset += bank.size();
+  }
+}
+
+void collect_event_secondary_banks(int64_t n_particles)
+{
+  vector<int64_t> offsets(n_particles);
+  int64_t total = 0;
+  for (int64_t i = 0; i < n_particles; ++i) {
+    offsets[i] = total;
+    total += simulation::particles[i].local_secondary_bank().size();
+  }
+
+  int64_t bank_offset =
+    simulation::shared_secondary_bank_write.extend_uninitialized(total);
+
+#pragma omp parallel for schedule(static)
+  for (int64_t i = 0; i < n_particles; ++i) {
+    auto& local_bank = simulation::particles[i].local_secondary_bank();
+    if (!local_bank.empty()) {
+      std::copy(local_bank.cbegin(), local_bank.cend(),
+        simulation::shared_secondary_bank_write.data() + bank_offset +
+          offsets[i]);
+      local_bank.clear();
+    }
+  }
+}
+
+} // namespace
 
 //==============================================================================
 // Non-member functions
@@ -921,11 +969,13 @@ void transport_history_based_shared_secondary()
   std::fill(simulation::progeny_per_particle.begin(),
     simulation::progeny_per_particle.end(), 0);
 
+  vector<vector<SourceSite>> thread_banks(num_threads());
+
   // Phase 1: Transport primary particles and deposit first generation of
   // secondaries in the shared secondary bank
 #pragma omp parallel
   {
-    vector<SourceSite> thread_bank;
+    auto& thread_bank = thread_banks[thread_num()];
     Particle p;
 
 #pragma omp for schedule(runtime)
@@ -937,15 +987,9 @@ void transport_history_based_shared_secondary()
       }
       p.local_secondary_bank().clear();
     }
-
-    // Drain thread-local bank into the shared secondary bank (once per thread)
-#pragma omp critical(SharedSecondaryBank)
-    {
-      for (auto& site : thread_bank) {
-        simulation::shared_secondary_bank_write.thread_unsafe_append(site);
-      }
-    }
   }
+  collect_history_secondary_banks(thread_banks);
+  thread_banks.clear();
 
   simulation::simulation_tracks_completed += settings::n_particles;
 
@@ -987,11 +1031,12 @@ void transport_history_based_shared_secondary()
       simulation::shared_secondary_bank_read.size());
     std::fill(simulation::progeny_per_particle.begin(),
       simulation::progeny_per_particle.end(), 0);
+    thread_banks.resize(num_threads());
 
     // Transport all secondary tracks from the shared secondary bank
 #pragma omp parallel
     {
-      vector<SourceSite> thread_bank;
+      auto& thread_bank = thread_banks[thread_num()];
       Particle p;
 
 #pragma omp for schedule(runtime)
@@ -1006,17 +1051,9 @@ void transport_history_based_shared_secondary()
         }
         p.local_secondary_bank().clear();
       }
-
-      // Drain thread-local bank into the shared secondary bank (once per
-      // thread)
-#pragma omp critical(SharedSecondaryBank)
-      {
-        for (auto& secondary_site : thread_bank) {
-          simulation::shared_secondary_bank_write.thread_unsafe_append(
-            secondary_site);
-        }
-      }
     } // End of transport loop over tracks in shared secondary bank
+    collect_history_secondary_banks(thread_banks);
+    thread_banks.clear();
     n_generation_depth++;
     simulation::simulation_tracks_completed += alive_secondary;
   } // End of loop over secondary generations
@@ -1080,13 +1117,7 @@ void transport_event_based_shared_secondary()
     process_transport_events();
     process_death_events(n_particles);
 
-    // Collect secondaries from all particle buffers into shared bank
-    for (int64_t i = 0; i < n_particles; i++) {
-      for (auto& site : simulation::particles[i].local_secondary_bank()) {
-        simulation::shared_secondary_bank_write.thread_unsafe_append(site);
-      }
-      simulation::particles[i].local_secondary_bank().clear();
-    }
+    collect_event_secondary_banks(n_particles);
 
     remaining_work -= n_particles;
     source_offset += n_particles;
@@ -1150,13 +1181,7 @@ void transport_event_based_shared_secondary()
       process_transport_events();
       process_death_events(n_particles);
 
-      // Collect secondaries from all particle buffers into shared bank
-      for (int64_t i = 0; i < n_particles; i++) {
-        for (auto& site : simulation::particles[i].local_secondary_bank()) {
-          simulation::shared_secondary_bank_write.thread_unsafe_append(site);
-        }
-        simulation::particles[i].local_secondary_bank().clear();
-      }
+      collect_event_secondary_banks(n_particles);
 
       sec_remaining -= n_particles;
       sec_offset += n_particles;

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -358,14 +358,20 @@ int64_t simulation_tracks_completed {0};
 
 namespace {
 
+//! Collect thread-local secondary banks into the shared secondary bank in
+//! sorted order.
+//!
+//! \param thread_banks  Secondary banks produced by each OpenMP thread
 void collect_sorted_history_secondary_banks(
   vector<vector<SourceSite>>& thread_banks)
 {
+  // Count the total number of all secondary sites produced
   int64_t n_collected = 0;
   for (const auto& bank : thread_banks) {
     n_collected += bank.size();
   }
 
+  // Count the expected number of progeny from per-parent progeny counts
   int64_t n_progeny = 0;
   for (int64_t count : simulation::progeny_per_particle) {
     n_progeny += count;
@@ -376,18 +382,20 @@ void collect_sorted_history_secondary_banks(
                 "secondary bank size during collection.");
   }
 
+  // Convert per-parent progeny counts to offsets into the sorted bank
   std::exclusive_scan(simulation::progeny_per_particle.begin(),
     simulation::progeny_per_particle.end(),
     simulation::progeny_per_particle.begin(), 0);
 
+  // Allocate the shared bank once for the complete generation
   simulation::shared_secondary_bank_write.resize(0);
   simulation::shared_secondary_bank_write.extend_uninitialized(n_progeny);
 
+  // Place each secondary according to its parent and progeny identifiers
   for (const auto& bank : thread_banks) {
     for (const auto& site : bank) {
       if (site.parent_id < 0 ||
-          site.parent_id >=
-            static_cast<int64_t>(simulation::progeny_per_particle.size())) {
+          site.parent_id >= simulation::progeny_per_particle.size()) {
         fatal_error(fmt::format("Invalid parent_id {} for banked site "
                                 "(expected range [0, {})).",
           site.parent_id, simulation::progeny_per_particle.size()));
@@ -403,8 +411,12 @@ void collect_sorted_history_secondary_banks(
   }
 }
 
+//! Collect particle-local secondary banks into the shared secondary bank.
+//!
+//! \param n_particles  Number of particles in the active event-based buffer
 void collect_event_secondary_banks(int64_t n_particles)
 {
+  // Compute offsets for each particle's local secondary bank.
   vector<int64_t> offsets(n_particles);
   int64_t total = 0;
   for (int64_t i = 0; i < n_particles; ++i) {
@@ -412,9 +424,11 @@ void collect_event_secondary_banks(int64_t n_particles)
     total += simulation::particles[i].local_secondary_bank().size();
   }
 
+  // Extend the shared bank once for all collected secondaries
   int64_t bank_offset =
     simulation::shared_secondary_bank_write.extend_uninitialized(total);
 
+  // Copy each local bank into its assigned range and clear the local storage
 #pragma omp parallel for schedule(static)
   for (int64_t i = 0; i < n_particles; ++i) {
     auto& local_bank = simulation::particles[i].local_secondary_bank();

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -380,7 +380,8 @@ void collect_sorted_history_secondary_banks(
     simulation::progeny_per_particle.end(),
     simulation::progeny_per_particle.begin(), 0);
 
-  simulation::shared_secondary_bank_write = SharedArray<SourceSite>(n_progeny);
+  simulation::shared_secondary_bank_write.resize(0);
+  simulation::shared_secondary_bank_write.extend_uninitialized(n_progeny);
 
   for (const auto& bank : thread_banks) {
     for (const auto& site : bank) {
@@ -1074,6 +1075,9 @@ void transport_history_based_shared_secondary()
         p.local_secondary_bank().clear();
       }
     } // End of transport loop over tracks in shared secondary bank
+    simulation::shared_secondary_bank_write =
+      std::move(simulation::shared_secondary_bank_read);
+    simulation::shared_secondary_bank_read = SharedArray<SourceSite>();
     collect_sorted_history_secondary_banks(thread_banks);
     thread_banks.clear();
     n_generation_depth++;

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -395,7 +395,8 @@ void collect_sorted_history_secondary_banks(
   for (const auto& bank : thread_banks) {
     for (const auto& site : bank) {
       if (site.parent_id < 0 ||
-          site.parent_id >= simulation::progeny_per_particle.size()) {
+          site.parent_id >=
+            static_cast<int64_t>(simulation::progeny_per_particle.size())) {
         fatal_error(fmt::format("Invalid parent_id {} for banked site "
                                 "(expected range [0, {})).",
           site.parent_id, simulation::progeny_per_particle.size()));

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -42,6 +42,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <numeric>
 #include <string>
 
 //==============================================================================
@@ -357,22 +358,47 @@ int64_t simulation_tracks_completed {0};
 
 namespace {
 
-void collect_history_secondary_banks(vector<vector<SourceSite>>& thread_banks)
+void collect_sorted_history_secondary_banks(
+  vector<vector<SourceSite>>& thread_banks)
 {
-  int64_t total = 0;
+  int64_t n_collected = 0;
   for (const auto& bank : thread_banks) {
-    total += bank.size();
+    n_collected += bank.size();
   }
 
-  simulation::shared_secondary_bank_write = SharedArray<SourceSite>(total);
+  int64_t n_progeny = 0;
+  for (int64_t count : simulation::progeny_per_particle) {
+    n_progeny += count;
+  }
 
-  int64_t offset = 0;
+  if (n_collected != n_progeny) {
+    fatal_error("Mismatch detected between sum of all particle progeny and "
+                "secondary bank size during collection.");
+  }
+
+  std::exclusive_scan(simulation::progeny_per_particle.begin(),
+    simulation::progeny_per_particle.end(),
+    simulation::progeny_per_particle.begin(), 0);
+
+  simulation::shared_secondary_bank_write = SharedArray<SourceSite>(n_progeny);
+
   for (const auto& bank : thread_banks) {
-    if (!bank.empty()) {
-      std::copy(bank.cbegin(), bank.cend(),
-        simulation::shared_secondary_bank_write.data() + offset);
+    for (const auto& site : bank) {
+      if (site.parent_id < 0 ||
+          site.parent_id >=
+            static_cast<int64_t>(simulation::progeny_per_particle.size())) {
+        fatal_error(fmt::format("Invalid parent_id {} for banked site "
+                                "(expected range [0, {})).",
+          site.parent_id, simulation::progeny_per_particle.size()));
+      }
+      int64_t idx =
+        simulation::progeny_per_particle[site.parent_id] + site.progeny_id;
+      if (idx < 0 || idx >= n_progeny) {
+        fatal_error("Mismatch detected between sum of all particle progeny and "
+                    "secondary bank size during collection.");
+      }
+      simulation::shared_secondary_bank_write[idx] = site;
     }
-    offset += bank.size();
   }
 }
 
@@ -988,7 +1014,7 @@ void transport_history_based_shared_secondary()
       p.local_secondary_bank().clear();
     }
   }
-  collect_history_secondary_banks(thread_banks);
+  collect_sorted_history_secondary_banks(thread_banks);
   thread_banks.clear();
 
   simulation::simulation_tracks_completed += settings::n_particles;
@@ -998,10 +1024,6 @@ void transport_history_based_shared_secondary()
   int n_generation_depth = 1;
   int64_t alive_secondary = 1;
   while (alive_secondary) {
-
-    // Sort the shared secondary bank by parent ID then progeny ID to
-    // ensure reproducibility.
-    sort_bank(simulation::shared_secondary_bank_write, false);
 
     // Synchronize the shared secondary bank amongst all MPI ranks, such
     // that each MPI rank has an approximately equal number of secondary
@@ -1052,7 +1074,7 @@ void transport_history_based_shared_secondary()
         p.local_secondary_bank().clear();
       }
     } // End of transport loop over tracks in shared secondary bank
-    collect_history_secondary_banks(thread_banks);
+    collect_sorted_history_secondary_banks(thread_banks);
     thread_banks.clear();
     n_generation_depth++;
     simulation::simulation_tracks_completed += alive_secondary;


### PR DESCRIPTION
# Description

This PR is a follow-on to #3995 with further optimizations I've made for when the shared secondary bank is turned on. The optimizations are focused on how thread-local banks are collected into the shared secondary bank. Currently, this involves a critical section to drain the thread-local banks into a single `SharedArray` followed by a sort on the array to preserve reproducibility. I've made the following changes:

- First, I avoided the critical section on the drain of thread-local banks by pre-allocating the full bank, which then allows us to copy data into the appropriate offset from each thread using an exclusive scan on the progeny per particle.
- Once I did that, I noted that we can precompute the index into the sorted array using the parent_id, progeny_id, and the progeny offsets, which allows us to entirely avoid the sort on the shared secondary bank.
- After a generation's read bank has been used, its storage is no longer needed which means we can reuse that storage as the next write bank. This avoids extra memory allocations when the next secondary generation is no larger than the current one.

## Performance Profiling

As I mentioned in #3995, these optimizations arose when I was observing poor performance on a D1S simulation using weight windows. To share some profiles as I was going through these optimizations. Here is the starting point (before #3995):
<img width="1400" height="284" alt="Before optimizations" src="https://github.com/user-attachments/assets/c515c03d-cc75-49c9-b723-8931b3457357" />

You can see a huge block from the memory allocation of the particle cross section caches (addressed in #3995) but also some other inefficiences due to the allocation/sorting of the shared secondary bank itself (addressed here). After the optimizations from #3995 and this PR, this is what the profile looks like now:
<img width="1400" height="252" alt="After optimizaitons" src="https://github.com/user-attachments/assets/38b4f585-9e7c-48a0-93e4-9a17fe4fa316" />

At this point, the major "overhead" from the shared secondary mode is computing random number seeds (`future_seed_coefficients`) and I don't think there's much we can do about that.

Overall for this problem, the performance with the shared secondary bank improved by about **2.3×** with both sets of optimizations, and whereas before it was about 37% of the performance with a local secondary bank, now it reaches 77% of the performance with a local secondary bank (turns out for this problem the load balancing between threads is not bad enough for shared secondary to give better performance than local).

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>