### PR TITLE
Set all tally estimators to collision in RR simulations

### DIFF
--- a/src/random_ray/random_ray_simulation.cpp
+++ b/src/random_ray/random_ray_simulation.cpp
@@ -55,8 +55,8 @@ void validate_random_ray_inputs()
     // only store a single position to use for determining which tally they map
     // to, so r() == r_last() and bins_crossed(...) may fail to match due to the
     // zero segment length. This has no impact on the results as random ray
-    // simulations are MOC-based; tallies all use tracklength estimators regardless
-    // of the value of 'estimator_'.
+    // simulations are MOC-based; tallies all use tracklength estimators
+    // regardless of the value of 'estimator_'.
     for (auto& tally : model::tallies) {
       tally->estimator_ = TallyEstimator::COLLISION;
     }

--- a/src/random_ray/random_ray_simulation.cpp
+++ b/src/random_ray/random_ray_simulation.cpp
@@ -50,6 +50,17 @@ void validate_random_ray_inputs()
       }
     }
 
+    // Silently set tally estimators to collision to ensure that source
+    // regions correctly map to tally bins. This is required as source regions
+    // only store a single position to use for determining which tally they map
+    // to, so r() == r_last() and bins_crossed(...) may fail to match due to the
+    // zero segment length. This has no impact on the results as random ray
+    // simulations are MOC-based; tallies all use tracklength estimators regardless
+    // of the value of 'estimator_'.
+    for (auto& tally : model::tallies) {
+      tally->estimator_ = TallyEstimator::COLLISION;
+    }
+
     // Validate filter types
     for (auto f : tally->filters()) {
       auto& filter = *model::tally_filters[f];


### PR DESCRIPTION
# Description

Obtaining results from a random ray simulation through the use of tallies in OpenMC relies of mapping each source region to a corresponding tally object. To facilitate this, source regions save the midpoint of the first ray that passes through them, which is then used to query tallies and find every tally object that maps spatially to the source region. In the vast majority of cases this works perfectly, however we  run into issues when a tally is set to use a tracklength estimator. The filter matches run `bins_crossed()` using a position (`r()`) and previous position (`r_last()`) that are the same, which results in zero-lengths being returned. In most filters this still counts as a bin being hit, but in some cases (MOAB/XDG unstructured mesh tallies, and very rarely tallies with no filters applied) this will not be registered which leads to source regions missing tally objects. 

This PR fixes this bug by silently setting all tallies to collision estimators before running a random ray simulation to ensure filter matches are obtained with `r()`. This has no impact on results as the random ray solver does not require the concept of estimators.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
