### PR TITLE
Resolve relative input paths relative to XML files

### DIFF
--- a/openmc/geometry.py
+++ b/openmc/geometry.py
@@ -11,6 +11,7 @@ import openmc
 import openmc._xml as xml
 from .plots import add_plot_params
 from .checkvalue import check_type, check_less_than, check_greater_than, PathLike
+from .utility_funcs import set_xml_input_path
 
 
 class Geometry:
@@ -290,11 +291,12 @@ class Geometry:
         if isinstance(materials, (str, os.PathLike)):
             materials = openmc.Materials.from_xml(materials)
 
-        parser = ET.XMLParser(huge_tree=True)
-        tree = ET.parse(path, parser=parser)
-        root = tree.getroot()
+        with set_xml_input_path(path):
+            parser = ET.XMLParser(huge_tree=True)
+            tree = ET.parse(path, parser=parser)
+            root = tree.getroot()
 
-        return cls.from_xml_element(root, materials)
+            return cls.from_xml_element(root, materials)
 
     def find(self, point) -> list:
         """Find cells/universes/lattices which contain a given point

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -20,7 +20,7 @@ import openmc.data
 import openmc.checkvalue as cv
 from ._xml import clean_indentation, get_elem_list, get_text
 from .mixin import IDManagerMixin
-from .utility_funcs import input_path
+from .utility_funcs import input_path, set_xml_input_path
 from . import waste
 from openmc.checkvalue import PathLike
 from openmc.stats import Univariate, Discrete, Mixture, Tabular
@@ -2286,11 +2286,12 @@ class Materials(cv.CheckedList):
             Materials collection
 
         """
-        parser = ET.XMLParser(huge_tree=True)
-        tree = ET.parse(path, parser=parser)
-        root = tree.getroot()
+        with set_xml_input_path(path):
+            parser = ET.XMLParser(huge_tree=True)
+            tree = ET.parse(path, parser=parser)
+            root = tree.getroot()
 
