### PR TITLE
Account for proton PDG number in ParticleType::is_nucleus

### DIFF
--- a/include/openmc/particle_type.h
+++ b/include/openmc/particle_type.h
@@ -80,7 +80,7 @@ public:
   constexpr bool is_nucleus() const
   {
     // PDG nuclear codes are >= 1000000000 (100ZZZAAAI format)
-    return pdg_number_ >= 1000000000;
+    return pdg_number_ >= 1000000000 || pdg_number_ == PDG_PROTON;
   }
 
   // Get transport index (0-3 for transportable particles, C_NONE otherwise)

--- a/include/openmc/particle_type.h
+++ b/include/openmc/particle_type.h
@@ -79,7 +79,9 @@ public:
   // Check if this represents a nucleus (vs elementary particle)
   constexpr bool is_nucleus() const
   {
-    // PDG nuclear codes are >= 1000000000 (100ZZZAAAI format)
+    // PDG nuclear codes are >= 1000000000 (100ZZZAAAI format). The proton has
+    // its own code rather than the H-1 nuclear one, but it is a bare nucleus
+    // and reaction-product bookkeeping needs to treat it as one.
     return pdg_number_ >= 1000000000 || pdg_number_ == PDG_PROTON;
   }
 


### PR DESCRIPTION
# Description

The `ParticleType::is_nucleus` method currently only checks for PDG numbers >= 1000000000, which misses out on H1 because a proton has the dedicated PDG number 2212. This PR fixes that.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)<s/>
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)