### PR TITLE
Use && instead of the alternative token 'and' in mesh.h

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -633,7 +633,7 @@ private:
 
   inline int sanitize_angular_index(int idx, bool full, int N) const
   {
-    if ((idx > 0) and (idx <= N)) {
+    if ((idx > 0) && (idx <= N)) {
       return idx;
     } else if (full) {
       return (idx + N - 1) % N + 1;
@@ -698,7 +698,7 @@ private:
 
   inline int sanitize_angular_index(int idx, bool full, int N) const
   {
-    if ((idx > 0) and (idx <= N)) {
+    if ((idx > 0) && (idx <= N)) {
       return idx;
     } else if (full) {
       return (idx + N - 1) % N + 1;


### PR DESCRIPTION
# Description

`SphericalMesh` and `CylindricalMesh` each spell the logical AND in `sanitize_angular_index` as `and` rather than `&&`. These two lines are the only alternative operator tokens in `src/` and `include/`, so the rest of the codebase already uses `&&` consistently.

Building against C++17, MSVC parses `and` as an identifier instead

```
include\openmc\mesh.h(636,19): error C3861: 'and': identifier not found
```

This PR just removes a smaller blockers identified in #1243.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>
