### PR TITLE
Replace exported C API error globals

### DIFF
--- a/include/openmc/capi.h
+++ b/include/openmc/capi.h
@@ -361,21 +361,24 @@ int openmc_properties_import(const char* filename);
 //! \return Error code
 int openmc_get_feature_enabled(const char* feature, bool* enabled);
 
-// Error codes
-extern int OPENMC_E_UNASSIGNED;
-extern int OPENMC_E_ALLOCATE;
-extern int OPENMC_E_OUT_OF_BOUNDS;
-extern int OPENMC_E_INVALID_SIZE;
-extern int OPENMC_E_INVALID_ARGUMENT;
-extern int OPENMC_E_INVALID_TYPE;
-extern int OPENMC_E_INVALID_ID;
-extern int OPENMC_E_GEOMETRY;
-extern int OPENMC_E_DATA;
-extern int OPENMC_E_PHYSICS;
-extern int OPENMC_E_WARNING;
+//! Return the message associated with the most recent C API error.
+//!
+//! The returned pointer is valid until the next error message is set.
+const char* openmc_get_err_msg();
 
-// Global variables
-extern char openmc_err_msg[256];
+typedef enum OpenmcErrorCode {
+  OPENMC_E_WARNING = 1,
+  OPENMC_E_UNASSIGNED = -1,
+  OPENMC_E_ALLOCATE = -2,
+  OPENMC_E_OUT_OF_BOUNDS = -3,
+  OPENMC_E_INVALID_SIZE = -4,
+  OPENMC_E_INVALID_ARGUMENT = -5,
+  OPENMC_E_INVALID_TYPE = -6,
+  OPENMC_E_INVALID_ID = -7,
+  OPENMC_E_GEOMETRY = -8,
+  OPENMC_E_DATA = -9,
+  OPENMC_E_PHYSICS = -10
+} OpenmcErrorCode;
 
 #ifdef __cplusplus
 }

