### PR TITLE
Let a mesh surface crossing change more than one index

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -295,6 +295,13 @@ public:
   int n_dimension_ {-1};               //!< Number of dimensions
 };
 
+//! Maximum number of axes a structured mesh may have.
+//
+//! Mesh indices, shapes and the per-axis distance-to-surface arrays are all
+//! sized by this, so it is the single place to change if a mesh type ever
+//! needs more.
+constexpr int MESH_MAX_AXES {3};
+
 class StructuredMesh : public Mesh {
 public:
   StructuredMesh() = default;
@@ -302,14 +309,15 @@ public:
   StructuredMesh(hid_t group) : Mesh {group} {};
   virtual ~StructuredMesh() = default;
 
-  using MeshIndex = std::array<int, 3>;
+  using MeshIndex = std::array<int, MESH_MAX_AXES>;
 
   struct MeshDistance {
     MeshDistance() = default;
-    MeshDistance(int _index, bool _max_surface, double _distance)
-      : next_index {_index}, max_surface {_max_surface}, distance {_distance}
+    MeshDistance(MeshIndex _offset, bool _max_surface, double _distance)
+      : offset {_offset}, max_surface {_max_surface}, distance {_distance}
     {}
-    int next_index {-1};
+    //! Change in each index when this surface is crossed
+    MeshIndex offset {0, 0, 0};
     bool max_surface {true};
     double distance {INFTY};
     bool operator<(const MeshDistance& o) const
@@ -317,6 +325,12 @@ public:
       return distance < o.distance;
     }
   };
+
+  //! Fold an index back into range on any periodic axis.
+  //
+  //! Called after an index is advanced by a MeshDistance offset. Meshes with a
+  //! periodic axis override this; for the rest it is a no-op.
+  virtual void sanitize_index(MeshIndex& idx) const {}
 
   Position sample_element(int32_t bin, uint64_t* seed) const override
   {
@@ -423,6 +437,17 @@ public:
   virtual MeshDistance distance_to_grid_boundary(const MeshIndex& ijk, int i,
     const Position& r0, const Direction& u, double l) const = 0;
 
+  //! Distance to travel to re-enter the mesh from outside it
+  //
+  //! \param[in] ijk Current (out of range) indices
+  //! \param[in] distances Distance to the next surface on each axis
+  //! \param[in] traveled_distance Distance travelled so far
+  //! \param[out] k_max Axis whose surface is crossed last, or -1
+  //! \return Updated travelled distance
+  double distance_to_mesh(const MeshIndex& ijk,
+    const std::array<MeshDistance, MESH_MAX_AXES>& distances,
+    double traveled_distance, int& k_max) const;
+
   //! Get a label for the mesh bin
   std::string bin_label(int bin) const override;
 
@@ -458,7 +483,8 @@ public:
   virtual double volume(const MeshIndex& ijk) const = 0;
 
   // Data members
-  std::array<int, 3> shape_; //!< Number of mesh elements in each dimension
+  std::array<int, MESH_MAX_AXES>
+    shape_; //!< Number of mesh elements in each dimension
 
 protected:
 };
@@ -587,6 +613,11 @@ public:
   CylindricalMesh(hid_t group);
 
   // Overridden methods
+  void sanitize_index(MeshIndex& idx) const override
+  {
+    idx[1] = sanitize_phi(idx[1]);
+  }
+
   virtual MeshIndex get_indices(Position r, bool& in_mesh) const override;
 
   int get_index_in_direction(double r, int i) const override;
@@ -654,6 +685,12 @@ public:
   SphericalMesh(hid_t group);
 
   // Overridden methods
+  void sanitize_index(MeshIndex& idx) const override
+  {
+    idx[1] = sanitize_theta(idx[1]);
+    idx[2] = sanitize_phi(idx[2]);
+  }
+
   virtual MeshIndex get_indices(Position r, bool& in_mesh) const override;
 
   int get_index_in_direction(double r, int i) const override;

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1208,7 +1208,7 @@ void StructuredMesh::raytrace_mesh(
   }
 
   // Calculate initial distances to next surfaces in all three dimensions
