### PR TITLE
Fix M_PI being unavailable where _USE_MATH_DEFINES comes too late

### DIFF
--- a/examples/custom_source/source_ring.cpp
+++ b/examples/custom_source/source_ring.cpp
@@ -1,3 +1,4 @@
+#define _USE_MATH_DEFINES
 #include <cmath>  // for M_PI
 #include <memory> // for unique_ptr
 

--- a/examples/parameterized_custom_source/parameterized_source_ring.cpp
+++ b/examples/parameterized_custom_source/parameterized_source_ring.cpp
@@ -1,3 +1,4 @@
+#define _USE_MATH_DEFINES
 #include <cmath>
 #include <memory>
 #include <unordered_map>

--- a/src/external/quartic_solver.cpp
+++ b/src/external/quartic_solver.cpp
@@ -1,5 +1,5 @@
-#include <algorithm>
 #define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
+#include <algorithm>
 #include <cmath>
 #include <complex>
 #include <cstdlib>

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1,11 +1,10 @@
 #include "openmc/mesh.h"
 #include <algorithm> // for copy, equal, min, min_element
 #include <cassert>
-#include <cstdint>        // for uint64_t
-#include <cstring>        // for memcpy
-#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
-#include <cmath>          // for ceil
-#include <cstddef>        // for size_t
+#include <cmath>   // for ceil
+#include <cstddef> // for size_t
+#include <cstdint> // for uint64_t
+#include <cstring> // for memcpy
 #include <limits>
 #include <numeric> // for accumulate
 #include <string>
@@ -1829,7 +1828,7 @@ StructuredMesh::MeshIndex CylindricalMesh::get_indices(
   } else {
     mapped_r[1] = std::atan2(r.y, r.x);
     if (mapped_r[1] < 0)
-      mapped_r[1] += 2 * M_PI;
+      mapped_r[1] += 2 * PI;
   }
 
   MeshIndex idx = StructuredMesh::get_indices(mapped_r, in_mesh);
@@ -2123,7 +2122,7 @@ StructuredMesh::MeshIndex SphericalMesh::get_indices(
     mapped_r[1] = std::acos(r.z / mapped_r.x);
     mapped_r[2] = std::atan2(r.y, r.x);
     if (mapped_r[2] < 0)
-      mapped_r[2] += 2 * M_PI;
+      mapped_r[2] += 2 * PI;
   }
 
   MeshIndex idx = StructuredMesh::get_indices(mapped_r, in_mesh);

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -1,7 +1,6 @@
 #include "openmc/plot.h"
 
 #include <algorithm>
-#define _USE_MATH_DEFINES // to make M_PI declared in Intel and MSVC compilers
 #include <cmath>
 #include <cstdio>
 #include <fstream>
@@ -1328,7 +1327,7 @@ std::pair<Position, Direction> RayTracePlot::get_pixel_ray(
   int horiz, int vert) const
 {
   // Compute field of view in radians
-  constexpr double DEGREE_TO_RADIAN = M_PI / 180.0;
+  constexpr double DEGREE_TO_RADIAN = PI / 180.0;
   double horiz_fov_radians = horizontal_field_of_view_ * DEGREE_TO_RADIAN;
   double p0 = static_cast<double>(pixels()[0]);
   double p1 = static_cast<double>(pixels()[1]);


### PR DESCRIPTION
# Description

This PR fixes `M_PI` being undeclared in three files ( Resolve #3175 ). #3238 added
`#define _USE_MATH_DEFINES` to them, but in all three it sits below an include that has
already pulled in `<cmath>`, so `math.h` is guarded by then and the definition never takes
effect. `quartic_solver.cpp` differs between the two because MSVC's `<algorithm>` reaches
`math.h` transitively and MinGW's libstdc++ does not. Since which header gets there first is
implementation-defined, the only position that is safe everywhere is above every include —
so `mesh.cpp` and `plot.cpp` sidestep the macro entirely. No test is added: `PI` is
bit-identical to `M_PI`, so there is no behaviour change to assert.

| file | MSVC 19.51 | MinGW GCC 14.2 | change |
|---|---|---|---|
| `src/mesh.cpp` | 2 errors | 2 errors | use `PI` from `include/openmc/constants.h` |
| `src/plot.cpp` | 1 error | 1 error | use `PI` from `include/openmc/constants.h` |
| `src/external/quartic_solver.cpp` | 3 errors | ok | vendored, `namespace oqs`: keep `M_PI`, move `#define` above the includes |

All three compile successfully with no external `-D_USE_MATH_DEFINES` after this fix.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
