### PR TITLE
Return discrete lines exactly in lin-lin tabular energy sampling

### DIFF
--- a/src/distribution_energy.cpp
+++ b/src/distribution_energy.cpp
@@ -220,20 +220,26 @@ double ContinuousTabular::sample(double E, uint64_t* seed) const
     }
 
   } else if (distribution_[l].interpolation == Interpolation::lin_lin) {
-    // Linear-linear interpolation
-    double E_l_k1 = distribution_[l].e_out[k + 1];
-    double p_l_k1 = distribution_[l].p[k + 1];
+    // Linear-linear interpolation. The inversion applies only to the
+    // continuous portion of the distribution; a sampled discrete line
+    // (k < n_discrete) is returned exactly, as in the histogram branch —
+    // otherwise (r1 - c_k) is negative and the sampled energy is shifted
+    // off the line.
+    if (k >= n_discrete) {
+      double E_l_k1 = distribution_[l].e_out[k + 1];
+      double p_l_k1 = distribution_[l].p[k + 1];
 
-    if (E_l_k != E_l_k1) {
-      double frac = (p_l_k1 - p_l_k) / (E_l_k1 - E_l_k);
-      if (frac == 0.0) {
-        E_out = E_l_k + (r1 - c_k) / p_l_k;
-      } else {
-        E_out =
-          E_l_k +
-          (std::sqrt(std::max(0.0, p_l_k * p_l_k + 2.0 * frac * (r1 - c_k))) -
-            p_l_k) /
-            frac;
+      if (E_l_k != E_l_k1) {
+        double frac = (p_l_k1 - p_l_k) / (E_l_k1 - E_l_k);
+        if (frac == 0.0) {
+          E_out = E_l_k + (r1 - c_k) / p_l_k;
+        } else {
+          E_out =
+            E_l_k +
+            (std::sqrt(std::max(0.0, p_l_k * p_l_k + 2.0 * frac * (r1 - c_k))) -
+              p_l_k) /
+              frac;
+        }
       }
     }
   } else {

--- a/src/distribution_energy.cpp
+++ b/src/distribution_energy.cpp
@@ -211,21 +211,23 @@ double ContinuousTabular::sample(double E, uint64_t* seed) const
   }
 
   double E_l_k = distribution_[l].e_out[k];
-  double p_l_k = distribution_[l].p[k];
-  double E_out = E_l_k;
-  if (distribution_[l].interpolation == Interpolation::histogram) {
-    // Histogram interpolation
-    if (p_l_k > 0.0 && k >= n_discrete) {
-      E_out = E_l_k + (r1 - c_k) / p_l_k;
-    }
 
-  } else if (distribution_[l].interpolation == Interpolation::lin_lin) {
-    // Linear-linear interpolation. The inversion applies only to the
-    // continuous portion of the distribution; a sampled discrete line
-    // (k < n_discrete) is returned exactly, as in the histogram branch —
-    // otherwise (r1 - c_k) is negative and the sampled energy is shifted
-    // off the line.
-    if (k >= n_discrete) {
+  if (k < n_discrete) {
+    // Discrete case
+    return E_l_k;
+  } else {
+    // Continuous case
+    double p_l_k = distribution_[l].p[k];
+    double E_out;
+    if (distribution_[l].interpolation == Interpolation::histogram) {
+      // Histogram interpolation
+      if (p_l_k > 0.0) {
+        E_out = E_l_k + (r1 - c_k) / p_l_k;
+      } else {
+        E_out = E_l_k;
+      }
+    } else if (distribution_[l].interpolation == Interpolation::lin_lin) {
+      // Linear-linear interpolation
       double E_l_k1 = distribution_[l].e_out[k + 1];
       double p_l_k1 = distribution_[l].p[k + 1];
 
@@ -240,36 +242,39 @@ double ContinuousTabular::sample(double E, uint64_t* seed) const
               p_l_k) /
               frac;
         }
+      } else {
+        E_out = E_l_k;
       }
-    }
-  } else {
-    throw std::runtime_error {"Unexpected interpolation for continuous energy "
-                              "distribution."};
-  }
-
-  // Now interpolate between incident energy bins i and i + 1
-  if (!histogram_interp && n_energy_out > 1 && k >= n_discrete) {
-    // Interpolation for energy E1 and EK
-    n_energy_out = distribution_[i].e_out.size();
-    n_discrete = distribution_[i].n_discrete;
-    const double E_i_1 = distribution_[i].e_out[n_discrete];
-    const double E_i_K = distribution_[i].e_out[n_energy_out - 1];
-
-    n_energy_out = distribution_[i + 1].e_out.size();
-    n_discrete = distribution_[i + 1].n_discrete;
-    const double E_i1_1 = distribution_[i + 1].e_out[n_discrete];
-    const double E_i1_K = distribution_[i + 1].e_out[n_energy_out - 1];
-
-    const double E_1 = E_i_1 + r * (E_i1_1 - E_i_1);
-    const double E_K = E_i_K + r * (E_i1_K - E_i_K);
-
-    if (l == i) {
-      return E_1 + (E_out - E_i_1) * (E_K - E_1) / (E_i_K - E_i_1);
     } else {
-      return E_1 + (E_out - E_i1_1) * (E_K - E_1) / (E_i1_K - E_i1_1);
+      throw std::runtime_error {
+        "Unexpected interpolation for continuous energy "
+        "distribution."};
     }
-  } else {
-    return E_out;
+
+    // Now interpolate between incident energy bins i and i + 1
+    if (!histogram_interp && n_energy_out > 1) {
+      // Interpolation for energy E1 and EK
+      n_energy_out = distribution_[i].e_out.size();
+      n_discrete = distribution_[i].n_discrete;
+      const double E_i_1 = distribution_[i].e_out[n_discrete];
+      const double E_i_K = distribution_[i].e_out[n_energy_out - 1];
+
+      n_energy_out = distribution_[i + 1].e_out.size();
+      n_discrete = distribution_[i + 1].n_discrete;
+      const double E_i1_1 = distribution_[i + 1].e_out[n_discrete];
+      const double E_i1_K = distribution_[i + 1].e_out[n_energy_out - 1];
+
+      const double E_1 = E_i_1 + r * (E_i1_1 - E_i_1);
+      const double E_K = E_i_K + r * (E_i1_K - E_i_K);
+
+      if (l == i) {
+        return E_1 + (E_out - E_i_1) * (E_K - E_1) / (E_i_K - E_i_1);
+      } else {
+        return E_1 + (E_out - E_i1_1) * (E_K - E_1) / (E_i1_K - E_i1_1);
+      }
+    } else {
+      return E_out;
+    }
   }
 }
 

