### PR TITLE
Resolve input file paths with std::filesystem

### DIFF
--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -14,7 +14,6 @@
 #include "openmc/photon.h"
 #include "openmc/settings.h"
 #include "openmc/simulation.h"
-#include "openmc/string_utils.h"
 #include "openmc/thermal.h"
 #include "openmc/timer.h"
 #include "openmc/wmp.h"
@@ -71,16 +70,12 @@ Library::Library(pugi::xml_node node, const std::string& directory)
   if (!check_for_node(node, "path")) {
     fatal_error("Missing library path");
   }
-  std::string path = get_node_value(node, "path");
+  std::filesystem::path path(get_node_value(node, "path"));
 
-  if (starts_with(path, "/")) {
-    path_ = path;
-  } else if (ends_with(directory, "/")) {
-    path_ = directory + path;
-  } else if (!directory.empty()) {
-    path_ = directory + "/" + path;
+  if (path.is_absolute() || directory.empty()) {
+    path_ = path.string();
   } else {
-    path_ = path;
+    path_ = (std::filesystem::path(directory) / path).string();
   }
 
   if (!file_exists(path_)) {
@@ -144,11 +139,15 @@ void read_cross_sections_xml(pugi::xml_node root)
   } else {
     settings::path_cross_sections = get_node_value(root, "cross_sections");
 
-    // If no '/' found, the file is probably in the input directory
-    auto pos = settings::path_cross_sections.rfind("/");
-    if (pos == std::string::npos && !settings::path_input.empty()) {
+    // If no directory component is given, the file is probably in the input
+    // directory. Note that this has to be determined with std::filesystem
+    // rather than by searching for a '/' so that Windows paths (which use a
+    // different separator and may be prefixed by a drive letter) work too.
+    std::filesystem::path p(settings::path_cross_sections);
+    if (p.is_relative() && !p.has_parent_path() &&
+        !settings::path_input.empty()) {
       settings::path_cross_sections =
-        settings::path_input + "/" + settings::path_cross_sections;
+        (std::filesystem::path(settings::path_input) / p).string();
     }
   }
 

--- a/src/dagmc.cpp
+++ b/src/dagmc.cpp
@@ -63,9 +63,10 @@ DAGUniverse::DAGUniverse(pugi::xml_node node)
 
   if (check_for_node(node, "filename")) {
     filename_ = get_node_value(node, "filename");
-    if (!starts_with(filename_, "/")) {
+    std::filesystem::path p(filename_);
+    if (p.is_relative()) {
       std::filesystem::path d(dir_name(settings::path_input));
-      filename_ = (d / filename_).string();
+      filename_ = (d / p).string();
     }
   } else {
     fatal_error("Must specify a file for the DAGMC universe");


### PR DESCRIPTION
# Description

Another fix broken out from #2919.

There were a few places in the code where we decided whether a path from an XML input was absolute by testing for a leading "/", and joined relative paths by concatenating with "/". Neither works on Windows, where paths are separated by backslashes and an absolute path normally starts with a drive letter: `C:\data\lib.h5` has no leading "/", so it would be treated as relative and joined onto the input directory. This PR fixes that by using `std::filesystem` for both the test and the join.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>