### PR TITLE
Fix filter equality for reaction and particle production filters

### DIFF
--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1431,6 +1431,12 @@ class ReactionFilter(Filter):
         self.bins = bins
         self.id = filter_id
 
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return False
+        else:
+            return np.array_equal(self.bins, other.bins)
+
     @Filter.bins.setter
     def bins(self, bins):
         if isinstance(bins, (str, Integral)):

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -1437,6 +1437,8 @@ class ReactionFilter(Filter):
         else:
             return np.array_equal(self.bins, other.bins)
 
+    __hash__ = Filter.__hash__
+
     @Filter.bins.setter
     def bins(self, bins):
         if isinstance(bins, (str, Integral)):
@@ -1874,6 +1876,21 @@ class ParticleProductionFilter(Filter):
             string += '{: <16}=\t{}\n'.format('\tEnergies', self.energies)
         string += '{: <16}=\t{}\n'.format('\tID', self.id)
         return string
+
+    def __eq__(self, other):
+        # Bins are (particle, E_low, E_high) tuples, so the base class's
+        # np.allclose() comparison cannot promote them to a common dtype.
+        if type(self) is not type(other):
+            return False
+        if self.particles != other.particles:
+            return False
+        if (self.energies is None) != (other.energies is None):
+            return False
+        if self.energies is None:
+            return True
+        return np.array_equal(self.energies, other.energies)
+
+    __hash__ = Filter.__hash__
 
     @property
     def particles(self):

--- a/openmc/filter.py
+++ b/openmc/filter.py
@@ -124,12 +124,8 @@ class Filter(IDManagerMixin, metaclass=FilterMeta):
         self.id = filter_id
 
     def __eq__(self, other):
-        if type(self) is not type(other):
-            return False
-        elif len(self.bins) != len(other.bins):
-            return False
-        else:
-            return np.allclose(self.bins, other.bins)
+        return type(self) is type(other) and np.array_equal(
+            self.bins, other.bins)
 
     def __gt__(self, other):
         if type(self) is not type(other):
@@ -758,16 +754,6 @@ class ParticleFilter(Filter):
         The number of filter bins
 
     """
-
-    def __eq__(self, other):
-        if type(self) is not type(other):
-            return False
-        elif len(self.bins) != len(other.bins):
-            return False
-        else:
-            return np.all(self.bins == other.bins)
-
-    __hash__ = Filter.__hash__
 
     @Filter.bins.setter
     def bins(self, bins):
@@ -1431,14 +1417,6 @@ class ReactionFilter(Filter):
         self.bins = bins
         self.id = filter_id
 
-    def __eq__(self, other):
-        if type(self) is not type(other):
-            return False
-        else:
-            return np.array_equal(self.bins, other.bins)
-
-    __hash__ = Filter.__hash__
-
     @Filter.bins.setter
     def bins(self, bins):
         if isinstance(bins, (str, Integral)):
@@ -1876,21 +1854,6 @@ class ParticleProductionFilter(Filter):
             string += '{: <16}=\t{}\n'.format('\tEnergies', self.energies)
         string += '{: <16}=\t{}\n'.format('\tID', self.id)
         return string
-
-    def __eq__(self, other):
-        # Bins are (particle, E_low, E_high) tuples, so the base class's
-        # np.allclose() comparison cannot promote them to a common dtype.
-        if type(self) is not type(other):
-            return False
-        if self.particles != other.particles:
-            return False
-        if (self.energies is None) != (other.energies is None):
-            return False
-        if self.energies is None:
-            return True
-        return np.array_equal(self.energies, other.energies)
-
-    __hash__ = Filter.__hash__
 
     @property
     def particles(self):

--- a/tests/unit_tests/test_filters.py
+++ b/tests/unit_tests/test_filters.py
@@ -73,6 +73,28 @@ def test_collision():
     assert np.all(new_f.bins == f.bins)
 
 
+def test_filter_equality():
+    # Equality should require exact agreement between numerical bins.
+    energy = openmc.EnergyFilter([0.0, 1.0])
+    assert energy == openmc.EnergyFilter([0.0, 1.0])
+    assert energy != openmc.EnergyFilter([0.0, 1.0 + 1.0e-8])
+
+    # The base implementation should also support nonnumeric and mixed bins.
+    particle = openmc.ParticleFilter('photon')
+    assert particle == openmc.ParticleFilter('photon')
+    assert openmc.ReactionFilter(2) == openmc.ReactionFilter('(n,elastic)')
+
+    production = openmc.ParticleProductionFilter(
+        'photon', [0.0, 1.0])
+    assert production == openmc.ParticleProductionFilter(
+        'photon', [0.0, 1.0])
+    assert production != openmc.ParticleProductionFilter(
+        'neutron', [0.0, 1.0])
+    assert production != openmc.ParticleProductionFilter('photon')
+    production_no_energy = openmc.ParticleProductionFilter('photon')
+    assert production_no_energy == openmc.ParticleProductionFilter('photon')
+
+
 def test_legendre():
     n = 5
     f = openmc.LegendreFilter(n)


### PR DESCRIPTION
# Description

`ReactionFilter` and `ParticleProductionFilter` are currently broken because the base `Filter.__eq__` implementation uses `np.allclose`, which cannot compare their string and mixed-type bins. This change uses `np.array_equal` in the base equality implementation to address that while also removing a redundant override from `ParticleFilter`. This ensures exact bin matching when comparing filters for tally merging.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)