### PR TITLE
Replace the IFP parameter enum with independent flags

### DIFF
--- a/include/openmc/ifp.h
+++ b/include/openmc/ifp.h
@@ -78,9 +78,8 @@ void resize_simulation_ifp_banks();
 //! \param[in] i_temp Index in the temporary bank vectors
 //! \param[in,out] delayed_groups Delayed group numbers
 //! \param[in,out] lifetimes Lifetimes lists
-void copy_ifp_data_from_fission_banks(
-  int64_t i_bank, int64_t i_temp, vector<vector<int>>& delayed_groups,
-  vector<vector<double>>& lifetimes);
+void copy_ifp_data_from_fission_banks(int64_t i_bank, int64_t i_temp,
+  vector<vector<int>>& delayed_groups, vector<vector<double>>& lifetimes);
 
 #ifdef OPENMC_MPI
 

--- a/include/openmc/ifp.h
+++ b/include/openmc/ifp.h
@@ -18,7 +18,7 @@ namespace openmc {
 template<typename T, typename U>
 void resize_ifp_data(vector<T>& delayed_groups, vector<U>& lifetimes, int64_t n)
 {
-  if (settings::ifp_delayed_on) {
+  if (settings::ifp_delayed_group_on) {
     delayed_groups.resize(n);
   }
   if (settings::ifp_lifetime_on) {

--- a/include/openmc/ifp.h
+++ b/include/openmc/ifp.h
@@ -10,16 +10,6 @@
 
 namespace openmc {
 
-//! Check the value of the IFP parameter for beta effective or both.
-//!
-//! \return true if "BetaEffective" or "Both", false otherwise.
-bool is_beta_effective_or_both();
-
-//! Check the value of the IFP parameter for generation time or both.
-//!
-//! \return true if "GenerationTime" or "Both", false otherwise.
-bool is_generation_time_or_both();
-
 //! Resize IFP vectors
 //!
 //! \param[in,out] delayed_groups List of delayed group numbers
@@ -28,10 +18,10 @@ bool is_generation_time_or_both();
 template<typename T, typename U>
 void resize_ifp_data(vector<T>& delayed_groups, vector<U>& lifetimes, int64_t n)
 {
-  if (is_beta_effective_or_both()) {
+  if (settings::ifp_delayed_on) {
     delayed_groups.resize(n);
   }
-  if (is_generation_time_or_both()) {
+  if (settings::ifp_lifetime_on) {
     lifetimes.resize(n);
   }
 }

--- a/include/openmc/ifp.h
+++ b/include/openmc/ifp.h
@@ -75,10 +75,12 @@ void resize_simulation_ifp_banks();
 //! Retrieve IFP data from the IFP fission banks.
 //!
 //! \param[in] i_bank Index in the fission banks
+//! \param[in] i_temp Index in the temporary bank vectors
 //! \param[in,out] delayed_groups Delayed group numbers
 //! \param[in,out] lifetimes Lifetimes lists
 void copy_ifp_data_from_fission_banks(
-  int i_bank, vector<int>& delayed_groups, vector<double>& lifetimes);
+  int64_t i_bank, int64_t i_temp, vector<vector<int>>& delayed_groups,
+  vector<vector<double>>& lifetimes);
 
 #ifdef OPENMC_MPI
 

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -24,14 +24,6 @@ enum class SSWCellType {
   To,
 };
 
-// Type of IFP parameters
-enum class IFPParameter {
-  None,
-  Both,
-  BetaEffective,
-  GenerationTime,
-};
-
 struct CollisionTrackConfig {
   bool mcpl_write {false}; //!< Write collision tracks using MCPL?
   std::unordered_set<int>
@@ -69,8 +61,9 @@ extern bool
   delayed_photon_scaling;   //!< Scale fission photon yield to include delayed
 extern "C" bool entropy_on; //!< calculate Shannon entropy?
 extern "C" bool
-  event_based;      //!< use event-based mode (instead of history-based)
-extern bool ifp_on; //!< Use IFP for kinetics parameters?
+  event_based;              //!< use event-based mode (instead of history-based)
+extern bool ifp_delayed_on; //!< Store delayed group IFP data?
+extern bool ifp_lifetime_on;     //!< Store lifetime IFP data?
 extern bool legendre_to_tabular; //!< convert Legendre distributions to tabular?
 extern bool material_cell_offsets;   //!< create material cells offsets?
 extern "C" bool output_summary;      //!< write summary.h5?
@@ -146,8 +139,6 @@ extern array<double, 4>
   time_cutoff; //!< Time cutoff in [s] for each particle type
 extern int
   ifp_n_generation; //!< Number of generation for Iterated Fission Probability
-extern IFPParameter
-  ifp_parameter; //!< Parameter to calculate for Iterated Fission Probability
 extern int
   legendre_to_tabular_points; //!< number of points to convert Legendres
 extern int max_order;         //!< Maximum Legendre order for multigroup data
@@ -203,6 +194,15 @@ extern int trigger_batch_interval; //!< Batch interval for triggers
 extern "C" int verbosity;          //!< How verbose to make output
 extern double weight_cutoff;       //!< Weight cutoff for Russian roulette
 extern double weight_survive;      //!< Survival weight after Russian roulette
+
+//! Whether Iterated Fission Probability is in use at all.
+//!
+//! Derived from ifp_delayed_on and ifp_lifetime_on rather than stored
+//! separately, so it cannot fall out of step with them.
+inline bool ifp_on()
+{
+  return ifp_delayed_on || ifp_lifetime_on;
+}
 
 } // namespace settings
 

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -196,9 +196,6 @@ extern double weight_cutoff;       //!< Weight cutoff for Russian roulette
 extern double weight_survive;      //!< Survival weight after Russian roulette
 
 //! Whether Iterated Fission Probability is in use at all.
-//!
-//! Derived from ifp_delayed_on and ifp_lifetime_on rather than stored
-//! separately, so it cannot fall out of step with them.
 inline bool ifp_on()
 {
   return ifp_delayed_on || ifp_lifetime_on;

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -61,9 +61,9 @@ extern bool
   delayed_photon_scaling;   //!< Scale fission photon yield to include delayed
 extern "C" bool entropy_on; //!< calculate Shannon entropy?
 extern "C" bool
-  event_based;              //!< use event-based mode (instead of history-based)
-extern bool ifp_delayed_on; //!< Store delayed group IFP data?
-extern bool ifp_lifetime_on;     //!< Store lifetime IFP data?
+  event_based; //!< use event-based mode (instead of history-based)
+extern bool ifp_delayed_group_on; //!< Store delayed group IFP data?
+extern bool ifp_lifetime_on;      //!< Store lifetime IFP data?
 extern bool legendre_to_tabular; //!< convert Legendre distributions to tabular?
 extern bool material_cell_offsets;   //!< create material cells offsets?
 extern "C" bool output_summary;      //!< write summary.h5?
@@ -198,7 +198,7 @@ extern double weight_survive;      //!< Survival weight after Russian roulette
 //! Whether Iterated Fission Probability is in use at all.
 inline bool ifp_on()
 {
-  return ifp_delayed_on || ifp_lifetime_on;
+  return ifp_delayed_group_on || ifp_lifetime_on;
 }
 
 } // namespace settings

--- a/src/bank.cpp
+++ b/src/bank.cpp
@@ -113,7 +113,7 @@ void sort_bank(SharedArray<SourceSite>& bank, bool is_fission_bank)
     sorted_bank = bank.data() + bank.size();
   }
 
-  if (settings::ifp_on && is_fission_bank) {
+  if (settings::ifp_on() && is_fission_bank) {
     allocate_temporary_vector_ifp(
       sorted_ifp_delayed_group_bank, sorted_ifp_lifetime_bank);
   }
@@ -135,7 +135,7 @@ void sort_bank(SharedArray<SourceSite>& bank, bool is_fission_bank)
                   "bank size during sorting.");
     }
     sorted_bank[idx] = site;
-    if (settings::ifp_on && is_fission_bank) {
+    if (settings::ifp_on() && is_fission_bank) {
       copy_ifp_data_from_fission_banks(
         i, sorted_ifp_delayed_group_bank[idx], sorted_ifp_lifetime_bank[idx]);
     }
@@ -143,7 +143,7 @@ void sort_bank(SharedArray<SourceSite>& bank, bool is_fission_bank)
 
   // Copy sorted bank into the fission bank
   std::copy(sorted_bank, sorted_bank + bank.size(), bank.data());
-  if (settings::ifp_on && is_fission_bank) {
+  if (settings::ifp_on() && is_fission_bank) {
     copy_ifp_data_to_fission_banks(
       sorted_ifp_delayed_group_bank.data(), sorted_ifp_lifetime_bank.data());
   }

--- a/src/bank.cpp
+++ b/src/bank.cpp
@@ -137,7 +137,7 @@ void sort_bank(SharedArray<SourceSite>& bank, bool is_fission_bank)
     sorted_bank[idx] = site;
     if (settings::ifp_on() && is_fission_bank) {
       copy_ifp_data_from_fission_banks(
-        i, sorted_ifp_delayed_group_bank[idx], sorted_ifp_lifetime_bank[idx]);
+        i, idx, sorted_ifp_delayed_group_bank, sorted_ifp_lifetime_bank);
     }
   }
 

--- a/src/eigenvalue.cpp
+++ b/src/eigenvalue.cpp
@@ -166,7 +166,7 @@ void synchronize_bank()
     temp_sites[index_temp] = simulation::fission_bank[idx];
     if (settings::ifp_on()) {
       copy_ifp_data_from_fission_banks(
-        idx, temp_delayed_groups[index_temp], temp_lifetimes[index_temp]);
+        idx, index_temp, temp_delayed_groups, temp_lifetimes);
     }
     ++index_temp;
 

--- a/src/eigenvalue.cpp
+++ b/src/eigenvalue.cpp
@@ -135,7 +135,7 @@ void synchronize_bank()
   // Temporary banks for IFP
   vector<vector<int>> temp_delayed_groups;
   vector<vector<double>> temp_lifetimes;
-  if (settings::ifp_on) {
+  if (settings::ifp_on()) {
     resize_ifp_data(
       temp_delayed_groups, temp_lifetimes, 3 * simulation::work_per_rank);
   }
@@ -164,7 +164,7 @@ void synchronize_bank()
   for (int64_t i = tooth_start; i < tooth_end; i++) {
     int64_t idx = std::floor(tooth) - start;
     temp_sites[index_temp] = simulation::fission_bank[idx];
-    if (settings::ifp_on) {
+    if (settings::ifp_on()) {
       copy_ifp_data_from_fission_banks(
         idx, temp_delayed_groups[index_temp], temp_lifetimes[index_temp]);
     }
@@ -206,7 +206,7 @@ void synchronize_bank()
 
   // IFP number of generation
   int ifp_n_generation;
-  if (settings::ifp_on) {
+  if (settings::ifp_on()) {
     broadcast_ifp_n_generation(
       ifp_n_generation, temp_delayed_groups, temp_lifetimes);
   }
@@ -225,7 +225,7 @@ void synchronize_bank()
       simulation::work_index.begin(), simulation::work_index.end(), start);
 
     // Resize IFP send buffers
-    if (settings::ifp_on && mpi::n_procs > 1) {
+    if (settings::ifp_on() && mpi::n_procs > 1) {
       resize_ifp_data(send_delayed_groups, send_lifetimes,
         ifp_n_generation * 3 * simulation::work_per_rank);
     }
@@ -243,12 +243,12 @@ void synchronize_bank()
           mpi::source_site, neighbor, mpi::rank, mpi::intracomm,
           &requests.back());
 
-        if (settings::ifp_on) {
+        if (settings::ifp_on()) {
           // Send IFP data
-          if (is_beta_effective_or_both())
+          if (settings::ifp_delayed_on)
             send_ifp_info(index_local, n, ifp_n_generation, neighbor, requests,
               temp_delayed_groups, send_delayed_groups);
-          if (is_generation_time_or_both())
+          if (settings::ifp_lifetime_on)
             send_ifp_info(index_local, n, ifp_n_generation, neighbor, requests,
               temp_lifetimes, send_lifetimes);
         }
@@ -290,7 +290,7 @@ void synchronize_bank()
   }
 
   // Resize IFP receive buffers
-  if (settings::ifp_on && mpi::n_procs > 1) {
+  if (settings::ifp_on() && mpi::n_procs > 1) {
     resize_ifp_data(recv_delayed_groups, recv_lifetimes,
       ifp_n_generation * simulation::work_per_rank);
   }
@@ -314,12 +314,12 @@ void synchronize_bank()
       MPI_Irecv(&simulation::source_bank[index_local], static_cast<int>(n),
         mpi::source_site, neighbor, neighbor, mpi::intracomm, &requests.back());
 
-      if (settings::ifp_on) {
+      if (settings::ifp_on()) {
         // Receive IFP data
-        if (is_beta_effective_or_both())
+        if (settings::ifp_delayed_on)
           receive_ifp_data(index_local, n, ifp_n_generation, neighbor, requests,
             recv_delayed_groups, deserialization_info);
-        if (is_generation_time_or_both())
+        if (settings::ifp_lifetime_on)
           receive_ifp_data(index_local, n, ifp_n_generation, neighbor, requests,
             recv_lifetimes, deserialization_info);
       }
@@ -332,7 +332,7 @@ void synchronize_bank()
       std::copy(&temp_sites[index_temp], &temp_sites[index_temp + n],
         &simulation::source_bank[index_local]);
 
-      if (settings::ifp_on) {
+      if (settings::ifp_on()) {
         copy_partial_ifp_data_to_source_banks(
           index_temp, n, index_local, temp_delayed_groups, temp_lifetimes);
       }
@@ -351,11 +351,11 @@ void synchronize_bank()
   int n_request = requests.size();
   MPI_Waitall(n_request, requests.data(), MPI_STATUSES_IGNORE);
 
-  if (settings::ifp_on) {
-    if (is_beta_effective_or_both())
+  if (settings::ifp_on()) {
+    if (settings::ifp_delayed_on)
       deserialize_ifp_info(ifp_n_generation, recv_delayed_groups,
         simulation::ifp_source_delayed_group_bank, deserialization_info);
-    if (is_generation_time_or_both())
+    if (settings::ifp_lifetime_on)
       deserialize_ifp_info(ifp_n_generation, recv_lifetimes,
         simulation::ifp_source_lifetime_bank, deserialization_info);
   }
@@ -363,7 +363,7 @@ void synchronize_bank()
 #else
   std::copy(temp_sites.data(), temp_sites.data() + settings::n_particles,
     simulation::source_bank.begin());
-  if (settings::ifp_on) {
+  if (settings::ifp_on()) {
     copy_complete_ifp_data_to_source_banks(temp_delayed_groups, temp_lifetimes);
   }
 #endif

--- a/src/eigenvalue.cpp
+++ b/src/eigenvalue.cpp
@@ -245,7 +245,7 @@ void synchronize_bank()
 
         if (settings::ifp_on()) {
           // Send IFP data
-          if (settings::ifp_delayed_on)
+          if (settings::ifp_delayed_group_on)
             send_ifp_info(index_local, n, ifp_n_generation, neighbor, requests,
               temp_delayed_groups, send_delayed_groups);
           if (settings::ifp_lifetime_on)
@@ -316,7 +316,7 @@ void synchronize_bank()
 
       if (settings::ifp_on()) {
         // Receive IFP data
-        if (settings::ifp_delayed_on)
+        if (settings::ifp_delayed_group_on)
           receive_ifp_data(index_local, n, ifp_n_generation, neighbor, requests,
             recv_delayed_groups, deserialization_info);
         if (settings::ifp_lifetime_on)
@@ -352,7 +352,7 @@ void synchronize_bank()
   MPI_Waitall(n_request, requests.data(), MPI_STATUSES_IGNORE);
 
   if (settings::ifp_on()) {
-    if (settings::ifp_delayed_on)
+    if (settings::ifp_delayed_group_on)
       deserialize_ifp_info(ifp_n_generation, recv_delayed_groups,
         simulation::ifp_source_delayed_group_bank, deserialization_info);
     if (settings::ifp_lifetime_on)

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -106,6 +106,7 @@ int openmc_finalize()
   settings::n_log_bins = 8000;
   settings::n_inactive = 0;
   settings::n_particles = -1;
+  settings::ifp_n_generation = -1;
   settings::output_summary = true;
   settings::output_tallies = true;
   settings::particle_restart_run = false;

--- a/src/ifp.cpp
+++ b/src/ifp.cpp
@@ -12,7 +12,7 @@ namespace openmc {
 
 void ifp(const Particle& p, int64_t idx)
 {
-  if (settings::ifp_delayed_on) {
+  if (settings::ifp_delayed_group_on) {
     const auto& delayed_groups =
       simulation::ifp_source_delayed_group_bank[p.current_work()];
     simulation::ifp_fission_delayed_group_bank[idx] =
@@ -36,7 +36,7 @@ void resize_simulation_ifp_banks()
 void copy_ifp_data_from_fission_banks(int64_t i_bank, int64_t i_temp,
   vector<vector<int>>& delayed_groups, vector<vector<double>>& lifetimes)
 {
-  if (settings::ifp_delayed_on) {
+  if (settings::ifp_delayed_group_on) {
     delayed_groups[i_temp] = simulation::ifp_fission_delayed_group_bank[i_bank];
   }
   if (settings::ifp_lifetime_on) {
@@ -50,7 +50,7 @@ void broadcast_ifp_n_generation(int& n_generation,
   const vector<vector<double>>& lifetimes)
 {
   if (mpi::rank == 0) {
-    if (settings::ifp_delayed_on) {
+    if (settings::ifp_delayed_group_on) {
       n_generation = static_cast<int>(delayed_groups[0].size());
     } else {
       n_generation = static_cast<int>(lifetimes[0].size());
@@ -63,7 +63,7 @@ void copy_partial_ifp_data_to_source_banks(int64_t idx, int n, int64_t i_bank,
   const vector<vector<int>>& delayed_groups,
   const vector<vector<double>>& lifetimes)
 {
-  if (settings::ifp_delayed_on) {
+  if (settings::ifp_delayed_group_on) {
     std::copy(&delayed_groups[idx], &delayed_groups[idx + n],
       &simulation::ifp_source_delayed_group_bank[i_bank]);
   }
@@ -78,7 +78,7 @@ void copy_complete_ifp_data_to_source_banks(
   const vector<vector<int>>& delayed_groups,
   const vector<vector<double>>& lifetimes)
 {
-  if (settings::ifp_delayed_on) {
+  if (settings::ifp_delayed_group_on) {
     std::copy(delayed_groups.data(),
       delayed_groups.data() + settings::n_particles,
       simulation::ifp_source_delayed_group_bank.begin());
@@ -92,7 +92,7 @@ void copy_complete_ifp_data_to_source_banks(
 void allocate_temporary_vector_ifp(
   vector<vector<int>>& delayed_groups, vector<vector<double>>& lifetimes)
 {
-  if (settings::ifp_delayed_on) {
+  if (settings::ifp_delayed_group_on) {
     delayed_groups.resize(simulation::fission_bank.size());
   }
   if (settings::ifp_lifetime_on) {
@@ -103,7 +103,7 @@ void allocate_temporary_vector_ifp(
 void copy_ifp_data_to_fission_banks(const vector<int>* const delayed_groups_ptr,
   const vector<double>* lifetimes_ptr)
 {
-  if (settings::ifp_delayed_on) {
+  if (settings::ifp_delayed_group_on) {
     std::copy(delayed_groups_ptr,
       delayed_groups_ptr + simulation::fission_bank.size(),
       simulation::ifp_fission_delayed_group_bank.data());

--- a/src/ifp.cpp
+++ b/src/ifp.cpp
@@ -10,33 +10,15 @@
 
 namespace openmc {
 
-bool is_beta_effective_or_both()
-{
-  if (settings::ifp_parameter == IFPParameter::BetaEffective ||
-      settings::ifp_parameter == IFPParameter::Both) {
-    return true;
-  }
-  return false;
-}
-
-bool is_generation_time_or_both()
-{
-  if (settings::ifp_parameter == IFPParameter::GenerationTime ||
-      settings::ifp_parameter == IFPParameter::Both) {
-    return true;
-  }
-  return false;
-}
-
 void ifp(const Particle& p, int64_t idx)
 {
-  if (is_beta_effective_or_both()) {
+  if (settings::ifp_delayed_on) {
     const auto& delayed_groups =
       simulation::ifp_source_delayed_group_bank[p.current_work()];
     simulation::ifp_fission_delayed_group_bank[idx] =
       _ifp(p.delayed_group(), delayed_groups);
   }
-  if (is_generation_time_or_both()) {
+  if (settings::ifp_lifetime_on) {
     const auto& lifetimes =
       simulation::ifp_source_lifetime_bank[p.current_work()];
     simulation::ifp_fission_lifetime_bank[idx] = _ifp(p.lifetime(), lifetimes);
@@ -54,10 +36,10 @@ void resize_simulation_ifp_banks()
 void copy_ifp_data_from_fission_banks(
   int i_bank, vector<int>& delayed_groups, vector<double>& lifetimes)
 {
-  if (is_beta_effective_or_both()) {
+  if (settings::ifp_delayed_on) {
     delayed_groups = simulation::ifp_fission_delayed_group_bank[i_bank];
   }
-  if (is_generation_time_or_both()) {
+  if (settings::ifp_lifetime_on) {
     lifetimes = simulation::ifp_fission_lifetime_bank[i_bank];
   }
 }
@@ -68,7 +50,7 @@ void broadcast_ifp_n_generation(int& n_generation,
   const vector<vector<double>>& lifetimes)
 {
   if (mpi::rank == 0) {
-    if (is_beta_effective_or_both()) {
+    if (settings::ifp_delayed_on) {
       n_generation = static_cast<int>(delayed_groups[0].size());
     } else {
       n_generation = static_cast<int>(lifetimes[0].size());
@@ -81,11 +63,11 @@ void copy_partial_ifp_data_to_source_banks(int64_t idx, int n, int64_t i_bank,
   const vector<vector<int>>& delayed_groups,
   const vector<vector<double>>& lifetimes)
 {
-  if (is_beta_effective_or_both()) {
+  if (settings::ifp_delayed_on) {
     std::copy(&delayed_groups[idx], &delayed_groups[idx + n],
       &simulation::ifp_source_delayed_group_bank[i_bank]);
   }
-  if (is_generation_time_or_both()) {
+  if (settings::ifp_lifetime_on) {
     std::copy(&lifetimes[idx], &lifetimes[idx + n],
       &simulation::ifp_source_lifetime_bank[i_bank]);
   }
@@ -96,12 +78,12 @@ void copy_complete_ifp_data_to_source_banks(
   const vector<vector<int>>& delayed_groups,
   const vector<vector<double>>& lifetimes)
 {
-  if (is_beta_effective_or_both()) {
+  if (settings::ifp_delayed_on) {
     std::copy(delayed_groups.data(),
       delayed_groups.data() + settings::n_particles,
       simulation::ifp_source_delayed_group_bank.begin());
   }
-  if (is_generation_time_or_both()) {
+  if (settings::ifp_lifetime_on) {
     std::copy(lifetimes.data(), lifetimes.data() + settings::n_particles,
       simulation::ifp_source_lifetime_bank.begin());
   }
@@ -110,10 +92,10 @@ void copy_complete_ifp_data_to_source_banks(
 void allocate_temporary_vector_ifp(
   vector<vector<int>>& delayed_groups, vector<vector<double>>& lifetimes)
 {
-  if (is_beta_effective_or_both()) {
+  if (settings::ifp_delayed_on) {
     delayed_groups.resize(simulation::fission_bank.size());
   }
-  if (is_generation_time_or_both()) {
+  if (settings::ifp_lifetime_on) {
     lifetimes.resize(simulation::fission_bank.size());
   }
 }
@@ -121,12 +103,12 @@ void allocate_temporary_vector_ifp(
 void copy_ifp_data_to_fission_banks(const vector<int>* const delayed_groups_ptr,
   const vector<double>* lifetimes_ptr)
 {
-  if (is_beta_effective_or_both()) {
+  if (settings::ifp_delayed_on) {
     std::copy(delayed_groups_ptr,
       delayed_groups_ptr + simulation::fission_bank.size(),
       simulation::ifp_fission_delayed_group_bank.data());
   }
-  if (is_generation_time_or_both()) {
+  if (settings::ifp_lifetime_on) {
     std::copy(lifetimes_ptr, lifetimes_ptr + simulation::fission_bank.size(),
       simulation::ifp_fission_lifetime_bank.data());
   }

--- a/src/ifp.cpp
+++ b/src/ifp.cpp
@@ -37,8 +37,7 @@ void copy_ifp_data_from_fission_banks(int64_t i_bank, int64_t i_temp,
   vector<vector<int>>& delayed_groups, vector<vector<double>>& lifetimes)
 {
   if (settings::ifp_delayed_on) {
-    delayed_groups[i_temp] =
-      simulation::ifp_fission_delayed_group_bank[i_bank];
+    delayed_groups[i_temp] = simulation::ifp_fission_delayed_group_bank[i_bank];
   }
   if (settings::ifp_lifetime_on) {
     lifetimes[i_temp] = simulation::ifp_fission_lifetime_bank[i_bank];

--- a/src/ifp.cpp
+++ b/src/ifp.cpp
@@ -34,13 +34,15 @@ void resize_simulation_ifp_banks()
 }
 
 void copy_ifp_data_from_fission_banks(
-  int i_bank, vector<int>& delayed_groups, vector<double>& lifetimes)
+  int64_t i_bank, int64_t i_temp, vector<vector<int>>& delayed_groups,
+  vector<vector<double>>& lifetimes)
 {
   if (settings::ifp_delayed_on) {
-    delayed_groups = simulation::ifp_fission_delayed_group_bank[i_bank];
+    delayed_groups[i_temp] =
+      simulation::ifp_fission_delayed_group_bank[i_bank];
   }
   if (settings::ifp_lifetime_on) {
-    lifetimes = simulation::ifp_fission_lifetime_bank[i_bank];
+    lifetimes[i_temp] = simulation::ifp_fission_lifetime_bank[i_bank];
   }
 }
 

--- a/src/ifp.cpp
+++ b/src/ifp.cpp
@@ -33,9 +33,8 @@ void resize_simulation_ifp_banks()
     simulation::ifp_fission_lifetime_bank, 3 * simulation::work_per_rank);
 }
 
-void copy_ifp_data_from_fission_banks(
-  int64_t i_bank, int64_t i_temp, vector<vector<int>>& delayed_groups,
-  vector<vector<double>>& lifetimes)
+void copy_ifp_data_from_fission_banks(int64_t i_bank, int64_t i_temp,
+  vector<vector<int>>& delayed_groups, vector<vector<double>>& lifetimes)
 {
   if (settings::ifp_delayed_on) {
     delayed_groups[i_temp] =

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -250,7 +250,7 @@ void create_fission_sites(Particle& p, int i_nuclide, const Reaction& rx)
         break;
       }
       // Iterated Fission Probability (IFP) method
-      if (settings::ifp_on) {
+      if (settings::ifp_on()) {
         ifp(p, idx);
       }
     } else {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -55,7 +55,7 @@ bool create_fission_neutrons {true};
 bool delayed_photon_scaling {true};
 bool entropy_on {false};
 bool event_based {false};
-bool ifp_delayed_on {false};
+bool ifp_delayed_group_on {false};
 bool ifp_lifetime_on {false};
 bool legendre_to_tabular {true};
 bool material_cell_offsets {true};
@@ -1351,7 +1351,7 @@ void free_memory_settings()
   settings::sourcepoint_batch.clear();
   settings::source_write_surf_id.clear();
   settings::res_scat_nuclides.clear();
-  settings::ifp_delayed_on = false;
+  settings::ifp_delayed_group_on = false;
   settings::ifp_lifetime_on = false;
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -55,7 +55,8 @@ bool create_fission_neutrons {true};
 bool delayed_photon_scaling {true};
 bool entropy_on {false};
 bool event_based {false};
-bool ifp_on {false};
+bool ifp_delayed_on {false};
+bool ifp_lifetime_on {false};
 bool legendre_to_tabular {true};
 bool material_cell_offsets {true};
 bool output_summary {true};
@@ -114,7 +115,6 @@ ElectronTreatment electron_treatment {ElectronTreatment::TTB};
 array<double, 4> energy_cutoff {0.0, 1000.0, 0.0, 0.0};
 array<double, 4> time_cutoff {INFTY, INFTY, INFTY, INFTY};
 int ifp_n_generation {-1};
-IFPParameter ifp_parameter {IFPParameter::None};
 int legendre_to_tabular_points {C_NONE};
 int max_order {0};
 int n_log_bins {8000};
@@ -1351,6 +1351,8 @@ void free_memory_settings()
   settings::sourcepoint_batch.clear();
   settings::source_write_surf_id.clear();
   settings::res_scat_nuclides.clear();
+  settings::ifp_delayed_on = false;
+  settings::ifp_lifetime_on = false;
 }
 
 //==============================================================================

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -459,7 +459,7 @@ void allocate_banks()
     init_fission_bank(3 * simulation::work_per_rank);
 
     // Allocate IFP bank
-    if (settings::ifp_on) {
+    if (settings::ifp_on()) {
       resize_simulation_ifp_banks();
     }
   }

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -196,7 +196,7 @@ Tally::Tally(pugi::xml_node node)
   // Determine which kinds of IFP data this tally requires. The two flags are
   // independent, so a score simply turns on the data it needs.
   bool wants_lifetime = false;
-  bool wants_delayed = false;
+  bool wants_delayed_group = false;
   for (int score : scores_) {
     switch (score) {
     case SCORE_IFP_TIME_NUM:
@@ -204,12 +204,12 @@ Tally::Tally(pugi::xml_node node)
       break;
     case SCORE_IFP_BETA_NUM:
     case SCORE_IFP_DENOM:
-      wants_delayed = true;
+      wants_delayed_group = true;
       break;
     }
   }
 
-  if (wants_lifetime || wants_delayed) {
+  if (wants_lifetime || wants_delayed_group) {
     // Validate once, when the first IFP tally is encountered
     if (!settings::ifp_on()) {
       if (settings::run_mode == RunMode::FIXED_SOURCE) {
@@ -235,7 +235,7 @@ Tally::Tally(pugi::xml_node node)
     // Only enable in eigenvalue mode; fixed source has already errored above
     if (settings::run_mode == RunMode::EIGENVALUE) {
       settings::ifp_lifetime_on |= wants_lifetime;
-      settings::ifp_delayed_group_on |= wants_delayed;
+      settings::ifp_delayed_group_on |= wants_delayed_group;
     }
   }
 

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -193,20 +193,30 @@ Tally::Tally(pugi::xml_node node)
     fatal_error(fmt::format("No scores specified on tally {}.", id_));
   }
 
-  // Set IFP if needed
-  if (!settings::ifp_on) {
-    // Determine if this tally has an IFP score
-    bool has_ifp_score = false;
-    for (int score : scores_) {
-      if (score == SCORE_IFP_TIME_NUM || score == SCORE_IFP_BETA_NUM ||
-          score == SCORE_IFP_DENOM) {
-        has_ifp_score = true;
-        break;
-      }
+  // Determine which kinds of IFP data this tally requires. The two flags are
+  // independent, so a score simply turns on the data it needs.
+  bool wants_lifetime = false;
+  bool wants_delayed = false;
+  for (int score : scores_) {
+    switch (score) {
+    case SCORE_IFP_TIME_NUM:
+      wants_lifetime = true;
+      break;
+    case SCORE_IFP_BETA_NUM:
+    case SCORE_IFP_DENOM:
+      wants_delayed = true;
+      break;
     }
+  }
 
-    // Check for errors
-    if (has_ifp_score) {
+  if (wants_lifetime || wants_delayed) {
+    // Validate once, when the first IFP tally is encountered
+    if (!settings::ifp_on()) {
+      if (settings::run_mode == RunMode::FIXED_SOURCE) {
+        fatal_error(
+          "Iterated Fission Probability can only be used in an eigenvalue "
+          "calculation.");
+      }
       if (settings::run_mode == RunMode::EIGENVALUE) {
         if (settings::ifp_n_generation < 0) {
           settings::ifp_n_generation = DEFAULT_IFP_N_GENERATION;
@@ -219,35 +229,13 @@ Tally::Tally(pugi::xml_node node)
           fatal_error("'ifp_n_generation' must be lower than or equal to the "
                       "number of inactive cycles.");
         }
-        settings::ifp_on = true;
-      } else if (settings::run_mode == RunMode::FIXED_SOURCE) {
-        fatal_error(
-          "Iterated Fission Probability can only be used in an eigenvalue "
-          "calculation.");
       }
     }
-  }
 
-  // Set IFP parameters if needed
-  if (settings::ifp_on) {
-    for (int score : scores_) {
-      switch (score) {
-      case SCORE_IFP_TIME_NUM:
-        if (settings::ifp_parameter == IFPParameter::None) {
-          settings::ifp_parameter = IFPParameter::GenerationTime;
-        } else if (settings::ifp_parameter == IFPParameter::BetaEffective) {
-          settings::ifp_parameter = IFPParameter::Both;
-        }
-        break;
-      case SCORE_IFP_BETA_NUM:
-      case SCORE_IFP_DENOM:
-        if (settings::ifp_parameter == IFPParameter::None) {
-          settings::ifp_parameter = IFPParameter::BetaEffective;
-        } else if (settings::ifp_parameter == IFPParameter::GenerationTime) {
-          settings::ifp_parameter = IFPParameter::Both;
-        }
-        break;
-      }
+    // Only enable in eigenvalue mode; fixed source has already errored above
+    if (settings::run_mode == RunMode::EIGENVALUE) {
+      settings::ifp_lifetime_on |= wants_lifetime;
+      settings::ifp_delayed_on |= wants_delayed;
     }
   }
 

--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -235,7 +235,7 @@ Tally::Tally(pugi::xml_node node)
     // Only enable in eigenvalue mode; fixed source has already errored above
     if (settings::run_mode == RunMode::EIGENVALUE) {
       settings::ifp_lifetime_on |= wants_lifetime;
-      settings::ifp_delayed_on |= wants_delayed;
+      settings::ifp_delayed_group_on |= wants_delayed;
     }
   }
 

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -957,7 +957,7 @@ void score_general_ce_nonanalog(Particle& p, int i_tally, int start_index,
     case SCORE_IFP_BETA_NUM:
       if (settings::ifp_on()) {
         if (p.type().is_neutron() && p.fission()) {
-          if (settings::ifp_delayed_on) {
+          if (settings::ifp_delayed_group_on) {
             const auto& delayed_groups =
               simulation::ifp_source_delayed_group_bank[p.current_work()];
             if (delayed_groups.size() == settings::ifp_n_generation) {
@@ -988,7 +988,7 @@ void score_general_ce_nonanalog(Particle& p, int i_tally, int start_index,
       if (settings::ifp_on()) {
         if (p.type().is_neutron() && p.fission()) {
           int ifp_data_size;
-          if (settings::ifp_delayed_on) {
+          if (settings::ifp_delayed_group_on) {
             ifp_data_size = static_cast<int>(
               simulation::ifp_source_delayed_group_bank[p.current_work()]
                 .size());

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -941,9 +941,9 @@ void score_general_ce_nonanalog(Particle& p, int i_tally, int start_index,
       break;
 
     case SCORE_IFP_TIME_NUM:
-      if (settings::ifp_on) {
+      if (settings::ifp_on()) {
         if (p.type().is_neutron() && p.fission()) {
-          if (is_generation_time_or_both()) {
+          if (settings::ifp_lifetime_on) {
             const auto& lifetimes =
               simulation::ifp_source_lifetime_bank[p.current_work()];
             if (lifetimes.size() == settings::ifp_n_generation) {
@@ -955,9 +955,9 @@ void score_general_ce_nonanalog(Particle& p, int i_tally, int start_index,
       break;
 
     case SCORE_IFP_BETA_NUM:
-      if (settings::ifp_on) {
+      if (settings::ifp_on()) {
         if (p.type().is_neutron() && p.fission()) {
-          if (is_beta_effective_or_both()) {
+          if (settings::ifp_delayed_on) {
             const auto& delayed_groups =
               simulation::ifp_source_delayed_group_bank[p.current_work()];
             if (delayed_groups.size() == settings::ifp_n_generation) {
@@ -985,10 +985,10 @@ void score_general_ce_nonanalog(Particle& p, int i_tally, int start_index,
       break;
 
     case SCORE_IFP_DENOM:
-      if (settings::ifp_on) {
+      if (settings::ifp_on()) {
         if (p.type().is_neutron() && p.fission()) {
           int ifp_data_size;
-          if (is_beta_effective_or_both()) {
+          if (settings::ifp_delayed_on) {
             ifp_data_size = static_cast<int>(
               simulation::ifp_source_delayed_group_bank[p.current_work()]
                 .size());


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Replace the IFP parameter enum with independent flags

No behaviour change and no regolds, with one small bug fix noted below. This is
the cleanup half of #3728, split out so the delayed-activation work can be
reviewed separately.

## Problem

IFP state is currently held in three places that have to agree with each other:

```cpp
extern bool ifp_on;               //!< Use IFP for kinetics parameters?
extern IFPParameter ifp_parameter;

enum class IFPParameter { None, Both, BetaEffective, GenerationTime };
```

`IFPParameter` is a two-bit set written out as four named states. Because it is
an enum rather than two bits, turning one on requires a state transition:

```cpp
case SCORE_IFP_TIME_NUM:
  if (settings::ifp_parameter == IFPParameter::None) {
    settings::ifp_parameter = IFPParameter::GenerationTime;
  } else if (settings::ifp_parameter == IFPParameter::BetaEffective) {
    settings::ifp_parameter = IFPParameter::Both;
  }
  break;
```

and reading one back requires a decoder, which is what
`is_beta_effective_or_both()` and `is_generation_time_or_both()` in `ifp.cpp`
exist to do. Between them they account for 24 call sites.

`ifp_on` is then a fourth piece of state that duplicates "is either bit set".

## Changes

The enum and the two decoders are gone. The two bits are stored as two bits:

```cpp
extern bool ifp_delayed_on;  //!< Store delayed group IFP data?
extern bool ifp_lifetime_on; //!< Store lifetime IFP data?
```

and `ifp_on` becomes derived rather than stored, so it cannot fall out of step
with them:

```cpp
inline bool ifp_on()
{
  return ifp_delayed_on || ifp_lifetime_on;
}
```

Setting the flags in `Tally::set_scores()` is now a `|=` per score rather than a
state machine, and every `is_*_or_both()` call site reads the corresponding flag
directly.

All existing `if (settings::ifp_on)` guards are preserved as
`if (settings::ifp_on())`. Nothing is executed that was not executed before, so
there is no performance question to answer here.

## Bug fix

`free_memory_settings()` did not reset `ifp_on` or `ifp_parameter`. Both are
derived from the tallies present in the model rather than read from XML, so a
second model loaded in the same process inherited IFP state from the first.

That is not only wasteful. The validation in `Tally::set_scores()` is guarded by
`if (!settings::ifp_on)`, so with the flag already set the whole block was
skipped for the second model. A fixed source run with IFP scores would not have
raised "Iterated Fission Probability can only be used in an eigenvalue
calculation", and an out-of-range `ifp_n_generation` would not have been caught.
This affects anything running more than one model per process: depletion,
`openmc.lib` scripting, and the test suite.

Both flags are now cleared in `free_memory_settings()`.

## Testing

No results change, so the existing IFP regression and unit tests cover this
unchanged. The validation reordering preserves the previous "check once, on the
first IFP tally" behaviour: validation runs while `ifp_on()` is still false, and
the flags are set afterwards.

## Notes

Follow-ups, kept out of this PR deliberately:

- The two data streams are structurally identical -- every function in `ifp.cpp`
  applies the same operation to a `vector<int>` stream and a `vector<double>`
  stream, and `eigenvalue.cpp` calls the MPI helpers once per stream. Folding
  the flag and both banks into one small type would remove most of that
  duplication. Still no behaviour change, so it can land on its own.
- Delayed activation of IFP tallies, which is the part of #3728 that changes
  results and requires regolds.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
