### PR TITLE
Don't name class members in OpenMP reduction clauses

### DIFF
--- a/src/random_ray/flat_source_domain.cpp
+++ b/src/random_ray/flat_source_domain.cpp
@@ -1074,13 +1074,16 @@ void FlatSourceDomain::apply_external_source_to_cell_and_children(
 
 void FlatSourceDomain::count_external_source_regions()
 {
-  n_external_source_regions_ = 0;
-#pragma omp parallel for reduction(+ : n_external_source_regions_)
+  // Naming a class member in a reduction clause is allowed as of OpenMP 5.1,
+  // but not every implementation supports it yet; accumulate into a local
+  int64_t n_external = 0;
+#pragma omp parallel for reduction(+ : n_external)
   for (int64_t sr = 0; sr < n_source_regions(); sr++) {
     if (source_regions_.external_source_present(sr)) {
-      n_external_source_regions_++;
+      n_external++;
     }
   }
+  n_external_source_regions_ = n_external;
 }
 
 void FlatSourceDomain::convert_external_sources(bool use_adjoint_sources)

--- a/src/random_ray/random_ray_simulation.cpp
+++ b/src/random_ray/random_ray_simulation.cpp
@@ -427,14 +427,16 @@ void RandomRaySimulation::simulate()
       // Start timer for transport
       simulation::time_transport.start();
 
-// Transport sweep over all random rays for the iteration
-#pragma omp parallel for schedule(dynamic)                                     \
-  reduction(+ : total_geometric_intersections_)
+      // Transport sweep over all random rays for the iteration. NOTE: Naming a
+      // class member in a reduction clause is allowed as of OpenMP 5.1, but not
+      // every implementation supports it yet; accumulate into a local
+      uint64_t n_intersections = 0;
+#pragma omp parallel for schedule(dynamic) reduction(+ : n_intersections)
       for (int i = 0; i < settings::n_particles; i++) {
         RandomRay ray(i, domain_.get());
-        total_geometric_intersections_ +=
-          ray.transport_history_based_single_ray();
+        n_intersections += ray.transport_history_based_single_ray();
       }
+      total_geometric_intersections_ += n_intersections;
 
       simulation::time_transport.stop();
 

--- a/src/secondary_correlated.cpp
+++ b/src/secondary_correlated.cpp
@@ -199,7 +199,7 @@ Distribution& CorrelatedAngleEnergy::sample_dist(
   }
 
   // Continuous portion
-  double c_k1;
+  double c_k1 {INFINITY};
   for (int j = n_discrete; j < end; ++j) {
     k = j;
     c_k1 = distribution_[l].c[k + 1];


### PR DESCRIPTION
# Description

Two more small fixes broken out from #2919.

## OpenMP reduction

OpenMP 5.1 added an exception permitting an accessible data member to appear in a reduction clause when the construct is inside a non-static member function, and that exception is retained in 6.0. However, not every implementation has caught up: GCC and Clang accepted it as an extension long before it was standardized, but MSVC's `/openmp:llvm` front end does not implement it and rejects the two loops in `random_ray_simulation.cpp` and `flat_source_domain.cpp` at parse time. The fix is to accumulate into a local variable and assign the member afterwards in the two places where this occurs, which compiles under every OpenMP version.

## Uninitialized variable in `CorrelatedAngleEnergy::sample_dist`

In CorrelatedAngleEnergy::sample_dist(), `c_k1` is only assigned inside the loop over the continuous portion of the outgoing energy distribution. That loop is skipped whenever a discrete line is selected (or there are no continuous bins), but `c_k1` is still read afterwards to decide which of the two neighboring angular distributions to use. Besides being undefined behavior, this can index out of bounds: if every outgoing energy is discrete, `k` may be the last valid index and the else branch samples `angle[k + 1]`, one past the end. The fix is to initialize `c_k1` to infinity, which makes that comparison select bin `k`. That is the correct choice in exactly the cases where the loop is skipped -- the sampled value does not lie between two tabulated points, so the angular distribution belonging to bin k is the one that applies.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>