### PR TITLE
Free WeightWindowGenerators' memory on cpp side

### DIFF
--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -1056,6 +1056,7 @@ void free_memory_weight_windows()
 {
   variance_reduction::ww_map.clear();
   variance_reduction::weight_windows.clear();
+  variance_reduction::weight_windows_generators.clear();
 }
 
 void finalize_variance_reduction()


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This PR free WeightWindowGenerators' memory on the cpp side.


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
