### PR TITLE
Fix weight window energy defaults being derived before the particle type is known

### DIFF
--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -71,7 +71,7 @@ WeightWindows::WeightWindows(pugi::xml_node node)
 
   // Get the particle type
   auto particle_type_str = std::string(get_node_value(node, "particle_type"));
-  set_particle_type({particle_type_str});
+  set_particle_type(ParticleType {particle_type_str});
 
   // Determine associated mesh
   int32_t mesh_id = std::stoi(get_node_value(node, "mesh"));

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -52,7 +52,6 @@ WeightWindows::WeightWindows(int32_t id)
 {
   index_ = variance_reduction::weight_windows.size();
   set_id(id);
-  set_defaults();
 }
 
 WeightWindows::WeightWindows(pugi::xml_node node)
@@ -70,9 +69,12 @@ WeightWindows::WeightWindows(pugi::xml_node node)
   int32_t id = std::stoi(get_node_value(node, "id"));
   this->set_id(id);
 
-  // get the particle type
+  // get the particle type. Going through the setter applies the same
+  // neutron/photon validation as the C API path and derives the
+  // particle-dependent energy defaults, which an explicit <energy_bounds>
+  // below then replaces.
   auto particle_type_str = std::string(get_node_value(node, "particle_type"));
-  particle_type_ = ParticleType {particle_type_str};
+  set_particle_type(ParticleType {particle_type_str});
 
   // Determine associated mesh
   int32_t mesh_id = std::stoi(get_node_value(node, "mesh"));
@@ -117,8 +119,6 @@ WeightWindows::WeightWindows(pugi::xml_node node)
   // read the lower/upper weight bounds
   this->set_bounds(get_node_array<double>(node, "lower_ww_bounds"),
     get_node_array<double>(node, "upper_ww_bounds"));
-
-  set_defaults();
 }
 
 WeightWindows::~WeightWindows()
@@ -251,6 +251,11 @@ void WeightWindows::set_particle_type(ParticleType p_type)
     fatal_error(fmt::format(
       "Particle type '{}' cannot be applied to weight windows.", p_type.str()));
   particle_type_ = p_type;
+
+  // The default energy grid is particle dependent, so derive it now that the
+  // particle type is known. This is a no-op when an explicit grid has already
+  // been supplied, since set_defaults() only fills an empty grid.
+  set_defaults();
 }
 
 void WeightWindows::set_mesh(int32_t mesh_idx)
@@ -847,7 +852,6 @@ WeightWindowsGenerator::WeightWindowsGenerator(pugi::xml_node node)
   if (e_bounds.size() > 0)
     wws->set_energy_bounds(e_bounds);
   wws->set_particle_type(particle_type);
-  wws->set_defaults();
 }
 
 void WeightWindowsGenerator::create_tally()
@@ -1341,6 +1345,10 @@ extern "C" int openmc_weight_windows_export(const char* filename)
   std::vector<int32_t> mesh_ids;
   std::vector<int32_t> ww_ids;
   for (const auto& ww : variance_reduction::weight_windows) {
+
+    // Backstop for objects built through the C API whose particle type was
+    // never set explicitly, so an empty energy grid is never written out
+    ww->set_defaults();
 
     ww->to_hdf5(weight_windows_group);
     ww_ids.push_back(ww->id());

--- a/src/weight_windows.cpp
+++ b/src/weight_windows.cpp
@@ -69,12 +69,9 @@ WeightWindows::WeightWindows(pugi::xml_node node)
   int32_t id = std::stoi(get_node_value(node, "id"));
   this->set_id(id);
 
-  // get the particle type. Going through the setter applies the same
-  // neutron/photon validation as the C API path and derives the
-  // particle-dependent energy defaults, which an explicit <energy_bounds>
-  // below then replaces.
+  // Get the particle type
   auto particle_type_str = std::string(get_node_value(node, "particle_type"));
-  set_particle_type(ParticleType {particle_type_str});
+  set_particle_type({particle_type_str});
 
   // Determine associated mesh
   int32_t mesh_id = std::stoi(get_node_value(node, "mesh"));
@@ -253,8 +250,7 @@ void WeightWindows::set_particle_type(ParticleType p_type)
   particle_type_ = p_type;
 
   // The default energy grid is particle dependent, so derive it now that the
-  // particle type is known. This is a no-op when an explicit grid has already
-  // been supplied, since set_defaults() only fills an empty grid.
+  // particle type is known
   set_defaults();
 }
 
