### PR TITLE
Persist evaluated MF6 product metadata

### DIFF
--- a/docs/source/io_formats/nuclear_data.rst
+++ b/docs/source/io_formats/nuclear_data.rst
@@ -65,6 +65,63 @@ temperature-dependent data set.  For example, the data set corresponding to
 
    Reaction product data is described in :ref:`product`.
 
+**/<nuclide name>/reactions/reaction_<mt>/evaluated_product_metadata/**
+
+   Optional, transport-isolated evaluated ENDF MF=6 product provenance. This
+   group is written only when
+   :meth:`openmc.data.IncidentNeutron.from_njoy` is explicitly called with
+   ``include_evaluated_product_metadata=True`` and the MF=6 section was
+   structurally consumed. It is not a ``product_<j>`` group and is not sampled
+   by OpenMC transport.
+
+   :Attributes: - **version** (*int32*) -- Group-local format version (1)
+                - **schema** (*UTF-8*) --
+                  ``openmc-evaluated-product-metadata/v2``
+                - **source_format** (*UTF-8*) -- ``ENDF-6``
+                - **result_status** (*UTF-8*) -- Always
+                  ``published_structurally_complete``
+                - **mf**, **mt**, **jp**, **lct** (*int32*) -- Raw ENDF section
+                  identity and controls
+                - **section_semantic_status** (*UTF-8*) -- ``complete``,
+                  ``unsupported_lang``, ``unsupported_ltp``,
+                  ``unsupported_frame``, or ``invalid_combination``
+
+   The group has exactly ordered children ``entry_0`` through ``entry_N-1``.
+   Every child stores raw **subsection_index**, **zap**, **lip**, and **law**
+   (*int32*); **awp** (*float64*); **awp_interpretation**,
+   **semantic_status**, **identity_status**, and **derived_particle** (*UTF-8*);
+   and **lidp** (*int32*, with -1 encoding null). It has rank-one int32
+   datasets **lang_values** and **ltp_values**, including zero-length datasets.
+   LAW=6 children additionally require scalar **apsx** (*float64*, finite and
+   positive) and **npsx** (*int32*, 3 through 2\ :sup:`31` - 1); other LAW
+   children contain neither attribute. APSX is the dimensionless total
+   final-state mass in neutron-mass units and NPSX is the dimensionless
+   final-state particle count.
+
+   AWP is a dimensionless mass ratio except for the ENDF primary-photon case
+   MT=102, ZAP=0, LAW=2, where it is an energy in eV. Raw ZAP/AWP/LIP remain
+   authoritative; derived identity is deliberately conservative. Missing groups
+   mean only ``not_published``; the direct parser distinguishes an absent MF=6
+   section from a typed structural failure. Unknown versions, malformed fields,
+   or gapped entry names are refused. The incident-neutron HDF5 file version
+   remains 3.0.
+
+   This representation is evaluated-data provenance only. It does not add ACE
+   products, alter secondary sampling, transport, random-number use, scoring,
+   or detector-response modelling; it does not establish final-state
+   completeness. ``published_structurally_complete`` means that the supported
+   MF=6 record envelopes and declared counts were consumed exactly. ``complete``
+   means that no implemented finite semantic rule was violated. LAW=1 with
+   LANG=2 requires LCT=2; another LCT makes that entry and its section
+   ``invalid_combination`` without preventing structural publication. The raw
+   section LCT control is retained, but no per-product frame interpretation is
+   published. This representation does not independently validate every ENDF
+   interpolation grid or constant control, nor does it establish distribution
+   normalization, conservation, or evaluation-wide physical consistency. In
+   particular, raw LAW=6 persistence does not enforce the sampling-level
+   relationship between APSX and an entry's AWP; consumers that interpret the
+   controls physically must validate that relationship separately.
+
 **/<nuclide name>/urr/<TTT>K/**
 
 <TTT>K is the temperature in Kelvin, rounded to the nearest integer, of the

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -19,7 +19,10 @@ from .fission_energy import FissionEnergyRelease
 from .function import Tabulated1D, Sum, ResonancesWithBackground
 from .njoy import make_ace, make_pendf
 from .product import Product
-from .reaction import Reaction, _get_photon_products_ace, FISSION_MTS
+from .reaction import (
+    Reaction, _get_photon_products_ace, FISSION_MTS,
+    get_evaluated_product_metadata,
+)
 from . import resonance as res
 from . import resonance_covariance as res_cov
 from .urr import ProbabilityTables
@@ -727,7 +730,8 @@ class IncidentNeutron(EqualityMixin):
         return data
 
     @classmethod
-    def from_njoy(cls, filename, temperatures=None, evaluation=None, **kwargs):
+    def from_njoy(cls, filename, temperatures=None, evaluation=None,
+                  include_evaluated_product_metadata=False, **kwargs):
         """Generate incident neutron data by running NJOY.
 
         Parameters
@@ -740,6 +744,11 @@ class IncidentNeutron(EqualityMixin):
         evaluation : openmc.data.endf.Evaluation, optional
             If the ENDF file contains multiple material evaluations, this
             argument indicates which evaluation to use.
+        include_evaluated_product_metadata : bool, optional
+            If True, attach structurally complete evaluated MF=6 provenance
+            metadata to matching ACE-derived reactions. The default False
+            preserves the pre-existing ACE/NJOY output and performs no MF=6
+            metadata parsing.
         **kwargs
             Keyword arguments passed to :func:`openmc.data.njoy.make_ace`
 
@@ -767,6 +776,12 @@ class IncidentNeutron(EqualityMixin):
             # may be wrong for higher metastable states (e.g., Hf178_m2)
             ev = evaluation if evaluation is not None else Evaluation(filename)
             data.name = ev.gnds_name
+
+            if include_evaluated_product_metadata:
+                for mt, reaction in data.reactions.items():
+                    result = get_evaluated_product_metadata(ev, mt)
+                    if result.result_status == 'published_structurally_complete':
+                        reaction.evaluated_product_metadata = result.metadata
 
             # Add 0K elastic scattering cross section
             if '0K' not in data.energy:

--- a/openmc/data/reaction.py
+++ b/openmc/data/reaction.py
@@ -1,9 +1,12 @@
 from collections.abc import Iterable, Callable, MutableMapping
 from copy import deepcopy
+from dataclasses import dataclass, field
 from io import StringIO
+import math
 from numbers import Real
 from warnings import warn
 
+import h5py
 import numpy as np
 
 import openmc.checkvalue as cv
@@ -80,6 +83,792 @@ REACTION_MT['absorption'] = 27
 REACTION_MT['capture'] = 102
 
 FISSION_MTS = (18, 19, 20, 21, 38)
+
+
+_METADATA_SEMANTIC_STATUS = (
+    'complete', 'unsupported_lang', 'unsupported_ltp', 'unsupported_frame',
+    'invalid_combination')
+_METADATA_STRUCTURAL_FAILURE = (
+    'unknown_law', 'unproven_cursor', 'truncated_record', 'count_mismatch',
+    'premature_end', 'trailing_record', 'invalid_header',
+    'invalid_law6_control')
+_METADATA_JP = (0, 1, 2, 10, 11, 12, 20, 21, 22)
+_METADATA_SCHEMA = 'openmc-evaluated-product-metadata/v2'
+_METADATA_RESULT = 'published_structurally_complete'
+_METADATA_UTF8 = h5py.string_dtype(encoding='utf-8')
+
+
+class _MetadataParseError(ValueError):
+    """Internal typed terminal outcome from the MF=6 cursor reader."""
+
+    def __init__(self, reason):
+        self.reason = reason
+        super().__init__(reason)
+
+
+def _metadata_declared_record_lines(reader, line):
+    """Return the number of physical lines declared by a record header."""
+    try:
+        n1 = int(line[44:55].strip() or 0)
+        n2 = int(line[55:66].strip() or 0)
+    except ValueError:
+        return None
+    if n1 < 0 or n2 < 0:
+        return (-1 if reader in (
+            get_list_record, get_tab1_record, get_tab2_record) else 1)
+    if reader is get_list_record:
+        return 1 + (n1 + 5)//6
+    if reader is get_tab1_record:
+        return 1 + (n1 + 2)//3 + (n2 + 2)//3
+    if reader is get_tab2_record:
+        return 1 + (n1 + 2)//3
+    return 1
+
+
+def _metadata_record(reader, file_obj, failure='truncated_record',
+                     eof_failure=None, parse_failure=None):
+    """Read one declared record envelope or raise a typed terminal outcome."""
+    if file_obj.tell() >= len(file_obj.getvalue()):
+        raise _MetadataParseError(eof_failure or failure)
+    remaining = file_obj.getvalue()[file_obj.tell():]
+    lines = remaining.splitlines(keepends=True)
+    expected_lines = _metadata_declared_record_lines(reader, lines[0])
+    if expected_lines == -1:
+        raise _MetadataParseError('count_mismatch')
+    if (expected_lines is not None and
+            (len(lines) < expected_lines or any(
+                len(line.rstrip('\r\n')) < 66
+                for line in lines[:expected_lines]))):
+        raise _MetadataParseError(failure)
+    try:
+        return reader(file_obj)
+    except (EOFError, IndexError, OSError, ValueError, TypeError) as exc:
+        raise _MetadataParseError(parse_failure or failure) from exc
+
+
+@dataclass(frozen=True)
+class EvaluatedProductMetadataEntry:
+    """Immutable evaluated MF=6 product-provenance entry.
+
+    The attributes are evaluated-data metadata only. They are not an OpenMC
+    transport product and do not describe a sampled final state.
+    """
+
+    subsection_index: int
+    zap: int
+    awp: float
+    awp_interpretation: str
+    lip: int
+    law: int
+    lang_values: tuple
+    lidp: int | None
+    ltp_values: tuple
+    semantic_status: str
+    identity_status: str
+    derived_particle: str | None
+    apsx: float | None = None
+    npsx: int | None = None
+
+    def __post_init__(self):
+        """Require LAW=6 controls only for LAW=6 entries."""
+        if self.law == 6:
+            if self.apsx is None or self.npsx is None:
+                raise ValueError('LAW=6 metadata requires APSX and NPSX')
+            if (isinstance(self.apsx, (bool, np.bool_)) or
+                    not isinstance(self.apsx, Real)):
+                raise ValueError('invalid LAW=6 metadata APSX')
+            apsx = float(self.apsx)
+            if not math.isfinite(apsx) or apsx <= 0.0:
+                raise ValueError('invalid LAW=6 metadata APSX')
+            if (isinstance(self.npsx, (bool, np.bool_)) or
+                    not isinstance(self.npsx, (int, np.integer)) or
+                    not 3 <= self.npsx <= 2**31 - 1):
+                raise ValueError('invalid LAW=6 metadata NPSX')
+        elif self.apsx is not None or self.npsx is not None:
+            raise ValueError('non-LAW=6 metadata cannot contain APSX or NPSX')
+
+
+@dataclass(frozen=True)
+class EvaluatedProductMetadata:
+    """Immutable, transport-isolated published MF=6 section metadata."""
+
+    mt: int
+    jp: int
+    lct: int
+    section_semantic_status: str
+    entries: tuple
+
+
+@dataclass(frozen=True)
+class EvaluatedProductMetadataResult:
+    """Result of direct MF=6 metadata parsing before any attachment.
+
+    A structural failure and an absent MF=6 section intentionally contain no
+    published metadata. This prevents a partially consumed cursor from being
+    attached to an ACE-derived reaction.
+    """
+
+    mt: int
+    result_status: str
+    structural_failure: str | None = None
+    jp: int | None = None
+    lct: int | None = None
+    section_semantic_status: str | None = None
+    hdf5_group_version: int | None = None
+    entries: tuple = ()
+    schema: str = field(default=_METADATA_SCHEMA, init=False)
+    source_format: str = field(default='ENDF-6', init=False)
+    mf: int = field(default=6, init=False)
+
+    def __post_init__(self):
+        if (isinstance(self.mt, (bool, np.bool_)) or
+                not isinstance(self.mt, (int, np.integer)) or
+                not 1 <= self.mt <= 999):
+            raise ValueError('invalid evaluated product metadata result MT')
+        empty = (self.jp is None and self.lct is None and
+                 self.section_semantic_status is None and
+                 self.hdf5_group_version is None and not self.entries)
+        if self.result_status == 'absent':
+            if self.structural_failure is not None or not empty:
+                raise ValueError('invalid absent metadata result')
+        elif self.result_status == 'structural_failure':
+            if self.structural_failure not in _METADATA_STRUCTURAL_FAILURE:
+                raise ValueError('invalid metadata structural failure')
+            if not empty:
+                raise ValueError('invalid structural-failure metadata result')
+        elif self.result_status == _METADATA_RESULT:
+            if (self.structural_failure is not None or
+                    self.hdf5_group_version != 1):
+                raise ValueError('invalid published metadata result')
+            _metadata_validate_published(self.metadata)
+        else:
+            raise ValueError('invalid evaluated product metadata result status')
+
+    @property
+    def metadata(self):
+        """Return the attachable object only for a published result."""
+        if self.result_status != _METADATA_RESULT:
+            return None
+        return EvaluatedProductMetadata(
+            self.mt, self.jp, self.lct, self.section_semantic_status,
+            self.entries)
+
+
+def _metadata_int(value, failure='count_mismatch'):
+    """Return an ENDF control integer or raise for a non-integral value."""
+    try:
+        valid = not isinstance(value, (bool, np.bool_)) and int(value) == value
+    except (OverflowError, TypeError, ValueError):
+        valid = False
+    if not valid:
+        raise _MetadataParseError(failure)
+    return int(value)
+
+
+def _metadata_status(statuses):
+    """Return the canonical maximum semantic status."""
+    return max(statuses, key=_METADATA_SEMANTIC_STATUS.index, default='complete')
+
+
+def _metadata_identity(zap, lip):
+    """Derive only unambiguous convenience identities from raw ZAP/LIP."""
+    if zap == 0:
+        return 'special_particle', 'photon'
+    if zap == 1:
+        return 'special_particle', 'neutron'
+    return 'raw_only', None
+
+
+def _metadata_identity_is_valid(zap, lip, status, derived):
+    """Return whether a raw or optionally derived identity is conservative."""
+    if zap in (0, 1):
+        return (status, derived) == _metadata_identity(zap, lip)
+    if status == 'raw_only':
+        return derived is None
+    if status != 'ground_state_nuclide' or derived is None or lip != 0:
+        return False
+    z, a = divmod(zap, 1000)
+    return (zap != 1000 and 1 <= z <= a < 1000 and
+            z < len(ATOMIC_SYMBOL) and derived == f'{ATOMIC_SYMBOL[z]}{a}')
+
+
+def _metadata_entry(index, params):
+    """Create a raw entry and its mutable semantic-reason collection."""
+    try:
+        awp = float(params[1])
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise _MetadataParseError('invalid_header') from exc
+    zap, lip, law = (_metadata_int(params[0], 'invalid_header'),
+                     _metadata_int(params[2], 'invalid_header'),
+                     _metadata_int(params[3], 'invalid_header'))
+    if not math.isfinite(awp) or awp < 0.0:
+        raise _MetadataParseError('invalid_header')
+    identity_status, derived_particle = _metadata_identity(zap, lip)
+    return {
+        'subsection_index': index, 'zap': zap, 'awp': awp, 'lip': lip,
+        'law': law, 'lang_values': [], 'lidp': None, 'ltp_values': [],
+        'semantic_statuses': [], 'identity_status': identity_status,
+        'derived_particle': derived_particle, 'apsx': None, 'npsx': None,
+    }
+
+
+def _metadata_law1(file_obj, entry, lct):
+    params, _ = _metadata_record(get_tab2_record, file_obj)
+    lang, ne = _metadata_int(params[2]), _metadata_int(params[5])
+    if ne < 0:
+        raise _MetadataParseError('count_mismatch')
+    entry['lang_values'].append(lang)
+    for _ in range(ne):
+        items, values = _metadata_record(get_list_record, file_obj)
+        nd, na, nw, nep = (_metadata_int(items[2]), _metadata_int(items[3]),
+                           _metadata_int(items[4]), _metadata_int(items[5]))
+        if (min(nd, na, nw, nep) < 0 or nd > nep or
+                nw != nep*(na + 2) or len(values) != nw):
+            raise _MetadataParseError('count_mismatch')
+        if lang == 2 and na not in (0, 1, 2):
+            raise _MetadataParseError('count_mismatch')
+        if lang in (11, 12, 13, 14, 15) and (na < 2 or na % 2):
+            raise _MetadataParseError('count_mismatch')
+    if lang not in (1, 2, 11, 12, 13, 14, 15):
+        entry['semantic_statuses'].append('unsupported_lang')
+    if lang == 2 and lct != 2:
+        entry['semantic_statuses'].append('invalid_combination')
+
+
+def _metadata_law2(file_obj, entry, lct):
+    params, _ = _metadata_record(get_tab2_record, file_obj)
+    ne = _metadata_int(params[5])
+    if ne < 0:
+        raise _MetadataParseError('count_mismatch')
+    for _ in range(ne):
+        items, values = _metadata_record(get_list_record, file_obj)
+        lang, nw, nl = (_metadata_int(items[2]), _metadata_int(items[4]),
+                        _metadata_int(items[5]))
+        if min(nw, nl) < 0 or len(values) != nw:
+            raise _MetadataParseError('count_mismatch')
+        entry['lang_values'].append(lang)
+        if lang == 0 and (nl < 1 or nw != nl):
+            raise _MetadataParseError('count_mismatch')
+        if lang in (12, 14) and (nl < 2 or nw != 2*nl):
+            raise _MetadataParseError('count_mismatch')
+        if lang not in (0, 12, 14):
+            entry['semantic_statuses'].append('unsupported_lang')
+    if lct != 2:
+        entry['semantic_statuses'].append('unsupported_frame')
+
+
+def _metadata_law5(file_obj, entry):
+    params, _ = _metadata_record(get_tab2_record, file_obj)
+    lidp, ne = _metadata_int(params[2]), _metadata_int(params[5])
+    if ne < 0:
+        raise _MetadataParseError('count_mismatch')
+    entry['lidp'] = lidp
+    if lidp not in (0, 1):
+        entry['semantic_statuses'].append('invalid_combination')
+    for _ in range(ne):
+        items, values = _metadata_record(get_list_record, file_obj)
+        ltp, nw, nl = (_metadata_int(items[2]), _metadata_int(items[4]),
+                       _metadata_int(items[5]))
+        if min(nw, nl) < 0 or len(values) != nw:
+            raise _MetadataParseError('count_mismatch')
+        entry['ltp_values'].append(ltp)
+        if ltp == 1 and lidp in (0, 1):
+            expected = 4*nl + 3 if lidp == 0 else 3*nl + 3
+        elif ltp == 2:
+            expected = nl + 1
+        elif ltp in (12, 14, 15):
+            expected = 2*nl
+        else:
+            expected = None
+        if expected is not None and nw != expected:
+            raise _MetadataParseError('count_mismatch')
+        if ltp not in (1, 2, 12, 14, 15):
+            entry['semantic_statuses'].append('unsupported_ltp')
+
+
+def _metadata_law6(file_obj, entry):
+    apsx, c2, l1, l2, n1, npsx = _metadata_record(
+        get_cont_record, file_obj, parse_failure='invalid_law6_control')
+    try:
+        apsx = float(apsx)
+        c2 = float(c2)
+        controls = (_metadata_int(l1, 'invalid_law6_control'),
+                    _metadata_int(l2, 'invalid_law6_control'),
+                    _metadata_int(n1, 'invalid_law6_control'))
+        npsx = _metadata_int(npsx, 'invalid_law6_control')
+    except _MetadataParseError as exc:
+        raise _MetadataParseError('invalid_law6_control') from exc
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise _MetadataParseError('invalid_law6_control') from exc
+    if (not math.isfinite(apsx) or apsx <= 0.0 or c2 != 0.0 or
+            controls != (0, 0, 0) or not 3 <= npsx <= 2**31 - 1):
+        raise _MetadataParseError('invalid_law6_control')
+    entry['apsx'] = apsx
+    entry['npsx'] = npsx
+
+
+def _metadata_law7(file_obj, entry, lct):
+    params, _ = _metadata_record(get_tab2_record, file_obj)
+    ne = _metadata_int(params[5])
+    if ne < 0:
+        raise _MetadataParseError('count_mismatch')
+    for _ in range(ne):
+        inner, _ = _metadata_record(get_tab2_record, file_obj)
+        nmu = _metadata_int(inner[5])
+        if nmu < 0:
+            raise _MetadataParseError('count_mismatch')
+        for _ in range(nmu):
+            _metadata_record(get_tab1_record, file_obj)
+    if lct != 1:
+        entry['semantic_statuses'].append('unsupported_frame')
+
+
+def _metadata_fission_semantics(mt, jp, entries):
+    """Apply the ENDF-102 MT=18 multiplicity-product sequence constraints."""
+    if jp == 0:
+        if any(entry['law'] < 0 for entry in entries):
+            for entry in entries:
+                entry['semantic_statuses'].append('invalid_combination')
+        return
+    if mt != 18:
+        for entry in entries:
+            entry['semantic_statuses'].append('invalid_combination')
+        return
+    jpp, jpn = divmod(jp, 10)
+    kinds = []
+    for entry in entries:
+        if entry['zap'] == 1:
+            kinds.append('neutron')
+        elif entry['zap'] == 0:
+            kinds.append('photon')
+        else:
+            entry['semantic_statuses'].append('invalid_combination')
+            kinds.append('other')
+    if kinds != sorted(kinds, key=lambda value: value == 'photon') or 'other' in kinds:
+        for entry in entries:
+            entry['semantic_statuses'].append('invalid_combination')
+    for kind, digit, negative in (('neutron', jpn, -5), ('photon', jpp, -15)):
+        subset = [
+            entry for entry, entry_kind in zip(entries, kinds)
+            if entry_kind == kind]
+        if digit == 0:
+            if any(entry['law'] < 0 for entry in subset):
+                for entry in subset:
+                    entry['semantic_statuses'].append('invalid_combination')
+            continue
+        if not subset:
+            for entry in entries:
+                entry['semantic_statuses'].append('invalid_combination')
+            continue
+        if subset[0]['law'] != 0:
+            for entry in subset:
+                entry['semantic_statuses'].append('invalid_combination')
+            continue
+        later = subset[1:]
+        valid = bool(later) and (
+            all(entry['law'] == negative for entry in later) if digit == 1
+            else all(entry['law'] > 0 for entry in later))
+        if not valid:
+            for entry in subset:
+                entry['semantic_statuses'].append('invalid_combination')
+
+
+def _metadata_validate_published(metadata, expected_mt=None):
+    """Validate the closed published object independently of its HDF5 wire."""
+    mt = _metadata_int(metadata.mt, 'invalid_header')
+    jp = _metadata_int(metadata.jp, 'invalid_header')
+    lct = _metadata_int(metadata.lct, 'invalid_header')
+    if not 1 <= mt <= 999 or jp not in _METADATA_JP or lct not in (1, 2, 3, 4):
+        raise ValueError('invalid evaluated product metadata controls')
+    if expected_mt is not None and mt != expected_mt:
+        raise ValueError('evaluated product metadata MT does not match reaction')
+    if jp != 0 and not metadata.entries:
+        raise ValueError('active JP requires an MF=6 product subsection')
+    raw_entries = []
+    for index, entry in enumerate(metadata.entries):
+        controls = (entry.subsection_index, entry.zap, entry.lip, entry.law)
+        if any(_metadata_int(value, 'invalid_header') != value
+               for value in controls):
+            raise ValueError('invalid evaluated product metadata entry control')
+        if entry.subsection_index != index:
+            raise ValueError('non-contiguous evaluated product metadata entries')
+        awp = float(entry.awp)
+        if not math.isfinite(awp) or awp < 0.0:
+            raise ValueError('invalid evaluated product metadata AWP')
+        law = entry.law
+        if law not in (-15, -5, 0, 1, 2, 3, 4, 5, 6, 7):
+            raise ValueError('invalid evaluated product metadata LAW')
+        photon_energy = (mt, entry.zap, law) == (102, 0, 2)
+        expected_awp = ('primary_photon_energy_eV' if photon_energy
+                        else 'mass_ratio')
+        if entry.awp_interpretation != expected_awp:
+            raise ValueError('invalid evaluated product metadata AWP interpretation')
+        if not _metadata_identity_is_valid(
+                entry.zap, entry.lip, entry.identity_status,
+                entry.derived_particle):
+            raise ValueError('invalid evaluated product metadata identity')
+        if entry.semantic_status not in _METADATA_SEMANTIC_STATUS:
+            raise ValueError('invalid evaluated product metadata status')
+        lang = tuple(_metadata_int(value) for value in entry.lang_values)
+        ltp = tuple(_metadata_int(value) for value in entry.ltp_values)
+        statuses = []
+        if lct == 3 and law != 1:
+            statuses.append('invalid_combination')
+        if law == 1:
+            if len(lang) != 1 or ltp or entry.lidp is not None:
+                raise ValueError('invalid LAW=1 metadata selectors')
+            if lang[0] not in (1, 2, 11, 12, 13, 14, 15):
+                statuses.append('unsupported_lang')
+            if lang[0] == 2 and lct != 2:
+                statuses.append('invalid_combination')
+        elif law == 2:
+            if ltp or entry.lidp is not None:
+                raise ValueError('invalid LAW=2 metadata selectors')
+            if any(value not in (0, 12, 14) for value in lang):
+                statuses.append('unsupported_lang')
+            if lct != 2:
+                statuses.append('unsupported_frame')
+        elif law == 5:
+            if lang or entry.lidp is None:
+                raise ValueError('invalid LAW=5 metadata selectors')
+            _metadata_int(entry.lidp)
+            if entry.lidp not in (0, 1):
+                statuses.append('invalid_combination')
+            if any(value not in (1, 2, 12, 14, 15) for value in ltp):
+                statuses.append('unsupported_ltp')
+        elif lang or ltp or entry.lidp is not None:
+            raise ValueError('invalid evaluated product metadata selectors')
+        if law == 7 and lct != 1:
+            statuses.append('unsupported_frame')
+        if law == 6:
+            if entry.apsx is None or entry.npsx is None:
+                raise ValueError('LAW=6 metadata requires APSX and NPSX')
+            if (isinstance(entry.apsx, (bool, np.bool_)) or
+                    not isinstance(entry.apsx, Real)):
+                raise ValueError('invalid LAW=6 metadata APSX')
+            apsx = float(entry.apsx)
+            if (not math.isfinite(apsx) or apsx <= 0.0 or
+                    isinstance(entry.npsx, (bool, np.bool_)) or
+                    not isinstance(entry.npsx, (int, np.integer)) or
+                    not 3 <= entry.npsx <= 2**31 - 1):
+                raise ValueError('invalid LAW=6 metadata controls')
+        elif entry.apsx is not None or entry.npsx is not None:
+            raise ValueError('non-LAW=6 metadata cannot contain APSX or NPSX')
+        raw_entries.append({
+            'zap': entry.zap, 'law': law, 'semantic_statuses': statuses})
+    _metadata_fission_semantics(mt, jp, raw_entries)
+    expected_statuses = tuple(
+        _metadata_status(entry['semantic_statuses']) for entry in raw_entries)
+    if expected_statuses != tuple(
+            entry.semantic_status for entry in metadata.entries):
+        raise ValueError('inconsistent evaluated product metadata semantics')
+    if _metadata_status(expected_statuses) != metadata.section_semantic_status:
+        raise ValueError('invalid evaluated product metadata aggregate status')
+
+
+def get_evaluated_product_metadata(ev, mt):
+    """Read a transport-isolated MF=6 metadata result for one MT.
+
+    The Evaluation section boundary is trusted because Evaluation has removed
+    SEND. All known LAW envelopes are consumed by this reader itself; it never
+    calls a sampled-distribution constructor and never touches ``Product``.
+    Structural completeness is limited to the supported envelopes and declared
+    counts; it is not a full ENDF normalization or conservation audit.
+
+    Parameters
+    ----------
+    ev : openmc.data.endf.Evaluation
+        Evaluation containing the selected MF=6 section text.
+    mt : int
+        Requested ENDF reaction number.
+
+    Returns
+    -------
+    EvaluatedProductMetadataResult
+        Closed direct result. Absent and structurally failed results retain the
+        requested MT but contain null controls and no entries. Only a
+        ``published_structurally_complete`` result exposes attachable
+        :attr:`EvaluatedProductMetadataResult.metadata`.
+
+    """
+    if (6, mt) not in ev.section:
+        return EvaluatedProductMetadataResult(mt=mt, result_status='absent')
+    try:
+        file_obj = StringIO(ev.section[6, mt])
+        head = _metadata_record(get_head_record, file_obj, 'invalid_header')
+        jp, lct, nk = (_metadata_int(head[2], 'invalid_header'),
+                       _metadata_int(head[3], 'invalid_header'),
+                       _metadata_int(head[4], 'invalid_header'))
+        head_n2 = _metadata_int(head[5], 'invalid_header')
+        if (jp not in _METADATA_JP or lct not in (1, 2, 3, 4) or
+                nk < 0 or head_n2 != 0):
+            return EvaluatedProductMetadataResult(
+                mt=mt, result_status='structural_failure',
+                structural_failure='invalid_header')
+        if jp != 0 and nk == 0:
+            return EvaluatedProductMetadataResult(
+                mt=mt, result_status='structural_failure',
+                structural_failure='invalid_header')
+        raw_entries = []
+        for index in range(nk):
+            params, _ = _metadata_record(
+                get_tab1_record, file_obj, eof_failure='premature_end')
+            entry = _metadata_entry(index, params)
+            law = entry['law']
+            if law not in (-15, -5, 0, 1, 2, 3, 4, 5, 6, 7):
+                return EvaluatedProductMetadataResult(
+                    mt=mt, result_status='structural_failure',
+                    structural_failure='unknown_law')
+            if lct == 3 and law != 1:
+                entry['semantic_statuses'].append('invalid_combination')
+            if law == 1:
+                _metadata_law1(file_obj, entry, lct)
+            elif law == 2:
+                _metadata_law2(file_obj, entry, lct)
+            elif law == 5:
+                _metadata_law5(file_obj, entry)
+            elif law == 6:
+                _metadata_law6(file_obj, entry)
+            elif law == 7:
+                _metadata_law7(file_obj, entry, lct)
+            raw_entries.append(entry)
+        if file_obj.read().strip():
+            return EvaluatedProductMetadataResult(
+                mt=mt, result_status='structural_failure',
+                structural_failure='trailing_record')
+        _metadata_fission_semantics(mt, jp, raw_entries)
+        entries = []
+        for entry in raw_entries:
+            law = entry['law']
+            interpretation = ('primary_photon_energy_eV'
+                              if (mt, entry['zap'], law) == (102, 0, 2)
+                              else 'mass_ratio')
+            entries.append(EvaluatedProductMetadataEntry(
+                entry['subsection_index'], entry['zap'], entry['awp'],
+                interpretation, entry['lip'], law, tuple(entry['lang_values']),
+                entry['lidp'], tuple(entry['ltp_values']),
+                _metadata_status(entry['semantic_statuses']),
+                entry['identity_status'], entry['derived_particle'],
+                entry['apsx'], entry['npsx']))
+        metadata = EvaluatedProductMetadata(
+            mt, jp, lct,
+            _metadata_status([entry.semantic_status for entry in entries]),
+            tuple(entries))
+        _metadata_validate_published(metadata)
+        return EvaluatedProductMetadataResult(
+            mt=mt, result_status=_METADATA_RESULT, jp=jp, lct=lct,
+            section_semantic_status=metadata.section_semantic_status,
+            hdf5_group_version=1, entries=metadata.entries)
+    except _MetadataParseError as exc:
+        return EvaluatedProductMetadataResult(
+            mt=mt, result_status='structural_failure',
+            structural_failure=exc.reason)
+    except (EOFError, IndexError, OSError, ValueError, TypeError):
+        return EvaluatedProductMetadataResult(
+            mt=mt, result_status='structural_failure',
+            structural_failure='unproven_cursor')
+
+
+def _metadata_text(value):
+    """Return a UTF-8 HDF5 attribute as text."""
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+    if not isinstance(value, str):
+        raise ValueError('invalid evaluated product metadata UTF-8 scalar')
+    return value
+
+
+def _metadata_hdf5_scalar(group, name, dtype):
+    """Return a scalar with the required HDF5 kind and width."""
+    value = group.attrs[name]
+    actual = group.attrs.get_id(name).dtype
+    expected = np.dtype(dtype)
+    if (np.asarray(value).shape != () or actual.kind != expected.kind or
+            actual.itemsize != expected.itemsize):
+        raise ValueError('invalid evaluated product metadata scalar dtype')
+    return value
+
+
+def _metadata_hdf5_text(group, name):
+    """Return a scalar variable-length UTF-8 HDF5 attribute."""
+    value = group.attrs[name]
+    dtype = group.attrs.get_id(name).dtype
+    info = h5py.check_string_dtype(dtype)
+    if (np.asarray(value).shape != () or info is None or
+            info.encoding != 'utf-8' or info.length is not None):
+        raise ValueError('invalid evaluated product metadata string dtype')
+    return _metadata_text(value)
+
+
+def _metadata_to_hdf5(metadata, group, expected_mt):
+    """Write the closed metadata wire representation below a reaction group."""
+    _metadata_validate_published(metadata, expected_mt)
+    metadata_group = group.create_group('evaluated_product_metadata')
+    metadata_group.attrs.create('version', np.int32(1), dtype=np.int32)
+    metadata_group.attrs.create('schema', _METADATA_SCHEMA,
+                                dtype=_METADATA_UTF8)
+    metadata_group.attrs.create('source_format', 'ENDF-6',
+                                dtype=_METADATA_UTF8)
+    metadata_group.attrs.create('result_status', _METADATA_RESULT,
+                                dtype=_METADATA_UTF8)
+    metadata_group.attrs.create('mf', np.int32(6), dtype=np.int32)
+    metadata_group.attrs.create('mt', np.int32(metadata.mt), dtype=np.int32)
+    metadata_group.attrs.create('jp', np.int32(metadata.jp), dtype=np.int32)
+    metadata_group.attrs.create('lct', np.int32(metadata.lct), dtype=np.int32)
+    metadata_group.attrs.create(
+        'section_semantic_status', metadata.section_semantic_status,
+        dtype=_METADATA_UTF8)
+    for index, entry in enumerate(metadata.entries):
+        entry_group = metadata_group.create_group(f'entry_{index}')
+        entry_group.attrs.create(
+            'subsection_index', np.int32(entry.subsection_index),
+            dtype=np.int32)
+        entry_group.attrs.create('zap', np.int32(entry.zap), dtype=np.int32)
+        entry_group.attrs.create('awp', np.float64(entry.awp),
+                                 dtype=np.float64)
+        entry_group.attrs.create(
+            'awp_interpretation', entry.awp_interpretation,
+            dtype=_METADATA_UTF8)
+        entry_group.attrs.create('lip', np.int32(entry.lip), dtype=np.int32)
+        entry_group.attrs.create('law', np.int32(entry.law), dtype=np.int32)
+        entry_group.attrs.create(
+            'lidp', np.int32(-1 if entry.lidp is None else entry.lidp),
+            dtype=np.int32)
+        entry_group.attrs.create(
+            'semantic_status', entry.semantic_status, dtype=_METADATA_UTF8)
+        entry_group.attrs.create(
+            'identity_status', entry.identity_status, dtype=_METADATA_UTF8)
+        entry_group.attrs.create(
+            'derived_particle', entry.derived_particle or '',
+            dtype=_METADATA_UTF8)
+        if entry.law == 6:
+            entry_group.attrs.create('apsx', np.float64(entry.apsx),
+                                     dtype=np.float64)
+            entry_group.attrs.create('npsx', np.int32(entry.npsx),
+                                     dtype=np.int32)
+        entry_group.create_dataset(
+            'lang_values', data=np.asarray(entry.lang_values, dtype=np.int32),
+            dtype=np.int32)
+        entry_group.create_dataset(
+            'ltp_values', data=np.asarray(entry.ltp_values, dtype=np.int32),
+            dtype=np.int32)
+
+
+def _metadata_from_hdf5(group, mt):
+    """Read and validate the closed metadata wire representation."""
+    required = {'version', 'schema', 'source_format', 'result_status', 'mf',
+                'mt', 'jp', 'lct', 'section_semantic_status'}
+    if set(group.attrs) != required:
+        raise ValueError('invalid evaluated product metadata group attributes')
+    if _metadata_int(_metadata_hdf5_scalar(
+            group, 'version', np.int32)) != 1:
+        raise ValueError('invalid evaluated product metadata group version')
+    if (_metadata_hdf5_text(group, 'schema') != _METADATA_SCHEMA or
+            _metadata_hdf5_text(group, 'source_format') != 'ENDF-6' or
+            _metadata_hdf5_text(group, 'result_status') != _METADATA_RESULT or
+            _metadata_int(_metadata_hdf5_scalar(group, 'mf', np.int32)) != 6 or
+            _metadata_int(_metadata_hdf5_scalar(
+                group, 'mt', np.int32)) != mt):
+        raise ValueError('invalid evaluated product metadata group identity')
+    jp = _metadata_int(_metadata_hdf5_scalar(group, 'jp', np.int32))
+    lct = _metadata_int(_metadata_hdf5_scalar(group, 'lct', np.int32))
+    if jp not in _METADATA_JP or lct not in (1, 2, 3, 4):
+        raise ValueError('invalid evaluated product metadata controls')
+    section_status = _metadata_hdf5_text(
+        group, 'section_semantic_status')
+    if section_status not in _METADATA_SEMANTIC_STATUS:
+        raise ValueError('invalid evaluated product metadata status')
+    names = sorted(
+        group,
+        key=lambda name: int(name[6:])
+        if name.startswith('entry_') and name[6:].isdigit() else -1)
+    if names != [f'entry_{i}' for i in range(len(names))]:
+        raise ValueError('non-contiguous evaluated product metadata entries')
+    entries = []
+    entry_attrs = {'subsection_index', 'zap', 'awp', 'awp_interpretation', 'lip',
+                   'law', 'lidp', 'semantic_status', 'identity_status',
+                   'derived_particle'}
+    for index, name in enumerate(names):
+        entry_group = group[name]
+        if (not isinstance(entry_group, h5py.Group) or
+                not entry_attrs <= set(entry_group.attrs) or
+                set(entry_group) != {'lang_values', 'ltp_values'}):
+            raise ValueError('invalid evaluated product metadata entry')
+        subsection_index = _metadata_int(_metadata_hdf5_scalar(
+            entry_group, 'subsection_index', np.int32))
+        zap = _metadata_int(_metadata_hdf5_scalar(
+            entry_group, 'zap', np.int32))
+        lip = _metadata_int(_metadata_hdf5_scalar(
+            entry_group, 'lip', np.int32))
+        law = _metadata_int(_metadata_hdf5_scalar(
+            entry_group, 'law', np.int32))
+        expected_attrs = entry_attrs | ({'apsx', 'npsx'} if law == 6 else set())
+        if set(entry_group.attrs) != expected_attrs:
+            raise ValueError('invalid evaluated product metadata entry')
+        lidp = _metadata_int(_metadata_hdf5_scalar(
+            entry_group, 'lidp', np.int32))
+        awp = float(_metadata_hdf5_scalar(
+            entry_group, 'awp', np.float64))
+        if subsection_index != index or not math.isfinite(awp) or awp < 0.0:
+            raise ValueError('invalid evaluated product metadata scalar')
+        if law not in (-15, -5, 0, 1, 2, 3, 4, 5, 6, 7):
+            raise ValueError('invalid evaluated product metadata LAW')
+        if law == 6:
+            apsx = float(_metadata_hdf5_scalar(
+                entry_group, 'apsx', np.float64))
+            npsx = _metadata_int(_metadata_hdf5_scalar(
+                entry_group, 'npsx', np.int32))
+            if (not math.isfinite(apsx) or apsx <= 0.0 or
+                    not 3 <= npsx <= 2**31 - 1):
+                raise ValueError('invalid LAW=6 metadata controls')
+        else:
+            apsx = None
+            npsx = None
+        interpretation = _metadata_hdf5_text(
+            entry_group, 'awp_interpretation')
+        photon_energy = (mt, zap, law) == (102, 0, 2)
+        expected_interpretation = (
+            'primary_photon_energy_eV' if photon_energy else 'mass_ratio')
+        if interpretation != expected_interpretation:
+            raise ValueError('invalid evaluated product metadata AWP interpretation')
+        lang_dset = entry_group['lang_values']
+        ltp_dset = entry_group['ltp_values']
+        if (not isinstance(lang_dset, h5py.Dataset) or
+                not isinstance(ltp_dset, h5py.Dataset) or
+                lang_dset.ndim != 1 or ltp_dset.ndim != 1 or
+                lang_dset.dtype.kind != np.dtype(np.int32).kind or
+                ltp_dset.dtype.kind != np.dtype(np.int32).kind or
+                lang_dset.dtype.itemsize != np.dtype(np.int32).itemsize or
+                ltp_dset.dtype.itemsize != np.dtype(np.int32).itemsize):
+            raise ValueError('invalid evaluated product metadata selector dtype')
+        lang = tuple(int(value) for value in lang_dset[()])
+        ltp = tuple(int(value) for value in ltp_dset[()])
+        status = _metadata_hdf5_text(entry_group, 'semantic_status')
+        identity = _metadata_hdf5_text(entry_group, 'identity_status')
+        derived = _metadata_hdf5_text(
+            entry_group, 'derived_particle') or None
+        identities = ('raw_only', 'special_particle',
+                      'ground_state_nuclide')
+        if status not in _METADATA_SEMANTIC_STATUS or identity not in identities:
+            raise ValueError('invalid evaluated product metadata entry status')
+        if law == 1 and (len(lang) != 1 or ltp or lidp != -1):
+            raise ValueError('invalid LAW=1 metadata selectors')
+        if law == 2 and (ltp or lidp != -1):
+            raise ValueError('invalid LAW=2 metadata selectors')
+        if law == 5 and (lang or lidp < 0):
+            raise ValueError('invalid LAW=5 metadata selectors')
+        if law not in (1, 2, 5) and (lang or ltp or lidp != -1):
+            raise ValueError('invalid metadata selectors')
+        if not _metadata_identity_is_valid(zap, lip, identity, derived):
+            raise ValueError('invalid evaluated product metadata identity')
+        entries.append(EvaluatedProductMetadataEntry(
+            subsection_index, zap, awp, interpretation, lip, law, lang,
+            None if lidp == -1 else lidp, ltp, status, identity, derived,
+            apsx, npsx))
+    metadata = EvaluatedProductMetadata(
+        mt, jp, lct, section_status, tuple(entries))
+    _metadata_validate_published(metadata)
+    return metadata
 
 
 def _get_products(ev, mt):
@@ -852,6 +1641,7 @@ class Reaction(EqualityMixin):
         self._xs = {}
         self._products = []
         self._derived_products = []
+        self.evaluated_product_metadata = None
 
         self.mt = mt
 
@@ -946,6 +1736,9 @@ class Reaction(EqualityMixin):
         for i, p in enumerate(self.products):
             pgroup = group.create_group(f'product_{i}')
             p.to_hdf5(pgroup)
+        if self.evaluated_product_metadata is not None:
+            _metadata_to_hdf5(
+                self.evaluated_product_metadata, group, self.mt)
 
     @classmethod
     def from_hdf5(cls, group, energy):
@@ -998,6 +1791,10 @@ class Reaction(EqualityMixin):
         for i in range(n_product):
             pgroup = group[f'product_{i}']
             rx.products.append(Product.from_hdf5(pgroup))
+
+        if 'evaluated_product_metadata' in group:
+            rx.evaluated_product_metadata = _metadata_from_hdf5(
+                group['evaluated_product_metadata'], mt)
 
         return rx
 

--- a/tests/unit_tests/test_data_neutron.py
+++ b/tests/unit_tests/test_data_neutron.py
@@ -1,10 +1,13 @@
 from collections.abc import Mapping, Callable
+import inspect
 import os
 
 import numpy as np
 import pandas as pd
 import pytest
+import h5py
 import openmc.data
+import openmc.data.neutron as neutron_module
 
 from . import needs_njoy
 
@@ -525,3 +528,757 @@ def test_high_temperature(endf_data):
 
     # Ensure that from_njoy works when given a high temperature
     openmc.data.IncidentNeutron.from_njoy(endf_file, temperatures=[123_456.0])
+
+
+class _MetadataEvaluation:
+    def __init__(self, text, mt=51):
+        self.section = {(6, mt): text}
+
+
+def _endf_record(c1=0.0, c2=0.0, l1=0, l2=0, n1=0, n2=0):
+    """Minimal fixed-width ENDF record for direct MF=6 parser tests."""
+    return (f'{c1:11.5E}{c2:11.5E}{l1:11d}{l2:11d}'
+            f'{n1:11d}{n2:11d}\n')
+
+
+def _endf_values(*values):
+    """One or more 66-column ENDF floating-point payload records."""
+    records = []
+    for start in range(0, len(values), 6):
+        fields = ''.join(f'{value:11.5E}' for value in values[start:start + 6])
+        records.append(f'{fields:66s}\n')
+    return ''.join(records)
+
+
+def _endf_integers(*values):
+    fields = ''.join(f'{value:11d}' for value in values)
+    return f'{fields:66s}\n'
+
+
+def _metadata_tab1(zap, awp, lip, law):
+    return (_endf_record(zap, awp, lip, law, 1, 2) +
+            _endf_integers(2, 2) +
+            _endf_values(0.0, 0.0, 20.0e6, 1.0))
+
+
+def _metadata_tab2(l1=0, n2=0):
+    return (_endf_record(0.0, 0.0, l1, 0, 1, n2) +
+            _endf_integers(n2, 2))
+
+
+def _metadata_list(l1, l2, n1, n2):
+    return (_endf_record(0.0, 0.0, l1, l2, n1, n2) +
+            _endf_values(*range(n1)))
+
+
+def _metadata_section(mt, lct, entries, jp=0, trailing=''):
+    text = _endf_record(26056.0, 55.0, jp, lct, len(entries), 0)
+    for zap, awp, lip, law, payload in entries:
+        text += _metadata_tab1(zap, awp, lip, law) + payload
+    return _MetadataEvaluation(text + trailing, mt)
+
+
+def _law1(lang, lists):
+    payload = _metadata_tab2(lang, len(lists))
+    for nep, na, nd, nw in lists:
+        payload += _metadata_list(nd, na, nw, nep)
+    return payload
+
+
+def _law2(lists):
+    payload = _metadata_tab2(0, len(lists))
+    for lang, nl, nw in lists:
+        payload += _metadata_list(lang, 0, nw, nl)
+    return payload
+
+
+def _law5(lidp, lists):
+    payload = _metadata_tab2(lidp, len(lists))
+    for ltp, nl, nw in lists:
+        payload += _metadata_list(ltp, 0, nw, nl)
+    return payload
+
+
+def _law6(apsx=4.0, c2=0.0, l1=0, l2=0, n1=0, npsx=3):
+    npsx_field = (f'{npsx:11d}' if isinstance(npsx, int)
+                  else f'{npsx:>11}')
+    return (f'{apsx:11.5E}{c2:11.5E}{l1:11d}{l2:11d}'
+            f'{n1:11d}{npsx_field}\n')
+
+
+def _law7(nmu_values):
+    payload = _metadata_tab2(0, len(nmu_values))
+    for nmu in nmu_values:
+        payload += _metadata_tab2(0, nmu)
+        payload += _metadata_tab1(0, 0.0, 0, 0) * nmu
+    return payload
+
+
+def _matrix_cases():
+    law1 = (1, 1.0, 0, 1,
+            _law1(2, [(3, 1, 0, 9), (2, 2, 2, 8)]))
+    law1_bad = (1, 1.0, 0, 1, _law1(1, [(2, 0, 0, 3)]))
+    law1_even = (1, 1.0, 0, 1, _law1(12, [(2, 2, 1, 8)]))
+    law2 = (1, 1.0, 0, 2, _law2([(0, 3, 3), (14, 2, 4)]))
+    capture = (0, 6129000.0, 0, 2, _law2([(0, 1, 1)]))
+    law5 = (1001, 1.0, 0, 5,
+            _law5(1, [(1, 2, 9), (2, 2, 3), (15, 2, 4)]))
+    law6 = (1, 1.0, 0, 6, _law6())
+    law7 = (1, 1.0, 0, 7, _law7([0, 2]))
+    fission_negative = [
+        (1, 1.0, 0, 0, ''), (1, 1.0, 0, -5, ''),
+        (0, 0.0, 0, 0, ''), (0, 0.0, 0, -15, '')]
+    fission_positive = [
+        (1, 1.0, 0, 0, ''), (1, 1.0, 0, 3, ''),
+        (0, 0.0, 0, 0, ''), (0, 0.0, 0, 4, '')]
+    return [
+        ('law1_exact_counts', _metadata_section(51, 3, [law1]),
+         'published_structurally_complete'),
+        ('law1_bad_nw', _metadata_section(51, 1, [law1_bad]),
+         'count_mismatch'),
+        ('law1_tabulated_even_na', _metadata_section(51, 1, [law1_even]),
+         'published_structurally_complete'),
+        ('law2_cm_and_counts', _metadata_section(51, 2, [law2]),
+         'published_structurally_complete'),
+        ('law2_capture_photon_awp_ev', _metadata_section(102, 2, [capture]),
+         'published_structurally_complete'),
+        ('law5_exact_lidp_counts', _metadata_section(51, 1, [law5]),
+         'published_structurally_complete'),
+        ('law6_controls', _metadata_section(51, 1, [law6]),
+         'published_structurally_complete'),
+        ('law7_nested_counts', _metadata_section(51, 1, [law7]),
+         'published_structurally_complete'),
+        ('law0_zero_payload', _metadata_section(
+            51, 1, [(1, 1.0, 0, 0, '')]),
+         'published_structurally_complete'),
+        ('law3_zero_payload', _metadata_section(
+            51, 1, [(1, 1.0, 0, 3, '')]),
+         'published_structurally_complete'),
+        ('law4_zero_payload', _metadata_section(
+            51, 1, [(1, 1.0, 0, 4, '')]),
+         'published_structurally_complete'),
+        ('negative_law_fission_order', _metadata_section(
+            18, 1, fission_negative, jp=11),
+         'published_structurally_complete'),
+        ('jp2_positive_law_sequence', _metadata_section(
+            18, 1, fission_positive, jp=22),
+         'published_structurally_complete'),
+        ('unknown_law_never_publishes', _metadata_section(
+            51, 1, [(1, 1.0, 0, 99, '')]), 'unknown_law'),
+        ('trailing_record_never_publishes', _metadata_section(
+            51, 1, [(1, 1.0, 0, 0, '')], trailing='unexpected'),
+         'trailing_record'),
+    ]
+
+
+@pytest.mark.parametrize('name,evaluation,expected', _matrix_cases(),
+                         ids=[case[0] for case in _matrix_cases()])
+def test_evaluated_product_metadata_matrix(name, evaluation, expected):
+    mt = next(mt for mf, mt in evaluation.section if mf == 6)
+    result = openmc.data.get_evaluated_product_metadata(evaluation, mt)
+    if expected == 'published_structurally_complete':
+        assert result.result_status == expected
+        assert result.structural_failure is None
+        assert result.metadata is not None
+        assert result.hdf5_group_version == 1
+        assert result.entries == result.metadata.entries
+        assert (result.jp, result.lct, result.section_semantic_status) == (
+            result.metadata.jp, result.metadata.lct,
+            result.metadata.section_semantic_status)
+        if name == 'law2_capture_photon_awp_ev':
+            entry = result.metadata.entries[0]
+            assert entry.awp == 6129000.0
+            assert entry.awp_interpretation == 'primary_photon_energy_eV'
+        elif name == 'law5_exact_lidp_counts':
+            entry = result.metadata.entries[0]
+            assert (entry.identity_status, entry.derived_particle) == (
+                'raw_only', None)
+            assert entry.ltp_values == (1, 2, 15)
+        elif name == 'law6_controls':
+            entry = result.metadata.entries[0]
+            assert (entry.apsx, entry.npsx) == (4.0, 3)
+        elif name == 'negative_law_fission_order':
+            assert tuple(entry.law for entry in result.metadata.entries) == (
+                0, -5, 0, -15)
+    else:
+        assert result.result_status == 'structural_failure'
+        assert result.structural_failure == expected
+        assert result.metadata is None
+        assert (result.jp, result.lct, result.section_semantic_status,
+                result.hdf5_group_version, result.entries) == (
+            None, None, None, None, ())
+
+
+def test_evaluated_product_metadata_direct_parser():
+    law0 = _metadata_section(51, 1, [(1, 1.0, 0, 0, '')])
+    result = openmc.data.get_evaluated_product_metadata(law0, 51)
+    assert result.result_status == 'published_structurally_complete'
+    assert result.metadata.entries[0].subsection_index == 0
+    assert result.metadata.entries[0].derived_particle == 'neutron'
+    assert result.metadata.entries[0].law == 0
+    assert (result.metadata.entries[0].apsx,
+            result.metadata.entries[0].npsx) == (None, None)
+
+    with pytest.raises(ValueError):
+        openmc.data.EvaluatedProductMetadataEntry(
+            0, 1, 1.0, 'mass_ratio', 0, 6, (), None, (), 'complete',
+            'special_particle', 'neutron')
+    for invalid_apsx in (True, '4.0'):
+        with pytest.raises(ValueError):
+            openmc.data.EvaluatedProductMetadataEntry(
+                0, 1, 1.0, 'mass_ratio', 0, 6, (), None, (), 'complete',
+                'special_particle', 'neutron', invalid_apsx, 3)
+    with pytest.raises(ValueError):
+        openmc.data.EvaluatedProductMetadataEntry(
+            0, 1, 1.0, 'mass_ratio', 0, 0, (), None, (), 'complete',
+            'special_particle', 'neutron', 4.0, 3)
+
+    absent = openmc.data.get_evaluated_product_metadata(
+        _MetadataEvaluation('', 52), 51)
+    assert absent == openmc.data.EvaluatedProductMetadataResult(51, 'absent')
+    assert (absent.schema, absent.source_format, absent.mf, absent.mt) == (
+        'openmc-evaluated-product-metadata/v2', 'ENDF-6', 6, 51)
+    assert (absent.jp, absent.lct, absent.section_semantic_status,
+            absent.hdf5_group_version, absent.entries) == (
+        None, None, None, None, ())
+
+    premature = _MetadataEvaluation(
+        _endf_record(26056.0, 55.0, 0, 1, 1, 0))
+    result = openmc.data.get_evaluated_product_metadata(premature, 51)
+    assert result.structural_failure == 'premature_end'
+
+    empty_active = _MetadataEvaluation(
+        _endf_record(26056.0, 55.0, 1, 1, 0, 0), 18)
+    result = openmc.data.get_evaluated_product_metadata(empty_active, 18)
+    assert result.result_status == 'structural_failure'
+    assert result.structural_failure == 'invalid_header'
+
+    nonzero_head_n2 = _MetadataEvaluation(
+        _endf_record(26056.0, 55.0, 0, 1, 0, 1))
+    result = openmc.data.get_evaluated_product_metadata(nonzero_head_n2, 51)
+    assert result.structural_failure == 'invalid_header'
+
+
+def test_evaluated_product_metadata_semantic_refusals():
+    invalid_lidp = _metadata_section(51, 1, [
+        (1001, 1.0, 0, 5, _law5(2, [(1, 2, 1)]))])
+    result = openmc.data.get_evaluated_product_metadata(invalid_lidp, 51)
+    entry = result.metadata.entries[0]
+    assert entry.identity_status == 'raw_only'
+    assert entry.derived_particle is None
+    assert entry.semantic_status == 'invalid_combination'
+
+    unsupported = _metadata_section(51, 1, [
+        (1, 1.0, 0, 1, _law1(999, [(1, 0, 0, 2)]))])
+    result = openmc.data.get_evaluated_product_metadata(unsupported, 51)
+    assert result.metadata.section_semantic_status == 'unsupported_lang'
+
+    inactive_negative = _metadata_section(
+        18, 1, [(1, 1.0, 0, -5, '')], jp=0)
+    result = openmc.data.get_evaluated_product_metadata(inactive_negative, 18)
+    assert result.metadata.section_semantic_status == 'invalid_combination'
+
+    chance_fission = _metadata_section(19, 1, [
+        (1, 1.0, 0, 0, ''), (1, 1.0, 0, -5, '')], jp=1)
+    result = openmc.data.get_evaluated_product_metadata(chance_fission, 19)
+    assert result.metadata.section_semantic_status == 'invalid_combination'
+
+    crossed_neutron = _metadata_section(18, 1, [
+        (1, 1.0, 0, -15, ''),
+        (0, 0.0, 0, 0, ''), (0, 0.0, 0, -15, '')], jp=10)
+    result = openmc.data.get_evaluated_product_metadata(crossed_neutron, 18)
+    assert result.metadata.section_semantic_status == 'invalid_combination'
+
+    crossed_photon = _metadata_section(18, 1, [
+        (1, 1.0, 0, 0, ''), (1, 1.0, 0, -5, ''),
+        (0, 0.0, 0, -5, '')], jp=1)
+    result = openmc.data.get_evaluated_product_metadata(crossed_photon, 18)
+    assert result.metadata.section_semantic_status == 'invalid_combination'
+
+    bad_tabulated_na = _metadata_section(51, 1, [
+        (1, 1.0, 0, 1, _law1(12, [(1, 0, 0, 2)]))])
+    result = openmc.data.get_evaluated_product_metadata(bad_tabulated_na, 51)
+    assert result.structural_failure == 'count_mismatch'
+
+
+@pytest.mark.parametrize('lang,na,expected', [
+    (1, 0, 'complete'),
+    (2, 0, 'complete'),
+    (2, 1, 'complete'),
+    (2, 2, 'complete'),
+    (11, 2, 'complete'),
+    (12, 2, 'complete'),
+    (13, 2, 'complete'),
+    (14, 2, 'complete'),
+    (15, 2, 'complete'),
+    (999, 0, 'unsupported_lang'),
+])
+def test_evaluated_product_metadata_law1_selectors(lang, na, expected):
+    nw = na + 2
+    evaluation = _metadata_section(51, 2 if lang == 2 else 1, [
+        (1, 1.0, 0, 1, _law1(lang, [(1, na, 0, nw)]))])
+    result = openmc.data.get_evaluated_product_metadata(evaluation, 51)
+    assert result.result_status == 'published_structurally_complete'
+    assert result.entries[0].semantic_status == expected
+
+
+@pytest.mark.parametrize('lct,expected', [
+    (1, 'invalid_combination'),
+    (2, 'complete'),
+    (3, 'invalid_combination'),
+    (4, 'invalid_combination'),
+])
+def test_evaluated_product_metadata_law1_lang2_lct_semantics(lct, expected):
+    evaluation = _metadata_section(51, lct, [
+        (1, 1.0, 0, 1, _law1(2, [(1, 0, 0, 2)]))])
+    result = openmc.data.get_evaluated_product_metadata(evaluation, 51)
+
+    assert result.result_status == 'published_structurally_complete'
+    assert result.metadata is not None
+    assert result.entries[0].semantic_status == expected
+    assert result.section_semantic_status == expected
+
+
+@pytest.mark.parametrize('lang,nl,nw,expected', [
+    (0, 1, 1, 'complete'),
+    (12, 2, 4, 'complete'),
+    (14, 2, 4, 'complete'),
+    (999, 0, 0, 'unsupported_lang'),
+])
+def test_evaluated_product_metadata_law2_selectors(lang, nl, nw, expected):
+    evaluation = _metadata_section(51, 2, [
+        (1, 1.0, 0, 2, _law2([(lang, nl, nw)]))])
+    result = openmc.data.get_evaluated_product_metadata(evaluation, 51)
+    assert result.result_status == 'published_structurally_complete'
+    assert result.entries[0].semantic_status == expected
+
+
+@pytest.mark.parametrize('lidp,ltp,nl,nw,expected', [
+    (0, 1, 1, 7, 'complete'),
+    (1, 1, 1, 6, 'complete'),
+    (0, 2, 1, 2, 'complete'),
+    (0, 12, 1, 2, 'complete'),
+    (0, 14, 1, 2, 'complete'),
+    (0, 15, 1, 2, 'complete'),
+    (0, 99, 0, 0, 'unsupported_ltp'),
+    (2, 1, 1, 1, 'invalid_combination'),
+])
+def test_evaluated_product_metadata_law5_selectors(
+        lidp, ltp, nl, nw, expected):
+    evaluation = _metadata_section(51, 1, [
+        (1001, 1.0, 0, 5, _law5(lidp, [(ltp, nl, nw)]))])
+    result = openmc.data.get_evaluated_product_metadata(evaluation, 51)
+    assert result.result_status == 'published_structurally_complete'
+    assert result.entries[0].semantic_status == expected
+
+
+def test_evaluated_product_metadata_law_envelope_mutations():
+    missing_law6 = _metadata_section(51, 1, [(1, 1.0, 0, 6, '')])
+    result = openmc.data.get_evaluated_product_metadata(missing_law6, 51)
+    assert result.structural_failure == 'truncated_record'
+
+    extra_law6 = _metadata_section(51, 1, [
+        (1, 1.0, 0, 6, _law6())],
+        trailing=_endf_record())
+    result = openmc.data.get_evaluated_product_metadata(extra_law6, 51)
+    assert result.structural_failure == 'trailing_record'
+
+    for nmu_values in ([], [1], [0, 1, 2]):
+        law7 = _metadata_section(51, 1, [
+            (1, 1.0, 0, 7, _law7(nmu_values))])
+        result = openmc.data.get_evaluated_product_metadata(law7, 51)
+        assert result.result_status == 'published_structurally_complete'
+
+    truncated_law7 = _metadata_section(51, 1, [
+        (1, 1.0, 0, 7, _metadata_tab2(0, 1) + _metadata_tab2(0, 1))])
+    result = openmc.data.get_evaluated_product_metadata(truncated_law7, 51)
+    assert result.structural_failure == 'truncated_record'
+
+    bad_law5 = _metadata_section(51, 1, [
+        (1001, 1.0, 0, 5, _law5(0, [(12, 1, 1)]))])
+    result = openmc.data.get_evaluated_product_metadata(bad_law5, 51)
+    assert result.structural_failure == 'count_mismatch'
+
+
+@pytest.mark.parametrize('payload', [
+    _law6(0.0),
+    _law6(float('nan')),
+    _law6(4.0, c2=1.0),
+    _law6(4.0, l1=1),
+    _law6(4.0, l2=1),
+    _law6(4.0, n1=1),
+    _law6(4.0, npsx='3.5'),
+    _law6(4.0, npsx=2),
+    _law6(4.0, npsx=2**31),
+], ids=[
+    'nonpositive_apsx', 'nonfinite_apsx', 'reserved_c2', 'reserved_l1',
+    'reserved_l2', 'reserved_n1', 'nonintegral_npsx', 'small_npsx',
+    'unrepresentable_npsx',
+])
+def test_evaluated_product_metadata_law6_invalid_controls_are_atomic(payload):
+    evaluation = _metadata_section(51, 1, [(1, 1.0, 0, 6, payload)])
+    result = openmc.data.get_evaluated_product_metadata(evaluation, 51)
+
+    assert result.result_status == 'structural_failure'
+    assert result.structural_failure == 'invalid_law6_control'
+    assert result.metadata is None
+    assert result.entries == ()
+
+
+def test_evaluated_product_metadata_law6_truncated_control_is_atomic():
+    evaluation = _metadata_section(51, 1, [
+        (1, 1.0, 0, 6, _law6()[:65])])
+    result = openmc.data.get_evaluated_product_metadata(evaluation, 51)
+
+    assert result.result_status == 'structural_failure'
+    assert result.structural_failure == 'truncated_record'
+    assert result.metadata is None
+    assert result.entries == ()
+
+
+def test_evaluated_product_metadata_boundaries_and_atomicity():
+    lct4 = _metadata_section(51, 4, [(1, 1.0, 0, 0, '')])
+    result = openmc.data.get_evaluated_product_metadata(lct4, 51)
+    assert result.section_semantic_status == 'complete'
+
+    lct3_nonlaw1 = _metadata_section(51, 3, [(1, 1.0, 0, 0, '')])
+    result = openmc.data.get_evaluated_product_metadata(lct3_nonlaw1, 51)
+    assert result.section_semantic_status == 'invalid_combination'
+
+    unknown_lct = _MetadataEvaluation(
+        _endf_record(26056.0, 55.0, 0, 5, 0, 0))
+    result = openmc.data.get_evaluated_product_metadata(unknown_lct, 51)
+    assert result.structural_failure == 'invalid_header'
+
+    truncated_tab1 = _MetadataEvaluation(
+        _endf_record(26056.0, 55.0, 0, 1, 1, 0) +
+        _endf_record(1.0, 1.0, 0, 0, 1, 2))
+    result = openmc.data.get_evaluated_product_metadata(truncated_tab1, 51)
+    assert result.structural_failure == 'truncated_record'
+    assert result.entries == ()
+
+    truncated_list = _metadata_section(51, 1, [
+        (1, 1.0, 0, 1,
+         _metadata_tab2(1, 1) + _endf_record(0.0, 0.0, 0, 0, 2, 1))])
+    result = openmc.data.get_evaluated_product_metadata(truncated_list, 51)
+    assert result.structural_failure == 'truncated_record'
+    assert result.entries == ()
+
+    corrupt_list_length = _metadata_section(51, 1, [
+        (1, 1.0, 0, 1,
+         _metadata_tab2(1, 1) + _endf_record(0.0, 0.0, 0, 0, -1, 1))])
+    result = openmc.data.get_evaluated_product_metadata(
+        corrupt_list_length, 51)
+    assert result.structural_failure == 'count_mismatch'
+    assert result.entries == ()
+
+    nk_over = _MetadataEvaluation(
+        _endf_record(26056.0, 55.0, 0, 1, 2, 0) +
+        _metadata_tab1(1, 1.0, 0, 0))
+    result = openmc.data.get_evaluated_product_metadata(nk_over, 51)
+    assert result.structural_failure == 'premature_end'
+
+    nk_under = _MetadataEvaluation(
+        _endf_record(26056.0, 55.0, 0, 1, 0, 0) +
+        _metadata_tab1(1, 1.0, 0, 0))
+    result = openmc.data.get_evaluated_product_metadata(nk_under, 51)
+    assert result.structural_failure == 'trailing_record'
+
+
+def test_evaluated_product_metadata_hdf5(tmp_path):
+    entry = openmc.data.EvaluatedProductMetadataEntry(
+        0, 0, 6129000.0, 'primary_photon_energy_eV', 0, 2, (0,), None,
+        (), 'complete', 'special_particle', 'photon')
+    metadata = openmc.data.EvaluatedProductMetadata(
+        102, 0, 2, 'complete', (entry,))
+    reaction = openmc.data.Reaction(102)
+    transport_product = openmc.data.Product('neutron')
+    reaction.products = [transport_product]
+    reaction.evaluated_product_metadata = metadata
+    filename = tmp_path / 'metadata.h5'
+    with h5py.File(filename, 'w') as h5file:
+        group = h5file.create_group('reaction_102')
+        reaction.to_hdf5(group)
+        metadata_group = group['evaluated_product_metadata']
+        assert metadata_group.attrs['version'] == 1
+        assert metadata_group.attrs['schema'] == (
+            'openmc-evaluated-product-metadata/v2')
+        assert metadata_group.attrs['result_status'] == (
+            'published_structurally_complete')
+        assert h5py.check_string_dtype(
+            metadata_group.attrs.get_id('schema').dtype).length is None
+        assert metadata_group.attrs.get_id('version').dtype == np.dtype('int32')
+        assert set(metadata_group) == {'entry_0'}
+        assert not any(name.startswith('product_') for name in metadata_group)
+        assert metadata_group['entry_0']['lang_values'].dtype == np.dtype('int32')
+        assert 'apsx' not in metadata_group['entry_0'].attrs
+        assert 'npsx' not in metadata_group['entry_0'].attrs
+        copied = openmc.data.Reaction.from_hdf5(group, {})
+        assert copied.products[0].particle == 'neutron'
+        assert copied.evaluated_product_metadata == metadata
+        del group['evaluated_product_metadata']
+        copied = openmc.data.Reaction.from_hdf5(group, {})
+        assert copied.evaluated_product_metadata is None
+
+    with h5py.File(filename, 'a') as h5file:
+        reaction.to_hdf5(h5file.create_group('malformed'))
+        h5file['malformed/evaluated_product_metadata'].attrs['version'] = 2
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(h5file['malformed'], {})
+
+        fixed = h5file.create_group('fixed_string')
+        reaction.to_hdf5(fixed)
+        wire = fixed['evaluated_product_metadata']
+        del wire.attrs['schema']
+        wire.attrs['schema'] = np.bytes_(
+            'openmc-evaluated-product-metadata/v2')
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(fixed, {})
+
+        unknown_field = h5file.create_group('unknown_field')
+        reaction.to_hdf5(unknown_field)
+        unknown_field['evaluated_product_metadata'].attrs['extra'] = 1
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(unknown_field, {})
+
+        gapped = h5file.create_group('gapped')
+        reaction.to_hdf5(gapped)
+        wire = gapped['evaluated_product_metadata']
+        wire.move('entry_0', 'entry_1')
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(gapped, {})
+
+        bad_rank = h5file.create_group('bad_rank')
+        reaction.to_hdf5(bad_rank)
+        entry_group = bad_rank['evaluated_product_metadata/entry_0']
+        del entry_group['lang_values']
+        entry_group.create_dataset(
+            'lang_values', data=np.zeros((1, 1), dtype=np.int32))
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(bad_rank, {})
+
+        inconsistent = h5file.create_group('inconsistent')
+        reaction.to_hdf5(inconsistent)
+        inconsistent['evaluated_product_metadata'].attrs['jp'] = np.int32(1)
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(inconsistent, {})
+
+        portable = h5file.create_group('opposite_endian')
+        reaction.to_hdf5(portable)
+        wire = portable['evaluated_product_metadata']
+        del wire.attrs['version']
+        wire.attrs.create('version', np.asarray(1, dtype='>i4'), dtype='>i4')
+        entry_group = wire['entry_0']
+        del entry_group.attrs['awp']
+        entry_group.attrs.create(
+            'awp', np.asarray(6129000.0, dtype='>f8'), dtype='>f8')
+        del entry_group['lang_values']
+        entry_group.create_dataset(
+            'lang_values', data=np.asarray([0], dtype='>i4'), dtype='>i4')
+        copied = openmc.data.Reaction.from_hdf5(portable, {})
+        assert copied.evaluated_product_metadata == metadata
+
+        bad_awp = h5file.create_group('bad_awp_interpretation')
+        reaction.to_hdf5(bad_awp)
+        entry_group = bad_awp['evaluated_product_metadata/entry_0']
+        entry_group.attrs.modify('awp_interpretation', 'arbitrary')
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(bad_awp, {})
+
+    invalid_metadata = openmc.data.EvaluatedProductMetadata(
+        102, 1, 2, 'complete', (entry,))
+    invalid_reaction = openmc.data.Reaction(102)
+    invalid_reaction.evaluated_product_metadata = invalid_metadata
+    with h5py.File(tmp_path / 'invalid_metadata.h5', 'w') as h5file:
+        with pytest.raises(ValueError):
+            invalid_reaction.to_hdf5(h5file.create_group('reaction_102'))
+
+    empty_active = openmc.data.EvaluatedProductMetadata(
+        18, 1, 1, 'complete', ())
+    empty_reaction = openmc.data.Reaction(18)
+    empty_reaction.evaluated_product_metadata = empty_active
+    with h5py.File(tmp_path / 'empty_active.h5', 'w') as h5file:
+        with pytest.raises(ValueError):
+            empty_reaction.to_hdf5(h5file.create_group('reaction_18'))
+
+    mismatched_reaction = openmc.data.Reaction(51)
+    mismatched_reaction.evaluated_product_metadata = metadata
+    with h5py.File(tmp_path / 'mismatched_mt.h5', 'w') as h5file:
+        with pytest.raises(ValueError):
+            mismatched_reaction.to_hdf5(h5file.create_group('reaction_51'))
+
+    ordered_evaluation = _metadata_section(18, 1, [
+        (1, 1.0, 0, 0, ''), (1, 1.0, 0, -5, ''),
+        (0, 0.0, 0, 0, ''), (0, 0.0, 0, -15, '')], jp=11)
+    ordered = openmc.data.get_evaluated_product_metadata(
+        ordered_evaluation, 18).metadata
+    ordered_reaction = openmc.data.Reaction(18)
+    ordered_reaction.evaluated_product_metadata = ordered
+    with h5py.File(tmp_path / 'ordered_metadata.h5', 'w') as h5file:
+        group = h5file.create_group('reaction_18')
+        ordered_reaction.to_hdf5(group)
+        copied = openmc.data.Reaction.from_hdf5(group, {})
+        assert copied.evaluated_product_metadata == ordered
+        assert tuple(entry.zap for entry in ordered.entries) == (1, 1, 0, 0)
+
+
+def test_evaluated_product_metadata_law6_hdf5_wire(tmp_path):
+    entry = openmc.data.EvaluatedProductMetadataEntry(
+        0, 1, 1.0, 'mass_ratio', 0, 6, (), None, (), 'complete',
+        'special_particle', 'neutron', 4.25, 3)
+    metadata = openmc.data.EvaluatedProductMetadata(
+        51, 0, 1, 'complete', (entry,))
+    reaction = openmc.data.Reaction(51)
+    reaction.evaluated_product_metadata = metadata
+    filename = tmp_path / 'law6_metadata.h5'
+
+    with h5py.File(filename, 'w') as h5file:
+        group = h5file.create_group('law6')
+        reaction.to_hdf5(group)
+        entry_group = group['evaluated_product_metadata/entry_0']
+        assert entry_group.attrs['apsx'] == 4.25
+        assert entry_group.attrs['npsx'] == 3
+        assert entry_group.attrs.get_id('apsx').dtype == np.dtype('float64')
+        assert entry_group.attrs.get_id('npsx').dtype == np.dtype('int32')
+        copied = openmc.data.Reaction.from_hdf5(group, {})
+        assert copied.evaluated_product_metadata == metadata
+
+    with h5py.File(filename, 'a') as h5file:
+        for name, mutate in [
+            ('missing_apsx', lambda attrs: attrs.__delitem__('apsx')),
+            ('missing_npsx', lambda attrs: attrs.__delitem__('npsx')),
+        ]:
+            group = h5file.create_group(name)
+            reaction.to_hdf5(group)
+            attrs = group['evaluated_product_metadata/entry_0'].attrs
+            mutate(attrs)
+            with pytest.raises(ValueError):
+                openmc.data.Reaction.from_hdf5(group, {})
+
+        wrong_apsx_dtype = h5file.create_group('wrong_apsx_dtype')
+        reaction.to_hdf5(wrong_apsx_dtype)
+        attrs = wrong_apsx_dtype['evaluated_product_metadata/entry_0'].attrs
+        del attrs['apsx']
+        attrs.create('apsx', np.float32(4.25), dtype=np.float32)
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(wrong_apsx_dtype, {})
+
+        wrong_apsx_rank = h5file.create_group('wrong_apsx_rank')
+        reaction.to_hdf5(wrong_apsx_rank)
+        attrs = wrong_apsx_rank['evaluated_product_metadata/entry_0'].attrs
+        del attrs['apsx']
+        attrs.create('apsx', np.asarray([4.25], dtype=np.float64),
+                     dtype=np.float64)
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(wrong_apsx_rank, {})
+
+        wrong_npsx_dtype = h5file.create_group('wrong_npsx_dtype')
+        reaction.to_hdf5(wrong_npsx_dtype)
+        attrs = wrong_npsx_dtype['evaluated_product_metadata/entry_0'].attrs
+        del attrs['npsx']
+        attrs.create('npsx', np.int64(2**31), dtype=np.int64)
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(wrong_npsx_dtype, {})
+
+        nonfinite = h5file.create_group('nonfinite_apsx')
+        reaction.to_hdf5(nonfinite)
+        nonfinite['evaluated_product_metadata/entry_0'].attrs.modify(
+            'apsx', np.float64(float('nan')))
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(nonfinite, {})
+
+        nonpositive = h5file.create_group('nonpositive_apsx')
+        reaction.to_hdf5(nonpositive)
+        nonpositive['evaluated_product_metadata/entry_0'].attrs.modify(
+            'apsx', np.float64(0.0))
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(nonpositive, {})
+
+        small_npsx = h5file.create_group('small_npsx')
+        reaction.to_hdf5(small_npsx)
+        small_npsx['evaluated_product_metadata/entry_0'].attrs.modify(
+            'npsx', np.int32(2))
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(small_npsx, {})
+
+        nonlaw = h5file.create_group('nonlaw_has_law6_field')
+        nonlaw_entry = openmc.data.EvaluatedProductMetadataEntry(
+            0, 1, 1.0, 'mass_ratio', 0, 0, (), None, (), 'complete',
+            'special_particle', 'neutron')
+        nonlaw_reaction = openmc.data.Reaction(51)
+        nonlaw_reaction.evaluated_product_metadata = (
+            openmc.data.EvaluatedProductMetadata(
+                51, 0, 1, 'complete', (nonlaw_entry,)))
+        nonlaw_reaction.to_hdf5(nonlaw)
+        nonlaw['evaluated_product_metadata/entry_0'].attrs.create(
+            'apsx', np.float64(4.25), dtype=np.float64)
+        with pytest.raises(ValueError):
+            openmc.data.Reaction.from_hdf5(nonlaw, {})
+
+
+def test_evaluated_product_metadata_default_is_off():
+    reaction = openmc.data.Reaction(51)
+    assert reaction.evaluated_product_metadata is None
+    assert reaction.products == []
+    parameter = inspect.signature(
+        openmc.data.IncidentNeutron.from_njoy).parameters[
+            'include_evaluated_product_metadata']
+    assert parameter.default is False
+
+
+def test_evaluated_product_metadata_from_njoy_opt_in(monkeypatch):
+    class FakeLibrary:
+        def __init__(self, filename):
+            self.tables = [object()]
+
+    created = []
+
+    def fake_from_ace(cls, table):
+        data = type('FakeIncidentNeutron', (), {})()
+        data.reactions = {51: openmc.data.Reaction(51)}
+        data.energy = {'0K': np.array([0.0])}
+        created.append(data)
+        return data
+
+    monkeypatch.setattr(neutron_module, 'make_ace', lambda *args, **kwargs: None)
+    monkeypatch.setattr(neutron_module, 'Library', FakeLibrary)
+    monkeypatch.setattr(
+        openmc.data.IncidentNeutron, 'from_ace', classmethod(fake_from_ace))
+
+    evaluation = type('FakeEvaluation', (), {
+        'gnds_name': 'Fe56', 'section': {}})()
+    calls = []
+
+    def fake_metadata(ev, mt):
+        calls.append((ev, mt))
+        entry = openmc.data.EvaluatedProductMetadataEntry(
+            0, 1, 1.0, 'mass_ratio', 0, 0, (), None, (), 'complete',
+            'special_particle', 'neutron')
+        return openmc.data.EvaluatedProductMetadataResult(
+            mt=mt, result_status='published_structurally_complete',
+            jp=0, lct=1, section_semantic_status='complete',
+            hdf5_group_version=1, entries=(entry,))
+
+    monkeypatch.setattr(
+        neutron_module, 'get_evaluated_product_metadata', fake_metadata)
+    default_data = openmc.data.IncidentNeutron.from_njoy(
+        'unused.endf', evaluation=evaluation, heatr=False)
+    assert calls == []
+    assert default_data.reactions[51].evaluated_product_metadata is None
+
+    opted_in = openmc.data.IncidentNeutron.from_njoy(
+        'unused.endf', evaluation=evaluation, heatr=False,
+        include_evaluated_product_metadata=True)
+    assert calls == [(evaluation, 51)]
+    assert opted_in.reactions[51].evaluated_product_metadata.mt == 51
+    assert opted_in.reactions[51].products == []
+
+    monkeypatch.setattr(
+        neutron_module, 'get_evaluated_product_metadata',
+        lambda ev, mt: openmc.data.EvaluatedProductMetadataResult(
+            mt=mt, result_status='structural_failure',
+            structural_failure='unknown_law'))
+    failed = openmc.data.IncidentNeutron.from_njoy(
+        'unused.endf', evaluation=evaluation, heatr=False,
+        include_evaluated_product_metadata=True)
+    assert failed.reactions[51].evaluated_product_metadata is None


### PR DESCRIPTION
## Summary

Add opt-in, transport-isolated persistence of structurally consumed evaluated ENDF MF=6 product metadata. The accepted snapshot is based on OpenMC `develop` `8202ef6fb11abee659113b88f8c30f2af0acf0be`; the tested pre-commit feature diff is 78,587 bytes (SHA-256 `2fe9c348186e2acb04904b0f00de6d3bf85b7e2aaf572e52e8d200a8f8194dcb`).

This is evaluated-data provenance only. It does not alter `Reaction.products`, add an ACE join, or expose the metadata to C++ transport. `IncidentNeutron.from_njoy(..., include_evaluated_product_metadata=True)` is the only producer opt-in; the default remains off.

## Parsing and persistence contract

- Preserve raw MF/MT/JP/LCT and ordered per-product ZAP/AWP/LIP/LAW controls.
- Accept JP `{0,1,2,10,11,12,20,21,22}` and LCT 1–4, with typed semantic statuses for supported-envelope but unsupported LANG/LTP/frame combinations.
- Consume known LAW 0–7 envelopes and the authorized `-5`/`-15` fission forms; unknown/truncated/count-mismatched/unproven envelopes fail structurally and publish nothing.
- Retain LAW=1/2/5 selectors and their documented count/frame rules without claiming distribution normalization or evaluation-wide physical validity.
- Persist LAW=6 APSX/NPSX only for LAW=6: APSX must be a finite positive non-Boolean real; NPSX a non-Boolean integer in `3..2^31-1`; reserved controls must be numeric zero. Invalid/reserved/unrepresentable controls fail atomically as `invalid_law6_control`. Raw persistence does not enforce an APSX/AWP sampling relation.
- Write strict float64 APSX and int32 NPSX attributes and refuse malformed, version-unknown, or gapped HDF5 metadata on readback. The ordinary nuclear data HDF5 version remains 3.0.

## Compatibility and isolation evidence

- Focused Python metadata suite: 59 passed, 32 deselected.
- Matrix verifier: 15 targeted cases passed; schema verifier: 9 valid and 23 invalid fixtures passed.
- Real O-16 NJOY2016 producer/Python persistence: two pinned runs, 13 MF=6 sections and 68 entries, ordinary HDF projections equal.
- Current and pinned v0.15.3 Python readers accept the enriched format-3.0 files without changing ordinary fields.
- Bateman Gate A: current `8202ef6f...` and v0.15.3 `27e38e89...`, each against metadata-off/on O-16, returned init/finalize zero in four fresh processes. This proves ordinary C++ reader compatibility, not C++ metadata loading.
- Bateman Gate B: two fresh current-reader serial runs against the synthetic U-235 off/on sidecar returned init/run/finalize zero. Exact normalized statepoint, separate source bank, 500 per-history track projections, and a nonempty one-cell fission raw SUM/SUM_SQ slab match. The result manifest is 139,171 bytes, SHA-256 `e10db488899c2568ab669fe163506d55eec444051cfed99715266f2b8d29a8c8`.
- Harness regression suite: 11 passed, including rejection of an empty tally slab. `git diff --check` passes.

Final independent scientific review: **GO C0/H0/M0** for this exact bounded publication snapshot.

## Limits

This PR does not establish production product binding, ACE-to-MF6 identity, per-RNG-draw identity, real U-235 evaluated physics, recoil/PKA, NRT/DPA, charged-particle transport qualification, HPGe detector response, calibration, or MCNP parity.