-  std::array<MeshDistance, 3> distances;
+  std::array<MeshDistance, MESH_MAX_AXES> distances;
   for (int k = 0; k < n; ++k) {
     distances[k] = distance_to_grid_boundary(ijk, k, local_r, u, 0.0);
   }
@@ -1238,7 +1238,9 @@ void StructuredMesh::raytrace_mesh(
 
       // Update cell and calculate distance to next surface in k-direction.
       // The two other directions are still valid!
-      ijk[k] = distances[k].next_index;
+      for (int j = 0; j < MESH_MAX_AXES; ++j)
+        ijk[j] += distances[k].offset[j];
+      sanitize_index(ijk);
       distances[k] =
         distance_to_grid_boundary(ijk, k, local_r, u, traveled_distance);
 
@@ -1251,22 +1253,9 @@ void StructuredMesh::raytrace_mesh(
         tally.surface(ijk, k, !distances[k].max_surface, true);
 
     } else { // not inside mesh
-
-      // For all directions outside the mesh, find the distance that we need
-      // to travel to reach the next surface. Use the largest distance, as
-      // only this will cross all outer surfaces.
-      int k_max {-1};
-      for (int k = 0; k < n; ++k) {
-        if ((ijk[k] < 1 || ijk[k] > shape_[k]) &&
-            (distances[k].distance > traveled_distance)) {
-          traveled_distance = distances[k].distance;
-          k_max = k;
-        }
-      }
-      // Assure some distance is traveled
-      if (k_max == -1) {
-        traveled_distance += TINY_BIT;
-      }
+      int k_max;
+      traveled_distance =
+        distance_to_mesh(ijk, distances, traveled_distance, k_max);
 
       // If r1 is not inside the mesh, exit here
       if (traveled_distance >= total_distance)
@@ -1285,6 +1274,29 @@ void StructuredMesh::raytrace_mesh(
         tally.surface(ijk, k_max, !distances[k_max].max_surface, true);
     }
   }
+}
+
+double StructuredMesh::distance_to_mesh(const MeshIndex& ijk,
+  const std::array<MeshDistance, MESH_MAX_AXES>& distances,
+  double traveled_distance, int& k_max) const
+{
+  // For all directions outside the mesh, find the distance that we need
+  // to travel to reach the next surface. Use the largest distance, as
+  // only this will cross all outer surfaces.
+  const int n = n_dimension_;
+  k_max = -1;
+  for (int k = 0; k < n; ++k) {
+    if ((ijk[k] < 1 || ijk[k] > shape_[k]) &&
+        (distances[k].distance > traveled_distance)) {
+      traveled_distance = distances[k].distance;
+      k_max = k;
+    }
+  }
+  // Assure some distance is traveled
+  if (k_max == -1) {
+    traveled_distance += TINY_BIT;
+  }
+  return traveled_distance;
 }
 
 void StructuredMesh::bins_crossed(Position r0, Position r1, const Direction& u,
@@ -1527,16 +1539,15 @@ StructuredMesh::MeshDistance RegularMesh::distance_to_grid_boundary(
   double l) const
 {
   MeshDistance d;
-  d.next_index = ijk[i];
   if (std::abs(u[i]) < FP_PRECISION)
     return d;
 
   d.max_surface = (u[i] > 0);
   if (d.max_surface && (ijk[i] <= shape_[i])) {
-    d.next_index++;
+    ++d.offset[i];
     d.distance = (positive_grid_boundary(ijk, i) - r0[i]) / u[i];
   } else if (!d.max_surface && (ijk[i] >= 1)) {
-    d.next_index--;
+    --d.offset[i];
     d.distance = (negative_grid_boundary(ijk, i) - r0[i]) / u[i];
   }
 
@@ -1699,16 +1710,15 @@ StructuredMesh::MeshDistance RectilinearMesh::distance_to_grid_boundary(
   double l) const
 {
   MeshDistance d;
-  d.next_index = ijk[i];
   if (std::abs(u[i]) < FP_PRECISION)
     return d;
 
   d.max_surface = (u[i] > 0);
   if (d.max_surface && (ijk[i] <= shape_[i])) {
-    d.next_index++;
+    ++d.offset[i];
     d.distance = (positive_grid_boundary(ijk, i) - r0[i]) / u[i];
   } else if (!d.max_surface && (ijk[i] > 0)) {
-    d.next_index--;
+    --d.offset[i];
     d.distance = (negative_grid_boundary(ijk, i) - r0[i]) / u[i];
   }
   return d;
@@ -1966,18 +1976,16 @@ StructuredMesh::MeshDistance CylindricalMesh::find_z_crossing(
   const Position& r, const Direction& u, double l, int shell) const
 {
   MeshDistance d;
-  d.next_index = shell;
-
   // Direction of flight is within xy-plane. Will never intersect z.
   if (std::abs(u.z) < FP_PRECISION)
     return d;
 
   d.max_surface = (u.z > 0.0);
   if (d.max_surface && (shell <= shape_[2])) {
-    d.next_index += 1;
+    ++d.offset[2];
     d.distance = (grid_[2][shell] - r.z) / u.z;
   } else if (!d.max_surface && (shell > 0)) {
-    d.next_index -= 1;
+    --d.offset[2];
     d.distance = (grid_[2][shell - 1] - r.z) / u.z;
   }
   return d;
@@ -1990,15 +1998,14 @@ StructuredMesh::MeshDistance CylindricalMesh::distance_to_grid_boundary(
   if (i == 0) {
 
     return std::min(
-      MeshDistance(ijk[i] + 1, true, find_r_crossing(r0, u, l, ijk[i])),
-      MeshDistance(ijk[i] - 1, false, find_r_crossing(r0, u, l, ijk[i] - 1)));
+      MeshDistance({1, 0, 0}, true, find_r_crossing(r0, u, l, ijk[i])),
+      MeshDistance({-1, 0, 0}, false, find_r_crossing(r0, u, l, ijk[i] - 1)));
 
   } else if (i == 1) {
 
-    return std::min(MeshDistance(sanitize_phi(ijk[i] + 1), true,
-                      find_phi_crossing(r0, u, l, ijk[i])),
-      MeshDistance(sanitize_phi(ijk[i] - 1), false,
-        find_phi_crossing(r0, u, l, ijk[i] - 1)));
+    return std::min(
+      MeshDistance({0, 1, 0}, true, find_phi_crossing(r0, u, l, ijk[i])),
+      MeshDistance({0, -1, 0}, false, find_phi_crossing(r0, u, l, ijk[i] - 1)));
 
   } else {
     return find_z_crossing(r0, u, l, ijk[i]);
@@ -2322,20 +2329,19 @@ StructuredMesh::MeshDistance SphericalMesh::distance_to_grid_boundary(
 
   if (i == 0) {
     return std::min(
-      MeshDistance(ijk[i] + 1, true, find_r_crossing(r0, u, l, ijk[i])),
-      MeshDistance(ijk[i] - 1, false, find_r_crossing(r0, u, l, ijk[i] - 1)));
+      MeshDistance({1, 0, 0}, true, find_r_crossing(r0, u, l, ijk[i])),
+      MeshDistance({-1, 0, 0}, false, find_r_crossing(r0, u, l, ijk[i] - 1)));
 
   } else if (i == 1) {
-    return std::min(MeshDistance(sanitize_theta(ijk[i] + 1), true,
-                      find_theta_crossing(r0, u, l, ijk[i])),
-      MeshDistance(sanitize_theta(ijk[i] - 1), false,
-        find_theta_crossing(r0, u, l, ijk[i] - 1)));
+    return std::min(
+      MeshDistance({0, 1, 0}, true, find_theta_crossing(r0, u, l, ijk[i])),
+      MeshDistance(
+        {0, -1, 0}, false, find_theta_crossing(r0, u, l, ijk[i] - 1)));
 
   } else {
-    return std::min(MeshDistance(sanitize_phi(ijk[i] + 1), true,
-                      find_phi_crossing(r0, u, l, ijk[i])),
-      MeshDistance(sanitize_phi(ijk[i] - 1), false,
-        find_phi_crossing(r0, u, l, ijk[i] - 1)));
+    return std::min(
+      MeshDistance({0, 0, 1}, true, find_phi_crossing(r0, u, l, ijk[i])),
+      MeshDistance({0, 0, -1}, false, find_phi_crossing(r0, u, l, ijk[i] - 1)));
   }
 }
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Let a mesh surface crossing change more than one index

Pure refactor of `StructuredMesh`. No behaviour change, no results change, no
regolds. Second of the pieces split out of #3857, and independent of it.

## Problem

`StructuredMesh::raytrace_mesh` assumes that crossing a surface changes exactly
one mesh index, and that the distance to the next surface on the other axes is
unaffected:

```cpp
// Update cell and calculate distance to next surface in k-direction.
// The two other directions are still valid!
ijk[k] = distances[k].next_index;
distances[k] = distance_to_grid_boundary(ijk, k, local_r, u, traveled_distance);

in_mesh = ((ijk[k] >= 1) && (ijk[k] <= shape_[k]));
```

That is true of every mesh currently in the code, but it is a property of those
meshes rather than of structured meshes in general, and the assumption is spread
across three separate places: `MeshDistance::next_index` being a single `int`,
the hard-coded refresh of only `distances[k]`, and the inline bounds check.

Two more things are entangled with it. Periodic index wrapping is done inside
each mesh's `distance_to_grid_boundary`, so `next_index` is pre-sanitized:

```cpp
MeshDistance(sanitize_phi(ijk[i] + 1), true, find_phi_crossing(...))
```

which means the value stored is not "where I am going" but "where I am going,
already folded". And the logic for re-entering the mesh from outside sits inline
in the middle of `raytrace_mesh`.

## Changes

Three changes, each exercised by code in this PR.

- `MeshDistance::next_index` (an `int`) becomes `offset` (a `MeshIndex`). A
  crossing now says how each index changes rather than naming a single
  destination. The existing meshes each set one component, so `ijk[i] + 1`
  becomes `{1, 0, 0}` and so on.
- `virtual void sanitize_index(MeshIndex&)`, called once after the index is
  advanced. `CylindricalMesh` and `SphericalMesh` override it with the
  `sanitize_phi` / `sanitize_theta` calls they previously folded into
  `distance_to_grid_boundary`. Default is a no-op.
- `distance_to_mesh(...)` extracts the re-entry block, moved verbatim, out of
  the middle of `raytrace_mesh`.

Plus `MESH_MAX_AXES`, replacing the hard-coded `3` in `MeshIndex`, `shape_` and
the per-axis distance array -- three independent literals that all had to agree.

## Why this is behaviour-preserving

- `offset` defaults to `{0, 0, 0}` and the old code set `next_index = ijk[i]`
  before any early return, so a crossing that does not happen leaves the index
  unchanged either way.
- `sanitize_index` applies the same `sanitize_phi` / `sanitize_theta` to the
  same axis, just after the index is advanced instead of before it is stored.
- Exactly `distances[k]` is still refreshed after a crossing.
- `distance_to_mesh` is the previous expression, unmoved.

## Value independent of #3857

The periodic wrapping that cylindrical and spherical meshes do gets a name and
one place to live rather than being folded into each mesh's distance
calculation, where it made `next_index` mean two things at once. And
`distance_to_mesh` is now a separately readable and testable function rather
than a block in the middle of the longest function in the file.

## Performance

Benchmarked against a synthetic stress case -- a 50³ mesh surface tally, 2000 particles, single-threaded -- chosen so that mesh tallying dominates transport time. Cylindrical and spherical meshes show no resolvable change. A regular mesh shows a small increase, bounded at roughly 12% of transport in that configuration by the least favourable reading of the data and under 3% by the robust one; four repeats per arm is not enough to pin it down further. Real models, where transport is not dominated by a fine mesh surface tally, would see a fraction of that. 

## Testing

No results change, so the existing mesh regression and unit tests cover this
unchanged. Nothing new is executed and no allocation is added on the transport
path -- `MeshIndex` is `std::array<int, 3>`, so `MeshDistance` grows by two ints
and stays a plain aggregate.

No new data members and no allocation. `MeshDistance` grows by two ints and
stays a plain aggregate.



# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