--- a/include/openmc/error.h
+++ b/include/openmc/error.h
@@ -18,20 +18,10 @@
 
 namespace openmc {
 
-inline void set_errmsg(const char* message)
-{
-  std::strcpy(openmc_err_msg, message);
-}
-
-inline void set_errmsg(const std::string& message)
-{
-  std::strcpy(openmc_err_msg, message.c_str());
-}
-
-inline void set_errmsg(const std::stringstream& message)
-{
-  std::strcpy(openmc_err_msg, message.str().c_str());
-}
+void set_errmsg(const char* message);
+void set_errmsg(const std::string& message);
+void set_errmsg(const std::stringstream& message);
+const char* get_errmsg();
 
 [[noreturn]] void fatal_error(const std::string& message, int err = -1);
 

--- a/openmc/lib/error.py
+++ b/openmc/lib/error.py
@@ -1,39 +1,49 @@
-from ctypes import c_int, c_char
+from ctypes import c_char_p
 from warnings import warn
 
 import openmc.exceptions as exc
 from . import _dll
 
 
+OPENMC_E_WARNING = 1
+OPENMC_E_UNASSIGNED = -1
+OPENMC_E_ALLOCATE = -2
+OPENMC_E_OUT_OF_BOUNDS = -3
+OPENMC_E_INVALID_SIZE = -4
+OPENMC_E_INVALID_ARGUMENT = -5
+OPENMC_E_INVALID_TYPE = -6
+OPENMC_E_INVALID_ID = -7
+OPENMC_E_GEOMETRY = -8
+OPENMC_E_DATA = -9
+OPENMC_E_PHYSICS = -10
+
+_dll.openmc_get_err_msg.restype = c_char_p
+
+
 def _error_handler(err, func, args):
     """Raise exception according to error code."""
 
-    # Get error code corresponding to global constant.
-    def errcode(s):
-        return c_int.in_dll(_dll, s).value
-
     # Get error message set by OpenMC library
-    errmsg = (c_char*256).in_dll(_dll, 'openmc_err_msg')
-    msg = errmsg.value.decode()
+    msg = _dll.openmc_get_err_msg().decode()
 
     # Raise exception type corresponding to error code
-    if err == errcode('OPENMC_E_ALLOCATE'):
+    if err == OPENMC_E_ALLOCATE:
         raise exc.AllocationError(msg)
-    elif err == errcode('OPENMC_E_OUT_OF_BOUNDS'):
+    elif err == OPENMC_E_OUT_OF_BOUNDS:
         raise exc.OutOfBoundsError(msg)
-    elif err == errcode('OPENMC_E_INVALID_ARGUMENT'):
+    elif err == OPENMC_E_INVALID_ARGUMENT:
         raise exc.InvalidArgumentError(msg)
-    elif err == errcode('OPENMC_E_INVALID_TYPE'):
+    elif err == OPENMC_E_INVALID_TYPE:
         raise exc.InvalidTypeError(msg)
-    if err == errcode('OPENMC_E_INVALID_ID'):
+    if err == OPENMC_E_INVALID_ID:
         raise exc.InvalidIDError(msg)
-    elif err == errcode('OPENMC_E_GEOMETRY'):
+    elif err == OPENMC_E_GEOMETRY:
         raise exc.GeometryError(msg)
-    elif err == errcode('OPENMC_E_DATA'):
+    elif err == OPENMC_E_DATA:
         raise exc.DataError(msg)
-    elif err == errcode('OPENMC_E_PHYSICS'):
+    elif err == OPENMC_E_PHYSICS:
         raise exc.PhysicsError(msg)
-    elif err == errcode('OPENMC_E_WARNING'):
+    elif err == OPENMC_E_WARNING:
         warn(msg)
     elif err < 0:
         if not msg:

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1338,7 +1338,7 @@ extern "C" int openmc_cell_set_temperature(
   int32_t index, double T, const int32_t* instance, bool set_contained)
 {
   if (index < 0 || index >= model::cells.size()) {
-    strcpy(openmc_err_msg, "Index in cells array is out of bounds.");
+    set_errmsg("Index in cells array is out of bounds.");
     return OPENMC_E_OUT_OF_BOUNDS;
   }
 
@@ -1356,7 +1356,7 @@ extern "C" int openmc_cell_set_density(
   int32_t index, double density, const int32_t* instance, bool set_contained)
 {
   if (index < 0 || index >= model::cells.size()) {
-    strcpy(openmc_err_msg, "Index in cells array is out of bounds.");
+    set_errmsg("Index in cells array is out of bounds.");
     return OPENMC_E_OUT_OF_BOUNDS;
   }
 
@@ -1374,7 +1374,7 @@ extern "C" int openmc_cell_get_temperature(
   int32_t index, const int32_t* instance, double* T)
 {
   if (index < 0 || index >= model::cells.size()) {
-    strcpy(openmc_err_msg, "Index in cells array is out of bounds.");
+    set_errmsg("Index in cells array is out of bounds.");
     return OPENMC_E_OUT_OF_BOUNDS;
   }
 
@@ -1392,7 +1392,7 @@ extern "C" int openmc_cell_get_density(
   int32_t index, const int32_t* instance, double* density)
 {
   if (index < 0 || index >= model::cells.size()) {
-    strcpy(openmc_err_msg, "Index in cells array is out of bounds.");
+    set_errmsg("Index in cells array is out of bounds.");
     return OPENMC_E_OUT_OF_BOUNDS;
   }
 

--- a/src/cross_sections.cpp
+++ b/src/cross_sections.cpp
@@ -210,7 +210,7 @@ void read_ce_cross_sections(const vector<vector<double>>& nuc_temps,
       const auto& temps = nuc_temps[i_nuc];
       int err = openmc_load_nuclide(name.c_str(), temps.data(), temps.size());
       if (err < 0)
-        throw std::runtime_error {openmc_err_msg};
+        throw std::runtime_error {get_errmsg()};
 
       already_read.insert(name);
     }

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -13,30 +13,41 @@
 #include <iostream>
 
 //==============================================================================
-// Global variables / constants
-//==============================================================================
-
-// Error codes
-int OPENMC_E_UNASSIGNED {-1};
-int OPENMC_E_ALLOCATE {-2};
-int OPENMC_E_OUT_OF_BOUNDS {-3};
-int OPENMC_E_INVALID_SIZE {-4};
-int OPENMC_E_INVALID_ARGUMENT {-5};
-int OPENMC_E_INVALID_TYPE {-6};
-int OPENMC_E_INVALID_ID {-7};
-int OPENMC_E_GEOMETRY {-8};
-int OPENMC_E_DATA {-9};
-int OPENMC_E_PHYSICS {-10};
-int OPENMC_E_WARNING {1};
-
-// Error message
-char openmc_err_msg[256];
-
-//==============================================================================
 // Functions
 //==============================================================================
 
 namespace openmc {
+
+namespace {
+
+std::string error_message;
+
+} // namespace
+
+void set_errmsg(const char* message)
+{
+  error_message = message;
+}
+
+void set_errmsg(const std::string& message)
+{
+  error_message = message;
+}
+
+void set_errmsg(const std::stringstream& message)
+{
+  error_message = message.str();
+}
+
+const char* get_errmsg()
+{
+  return error_message.c_str();
+}
+
+extern "C" const char* openmc_get_err_msg()
+{
+  return get_errmsg();
+}
 
 #ifdef OPENMC_MPI
 void abort_mpi(int code)

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -258,7 +258,7 @@ int parse_command_line(int argc, char* argv[])
         settings::verbosity = std::stoi(argv[i]);
         if (settings::verbosity > 10 || settings::verbosity < 1) {
           auto msg = fmt::format("Invalid verbosity: {}.", settings::verbosity);
-          strcpy(openmc_err_msg, msg.c_str());
+          set_errmsg(msg);
           return OPENMC_E_INVALID_ARGUMENT;
         }
 
@@ -283,7 +283,7 @@ int parse_command_line(int argc, char* argv[])
         } else {
           auto msg =
             fmt::format("Unrecognized file after restart flag: {}.", filetype);
-          strcpy(openmc_err_msg, msg.c_str());
+          set_errmsg(msg);
           return OPENMC_E_INVALID_ARGUMENT;
         }
 
@@ -299,7 +299,7 @@ int parse_command_line(int argc, char* argv[])
             if (filetype != "source") {
               std::string msg {
                 "Second file after restart flag must be a source file"};
-              strcpy(openmc_err_msg, msg.c_str());
+              set_errmsg(msg);
               return OPENMC_E_INVALID_ARGUMENT;
             }
 
@@ -325,7 +325,7 @@ int parse_command_line(int argc, char* argv[])
         // Read number of threads
         if (i + 1 >= argc) {
           std::string msg {"Number of threads not specified."};
-          strcpy(openmc_err_msg, msg.c_str());
+          set_errmsg(msg);
           return OPENMC_E_INVALID_ARGUMENT;
         }
         i += 1;
@@ -335,7 +335,7 @@ int parse_command_line(int argc, char* argv[])
         int n_threads = std::stoi(argv[i]);
         if (n_threads < 1) {
           std::string msg {"Number of threads must be positive."};
-          strcpy(openmc_err_msg, msg.c_str());
+          set_errmsg(msg);
           return OPENMC_E_INVALID_ARGUMENT;
         }
         omp_set_num_threads(n_threads);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,7 @@ int main(int argc, char* argv[])
     // This happens for the -h and -v flags
     return 0;
   } else if (err) {
-    fatal_error(openmc_err_msg);
+    fatal_error(openmc_get_err_msg());
   }
 
   // start problem based on mode
@@ -57,12 +57,12 @@ int main(int argc, char* argv[])
     break;
   }
   if (err)
-    fatal_error(openmc_err_msg);
+    fatal_error(openmc_get_err_msg());
 
   // Finalize and free up memory
   err = openmc_finalize();
   if (err)
-    fatal_error(openmc_err_msg);
+    fatal_error(openmc_get_err_msg());
 
     // If MPI is in use and enabled, terminate it
 #ifdef OPENMC_MPI

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -1030,7 +1030,7 @@ void Material::set_densities(
     if (data::nuclide_map.find(nuc) == data::nuclide_map.end()) {
       int err = openmc_load_nuclide(nuc.c_str(), nullptr, 0);
       if (err < 0)
-        throw std::runtime_error {openmc_err_msg};
+        throw std::runtime_error {get_errmsg()};
     }
 
     nuclide_[i] = data::nuclide_map.at(nuc);
@@ -1165,7 +1165,7 @@ void Material::add_nuclide(const std::string& name, double density)
   // If nuclide wasn't found, extend nuclide/density arrays
   int err = openmc_load_nuclide(name.c_str(), nullptr, 0);
   if (err < 0)
-    throw std::runtime_error {openmc_err_msg};
+    throw std::runtime_error {get_errmsg()};
 
   // Append new nuclide/density
   int i_nuc = data::nuclide_map[name];

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1455,7 +1455,7 @@ RegularMesh::RegularMesh(pugi::xml_node node) : StructuredMesh {node}
   }
 
   if (int err = set_grid()) {
-    fatal_error(openmc_err_msg);
+    fatal_error(get_errmsg());
   }
 }
 
@@ -1491,7 +1491,7 @@ RegularMesh::RegularMesh(hid_t group) : StructuredMesh {group}
   }
 
   if (int err = set_grid()) {
-    fatal_error(openmc_err_msg);
+    fatal_error(get_errmsg());
   }
 }
 
