### PR TITLE
Void guard kappa-fission when tallying in the random ray solver

### DIFF
--- a/src/random_ray/flat_source_domain.cpp
+++ b/src/random_ray/flat_source_domain.cpp
@@ -682,10 +682,13 @@ void FlatSourceDomain::random_ray_tally()
           break;
 
         case SCORE_KAPPA_FISSION:
-          score =
-            flux * volume *
-            kappa_fission_[(material * ntemperature_ + temp) * negroups_ + g] *
-            density_mult;
+          if (material != MATERIAL_VOID) {
+            score =
+              flux * volume *
+              kappa_fission_[(material * ntemperature_ + temp) * negroups_ +
+                             g] *
+              density_mult;
+          }
           break;
 
         default:


### PR DESCRIPTION
# Description

#3714 added support for fission heating tallies in the random ray solver. However, the implementation doesn't guard against void materials when indexing the flattened kappa-fission cross section array during the tally operation. This causes array accesses to uninitialized memory (scrambling tally results), which this pull request fixes.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
