### PR TITLE
Allow user tallies during R2S neutron transport step

### DIFF
--- a/docs/source/usersguide/decay_sources.rst
+++ b/docs/source/usersguide/decay_sources.rst
@@ -131,6 +131,11 @@ can be run::
 
     r2s.run(timesteps, source_rates, bounding_boxes=bounding_boxes)
 
+Neutron tally results from the transport step are available in the
+``r2s.results['neutron_tallies']`` list, in the same order as the tallies on
+``r2s.neutron_model``. Photon tally results remain available through
+``r2s.results['photon_tallies']``.
+
 If not specified otherwise, a photon transport calculation is run at each time
 in the depletion schedule for which a decay photon source exists. Times without
 a decay photon source, such as the initial state of a model containing only

--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -145,205 +145,205 @@ def get_microxs_and_flux(
     # Save any original tallies on the model
     original_tallies = list(model.tallies)
 
-    try:
-        # Determine what reactions and nuclides are available in chain
-        chain = _get_chain(chain_file)
-        if reactions is None:
-            reactions = chain.reactions
-        if not nuclides:
-            cross_sections = _find_cross_sections(model)
-            nuclides_with_data = _get_nuclides_with_data(cross_sections)
-            nuclides = [nuc.name for nuc in chain.nuclides
-                        if nuc.name in nuclides_with_data]
+    # Determine what reactions and nuclides are available in chain
+    chain = _get_chain(chain_file)
+    if reactions is None:
+        reactions = chain.reactions
+    if not nuclides:
+        cross_sections = _find_cross_sections(model)
+        nuclides_with_data = _get_nuclides_with_data(cross_sections)
+        nuclides = [nuc.name for nuc in chain.nuclides
+                    if nuc.name in nuclides_with_data]
 
-        # Set up the reaction rate and flux tallies. When energies are omitted,
-        # no energy filter is needed for the transport calculation. A one-group
-        # energy range is still needed later if flux collapse is requested.
-        collapse_energies = energies
-        if energies is None:
-            energy_filter = None
-            collapse_energies = [0.0, 100.0e6]
-        elif isinstance(energies, str):
-            energy_filter = openmc.EnergyFilter.from_group_structure(energies)
+    # Set up the reaction rate and flux tallies. When energies are omitted,
+    # no energy filter is needed for the transport calculation. A one-group
+    # energy range is still needed later if flux collapse is requested.
+    collapse_energies = energies
+    if energies is None:
+        energy_filter = None
+        collapse_energies = [0.0, 100.0e6]
+    elif isinstance(energies, str):
+        energy_filter = openmc.EnergyFilter.from_group_structure(energies)
+    else:
+        energy_filter = openmc.EnergyFilter(energies)
+
+    # Build list of domain filters
+    if isinstance(domains, openmc.Filter):
+        domain_filters = [domains]
+    elif isinstance(domains, openmc.MeshBase):
+        domain_filters = [openmc.MeshFilter(domains)]
+    elif isinstance(domains, Sequence) and len(domains) > 0 and \
+            isinstance(domains[0], openmc.Filter):
+        domain_filters = list(domains)
+    elif isinstance(domains[0], openmc.Material):
+        domain_filters = [openmc.MaterialFilter(domains)]
+    elif isinstance(domains[0], openmc.Cell):
+        domain_filters = [openmc.CellFilter(domains)]
+    elif isinstance(domains[0], openmc.Universe):
+        domain_filters = [openmc.UniverseFilter(domains)]
+    else:
+        raise ValueError(f"Unsupported domain type: {type(domains[0])}")
+
+    # Prepare reaction-rate nuclides/reactions
+    rr_nuclides: list[str] = []
+    rr_reactions: list[str] = []
+    if reaction_rate_mode == 'direct':
+        rr_nuclides = list(nuclides)
+        rr_reactions = list(reactions)
+    elif reaction_rate_mode == 'flux' and reaction_rate_opts:
+        opts = reaction_rate_opts or {}
+        rr_reactions = list(opts.get('reactions', []))
+        if rr_reactions:
+            rr_nuclides = list(opts.get('nuclides', nuclides))
         else:
-            energy_filter = openmc.EnergyFilter(energies)
+            rr_nuclides = list(opts.get('nuclides', []))
+        # Keep only requested pairs within overall sets
+        if rr_nuclides:
+            rr_nuclides = [n for n in rr_nuclides if n in set(nuclides)]
+        if rr_reactions:
+            rr_reactions = [r for r in rr_reactions if r in set(reactions)]
 
-        # Build list of domain filters
-        if isinstance(domains, openmc.Filter):
-            domain_filters = [domains]
-        elif isinstance(domains, openmc.MeshBase):
-            domain_filters = [openmc.MeshFilter(domains)]
-        elif isinstance(domains, Sequence) and len(domains) > 0 and \
-                isinstance(domains[0], openmc.Filter):
-            domain_filters = list(domains)
-        elif isinstance(domains[0], openmc.Material):
-            domain_filters = [openmc.MaterialFilter(domains)]
-        elif isinstance(domains[0], openmc.Cell):
-            domain_filters = [openmc.CellFilter(domains)]
-        elif isinstance(domains[0], openmc.Universe):
-            domain_filters = [openmc.UniverseFilter(domains)]
+    # Use 1-group energy filter for RR in flux mode
+    has_rr = bool(rr_nuclides and rr_reactions)
+    if has_rr and reaction_rate_mode == 'flux' and energy_filter is not None:
+        rr_energy_filter = openmc.EnergyFilter(
+            [energy_filter.values[0], energy_filter.values[-1]])
+    else:
+        rr_energy_filter = energy_filter
+
+    # Create one flux tally (and optionally one RR tally) per domain filter.
+    flux_tallies = []
+    rr_tallies = []
+    model.tallies = original_tallies if include_model_tallies else []
+    for i, domain_filter in enumerate(domain_filters):
+        flux_tally = openmc.Tally(name=f'MicroXS flux {i}')
+        flux_tally.filters = [domain_filter]
+        if energy_filter is not None:
+            flux_tally.filters.append(energy_filter)
+        flux_tally.scores = ['flux']
+        model.tallies.append(flux_tally)
+        flux_tallies.append(flux_tally)
+
+        if has_rr:
+            rr_tally = openmc.Tally(name=f'MicroXS RR {i}')
+            rr_tally.filters = [domain_filter]
+            if rr_energy_filter is not None:
+                rr_tally.filters.append(rr_energy_filter)
+            rr_tally.nuclides = rr_nuclides
+            rr_tally.multiply_density = False
+            rr_tally.scores = rr_reactions
+            model.tallies.append(rr_tally)
+            rr_tallies.append(rr_tally)
+
+    if openmc.lib.is_initialized:
+        openmc.lib.finalize()
+
+        if comm.rank == 0:
+            model.export_to_model_xml()
+        comm.barrier()
+        # Reinitialize with tallies
+        output = run_kwargs.get('output', True) if run_kwargs else True
+        openmc.lib.init(intracomm=comm, output=output)
+
+    with TemporaryDirectory() as temp_dir:
+        # Indicate to run in temporary directory unless being executed through
+        # openmc.lib, in which case we don't need to specify the cwd
+        run_kwargs = dict(run_kwargs) if run_kwargs else {}
+        if not openmc.lib.is_initialized:
+            run_kwargs.setdefault('cwd', temp_dir)
+
+        # Run transport simulation and synchronize
+        statepoint_path = model.run(**run_kwargs)
+        comm.barrier()
+
+        if comm.rank == 0:
+            # Move the statepoint file if it is being saved to a specific path
+            if path_statepoint is not None:
+                shutil.move(statepoint_path, path_statepoint)
+                statepoint_path = path_statepoint
+
+            # Export the model to path_input if provided
+            if path_input is not None:
+                model.export_to_model_xml(path_input)
+
+        # Broadcast updated statepoint path to all ranks
+        statepoint_path = comm.bcast(statepoint_path)
+
+        # Read in tally results (on all ranks)
+        with StatePoint(statepoint_path) as sp:
+            for i in range(len(flux_tallies)):
+                flux_tallies[i] = sp.tallies[flux_tallies[i].id]
+                flux_tallies[i]._read_results()
+                if rr_tallies:
+                    rr_tallies[i] = sp.tallies[rr_tallies[i].id]
+                    rr_tallies[i]._read_results()
+
+    # Concatenate results across all domain filters
+    fluxes = []
+    all_flux_arrays = []
+    for flux_tally in flux_tallies:
+        # Get flux values and make energy groups last dimension
+        flux = flux_tally.get_reshaped_data()
+        if energy_filter is None:
+            flux = flux[..., np.newaxis]  # (domains, 1, 1, groups)
         else:
-            raise ValueError(f"Unsupported domain type: {type(domains[0])}")
+            # (domains, groups, 1, 1) -> (domains, 1, 1, groups)
+            flux = np.moveaxis(flux, 1, -1)
+        all_flux_arrays.append(flux)
+        fluxes.extend(flux.squeeze((1, 2)))
 
-        # Prepare reaction-rate nuclides/reactions
-        rr_nuclides: list[str] = []
-        rr_reactions: list[str] = []
-        if reaction_rate_mode == 'direct':
-            rr_nuclides = list(nuclides)
-            rr_reactions = list(reactions)
-        elif reaction_rate_mode == 'flux' and reaction_rate_opts:
-            opts = reaction_rate_opts or {}
-            rr_reactions = list(opts.get('reactions', []))
-            if rr_reactions:
-                rr_nuclides = list(opts.get('nuclides', nuclides))
+    # If we built reaction-rate tallies, compute microscopic cross sections
+    if rr_tallies:
+        direct_micros = []
+        for flux_arr, rr_tally in zip(all_flux_arrays, rr_tallies):
+            flux = flux_arr
+            # Get reaction rates and make energy groups last dimension
+            reaction_rates = rr_tally.get_reshaped_data()
+            if rr_energy_filter is None:
+                # (domains, nuclides, reactions) ->
+                # (domains, nuclides, reactions, groups)
+                reaction_rates = reaction_rates[..., np.newaxis]
             else:
-                rr_nuclides = list(opts.get('nuclides', []))
-            # Keep only requested pairs within overall sets
-            if rr_nuclides:
-                rr_nuclides = [n for n in rr_nuclides if n in set(nuclides)]
-            if rr_reactions:
-                rr_reactions = [r for r in rr_reactions if r in set(reactions)]
+                # (domains, groups, nuclides, reactions) ->
+                # (domains, nuclides, reactions, groups)
+                reaction_rates = np.moveaxis(reaction_rates, 1, -1)
 
-        # Use 1-group energy filter for RR in flux mode
-        has_rr = bool(rr_nuclides and rr_reactions)
-        if has_rr and reaction_rate_mode == 'flux' and energy_filter is not None:
-            rr_energy_filter = openmc.EnergyFilter(
-                [energy_filter.values[0], energy_filter.values[-1]])
-        else:
-            rr_energy_filter = energy_filter
+            # If RR is 1-group, sum flux over groups
+            if reaction_rate_mode == "flux":
+                flux = flux.sum(axis=-1, keepdims=True)
 
-        # Create one flux tally (and optionally one RR tally) per domain filter.
-        flux_tallies = []
-        rr_tallies = []
-        model.tallies = original_tallies if include_model_tallies else []
-        for i, domain_filter in enumerate(domain_filters):
-            flux_tally = openmc.Tally(name=f'MicroXS flux {i}')
-            flux_tally.filters = [domain_filter]
-            if energy_filter is not None:
-                flux_tally.filters.append(energy_filter)
-            flux_tally.scores = ['flux']
-            model.tallies.append(flux_tally)
-            flux_tallies.append(flux_tally)
+            xs = np.zeros_like(reaction_rates)
+            d, _, _, g = np.nonzero(flux)
+            xs[d, ..., g] = reaction_rates[d, ..., g] / flux[d, :, :, g]
+            direct_micros.extend(
+                MicroXS(xs_i, rr_nuclides, rr_reactions) for xs_i in xs)
 
-            if has_rr:
-                rr_tally = openmc.Tally(name=f'MicroXS RR {i}')
-                rr_tally.filters = [domain_filter]
-                if rr_energy_filter is not None:
-                    rr_tally.filters.append(rr_energy_filter)
-                rr_tally.nuclides = rr_nuclides
-                rr_tally.multiply_density = False
-                rr_tally.scores = rr_reactions
-                model.tallies.append(rr_tally)
-                rr_tallies.append(rr_tally)
+    if reaction_rate_mode == 'flux':
+        # Compute flux-collapsed microscopic XS
+        flux_micros = [MicroXS.from_multigroup_flux(
+            energies=collapse_energies,
+            multigroup_flux=flux_i,
+            chain_file=chain_file,
+            nuclides=nuclides,
+            reactions=reactions
+        ) for flux_i in fluxes]
 
-        if openmc.lib.is_initialized:
-            openmc.lib.finalize()
+        # We need to return one-group fluxes to match the microscopic cross
+        # sections, which are always one-group by virtue of the collapse
+        fluxes = [flux.sum(keepdims=True) for flux in fluxes]
 
-            if comm.rank == 0:
-                model.export_to_model_xml()
-            comm.barrier()
-            # Reinitialize with tallies
-            output = run_kwargs.get('output', True) if run_kwargs else True
-            openmc.lib.init(intracomm=comm, output=output)
+    # Decide which micros to use and merge if needed
+    if reaction_rate_mode == 'flux' and rr_tallies:
+        micros = [m1.merge(m2) for m1, m2 in zip(flux_micros, direct_micros)]
+    elif rr_tallies:
+        micros = direct_micros
+    else:
+        micros = flux_micros
 
-        with TemporaryDirectory() as temp_dir:
-            # Indicate to run in temporary directory unless being executed through
-            # openmc.lib, in which case we don't need to specify the cwd
-            run_kwargs = dict(run_kwargs) if run_kwargs else {}
-            if not openmc.lib.is_initialized:
-                run_kwargs.setdefault('cwd', temp_dir)
+    model.tallies = original_tallies
 
-            # Run transport simulation and synchronize
-            statepoint_path = model.run(**run_kwargs)
-            comm.barrier()
+    return fluxes, micros
 
-            if comm.rank == 0:
-                # Move the statepoint file if it is being saved to a specific path
-                if path_statepoint is not None:
-                    shutil.move(statepoint_path, path_statepoint)
-                    statepoint_path = path_statepoint
-
-                # Export the model to path_input if provided
-                if path_input is not None:
-                    model.export_to_model_xml(path_input)
-
-            # Broadcast updated statepoint path to all ranks
-            statepoint_path = comm.bcast(statepoint_path)
-
-            # Read in tally results (on all ranks)
-            with StatePoint(statepoint_path) as sp:
-                for i in range(len(flux_tallies)):
-                    flux_tallies[i] = sp.tallies[flux_tallies[i].id]
-                    flux_tallies[i]._read_results()
-                    if rr_tallies:
-                        rr_tallies[i] = sp.tallies[rr_tallies[i].id]
-                        rr_tallies[i]._read_results()
-
-        # Concatenate results across all domain filters
-        fluxes = []
-        all_flux_arrays = []
-        for flux_tally in flux_tallies:
-            # Get flux values and make energy groups last dimension
-            flux = flux_tally.get_reshaped_data()
-            if energy_filter is None:
-                flux = flux[..., np.newaxis]  # (domains, 1, 1, groups)
-            else:
-                # (domains, groups, 1, 1) -> (domains, 1, 1, groups)
-                flux = np.moveaxis(flux, 1, -1)
-            all_flux_arrays.append(flux)
-            fluxes.extend(flux.squeeze((1, 2)))
-
-        # If we built reaction-rate tallies, compute microscopic cross sections
-        if rr_tallies:
-            direct_micros = []
-            for flux_arr, rr_tally in zip(all_flux_arrays, rr_tallies):
-                flux = flux_arr
-                # Get reaction rates and make energy groups last dimension
-                reaction_rates = rr_tally.get_reshaped_data()
-                if rr_energy_filter is None:
-                    # (domains, nuclides, reactions) ->
-                    # (domains, nuclides, reactions, groups)
-                    reaction_rates = reaction_rates[..., np.newaxis]
-                else:
-                    # (domains, groups, nuclides, reactions) ->
-                    # (domains, nuclides, reactions, groups)
-                    reaction_rates = np.moveaxis(reaction_rates, 1, -1)
-
-                # If RR is 1-group, sum flux over groups
-                if reaction_rate_mode == "flux":
-                    flux = flux.sum(axis=-1, keepdims=True)
-
-                xs = np.zeros_like(reaction_rates)
-                d, _, _, g = np.nonzero(flux)
-                xs[d, ..., g] = reaction_rates[d, ..., g] / flux[d, :, :, g]
-                direct_micros.extend(
-                    MicroXS(xs_i, rr_nuclides, rr_reactions) for xs_i in xs)
-
-        if reaction_rate_mode == 'flux':
-            # Compute flux-collapsed microscopic XS
-            flux_micros = [MicroXS.from_multigroup_flux(
-                energies=collapse_energies,
-                multigroup_flux=flux_i,
-                chain_file=chain_file,
-                nuclides=nuclides,
-                reactions=reactions
-            ) for flux_i in fluxes]
-
-            # We need to return one-group fluxes to match the microscopic cross
-            # sections, which are always one-group by virtue of the collapse
-            fluxes = [flux.sum(keepdims=True) for flux in fluxes]
-
-        # Decide which micros to use and merge if needed
-        if reaction_rate_mode == 'flux' and rr_tallies:
-            micros = [m1.merge(m2) for m1, m2 in zip(flux_micros, direct_micros)]
-        elif rr_tallies:
-            micros = direct_micros
-        else:
-            micros = flux_micros
-
-        return fluxes, micros
-    finally:
-        model.tallies = original_tallies
 
 
 class MicroXS:

--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -61,6 +61,10 @@ def get_microxs_and_flux(
     sections that can be used in depletion calculations with the
     :class:`~openmc.deplete.IndependentOperator` class.
 
+    Any tallies already assigned to ``model`` are included in the transport
+    solve alongside the tallies created by this function. The original tally
+    collection is restored before returning.
+
     .. versionadded:: 0.14.0
 
     .. versionchanged:: 0.15.3
@@ -205,7 +209,7 @@ def get_microxs_and_flux(
     # Create one flux tally (and optionally one RR tally) per domain filter.
     flux_tallies = []
     rr_tallies = []
-    model.tallies = []
+    model.tallies = original_tallies
     for i, domain_filter in enumerate(domain_filters):
         flux_tally = openmc.Tally(name=f'MicroXS flux {i}')
         flux_tally.filters = [domain_filter]

--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -140,7 +140,6 @@ def get_microxs_and_flux(
 
     """
     check_value('reaction_rate_mode', reaction_rate_mode, {'direct', 'flux'})
-    check_type('include_model_tallies', include_model_tallies, bool)
 
     # Save any original tallies on the model
     original_tallies = list(model.tallies)
@@ -155,9 +154,9 @@ def get_microxs_and_flux(
         nuclides = [nuc.name for nuc in chain.nuclides
                     if nuc.name in nuclides_with_data]
 
-    # Set up the reaction rate and flux tallies. When energies are omitted,
-    # no energy filter is needed for the transport calculation. A one-group
-    # energy range is still needed later if flux collapse is requested.
+    # Set up the reaction rate and flux tallies. When energies are omitted, no
+    # energy filter is needed for the transport calculation. A one-group energy
+    # range is still needed later if flux collapse is requested.
     collapse_energies = energies
     if energies is None:
         energy_filter = None
@@ -340,10 +339,10 @@ def get_microxs_and_flux(
     else:
         micros = flux_micros
 
+    # Reset tallies
     model.tallies = original_tallies
 
     return fluxes, micros
-
 
 
 class MicroXS:

--- a/openmc/deplete/microxs.py
+++ b/openmc/deplete/microxs.py
@@ -53,6 +53,7 @@ def get_microxs_and_flux(
     path_input: PathLike | None = None,
     run_kwargs=None,
     reaction_rate_opts: dict | None = None,
+    include_model_tallies: bool = False,
 ) -> tuple[list[np.ndarray], list[MicroXS]]:
     """Generate microscopic cross sections and fluxes for multiple domains.
 
@@ -61,14 +62,13 @@ def get_microxs_and_flux(
     sections that can be used in depletion calculations with the
     :class:`~openmc.deplete.IndependentOperator` class.
 
-    Any tallies already assigned to ``model`` are included in the transport
-    solve alongside the tallies created by this function. The original tally
-    collection is restored before returning.
-
     .. versionadded:: 0.14.0
 
     .. versionchanged:: 0.15.3
         Added `reaction_rate_mode`, `path_statepoint`, `path_input` arguments.
+
+    .. versionchanged:: 0.16.0
+        Added the `include_model_tallies` argument.
 
     Parameters
     ----------
@@ -122,6 +122,10 @@ def get_microxs_and_flux(
         over one energy bin spanning the full `energies` range. Supported keys:
         "nuclides", "reactions". If "reactions" are specified without
         "nuclides", all selected nuclides are used.
+    include_model_tallies : bool, optional
+        Whether to include tallies already assigned to ``model`` in the
+        transport solve. The original tally collection is restored after the
+        solve, including if an exception is raised. Defaults to False.
 
     Returns
     -------
@@ -136,209 +140,210 @@ def get_microxs_and_flux(
 
     """
     check_value('reaction_rate_mode', reaction_rate_mode, {'direct', 'flux'})
+    check_type('include_model_tallies', include_model_tallies, bool)
 
     # Save any original tallies on the model
     original_tallies = list(model.tallies)
 
-    # Determine what reactions and nuclides are available in chain
-    chain = _get_chain(chain_file)
-    if reactions is None:
-        reactions = chain.reactions
-    if not nuclides:
-        cross_sections = _find_cross_sections(model)
-        nuclides_with_data = _get_nuclides_with_data(cross_sections)
-        nuclides = [nuc.name for nuc in chain.nuclides
-                    if nuc.name in nuclides_with_data]
+    try:
+        # Determine what reactions and nuclides are available in chain
+        chain = _get_chain(chain_file)
+        if reactions is None:
+            reactions = chain.reactions
+        if not nuclides:
+            cross_sections = _find_cross_sections(model)
+            nuclides_with_data = _get_nuclides_with_data(cross_sections)
+            nuclides = [nuc.name for nuc in chain.nuclides
+                        if nuc.name in nuclides_with_data]
 
-    # Set up the reaction rate and flux tallies. When energies are omitted, no
-    # energy filter is needed for the transport calculation. A one-group energy
-    # range is still needed later if flux collapse is requested.
-    collapse_energies = energies
-    if energies is None:
-        energy_filter = None
-        collapse_energies = [0.0, 100.0e6]
-    elif isinstance(energies, str):
-        energy_filter = openmc.EnergyFilter.from_group_structure(energies)
-    else:
-        energy_filter = openmc.EnergyFilter(energies)
-
-    # Build list of domain filters
-    if isinstance(domains, openmc.Filter):
-        domain_filters = [domains]
-    elif isinstance(domains, openmc.MeshBase):
-        domain_filters = [openmc.MeshFilter(domains)]
-    elif isinstance(domains, Sequence) and len(domains) > 0 and \
-            isinstance(domains[0], openmc.Filter):
-        domain_filters = list(domains)
-    elif isinstance(domains[0], openmc.Material):
-        domain_filters = [openmc.MaterialFilter(domains)]
-    elif isinstance(domains[0], openmc.Cell):
-        domain_filters = [openmc.CellFilter(domains)]
-    elif isinstance(domains[0], openmc.Universe):
-        domain_filters = [openmc.UniverseFilter(domains)]
-    else:
-        raise ValueError(f"Unsupported domain type: {type(domains[0])}")
-
-    # Prepare reaction-rate nuclides/reactions
-    rr_nuclides: list[str] = []
-    rr_reactions: list[str] = []
-    if reaction_rate_mode == 'direct':
-        rr_nuclides = list(nuclides)
-        rr_reactions = list(reactions)
-    elif reaction_rate_mode == 'flux' and reaction_rate_opts:
-        opts = reaction_rate_opts or {}
-        rr_reactions = list(opts.get('reactions', []))
-        if rr_reactions:
-            rr_nuclides = list(opts.get('nuclides', nuclides))
+        # Set up the reaction rate and flux tallies. When energies are omitted,
+        # no energy filter is needed for the transport calculation. A one-group
+        # energy range is still needed later if flux collapse is requested.
+        collapse_energies = energies
+        if energies is None:
+            energy_filter = None
+            collapse_energies = [0.0, 100.0e6]
+        elif isinstance(energies, str):
+            energy_filter = openmc.EnergyFilter.from_group_structure(energies)
         else:
-            rr_nuclides = list(opts.get('nuclides', []))
-        # Keep only requested pairs within overall sets
-        if rr_nuclides:
-            rr_nuclides = [n for n in rr_nuclides if n in set(nuclides)]
-        if rr_reactions:
-            rr_reactions = [r for r in rr_reactions if r in set(reactions)]
+            energy_filter = openmc.EnergyFilter(energies)
 
-    # Use 1-group energy filter for RR in flux mode
-    has_rr = bool(rr_nuclides and rr_reactions)
-    if has_rr and reaction_rate_mode == 'flux' and energy_filter is not None:
-        rr_energy_filter = openmc.EnergyFilter(
-            [energy_filter.values[0], energy_filter.values[-1]])
-    else:
-        rr_energy_filter = energy_filter
-
-    # Create one flux tally (and optionally one RR tally) per domain filter.
-    flux_tallies = []
-    rr_tallies = []
-    model.tallies = original_tallies
-    for i, domain_filter in enumerate(domain_filters):
-        flux_tally = openmc.Tally(name=f'MicroXS flux {i}')
-        flux_tally.filters = [domain_filter]
-        if energy_filter is not None:
-            flux_tally.filters.append(energy_filter)
-        flux_tally.scores = ['flux']
-        model.tallies.append(flux_tally)
-        flux_tallies.append(flux_tally)
-
-        if has_rr:
-            rr_tally = openmc.Tally(name=f'MicroXS RR {i}')
-            rr_tally.filters = [domain_filter]
-            if rr_energy_filter is not None:
-                rr_tally.filters.append(rr_energy_filter)
-            rr_tally.nuclides = rr_nuclides
-            rr_tally.multiply_density = False
-            rr_tally.scores = rr_reactions
-            model.tallies.append(rr_tally)
-            rr_tallies.append(rr_tally)
-
-    if openmc.lib.is_initialized:
-        openmc.lib.finalize()
-
-        if comm.rank == 0:
-            model.export_to_model_xml()
-        comm.barrier()
-        # Reinitialize with tallies
-        output = run_kwargs.get('output', True) if run_kwargs else True
-        openmc.lib.init(intracomm=comm, output=output)
-
-    with TemporaryDirectory() as temp_dir:
-        # Indicate to run in temporary directory unless being executed through
-        # openmc.lib, in which case we don't need to specify the cwd
-        run_kwargs = dict(run_kwargs) if run_kwargs else {}
-        if not openmc.lib.is_initialized:
-            run_kwargs.setdefault('cwd', temp_dir)
-
-        # Run transport simulation and synchronize
-        statepoint_path = model.run(**run_kwargs)
-        comm.barrier()
-
-        if comm.rank == 0:
-            # Move the statepoint file if it is being saved to a specific path
-            if path_statepoint is not None:
-                shutil.move(statepoint_path, path_statepoint)
-                statepoint_path = path_statepoint
-
-            # Export the model to path_input if provided
-            if path_input is not None:
-                model.export_to_model_xml(path_input)
-
-        # Broadcast updated statepoint path to all ranks
-        statepoint_path = comm.bcast(statepoint_path)
-
-        # Read in tally results (on all ranks)
-        with StatePoint(statepoint_path) as sp:
-            for i in range(len(flux_tallies)):
-                flux_tallies[i] = sp.tallies[flux_tallies[i].id]
-                flux_tallies[i]._read_results()
-                if rr_tallies:
-                    rr_tallies[i] = sp.tallies[rr_tallies[i].id]
-                    rr_tallies[i]._read_results()
-
-    # Concatenate results across all domain filters
-    fluxes = []
-    all_flux_arrays = []
-    for flux_tally in flux_tallies:
-        # Get flux values and make energy groups last dimension
-        flux = flux_tally.get_reshaped_data()
-        if energy_filter is None:
-            flux = flux[..., np.newaxis]  # (domains, 1, 1, groups)
+        # Build list of domain filters
+        if isinstance(domains, openmc.Filter):
+            domain_filters = [domains]
+        elif isinstance(domains, openmc.MeshBase):
+            domain_filters = [openmc.MeshFilter(domains)]
+        elif isinstance(domains, Sequence) and len(domains) > 0 and \
+                isinstance(domains[0], openmc.Filter):
+            domain_filters = list(domains)
+        elif isinstance(domains[0], openmc.Material):
+            domain_filters = [openmc.MaterialFilter(domains)]
+        elif isinstance(domains[0], openmc.Cell):
+            domain_filters = [openmc.CellFilter(domains)]
+        elif isinstance(domains[0], openmc.Universe):
+            domain_filters = [openmc.UniverseFilter(domains)]
         else:
-            # (domains, groups, 1, 1) -> (domains, 1, 1, groups)
-            flux = np.moveaxis(flux, 1, -1)
-        all_flux_arrays.append(flux)
-        fluxes.extend(flux.squeeze((1, 2)))
+            raise ValueError(f"Unsupported domain type: {type(domains[0])}")
 
-    # If we built reaction-rate tallies, compute microscopic cross sections
-    if rr_tallies:
-        direct_micros = []
-        for flux_arr, rr_tally in zip(all_flux_arrays, rr_tallies):
-            flux = flux_arr
-            # Get reaction rates and make energy groups last dimension
-            reaction_rates = rr_tally.get_reshaped_data()
-            if rr_energy_filter is None:
-                # (domains, nuclides, reactions) ->
-                # (domains, nuclides, reactions, groups)
-                reaction_rates = reaction_rates[..., np.newaxis]
+        # Prepare reaction-rate nuclides/reactions
+        rr_nuclides: list[str] = []
+        rr_reactions: list[str] = []
+        if reaction_rate_mode == 'direct':
+            rr_nuclides = list(nuclides)
+            rr_reactions = list(reactions)
+        elif reaction_rate_mode == 'flux' and reaction_rate_opts:
+            opts = reaction_rate_opts or {}
+            rr_reactions = list(opts.get('reactions', []))
+            if rr_reactions:
+                rr_nuclides = list(opts.get('nuclides', nuclides))
             else:
-                # (domains, groups, nuclides, reactions) ->
-                # (domains, nuclides, reactions, groups)
-                reaction_rates = np.moveaxis(reaction_rates, 1, -1)
+                rr_nuclides = list(opts.get('nuclides', []))
+            # Keep only requested pairs within overall sets
+            if rr_nuclides:
+                rr_nuclides = [n for n in rr_nuclides if n in set(nuclides)]
+            if rr_reactions:
+                rr_reactions = [r for r in rr_reactions if r in set(reactions)]
 
-            # If RR is 1-group, sum flux over groups
-            if reaction_rate_mode == "flux":
-                flux = flux.sum(axis=-1, keepdims=True)
+        # Use 1-group energy filter for RR in flux mode
+        has_rr = bool(rr_nuclides and rr_reactions)
+        if has_rr and reaction_rate_mode == 'flux' and energy_filter is not None:
+            rr_energy_filter = openmc.EnergyFilter(
+                [energy_filter.values[0], energy_filter.values[-1]])
+        else:
+            rr_energy_filter = energy_filter
 
-            xs = np.zeros_like(reaction_rates)
-            d, _, _, g = np.nonzero(flux)
-            xs[d, ..., g] = reaction_rates[d, ..., g] / flux[d, :, :, g]
-            direct_micros.extend(
-                MicroXS(xs_i, rr_nuclides, rr_reactions) for xs_i in xs)
+        # Create one flux tally (and optionally one RR tally) per domain filter.
+        flux_tallies = []
+        rr_tallies = []
+        model.tallies = original_tallies if include_model_tallies else []
+        for i, domain_filter in enumerate(domain_filters):
+            flux_tally = openmc.Tally(name=f'MicroXS flux {i}')
+            flux_tally.filters = [domain_filter]
+            if energy_filter is not None:
+                flux_tally.filters.append(energy_filter)
+            flux_tally.scores = ['flux']
+            model.tallies.append(flux_tally)
+            flux_tallies.append(flux_tally)
 
-    if reaction_rate_mode == 'flux':
-        # Compute flux-collapsed microscopic XS
-        flux_micros = [MicroXS.from_multigroup_flux(
-            energies=collapse_energies,
-            multigroup_flux=flux_i,
-            chain_file=chain_file,
-            nuclides=nuclides,
-            reactions=reactions
-        ) for flux_i in fluxes]
+            if has_rr:
+                rr_tally = openmc.Tally(name=f'MicroXS RR {i}')
+                rr_tally.filters = [domain_filter]
+                if rr_energy_filter is not None:
+                    rr_tally.filters.append(rr_energy_filter)
+                rr_tally.nuclides = rr_nuclides
+                rr_tally.multiply_density = False
+                rr_tally.scores = rr_reactions
+                model.tallies.append(rr_tally)
+                rr_tallies.append(rr_tally)
 
-        # We need to return one-group fluxes to match the microscopic cross
-        # sections, which are always one-group by virtue of the collapse
-        fluxes = [flux.sum(keepdims=True) for flux in fluxes]
+        if openmc.lib.is_initialized:
+            openmc.lib.finalize()
 
-    # Decide which micros to use and merge if needed
-    if reaction_rate_mode == 'flux' and rr_tallies:
-        micros = [m1.merge(m2) for m1, m2 in zip(flux_micros, direct_micros)]
-    elif rr_tallies:
-        micros = direct_micros
-    else:
-        micros = flux_micros
+            if comm.rank == 0:
+                model.export_to_model_xml()
+            comm.barrier()
+            # Reinitialize with tallies
+            output = run_kwargs.get('output', True) if run_kwargs else True
+            openmc.lib.init(intracomm=comm, output=output)
 
-    # Reset tallies
-    model.tallies = original_tallies
+        with TemporaryDirectory() as temp_dir:
+            # Indicate to run in temporary directory unless being executed through
+            # openmc.lib, in which case we don't need to specify the cwd
+            run_kwargs = dict(run_kwargs) if run_kwargs else {}
+            if not openmc.lib.is_initialized:
+                run_kwargs.setdefault('cwd', temp_dir)
 
-    return fluxes, micros
+            # Run transport simulation and synchronize
+            statepoint_path = model.run(**run_kwargs)
+            comm.barrier()
+
+            if comm.rank == 0:
+                # Move the statepoint file if it is being saved to a specific path
+                if path_statepoint is not None:
+                    shutil.move(statepoint_path, path_statepoint)
+                    statepoint_path = path_statepoint
+
+                # Export the model to path_input if provided
+                if path_input is not None:
+                    model.export_to_model_xml(path_input)
+
+            # Broadcast updated statepoint path to all ranks
+            statepoint_path = comm.bcast(statepoint_path)
+
+            # Read in tally results (on all ranks)
+            with StatePoint(statepoint_path) as sp:
+                for i in range(len(flux_tallies)):
+                    flux_tallies[i] = sp.tallies[flux_tallies[i].id]
+                    flux_tallies[i]._read_results()
+                    if rr_tallies:
+                        rr_tallies[i] = sp.tallies[rr_tallies[i].id]
+                        rr_tallies[i]._read_results()
+
+        # Concatenate results across all domain filters
+        fluxes = []
+        all_flux_arrays = []
+        for flux_tally in flux_tallies:
+            # Get flux values and make energy groups last dimension
+            flux = flux_tally.get_reshaped_data()
+            if energy_filter is None:
+                flux = flux[..., np.newaxis]  # (domains, 1, 1, groups)
+            else:
+                # (domains, groups, 1, 1) -> (domains, 1, 1, groups)
+                flux = np.moveaxis(flux, 1, -1)
+            all_flux_arrays.append(flux)
+            fluxes.extend(flux.squeeze((1, 2)))
+
+        # If we built reaction-rate tallies, compute microscopic cross sections
+        if rr_tallies:
+            direct_micros = []
+            for flux_arr, rr_tally in zip(all_flux_arrays, rr_tallies):
+                flux = flux_arr
+                # Get reaction rates and make energy groups last dimension
+                reaction_rates = rr_tally.get_reshaped_data()
+                if rr_energy_filter is None:
+                    # (domains, nuclides, reactions) ->
+                    # (domains, nuclides, reactions, groups)
+                    reaction_rates = reaction_rates[..., np.newaxis]
+                else:
+                    # (domains, groups, nuclides, reactions) ->
+                    # (domains, nuclides, reactions, groups)
+                    reaction_rates = np.moveaxis(reaction_rates, 1, -1)
+
+                # If RR is 1-group, sum flux over groups
+                if reaction_rate_mode == "flux":
+                    flux = flux.sum(axis=-1, keepdims=True)
+
+                xs = np.zeros_like(reaction_rates)
+                d, _, _, g = np.nonzero(flux)
+                xs[d, ..., g] = reaction_rates[d, ..., g] / flux[d, :, :, g]
+                direct_micros.extend(
+                    MicroXS(xs_i, rr_nuclides, rr_reactions) for xs_i in xs)
+
+        if reaction_rate_mode == 'flux':
+            # Compute flux-collapsed microscopic XS
+            flux_micros = [MicroXS.from_multigroup_flux(
+                energies=collapse_energies,
+                multigroup_flux=flux_i,
+                chain_file=chain_file,
+                nuclides=nuclides,
+                reactions=reactions
+            ) for flux_i in fluxes]
+
+            # We need to return one-group fluxes to match the microscopic cross
+            # sections, which are always one-group by virtue of the collapse
+            fluxes = [flux.sum(keepdims=True) for flux in fluxes]
+
+        # Decide which micros to use and merge if needed
+        if reaction_rate_mode == 'flux' and rr_tallies:
+            micros = [m1.merge(m2) for m1, m2 in zip(flux_micros, direct_micros)]
+        elif rr_tallies:
+            micros = direct_micros
+        else:
+            micros = flux_micros
+
+        return fluxes, micros
+    finally:
+        model.tallies = original_tallies
 
 
 class MicroXS:

--- a/openmc/deplete/r2s.py
+++ b/openmc/deplete/r2s.py
@@ -362,9 +362,9 @@ class R2SManager:
         micro_kwargs['path_statepoint'] = statepoint_path
 
         # Determine neutron tally IDs based on whether model tallies are included
-        include_model_tallies = micro_kwargs['include_model_tallies']
-        neutron_tally_ids = [tally.id for tally in self.neutron_model.tallies] \
-            if include_model_tallies else []
+        neutron_tally_ids = []
+        if micro_kwargs['include_model_tallies']:
+            neutron_tally_ids = [tally.id for tally in self.neutron_model.tallies]
 
         # Run neutron transport and get fluxes and micros. Run via openmc.lib to
         # maintain a consistent parallelism strategy with the activation step.

--- a/openmc/deplete/r2s.py
+++ b/openmc/deplete/r2s.py
@@ -111,10 +111,7 @@ class R2SManager:
         Indicates whether the R2S calculation uses mesh elements ('mesh-based')
         as the spatial discretization or a list of cells ('cell-based').
     results : dict
-        A dictionary that stores results from the R2S calculation. In
-        particular, ``results['neutron_tallies']`` contains user-defined
-        neutron tally results from the neutron transport step, while
-        ``results['photon_tallies']`` contains photon tally results.
+        A dictionary that stores results from the R2S calculation.
 
     """
     def __init__(
@@ -201,8 +198,7 @@ class R2SManager:
         micro_kwargs : dict, optional
             Additional keyword arguments passed to
             :func:`openmc.deplete.get_microxs_and_flux` during the neutron
-            transport step. Existing neutron model tallies are included by
-            default; pass ``include_model_tallies=False`` to exclude them.
+            transport step.
         mat_vol_kwargs : dict, optional
             Additional keyword arguments passed to
             :meth:`openmc.MeshBase.material_volumes`.
@@ -241,7 +237,6 @@ class R2SManager:
         if operator_kwargs is None:
             operator_kwargs = {}
         run_kwargs.setdefault('output', False)
-        micro_kwargs.setdefault('include_model_tallies', True)
         micro_kwargs.setdefault('run_kwargs', run_kwargs)
 
         # DecaySpectrum distributions are resolved in the C++ solver using
@@ -307,8 +302,6 @@ class R2SManager:
         micro_kwargs : dict, optional
             Additional keyword arguments passed to
             :func:`openmc.deplete.get_microxs_and_flux`.
-            Existing neutron model tallies are included by default; pass
-            ``include_model_tallies=False`` to exclude them.
 
         """
 
@@ -365,11 +358,13 @@ class R2SManager:
         micro_kwargs.setdefault('include_model_tallies', True)
         micro_kwargs.setdefault('path_statepoint', output_dir / 'statepoint.h5')
         micro_kwargs.setdefault('path_input', output_dir / 'model.xml')
+        statepoint_path = Path(micro_kwargs['path_statepoint']).resolve()
+        micro_kwargs['path_statepoint'] = statepoint_path
+
+        # Determine neutron tally IDs based on whether model tallies are included
         include_model_tallies = micro_kwargs['include_model_tallies']
         neutron_tally_ids = [tally.id for tally in self.neutron_model.tallies] \
             if include_model_tallies else []
-        statepoint_path = Path(micro_kwargs['path_statepoint']).resolve()
-        micro_kwargs['path_statepoint'] = statepoint_path
 
         # Run neutron transport and get fluxes and micros. Run via openmc.lib to
         # maintain a consistent parallelism strategy with the activation step.
@@ -383,8 +378,7 @@ class R2SManager:
             ]
 
         # Save the IDs separately from the statepoint so that neutron tally
-        # results can be restored by load_results without including internal
-        # MicroXS tallies.
+        # results can be restored by load_results
         if comm.rank == 0:
             with open(output_dir / 'tally_ids.json', 'w') as f:
                 json.dump(neutron_tally_ids, f)
@@ -829,7 +823,7 @@ class R2SManager:
                 micros_dict[f'domain_{i}'] for i in range(len(micros_dict))
             ]
 
-        # Load neutron tally results from the neutron transport statepoint.
+        # Load neutron tally results from the neutron transport statepoint
         tally_ids_path = neutron_dir / 'tally_ids.json'
         statepoint_path = neutron_dir / 'statepoint.h5'
         if tally_ids_path.exists() and statepoint_path.exists():

--- a/openmc/deplete/r2s.py
+++ b/openmc/deplete/r2s.py
@@ -201,7 +201,8 @@ class R2SManager:
         micro_kwargs : dict, optional
             Additional keyword arguments passed to
             :func:`openmc.deplete.get_microxs_and_flux` during the neutron
-            transport step.
+            transport step. Existing neutron model tallies are included by
+            default; pass ``include_model_tallies=False`` to exclude them.
         mat_vol_kwargs : dict, optional
             Additional keyword arguments passed to
             :meth:`openmc.MeshBase.material_volumes`.
@@ -240,6 +241,7 @@ class R2SManager:
         if operator_kwargs is None:
             operator_kwargs = {}
         run_kwargs.setdefault('output', False)
+        micro_kwargs.setdefault('include_model_tallies', True)
         micro_kwargs.setdefault('run_kwargs', run_kwargs)
 
         # DecaySpectrum distributions are resolved in the C++ solver using
@@ -305,6 +307,8 @@ class R2SManager:
         micro_kwargs : dict, optional
             Additional keyword arguments passed to
             :func:`openmc.deplete.get_microxs_and_flux`.
+            Existing neutron model tallies are included by default; pass
+            ``include_model_tallies=False`` to exclude them.
 
         """
 
@@ -358,9 +362,12 @@ class R2SManager:
         # Set default keyword arguments for microxs and flux calculation
         if micro_kwargs is None:
             micro_kwargs = {}
+        micro_kwargs.setdefault('include_model_tallies', True)
         micro_kwargs.setdefault('path_statepoint', output_dir / 'statepoint.h5')
         micro_kwargs.setdefault('path_input', output_dir / 'model.xml')
-        neutron_tally_ids = [tally.id for tally in self.neutron_model.tallies]
+        include_model_tallies = micro_kwargs['include_model_tallies']
+        neutron_tally_ids = [tally.id for tally in self.neutron_model.tallies] \
+            if include_model_tallies else []
         statepoint_path = Path(micro_kwargs['path_statepoint']).resolve()
         micro_kwargs['path_statepoint'] = statepoint_path
 

--- a/openmc/deplete/r2s.py
+++ b/openmc/deplete/r2s.py
@@ -111,7 +111,10 @@ class R2SManager:
         Indicates whether the R2S calculation uses mesh elements ('mesh-based')
         as the spatial discretization or a list of cells ('cell-based').
     results : dict
-        A dictionary that stores results from the R2S calculation.
+        A dictionary that stores results from the R2S calculation. In
+        particular, ``results['neutron_tallies']`` contains user-defined
+        neutron tally results from the neutron transport step, while
+        ``results['photon_tallies']`` contains photon tally results.
 
     """
     def __init__(
@@ -286,8 +289,10 @@ class R2SManager:
         mesh-material filters, and retrieves the fluxes and microscopic cross
         sections for each mesh/material combination via a single transport
         solve. This step will populate the 'fluxes' and 'micros' keys in the
-        results dictionary. For a mesh-based calculation, it will also populate
-        the 'mesh_material_volumes' key (a list of
+        results dictionary. Any tallies assigned to ``neutron_model`` are run
+        in the same transport solve and their results are stored under the
+        'neutron_tallies' key. For a mesh-based calculation, this step will
+        also populate the 'mesh_material_volumes' key (a list of
         :class:`~openmc.MeshMaterialVolumes`, one per mesh).
 
         Parameters
@@ -355,12 +360,27 @@ class R2SManager:
             micro_kwargs = {}
         micro_kwargs.setdefault('path_statepoint', output_dir / 'statepoint.h5')
         micro_kwargs.setdefault('path_input', output_dir / 'model.xml')
+        neutron_tally_ids = [tally.id for tally in self.neutron_model.tallies]
+        statepoint_path = Path(micro_kwargs['path_statepoint']).resolve()
+        micro_kwargs['path_statepoint'] = statepoint_path
 
         # Run neutron transport and get fluxes and micros. Run via openmc.lib to
         # maintain a consistent parallelism strategy with the activation step.
         with TemporarySession(output=False):
             self.results['fluxes'], self.results['micros'] = get_microxs_and_flux(
                 self.neutron_model, domains, **micro_kwargs)
+
+        with openmc.StatePoint(statepoint_path) as sp:
+            self.results['neutron_tallies'] = [
+                sp.tallies[tally_id] for tally_id in neutron_tally_ids
+            ]
+
+        # Save the IDs separately from the statepoint so that neutron tally
+        # results can be restored by load_results without including internal
+        # MicroXS tallies.
+        if comm.rank == 0:
+            with open(output_dir / 'tally_ids.json', 'w') as f:
+                json.dump(neutron_tally_ids, f)
 
         # Save flux and micros to file
         if comm.rank == 0:
@@ -801,6 +821,17 @@ class R2SManager:
             self.results['micros'] = [
                 micros_dict[f'domain_{i}'] for i in range(len(micros_dict))
             ]
+
+        # Load neutron tally results from the neutron transport statepoint.
+        tally_ids_path = neutron_dir / 'tally_ids.json'
+        statepoint_path = neutron_dir / 'statepoint.h5'
+        if tally_ids_path.exists() and statepoint_path.exists():
+            with tally_ids_path.open('r') as f:
+                tally_ids = json.load(f)
+            with openmc.StatePoint(statepoint_path) as sp:
+                self.results['neutron_tallies'] = [
+                    sp.tallies[tally_id] for tally_id in tally_ids
+                ]
 
         # Load activation results
         activation_dir = path / 'activation'

--- a/tests/unit_tests/test_deplete_microxs.py
+++ b/tests/unit_tests/test_deplete_microxs.py
@@ -143,6 +143,10 @@ def test_hybrid_tally_setup():
     # Define 2-group energy structure for the test
     energies = [0., 0.625, 2.0e7]
 
+    user_tally = openmc.Tally(name='User tally')
+    user_tally.scores = ['flux']
+    model.tallies = [user_tally]
+
     # Function to replace Model.run and capture the tallies that were created
     captured = {}
     def capture_run(**kwargs):
@@ -165,6 +169,7 @@ def test_hybrid_tally_setup():
 
     # Check that both tallies were created with the expected properties
     tally_names = [t.name for t in captured['tallies']]
+    assert 'User tally' in tally_names
     assert 'MicroXS flux 0' in tally_names
     assert 'MicroXS RR 0' in tally_names
 

--- a/tests/unit_tests/test_deplete_microxs.py
+++ b/tests/unit_tests/test_deplete_microxs.py
@@ -129,7 +129,8 @@ def test_microxs_zero_flux():
     assert np.all(microxs.data == 0.0)
 
 
-def test_hybrid_tally_setup():
+@pytest.mark.parametrize('include_model_tallies', [None, False, True])
+def test_hybrid_tally_setup(include_model_tallies):
     """In hybrid mode a 1-group RR tally is added alongside the flux tally."""
     # Create a simple model with one material and a few nuclides for testing
     model = openmc.Model()
@@ -155,23 +156,28 @@ def test_hybrid_tally_setup():
 
     # Call get_microxs_and_flux but replace Model.run with a function that
     # captures the tallies and raises StopIteration to exit early
+    kwargs = {
+        'nuclides': ['U235', 'O16'],
+        'reactions': ['fission', '(n,gamma)'],
+        'energies': energies,
+        'reaction_rate_mode': 'flux',
+        'reaction_rate_opts': {
+            'nuclides': ['U235'], 'reactions': ['fission']
+        },
+        'chain_file': CHAIN_FILE,
+    }
+    if include_model_tallies is not None:
+        kwargs['include_model_tallies'] = include_model_tallies
     with patch.object(model, 'run', side_effect=capture_run):
         with pytest.raises(StopIteration):
-            get_microxs_and_flux(
-                model, [mat],
-                nuclides=['U235', 'O16'],
-                reactions=['fission', '(n,gamma)'],
-                energies=energies,
-                reaction_rate_mode='flux',
-                reaction_rate_opts={'nuclides': ['U235'], 'reactions': ['fission']},
-                chain_file=CHAIN_FILE,
-            )
+            get_microxs_and_flux(model, [mat], **kwargs)
 
     # Check that both tallies were created with the expected properties
     tally_names = [t.name for t in captured['tallies']]
-    assert 'User tally' in tally_names
+    assert ('User tally' in tally_names) is (include_model_tallies is True)
     assert 'MicroXS flux 0' in tally_names
     assert 'MicroXS RR 0' in tally_names
+    assert model.tallies == [user_tally]
 
     # Check that the RR tally has the expected nuclides and reactions
     rr = next(t for t in captured['tallies'] if t.name == 'MicroXS RR 0')

--- a/tests/unit_tests/test_deplete_microxs.py
+++ b/tests/unit_tests/test_deplete_microxs.py
@@ -177,7 +177,6 @@ def test_hybrid_tally_setup(include_model_tallies):
     assert ('User tally' in tally_names) is (include_model_tallies is True)
     assert 'MicroXS flux 0' in tally_names
     assert 'MicroXS RR 0' in tally_names
-    assert model.tallies == [user_tally]
 
     # Check that the RR tally has the expected nuclides and reactions
     rr = next(t for t in captured['tallies'] if t.name == 'MicroXS RR 0')

--- a/tests/unit_tests/test_r2s.py
+++ b/tests/unit_tests/test_r2s.py
@@ -78,6 +78,7 @@ def test_r2s_mesh_expected_output(simple_model_and_mesh, tmp_path):
     nt = Path(outdir) / 'neutron_transport'
     assert (nt / 'fluxes.npy').exists()
     assert (nt / 'micros.h5').exists()
+    assert (nt / 'tally_ids.json').exists()
     assert (nt / 'mesh_material_volumes_0.npz').exists()
     act = Path(outdir) / 'activation'
     assert (act / 'depletion_results.h5').exists()
@@ -89,6 +90,7 @@ def test_r2s_mesh_expected_output(simple_model_and_mesh, tmp_path):
     # Basic results structure checks
     assert len(r2s.results['fluxes']) == 2
     assert len(r2s.results['micros']) == 2
+    assert r2s.results['neutron_tallies'] == []
     assert len(r2s.results['mesh_material_volumes']) == 1
     assert len(r2s.results['mesh_material_volumes'][0]) == 2
     assert len(r2s.results['activation_materials']) == 2
@@ -107,6 +109,7 @@ def test_r2s_mesh_expected_output(simple_model_and_mesh, tmp_path):
     r2s_loaded.load_results(outdir)
     assert len(r2s_loaded.results['fluxes']) == 2
     assert len(r2s_loaded.results['micros']) == 2
+    assert r2s_loaded.results['neutron_tallies'] == []
     assert len(r2s_loaded.results['mesh_material_volumes']) == 1
     assert len(r2s_loaded.results['mesh_material_volumes'][0]) == 2
     assert len(r2s_loaded.results['activation_materials']) == 2
@@ -181,7 +184,7 @@ def test_r2s_multi_mesh(simple_model_and_mesh, tmp_path):
 
 def test_r2s_cell_expected_output(simple_model_and_mesh, tmp_path):
     model, (c1, c2), _ = simple_model_and_mesh
-    tally = openmc.Tally()
+    tally = openmc.Tally(name='neutron flux')
     tally.scores = ['flux']
     model.tallies = [tally]
 
@@ -208,6 +211,7 @@ def test_r2s_cell_expected_output(simple_model_and_mesh, tmp_path):
     nt = Path(outdir) / 'neutron_transport'
     assert (nt / 'fluxes.npy').exists()
     assert (nt / 'micros.h5').exists()
+    assert (nt / 'tally_ids.json').exists()
     act = Path(outdir) / 'activation'
     assert (act / 'depletion_results.h5').exists()
     pt = Path(outdir) / 'photon_transport'
@@ -217,6 +221,9 @@ def test_r2s_cell_expected_output(simple_model_and_mesh, tmp_path):
     # Basic results structure checks
     assert len(r2s.results['fluxes']) == 2
     assert len(r2s.results['micros']) == 2
+    assert len(r2s.results['neutron_tallies']) == 1
+    assert r2s.results['neutron_tallies'][0].id == tally.id
+    assert r2s.results['neutron_tallies'][0].mean[0] > 0.0
     assert len(r2s.results['activation_materials']) == 2
     assert len(r2s.results['depletion_results']) == 2
     assert r2s.photon_model.tallies[0].contains_filter(
@@ -236,6 +243,9 @@ def test_r2s_cell_expected_output(simple_model_and_mesh, tmp_path):
     r2s_loaded.load_results(outdir)
     assert len(r2s_loaded.results['fluxes']) == 2
     assert len(r2s_loaded.results['micros']) == 2
+    assert len(r2s_loaded.results['neutron_tallies']) == 1
+    assert r2s_loaded.results['neutron_tallies'][0].id == tally.id
+    assert r2s_loaded.results['neutron_tallies'][0].mean[0] > 0.0
     assert len(r2s_loaded.results['activation_materials']) == 2
     assert len(r2s_loaded.results['depletion_results']) == 2
 


### PR DESCRIPTION
# Description

Currently, users running an R2S calculation who want to collect additional tallies during the neutron transport step must perform a separate neutron transport calculation because `get_microxs_and_flux` excludes user-specified model tallies. This change adds the `include_model_tallies` argument, allowing those pre-existing tallies to be included in the same transport run; `R2SManager` enables this behavior by default while still allowing users to disable it when desired.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)