### PR TITLE
Fix use of invalidated iterators in Region constructor

### DIFF
--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -640,8 +640,12 @@ Region::Region(std::string region_spec, int32_t cell_id)
     // Remove complement operators using DeMorgan's laws
     auto it = std::find(expression_.begin(), expression_.end(), OP_COMPLEMENT);
     while (it != expression_.end()) {
-      // Erase complement
-      expression_.erase(it);
+      // Erase complement. Note that erase invalidates the iterator, so we have
+      // to use the iterator it returns, which points to the token that
+      // followed the complement operator.
+      it = expression_.erase(it);
+      if (it == expression_.end())
+        break;
 
       // Define stop given left parenthesis or not
       auto stop = it;
@@ -693,12 +697,12 @@ Region::Region(std::string region_spec, int32_t cell_id)
 
     // If this cell is simple, remove all the superfluous operator tokens.
     if (simple_) {
-      for (auto it = expression_.begin(); it != expression_.end(); it++) {
-        if (*it == OP_INTERSECTION || *it > OP_COMPLEMENT) {
-          expression_.erase(it);
-          it--;
-        }
-      }
+      expression_.erase(std::remove_if(expression_.begin(), expression_.end(),
+                          [](int32_t token) {
+                            return token == OP_INTERSECTION ||
+                                   token > OP_COMPLEMENT;
+                          }),
+        expression_.end());
     }
     expression_.shrink_to_fit();
 


### PR DESCRIPTION
# Description

This fix originally appeared in #2919. I'm breaking it out into a small, self-contained PR and will do the same with other fixes there.

`Region::Region()` has two loops that erase from `expression_` and then keep using the iterator that was just invalidated. Both happen to work with libstdc++ in release mode because the erased slot still holds a usable value, but they are undefined behavior and abort under MSVC's checked iterators. The first loop is rewritten to use the iterator returned by erase(), which points at the token that followed the complement operator. The second is replaced by the [erase-remove idiom](https://en.wikipedia.org/wiki/Erase%E2%80%93remove_idiom), which also avoids decrementing an iterator that may be at begin().

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>