### PR TITLE
Write unstructured mesh exodus file from one MPI rank

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3868,6 +3868,14 @@ void LibMesh::set_score_data(const std::string& var_name,
 
 void LibMesh::write(const std::string& filename) const
 {
+  // A serial libMesh communicator considers every OpenMC rank to be its
+  // processor 0. Restrict the non-collective write to the OpenMC master in
+  // that case. With a parallel communicator, all ranks must participate in
+  // libMesh's solution assembly.
+  if (settings::libmesh_comm->size() == 1 && !mpi::master) {
+    return;
+  }
+
   write_message(fmt::format(
     "Writing file: {}.e for unstructured mesh {}", filename, this->id_));
   libMesh::ExodusII_IO exo(*m_);

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -877,7 +877,9 @@ void write_unstructured_mesh_results()
         simulation::current_batch, batch_width);
 
       // Write the unstructured mesh and data to file
-      umesh->write(filename);
+      if (mpi::master) {
+        umesh->write(filename);
+      }
 
       // remove score data added for this mesh write
       umesh->remove_scores();

--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -877,9 +877,7 @@ void write_unstructured_mesh_results()
         simulation::current_batch, batch_width);
 
       // Write the unstructured mesh and data to file
-      if (mpi::master) {
-        umesh->write(filename);
-      }
+      umesh->write(filename);
 
       // remove score data added for this mesh write
       umesh->remove_scores();


### PR DESCRIPTION
# Description

@amandalund and I ran into an error running an unstructured mesh tally benchmark wherein when the run was done and OpenMC tried to write an exodus file with the tally results, it would crash with "Error writing mesh connectivities". <s>This is because multiple MPI ranks were trying to write the same file. This PR adds an `if (mpi::master)` guard to ensure only one rank writes the file.</s>

UPDATE: The original assessment was wrong (upon reaching a deadlock in CI). I've updated the fix to distinguish serial and parallel libMesh communicators at runtime: serial libMesh restricts Exodus output to the OpenMC master, while MPI-enabled libMesh allows all ranks to participate in the required collective assembly (which is required by libMesh). This should hopefully resolve both the performance benchmark's competing-writer error and the CI deadlock here.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)