### PR TITLE
Refactor neutron macroscopic cross section reset

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -814,9 +814,6 @@ void Material::calculate_xs(Particle& p) const
 {
   // Set all material macroscopic cross sections to zero
   p.macro_xs().total = 0.0;
-  p.macro_xs().absorption = 0.0;
-  p.macro_xs().fission = 0.0;
-  p.macro_xs().nu_fission = 0.0;
 
   if (p.type().is_neutron()) {
     this->calculate_neutron_xs(p);
@@ -827,6 +824,10 @@ void Material::calculate_xs(Particle& p) const
 
 void Material::calculate_neutron_xs(Particle& p) const
 {
+  p.macro_xs().absorption = 0.0;
+  p.macro_xs().fission = 0.0;
+  p.macro_xs().nu_fission = 0.0;
+
   // Find energy index on energy grid
   int neutron = ParticleType::neutron().transport_index();
   int i_grid =


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Currently the neutron macroscopic cross sections are reset also for photons.
This PR change that so that they will be reset in the appropriate place.



# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
