### PR TITLE
Fix post-commit clang-format exit handling

### DIFF
--- a/tools/dev/post-commit.git-clang-format
+++ b/tools/dev/post-commit.git-clang-format
@@ -21,7 +21,19 @@ to apply formatting.\e[0m
 fi
 
 printf "\e[2;37;40mRunning git-clang-format...\e[0m" >&2
-CLANG_FORMAT_RESULT="$(git-clang-format HEAD^)"
+if CLANG_FORMAT_RESULT="$(git-clang-format HEAD^)"; then
+  GCF_STATUS=0
+else
+  GCF_STATUS=$?
+fi
+
+# git-clang-format returns 1 when it successfully applies formatting changes.
+# Any other nonzero status indicates an actual failure.
+if [ "${GCF_STATUS}" -gt 1 ]; then
+  printf "%s\n" "${CLANG_FORMAT_RESULT}" >&2
+  printf "git-clang-format failed with status %s\n" "${GCF_STATUS}" >&2
+  exit "${GCF_STATUS}"
+fi
 
 if git diff-files --quiet ; then
   printf "\r\e[2;32mAll code changes were properly formatted\e[0m\n" >&2


### PR DESCRIPTION
# Description

This PR makes a small fix in the bundled post-commit hook for running clang-format. Namely, `git-clang-format` returns the exit status 1 after a successful formatting update, so the hook should only treat statuses > 1 as a true error. Accounting for this allows the post-commit hook to stage formatting changes and amend the commit as intended. Previously, `set -e` caused the hook to exit when `git-clang-format` applied changes, leaving the commit unformatted and the working tree modified.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] <s>I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)</s>
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>