### PR TITLE
Reset temperature range data to original values

### DIFF
--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -169,8 +169,8 @@ int openmc_finalize()
 
   data::energy_max = {INFTY, INFTY, INFTY, INFTY};
   data::energy_min = {0.0, 0.0, 0.0, 0.0};
-  data::temperature_min = 0.0;
-  data::temperature_max = INFTY;
+  data::temperature_min = INFTY;
+  data::temperature_max = 0.0;
   data::mg = {};
   model::root_universe = -1;
   model::plotter_seed = 1;


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

Currently when finalizing the simulation the temperature range variables are not restored correctly.

Effect: in any process that initializes the library more than once, the data-availability check in Cell::set_temperature() silently stops working from the second session onward. Single-session runs are unaffected.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
