### PR TITLE
Add analytic tests for ray-traced intersection distances

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,7 +532,7 @@ else()
 endif()
 
 if(OPENMC_USE_DAGMC)
-  target_compile_definitions(libopenmc PRIVATE OPENMC_DAGMC_ENABLED)
+  target_compile_definitions(libopenmc PUBLIC OPENMC_DAGMC_ENABLED)
   target_link_libraries(libopenmc dagmc-shared)
 
   if(OPENMC_USE_UWUW)

--- a/tests/cpp_unit_tests/CMakeLists.txt
+++ b/tests/cpp_unit_tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_NAMES
   test_math
   test_mcpl_stat_sum
   test_mesh
+  test_ray
   test_region
   test_tensor
   # Add additional unit test files here

--- a/tests/cpp_unit_tests/test_ray.cpp
+++ b/tests/cpp_unit_tests/test_ray.cpp
@@ -1,0 +1,117 @@
+#include <cmath>
+#include <utility>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <pugixml.hpp>
+
+#include "openmc/geometry.h"
+#include "openmc/geometry_aux.h"
+#include "openmc/ray.h"
+#include "openmc/settings.h"
+#include "openmc/surface.h"
+
+namespace {
+
+using Catch::Matchers::WithinAbs;
+
+constexpr double DISTANCE_TOLERANCE = 1.0e-12;
+
+class SphericalShellFixture {
+public:
+  SphericalShellFixture()
+    : run_mode_(openmc::settings::run_mode),
+      root_universe_(openmc::model::root_universe),
+      n_coord_levels_(openmc::model::n_coord_levels)
+  {
+    openmc::settings::run_mode = openmc::RunMode::PLOTTING;
+
+    constexpr auto geometry = R"(
+      <geometry>
+        <surface id="1" type="sphere" coeffs="0 0 0 1"/>
+        <surface id="2" type="sphere" coeffs="0 0 0 2"
+                 boundary="vacuum"/>
+        <cell id="1" material="void" region="-1"/>
+        <cell id="2" material="void" region="1 -2"/>
+      </geometry>
+    )";
+
+    auto result = document_.load_string(geometry);
+    REQUIRE(result);
+    openmc::read_geometry_xml(document_.document_element());
+    openmc::finalize_geometry();
+    openmc::finalize_cell_densities();
+  }
+
+  ~SphericalShellFixture()
+  {
+    openmc::free_memory_geometry();
+    openmc::free_memory_surfaces();
+    openmc::model::universe_level_counts.clear();
+    openmc::model::root_universe = root_universe_;
+    openmc::model::n_coord_levels = n_coord_levels_;
+    openmc::settings::run_mode = run_mode_;
+  }
+
+private:
+  pugi::xml_document document_;
+  openmc::RunMode run_mode_;
+  int root_universe_;
+  int n_coord_levels_;
+};
+
+class RecordingRay : public openmc::Ray {
+public:
+  using Ray::Ray;
+
+  void on_intersection() override
+  {
+    intersections.emplace_back(
+      traversal_distance_, boundary().surface_index() + 1);
+  }
+
+  openmc::vector<std::pair<double, int>> intersections;
+};
+
+} // namespace
+
+TEST_CASE_METHOD(SphericalShellFixture, "Trace a single chord through a sphere")
+{
+  constexpr double impact_parameter = 1.5;
+  const double half_chord =
+    std::sqrt(4.0 - impact_parameter * impact_parameter);
+
+  RecordingRay ray({-3.0, impact_parameter, 0.0}, {1.0, 0.0, 0.0});
+  ray.trace();
+
+  REQUIRE(ray.intersections.size() == 2);
+  CHECK(ray.intersections[0].second == 2);
+  CHECK_THAT(ray.intersections[0].first, WithinAbs(0.0, DISTANCE_TOLERANCE));
+  CHECK(ray.intersections[1].second == 2);
+  CHECK_THAT(ray.intersections[1].first,
+    WithinAbs(2.0 * half_chord, DISTANCE_TOLERANCE));
+}
+
+TEST_CASE_METHOD(
+  SphericalShellFixture, "Trace both segments of a spherical shell")
+{
+  constexpr double impact_parameter = 0.5;
+  const double outer = std::sqrt(4.0 - impact_parameter * impact_parameter);
+  const double inner = std::sqrt(1.0 - impact_parameter * impact_parameter);
+
+  RecordingRay ray({-3.0, impact_parameter, 0.0}, {1.0, 0.0, 0.0});
+  ray.trace();
+
+  REQUIRE(ray.intersections.size() == 4);
+  CHECK(ray.intersections[0].second == 2);
+  CHECK_THAT(ray.intersections[0].first, WithinAbs(0.0, DISTANCE_TOLERANCE));
+  CHECK(ray.intersections[1].second == 1);
+  CHECK_THAT(
+    ray.intersections[1].first, WithinAbs(outer - inner, DISTANCE_TOLERANCE));
+  CHECK(ray.intersections[2].second == 1);
+  CHECK_THAT(
+    ray.intersections[2].first, WithinAbs(outer + inner, DISTANCE_TOLERANCE));
+  CHECK(ray.intersections[3].second == 2);
+  CHECK_THAT(
+    ray.intersections[3].first, WithinAbs(2.0 * outer, DISTANCE_TOLERANCE));
+}


### PR DESCRIPTION
# Description

Add focused C++ unit tests for `Ray::trace()` using a concentric-sphere CSG geometry.

The tests verify:

- the analytic chord length through a sphere, `2 * sqrt(R^2 - b^2)`;
- all four cumulative intersection distances for a ray crossing a spherical shell and its inner region.

Together, these cases exercise entry from outside the model, multiple internal surface crossings, re-entry into a cell, and final leakage through a vacuum boundary. This adds direct analytic coverage for the reusable `Ray` implementation generalized in #3816 and separated into its own source files in #3845.

No production behavior or public API is changed.

# Testing

- `cmake --build build --target test_ray -j2`
- `ctest --test-dir build -R '^test_ray$' --output-on-failure`
- All nine locally available C++ test executables pass; the optional MCPL test was excluded because MCPL is not installed.
- A local mutation check confirmed the assertions detect `TINY_BIT`-scale errors in accumulated traversal distances.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on the C++ source file
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (not applicable)
- [x] I have made corresponding changes to the documentation (not applicable; test-only change)
- [x] I have added tests that prove the covered behavior works
