### PR TITLE
Release notes for 0.16.0

### DIFF
--- a/docs/source/pythonapi/base.rst
+++ b/docs/source/pythonapi/base.rst
@@ -21,6 +21,7 @@ Simulation Settings
    :nosignatures:
    :template: myclass.rst
 
+   openmc.ParticleType
    openmc.SourceBase
    openmc.IndependentSource
    openmc.FileSource
@@ -184,6 +185,13 @@ Geometry Plotting
    openmc.WireframeRayTracePlot
    openmc.SolidRayTracePlot
    openmc.Plots
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+   :template: myfunction.rst
+
+   openmc.id_map_to_rgb
 
 Running OpenMC
 --------------

--- a/docs/source/pythonapi/base.rst
+++ b/docs/source/pythonapi/base.rst
@@ -186,13 +186,6 @@ Geometry Plotting
    openmc.SolidRayTracePlot
    openmc.Plots
 
-.. autosummary::
-   :toctree: generated
-   :nosignatures:
-   :template: myfunction.rst
-
-   openmc.id_map_to_rgb
-
 Running OpenMC
 --------------
 

--- a/docs/source/pythonapi/capi.rst
+++ b/docs/source/pythonapi/capi.rst
@@ -42,6 +42,9 @@ Functions
    run_in_memory
    run_random_ray
    sample_external_source
+   slice_data
+   slice_data_overlap_count
+   slice_data_overlap_info
    simulation_finalize
    simulation_init
    source_bank

--- a/docs/source/pythonapi/examples.rst
+++ b/docs/source/pythonapi/examples.rst
@@ -10,6 +10,8 @@ Simple Models
    :nosignatures:
    :template: myfunction.rst
 
+   openmc.examples.random_ray_pin_cell
+   openmc.examples.random_ray_three_region_cube_with_detectors
    openmc.examples.slab_mg
    openmc.examples.sphere_with_shielded_pocket
 

--- a/docs/source/releasenotes/0.16.0.rst
+++ b/docs/source/releasenotes/0.16.0.rst
@@ -196,6 +196,8 @@ New Features
   (`#4033 <https://github.com/openmc-dev/openmc/pull/4033>`_)
 - Added elemental photon mass energy-absorption coefficients
   (`#4039 <https://github.com/openmc-dev/openmc/pull/4039>`_)
+- Allow user tallies during R2S neutron transport step
+  (`#4046 <https://github.com/openmc-dev/openmc/pull/4046>`_)
 
 ---------------------------
 Bug Fixes and Small Changes
@@ -396,3 +398,11 @@ Bug Fixes and Small Changes
   (`#4047 <https://github.com/openmc-dev/openmc/pull/4047>`_)
 - Use ``&&`` instead of the alternative token 'and' in mesh.h
   (`#4048 <https://github.com/openmc-dev/openmc/pull/4048>`_)
+- Don't name class members in OpenMP reduction clauses
+  (`#4049 <https://github.com/openmc-dev/openmc/pull/4049>`_)
+- Give run_mode and rel_max_lost_particles C linkage
+  (`#4050 <https://github.com/openmc-dev/openmc/pull/4050>`_)
+- Resolve input file paths with std::filesystem
+  (`#4051 <https://github.com/openmc-dev/openmc/pull/4051>`_)
+- Add missing include in event.h
+  (`#4052 <https://github.com/openmc-dev/openmc/pull/4052>`_)

--- a/docs/source/releasenotes/0.16.0.rst
+++ b/docs/source/releasenotes/0.16.0.rst
@@ -30,7 +30,7 @@ and adds support for Python 3.14. The documented minimum build environment is
 GCC 11.4 and CMake 3.22.
 
 The Python :class:`ParticleType` interface is now a regular class backed by
-Particle Data Group Monte Carlo numbers rather than an ``IntEnum``. Particle
+Particle Data Group (PDG) Monte Carlo numbers rather than an ``IntEnum``. Particle
 types stored in OpenMC output files now use PDG numbers, and the corresponding
 C++ factories use function-call syntax such as ``ParticleType::neutron()``.
 

--- a/docs/source/releasenotes/0.16.0.rst
+++ b/docs/source/releasenotes/0.16.0.rst
@@ -71,8 +71,6 @@ New Features
   (`#3460 <https://github.com/openmc-dev/openmc/pull/3460>`_)
 - Allowed :class:`~openmc.stats.CylindricalIndependent` to use an arbitrary
   symmetry axis (`#3474 <https://github.com/openmc-dev/openmc/pull/3474>`_)
-- Replaced the external ``vectfit`` dependency with an internal vector-fitting
-  implementation (`#3493 <https://github.com/openmc-dev/openmc/pull/3493>`_)
 - Added :class:`SlicePlot` and :class:`VoxelPlot` in place of the legacy
   :class:`Plot` interface
   (`#3528 <https://github.com/openmc-dev/openmc/pull/3528>`_)
@@ -80,21 +78,11 @@ New Features
   (`#3550 <https://github.com/openmc-dev/openmc/pull/3550>`_)
 - Generalized rotational periodic boundary conditions to the x-, y-, and
   z-axes (`#3591 <https://github.com/openmc-dev/openmc/pull/3591>`_)
-- Migrated internal sparse data structures to SciPy sparse arrays
-  (`#3613 <https://github.com/openmc-dev/openmc/pull/3613>`_)
 - Added VTKHDF output support for unstructured meshes with hexahedral elements
   (`#3623 <https://github.com/openmc-dev/openmc/pull/3623>`_)
-- Added Python 3.14 support and raised the minimum supported Python version to
-  3.12 (`#3642 <https://github.com/openmc-dev/openmc/pull/3642>`_)
 - Allowed nuclides, elements, density, temperature, and volume to be specified
   in the :class:`Material` constructor
   (`#3649 <https://github.com/openmc-dev/openmc/pull/3649>`_)
-- Modernized and made relocatable the installed CMake package configuration
-  (`#3653 <https://github.com/openmc-dev/openmc/pull/3653>`_)
-- Updated the documented minimum build environment to GCC 11.4 and CMake 3.22
-  (`#3666 <https://github.com/openmc-dev/openmc/pull/3666>`_)
-- Improved automatic multigroup cross-section generation for random ray models
-  (`#3658 <https://github.com/openmc-dev/openmc/pull/3658>`_)
 - Added overlap IDs to :meth:`Model.id_map`
   (`#3669 <https://github.com/openmc-dev/openmc/pull/3669>`_)
 - Added a command-line option for controlling output verbosity
@@ -113,9 +101,6 @@ New Features
   (`#3717 <https://github.com/openmc-dev/openmc/pull/3717>`_)
 - Added distributed cell-density support to the random ray solver
   (`#3720 <https://github.com/openmc-dev/openmc/pull/3720>`_)
-- Accelerated reaction-rate lookup in
-  :class:`~openmc.deplete.FluxCollapseHelper`
-  (`#3724 <https://github.com/openmc-dev/openmc/pull/3724>`_)
 - Added optional material bounding boxes to
   :meth:`MeshBase.material_volumes`
   (`#3731 <https://github.com/openmc-dev/openmc/pull/3731>`_)
@@ -127,8 +112,6 @@ New Features
   (`#3742 <https://github.com/openmc-dev/openmc/pull/3742>`_)
 - Added ``MeshBase.n_elements`` and common bounding-box properties to the mesh
   protocol (`#3745 <https://github.com/openmc-dev/openmc/pull/3745>`_)
-- Added warnings when undefined attributes are assigned to :class:`Settings`
-  (`#3746 <https://github.com/openmc-dev/openmc/pull/3746>`_)
 - Added C API bindings for random ray execution and configuration
   (`#3749 <https://github.com/openmc-dev/openmc/pull/3749>`_)
 - Generalized :class:`ParticleType` using the PDG Monte Carlo numbering scheme
@@ -137,16 +120,8 @@ New Features
   (`#3760 <https://github.com/openmc-dev/openmc/pull/3760>`_)
 - Added truncated normal distributions
   (`#3761 <https://github.com/openmc-dev/openmc/pull/3761>`_)
-- Added approximate neutron velocities when multigroup inverse-velocity data is
-  unavailable (`#3766 <https://github.com/openmc-dev/openmc/pull/3766>`_)
-- Parallelized scattering-matrix transposition for adjoint random ray solves
-  (`#3768 <https://github.com/openmc-dev/openmc/pull/3768>`_)
 - Enabled tracklength tallies of microscopic cross sections in void materials
   (`#3771 <https://github.com/openmc-dev/openmc/pull/3771>`_)
-- Changed distributed-instance XML data to subelements to support very large
-  instance lists (`#3774 <https://github.com/openmc-dev/openmc/pull/3774>`_)
-- Precomputed random ray source-update offsets for improved performance
-  (`#3775 <https://github.com/openmc-dev/openmc/pull/3775>`_)
 - Allowed tally scores and filters to be supplied to the :class:`Tally`
   constructor (`#3777 <https://github.com/openmc-dev/openmc/pull/3777>`_)
 - Added support for mixture distributions to
