### PR TITLE
allow overlay material

### DIFF
--- a/docs/source/io_formats/tallies.rst
+++ b/docs/source/io_formats/tallies.rst
@@ -50,6 +50,22 @@ The ``<tally>`` element accepts the following sub-elements:
 
         <nuclides>U235 Pu239 total</nuclides>
 
+    An entry of the form ``material:<id>`` is a *virtual overlay material*
+    rather than a nuclide. Such a bin scores the macroscopic response of the
+    given material (the sum over its nuclides of atom density times microscopic
+    cross section) everywhere in the geometry, including in void and in regions
+    filled with other materials. This makes it possible to map, say, the
+    response of a silicon detector without placing any silicon in the model:
+
+    .. code-block:: xml
+
+        <nuclides>material:7</nuclides>
+
+    Overlay materials require ``multiply_density`` to be false. They are not
+    supported for the ``analog`` estimator, for surface or pulse-height
+    tallies, or for scores that do not depend on the nuclide (``flux``,
+    ``inverse-velocity``, ``events`` and the IFP scores).
+
     *Default*: total
 
   :estimator:
@@ -71,7 +87,9 @@ The ``<tally>`` element accepts the following sub-elements:
 
   :multiply_density:
     A boolean that indicates whether reaction rate scores should be computed by
-    multiplying by the atom density of a nuclide present in a material.
+    multiplying by the atom density of a nuclide present in a material. Setting
+    it to false decouples the tally from whatever fills the geometry, which is
+    what makes per-nuclide and ``material:<id>`` overlay bins meaningful.
 
     *Default*: true
 

--- a/docs/source/usersguide/tallies.rst
+++ b/docs/source/usersguide/tallies.rst
@@ -93,6 +93,52 @@ U238 (separately), we'd set::
 You can also list 'all' as a nuclide which will give you a separate reaction
 rate for every nuclide in the model.
 
+.. _usersguide_virtual_overlay:
+
+-------------------------
+Virtual Overlay Materials
+-------------------------
+
+By default, reaction rate scores are multiplied by the atom density of the
+nuclide in whatever material the particle is travelling through, so a tally
+only responds where that nuclide is actually present. Setting
+:attr:`Tally.multiply_density` to ``False`` removes that factor, which makes it
+possible to score a response for a nuclide that appears nowhere in the model::
+
+  tally = openmc.Tally()
+  tally.scores = ['heating']
+  tally.nuclides = ['Si28']
+  tally.multiply_density = False
+
+Each bin then holds a microscopic quantity for a fictitious density of one
+atom per barn-cm. To get the response of a whole *material* rather than a
+single nuclide, pass an :class:`openmc.Material` in the nuclide list::
+
+  silicon = openmc.Material()
+  silicon.add_element('Si', 1.0)
+  silicon.set_density('g/cm3', 2.33)
+
+  tally = openmc.Tally()
+  tally.scores = ['heating']
+  tally.nuclides = [silicon]
+  tally.multiply_density = False
+
+This produces a single bin holding the material's macroscopic response, i.e.
+the sum over the material's nuclides of atom density times microscopic cross
+section, evaluated everywhere in the geometry including in void. With a
+'heating' score the result is in eV/cm\ :sup:`3` per source particle at the
+overlay material's own density, so the absorbed dose in Gy per source particle
+is the tally result multiplied by :math:`1.602\times 10^{-19}` J/eV and divided
+by the material's mass density in kg/cm\ :sup:`3`. A typical use is mapping the
+dose in a silicon detector or in tissue without perturbing the transport
+problem by adding those materials to the geometry.
+
+The overlay material does not need to be assigned to any cell, and it is
+written to the model automatically. A few restrictions apply: overlay materials
+require ``multiply_density`` to be ``False``, they cannot be used with the
+'analog' estimator or on surface and pulse-height tallies, and they cannot be
+combined with scores that do not depend on the nuclide such as 'flux'.
+
 The following tables show all valid scores:
 
 .. table:: **Flux scores: units are particle-cm per source particle.**