@@ -1658,7 +1658,7 @@ RectilinearMesh::RectilinearMesh(pugi::xml_node node) : StructuredMesh {node}
   grid_[2] = get_node_array<double>(node, "z_grid");
 
   if (int err = set_grid()) {
-    fatal_error(openmc_err_msg);
+    fatal_error(get_errmsg());
   }
 }
 
@@ -1671,7 +1671,7 @@ RectilinearMesh::RectilinearMesh(hid_t group) : StructuredMesh {group}
   read_dataset(group, "z_grid", grid_[2]);
 
   if (int err = set_grid()) {
-    fatal_error(openmc_err_msg);
+    fatal_error(get_errmsg());
   }
 }
 
@@ -1806,7 +1806,7 @@ CylindricalMesh::CylindricalMesh(pugi::xml_node node)
   origin_ = get_node_position(node, "origin");
 
   if (int err = set_grid()) {
-    fatal_error(openmc_err_msg);
+    fatal_error(get_errmsg());
   }
 }
 
@@ -1819,7 +1819,7 @@ CylindricalMesh::CylindricalMesh(hid_t group) : PeriodicStructuredMesh {group}
   read_dataset(group, "origin", origin_);
 
   if (int err = set_grid()) {
-    fatal_error(openmc_err_msg);
+    fatal_error(get_errmsg());
   }
 }
 
