### PR TITLE
Determine surface-source starting half-space from particle direction

### DIFF
--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -182,10 +182,21 @@ void Particle::from_source(const SourceSite* src)
   parent_nuclide() = src->parent_nuclide;
   delayed_group() = src->delayed_group;
 
-  // Convert signed surface ID to signed index
+  // If the source has a surface ID assigned, attempt to determine the signed
+  // surface index by comparing the particle's direction with the surface
+  // normal. This only works if the particle is on the surface.
   if (src->surf_id != SURFACE_NONE) {
-    int index_plus_one = model::surface_map[std::abs(src->surf_id)] + 1;
-    surface() = (src->surf_id > 0) ? index_plus_one : -index_plus_one;
+    auto it = model::surface_map.find(std::abs(src->surf_id));
+    if (it != model::surface_map.end()) {
+      int i_surface = it->second;
+      const auto& surf = *model::surfaces[i_surface];
+      if (surf.geom_type() == GeometryType::CSG &&
+          std::abs(surf.evaluate(r())) < FP_COINCIDENT) {
+        int index_plus_one = i_surface + 1;
+        surface() =
+          (u().dot(surf.normal(r())) > 0.0) ? index_plus_one : -index_plus_one;
+      }
+    }
   }
 
   wgt_born() = src->wgt_born;

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -182,20 +182,12 @@ void Particle::from_source(const SourceSite* src)
   parent_nuclide() = src->parent_nuclide;
   delayed_group() = src->delayed_group;
 