@@ -154,12 +129,8 @@ New Features
   (`#3784 <https://github.com/openmc-dev/openmc/pull/3784>`_)
 - Added C API bindings for :class:`~openmc.lib.SolidRayTracePlot`
   (`#3789 <https://github.com/openmc-dev/openmc/pull/3789>`_)
-- Simplified :meth:`Model.convert_to_multigroup` setup for DAGMC models
-  (`#3801 <https://github.com/openmc-dev/openmc/pull/3801>`_)
 - Added upper and lower interpolation bounds to multigroup cross-section data
   (`#3803 <https://github.com/openmc-dev/openmc/pull/3803>`_)
-- Replaced the ``xtensor`` and ``xtl`` dependencies with internal tensor and
-  view classes (`#3805 <https://github.com/openmc-dev/openmc/pull/3805>`_)
 - Added a C API and :func:`openmc.lib.slice_data` interface for raster slice
   plots (`#3806 <https://github.com/openmc-dev/openmc/pull/3806>`_)
 - Added settings for loading property files and controlling surface-grazing
@@ -168,31 +139,22 @@ New Features
   (`#3809 <https://github.com/openmc-dev/openmc/pull/3809>`_)
 - Added S2 directional sampling to the random ray solver
   (`#3811 <https://github.com/openmc-dev/openmc/pull/3811>`_)
-- Extended ray-traced plot data for use by estimators
-  (`#3816 <https://github.com/openmc-dev/openmc/pull/3816>`_)
 - Added :meth:`RegularMesh.get_indices_at_coords`
   (`#3824 <https://github.com/openmc-dev/openmc/pull/3824>`_)
 - Allowed :meth:`MeshBase.from_domain` to accept bounding boxes directly
   (`#3828 <https://github.com/openmc-dev/openmc/pull/3828>`_)
-- Parallelized external-source sampling and made rejection counters thread-safe
-  (`#3830 <https://github.com/openmc-dev/openmc/pull/3830>`_)
 - Added hybrid-domain tallies to
   :func:`~openmc.deplete.get_microxs_and_flux`
   (`#3831 <https://github.com/openmc-dev/openmc/pull/3831>`_)
-- Improved depletion performance for models with transfer rates
-  (`#3839 <https://github.com/openmc-dev/openmc/pull/3839>`_)
 - Added a setting to disable atomic relaxation
   (`#3855 <https://github.com/openmc-dev/openmc/pull/3855>`_)
 - Added :func:`openmc.stats.fusion_neutron_spectrum`
   (`#3862 <https://github.com/openmc-dev/openmc/pull/3862>`_)
-- Added a shared secondary-particle bank for load balancing histories across
-  threads and MPI ranks (`#3863 <https://github.com/openmc-dev/openmc/pull/3863>`_)
 - Added support for multiple meshes in R2S calculations
   (`#3860 <https://github.com/openmc-dev/openmc/pull/3860>`_)
-- Allowed :meth:`openmc.deplete.StepResult.get_material` to accept integer IDs
-  (`#3872 <https://github.com/openmc-dev/openmc/pull/3872>`_)
-- Allowed sequences of group boundaries in :meth:`Model.convert_to_multigroup`
-  (`#3873 <https://github.com/openmc-dev/openmc/pull/3873>`_)
+- Added a shared secondary-particle bank for load balancing histories across
+  threads and MPI ranks (`#3863
+  <https://github.com/openmc-dev/openmc/pull/3863>`_)
 - Added :meth:`RectilinearMesh.get_indices_at_coords`
   (`#3876 <https://github.com/openmc-dev/openmc/pull/3876>`_)
 - Expanded DAGMC cell material, density, and temperature overrides
@@ -201,8 +163,6 @@ New Features
   (`#3903 <https://github.com/openmc-dev/openmc/pull/3903>`_)
 - Added optional substeps to CRAM depletion solves
   (`#3908 <https://github.com/openmc-dev/openmc/pull/3908>`_)
-- Added per-cubic-meter units to material activity and decay-heat methods
-  (`#3912 <https://github.com/openmc-dev/openmc/pull/3912>`_)
 - Extended :attr:`RegularMesh.volumes` to one- and two-dimensional meshes
   (`#3914 <https://github.com/openmc-dev/openmc/pull/3914>`_)
 - Enabled the tracklength estimator for neutron-heating tallies
@@ -211,8 +171,6 @@ New Features
   (`#3919 <https://github.com/openmc-dev/openmc/pull/3919>`_)
 - Added :class:`openmc.stats.DecaySpectrum` and integrated it with R2S
   workflows (`#3930 <https://github.com/openmc-dev/openmc/pull/3930>`_)
-- Allowed ``openmc.data.endf.Material`` objects in nuclear-data ``from_endf``
-  methods (`#3932 <https://github.com/openmc-dev/openmc/pull/3932>`_)
 - Enabled pulse-height tallies in coupled neutron--photon calculations
   (`#3937 <https://github.com/openmc-dev/openmc/pull/3937>`_)
 - Added a description attribute to :class:`Model`
@@ -230,19 +188,12 @@ New Features
   (`#3999 <https://github.com/openmc-dev/openmc/pull/3999>`_)
 - Enabled parent-nuclide tally breakdowns in R2S calculations
   (`#4013 <https://github.com/openmc-dev/openmc/pull/4013>`_)
-- Added partial-current labels for :class:`MeshSurfaceFilter`
-  (`#4021 <https://github.com/openmc-dev/openmc/pull/4021>`_)
 - Added control over NJOY's damage-energy threshold
   (`#4022 <https://github.com/openmc-dev/openmc/pull/4022>`_)
-- Optimized depletion-chain loading and material activity calculations
-  (`#4025 <https://github.com/openmc-dev/openmc/pull/4025>`_)
 - Added a length multiplier to :class:`DAGMCUniverse`
   (`#4033 <https://github.com/openmc-dev/openmc/pull/4033>`_)
 - Added elemental photon mass energy-absorption coefficients
   (`#4039 <https://github.com/openmc-dev/openmc/pull/4039>`_)
-- Processed photon-induced electrons and positrons at their birth location and
-  attributed their heating to the parent photon
-  (`#4040 <https://github.com/openmc-dev/openmc/pull/4040>`_)
 
 ---------------------------
 Bug Fixes and Small Changes
@@ -251,12 +202,24 @@ Bug Fixes and Small Changes
 - Corrected type handling and generalized
   :func:`~openmc.stats.combine_distributions`
   (`#3445 <https://github.com/openmc-dev/openmc/pull/3445>`_)
+- Replaced the external ``vectfit`` dependency with an internal vector-fitting
+  implementation (`#3493 <https://github.com/openmc-dev/openmc/pull/3493>`_)
 - Normalized random ray eigenvalue fluxes consistently with Monte Carlo tallies
   (`#3595 <https://github.com/openmc-dev/openmc/pull/3595>`_)
+- Migrated internal sparse data structures to SciPy sparse arrays
+  (`#3613 <https://github.com/openmc-dev/openmc/pull/3613>`_)
+- Added Python 3.14 support and raised the minimum supported Python version to
+  3.12 (`#3642 <https://github.com/openmc-dev/openmc/pull/3642>`_)
+- Modernized and made relocatable the installed CMake package configuration
+  (`#3653 <https://github.com/openmc-dev/openmc/pull/3653>`_)
 - Restored the DAGMC universe name when exporting XML
   (`#3657 <https://github.com/openmc-dev/openmc/pull/3657>`_)
+- Improved automatic multigroup cross-section generation for random ray models
+  (`#3658 <https://github.com/openmc-dev/openmc/pull/3658>`_)
 - Corrected temperature assignment in :func:`openmc.model.borated_water`
   (`#3662 <https://github.com/openmc-dev/openmc/pull/3662>`_)
+- Updated the documented minimum build environment to GCC 11.4 and CMake 3.22
+  (`#3666 <https://github.com/openmc-dev/openmc/pull/3666>`_)
 - Fixed :class:`DistribcellFilter` when applying tally results to a model
   (`#3667 <https://github.com/openmc-dev/openmc/pull/3667>`_)
 - Corrected source-location scaling in plots with non-centimeter axis units
@@ -279,36 +242,59 @@ Bug Fixes and Small Changes
   (`#3708 <https://github.com/openmc-dev/openmc/pull/3708>`_)
 - Corrected temperature-list handling in multigroup cross-section libraries
   (`#3712 <https://github.com/openmc-dev/openmc/pull/3712>`_)
+- Accelerated reaction-rate lookup in
+  :class:`~openmc.deplete.FluxCollapseHelper`
+  (`#3724 <https://github.com/openmc-dev/openmc/pull/3724>`_)
 - Corrected operator precedence in nested CSG union and intersection
   expressions (`#3730 <https://github.com/openmc-dev/openmc/pull/3730>`_)
 - Preserved material names in depletion results
   (`#3738 <https://github.com/openmc-dev/openmc/pull/3738>`_)
 - Restored compatibility with pandas 3
   (`#3743 <https://github.com/openmc-dev/openmc/pull/3743>`_)
