### PR TITLE
Access element subshell map data only if it has atomic relaxation data

### DIFF
--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -359,8 +359,8 @@ void sample_photon_reaction(Particle& p)
     // Allow electrons to fill orbital and produce Auger electrons and
     // fluorescent photons. Since Compton subshell data does not match atomic
     // relaxation data, use the mapping between the data to find the subshell
-    if (settings::atomic_relaxation && i_shell >= 0 &&
-        element.subshell_map_[i_shell] >= 0) {
+    if (settings::atomic_relaxation && element.has_atomic_relaxation_ &&
+        i_shell >= 0 && element.subshell_map_[i_shell] >= 0) {
       element.atomic_relaxation(element.subshell_map_[i_shell], p);
     }
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Currently openmc access element subshell map data for elements without atomic relaxation data.
This PR fix that with a simple guard.

I've tested that this works with FENDL data.
I did not add a test because we do not have an element without relaxation data in the test data.

Fixes #3992

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
