### PR TITLE
Update Python package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm", "wheel"]
+requires = ["setuptools>=77.0.3", "setuptools-scm", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,13 +10,13 @@ authors = [
 description = "OpenMC"
 dynamic = ["version"]
 requires-python = ">=3.12"
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: End Users/Desktop",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Topic :: Scientific/Engineering",
     "Programming Language :: C++",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77.0.3", "setuptools-scm", "wheel"]
+requires = ["setuptools>=80", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
# Description

This updates `pyproject.toml` to follow current Python packaging guidance, including [PEP 639](https://peps.python.org/pep-0639/) and the [PyPA license metadata recommendations](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license).

- Declare the MIT license using an [SPDX license expression](https://packaging.python.org/en/latest/specifications/license-expression/)
- Explicitly include `LICENSE` through [`project.license-files`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-files)
- Remove the deprecated [PyPI license classifier](https://peps.python.org/pep-0639/#deprecate-license-classifiers)
- Require recent versions of [setuptools](https://setuptools.pypa.io/en/latest/userguide/quickstart.html) and [setuptools-scm](https://setuptools-scm.readthedocs.io/en/stable/usage/)
- Remove the unnecessary `wheel` build dependency, as recommended by the [setuptools build-system guidance](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use)

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>