+- Added warnings when undefined attributes are assigned to :class:`Settings`
+  (`#3746 <https://github.com/openmc-dev/openmc/pull/3746>`_)
 - Fixed plotting models that use multigroup cross sections
   (`#3748 <https://github.com/openmc-dev/openmc/pull/3748>`_)
 - Prevented unstable ground-state Ta180 from being added for natural tantalum
   (`#3750 <https://github.com/openmc-dev/openmc/pull/3750>`_)
 - Resolved conflicts between weight windows and global Russian roulette
   (`#3751 <https://github.com/openmc-dev/openmc/pull/3751>`_)
+- Added approximate neutron velocities when multigroup inverse-velocity data is
+  unavailable (`#3766 <https://github.com/openmc-dev/openmc/pull/3766>`_)
+- Parallelized scattering-matrix transposition for adjoint random ray solves
+  (`#3768 <https://github.com/openmc-dev/openmc/pull/3768>`_)
 - Removed a variable-length-array compiler extension
   (`#3769 <https://github.com/openmc-dev/openmc/pull/3769>`_)
 - Rejected nonpositive surface IDs
   (`#3772 <https://github.com/openmc-dev/openmc/pull/3772>`_)
 - Corrected length-multiplier use in libMesh methods
   (`#3773 <https://github.com/openmc-dev/openmc/pull/3773>`_)
+- Changed distributed-instance XML data to subelements to support very large
+  instance lists (`#3774 <https://github.com/openmc-dev/openmc/pull/3774>`_)
+- Precomputed random ray source-update offsets for improved performance
+  (`#3775 <https://github.com/openmc-dev/openmc/pull/3775>`_)
 - Improved radial crossing checks in cylindrical and spherical meshes
   (`#3792 <https://github.com/openmc-dev/openmc/pull/3792>`_)
 - Removed ``setuptools`` from runtime dependencies
   (`#3794 <https://github.com/openmc-dev/openmc/pull/3794>`_)
+- Simplified :meth:`Model.convert_to_multigroup` setup for DAGMC models
+  (`#3801 <https://github.com/openmc-dev/openmc/pull/3801>`_)
 - Prevented ``None`` temperature values in automatically generated multigroup
   data (`#3802 <https://github.com/openmc-dev/openmc/pull/3802>`_)
+- Replaced the ``xtensor`` and ``xtl`` dependencies with internal tensor and
+  view classes (`#3805 <https://github.com/openmc-dev/openmc/pull/3805>`_)
 - Enforced positive mesh radii in the Python API
   (`#3813 <https://github.com/openmc-dev/openmc/pull/3813>`_)
+- Extended ray-traced plot data for use by estimators
+  (`#3816 <https://github.com/openmc-dev/openmc/pull/3816>`_)
 - Corrected :meth:`MeshFilter.get_pandas_dataframe` for non-regular meshes
   (`#3817 <https://github.com/openmc-dev/openmc/pull/3817>`_)
 - Corrected pulse-height scoring when no cell filter is present
   (`#3821 <https://github.com/openmc-dev/openmc/pull/3821>`_)
+- Parallelized external-source sampling and made rejection counters thread-safe
+  (`#3830 <https://github.com/openmc-dev/openmc/pull/3830>`_)
+- Improved depletion performance for models with transfer rates
+  (`#3839 <https://github.com/openmc-dev/openmc/pull/3839>`_)
 - Corrected surface-normal determination in solid ray-traced plots
   (`#3846 <https://github.com/openmc-dev/openmc/pull/3846>`_)
 - Corrected parsing of cell data in the Python API
@@ -317,6 +303,10 @@ Bug Fixes and Small Changes
   at large pitch (`#3853 <https://github.com/openmc-dev/openmc/pull/3853>`_)
 - Closed redirected standard-output file descriptors after use
   (`#3864 <https://github.com/openmc-dev/openmc/pull/3864>`_)
+- Allowed :meth:`openmc.deplete.StepResult.get_material` to accept integer IDs
+  (`#3872 <https://github.com/openmc-dev/openmc/pull/3872>`_)
+- Allowed sequences of group boundaries in :meth:`Model.convert_to_multigroup`
+  (`#3873 <https://github.com/openmc-dev/openmc/pull/3873>`_)
 - Clipped small negative atom densities produced by CRAM
   (`#3879 <https://github.com/openmc-dev/openmc/pull/3879>`_)
 - Corrected surface-source particle counts under MPI
@@ -325,6 +315,10 @@ Bug Fixes and Small Changes
   (`#3907 <https://github.com/openmc-dev/openmc/pull/3907>`_)
 - Fixed an MPI hang during depletion calculations
   (`#3910 <https://github.com/openmc-dev/openmc/pull/3910>`_)
+- Added per-cubic-meter units to material activity and decay-heat methods
+  (`#3912 <https://github.com/openmc-dev/openmc/pull/3912>`_)
+- Allowed ``openmc.data.endf.Material`` objects in nuclear-data ``from_endf``
+  methods (`#3932 <https://github.com/openmc-dev/openmc/pull/3932>`_)
 - Reevaluated geometry after close collisions that follow a surface crossing
   (`#3933 <https://github.com/openmc-dev/openmc/pull/3933>`_)
 - Corrected virtual-surface crossing behavior
@@ -375,10 +369,14 @@ Bug Fixes and Small Changes
   (`#4019 <https://github.com/openmc-dev/openmc/pull/4019>`_)
 - Avoided accessing atomic-relaxation maps when no relaxation data is present
   (`#4020 <https://github.com/openmc-dev/openmc/pull/4020>`_)
+- Added partial-current labels for :class:`MeshSurfaceFilter`
+  (`#4021 <https://github.com/openmc-dev/openmc/pull/4021>`_)
 - Corrected ``M_PI`` availability on affected compilers
   (`#4023 <https://github.com/openmc-dev/openmc/pull/4023>`_)
 - Determined surface-source starting half-spaces from particle direction
   (`#4024 <https://github.com/openmc-dev/openmc/pull/4024>`_)
+- Optimized depletion-chain loading and material activity calculations
+  (`#4025 <https://github.com/openmc-dev/openmc/pull/4025>`_)
 - Corrected sparse storage of multidimensional tally results
   (`#4030 <https://github.com/openmc-dev/openmc/pull/4030>`_)
 - Resolved relative input paths against the XML file that contains them
@@ -389,3 +387,6 @@ Bug Fixes and Small Changes
   (`#4037 <https://github.com/openmc-dev/openmc/pull/4037>`_)
 - Limited unstructured-mesh Exodus output to one MPI rank
   (`#4038 <https://github.com/openmc-dev/openmc/pull/4038>`_)
+- Processed photon-induced electrons and positrons at their birth location and
+  attributed their heating to the parent photon
+  (`#4040 <https://github.com/openmc-dev/openmc/pull/4040>`_)

--- a/docs/source/releasenotes/0.16.0.rst
+++ b/docs/source/releasenotes/0.16.0.rst
@@ -190,6 +190,8 @@ New Features
   (`#4013 <https://github.com/openmc-dev/openmc/pull/4013>`_)
 - Added control over NJOY's damage-energy threshold
   (`#4022 <https://github.com/openmc-dev/openmc/pull/4022>`_)
+- Apply virtual material densities to microscopic tally results
+  (`#4029 <https://github.com/openmc-dev/openmc/pull/4029>`_)
 - Added a length multiplier to :class:`DAGMCUniverse`
   (`#4033 <https://github.com/openmc-dev/openmc/pull/4033>`_)
 - Added elemental photon mass energy-absorption coefficients

--- a/docs/source/releasenotes/0.16.0.rst
+++ b/docs/source/releasenotes/0.16.0.rst
@@ -390,3 +390,7 @@ Bug Fixes and Small Changes
 - Processed photon-induced electrons and positrons at their birth location and
   attributed their heating to the parent photon
   (`#4040 <https://github.com/openmc-dev/openmc/pull/4040>`_)
+- Fix use of invalidated iterators in Region constructor
+  (`#4047 <https://github.com/openmc-dev/openmc/pull/4047>`_)
+- Use ``&&`` instead of the alternative token 'and' in mesh.h
+  (`#4048 <https://github.com/openmc-dev/openmc/pull/4048>`_)

