### PR TITLE
Apply virtual material densities to microscopic tally results

### DIFF
--- a/docs/source/usersguide/tallies.rst
+++ b/docs/source/usersguide/tallies.rst
@@ -359,6 +359,59 @@ The following tables show all valid scores:
     |                      |probability (IFP) method.                          |
     +----------------------+---------------------------------------------------+
 
+.. _usersguide_virtual_material:
+
+-----------------
+Virtual Materials
+-----------------
+
+Reaction-rate scores normally include the atom densities of the materials in the
+model. Setting :attr:`Tally.multiply_density` to ``False`` instead produces
+microscopic, nuclide-wise results. After a simulation, densities from a *virtual
+material* can be applied to these results with
+:meth:`Tally.apply_virtual_material`. This is useful for determining the
+response of a material that is not actually present in the transport model.
+
+For example, the absorbed dose in silicon can be calculated in a region that
+does not contain silicon as follows. In this example, ``dose_cell`` identifies
+the region of interest that has its volume set in cm³.
+
+::
+
+    silicon = openmc.Material(name='virtual silicon')
+    silicon.add_element('Si', 1.0)
+    silicon.set_density('g/cm3', 2.329)
+
+    tally = openmc.Tally(name='silicon heating')
+    tally.filters = [openmc.CellFilter(dose_cell)]
+    tally.scores = ['heating']
+    tally.nuclides = silicon.get_nuclides()
+    tally.multiply_density = False
+
+    model.tallies = [tally]
+    model.run(apply_tally_results=True)
+
+    # Apply the silicon atom densities without collapsing the nuclide axis
+    tally.apply_virtual_material(silicon)
+
+    # Sum over nuclides and convert deposited energy to dose
+    ev_per_source = tally.mean.sum()
+    joule_per_source = ev_per_source * openmc.data.JOULE_PER_EV
+    kg = silicon.get_mass(volume=dose_cell.volume) * 1.0e-3
+    gy_per_source = joule_per_source / kg
+
+Before the virtual material is applied, the nuclide-wise heating results have
+units of eV-b-cm/(atom-source). Multiplication by atom densities in atom/b-cm
+gives eV/source while retaining the nuclide dimension. The explicit sum above
+combines the nuclide contributions. Finally, dividing the deposited energy in
+joules by the virtual silicon mass in kilograms gives absorbed dose in
+Gy/source.
+
+The tally must contain individual nuclide bins; a ``'total'`` nuclide bin cannot
+be used because a material density cannot be assigned to its constituent
+nuclides. Tally nuclides that do not occur in the virtual material are treated
+as having zero atom density.
+
 .. _usersguide_tally_normalization:
 
 ------------------------------

--- a/docs/source/usersguide/tallies.rst
+++ b/docs/source/usersguide/tallies.rst
@@ -395,10 +395,11 @@ the region of interest that has its volume set in cm³.
     tally.apply_virtual_material(silicon)
 
     # Sum over nuclides and convert deposited energy to dose
