### PR TITLE
Add missing include in event.h

### DIFF
--- a/include/openmc/event.h
+++ b/include/openmc/event.h
@@ -4,6 +4,8 @@
 //! \file event.h
 //! \brief Event-based data structures and methods
 
+#include <tuple> // for tie
+
 #include "openmc/particle.h"
 #include "openmc/shared_array.h"
 


### PR DESCRIPTION
# Description

Simple one-liner broken out from #2919; event.h was missing an include for `std::tie`

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>