--- a/docs/source/releasenotes/0.16.0.rst
+++ b/docs/source/releasenotes/0.16.0.rst
@@ -1,0 +1,391 @@
+====================
+What's New in 0.16.0
+====================
+
+.. currentmodule:: openmc
+
+-------
+Summary
+-------
+
+This release of OpenMC introduces many new features, improvements, and bug fixes
+throughout the codebase. The primary Monte Carlo solver has been expanded with
+surface-flux tallies, reaction and secondary-particle production filters, source
+biasing, coupled neutron--photon pulse-height support, a shared
+secondary-particle bank, and generalized particle identifiers based on PDG
+numbering. The random ray solver gains local adjoint sources, temperature and
+distributed-density feedback, fission-heating tallies, and a weight-window
+bootstrapping workflow for multigroup cross sections. Depletion and
+shutdown-dose workflows now support reactivity control, CRAM substeps, multiple
+R2S meshes, and decay-spectrum source distributions. The Python API also adds
+dedicated slice and voxel plot classes, native tokamak sources, new mesh
+utilities, and photon attenuation and energy-absorption data.
+
+------------------------------------
+Compatibility Notes and Deprecations
+------------------------------------
+
+Python 3.11 is no longer supported; OpenMC now requires Python 3.12 or newer
+and adds support for Python 3.14. The documented minimum build environment is
+GCC 11.4 and CMake 3.22.
+
+The Python :class:`ParticleType` interface is now a regular class backed by
+Particle Data Group Monte Carlo numbers rather than an ``IntEnum``. Particle
+types stored in OpenMC output files now use PDG numbers, and the corresponding
+C++ factories use function-call syntax such as ``ParticleType::neutron()``.
+
+The :class:`Plot` compatibility constructor is deprecated. Use
+:class:`SlicePlot` for two-dimensional raster plots or :class:`VoxelPlot` for
+voxel plots. The :func:`openmc.lib.id_map` and :func:`openmc.lib.property_map`
+functions are also deprecated in favor of :func:`openmc.lib.slice_data`.
+
+The ``MeshBase.num_mesh_cells`` property is deprecated in favor of
+``MeshBase.n_elements``. The ``nparticles`` and ``temperature_settings``
+arguments to :meth:`Model.convert_to_multigroup` are deprecated; pass settings
+such as ``particles`` and ``temperature`` as keyword arguments instead.
+
+Distributed material, temperature, and density instance lists are now written as
+XML subelements rather than attributes to support very large models. Existing
+attribute-based input remains readable.
+
+Photon-induced electrons and positrons are now processed at their birth
+location. Their energy deposition is attributed to the parent photon in heating
+tallies.
+
+------------
+New Features
+------------
+
+- Added reactivity control during coupled transport-depletion calculations
+  (`#2693 <https://github.com/openmc-dev/openmc/pull/2693>`_)
+- Added rotation support to :class:`MeshFilter`
+  (`#3176 <https://github.com/openmc-dev/openmc/pull/3176>`_)
+- Added ICRP-74 ambient dose-equivalent coefficients
+  (`#3256 <https://github.com/openmc-dev/openmc/pull/3256>`_)
+- Added additional interpolation schemes to :class:`~openmc.stats.Tabular`
+  (`#3413 <https://github.com/openmc-dev/openmc/pull/3413>`_)
+- Added :class:`ParticleProductionFilter` for filtering secondary-particle
+  production by particle type and energy
+  (`#3453 <https://github.com/openmc-dev/openmc/pull/3453>`_)
+- Added source-distribution biasing capabilities
+  (`#3460 <https://github.com/openmc-dev/openmc/pull/3460>`_)
+- Allowed :class:`~openmc.stats.CylindricalIndependent` to use an arbitrary
+  symmetry axis (`#3474 <https://github.com/openmc-dev/openmc/pull/3474>`_)
+- Replaced the external ``vectfit`` dependency with an internal vector-fitting
+  implementation (`#3493 <https://github.com/openmc-dev/openmc/pull/3493>`_)
+- Added :class:`SlicePlot` and :class:`VoxelPlot` in place of the legacy
+  :class:`Plot` interface
+  (`#3528 <https://github.com/openmc-dev/openmc/pull/3528>`_)
+- Added angular probability-density evaluation for angle-energy distributions
+  (`#3550 <https://github.com/openmc-dev/openmc/pull/3550>`_)
+- Generalized rotational periodic boundary conditions to the x-, y-, and
+  z-axes (`#3591 <https://github.com/openmc-dev/openmc/pull/3591>`_)
+- Migrated internal sparse data structures to SciPy sparse arrays
+  (`#3613 <https://github.com/openmc-dev/openmc/pull/3613>`_)
+- Added VTKHDF output support for unstructured meshes with hexahedral elements
+  (`#3623 <https://github.com/openmc-dev/openmc/pull/3623>`_)
+- Added Python 3.14 support and raised the minimum supported Python version to
+  3.12 (`#3642 <https://github.com/openmc-dev/openmc/pull/3642>`_)
+- Allowed nuclides, elements, density, temperature, and volume to be specified
+  in the :class:`Material` constructor
+  (`#3649 <https://github.com/openmc-dev/openmc/pull/3649>`_)
+- Modernized and made relocatable the installed CMake package configuration
+  (`#3653 <https://github.com/openmc-dev/openmc/pull/3653>`_)
+- Updated the documented minimum build environment to GCC 11.4 and CMake 3.22
+  (`#3666 <https://github.com/openmc-dev/openmc/pull/3666>`_)
+- Improved automatic multigroup cross-section generation for random ray models
+  (`#3658 <https://github.com/openmc-dev/openmc/pull/3658>`_)
+- Added overlap IDs to :meth:`Model.id_map`
+  (`#3669 <https://github.com/openmc-dev/openmc/pull/3669>`_)
+- Added a command-line option for controlling output verbosity
+  (`#3680 <https://github.com/openmc-dev/openmc/pull/3680>`_)
+- Added JEFF-4.0 and JENDL-5 thermal-scattering material names
+  (`#3693 <https://github.com/openmc-dev/openmc/pull/3693>`_)
+- Added block restriction for libMesh unstructured-mesh tallies
+  (`#3694 <https://github.com/openmc-dev/openmc/pull/3694>`_)
+- Added :meth:`Material.get_photon_contact_dose_rate`
+  (`#3700 <https://github.com/openmc-dev/openmc/pull/3700>`_)
+- Added lethargy-weighted conversion between multigroup flux structures
+  (`#3705 <https://github.com/openmc-dev/openmc/pull/3705>`_)
+- Enabled fission-heating tallies in the random ray solver
+  (`#3714 <https://github.com/openmc-dev/openmc/pull/3714>`_)
+- Added local adjoint sources for random ray calculations
+  (`#3717 <https://github.com/openmc-dev/openmc/pull/3717>`_)
+- Added distributed cell-density support to the random ray solver
+  (`#3720 <https://github.com/openmc-dev/openmc/pull/3720>`_)
+- Accelerated reaction-rate lookup in
+  :class:`~openmc.deplete.FluxCollapseHelper`
+  (`#3724 <https://github.com/openmc-dev/openmc/pull/3724>`_)
+- Added optional material bounding boxes to
+  :meth:`MeshBase.material_volumes`
+  (`#3731 <https://github.com/openmc-dev/openmc/pull/3731>`_)
+- Added :func:`openmc.examples.random_ray_pin_cell`
+  (`#3735 <https://github.com/openmc-dev/openmc/pull/3735>`_)
+- Added temperature-feedback support to the random ray solver
+  (`#3737 <https://github.com/openmc-dev/openmc/pull/3737>`_)
+- Implemented surface-flux tallies
+  (`#3742 <https://github.com/openmc-dev/openmc/pull/3742>`_)
+- Added ``MeshBase.n_elements`` and common bounding-box properties to the mesh
+  protocol (`#3745 <https://github.com/openmc-dev/openmc/pull/3745>`_)
+- Added warnings when undefined attributes are assigned to :class:`Settings`
+  (`#3746 <https://github.com/openmc-dev/openmc/pull/3746>`_)
+- Added C API bindings for random ray execution and configuration
+  (`#3749 <https://github.com/openmc-dev/openmc/pull/3749>`_)
+- Generalized :class:`ParticleType` using the PDG Monte Carlo numbering scheme
+  (`#3756 <https://github.com/openmc-dev/openmc/pull/3756>`_)
+- Added a parameterized C++ constructor for spatial box distributions
+  (`#3760 <https://github.com/openmc-dev/openmc/pull/3760>`_)
+- Added truncated normal distributions
+  (`#3761 <https://github.com/openmc-dev/openmc/pull/3761>`_)
+- Added approximate neutron velocities when multigroup inverse-velocity data is
+  unavailable (`#3766 <https://github.com/openmc-dev/openmc/pull/3766>`_)
+- Parallelized scattering-matrix transposition for adjoint random ray solves
+  (`#3768 <https://github.com/openmc-dev/openmc/pull/3768>`_)
+- Enabled tracklength tallies of microscopic cross sections in void materials
+  (`#3771 <https://github.com/openmc-dev/openmc/pull/3771>`_)
+- Changed distributed-instance XML data to subelements to support very large
+  instance lists (`#3774 <https://github.com/openmc-dev/openmc/pull/3774>`_)
+- Precomputed random ray source-update offsets for improved performance
+  (`#3775 <https://github.com/openmc-dev/openmc/pull/3775>`_)
+- Allowed tally scores and filters to be supplied to the :class:`Tally`
+  constructor (`#3777 <https://github.com/openmc-dev/openmc/pull/3777>`_)
+- Added support for mixture distributions to
+  :func:`~openmc.stats.combine_distributions`
+  (`#3784 <https://github.com/openmc-dev/openmc/pull/3784>`_)
+- Added C API bindings for :class:`~openmc.lib.SolidRayTracePlot`
+  (`#3789 <https://github.com/openmc-dev/openmc/pull/3789>`_)
+- Simplified :meth:`Model.convert_to_multigroup` setup for DAGMC models
+  (`#3801 <https://github.com/openmc-dev/openmc/pull/3801>`_)
+- Added upper and lower interpolation bounds to multigroup cross-section data
+  (`#3803 <https://github.com/openmc-dev/openmc/pull/3803>`_)
+- Replaced the ``xtensor`` and ``xtl`` dependencies with internal tensor and
+  view classes (`#3805 <https://github.com/openmc-dev/openmc/pull/3805>`_)
+- Added a C API and :func:`openmc.lib.slice_data` interface for raster slice
+  plots (`#3806 <https://github.com/openmc-dev/openmc/pull/3806>`_)
+- Added settings for loading property files and controlling surface-grazing
+  behavior (`#3808 <https://github.com/openmc-dev/openmc/pull/3808>`_)
+- Added :class:`ReactionFilter` for filtering tally events by reaction type
+  (`#3809 <https://github.com/openmc-dev/openmc/pull/3809>`_)
+- Added S2 directional sampling to the random ray solver
+  (`#3811 <https://github.com/openmc-dev/openmc/pull/3811>`_)
+- Extended ray-traced plot data for use by estimators
+  (`#3816 <https://github.com/openmc-dev/openmc/pull/3816>`_)
+- Added :meth:`RegularMesh.get_indices_at_coords`
+  (`#3824 <https://github.com/openmc-dev/openmc/pull/3824>`_)
+- Allowed :meth:`MeshBase.from_domain` to accept bounding boxes directly
+  (`#3828 <https://github.com/openmc-dev/openmc/pull/3828>`_)
+- Parallelized external-source sampling and made rejection counters thread-safe
+  (`#3830 <https://github.com/openmc-dev/openmc/pull/3830>`_)
+- Added hybrid-domain tallies to
+  :func:`~openmc.deplete.get_microxs_and_flux`
+  (`#3831 <https://github.com/openmc-dev/openmc/pull/3831>`_)
+- Improved depletion performance for models with transfer rates
+  (`#3839 <https://github.com/openmc-dev/openmc/pull/3839>`_)
+- Added a setting to disable atomic relaxation
+  (`#3855 <https://github.com/openmc-dev/openmc/pull/3855>`_)
+- Added :func:`openmc.stats.fusion_neutron_spectrum`
+  (`#3862 <https://github.com/openmc-dev/openmc/pull/3862>`_)
+- Added a shared secondary-particle bank for load balancing histories across
+  threads and MPI ranks (`#3863 <https://github.com/openmc-dev/openmc/pull/3863>`_)
+- Added support for multiple meshes in R2S calculations
+  (`#3860 <https://github.com/openmc-dev/openmc/pull/3860>`_)
+- Allowed :meth:`openmc.deplete.StepResult.get_material` to accept integer IDs
+  (`#3872 <https://github.com/openmc-dev/openmc/pull/3872>`_)
+- Allowed sequences of group boundaries in :meth:`Model.convert_to_multigroup`
+  (`#3873 <https://github.com/openmc-dev/openmc/pull/3873>`_)
+- Added :meth:`RectilinearMesh.get_indices_at_coords`
+  (`#3876 <https://github.com/openmc-dev/openmc/pull/3876>`_)
+- Expanded DAGMC cell material, density, and temperature overrides
+  (`#3888 <https://github.com/openmc-dev/openmc/pull/3888>`_)
+- Added ``from_bounding_box`` constructors to structured mesh classes
+  (`#3903 <https://github.com/openmc-dev/openmc/pull/3903>`_)
+- Added optional substeps to CRAM depletion solves
+  (`#3908 <https://github.com/openmc-dev/openmc/pull/3908>`_)
+- Added per-cubic-meter units to material activity and decay-heat methods
+  (`#3912 <https://github.com/openmc-dev/openmc/pull/3912>`_)
+- Extended :attr:`RegularMesh.volumes` to one- and two-dimensional meshes
+  (`#3914 <https://github.com/openmc-dev/openmc/pull/3914>`_)
+- Enabled the tracklength estimator for neutron-heating tallies
+  (`#3915 <https://github.com/openmc-dev/openmc/pull/3915>`_)
+- Added :meth:`SphericalMesh.get_indices_at_coords`
+  (`#3919 <https://github.com/openmc-dev/openmc/pull/3919>`_)
+- Added :class:`openmc.stats.DecaySpectrum` and integrated it with R2S
+  workflows (`#3930 <https://github.com/openmc-dev/openmc/pull/3930>`_)
+- Allowed ``openmc.data.endf.Material`` objects in nuclear-data ``from_endf``
+  methods (`#3932 <https://github.com/openmc-dev/openmc/pull/3932>`_)
+- Enabled pulse-height tallies in coupled neutron--photon calculations
+  (`#3937 <https://github.com/openmc-dev/openmc/pull/3937>`_)
+- Added a description attribute to :class:`Model`
+  (`#3956 <https://github.com/openmc-dev/openmc/pull/3956>`_)
+- Allowed a depletion chain to provide half-life data to
+  :meth:`Material.get_activity`
+  (`#3957 <https://github.com/openmc-dev/openmc/pull/3957>`_)
+- Added random ray forward-flux storage during adjoint calculations
+  (`#3962 <https://github.com/openmc-dev/openmc/pull/3962>`_)
+- Added a weight-window bootstrapping workflow for multigroup cross-section
+  generation (`#3965 <https://github.com/openmc-dev/openmc/pull/3965>`_)
+- Added overlap detection to the interactive plotter
+  (`#3969 <https://github.com/openmc-dev/openmc/pull/3969>`_)
+- Added :class:`TokamakSource` for native parametric tokamak source sampling
+  (`#3999 <https://github.com/openmc-dev/openmc/pull/3999>`_)
+- Enabled parent-nuclide tally breakdowns in R2S calculations
+  (`#4013 <https://github.com/openmc-dev/openmc/pull/4013>`_)
+- Added partial-current labels for :class:`MeshSurfaceFilter`
+  (`#4021 <https://github.com/openmc-dev/openmc/pull/4021>`_)
+- Added control over NJOY's damage-energy threshold
+  (`#4022 <https://github.com/openmc-dev/openmc/pull/4022>`_)
+- Optimized depletion-chain loading and material activity calculations
+  (`#4025 <https://github.com/openmc-dev/openmc/pull/4025>`_)
+- Added a length multiplier to :class:`DAGMCUniverse`
+  (`#4033 <https://github.com/openmc-dev/openmc/pull/4033>`_)
+- Added elemental photon mass energy-absorption coefficients
+  (`#4039 <https://github.com/openmc-dev/openmc/pull/4039>`_)
+- Processed photon-induced electrons and positrons at their birth location and
+  attributed their heating to the parent photon
+  (`#4040 <https://github.com/openmc-dev/openmc/pull/4040>`_)
+
+---------------------------
+Bug Fixes and Small Changes
+---------------------------
+
+- Corrected type handling and generalized
+  :func:`~openmc.stats.combine_distributions`
+  (`#3445 <https://github.com/openmc-dev/openmc/pull/3445>`_)
+- Normalized random ray eigenvalue fluxes consistently with Monte Carlo tallies
+  (`#3595 <https://github.com/openmc-dev/openmc/pull/3595>`_)
+- Restored the DAGMC universe name when exporting XML
+  (`#3657 <https://github.com/openmc-dev/openmc/pull/3657>`_)
+- Corrected temperature assignment in :func:`openmc.model.borated_water`
+  (`#3662 <https://github.com/openmc-dev/openmc/pull/3662>`_)
+- Fixed :class:`DistribcellFilter` when applying tally results to a model
+  (`#3667 <https://github.com/openmc-dev/openmc/pull/3667>`_)
+- Corrected source-location scaling in plots with non-centimeter axis units
+  (`#3668 <https://github.com/openmc-dev/openmc/pull/3668>`_)
+- Limited IFP settings parsing to eigenvalue and fixed-source run modes
+  (`#3673 <https://github.com/openmc-dev/openmc/pull/3673>`_)
+- Corrected the HDF5 source-bank structure size
+  (`#3676 <https://github.com/openmc-dev/openmc/pull/3676>`_)
+- Reported an error when IFP is used outside eigenvalue mode
+  (`#3681 <https://github.com/openmc-dev/openmc/pull/3681>`_)
+- Corrected rotational periodic boundary conditions
+  (`#3692 <https://github.com/openmc-dev/openmc/pull/3692>`_)
+- Corrected rectangular-lattice corner crossing behavior
+  (`#3703 <https://github.com/openmc-dev/openmc/pull/3703>`_)
+- Ensured DAGMC model files are closed after loading
+  (`#3706 <https://github.com/openmc-dev/openmc/pull/3706>`_)
+- Ensured multigroup cross-section HDF5 files are closed after loading
+  (`#3707 <https://github.com/openmc-dev/openmc/pull/3707>`_)
+- Corrected subgroup names in multigroup cross-section HDF5 output
+  (`#3708 <https://github.com/openmc-dev/openmc/pull/3708>`_)
+- Corrected temperature-list handling in multigroup cross-section libraries
+  (`#3712 <https://github.com/openmc-dev/openmc/pull/3712>`_)
+- Corrected operator precedence in nested CSG union and intersection
+  expressions (`#3730 <https://github.com/openmc-dev/openmc/pull/3730>`_)
+- Preserved material names in depletion results
+  (`#3738 <https://github.com/openmc-dev/openmc/pull/3738>`_)
+- Restored compatibility with pandas 3
+  (`#3743 <https://github.com/openmc-dev/openmc/pull/3743>`_)
+- Fixed plotting models that use multigroup cross sections
+  (`#3748 <https://github.com/openmc-dev/openmc/pull/3748>`_)
+- Prevented unstable ground-state Ta180 from being added for natural tantalum
+  (`#3750 <https://github.com/openmc-dev/openmc/pull/3750>`_)
+- Resolved conflicts between weight windows and global Russian roulette
+  (`#3751 <https://github.com/openmc-dev/openmc/pull/3751>`_)
+- Removed a variable-length-array compiler extension
+  (`#3769 <https://github.com/openmc-dev/openmc/pull/3769>`_)
+- Rejected nonpositive surface IDs
+  (`#3772 <https://github.com/openmc-dev/openmc/pull/3772>`_)
+- Corrected length-multiplier use in libMesh methods
+  (`#3773 <https://github.com/openmc-dev/openmc/pull/3773>`_)
+- Improved radial crossing checks in cylindrical and spherical meshes
+  (`#3792 <https://github.com/openmc-dev/openmc/pull/3792>`_)
+- Removed ``setuptools`` from runtime dependencies
+  (`#3794 <https://github.com/openmc-dev/openmc/pull/3794>`_)
+- Prevented ``None`` temperature values in automatically generated multigroup
+  data (`#3802 <https://github.com/openmc-dev/openmc/pull/3802>`_)
+- Enforced positive mesh radii in the Python API
+  (`#3813 <https://github.com/openmc-dev/openmc/pull/3813>`_)
+- Corrected :meth:`MeshFilter.get_pandas_dataframe` for non-regular meshes
+  (`#3817 <https://github.com/openmc-dev/openmc/pull/3817>`_)
+- Corrected pulse-height scoring when no cell filter is present
+  (`#3821 <https://github.com/openmc-dev/openmc/pull/3821>`_)
+- Corrected surface-normal determination in solid ray-traced plots
+  (`#3846 <https://github.com/openmc-dev/openmc/pull/3846>`_)
+- Corrected parsing of cell data in the Python API
+  (`#3848 <https://github.com/openmc-dev/openmc/pull/3848>`_)
+- Avoided numerical cancellation in rectangular-lattice distance calculations
+  at large pitch (`#3853 <https://github.com/openmc-dev/openmc/pull/3853>`_)
+- Closed redirected standard-output file descriptors after use
+  (`#3864 <https://github.com/openmc-dev/openmc/pull/3864>`_)
+- Clipped small negative atom densities produced by CRAM
+  (`#3879 <https://github.com/openmc-dev/openmc/pull/3879>`_)
+- Corrected surface-source particle counts under MPI
+  (`#3901 <https://github.com/openmc-dev/openmc/pull/3901>`_)
+- Removed self-loops from spontaneous-fission decay modes
+  (`#3907 <https://github.com/openmc-dev/openmc/pull/3907>`_)
+- Fixed an MPI hang during depletion calculations
+  (`#3910 <https://github.com/openmc-dev/openmc/pull/3910>`_)
+- Reevaluated geometry after close collisions that follow a surface crossing
+  (`#3933 <https://github.com/openmc-dev/openmc/pull/3933>`_)
+- Corrected virtual-surface crossing behavior
+  (`#3934 <https://github.com/openmc-dev/openmc/pull/3934>`_)
+- Added missing volume checks to material activity and decay-heat calculations
+  (`#3939 <https://github.com/openmc-dev/openmc/pull/3939>`_)
+- Reported a missing value for the ``--threads`` command-line option
+  (`#3940 <https://github.com/openmc-dev/openmc/pull/3940>`_)
+- Guarded average-molar-mass calculations and validated depletion inputs
+  (`#3941 <https://github.com/openmc-dev/openmc/pull/3941>`_)
+- Corrected an undefined scattering variable in multigroup library generation
+  (`#3943 <https://github.com/openmc-dev/openmc/pull/3943>`_)
+- Corrected collision-track output for photon transport
+  (`#3946 <https://github.com/openmc-dev/openmc/pull/3946>`_)
+- Corrected directional index lookup for regular meshes
+  (`#3948 <https://github.com/openmc-dev/openmc/pull/3948>`_)
+- Avoided inconsistent sparse data on summed D1S tallies
+  (`#3949 <https://github.com/openmc-dev/openmc/pull/3949>`_)
+- Preserved collision counts when particles are split
+  (`#3958 <https://github.com/openmc-dev/openmc/pull/3958>`_)
+- Enabled external source rates with transfer rates that specify destination
+  materials (`#3959 <https://github.com/openmc-dev/openmc/pull/3959>`_)
+- Prevented 32-bit overflow in tally indexing and weight-window generation
+  (`#3960 <https://github.com/openmc-dev/openmc/pull/3960>`_)
+- Updated libMesh node access to non-deprecated methods
+  (`#3963 <https://github.com/openmc-dev/openmc/pull/3963>`_)
+- Corrected several independent-operator depletion issues
+  (`#3977 <https://github.com/openmc-dev/openmc/pull/3977>`_)
+- Restored compatibility with NumPy 2.5
+  (`#3981 <https://github.com/openmc-dev/openmc/pull/3981>`_)
+- Preserved material names and distinguished same-named materials during
+  multigroup conversion (`#3984 <https://github.com/openmc-dev/openmc/pull/3984>`_)
+- Loaded photon cross sections when a file source contains photons
+  (`#3988 <https://github.com/openmc-dev/openmc/pull/3988>`_)
+- Disabled weight-window processing for nonpositive lower bounds
+  (`#3990 <https://github.com/openmc-dev/openmc/pull/3990>`_)
+- Made :class:`~openmc.deplete.R2SManager` output handling consistent
+  (`#3994 <https://github.com/openmc-dev/openmc/pull/3994>`_)
+- Fixed compilation with GCC 16 and newer ``fmt`` versions
+  (`#4000 <https://github.com/openmc-dev/openmc/pull/4000>`_)
+- Corrected plotting of distributed cell densities by instance
+  (`#4006 <https://github.com/openmc-dev/openmc/pull/4006>`_)
+- Enabled weight windows automatically when a weight-window file is specified
+  (`#4007 <https://github.com/openmc-dev/openmc/pull/4007>`_)
+- Normalized particle direction after periodic crossings
+  (`#4015 <https://github.com/openmc-dev/openmc/pull/4015>`_)
+- Reset cached filter matches correctly during pulse-height scoring
+  (`#4019 <https://github.com/openmc-dev/openmc/pull/4019>`_)
+- Avoided accessing atomic-relaxation maps when no relaxation data is present
+  (`#4020 <https://github.com/openmc-dev/openmc/pull/4020>`_)
+- Corrected ``M_PI`` availability on affected compilers
+  (`#4023 <https://github.com/openmc-dev/openmc/pull/4023>`_)
+- Determined surface-source starting half-spaces from particle direction
+  (`#4024 <https://github.com/openmc-dev/openmc/pull/4024>`_)
+- Corrected sparse storage of multidimensional tally results
+  (`#4030 <https://github.com/openmc-dev/openmc/pull/4030>`_)
+- Resolved relative input paths against the XML file that contains them
+  (`#4031 <https://github.com/openmc-dev/openmc/pull/4031>`_)
+- Corrected Compton-shell selection and Doppler broadening
+  (`#4036 <https://github.com/openmc-dev/openmc/pull/4036>`_)
+- Fixed MPI tally reductions with counts larger than ``INT_MAX``
+  (`#4037 <https://github.com/openmc-dev/openmc/pull/4037>`_)
+- Limited unstructured-mesh Exodus output to one MPI rank
+  (`#4038 <https://github.com/openmc-dev/openmc/pull/4038>`_)