--- a/src/secondary_correlated.cpp
+++ b/src/secondary_correlated.cpp
@@ -219,6 +219,12 @@ Distribution& CorrelatedAngleEnergy::sample_dist(
       E_out = E_l_k;
     }
 
+  } else if (k < n_discrete) {
+    // A sampled discrete line is returned exactly (the lin-lin inversion
+    // below applies only to the continuous portion; with (r1 - c_k)
+    // negative it would shift the sampled energy off the line)
+    E_out = E_l_k;
+
   } else if (distribution_[l].interpolation == Interpolation::lin_lin) {
     // Linear-linear interpolation
     double E_l_k1 = distribution_[l].e_out[k + 1];

--- a/src/secondary_correlated.cpp
+++ b/src/secondary_correlated.cpp
@@ -210,40 +210,37 @@ Distribution& CorrelatedAngleEnergy::sample_dist(
   }
 
   double E_l_k = distribution_[l].e_out[k];
-  double p_l_k = distribution_[l].p[k];
-  if (distribution_[l].interpolation == Interpolation::histogram) {
-    // Histogram interpolation
-    if (p_l_k > 0.0 && k >= n_discrete) {
-      E_out = E_l_k + (r1 - c_k) / p_l_k;
-    } else {
-      E_out = E_l_k;
-    }
-
-  } else if (k < n_discrete) {
-    // A sampled discrete line is returned exactly (the lin-lin inversion
-    // below applies only to the continuous portion; with (r1 - c_k)
-    // negative it would shift the sampled energy off the line)
+  if (k < n_discrete) {
+    // Discrete case
     E_out = E_l_k;
+  } else {
+    // Continuous case
+    double p_l_k = distribution_[l].p[k];
+    if (distribution_[l].interpolation == Interpolation::histogram) {
+      // Histogram interpolation
+      if (p_l_k > 0.0) {
+        E_out = E_l_k + (r1 - c_k) / p_l_k;
+      } else {
+        E_out = E_l_k;
+      }
+    } else if (distribution_[l].interpolation == Interpolation::lin_lin) {
+      // Linear-linear interpolation
+      double E_l_k1 = distribution_[l].e_out[k + 1];
+      double p_l_k1 = distribution_[l].p[k + 1];
 
-  } else if (distribution_[l].interpolation == Interpolation::lin_lin) {
-    // Linear-linear interpolation
-    double E_l_k1 = distribution_[l].e_out[k + 1];
-    double p_l_k1 = distribution_[l].p[k + 1];
-
-    double frac = (p_l_k1 - p_l_k) / (E_l_k1 - E_l_k);
-    if (frac == 0.0) {
-      E_out = E_l_k + (r1 - c_k) / p_l_k;
-    } else {
-      E_out =
-        E_l_k +
-        (std::sqrt(std::max(0.0, p_l_k * p_l_k + 2.0 * frac * (r1 - c_k))) -
-          p_l_k) /
-          frac;
+      double frac = (p_l_k1 - p_l_k) / (E_l_k1 - E_l_k);
+      if (frac == 0.0) {
+        E_out = E_l_k + (r1 - c_k) / p_l_k;
+      } else {
+        E_out =
+          E_l_k +
+          (std::sqrt(std::max(0.0, p_l_k * p_l_k + 2.0 * frac * (r1 - c_k))) -
+            p_l_k) /
+            frac;
+      }
     }
-  }
 
-  // Now interpolate between incident energy bins i and i + 1
-  if (k >= n_discrete) {
+    // Now interpolate between incident energy bins i and i + 1
     if (l == i) {
       E_out = E_1 + (E_out - E_i_1) * (E_K - E_1) / (E_i_K - E_i_1);
     } else {

--- a/src/secondary_kalbach.cpp
+++ b/src/secondary_kalbach.cpp
@@ -182,6 +182,14 @@ void KalbachMann::sample_params(
     km_r = distribution_[l].r[k];
     km_a = distribution_[l].a[k];
 
+  } else if (k < n_discrete) {
+    // A sampled discrete line is returned exactly (the lin-lin inversion
+    // below applies only to the continuous portion; with (r1 - c_k)
+    // negative it would shift the sampled energy off the line)
+    E_out = E_l_k;
+    km_r = distribution_[l].r[k];
+    km_a = distribution_[l].a[k];
+
   } else {
     // Linear-linear interpolation
     double E_l_k1 = distribution_[l].e_out[k + 1];

--- a/src/secondary_kalbach.cpp
+++ b/src/secondary_kalbach.cpp
@@ -169,54 +169,53 @@ void KalbachMann::sample_params(
   }
 
   double E_l_k = distribution_[l].e_out[k];
-  double p_l_k = distribution_[l].p[k];
-  if (distribution_[l].interpolation == Interpolation::histogram) {
-    // Histogram interpolation
-    if (p_l_k > 0.0 && k >= n_discrete) {
-      E_out = E_l_k + (r1 - c_k) / p_l_k;
-    } else {
-      E_out = E_l_k;
-    }
-
-    // Determine Kalbach-Mann parameters
-    km_r = distribution_[l].r[k];
-    km_a = distribution_[l].a[k];
-
-  } else if (k < n_discrete) {
-    // A sampled discrete line is returned exactly (the lin-lin inversion
-    // below applies only to the continuous portion; with (r1 - c_k)
-    // negative it would shift the sampled energy off the line)
+  if (k < n_discrete) {
+    // Discrete case
     E_out = E_l_k;
     km_r = distribution_[l].r[k];
     km_a = distribution_[l].a[k];
 
   } else {
-    // Linear-linear interpolation
-    double E_l_k1 = distribution_[l].e_out[k + 1];
-    double p_l_k1 = distribution_[l].p[k + 1];
+    // Continuous case
+    double p_l_k = distribution_[l].p[k];
+    if (distribution_[l].interpolation == Interpolation::histogram) {
+      // Histogram interpolation
+      if (p_l_k > 0.0) {
+        E_out = E_l_k + (r1 - c_k) / p_l_k;
+      } else {
+        E_out = E_l_k;
+      }
 
-    double frac = (p_l_k1 - p_l_k) / (E_l_k1 - E_l_k);
-    if (frac == 0.0) {
-      E_out = E_l_k + (r1 - c_k) / p_l_k;
+      // Determine Kalbach-Mann parameters
+      km_r = distribution_[l].r[k];
+      km_a = distribution_[l].a[k];
+
     } else {
-      E_out =
-        E_l_k +
-        (std::sqrt(std::max(0.0, p_l_k * p_l_k + 2.0 * frac * (r1 - c_k))) -
-          p_l_k) /
-          frac;
+      // Linear-linear interpolation
+      double E_l_k1 = distribution_[l].e_out[k + 1];
+      double p_l_k1 = distribution_[l].p[k + 1];
+
+      double frac = (p_l_k1 - p_l_k) / (E_l_k1 - E_l_k);
+      if (frac == 0.0) {
+        E_out = E_l_k + (r1 - c_k) / p_l_k;
+      } else {
+        E_out =
+          E_l_k +
+          (std::sqrt(std::max(0.0, p_l_k * p_l_k + 2.0 * frac * (r1 - c_k))) -
+            p_l_k) /
+            frac;
+      }
+
+      // Determine Kalbach-Mann parameters
+      km_r = distribution_[l].r[k] +
+             (E_out - E_l_k) / (E_l_k1 - E_l_k) *
+               (distribution_[l].r[k + 1] - distribution_[l].r[k]);
+      km_a = distribution_[l].a[k] +
+             (E_out - E_l_k) / (E_l_k1 - E_l_k) *
+               (distribution_[l].a[k + 1] - distribution_[l].a[k]);
     }
 
-    // Determine Kalbach-Mann parameters
-    km_r = distribution_[l].r[k] +
-           (E_out - E_l_k) / (E_l_k1 - E_l_k) *
-             (distribution_[l].r[k + 1] - distribution_[l].r[k]);
-    km_a = distribution_[l].a[k] +
-           (E_out - E_l_k) / (E_l_k1 - E_l_k) *
-             (distribution_[l].a[k + 1] - distribution_[l].a[k]);
-  }
-
-  // Now interpolate between incident energy bins i and i + 1
-  if (k >= n_discrete) {
+    // Now interpolate between incident energy bins i and i + 1
     if (l == i) {
       E_out = E_1 + (E_out - E_i_1) * (E_K - E_1) / (E_i_K - E_i_1);
     } else {


### PR DESCRIPTION
# Description

Fixes #4068.

`ContinuousTabular`, `KalbachMann`, and `CorrelatedAngleEnergy` guard their histogram interpolation branch with `k >= n_discrete` (a sampled discrete line is returned at exactly its tabulated energy), but not the lin-lin branch — a discrete hit leaves the CDF walk with `r1 < c_k`, so the lin-lin inversion runs with a negative `(r1 - c_k)` and shifts the sampled energy below the line.

This PR mirrors the histogram guard in all three samplers. For Kalbach-Mann, the discrete branch takes `r[k]`/`a[k]` directly — identical to what the parameter interpolation reduces to at `E_out = E_l_k`, so no behavior change beyond the energy fix.

**Impact** (measured against the official ENDF/B-VIII.0 HDF5 library; details in #4068): the discrete-lines-with-lin-lin combination appears in **19,913 secondary-photon tables** (discrete gammas of (n,2n)/(n,3n)/(n,n′)-continuum reactions across ~half the nuclides) and in **zero neutron-product tables** — so coupled neutron–photon runs currently sample smeared gamma lines, while neutron-only results are unaffected by this change.

Found while porting the transport engine to Apple Silicon GPUs ([dallonby/openmc-metal](https://github.com/dallonby/openmc-metal)).

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run clang-format on any C++ source files (if applicable)
- [ ] I have followed the style guidelines for Python source files (not applicable)
- [ ] I have made corresponding changes to the documentation (not applicable — behavior now matches the documented tabular sampling)
- [ ] I have added tests that prove my fix is effective (none added — happy to add a unit test sampling a synthetic discrete+lin-lin table on request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)