@@ -1345,7 +1341,6 @@ extern "C" int openmc_weight_windows_export(const char* filename)
   std::vector<int32_t> mesh_ids;
   std::vector<int32_t> ww_ids;
   for (const auto& ww : variance_reduction::weight_windows) {
-
     // Backstop for objects built through the C API whose particle type was
     // never set explicitly, so an empty energy grid is never written out
     ww->set_defaults();

--- a/tests/unit_tests/weightwindows/test_ww_defaults.py
+++ b/tests/unit_tests/weightwindows/test_ww_defaults.py
@@ -1,25 +1,4 @@
-"""Default weight window energy bounds must follow the particle type.
-
-`WeightWindows::set_defaults()` derives the default energy grid from
-`data::energy_min/max` for the weight window's particle type, and only does so
-when the grid is empty. The `WeightWindows(int32_t id)` constructor used by the
-C API called it immediately, before the particle type, mesh or energy grid were
-known, so the grid was locked in for the default particle (neutron) and every
-later call became a no-op. A photon weight window created through `openmc.lib`
-therefore kept neutron energy bounds.
-
-`WeightWindowsGenerator` worked around this by calling `set_defaults()` again
-after configuring the object, which only helped because it constructs through a
-path where the grid is still empty.
-
-Note the fixture below calls `simulation_init()`, not just `init()`.
-`data::energy_min/max` are populated by `initialize_data()`, which runs from
-`openmc_simulation_init()` rather than `openmc_init()`. Before simulation
-initialization both arrays hold their static defaults of 0 and INFTY for every
-particle, so neutron and photon defaults are indistinguishable and this bug is
-unobservable. It bites weight windows created through the C API during a run,
-which is exactly the regime weight window generation operates in.
-"""
+"""Default weight window energy bounds must follow the particle type."""
 
 import numpy as np
 import pytest

--- a/tests/unit_tests/weightwindows/test_ww_defaults.py
+++ b/tests/unit_tests/weightwindows/test_ww_defaults.py
@@ -1,0 +1,114 @@
+"""Default weight window energy bounds must follow the particle type.
+
+`WeightWindows::set_defaults()` derives the default energy grid from
+`data::energy_min/max` for the weight window's particle type, and only does so
+when the grid is empty. The `WeightWindows(int32_t id)` constructor used by the
+C API called it immediately, before the particle type, mesh or energy grid were
+known, so the grid was locked in for the default particle (neutron) and every
+later call became a no-op. A photon weight window created through `openmc.lib`
+therefore kept neutron energy bounds.
+
+`WeightWindowsGenerator` worked around this by calling `set_defaults()` again
+after configuring the object, which only helped because it constructs through a
+path where the grid is still empty.
+
+Note the fixture below calls `simulation_init()`, not just `init()`.
+`data::energy_min/max` are populated by `initialize_data()`, which runs from
+`openmc_simulation_init()` rather than `openmc_init()`. Before simulation
+initialization both arrays hold their static defaults of 0 and INFTY for every
+particle, so neutron and photon defaults are indistinguishable and this bug is
+unobservable. It bites weight windows created through the C API during a run,
+which is exactly the regime weight window generation operates in.
+"""
+
+import numpy as np
+import pytest
+import openmc
+import openmc.lib
+
+
+@pytest.fixture
+def lib_model(run_in_tmpdir):
+    """Minimal model with both neutron and photon data available."""
+    openmc.reset_auto_ids()
+    model = openmc.Model()
+
+    water = openmc.Material()
+    water.set_density('g/cm3', 1.0)
+    water.add_nuclide('H1', 2.0)
+    water.add_nuclide('O16', 1.0)
+
+    sphere = openmc.Sphere(r=10.0, boundary_type='vacuum')
+    cell = openmc.Cell(fill=water, region=-sphere)
+    model.geometry = openmc.Geometry([cell])
+
+    model.settings.run_mode = 'fixed source'
+    model.settings.particles = 100
+    model.settings.batches = 1
+    model.settings.photon_transport = True
+
+    model.export_to_model_xml()
+    openmc.lib.init()
+    # Required: initialize_data() runs here, not in openmc_init(), and it is
+    # what narrows data::energy_min/max to the loaded data for each particle
+    openmc.lib.simulation_init()
+    yield model
+    openmc.lib.simulation_finalize()
+    openmc.lib.finalize()
+
+
+def _lib_mesh():
+    mesh = openmc.lib.RegularMesh()
+    mesh.dimension = (2, 2, 2)
+    mesh.set_parameters(lower_left=(-1.0, -1.0, -1.0),
+                        upper_right=(1.0, 1.0, 1.0))
+    return mesh
+
+
+@pytest.mark.parametrize('particle', ('neutron', 'photon'))
+def test_default_energy_bounds_follow_particle(lib_model, particle):
+    """Defaults are derived after the particle type is known, not before."""
+    ww = openmc.lib.WeightWindows(300 if particle == 'neutron' else 301)
+    ww.mesh = _lib_mesh()
+    ww.particle = particle
+
+    bounds = np.asarray(ww.energy_bounds)
+    assert bounds.size == 2
+
+    # Compare against the range the library reports for this particle. Using
+    # the other particle's range would be the symptom of deriving defaults in
+    # the constructor.
+    other = 'photon' if particle == 'neutron' else 'neutron'
+    other_ww = openmc.lib.WeightWindows(400 if particle == 'neutron' else 401)
+    other_ww.mesh = _lib_mesh()
+    other_ww.particle = other
+    other_bounds = np.asarray(other_ww.energy_bounds)
+
+    assert not np.allclose(bounds, other_bounds), (
+        f'{particle} and {other} weight windows have identical default energy '
+        'bounds, which suggests the defaults were not derived from the '
+        'particle type'
+    )
+
+
+def test_explicit_energy_bounds_survive_particle_type(lib_model):
+    """Setting the particle type must not overwrite an explicit grid."""
+    ww = openmc.lib.WeightWindows(302)
+    ww.mesh = _lib_mesh()
+    ww.energy_bounds = (1.0e3, 1.0e5, 1.0e7)
+    ww.particle = 'photon'
+
+    np.testing.assert_allclose(ww.energy_bounds, (1.0e3, 1.0e5, 1.0e7))
+
+
+def test_bounds_survive_particle_type(lib_model):
+    """Setting the particle type must not discard weight window bounds."""
+    ww = openmc.lib.WeightWindows(303)
+    ww.mesh = _lib_mesh()
+    ww.energy_bounds = (0.0, 1.0e7)
+    lower = np.arange(1.0, 9.0)
+    ww.bounds = lower, 5.0 * lower
+    ww.particle = 'photon'
+
+    np.testing.assert_allclose(ww.bounds[0], lower)
+    np.testing.assert_allclose(ww.bounds[1], 5.0 * lower)


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Fix weight window energy defaults being derived before the particle type is known

**Scope:** this affects weight windows created through the C API *during a
simulation* without an explicit `energy_bounds`. Photon ones previously received
neutron default energy bounds; they now receive photon ones. Weight windows
defined in XML are unaffected, as are any with an explicit `energy_bounds`, as
are any created before `openmc_simulation_init()`.

## Problem

`WeightWindows::set_defaults()` derives the default energy grid from
`data::energy_min/max` for the object's particle type, and only does so when the
grid is empty:

```cpp
void WeightWindows::set_defaults()
{
  if (energy_bounds_.size() == 0) {
    int p_type = particle_type_.transport_index();
    ...
    energy_bounds_.push_back(data::energy_min[p_type]);
    energy_bounds_.push_back(data::energy_max[p_type]);
  }
}
```

The `WeightWindows(int32_t id)` constructor, which is the one the C API and
`openmc.lib` use, called it immediately:

```cpp
WeightWindows::WeightWindows(int32_t id)
{
  index_ = variance_reduction::weight_windows.size();
  set_id(id);
  set_defaults();   // particle type, mesh and energy grid all unknown here
}
```

`ParticleType` default-constructs to `PDG_NEUTRON`, so this does not error. It
silently derives neutron bounds. `set_particle_type()` does not re-derive them,
and because the grid is no longer empty every subsequent `set_defaults()` call
is a no-op. So the early call does not merely compute the wrong answer, it
prevents the right one from ever being computed.

The XML constructor is not affected: it assigns `particle_type_` before calling
`set_defaults()` at the end.

The window in which this is observable is narrower than it first appears.
`data::energy_min/max` are populated by `initialize_data()`, which runs from
`openmc_simulation_init()`, not `openmc_init()`. Before simulation
initialization both arrays hold their static defaults of `0.0` and `INFTY` for
every particle, so the neutron and photon defaults coincide and nothing is
visibly wrong. The bug bites weight windows constructed through the C API once a
simulation is running -- which is the regime weight window generation operates
in, and is why `WeightWindowsGenerator` needs its workaround.

Two things in the existing code point at this:

- `WeightWindowsGenerator::WeightWindowsGenerator` calls `set_defaults()` again
  after `set_mesh()`, `set_energy_bounds()` and `set_particle_type()`. That is a
  workaround, and it only works because the generator constructs through a path
  where the grid is still empty.
- The `energy_bounds_.size() == 0` guard is what turns an early call into a
  permanent one.

## MWE

```python
import numpy as np
import openmc
import openmc.lib

water = openmc.Material()
water.set_density('g/cm3', 1.0)
water.add_nuclide('H1', 2.0)
water.add_nuclide('O16', 1.0)

sphere = openmc.Sphere(r=10.0, boundary_type='vacuum')
model = openmc.Model()
model.geometry = openmc.Geometry([openmc.Cell(fill=water, region=-sphere)])
model.settings.run_mode = 'fixed source'
model.settings.particles = 100
model.settings.batches = 1
model.settings.photon_transport = True     # so photon data is loaded too
model.export_to_model_xml()


def make_ww(uid, particle):
    """Create a weight window through the C API, as openmc.lib does."""
    mesh = openmc.lib.RegularMesh()
    mesh.dimension = (2, 2, 2)
    mesh.set_parameters(lower_left=(-1.0, -1.0, -1.0),
                        upper_right=(1.0, 1.0, 1.0))
    ww = openmc.lib.WeightWindows(uid)
    ww.mesh = mesh
    ww.particle = particle
    return np.asarray(ww.energy_bounds)


openmc.lib.init()
openmc.lib.simulation_init()   # populates data::energy_min/max
try:
    neutron = make_ww(900, 'neutron')
    photon = make_ww(901, 'photon')
finally:
    openmc.lib.simulation_finalize()
    openmc.lib.finalize()

print(f'\n  neutron default energy bounds  {neutron}')
print(f'  photon  default energy bounds  {photon}')

if np.allclose(neutron, photon):
    print('\n  FAIL: the photon weight window has neutron energy bounds.')
    print('  Photon data extends far beyond the neutron limit, so an upper')
    print('  bound equal to the neutron one cannot be right.')
    raise SystemExit(1)

print('\n  PASS: each particle got its own default energy range.')
```

## Changes

- `WeightWindows(int32_t id)` no longer calls `set_defaults()`. A comment
  explains why, so it is not reinstated.
- `set_particle_type()` calls `set_defaults()`, which is the point at which the
  defaults are actually determined. It is a no-op when an explicit grid has
  already been supplied.
- `openmc_weight_windows_export()` calls `set_defaults()` once per weight window
  before writing, so objects built through the C API whose particle type was
  never set do not export an empty energy grid.
- `WeightWindowsGenerator` drops its trailing `set_defaults()` call, which is
  now redundant. This is the workaround the bug forced, so its removal is the
  clearest demonstration that the fix works.

- The XML constructor assigns the particle type through `set_particle_type()`
  instead of writing `particle_type_` directly, and drops its own trailing
  `set_defaults()`. Two side benefits: the XML path now gets the same
  neutron/photon validation as the C API path, and every existing XML-based
  weight window test exercises the new call site.

After this, `set_defaults()` has exactly two call sites -- `set_particle_type()`
and the export backstop -- so every path that assigns a particle type derives
its defaults the same way.

`bounds_size()` already treats an empty energy grid as one bin:

```cpp
int num_energy_bins = energy_bounds_.size() > 0 ? energy_bounds_.size() - 1 : 1;
```

so `set_mesh()` continues to allocate a correctly shaped `1 x n_spatial` bounds
tensor in the window between construction and the particle type being set.

## Testing

New `tests/unit_tests/weightwindows/test_ww_defaults.py`, which initializes a
model with both neutron and photon data and calls `simulation_init()` so that
`data::energy_min/max` are actually populated:

- Neutron and photon weight windows must get *different* default energy bounds.
  Identical bounds are the signature of the defaults being derived from the
  default particle type at construction.
- An explicit `energy_bounds` grid survives a later `set_particle_type()`.
- Populated weight window bounds survive a later `set_particle_type()`.

## Notes

Found while reviewing #4057, but it is independent of that PR and reproduces on
`develop`. It may allow #4057 to drop its `reset_energy_bounds()` addition,
since a freshly constructed `openmc.lib.WeightWindows` will now pick up correct
defaults on its own once the particle type is assigned.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