--- a/docs/source/releasenotes/index.rst
+++ b/docs/source/releasenotes/index.rst
@@ -7,6 +7,7 @@ Release Notes
 .. toctree::
   :maxdepth: 1
 
+  0.16.0
   0.15.3
   0.15.2
   0.15.1

--- a/openmc/data/data.py
+++ b/openmc/data/data.py
@@ -317,7 +317,7 @@ def half_life(
 
     .. versionadded:: 0.13.1
 
-    .. versionchanged:: 0.15.4
+    .. versionchanged:: 0.16.0
         Added the ``chain_file`` argument.
 
     Parameters
@@ -367,7 +367,7 @@ def decay_constant(
 
     .. versionadded:: 0.13.1
 
-    .. versionchanged:: 0.15.4
+    .. versionchanged:: 0.16.0
         Added the ``chain_file`` argument.
 
     Parameters

--- a/openmc/data/dose/mass_attenuation.py
+++ b/openmc/data/dose/mass_attenuation.py
@@ -105,6 +105,8 @@ def mass_energy_absorption_coefficient(
     from `NIST Standard Reference Database 126
     <https://doi.org/10.18434/T4D01F>`_: X-Ray Mass Attenuation Coefficients.
 
+    .. versionadded:: 0.16.0
+
     Parameters
     ----------
     material : str or int
@@ -161,6 +163,8 @@ def mass_attenuation_coefficient(element):
     mass thickness. Values for each element are obtained from `NIST Standard
     Reference Database 8 <https://doi.org/10.18434/T48G6X>`_: XCOM Photon Cross
     Sections Database.
+
+    .. versionadded:: 0.16.0
 
     Parameters
     ----------

--- a/openmc/deplete/abc.py
+++ b/openmc/deplete/abc.py
@@ -577,7 +577,7 @@ class Integrator(ABC):
         factorizations may be reused across them, improving accuracy for
         nuclides with large decay-constant × timestep products.
 
-        .. versionadded:: 0.15.4
+        .. versionadded:: 0.16.0
     continue_timesteps : bool, optional
         Whether or not to treat the current solve as a continuation of a
         previous simulation. Defaults to `False`. When `False`, the depletion
@@ -1192,7 +1192,7 @@ class Integrator(ABC):
         ...     target=1.0
         ... )
 
-        .. versionadded:: 0.15.4
+        .. versionadded:: 0.16.0
 
         """
         self._keff_search_control = _KeffSearchControl(
@@ -1256,7 +1256,7 @@ class SIIntegrator(Integrator):
         factorizations may be reused across them, improving accuracy for
         nuclides with large decay-constant × timestep products.
 
-        .. versionadded:: 0.15.4
+        .. versionadded:: 0.16.0
     continue_timesteps : bool, optional
         Whether or not to treat the current solve as a continuation of a
         previous simulation. Defaults to `False`. If `False`, all time steps and

--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -137,7 +137,7 @@ class Results(list):
             ``None`` or an explicit chain, nuclides absent from the chain fall
             back to ENDF/B-VIII.0 data.
 
-            .. versionadded:: 0.15.4
+            .. versionadded:: 0.16.0
 
         Returns
         -------

--- a/openmc/examples.py
+++ b/openmc/examples.py
@@ -876,6 +876,8 @@ def random_ray_pin_cell(second_temp = False) -> openmc.Model:
     """Create a PWR pin cell example using C5G7 cross section data.
     cross section data.
 
+    .. versionadded:: 0.16.0
+
     Parameters
     ----------
     second_temp : bool, optional
@@ -1327,6 +1329,8 @@ def random_ray_three_region_cube_with_detectors() -> openmc.Model:
     region. The model returned by this function contains cell tallies on each
     detector.
 
+    .. versionadded:: 0.16.0
+
     Returns
     -------
     model : openmc.Model
@@ -1623,6 +1627,8 @@ def random_ray_three_region_cube_with_detectors() -> openmc.Model:
 
 def sphere_with_shielded_pocket() -> openmc.Model:
     """Create a continuous energy deep-shielding model with a far detector pocket.
+
+    .. versionadded:: 0.16.0
 
     A concrete sphere is centered at the origin. A 2 MeV isotropic neutron
     source sits in a small air cavity just inside the sphere surface on the -x

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1404,7 +1404,7 @@ class CollisionFilter(Filter):
 class ReactionFilter(Filter):
     """Bins tally events based on the reaction type (MT number).
 
-    .. versionadded:: 0.15.4
+    .. versionadded:: 0.16.0
 
     Parameters
     ----------
@@ -1821,7 +1821,7 @@ class ParticleProductionFilter(Filter):
 
     The incident particle type can be filtered using :class:`ParticleFilter`.
 
-    .. versionadded:: 0.15.4
+    .. versionadded:: 0.16.0
 
     Parameters
     ----------

--- a/openmc/lib/core.py
+++ b/openmc/lib/core.py
@@ -486,6 +486,8 @@ def run(output=True):
 def run_random_ray(output=True):
     """Run a random ray simulation
 
+    .. versionadded:: 0.16.0
+
     Parameters
     ----------
     output : bool, optional

--- a/openmc/lib/filter.py
+++ b/openmc/lib/filter.py
@@ -609,6 +609,12 @@ class ParticleFilter(Filter):
 
 
 class ParticleProductionFilter(Filter):
+    """Filter secondary-particle production events.
+
+    .. versionadded:: 0.16.0
+
+    """
+
     filter_type = 'particleproduction'
 
 
@@ -617,6 +623,12 @@ class PolarFilter(Filter):
 
 
 class ReactionFilter(Filter):
+    """Filter tally events by reaction type.
+
+    .. versionadded:: 0.16.0
+
+    """
+
     filter_type = 'reaction'
 
 

--- a/openmc/lib/plot.py
+++ b/openmc/lib/plot.py
@@ -91,6 +91,8 @@ def slice_data(origin, width=None, basis='xy', u_span=None, v_span=None,
                 include_properties=True):
     """Generate a 2D raster of geometry and property data for plotting.
 
+    .. versionadded:: 0.16.0
+
     Parameters
     ----------
     origin : sequence of float
@@ -274,6 +276,8 @@ _dll.openmc_slice_data_overlap_info.errcheck = _error_handler
 def slice_data_overlap_count() -> int:
     """Return the number of unique overlaps from the last slice plot.
 
+    .. versionadded:: 0.16.0
+
     Returns
     -------
     int
@@ -287,6 +291,8 @@ def slice_data_overlap_count() -> int:
 
 def slice_data_overlap_info() -> np.ndarray:
     """Return identifying information for overlaps from the last slice plot.
+
+    .. versionadded:: 0.16.0
 
     Returns
     -------
@@ -431,6 +437,8 @@ class SolidRayTracePlot(_FortranObjectWithID):
     This class exposes a solid ray-traced plot that is stored internally in
     the OpenMC library. To obtain a view of an existing plot with a given ID,
     use the :data:`openmc.lib.plots` mapping.
+
+    .. versionadded:: 0.16.0
 
     Parameters
     ----------

--- a/openmc/material.py
+++ b/openmc/material.py
@@ -1421,7 +1421,7 @@ class Material(IDManagerMixin):
             ``None`` or an explicit chain, nuclides absent from the chain fall
             back to ENDF/B-VIII.0 data.
 
-            .. versionadded:: 0.15.4
+            .. versionadded:: 0.16.0
 
         Returns
         -------

--- a/openmc/mesh.py
+++ b/openmc/mesh.py
@@ -1514,7 +1514,7 @@ class RegularMesh(StructuredMesh):
     def get_indices_at_coords(self, coords: Sequence[float]) -> tuple:
         """Finds the index of the mesh element at the specified coordinates.
 
-        .. versionadded:: 0.15.4
+        .. versionadded:: 0.16.0
 
         Parameters
         ----------
@@ -1768,7 +1768,7 @@ class RectilinearMesh(StructuredMesh):
     def get_indices_at_coords(self, coords: Sequence[float]) -> tuple[int, int, int]:
         """Find the mesh cell indices containing the specified coordinates.
 
-        .. versionadded:: 0.15.4
+        .. versionadded:: 0.16.0
 
         Parameters
         ----------
@@ -2665,7 +2665,7 @@ class SphericalMesh(StructuredMesh):
     ) -> tuple[int, int, int]:
         """Find the mesh cell indices containing the specified coordinates.
 
-        .. versionadded:: 0.15.4
+        .. versionadded:: 0.16.0
 
         Parameters
         ----------

--- a/openmc/mgxs/groups.py
+++ b/openmc/mgxs/groups.py
@@ -348,8 +348,9 @@ def convert_flux_groups(flux, source_groups, target_groups):
     -----
     The assumption of constant flux per unit lethargy within each source
     group is physically reasonable for most reactor spectra but is not
-    exact. For best accuracy, use source spectra with sufficiently fine
-    energy resolution.
+    exact [1]_. For best accuracy, use source spectra with sufficiently fine
+    energy resolution. A similar group-conversion approach is available in
+    FISPACT-II [2]_.
 
     Examples
     --------

--- a/openmc/mgxs/groups.py
+++ b/openmc/mgxs/groups.py
@@ -310,7 +310,7 @@ def convert_flux_groups(flux, source_groups, target_groups):
     unit lethargy within each source group and distributes flux to target
     groups proportionally to their lethargy width.
 
-    .. versionadded:: 0.15.4
+    .. versionadded:: 0.16.0
 
     Parameters
     ----------

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -2677,7 +2677,7 @@ class Model:
             Number of particles to simulate per batch when generating MGXS.
             Defaults to 2000.
 
-            .. deprecated:: 0.15.4
+            .. deprecated:: 0.16.0
                 Pass ``particles`` as a keyword argument instead.
         overwrite_mgxs_library : bool, optional
             Whether to overwrite an existing MGXS library file.
@@ -2713,7 +2713,7 @@ class Model:
             Valid entries for temperature_settings are the same as the valid
             entries in openmc.Settings.temperature_settings.
 
-            .. deprecated:: 0.15.4
+            .. deprecated:: 0.16.0
                 Pass ``temperature`` as a keyword argument instead.
         **kwargs
             :class:`openmc.Settings` attributes used to customize the continuous
@@ -2730,7 +2730,7 @@ class Model:
             enables. Cannot be combined with the deprecated ``nparticles`` or
             ``temperature_settings`` arguments.
 
-            .. versionadded:: 0.15.4
+            .. versionadded:: 0.16.0
         """
         if not isinstance(groups, openmc.mgxs.EnergyGroups):
             groups = openmc.mgxs.EnergyGroups(groups)

--- a/openmc/model/model.py
+++ b/openmc/model/model.py
@@ -24,7 +24,7 @@ from openmc.executor import _process_CLI_arguments
 from openmc.checkvalue import (check_type, check_value, check_greater_than,
                                check_length, PathLike)
 from openmc.exceptions import InvalidIDError
-from openmc.plots import add_plot_params, _BASIS_INDICES, id_map_to_rgb
+from openmc.plots import add_plot_params, _BASIS_INDICES, _id_map_to_rgb
 from openmc.utility_funcs import change_directory, set_xml_input_path
 
 
@@ -1399,7 +1399,7 @@ class Model:
             colors = plot.colors
 
         # Convert ID map to RGB image
-        img = id_map_to_rgb(
+        img = _id_map_to_rgb(
             id_map=id_map,
             color_by=color_by,
             colors=colors,

--- a/openmc/particle_type.py
+++ b/openmc/particle_type.py
@@ -46,6 +46,10 @@ class ParticleType:
     to uniquely identify particle types. This includes elementary particles
     (neutrons, photons, etc.) and nuclear codes for isotopes.
 
+    .. versionchanged:: 0.16.0
+        Changed from an ``IntEnum`` to a class backed by PDG Monte Carlo
+        particle numbers.
+
     Parameters
     ----------
     value : str, int, or ParticleType

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -365,6 +365,8 @@ def id_map_to_rgb(
 ) -> np.ndarray:
     """Convert ID map array to RGB image array.
 
+    .. versionadded:: 0.16.0
+
     Parameters
     ----------
     id_map : numpy.ndarray
@@ -1140,7 +1142,7 @@ class VoxelPlot(PlotBase):
     (255, 255, 255) would be white, or by a string indicating a
     valid `SVG color <https://www.w3.org/TR/SVG11/types.html#ColorKeywords>`_.
 
-    .. versionadded:: 0.15.1
+    .. versionadded:: 0.16.0
 
     Parameters
     ----------

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -716,7 +716,7 @@ class SlicePlot(PlotBase):
     (255, 255, 255) would be white, or by a string indicating a
     valid `SVG color <https://www.w3.org/TR/SVG11/types.html#ColorKeywords>`_.
 
-    .. versionadded:: 0.15.4
+    .. versionadded:: 0.16.0
 
     Parameters
     ----------
@@ -1382,7 +1382,7 @@ class VoxelPlot(PlotBase):
 def Plot(plot_id=None, name=''):
     """Legacy Plot class for backward compatibility.
 
-    .. deprecated:: 0.15.4
+    .. deprecated:: 0.16.0
         Use :class:`SlicePlot` for 2D slice plots or :class:`VoxelPlot` for 3D voxel plots.
 
     """

--- a/openmc/plots.py
+++ b/openmc/plots.py
@@ -357,15 +357,13 @@ def voxel_to_vtk(voxel_file: PathLike, output: PathLike = 'plot.vti'):
     return output
 
 
-def id_map_to_rgb(
+def _id_map_to_rgb(
     id_map: np.ndarray,
     color_by: str = 'cell',
     colors: dict | None = None,
     overlap_color: Sequence[int] | str = (255, 0, 0)
 ) -> np.ndarray:
     """Convert ID map array to RGB image array.
-
-    .. versionadded:: 0.16.0
 
     Parameters
     ----------

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -268,7 +268,7 @@ class Settings:
         enabled automatically for fixed-source simulations with weight
         windows active, and disabled otherwise.
 
-        .. versionadded:: 0.15.4
+        .. versionadded:: 0.16.0
     source : Iterable of openmc.SourceBase
         Distribution of source sites in space, angle, and energy
     source_rejection_fraction : float

--- a/openmc/source.py
+++ b/openmc/source.py
@@ -921,7 +921,7 @@ class TokamakSource(SourceBase):
     :math:`\Delta` is the Shafranov shift, and :math:`Z_\mathrm{shift}` is
     the vertical shift.
 
-    .. versionadded:: 0.15.4
+    .. versionadded:: 0.16.0
 
     Parameters
     ----------

--- a/openmc/stats/multivariate.py
+++ b/openmc/stats/multivariate.py
@@ -1281,7 +1281,7 @@ def cylindrical_uniform(
     a flat ring (annulus) at z=0 in the local coordinate frame. Optionally, the
     range of angles can be restricted by the `phis` argument.
 
-    .. versionadded:: 0.15.4
+    .. versionadded:: 0.16.0
 
     Parameters
     ----------

--- a/openmc/stats/univariate.py
+++ b/openmc/stats/univariate.py
@@ -1062,7 +1062,7 @@ class Normal(Univariate):
     the distribution is renormalized so that the PDF integrates to 1 over the
     truncation interval.
 
-    .. versionchanged:: 0.15.4
+    .. versionchanged:: 0.16.0
         Added optional truncation bounds via `lower` and `upper` parameters.
 
     Parameters
@@ -1313,7 +1313,7 @@ def fusion_neutron_spectrum(
     T_i \le 40` keV and Table IV for :math:`40 < T_i < 100` keV. The returned
     distribution is a normal (Gaussian) approximation to the spectrum.
 
-    .. versionadded:: 0.15.4
+    .. versionadded:: 0.16.0
 
     Parameters
     ----------
@@ -2212,7 +2212,7 @@ class DecaySpectrum(Univariate):
     necessary so that the C++ solver can compute the total photon emission rate
     in [photons/s], which is used as the source strength.
 
-    .. versionadded:: 0.15.4
+    .. versionadded:: 0.16.0
 
     Parameters
     ----------

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -7,7 +7,6 @@ import pytest
 
 import openmc
 import openmc.lib
-from openmc.plots import id_map_to_rgb
 
 
 @pytest.fixture(scope='function')
@@ -1057,47 +1056,6 @@ def test_keff_search(run_in_tmpdir):
     # Check that total_batches property works
     assert result.total_batches == sum(result.batches)
     assert result.total_batches > 0
-
-
-def test_id_map_to_rgb():
-    """Test conversion of ID map to RGB image array."""
-    # Create a simple model
-    mat = openmc.Material()
-    mat.set_density('g/cm3', 1.0)
-    mat.add_nuclide('Li7', 1.0)
-
-    sphere = openmc.Sphere(r=5.0, boundary_type='vacuum')
-    cell = openmc.Cell(fill=mat, region=-sphere)
-    geometry = openmc.Geometry([cell])
-    settings = openmc.Settings(
-        batches=10, particles=100, run_mode='fixed source'
-    )
-    model = openmc.Model(geometry, settings=settings)
-
-    id_data = np.zeros((10, 10, 3), dtype=np.int32)
-    id_data[:, :, 0] = cell.id  # Cell IDs
-    id_data[:, :, 2] = mat.id   # Material IDs
-
-    # Test color_by with default colors
-    for color_by in ['cell', 'material']:
-        rgb = id_map_to_rgb(id_data, color_by=color_by)
-        assert rgb.shape == (10, 10, 3)
-        assert rgb.dtype == float
-        assert np.all((rgb >= 0) & (rgb <= 1))  # RGB values in [0, 1]
-
-    # Test with custom colors
-    colors = {cell.id: (255, 0, 0)}  # Red
-    rgb_custom = id_map_to_rgb(id_data, color_by='cell', colors=colors)
-    assert np.allclose(rgb_custom, [1.0, 0.0, 0.0])  # All pixels should be red
-
-    # Test with overlaps
-    id_data_overlap = id_data.copy()
-    id_data_overlap[5:, 5:, 0] = -3  # Mark some pixels as overlaps
-    rgb_overlap = id_map_to_rgb(
-        id_data_overlap, overlap_color=(0, 255, 0)
-    )
-    # Check that overlap region is green
-    assert np.allclose(rgb_overlap[5:, 5:], [0.0, 1.0, 0.0])
 
 
 def test_convert_to_multigroup_preserves_material_names(run_in_tmpdir):


### PR DESCRIPTION
# Description

This PR adds release notes for a version 0.16.0. As @shimwell suggested, some of the changes here warrant a bump in the minor version (photon/electron/positron heating breakdown being one) so I'm planning on tagging as 0.16.0 rather than 0.15.4. Other than the release notes, there are a few minor updates in the documentation, and I've made `id_map_to_rgb` a private function (I don't think it was ever meant to be exposed as a public function).

After this is merged, I'll go ahead and tag v0.16.0!

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>