### PR TITLE
Replace linear search in ContinuousTabular with binary search

### DIFF
--- a/src/distribution_energy.cpp
+++ b/src/distribution_energy.cpp
@@ -191,7 +191,8 @@ double ContinuousTabular::sample(double E, uint64_t* seed) const
 
   // Discrete portion
   if (n_discrete > 0) {
-    int idx = upper_bound_index(distribution_[l].c.begin(), distribution_[l].c.begin() + n_discrete, r1);
+    int idx = upper_bound_index(
+      distribution_[l].c.begin(), distribution_[l].c.begin() + n_discrete, r1);
     if (idx + 1 < n_discrete) {
       k = idx + 1;
       end = k;
@@ -203,7 +204,8 @@ double ContinuousTabular::sample(double E, uint64_t* seed) const
 
   // Continuous portion
   if (n_discrete < end) {
-    int idx = upper_bound_index(distribution_[l].c.begin() + n_discrete + 1, distribution_[l].c.begin() + end + 1, r1);
+    int idx = upper_bound_index(distribution_[l].c.begin() + n_discrete + 1,
+      distribution_[l].c.begin() + end + 1, r1);
     k = idx + n_discrete + 1;
     c_k = distribution_[l].c[k];
   }

--- a/src/distribution_energy.cpp
+++ b/src/distribution_energy.cpp
@@ -190,24 +190,22 @@ double ContinuousTabular::sample(double E, uint64_t* seed) const
   int end = n_energy_out - 2;
 
   // Discrete portion
-  for (int j = 0; j < n_discrete; ++j) {
-    k = j;
-    c_k = distribution_[l].c[k];
-    if (r1 < c_k) {
-      end = j;
-      break;
+  if (n_discrete > 0) {
+    int idx = upper_bound_index(distribution_[l].c.begin(), distribution_[l].c.begin() + n_discrete, r1);
+    if (idx + 1 < n_discrete) {
+      k = idx + 1;
+      end = k;
+    } else {
+      k = n_discrete - 1;
     }
+    c_k = distribution_[l].c[k];
   }
 
   // Continuous portion
-  double c_k1;
-  for (int j = n_discrete; j < end; ++j) {
-    k = j;
-    c_k1 = distribution_[l].c[k + 1];
-    if (r1 < c_k1)
-      break;
-    k = j + 1;
-    c_k = c_k1;
+  if (n_discrete < end) {
+    int idx = upper_bound_index(distribution_[l].c.begin() + n_discrete + 1, distribution_[l].c.begin() + end + 1, r1);
+    k = idx + n_discrete + 1;
+    c_k = distribution_[l].c[k];
   }
 
   double E_l_k = distribution_[l].e_out[k];


### PR DESCRIPTION
# Description

Currently, the sampling algorithm in `ContinuousTabular::sample` relies on two linear searches to locate the corresponding point in the CDF. Since the CDF is monotonically increasing, a binary search can be implemented for $\mathcal{O}(\log\ n)$ complexity instead of the $\mathcal{O}(n)$ complexity of the linear search.

# Effect
Performance improvements up to 10% have been found with simple cases and identical results for a fixed seed.
Example case is the Jezebel benchmark from ICSBEP running `openmc -s 4` with 500 batches and 100,000 particles. The runtimes are averaged over 5 runs for each search algorithm.


| **Search Type**   	| Linear 	| Binary 	| Difference 	|
|-------------------	|--------	|--------	|------------	|
| Total Runtime (s)     	| 43.139±0.439 	| 39.938±0.938 	| 3.201±1.036     	|
| Transport Runtime (s)	| 27.402±0.280	| 23.586±0.554 	| 3.816±0.608         	|


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
