### PR TITLE
Give run_mode and rel_max_lost_particles C linkage

### DIFF
--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -126,7 +126,7 @@ extern "C" const char* path_statepoint_c; //!< C pointer to statepoint file name
 
 extern "C" int32_t n_inactive;         //!< number of inactive batches
 extern "C" int32_t max_lost_particles; //!< maximum number of lost particles
-extern double
+extern "C" double
   rel_max_lost_particles; //!< maximum number of lost particles, relative to the
                           //!< total number of particles
 extern "C" int32_t
@@ -160,7 +160,7 @@ extern double res_scat_energy_min; //!< Min energy in [eV] for res. upscattering
 extern double res_scat_energy_max; //!< Max energy in [eV] for res. upscattering
 extern vector<std::string>
   res_scat_nuclides;           //!< Nuclides using res. upscattering treatment
-extern RunMode run_mode;       //!< Run mode (eigenvalue, fixed src, etc.)
+extern "C" RunMode run_mode;   //!< Run mode (eigenvalue, fixed src, etc.)
 extern SolverType solver_type; //!< Solver Type (Monte Carlo or Random Ray)
 extern std::unordered_set<int>
   sourcepoint_batch; //!< Batches when source should be written


### PR DESCRIPTION
# Description

`openmc.lib` reads both of these globals and both are declared in `namespace openmc::settings` without `extern "C"`, so the symbols are name-mangled and the lookup has never resolved.

On a Linux build of current `develop`:

```python
>>> ctypes.c_int.in_dll(dll, 'run_mode')
ValueError: openmc/lib/libopenmc.so: undefined symbol: run_mode
```

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
~- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~
~- [ ] I have made corresponding changes to the documentation (if applicable)~
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