-  // If the source has a surface ID assigned, attempt to determine the signed
-  // surface index by comparing the particle's direction with the surface
-  // normal. This only works if the particle is on the surface.
+  // Convert signed surface ID to signed index
   if (src->surf_id != SURFACE_NONE) {
     auto it = model::surface_map.find(std::abs(src->surf_id));
     if (it != model::surface_map.end()) {
-      int i_surface = it->second;
-      const auto& surf = *model::surfaces[i_surface];
-      if (surf.geom_type() == GeometryType::CSG &&
-          std::abs(surf.evaluate(r())) < FP_COINCIDENT) {
-        int index_plus_one = i_surface + 1;
-        surface() =
-          (u().dot(surf.normal(r())) > 0.0) ? index_plus_one : -index_plus_one;
-      }
+      int index_plus_one = it->second + 1;
+      surface() = (src->surf_id > 0) ? index_plus_one : -index_plus_one;
     }
   }
 

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -556,19 +556,17 @@ SourceSite FileSource::sample(uint64_t* seed) const
   // normal cell search to locate the particle.
   if (site.surf_id != SURFACE_NONE) {
     auto it = model::surface_map.find(std::abs(site.surf_id));
-    if (it == model::surface_map.end()) {
-      site.surf_id = SURFACE_NONE;
-    } else {
+    if (it != model::surface_map.end()) {
       const auto& surf = *model::surfaces[it->second];
       if (surf.geom_type() == GeometryType::CSG &&
           std::abs(surf.evaluate(site.r)) < FP_COINCIDENT) {
         int surf_id = std::abs(site.surf_id);
         site.surf_id =
           (site.u.dot(surf.normal(site.r)) > 0.0) ? surf_id : -surf_id;
-      } else {
-        site.surf_id = SURFACE_NONE;
+        return site;
       }
     }
+    site.surf_id = SURFACE_NONE;
   }
 
   return site;

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -38,6 +38,7 @@
 #include "openmc/simulation.h"
 #include "openmc/state_point.h"
 #include "openmc/string_utils.h"
+#include "openmc/surface.h"
 #include "openmc/xml_interface.h"
 
 namespace openmc {
@@ -547,7 +548,30 @@ SourceSite FileSource::sample(uint64_t* seed) const
 {
   // Sample a particle randomly from list
   size_t i_site = sites_.size() * prn(seed);
-  return sites_[i_site];
+  SourceSite site = sites_[i_site];
+
+  // Surface source files store unsigned surface IDs. If the ID refers to a CSG
+  // surface containing the source site, determine the signed half-space from
+  // the particle direction. Otherwise, ignore the surface ID and allow the
+  // normal cell search to locate the particle.
+  if (site.surf_id != SURFACE_NONE) {
+    auto it = model::surface_map.find(std::abs(site.surf_id));
+    if (it == model::surface_map.end()) {
+      site.surf_id = SURFACE_NONE;
+    } else {
+      const auto& surf = *model::surfaces[it->second];
+      if (surf.geom_type() == GeometryType::CSG &&
+          std::abs(surf.evaluate(site.r)) < FP_COINCIDENT) {
+        int surf_id = std::abs(site.surf_id);
+        site.surf_id =
+          (site.u.dot(surf.normal(site.r)) > 0.0) ? surf_id : -surf_id;
+      } else {
+        site.surf_id = SURFACE_NONE;
+      }
+    }
+  }
+
+  return site;
 }
 
 //==============================================================================

--- a/tests/unit_tests/test_surface_source_write.py
+++ b/tests/unit_tests/test_surface_source_write.py
@@ -193,6 +193,46 @@ def test_particle_direction(parameter, run_in_tmpdir, model):
                 assert False
 
 
+@pytest.mark.parametrize(
+    "direction",
+    [(1.0, 0.0, 0.0), (-1.0, 0.0, 0.0)],
+)
+@pytest.mark.parametrize(
+    "source_surface_id, reuse_surface_id",
+    [(20, False), (10, False), (10, True)],
+    ids=["matching", "missing", "reused"],
+)
+def test_source_surface_id(
+    direction, source_surface_id, reuse_surface_id, run_in_tmpdir
+):
+    """A source surface is used only when it matches the model surface."""
+    source = openmc.SourceParticle(
+        r=(0.0, 0.0, 0.0), u=direction, surf_id=source_surface_id
+    )
+    openmc.write_source_file([source], "surface_source.h5")
+
+    # Surface 20 is the source surface in this model. Surface 10 is either
+    # absent or reused for an unrelated boundary that does not contain the
+    # source position.
+    left = openmc.XPlane(-1.0, surface_id=1, boundary_type="vacuum")
+    middle = openmc.XPlane(0.0, surface_id=20)
+    right = openmc.XPlane(1.0, surface_id=30, boundary_type="vacuum")
+    bottom = openmc.YPlane(-1.0, surface_id=40, boundary_type="vacuum")
+    top_id = 10 if reuse_surface_id else 50
+    top = openmc.YPlane(1.0, surface_id=top_id, boundary_type="vacuum")
+    cells = [
+        openmc.Cell(region=+left & -middle & +bottom & -top),
+        openmc.Cell(region=+middle & -right & +bottom & -top),
+    ]
+
+    model = openmc.Model(geometry=openmc.Geometry(cells))
+    model.settings.run_mode = "fixed source"
+    model.settings.particles = 10
+    model.settings.batches = 1
+    model.settings.source = openmc.FileSource("surface_source.h5")
+    model.run()
+
+
 @pytest.fixture
 def model_dagmc(request):
     """Model based on the mesh file 'dagmc.h5m' available from

--- a/tests/unit_tests/test_surface_source_write.py
+++ b/tests/unit_tests/test_surface_source_write.py
@@ -193,33 +193,27 @@ def test_particle_direction(parameter, run_in_tmpdir, model):
                 assert False
 
 
-@pytest.mark.parametrize(
-    "direction",
-    [(1.0, 0.0, 0.0), (-1.0, 0.0, 0.0)],
-)
-@pytest.mark.parametrize(
-    "source_surface_id, reuse_surface_id",
-    [(20, False), (10, False), (10, True)],
-    ids=["matching", "missing", "reused"],
-)
-def test_source_surface_id(
-    direction, source_surface_id, reuse_surface_id, run_in_tmpdir
-):
-    """A source surface is used only when it matches the model surface."""
-    source = openmc.SourceParticle(
-        r=(0.0, 0.0, 0.0), u=direction, surf_id=source_surface_id
-    )
-    openmc.write_source_file([source], "surface_source.h5")
+def test_surface_source_id(run_in_tmpdir):
+    """Test handling of surface IDs for source particles."""
 
-    # Surface 20 is the source surface in this model. Surface 10 is either
-    # absent or reused for an unrelated boundary that does not contain the
-    # source position.
+    # Surface 20 is the surface matching the source in this model. Surface 11 is
+    # absent and surface 10 is reused for an unrelated boundary that does not
+    # contain the source position.
+    sources = []
+    for direction in ((1.0, 0.0, 0.0), (-1.0, 0.0, 0.0)):
+        for source_surface_id in (20, 11, 10):
+            filename = f"surface_source_{len(sources)}.h5"
+            site = openmc.SourceParticle(
+                r=(0.0, 0.0, 0.0), u=direction, surf_id=source_surface_id
+            )
+            openmc.write_source_file([site], filename)
+            sources.append(openmc.FileSource(filename))
+
     left = openmc.XPlane(-1.0, surface_id=1, boundary_type="vacuum")
     middle = openmc.XPlane(0.0, surface_id=20)
     right = openmc.XPlane(1.0, surface_id=30, boundary_type="vacuum")
     bottom = openmc.YPlane(-1.0, surface_id=40, boundary_type="vacuum")
-    top_id = 10 if reuse_surface_id else 50
-    top = openmc.YPlane(1.0, surface_id=top_id, boundary_type="vacuum")
+    top = openmc.YPlane(1.0, surface_id=10, boundary_type="vacuum")
     cells = [
         openmc.Cell(region=+left & -middle & +bottom & -top),
         openmc.Cell(region=+middle & -right & +bottom & -top),
@@ -227,9 +221,9 @@ def test_source_surface_id(
 
     model = openmc.Model(geometry=openmc.Geometry(cells))
     model.settings.run_mode = "fixed source"
-    model.settings.particles = 10
+    model.settings.particles = 1000
     model.settings.batches = 1
-    model.settings.source = openmc.FileSource("surface_source.h5")
+    model.settings.source = sources
     model.run()
 
 


### PR DESCRIPTION
# Description

Recently, I've been working with some colleagues on a two-step workflow for a shielding calculation. In the first step, particles are accumulated on a surface through surface source, and in the second step the surface source is used as the starting source. We ran into problems with particles getting lost in the second step and I've traced it down to some bugs with how surface IDs that are written to a surface source file are used when that source file is used as the source in a new calculation. First, the surface ID that is written to the source file is unsigned, but when OpenMC reads the source file it treats the surface ID as being signed (i.e., always on the positive side of the surface). Second, if the surface ID is not present in the model, rather than being ignored it ends up defaulting to the first surface in the model by virtue of calling `surface_map[surf_id]` when `surf_id` is not in the map.

Rather than write a signed surface ID to the surface source file, I've fixed the underlying issue by having surface source particles determine their starting half-space using the particle direction and the referenced surface normal. The surface ID is used only when the ID exists and the source position is coincident with that CSG surface; missing or mismatched IDs fall back to normal cell search.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)