-        return cls.from_xml_element(root)
+            return cls.from_xml_element(root)
 
 
     def deplete(

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -25,7 +25,7 @@ from openmc.checkvalue import (check_type, check_value, check_greater_than,
                                check_length, PathLike)
 from openmc.exceptions import InvalidIDError
 from openmc.plots import add_plot_params, _BASIS_INDICES, id_map_to_rgb
-from openmc.utility_funcs import change_directory
+from openmc.utility_funcs import change_directory, set_xml_input_path
 
 
 # Protocol for a function that is passed to search_keff
@@ -384,30 +384,31 @@ class Model:
         path : PathLike
             Path to model.xml file
         """
-        parser = ET.XMLParser(huge_tree=True)
-        tree = ET.parse(path, parser=parser)
-        root = tree.getroot()
+        with set_xml_input_path(path):
+            parser = ET.XMLParser(huge_tree=True)
+            tree = ET.parse(path, parser=parser)
+            root = tree.getroot()
 
-        model = cls()
+            model = cls()
 
-        desc_elem = root.find('description')
-        if desc_elem is not None and desc_elem.text:
-            model.description = desc_elem.text
+            desc_elem = root.find('description')
+            if desc_elem is not None and desc_elem.text:
+                model.description = desc_elem.text
 
-        meshes = {}
-        model.settings = openmc.Settings.from_xml_element(
-            root.find('settings'), meshes)
-        model.materials = openmc.Materials.from_xml_element(
-            root.find('materials'))
-        model.geometry = openmc.Geometry.from_xml_element(
-            root.find('geometry'), model.materials)
+            meshes = {}
+            model.settings = openmc.Settings.from_xml_element(
+                root.find('settings'), meshes)
+            model.materials = openmc.Materials.from_xml_element(
+                root.find('materials'))
+            model.geometry = openmc.Geometry.from_xml_element(
+                root.find('geometry'), model.materials)
 
-        if root.find('tallies') is not None:
-            model.tallies = openmc.Tallies.from_xml_element(
-                root.find('tallies'), meshes)
+            if root.find('tallies') is not None:
+                model.tallies = openmc.Tallies.from_xml_element(
+                    root.find('tallies'), meshes)
 
-        if root.find('plots') is not None:
-            model.plots = openmc.Plots.from_xml_element(root.find('plots'))
+            if root.find('plots') is not None:
+                model.plots = openmc.Plots.from_xml_element(root.find('plots'))
 
         return model
 

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from numbers import Integral, Real
 from pathlib import Path

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -14,6 +14,7 @@ from openmc.checkvalue import PathLike
 
 from ._xml import clean_indentation, get_elem_list, get_text
 from .mixin import IDManagerMixin
+from .utility_funcs import set_xml_input_path
 
 _BASES = {'xy', 'xz', 'yz'}
 
@@ -2190,7 +2191,7 @@ class Plots(cv.CheckedList):
         tree.write(str(p), xml_declaration=True, encoding='utf-8')
 
     @classmethod
-    def from_xml_element(cls, elem):
+    def from_xml_element(cls, elem) -> Plots:
         """Generate plots collection from XML file
 
         Parameters
@@ -2224,7 +2225,7 @@ class Plots(cv.CheckedList):
         return plots
 
     @classmethod
-    def from_xml(cls, path='plots.xml'):
+    def from_xml(cls, path: PathLike = 'plots.xml') -> Plots:
         """Generate plots collection from XML file
 
         Parameters
@@ -2238,7 +2239,8 @@ class Plots(cv.CheckedList):
             Plots collection
 
         """
-        parser = ET.XMLParser(huge_tree=True)
-        tree = ET.parse(path, parser=parser)
-        root = tree.getroot()
-        return cls.from_xml_element(root)
+        with set_xml_input_path(path):
+            parser = ET.XMLParser(huge_tree=True)
+            tree = ET.parse(path, parser=parser)
+            root = tree.getroot()
+            return cls.from_xml_element(root)

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -15,7 +15,7 @@ from openmc.stats.multivariate import MeshSpatial
 from ._xml import clean_indentation, get_elem_list, get_text
 from .mesh import _read_meshes, RegularMesh, MeshBase
 from .source import SourceBase, MeshSource, IndependentSource
-from .utility_funcs import input_path
+from .utility_funcs import input_path, set_xml_input_path
 from .volume import VolumeCalculation
 from .weight_windows import WeightWindows, WeightWindowGenerator, WeightWindowsList
 
@@ -2775,8 +2775,9 @@ class Settings:
             Settings object
 
         """
-        parser = ET.XMLParser(huge_tree=True)
-        tree = ET.parse(path, parser=parser)
-        root = tree.getroot()
-        meshes = _read_meshes(root)
-        return cls.from_xml_element(root, meshes)
+        with set_xml_input_path(path):
+            parser = ET.XMLParser(huge_tree=True)
+            tree = ET.parse(path, parser=parser)
+            root = tree.getroot()
+            meshes = _read_meshes(root)
+            return cls.from_xml_element(root, meshes)

--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -36,6 +36,7 @@ from openmc.arithmetic import (
 from ._sparse_compat import lil_array
 from ._xml import clean_indentation, get_elem_list, get_text
 from .mixin import IDManagerMixin
+from .utility_funcs import set_xml_input_path
 from .mesh import MeshBase
 
 
@@ -3932,7 +3933,8 @@ class Tallies(cv.CheckedList):
             Tallies object
 
         """
-        parser = ET.XMLParser(huge_tree=True)
-        tree = ET.parse(path, parser=parser)
-        root = tree.getroot()
-        return cls.from_xml_element(root)
+        with set_xml_input_path(path):
+            parser = ET.XMLParser(huge_tree=True)
+            tree = ET.parse(path, parser=parser)
+            root = tree.getroot()
+            return cls.from_xml_element(root)

--- a/openmc/utility_funcs.py
+++ b/openmc/utility_funcs.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from contextvars import ContextVar
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -7,6 +8,19 @@ import h5py
 
 import openmc
 from .checkvalue import PathLike
+
+
+_XML_INPUT_PATH = ContextVar('_XML_INPUT_PATH', default=None)
+
+
+@contextmanager
+def set_xml_input_path(path: PathLike):
+    """Set the containing XML directory for resolving input paths."""
+    token = _XML_INPUT_PATH.set(Path(path).resolve().parent)
+    try:
+        yield
+    finally:
+        _XML_INPUT_PATH.reset(token)
 
 
 @contextmanager
@@ -56,7 +70,11 @@ def input_path(filename: PathLike) -> Path:
 
     """
     if openmc.config['resolve_paths']:
-        return Path(filename).resolve()
+        path = Path(filename)
+        xml_dir = _XML_INPUT_PATH.get()
+        if xml_dir is not None and not path.is_absolute():
+            path = xml_dir / path
+        return path.resolve()
     else:
         return Path(filename)
 

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -224,99 +224,19 @@ def test_from_xml(run_in_tmpdir, pin_model_attributes):
 def test_xml_input_paths(tmp_path, monkeypatch, resolve_paths):
     """Input paths are interpreted relative to the containing XML file."""
     with openmc.config.patch('resolve_paths', False):
-        material = openmc.Material()
-        materials = openmc.Materials([material])
-        materials.cross_sections = 'cross_sections.xml'
-
-        dagmc_universe = openmc.DAGMCUniverse('dagmc.h5m')
-        geometry = openmc.Geometry(dagmc_universe)
-
-        settings = openmc.Settings()
-        settings.source = [
-            openmc.FileSource('source.h5'),
-            openmc.CompiledSource('source.so'),
-            openmc.FileSource(tmp_path / 'absolute_source.h5'),
-        ]
-        settings.properties_file = 'properties.h5'
-        settings.surf_source_read = {'path': 'surface_source.h5'}
-        settings.weight_windows_file = 'weight_windows.h5'
-
-        mesh = openmc.UnstructuredMesh('mesh.h5m', 'moab')
-        tally = openmc.Tally()
-        tally.filters = [openmc.MeshFilter(mesh)]
-        tally.scores = ['flux']
-        tallies = openmc.Tallies([tally])
-
-        model = openmc.Model(
-            geometry, materials, settings, tallies=tallies)
+        univ = openmc.DAGMCUniverse('dagmc.h5m')
+        model = openmc.Model(geometry=openmc.Geometry(univ))
         model_dir = tmp_path / 'model'
         model.export_to_model_xml(model_dir)
 
-        component_dir = tmp_path / 'components'
-        component_dir.mkdir()
-        materials.export_to_xml(component_dir)
-        geometry.export_to_xml(component_dir)
-        settings.export_to_xml(component_dir)
-        tallies.export_to_xml(component_dir)
-
-    def expected(directory, filename):
-        path = Path(filename)
-        return (directory / path).resolve() if resolve_paths else path
-
-    def check_paths(loaded_model, directory):
-        assert loaded_model.materials.cross_sections == expected(
-            directory, 'cross_sections.xml')
-        assert loaded_model.geometry.root_universe.filename == expected(
-            directory, 'dagmc.h5m')
-        assert loaded_model.settings.source[0].path == expected(
-            directory, 'source.h5')
-        assert loaded_model.settings.source[1].library == expected(
-            directory, 'source.so')
-        assert loaded_model.settings.source[2].path == \
-            tmp_path / 'absolute_source.h5'
-        assert loaded_model.settings.properties_file == expected(
-            directory, 'properties.h5')
-        assert loaded_model.settings.surf_source_read['path'] == expected(
-            directory, 'surface_source.h5')
-        assert loaded_model.settings.weight_windows_file == expected(
-            directory, 'weight_windows.h5')
-        assert loaded_model.tallies[0].filters[0].mesh.filename == expected(
-            directory, 'mesh.h5m')
-
     monkeypatch.chdir(tmp_path)
-    original_dir = Path.cwd()
     with openmc.config.patch('resolve_paths', resolve_paths):
         openmc.reset_auto_ids()
         loaded_model = openmc.Model.from_model_xml('model/model.xml')
-        check_paths(loaded_model, model_dir)
-
-        openmc.reset_auto_ids()
-        loaded_components = openmc.Model.from_xml(
-            geometry='components/geometry.xml',
-            materials='components/materials.xml',
-            settings='components/settings.xml',
-            tallies='components/tallies.xml',
-            plots='components/missing-plots.xml',
-        )
-        check_paths(loaded_components, component_dir)
-
-    assert Path.cwd() == original_dir
-
-
-def test_xml_input_path_context_reset(tmp_path, monkeypatch):
-    """The XML input directory is cleared when parsing raises an exception."""
-    input_dir = tmp_path / 'inputs'
-    input_dir.mkdir()
-    invalid_xml = input_dir / 'model.xml'
-    invalid_xml.write_text('<model>', encoding='utf-8')
-    monkeypatch.chdir(tmp_path)
-
-    with openmc.config.patch('resolve_paths', True):
-        with pytest.raises(ET.XMLSyntaxError):
-            openmc.Model.from_model_xml(invalid_xml)
-
-        universe = openmc.DAGMCUniverse('dagmc.h5m')
-        assert universe.filename == (tmp_path / 'dagmc.h5m').resolve()
+        expected = (model_dir / 'dagmc.h5m').resolve()
+        if not resolve_paths:
+            expected = Path('dagmc.h5m')
+        assert loaded_model.geometry.root_universe.filename == expected
 
 
 def test_init_finalize_lib(run_in_tmpdir, pin_model_attributes, mpi_intracomm):

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -2,7 +2,6 @@ from math import pi
 from pathlib import Path
 import os
 
-import lxml.etree as ET
 import numpy as np
 import pytest
 

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -2,6 +2,7 @@ from math import pi
 from pathlib import Path
 import os
 
+import lxml.etree as ET
 import numpy as np
 import pytest
 
@@ -217,6 +218,105 @@ def test_from_xml(run_in_tmpdir, pin_model_attributes):
              test_model.geometry.root_universe.cells[4]},
         'inf fuel': {test_model.geometry.root_universe.cells[2].fill.cells[1]}}
     assert test_model.is_initialized is False
+
+
+@pytest.mark.parametrize('resolve_paths', [True, False])
+def test_xml_input_paths(tmp_path, monkeypatch, resolve_paths):
+    """Input paths are interpreted relative to the containing XML file."""
+    with openmc.config.patch('resolve_paths', False):
+        material = openmc.Material()
+        materials = openmc.Materials([material])
+        materials.cross_sections = 'cross_sections.xml'
+
+        dagmc_universe = openmc.DAGMCUniverse('dagmc.h5m')
+        geometry = openmc.Geometry(dagmc_universe)
+
+        settings = openmc.Settings()
+        settings.source = [
+            openmc.FileSource('source.h5'),
+            openmc.CompiledSource('source.so'),
+            openmc.FileSource(tmp_path / 'absolute_source.h5'),
+        ]
+        settings.properties_file = 'properties.h5'
+        settings.surf_source_read = {'path': 'surface_source.h5'}
+        settings.weight_windows_file = 'weight_windows.h5'
+
+        mesh = openmc.UnstructuredMesh('mesh.h5m', 'moab')
+        tally = openmc.Tally()
+        tally.filters = [openmc.MeshFilter(mesh)]
+        tally.scores = ['flux']
+        tallies = openmc.Tallies([tally])
+
+        model = openmc.Model(
+            geometry, materials, settings, tallies=tallies)
+        model_dir = tmp_path / 'model'
+        model.export_to_model_xml(model_dir)
+
+        component_dir = tmp_path / 'components'
+        component_dir.mkdir()
+        materials.export_to_xml(component_dir)
+        geometry.export_to_xml(component_dir)
+        settings.export_to_xml(component_dir)
+        tallies.export_to_xml(component_dir)
+
+    def expected(directory, filename):
+        path = Path(filename)
+        return (directory / path).resolve() if resolve_paths else path
+
+    def check_paths(loaded_model, directory):
+        assert loaded_model.materials.cross_sections == expected(
+            directory, 'cross_sections.xml')
+        assert loaded_model.geometry.root_universe.filename == expected(
+            directory, 'dagmc.h5m')
+        assert loaded_model.settings.source[0].path == expected(
+            directory, 'source.h5')
+        assert loaded_model.settings.source[1].library == expected(
+            directory, 'source.so')
+        assert loaded_model.settings.source[2].path == \
+            tmp_path / 'absolute_source.h5'
+        assert loaded_model.settings.properties_file == expected(
+            directory, 'properties.h5')
+        assert loaded_model.settings.surf_source_read['path'] == expected(
+            directory, 'surface_source.h5')
+        assert loaded_model.settings.weight_windows_file == expected(
+            directory, 'weight_windows.h5')
+        assert loaded_model.tallies[0].filters[0].mesh.filename == expected(
+            directory, 'mesh.h5m')
+
+    monkeypatch.chdir(tmp_path)
+    original_dir = Path.cwd()
+    with openmc.config.patch('resolve_paths', resolve_paths):
+        openmc.reset_auto_ids()
+        loaded_model = openmc.Model.from_model_xml('model/model.xml')
+        check_paths(loaded_model, model_dir)
+
+        openmc.reset_auto_ids()
+        loaded_components = openmc.Model.from_xml(
+            geometry='components/geometry.xml',
+            materials='components/materials.xml',
+            settings='components/settings.xml',
+            tallies='components/tallies.xml',
+            plots='components/missing-plots.xml',
+        )
+        check_paths(loaded_components, component_dir)
+
+    assert Path.cwd() == original_dir
+
+
+def test_xml_input_path_context_reset(tmp_path, monkeypatch):
+    """The XML input directory is cleared when parsing raises an exception."""
+    input_dir = tmp_path / 'inputs'
+    input_dir.mkdir()
+    invalid_xml = input_dir / 'model.xml'
+    invalid_xml.write_text('<model>', encoding='utf-8')
+    monkeypatch.chdir(tmp_path)
+
+    with openmc.config.patch('resolve_paths', True):
+        with pytest.raises(ET.XMLSyntaxError):
+            openmc.Model.from_model_xml(invalid_xml)
+
+        universe = openmc.DAGMCUniverse('dagmc.h5m')
+        assert universe.filename == (tmp_path / 'dagmc.h5m').resolve()
 
 
 def test_init_finalize_lib(run_in_tmpdir, pin_model_attributes, mpi_intracomm):


### PR DESCRIPTION
# Description

Currently, if you call `Model.from_model_xml()` on a model.xml file that is not in your current directory, any files that it references with a relative path will be treated as though they are relative to your current working directory rather than the parent directory of the XML file itself. This PR fixes this so that XML-loading entry points now establish the directory containing the source XML file as the path-resolution context. Nested inputs such as DAGMC geometry, meshes, and other referenced files are therefore found relative to the XML file rather than the process's current working directory when `openmc.config['resolve_paths']` is enabled. The context is scoped and safely restored after parsing, including nested XML-loading operations.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
