### PR TITLE
Fix Legendre coefficients in AngleDistribution.from_endf

### DIFF
--- a/openmc/data/angle_distribution.py
+++ b/openmc/data/angle_distribution.py
@@ -260,7 +260,7 @@ class AngleDistribution(EqualityMixin):
             for i in range(n_energy):
                 items, al = get_list_record(file_obj)
                 energy[i] = items[1]
-                coefficients = np.asarray([1.0] + al)
+                coefficients = np.insert(al, 0, 1.0)
                 mu.append(Legendre(coefficients))
 
         elif ltt == 2 and li == 0:
@@ -288,7 +288,7 @@ class AngleDistribution(EqualityMixin):
             for i in range(n_energy_legendre):
                 items, al = get_list_record(file_obj)
                 energy_legendre[i] = items[1]
-                coefficients = np.asarray([1.0] + al)
+                coefficients = np.insert(al, 0, 1.0)
                 mu.append(Legendre(coefficients))
 
             params, tab2 = get_tab2_record(file_obj)


### PR DESCRIPTION
# Description

While working on another feature, I noticed that the Legendre coefficients read in `AngleDistribution.from_endf` are wrong. This happens because of the line `[1.0] + al` where `al` are the higher-order Legendre coefficients. It used to be a list so `[1.0] + al` made sense but when we switched to the `endf` module, `al` is now a numpy array so doing `[1.0] + al` adds 1 to every entry by array broadcasting. The updated code fixes that.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)