### PR TITLE
Remove unnecessary integer assigned to cross section libraries

### DIFF
--- a/include/openmc/cross_sections.h
+++ b/include/openmc/cross_sections.h
@@ -17,13 +17,7 @@ namespace openmc {
 class Library {
 public:
   // Types, enums
-  enum class Type {
-    neutron = 1,
-    photon = 3,
-    thermal = 2,
-    multigroup = 4,
-    wmp = 5
-  };
+  enum class Type { neutron, photon, thermal, multigroup, wmp };
 
   // Constructors
   Library() {};


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR remove unused integers assigned to nuclear data libraries.
# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