-    ev_per_source = tally.mean.sum()
-    joule_per_source = ev_per_source * openmc.data.JOULE_PER_EV
-    kg = silicon.get_mass(volume=dose_cell.volume) * 1.0e-3
-    gy_per_source = joule_per_source / kg
+    eV_per_source = tally.mean.sum()
+    J_per_source = eV_per_source * openmc.data.JOULE_PER_EV
+    J_per_cm3_source = J_per_source / dose_cell.volume
+    kg_per_cm3 = silicon.get_mass_density() * 1.0e-3
+    Gy_per_source = J_per_cm3_source / kg_per_cm3
 
 Before the virtual material is applied, the nuclide-wise heating results have
 units of eV-b-cm/(atom-source). Multiplication by atom densities in atom/b-cm

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -17,16 +17,16 @@ from scipy.stats import chi2, norm
 import openmc
 import openmc.checkvalue as cv
 from openmc.filter import (
-    Filter, 
-    DistribcellFilter, 
-    EnergyFunctionFilter, 
-    DelayedGroupFilter, 
-    FilterMeta, 
+    Filter,
+    DistribcellFilter,
+    EnergyFunctionFilter,
+    DelayedGroupFilter,
+    FilterMeta,
     MeshFilter,
     MeshBornFilter,
 )
 from openmc.arithmetic import (
-    CrossFilter, 
+    CrossFilter,
     AggregateFilter,
     CrossScore,
     AggregateScore,
@@ -1511,6 +1511,64 @@ class Tally(IDManagerMixin):
         self._higher_moments = False
         self._num_realizations = 0
         self._results_read = False
+
+    def apply_virtual_material(self, material: openmc.Material) -> None:
+        """Apply nuclide densities from a material to tally results.
+
+        This method multiplies each nuclide bin in the tally by the
+        corresponding atom density in ``material``. Nuclides that are not
+        present in the material are multiplied by zero. The operation is
+        performed in place and the nuclide dimension is preserved.
+
+        .. versionadded:: 0.15.4
+
+        Parameters
+        ----------
+        material : openmc.Material
+            Material whose nuclide atom densities are to be applied
+
+        Raises
+        ------
+        ValueError
+            If ``multiply_density`` is ``True``, the tally has no results, or
+            the tally contains a nuclide bin that does not represent a single
+            nuclide.
+
+        """
+        cv.check_type('virtual material', material, openmc.Material)
+
+        if self.multiply_density:
+            raise ValueError('Unable to apply a virtual material when '
+                             'multiply_density is True.')
+
+        # Accessing sum ensures that results are read from the statepoint before
+        # inspecting nuclide bins or modifying the underlying moments
+        if self.sum is None:
+            raise ValueError('Unable to apply a virtual material since the '
+                             'tally does not contain any results.')
+
+        if any(not isinstance(n, str) or n == 'total' for n in self.nuclides):
+            raise ValueError('Unable to apply a virtual material unless every '
+                             'nuclide bin represents a single nuclide.')
+
+        # Get the matching nuclide atom densities in [atom/b-cm]
+        densities = material.get_nuclide_atom_densities()
+        factors = np.array(
+            [densities.get(nuclide, 0.0) for nuclide in self.nuclides]
+        )[np.newaxis, :, np.newaxis]
+
+        # Scale the raw moments by the atom densities
+        self._sum *= factors
+        self._sum_sq *= factors**2
+        if self._sum_third is not None:
+            self._sum_third *= factors**3
+        if self._sum_fourth is not None:
+            self._sum_fourth *= factors**4
+
+        # Recompute derived statistics from the scaled raw moments on demand
+        self._mean = None
+        self._std_dev = None
+        self._vov = None
 
     @classmethod
     def from_xml_element(cls, elem, **kwargs):

--- a/tests/unit_tests/test_tallies.py
+++ b/tests/unit_tests/test_tallies.py
@@ -166,6 +166,86 @@ def test_tally_application(sphere_model, run_in_tmpdir):
     assert (sp_tally.mean == tally.mean).all()
     assert sp_tally.nuclides == tally.nuclides
 
+
+def _virtual_material_tally():
+    tally = openmc.Tally()
+    tally.filters = [openmc.EnergyFilter([0.0, 1.0, 2.0])]
+    tally.nuclides = ['Si28', 'Si29', 'O16']
+    tally.scores = ['heating', 'damage-energy']
+    tally.multiply_density = False
+    tally._sp_filename = 'dummy.h5'
+    tally._results_read = True
+    tally._higher_moments = True
+
+    shape = (2, 3, 2)
+    n_realizations = 5
+    samples = np.arange(
+        1.0, n_realizations*np.prod(shape) + 1.0
+    ).reshape(n_realizations, *shape)
+    tally._num_realizations = samples.shape[0]
+    tally._sum = np.sum(samples, axis=0)
+    tally._sum_sq = np.sum(samples**2, axis=0)
+    tally._sum_third = np.sum(samples**3, axis=0)
+    tally._sum_fourth = np.sum(samples**4, axis=0)
+    return tally
+
+
+def test_apply_virtual_material():
+    tally = _virtual_material_tally()
+
+    material = openmc.Material()
+    material.add_nuclide('Si28', 0.04)
+    material.add_nuclide('Si29', 0.01)
+    material.set_density('sum')
+
+    original_sum = tally.sum.copy()
+    original_sum_sq = tally.sum_sq.copy()
+    original_sum_third = tally.sum_third.copy()
+    original_sum_fourth = tally.sum_fourth.copy()
+    original_mean = tally.mean.copy()
+    original_std_dev = tally.std_dev.copy()
+    original_shape = tally.shape
+
+    result = tally.apply_virtual_material(material)
+
+    factors = np.array([0.04, 0.01, 0.0])[np.newaxis, :, np.newaxis]
+    assert result is None
+    assert tally.shape == original_shape
+    assert tally.nuclides == ['Si28', 'Si29', 'O16']
+    assert tally.scores == ['heating', 'damage-energy']
+    assert tally.multiply_density is False
+    assert tally.sum == pytest.approx(original_sum * factors)
+    assert tally.sum_sq == pytest.approx(original_sum_sq * factors**2)
+    assert tally.sum_third == pytest.approx(original_sum_third * factors**3)
+    assert tally.sum_fourth == pytest.approx(original_sum_fourth * factors**4)
+    assert tally.mean == pytest.approx(original_mean * factors)
+    assert tally.std_dev == pytest.approx(original_std_dev * factors)
+
+
+def test_apply_virtual_material_errors():
+    material = openmc.Material()
+    material.add_nuclide('Si28', 1.0)
+    material.set_density('atom/b-cm', 0.05)
+
+    tally = _virtual_material_tally()
+    with pytest.raises(TypeError):
+        tally.apply_virtual_material('silicon')
+
+    tally.multiply_density = True
+    with pytest.raises(ValueError, match='multiply_density is True'):
+        tally.apply_virtual_material(material)
+
+    tally = openmc.Tally()
+    tally.multiply_density = False
+    with pytest.raises(ValueError, match='does not contain any results'):
+        tally.apply_virtual_material(material)
+
+    tally = _virtual_material_tally()
+    tally.nuclides = ['total']
+    with pytest.raises(ValueError, match='single nuclide'):
+        tally.apply_virtual_material(material)
+
+
 def _tally_from_data(x, *, higher_moments=True, normality=True):
     t = openmc.Tally()
     t.scores = ["flux"]  # 1 score


### PR DESCRIPTION
# Description

This PR is an alternative to #4027. It adds an in-place `Tally.apply_virtual_material()` method for applying the
nuclide atom densities of an `openmc.Material` to tally results generated with `multiply_density=False`. This supports calculations such as determining dose in silicon when silicon is not present in the transport model. The method preserves the tally's nuclide dimension, scales all statistical moments consistently, and assigns zero density to tally nuclides absent from the virtual material. The new method only requires 60 lines of code, most of which is just documentation/error checks; the actual implementation is ~15 lines.

I've also added a section in the user's guide discussing the use of virtual materials, showing an example of computing dose in Si.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)