### PR TITLE
normalize new_u after periodic crossing to prevent unnormalized direction

### DIFF
--- a/src/boundary_condition.cpp
+++ b/src/boundary_condition.cpp
@@ -38,6 +38,9 @@ void VacuumBC::handle_particle(Particle& p, const Surface& surf) const
 void ReflectiveBC::handle_particle(Particle& p, const Surface& surf) const
 {
   Direction u = surf.reflect(p.r(), p.u(), &p);
+
+  // normalize reflected u to ensure no floating point error leads to
+  // unnormalized directions
   u /= u.norm();
 
   // Handle the effects of the surface albedo on the particle's weight.
@@ -53,6 +56,9 @@ void ReflectiveBC::handle_particle(Particle& p, const Surface& surf) const
 void WhiteBC::handle_particle(Particle& p, const Surface& surf) const
 {
   Direction u = surf.diffuse_reflect(p.r(), p.u(), p.current_seed());
+
+  // normalize outgoing u to ensure no floating point error leads to
+  // unnormalized directions
   u /= u.norm();
 
   // Handle the effects of the surface albedo on the particle's weight.
@@ -240,6 +246,10 @@ void RotationalPeriodicBC::handle_particle(
   new_u[zero_axis_idx_] = u[zero_axis_idx_];
   new_u[axis_1_idx_] = cos_theta * u[axis_1_idx_] - sin_theta * u[axis_2_idx_];
   new_u[axis_2_idx_] = sin_theta * u[axis_1_idx_] + cos_theta * u[axis_2_idx_];
+
+  // normalize new_u to ensure no floating point error leads to unnormalized
+  // directions
+  new_u /= new_u.norm();
 
   // Handle the effects of the surface albedo on the particle's weight.
   BoundaryCondition::handle_albedo(p, surf);


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description
Closes #3970. After many months and much support from @pshriwise and @gonuke, we've come to a resolution to an issue I was having with my model related to using a periodic BC aligned to the y-axis, see forum [post](https://openmc.discourse.group/t/flip-normal-and-physics-for-periodic-problems/6148/5?u=ligross).

It turns out that most boundary conditions in OpenMC re-normalize particle direction after they cross a boundary (e.g. reflective or white BCs) and that ~6 years ago, this was not done for the periodic case. It wasn't an issue for a while due to the restriction that models must use z-axis aligned periodicity. However, allowing arbitrary periodic BCs #3591 combined with logic in [rotate_angle](https://github.com/openmc-dev/openmc/blob/e783e014715cfb03df44616fc06e8ac5168f0df1/src/math_functions.cpp#L787-L798) exposed a rare, but consistent, behavior that the un-normalized nature of the direction vector could grow beyond unity until eventually, a negative distance to collision gets computed. This negative distance results from an assumption of unity norm directions in the function logic. In this case, OpenMC reports a `-nan` batch and has a fatal error.

We've tried a lot to debug, however the most relevant is that 
1) When my model is rotated to use z-periodicity, the `-nan` goes away
2) When my model remains y-aligned but the BC is changed from periodic to reflective, the `-nan` goes away
2) Patrick was able to reproduce the `-nan` by removing the normalization in the reflective BC case in `boundary_condition.cpp` and re-running my y-aligned model while only changing the BC to reflective. 

It seems there are very small amounts of floating point error picked up that magnify each time they cross a boundary or for lucky (unlucky?) directions interacting with `rotate_angle`'s branching on the `b` parameter.

This solution will make the code more consistent with itself i.e. normalizing after any type of boundary crossing that is not transnational. Thankfully, this solution means that only periodic BC related tests need to be re-golded (which I will do in the next commit). I have a feeling of which tests should fail with this change (see below), but I'm going to let them fail just to be sure. 
```
ligross@cnerg-docker-09:~/research/openmc/tests/regression_tests (normalize_after_periodic_crossing) $ ls per*
periodic:
__init__.py  inputs_true.dat  results_true.dat  test.py

periodic_6fold:
False-False  False-True  __init__.py  test.py  True-False  True-True

periodic_cyls:
__init__.py  test.py  xcyl_model  ycyl_model

periodic_hex:
__init__.py  inputs_true.dat  results_true.dat  test.py
```
# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [ ] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [ ] ~~I have made corresponding changes to the documentation (if applicable)~~
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
