### PR TITLE
Override NJOY default damage energy threshold

### DIFF
--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -259,14 +259,14 @@ broadr / %%%%%%%%%%%%%%%%%%%%%%% Doppler broaden XS %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 _TEMPLATE_HEATR = """
 heatr / %%%%%%%%%%%%%%%%%%%%%%%%% Add heating kerma %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 {nendf} {nheatr_in} {nheatr} /
-{mat} 4 0 0 0 0 {damage_threshold}/
+{mat} 4 0 0 0 0 {ed}/
 302 318 402 444 /
 """
 
 _TEMPLATE_HEATR_LOCAL = """
 heatr / %%%%%%%%%%%%%%%%% Add heating kerma (local photons) %%%%%%%%%%%%%%%%%%%%
 {nendf} {nheatr_in} {nheatr_local} /
-{mat} 4 0 0 1 0 {damage_threshold}/
+{mat} 4 0 0 1 0 {ed}/
 302 318 402 444 /
 """
 
@@ -411,7 +411,7 @@ def make_pendf(filename, pendf='pendf', **kwargs):
 def make_ace(filename, temperatures=None, acer=True, xsdir=None,
              output_dir=None, pendf=False, error=0.001, broadr=True,
              heatr=True, gaspr=True, purr=True, evaluation=None,
-             smoothing=True, damage_threshold=None, **kwargs):
+             smoothing=True, displacement_energy=None, **kwargs):
     """Generate incident neutron ACE file from an ENDF file
 
     File names can be passed to
@@ -463,8 +463,9 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
         indicates which evaluation should be used.
     smoothing : bool, optional
         If the smoothing option (ACER card 6) is on (True) or off (False).
-    damage_threshold : float, optional
-        Displacement damage threshold in eV. Used in heatr to calculate damage-energy cross section. When None use NJOY defaults.
+    displacement_energy : float, optional
+        Threshold displacement energy in [eV]. Used in HEATR to calculate
+        damage-energy cross section. When None, use NJOY defaults.
     **kwargs
         Keyword arguments passed to :func:`openmc.data.njoy.run`
 
@@ -517,12 +518,7 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
 
     # heatr
     if heatr:
-        # prevent using NJOY default by setting to a small number
-        if damage_threshold == 0.0:
-            damage_threshold = 1e-5
-        # the NJOY default is 0
-        if damage_threshold is None:
-            damage_threshold = 0.0
+        ed = displacement_energy if displacement_energy is not None else 0
         nheatr_in = nlast
         nheatr_local = nheatr_in + 1
         tapeout[nheatr_local] = (output_dir / "heatr_local") if heatr is True \

--- a/openmc/data/njoy.py
+++ b/openmc/data/njoy.py
@@ -259,14 +259,14 @@ broadr / %%%%%%%%%%%%%%%%%%%%%%% Doppler broaden XS %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 _TEMPLATE_HEATR = """
 heatr / %%%%%%%%%%%%%%%%%%%%%%%%% Add heating kerma %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 {nendf} {nheatr_in} {nheatr} /
-{mat} 4 0 0 0 /
+{mat} 4 0 0 0 0 {damage_threshold}/
 302 318 402 444 /
 """
 
 _TEMPLATE_HEATR_LOCAL = """
 heatr / %%%%%%%%%%%%%%%%% Add heating kerma (local photons) %%%%%%%%%%%%%%%%%%%%
 {nendf} {nheatr_in} {nheatr_local} /
-{mat} 4 0 0 1 /
+{mat} 4 0 0 1 0 {damage_threshold}/
 302 318 402 444 /
 """
 
@@ -411,7 +411,7 @@ def make_pendf(filename, pendf='pendf', **kwargs):
 def make_ace(filename, temperatures=None, acer=True, xsdir=None,
              output_dir=None, pendf=False, error=0.001, broadr=True,
              heatr=True, gaspr=True, purr=True, evaluation=None,
-             smoothing=True, **kwargs):
+             smoothing=True, damage_threshold=None, **kwargs):
     """Generate incident neutron ACE file from an ENDF file
 
     File names can be passed to
@@ -463,6 +463,8 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
         indicates which evaluation should be used.
     smoothing : bool, optional
         If the smoothing option (ACER card 6) is on (True) or off (False).
+    damage_threshold : float, optional
+        Displacement damage threshold in eV. Used in heatr to calculate damage-energy cross section. When None use NJOY defaults.
     **kwargs
         Keyword arguments passed to :func:`openmc.data.njoy.run`
 
@@ -515,6 +517,12 @@ def make_ace(filename, temperatures=None, acer=True, xsdir=None,
 
     # heatr
     if heatr:
+        # prevent using NJOY default by setting to a small number
+        if damage_threshold == 0.0:
+            damage_threshold = 1e-5
+        # the NJOY default is 0
+        if damage_threshold is None:
+            damage_threshold = 0.0
         nheatr_in = nlast
         nheatr_local = nheatr_in + 1
         tapeout[nheatr_local] = (output_dir / "heatr_local") if heatr is True \

--- a/tests/unit_tests/test_data_neutron.py
+++ b/tests/unit_tests/test_data_neutron.py
@@ -244,6 +244,14 @@ def test_kerma(run_in_tmpdir, am244, h2):
     assert 901 in read_in
     assert np.all(read_in[901].xs['300K'].y == h2[901].xs['300K'].y)
 
+@needs_njoy
+def test_damage_energy(tmpdir, endf_data):
+    endf_file = os.path.join(endf_data, 'neutrons', 'n-014_Si_030.endf')
+    si30 = openmc.data.IncidentNeutron.from_njoy(endf_file)
+
+    si30_copy = openmc.data.IncidentNeutron.from_njoy(endf_file, damage_threshold=100)
+    assert not np.allclose(si30[444].xs['294K'].y, si30_copy[444].xs['294K'](si30[444].xs['294K'].x))
+                            
 
 def test_urr(pu239):
     for T, ptable in pu239.urr.items():

--- a/tests/unit_tests/test_data_neutron.py
+++ b/tests/unit_tests/test_data_neutron.py
@@ -244,14 +244,6 @@ def test_kerma(run_in_tmpdir, am244, h2):
     assert 901 in read_in
     assert np.all(read_in[901].xs['300K'].y == h2[901].xs['300K'].y)
 
-@needs_njoy
-def test_damage_energy(tmpdir, endf_data):
-    endf_file = os.path.join(endf_data, 'neutrons', 'n-014_Si_030.endf')
-    si30 = openmc.data.IncidentNeutron.from_njoy(endf_file)
-
-    si30_copy = openmc.data.IncidentNeutron.from_njoy(endf_file, damage_threshold=100)
-    assert not np.allclose(si30[444].xs['294K'].y, si30_copy[444].xs['294K'](si30[444].xs['294K'].x))
-                            
 
 def test_urr(pu239):
     for T, ptable in pu239.urr.items():


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Please include a summary of the change and which issue is fixed if applicable. Please also include relevant motivation and context.

Currently when generating neutron data with NJOY we use the default NJOY displacement threshold energy. (NJOY has different defaults for various atoms).
This value is used to calculate the damage-energy score.
This PR let us override the NJOY defaults with our own threshold energy.

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