--- a/include/openmc/tallies/tally.h
+++ b/include/openmc/tallies/tally.h
@@ -17,6 +17,31 @@
 namespace openmc {
 
 //==============================================================================
+// Nuclide bin encoding
+//==============================================================================
+
+//! Entry in Tally::nuclides_ indicating the total rate over the local material
+constexpr int NUCLIDE_BIN_TOTAL {-1};
+
+//! Encode a material index as an entry in Tally::nuclides_.
+//
+//! Such a bin makes the tally respond to a virtual overlay material rather
+//! than to a single nuclide. Entries less than NUCLIDE_BIN_TOTAL are material
+//! bins; entries of zero or greater are indices into data::nuclides.
+inline int nuclide_bin_from_material(int i_material)
+{
+  return NUCLIDE_BIN_TOTAL - 1 - i_material;
+}
+
+//! Decode an entry in Tally::nuclides_ into an index into model::materials,
+//! or C_NONE if the entry is not a virtual overlay material bin.
+inline int material_from_nuclide_bin(int nuclide_bin)
+{
+  return nuclide_bin < NUCLIDE_BIN_TOTAL ? NUCLIDE_BIN_TOTAL - 1 - nuclide_bin
+                                         : C_NONE;
+}
+
+//==============================================================================
 //! A user-specified flux-weighted (or current) measurement.
 //==============================================================================
 
@@ -53,6 +78,9 @@ public:
   void set_nuclides(pugi::xml_node node);
 
   void set_nuclides(const vector<std::string>& nuclides);
+
+  //! Whether any nuclide bin refers to a virtual overlay material
+  bool has_material_bins() const;
 
   const tensor::Tensor<double>& results() const { return results_; }
 
@@ -152,8 +180,10 @@ public:
 
   vector<int> scores_; //!< Filter integrands (e.g. flux, fission)
 
-  //! Index of each nuclide to be tallied.  -1 indicates total material.
-  vector<int> nuclides_ {-1};
+  //! Index of each nuclide to be tallied.  NUCLIDE_BIN_TOTAL indicates the
+  //! total rate over the local material and values below it are virtual
+  //! overlay materials, see material_from_nuclide_bin.
+  vector<int> nuclides_ {NUCLIDE_BIN_TOTAL};
 
   //! Results for each bin -- the first dimension of the array is for the
   //! combination of filters (e.g. specific cell, specific energy group, etc.)

--- a/openmc/lib/tally.py
+++ b/openmc/lib/tally.py
@@ -12,6 +12,7 @@ from . import _dll, Nuclide
 from .core import _FortranObjectWithID
 from .error import _error_handler
 from .filter import _get_filter
+from .material import Material
 
 
 __all__ = ['Tally', 'tallies', 'global_tallies', 'num_realizations']
@@ -320,8 +321,16 @@ class Tally(_FortranObjectWithID):
         nucs = POINTER(c_int)()
         n = c_int()
         _dll.openmc_tally_get_nuclides(self._index, nucs, n)
-        return [Nuclide(nucs[i]).name if nucs[i] >= 0 else 'total'
-                for i in range(n.value)]
+
+        def name(bin):
+            if bin >= 0:
+                return Nuclide(bin).name
+            if bin == -1:
+                return 'total'
+            # Virtual overlay material bin, see material_from_nuclide_bin
+            return f'material:{Material(index=-2 - bin).id}'
+
+        return [name(nucs[i]) for i in range(n.value)]
 
     @nuclides.setter
     def nuclides(self, nuclides):

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -245,6 +245,43 @@ class Model:
 
         return materials
 
+    def _materials_for_export(self) -> openmc.Materials:
+        """Collect the materials that need to be written to XML.
+
+        This is the materials collection if one was specified, otherwise all
+        materials found in the geometry. Virtual overlay materials used as
+        tally nuclide bins are appended since they need to be defined for the
+        transport solver even though nothing in the geometry is filled by them.
+
+        Returns
+        -------
+        openmc.Materials
+            Materials to export
+
+        """
+        if self.materials:
+            materials = self.materials
+        else:
+            materials = openmc.Materials(
+                self.geometry.get_all_materials().values())
+
+        existing_ids = {mat.id for mat in materials}
+        overlay = [mat for tally in self.tallies
+                   for mat in tally.overlay_materials
+                   if mat.id not in existing_ids]
+        if not overlay:
+            return materials
+
+        # Don't mutate a user-supplied collection, but keep its settings
+        combined = openmc.Materials(materials)
+        combined.cross_sections = materials.cross_sections
+        for mat in overlay:
+            if mat.id not in existing_ids:
+                combined.append(mat)
+                existing_ids.add(mat.id)
+
+        return combined
+
     def add_kinetics_parameters_tallies(self, num_groups: int | None = None):
         """Add tallies for calculating kinetics parameters using the IFP method.
 
@@ -635,12 +672,8 @@ class Model:
         # If a materials collection was specified, export it. Otherwise, look
         # for all materials in the geometry and use that to automatically build
         # a collection.
-        if self.materials:
-            self.materials.export_to_xml(d, nuclides_to_ignore=nuclides_to_ignore)
-        else:
-            materials = openmc.Materials(self.geometry.get_all_materials()
-                                         .values())
-            materials.export_to_xml(d, nuclides_to_ignore=nuclides_to_ignore)
+        materials = self._materials_for_export()
+        materials.export_to_xml(d, nuclides_to_ignore=nuclides_to_ignore)
 
         if self.tallies:
             self.tallies.export_to_xml(d)
@@ -701,11 +734,7 @@ class Model:
         # If a materials collection was specified, export it. Otherwise, look
         # for all materials in the geometry and use that to automatically build
         # a collection.
-        if self.materials:
-            materials = self.materials
-        else:
-            materials = openmc.Materials(self.geometry.get_all_materials()
-                                         .values())
+        materials = self._materials_for_export()
 
         with open(xml_path, 'w', encoding='utf-8', errors='xmlcharrefreplace') as fh:
             # write the XML header

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -47,9 +47,10 @@ from .mesh import MeshBase
 _PRODUCT_TYPES = ['tensor', 'entrywise']
 
 # The following indicate acceptable types when setting Tally.scores,
-# Tally.nuclides, and Tally.filters
+# Tally.nuclides, and Tally.filters. A Material is only accepted as a nuclide
+# when multiply_density is False, where it acts as a virtual overlay material.
 _SCORE_CLASSES = (str, CrossScore, AggregateScore)
-_NUCLIDE_CLASSES = (str, CrossNuclide, AggregateNuclide)
+_NUCLIDE_CLASSES = (str, CrossNuclide, AggregateNuclide, openmc.Material)
 _FILTER_CLASSES = (Filter, CrossFilter, AggregateFilter)
 
 # Valid types of estimators
@@ -71,8 +72,10 @@ class Tally(IDManagerMixin):
         List of scores, e.g. ['flux', 'fission']
     filters : list of openmc.Filter, optional
         List of filters for the tally
-    nuclides : list of str, optional
-        List of nuclides to score results for
+    nuclides : list of str or openmc.Material, optional
+        List of nuclides to score results for. When :attr:`multiply_density` is
+        False, an :class:`openmc.Material` may be given in place of a nuclide
+        name to score the macroscopic response of a virtual overlay material.
     estimator : {'analog', 'tracklength', 'collision'}, optional
         Type of estimator for the tally
     triggers : list of openmc.Trigger, optional
@@ -92,8 +95,17 @@ class Tally(IDManagerMixin):
         .. versionadded:: 0.14.0
     filters : list of openmc.Filter
         List of specified filters for the tally
-    nuclides : list of str
-        List of nuclides to score results for
+    nuclides : list of str or openmc.Material
+        List of nuclides to score results for. A :class:`openmc.Material`
+        entry is a virtual overlay material: the bin scores that material's
+        macroscopic response (sum over its nuclides of atom density times
+        microscopic cross section) everywhere in the geometry, including in
+        void and in regions filled with other materials. Overlay materials
+        require :attr:`multiply_density` to be False and are not supported for
+        the 'analog' estimator or for scores that do not depend on the
+        nuclide, such as 'flux'.
+
+        .. versionadded:: 0.15.4
     scores : list of str
         List of defined scores, e.g. 'flux', 'fission', etc.
     estimator : {'analog', 'tracklength', 'collision'}
@@ -237,7 +249,10 @@ class Tally(IDManagerMixin):
             parts.append('{: <15}=\t{}'.format('Derivative ID', self.derivative.id))
         filters = ', '.join(type(f).__name__ for f in self.filters)
         parts.append('{: <15}=\t{}'.format('Filters', filters))
-        nuclides = ' '.join(str(nuclide) for nuclide in self.nuclides)
+        nuclides = ' '.join(
+            f'material:{nuclide.id}'
+            if isinstance(nuclide, openmc.Material) else str(nuclide)
+            for nuclide in self.nuclides)
         parts.append('{: <15}=\t{}'.format('Nuclides', nuclides))
         parts.append('{: <15}=\t{}'.format('Scores', self.scores))
         parts.append('{: <15}=\t{}'.format('Estimator', self.estimator))
@@ -331,6 +346,12 @@ class Tally(IDManagerMixin):
 
         self._nuclides = cv.CheckedList(_NUCLIDE_CLASSES, 'tally nuclides',
                                         nuclides)
+
+    @property
+    def overlay_materials(self):
+        """list of openmc.Material : Virtual overlay materials among the
+        tally's nuclide bins"""
+        return [n for n in self._nuclides if isinstance(n, openmc.Material)]
 
     @property
     def num_nuclides(self):
@@ -1446,8 +1467,14 @@ class Tally(IDManagerMixin):
 
         # Optional Nuclides
         if self.nuclides:
+            if self.overlay_materials and self.multiply_density:
+                raise ValueError(
+                    f'Tally ID="{self.id}" specifies a material as a nuclide '
+                    'bin, which requires multiply_density to be False.')
             subelement = ET.SubElement(element, "nuclides")
-            subelement.text = ' '.join(str(n) for n in self.nuclides)
+            subelement.text = ' '.join(
+                f'material:{n.id}' if isinstance(n, openmc.Material) else str(n)
+                for n in self.nuclides)
 
         # Scores
         if len(self.scores) == 0:
@@ -1633,8 +1660,11 @@ class Tally(IDManagerMixin):
 
         Parameters
         ----------
-        nuclide : str
-            The name of the Nuclide (e.g., 'H1', 'U238')
+        nuclide : str or openmc.Material
+            The name of the Nuclide (e.g., 'H1', 'U238'), or a virtual overlay
+            material. An overlay material may also be given by the string
+            ``'material:<id>'``, which is how it is labelled in statepoint
+            files.
 
         Returns
         -------
@@ -1648,9 +1678,19 @@ class Tally(IDManagerMixin):
             in the Tally.
 
         """
+        # An overlay material is labelled 'material:<id>' once results have been
+        # read back, so match a Material against either representation
+        label = (f'material:{nuclide.id}'
+                 if isinstance(nuclide, openmc.Material) else nuclide)
+
         # Look for the user-requested nuclide in all of the Tally's nuclides
         for i, test_nuclide in enumerate(self.nuclides):
             if test_nuclide == nuclide:
+                return i
+            test_label = (f'material:{test_nuclide.id}'
+                          if isinstance(test_nuclide, openmc.Material)
+                          else test_nuclide)
+            if test_label == label:
                 return i
 
         msg = (f'Unable to get the nuclide index for Tally since "{nuclide}" '
@@ -1760,8 +1800,8 @@ class Tally(IDManagerMixin):
 
         Parameters
         ----------
-        nuclides : list of str
-            A list of nuclide name strings
+        nuclides : list of str or openmc.Material
+            A list of nuclide name strings or virtual overlay materials
             (e.g., ['U235', 'U238']; default is [])
 
         Returns
@@ -1771,14 +1811,14 @@ class Tally(IDManagerMixin):
 
         """
 
-        cv.check_iterable_type('nuclides', nuclides, str)
+        cv.check_iterable_type('nuclides', nuclides, (str, openmc.Material))
 
         # If user did not specify any specific Nuclides, use them all
         if not nuclides:
             return np.arange(self.num_nuclides)
 
         # Determine the score indices from any of the requested scores
-        nuclide_indices = np.zeros_like(nuclides, dtype=int)
+        nuclide_indices = np.zeros(len(nuclides), dtype=int)
         for i, nuclide in enumerate(nuclides):
             nuclide_indices[i] = self.get_nuclide_index(nuclide)
         return nuclide_indices
@@ -1987,6 +2027,8 @@ class Tally(IDManagerMixin):
                 if isinstance(nuclide, openmc.AggregateNuclide):
                     nuclides.append(nuclide.name)
                     column_name = f'{nuclide.aggregate_op}(nuclide)'
+                elif isinstance(nuclide, openmc.Material):
+                    nuclides.append(f'material:{nuclide.id}')
                 else:
                     nuclides.append(nuclide)
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -26,6 +26,7 @@
 #include "openmc/error.h"
 #include "openmc/geometry.h"
 #include "openmc/lattice.h"
+#include "openmc/material.h"
 #include "openmc/math_functions.h"
 #include "openmc/message_passing.h"
 #include "openmc/mgxs_interface.h"
@@ -710,8 +711,12 @@ void write_tallies()
       int score_index = 0;
       for (auto i_nuclide : tally.nuclides_) {
         // Write label for this nuclide bin.
-        if (i_nuclide == -1) {
+        int i_material = material_from_nuclide_bin(i_nuclide);
+        if (i_nuclide == NUCLIDE_BIN_TOTAL) {
           fmt::print(tallies_out, "{0:{1}}Total Material\n", "", indent + 1);
+        } else if (i_material != C_NONE) {
+          fmt::print(tallies_out, "{0:{1}}Material {2}\n", "", indent + 1,
+            model::materials[i_material]->id());
         } else {
           if (settings::run_CE) {
             fmt::print(tallies_out, "{0:{1}}{2}\n", "", indent + 1,

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -15,6 +15,7 @@
 #include "openmc/error.h"
 #include "openmc/file_utils.h"
 #include "openmc/hdf5_interface.h"
+#include "openmc/material.h"
 #include "openmc/mcpl_interface.h"
 #include "openmc/mesh.h"
 #include "openmc/message_passing.h"
@@ -238,8 +239,12 @@ extern "C" int openmc_statepoint_write(const char* filename, bool* write_source)
         // Write the nuclides this tally scores
         vector<std::string> nuclides;
         for (auto i_nuclide : tally->nuclides_) {
-          if (i_nuclide == -1) {
+          int i_material = material_from_nuclide_bin(i_nuclide);
+          if (i_nuclide == NUCLIDE_BIN_TOTAL) {
             nuclides.push_back("total");
+          } else if (i_material != C_NONE) {
+            nuclides.push_back(
+              fmt::format("material:{}", model::materials[i_material]->id()));
           } else {
             if (settings::run_CE) {
               nuclides.push_back(data::nuclides[i_nuclide]->name_);

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -7,6 +7,7 @@
 #include "openmc/container_util.h"
 #include "openmc/error.h"
 #include "openmc/file_utils.h"
+#include "openmc/material.h"
 #include "openmc/mesh.h"
 #include "openmc/message_passing.h"
 #include "openmc/mgxs_interface.h"
@@ -44,6 +45,7 @@
 #include <cstddef>  // for size_t
 #include <iterator> // for back_inserter
 #include <string>
+#include <string_view>
 
 namespace openmc {
 
@@ -590,7 +592,7 @@ void Tally::set_scores(const vector<std::string>& scores)
     switch (score) {
     case SCORE_FLUX:
       if (!nuclides_.empty())
-        if (!(nuclides_.size() == 1 && nuclides_[0] == -1))
+        if (!(nuclides_.size() == 1 && nuclides_[0] == NUCLIDE_BIN_TOTAL))
           fatal_error("Cannot tally flux for an individual nuclide.");
       if (energyout_present)
         fatal_error("Cannot tally flux with an outgoing energy filter.");
@@ -734,23 +736,44 @@ void Tally::set_nuclides(pugi::xml_node node)
 
   // By default, we tally just the total material rates.
   if (!check_for_node(node, "nuclides")) {
-    nuclides_.push_back(-1);
+    nuclides_.push_back(NUCLIDE_BIN_TOTAL);
     return;
   }
 
   // The user provided specifics nuclides.  Parse it as an array with either
-  // "total" or a nuclide name like "U235" in each position.
+  // "total", a nuclide name like "U235", or a virtual overlay material like
+  // "material:3" in each position.
   auto words = get_node_array<std::string>(node, "nuclides");
   this->set_nuclides(words);
 }
 
 void Tally::set_nuclides(const vector<std::string>& nuclides)
 {
+  constexpr std::string_view material_prefix {"material:"};
+
   nuclides_.clear();
 
   for (const auto& nuc : nuclides) {
     if (nuc == "total") {
-      nuclides_.push_back(-1);
+      nuclides_.push_back(NUCLIDE_BIN_TOTAL);
+    } else if (nuc.compare(0, material_prefix.size(), material_prefix) == 0) {
+      // A virtual overlay material: the bin responds to the macroscopic cross
+      // section of the given material regardless of what fills the geometry.
+      int32_t mat_id;
+      try {
+        mat_id = std::stoi(nuc.substr(material_prefix.size()));
+      } catch (const std::exception&) {
+        throw std::runtime_error {fmt::format(
+          "Invalid material specification '{}' on tally {}.", nuc, id_)};
+      }
+      auto search = model::material_map.find(mat_id);
+      if (search == model::material_map.end()) {
+        throw std::runtime_error {
+          fmt::format("Could not find material {} specified as a nuclide bin "
+                      "on tally {}.",
+            mat_id, id_)};
+      }
+      nuclides_.push_back(nuclide_bin_from_material(search->second));
     } else {
       auto search = data::nuclide_map.find(nuc);
       if (search == data::nuclide_map.end()) {
@@ -761,6 +784,12 @@ void Tally::set_nuclides(const vector<std::string>& nuclides)
       nuclides_.push_back(data::nuclide_map.at(nuc));
     }
   }
+}
+
+bool Tally::has_material_bins() const
+{
+  return std::any_of(nuclides_.begin(), nuclides_.end(),
+    [](int bin) { return material_from_nuclide_bin(bin) != C_NONE; });
 }
 
 void Tally::init_triggers(pugi::xml_node node)
@@ -963,8 +992,12 @@ std::string Tally::nuclide_name(int nuclide_idx) const
   }
 
   int nuclide = nuclides_.at(nuclide_idx);
-  if (nuclide == -1) {
+  if (nuclide == NUCLIDE_BIN_TOTAL) {
     return "total";
+  }
+  int i_material = material_from_nuclide_bin(nuclide);
+  if (i_material != C_NONE) {
+    return fmt::format("material:{}", model::materials.at(i_material)->id());
   }
   return data::nuclides.at(nuclide)->name_;
 }
@@ -1174,6 +1207,54 @@ void add_to_time_grid(vector<double> grid)
   model::time_grid.swap(merged);
 }
 
+//! Check that a tally using virtual overlay material bins is configured in a
+//! way the overlay can actually be scored.
+static void validate_material_bins(const Tally& tally)
+{
+  if (!tally.has_material_bins())
+    return;
+
+  if (tally.multiply_density()) {
+    fatal_error(fmt::format("Tally {} specifies a material as a nuclide bin, "
+                            "which requires multiply_density to be false.",
+      tally.id_));
+  }
+
+  if (tally.type_ != TallyType::VOLUME) {
+    fatal_error(
+      fmt::format("Tally {} specifies a material as a nuclide bin, which is "
+                  "only supported for volumetric tallies.",
+        tally.id_));
+  }
+
+  if (tally.estimator_ == TallyEstimator::ANALOG) {
+    fatal_error(
+      fmt::format("Tally {} specifies a material as a nuclide bin, which is "
+                  "not supported for the analog estimator. Use a tracklength "
+                  "or collision estimator instead.",
+        tally.id_));
+  }
+
+  // A material bin accumulates the contribution of every nuclide in the
+  // overlay material into a single bin, so scores that do not depend on the
+  // nuclide would be counted once per nuclide.
+  for (int score : tally.scores_) {
+    switch (score) {
+    case SCORE_FLUX:
+    case SCORE_INVERSE_VELOCITY:
+    case SCORE_EVENTS:
+    case SCORE_IFP_TIME_NUM:
+    case SCORE_IFP_BETA_NUM:
+    case SCORE_IFP_DENOM:
+      fatal_error(
+        fmt::format("Cannot tally {} on tally {} because the score does not "
+                    "depend on the nuclide and the tally specifies a material "
+                    "as a nuclide bin.",
+          reaction_name(score), tally.id_));
+    }
+  }
+}
+
 void setup_active_tallies()
 {
   model::active_tallies.clear();
@@ -1190,6 +1271,7 @@ void setup_active_tallies()
     const auto& tally {*model::tallies[i]};
 
     if (tally.active_) {
+      validate_material_bins(tally);
       model::active_tallies.push_back(i);
       bool mesh_present = (tally.get_filter<MeshFilter>() ||
                            tally.get_filter<MeshMaterialFilter>());
@@ -1501,24 +1583,12 @@ extern "C" int openmc_tally_set_nuclides(
   }
 
   vector<std::string> words(nuclides, nuclides + n);
-  vector<int> nucs;
-  for (auto word : words) {
-    if (word == "total") {
-      nucs.push_back(-1);
-    } else {
-      auto search = data::nuclide_map.find(word);
-      if (search == data::nuclide_map.end()) {
-        int err = openmc_load_nuclide(word.c_str(), nullptr, 0);
-        if (err < 0) {
-          set_errmsg(openmc_err_msg);
-          return OPENMC_E_DATA;
-        }
-      }
-      nucs.push_back(data::nuclide_map.at(word));
-    }
+  try {
+    model::tallies[index]->set_nuclides(words);
+  } catch (const std::exception& e) {
+    set_errmsg(e.what());
+    return OPENMC_E_DATA;
   }
-
-  model::tallies[index]->nuclides_ = nucs;
 
   return 0;
 }

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -2404,6 +2404,45 @@ void score_analog_tally_mg(Particle& p)
     match.bins_present_ = false;
 }
 
+//! Score a nuclide bin that refers to a virtual overlay material.
+//
+//! The bin responds to the overlay material's macroscopic cross section
+//! everywhere in the geometry, including in regions filled with other
+//! materials and in void. Each nuclide of the overlay material is scored into
+//! the same bin weighted by the overlay material's own atom density, so the
+//! bin accumulates Sum_i N_i * sigma_i. Only meaningful when the tally has
+//! multiply_density set to false.
+
+void score_material_overlay(Particle& p, int i_tally, int start_index,
+  int64_t filter_index, double filter_weight, double flux, int i_material,
+  int& i_log_union)
+{
+  const Material& mat {*model::materials[i_material]};
+
+  for (int i = 0; i < mat.nuclide_.size(); ++i) {
+    int i_nuclide = mat.nuclide_[i];
+    double atom_density = mat.atom_density_(i);
+
+    if (settings::run_CE) {
+      if (p.type().is_neutron()) {
+        // The overlay nuclide is generally absent from the material the
+        // particle is travelling through, so its micro xs cache is stale.
+        if (i_log_union == C_NONE) {
+          int neutron = ParticleType::neutron().transport_index();
+          i_log_union = std::log(p.E() / data::energy_min[neutron]) /
+                        simulation::log_spacing;
+        }
+        p.update_neutron_xs(i_nuclide, i_log_union);
+      }
+      score_general_ce_nonanalog(p, i_tally, start_index, filter_index,
+        filter_weight, i_nuclide, atom_density, flux);
+    } else {
+      score_general_mg(p, i_tally, start_index, filter_index, filter_weight,
+        i_nuclide, atom_density, flux);
+    }
+  }
+}
+
 void score_tracklength_tally_general(
   Particle& p, double flux, const vector<int>& tallies)
 {
@@ -2429,6 +2468,15 @@ void score_tracklength_tally_general(
       // Loop over nuclide bins.
       for (auto i = 0; i < tally.nuclides_.size(); ++i) {
         auto i_nuclide = tally.nuclides_[i];
+
+        // A nuclide bin may instead refer to a virtual overlay material, in
+        // which case every nuclide of that material scores into the same bin.
+        int i_overlay = material_from_nuclide_bin(i_nuclide);
+        if (i_overlay != C_NONE) {
+          score_material_overlay(p, i_tally, i * tally.scores_.size(),
+            filter_index, filter_weight, flux, i_overlay, i_log_union);
+          continue;
+        }
 
         double atom_density = 0.;
         if (i_nuclide >= 0) {
@@ -2559,6 +2607,15 @@ void score_collision_tally(Particle& p)
       // Loop over nuclide bins.
       for (auto i = 0; i < tally.nuclides_.size(); ++i) {
         auto i_nuclide = tally.nuclides_[i];
+
+        // A nuclide bin may instead refer to a virtual overlay material, in
+        // which case every nuclide of that material scores into the same bin.
+        int i_overlay = material_from_nuclide_bin(i_nuclide);
+        if (i_overlay != C_NONE) {
+          score_material_overlay(p, i_tally, i * tally.scores_.size(),
+            filter_index, filter_weight, flux, i_overlay, i_log_union);
+          continue;
+        }
 
         double atom_density = 0.;
         if (i_nuclide >= 0) {

--- a/tests/unit_tests/test_tally_multiply_density.py
+++ b/tests/unit_tests/test_tally_multiply_density.py
@@ -48,3 +48,95 @@ def test_micro_macro_compare(run_in_tmpdir):
 
     # For micro tally, H3 scores should be positive
     assert np.all(tally_micro.get_values(nuclides=['H3']) > 0.0)
+
+
+def test_overlay_material(run_in_tmpdir):
+    """An overlay material bin should give the material's macroscopic rate."""
+    # The geometry is filled with iron and contains no hydrogen at all, so the
+    # overlay material can only be scored if it is decoupled from the geometry
+    iron = openmc.Material()
+    iron.add_nuclide('Fe56', 1.0)
+    iron.set_density('g/cm3', 7.874)
+
+    water = openmc.Material()
+    water.add_components({'H1': 2.0, 'O16': 1.0})
+    water.set_density('g/cm3', 1.0)
+
+    sph = openmc.Sphere(r=10.0, boundary_type='vacuum')
+    cell = openmc.Cell(fill=iron, region=-sph)
+    model = openmc.Model()
+    model.geometry = openmc.Geometry([cell])
+    model.settings.run_mode = 'fixed source'
+    model.settings.particles = 1000
+    model.settings.batches = 10
+
+    # One tally with a single overlay material bin and one with a bin per
+    # nuclide of that material. Summing the latter weighted by atom density
+    # must reproduce the former.
+    tally_mat = openmc.Tally()
+    tally_mat.nuclides = [water]
+    tally_mat.scores = ['total', 'absorption']
+    tally_mat.multiply_density = False
+
+    tally_nucs = openmc.Tally()
+    tally_nucs.nuclides = ['H1', 'O16']
+    tally_nucs.scores = ['total', 'absorption']
+    tally_nucs.multiply_density = False
+
+    model.tallies = [tally_mat, tally_nucs]
+
+    sp_filename = model.run()
+    with openmc.StatePoint(sp_filename) as sp:
+        tally_mat = sp.tallies[tally_mat.id]
+        tally_nucs = sp.tallies[tally_nucs.id]
+
+    # The overlay material is not in the geometry but must still be written
+    assert water.id in {m.id for m in model._materials_for_export()}
+
+    # The nuclide axis label round trips through the statepoint
+    assert tally_mat.nuclides == [f'material:{water.id}']
+
+    # The tolerance is loose because the atom densities used here come from
+    # openmc.data.atomic_mass whereas the solver derives them from the AWR
+    # values in the nuclear data files, which differ by a few parts in 1e5
+    density = water.get_nuclide_atom_densities()
+    expected = sum(density[nuc] * tally_nucs.get_values(nuclides=[nuc])
+                   for nuc in ('H1', 'O16'))
+    assert tally_mat.get_values() == pytest.approx(expected, rel=1e-4)
+
+    # The scores are nonzero, i.e. the comparison above is not 0 == 0
+    assert np.all(tally_mat.get_values() > 0.0)
+
+
+def test_overlay_material_errors(run_in_tmpdir):
+    mat = openmc.Material()
+    mat.add_nuclide('H1', 1.0)
+    mat.set_density('g/cm3', 1.0)
+
+    sph = openmc.Sphere(r=10.0, boundary_type='vacuum')
+    cell = openmc.Cell(fill=mat, region=-sph)
+    model = openmc.Model()
+    model.geometry = openmc.Geometry([cell])
+    model.settings.run_mode = 'fixed source'
+    model.settings.particles = 100
+    model.settings.batches = 2
+
+    # An overlay material requires multiply_density to be False
+    tally = openmc.Tally()
+    tally.nuclides = [mat]
+    tally.scores = ['absorption']
+    model.tallies = [tally]
+    with pytest.raises(ValueError, match='multiply_density'):
+        model.export_to_model_xml()
+
+    # 'flux' does not depend on the nuclide
+    tally.multiply_density = False
+    tally.scores = ['flux']
+    with pytest.raises(RuntimeError, match='flux'):
+        model.run()
+
+    # The overlay is only scored on the tracklength and collision paths
+    tally.scores = ['absorption']
+    tally.estimator = 'analog'
+    with pytest.raises(RuntimeError, match='analog estimator'):
+        model.run()


### PR DESCRIPTION
This PR allows a material to be used as a tally nuclide bin (virtual overlay material)

`multiply_density=False` lets a tally respond to a nuclide that is not present in the geometry, and #3771 extended that to void so the response is scored everywhere. That combination is very useful in fusion neutronics: it gives you the dose, damage or reaction rate a detector or a component *would* see at any point in the model, without perturbing the transport problem by actually putting that material into the geometry.

The gap is that the response is currently per nuclide and microscopic. Real questions are almost always about a material, not a nuclide: absorbed dose in a silicon diode for example. To get that today you have to tally every nuclide of the material separately and recombine the bins by hand, weighted by atom density.

This PR lets you pass the material itself.

## What this adds

```python
silicon = openmc.Material()
silicon.add_element('Si', 1.0)
silicon.set_density('g/cm3', 2.33)

tally = openmc.Tally()
tally.filters = [openmc.MeshFilter(mesh)]
tally.scores = ['heating']
tally.nuclides = [silicon]
tally.multiply_density = False
```

This produces a **single** bin holding the material's macroscopic response, `sum_i N_i * sigma_i`, using the overlay material's own atom densities and evaluated everywhere in the geometry including void and regions filled with
something else. For a `heating` score the result is eV/cm^3 per source particle, so the absorbed dose in Gy is the result multiplied by 1.602e-19 J/eV and divided by the material's mass density in kg/cm^3.

The overlay material does not need to be assigned to any cell. `Model` picks up materials referenced by tallies and writes them out, so nothing extra is required from the user.

Mixed bins work, for example `nuclides = ['Fe56', silicon]`.

This is a bit of a hack as Tally.nuclides` is now doing two things: it is a list of nuclides, and it can also carry a material. Which is perhaps something we should avoid but the alternative was to add a separate keyword which I think would also not be popular.

Fixes # (issue)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