@@ -2103,7 +2103,7 @@ SphericalMesh::SphericalMesh(pugi::xml_node node)
   origin_ = get_node_position(node, "origin");
 
   if (int err = set_grid()) {
-    fatal_error(openmc_err_msg);
+    fatal_error(get_errmsg());
   }
 }
 
@@ -2117,7 +2117,7 @@ SphericalMesh::SphericalMesh(hid_t group) : PeriodicStructuredMesh {group}
   read_dataset(group, "origin", origin_);
 
   if (int err = set_grid()) {
-    fatal_error(openmc_err_msg);
+    fatal_error(get_errmsg());
   }
 }
 

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -756,7 +756,7 @@ void Tally::set_nuclides(const vector<std::string>& nuclides)
       if (search == data::nuclide_map.end()) {
         int err = openmc_load_nuclide(nuc.c_str(), nullptr, 0);
         if (err < 0)
-          throw std::runtime_error {openmc_err_msg};
+          throw std::runtime_error {get_errmsg()};
       }
       nuclides_.push_back(data::nuclide_map.at(nuc));
     }
@@ -1510,7 +1510,6 @@ extern "C" int openmc_tally_set_nuclides(
       if (search == data::nuclide_map.end()) {
         int err = openmc_load_nuclide(word.c_str(), nullptr, 0);
         if (err < 0) {
-          set_errmsg(openmc_err_msg);
           return OPENMC_E_DATA;
         }
       }

--- a/tests/regression_tests/cpp_driver/driver.cpp
+++ b/tests/regression_tests/cpp_driver/driver.cpp
@@ -26,7 +26,7 @@ int main(int argc, char** argv)
   int err = openmc_init(argc, argv, nullptr);
 #endif
   if (err)
-    fatal_error(openmc_err_msg);
+    fatal_error(openmc_get_err_msg());
 
   // create a new cell filter
   auto cell_filter = Filter::create<CellFilter>();

--- a/tests/regression_tests/dagmc/external/main.cpp
+++ b/tests/regression_tests/dagmc/external/main.cpp
@@ -25,7 +25,7 @@ int main(int argc, char* argv[])
     // This happens for the -h and -v flags
     return EXIT_SUCCESS;
   } else if (openmc_err) {
-    fatal_error(openmc_err_msg);
+    fatal_error(openmc_get_err_msg());
   }
 
   // Create DAGMC ptr
@@ -106,12 +106,12 @@ int main(int argc, char* argv[])
   // Run OpenMC
   openmc_err = openmc_run();
   if (openmc_err)
-    fatal_error(openmc_err_msg);
+    fatal_error(openmc_get_err_msg());
 
   // Deallocate memory
   openmc_err = openmc_finalize();
   if (openmc_err)
-    fatal_error(openmc_err_msg);
+    fatal_error(openmc_get_err_msg());
 
 #ifdef OPENMC_MPI
   MPI_Finalize();

--- a/tests/regression_tests/external_moab/main.cpp
+++ b/tests/regression_tests/external_moab/main.cpp
@@ -18,7 +18,7 @@ int main(int argc, char* argv[])
     // This happens for the -h and -v flags
     return EXIT_SUCCESS;
   } else if (openmc_err) {
-    fatal_error(openmc_err_msg);
+    fatal_error(openmc_get_err_msg());
   }
 
   // Create MOAB interface
@@ -87,12 +87,12 @@ int main(int argc, char* argv[])
   // Run OpenMC
   openmc_err = openmc_run();
   if (openmc_err)
-    fatal_error(openmc_err_msg);
+    fatal_error(openmc_get_err_msg());
 
   // Deallocate memory
   openmc_err = openmc_finalize();
   if (openmc_err)
-    fatal_error(openmc_err_msg);
+    fatal_error(openmc_get_err_msg());
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
# Description

Another PR focused on avoiding `OPENMC_API` for Windows support. This PR replaces the exported `OPENMC_E_*` variables with a C enum and replaces the fixed-size exported error-message buffer with an internal string exposed through a new `openmc_get_err_msg` C API function. C++ and Python callers now retrieve error text through the function instead of accessing shared-library data directly. This also has the nice effect of eliminating the fixed 256-character limit that was in place before.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)