### PR TITLE
Fix restart k-effective accumulation when generations_per_batch > 1

### DIFF
--- a/src/state_point.cpp
+++ b/src/state_point.cpp
@@ -368,7 +368,11 @@ extern "C" int openmc_statepoint_write(const char* filename, bool* write_source)
 void restart_set_keff()
 {
   if (simulation::restart_batch > settings::n_inactive) {
-    for (int i = settings::n_inactive; i < simulation::restart_batch; ++i) {
+    // k_generation has one entry per generation rather than per batch, so the
+    // active portion of the array must be indexed by generation
+    int i_start = settings::gen_per_batch * settings::n_inactive;
+    int i_end = settings::gen_per_batch * simulation::restart_batch;
+    for (int i = i_start; i < i_end; ++i) {
       simulation::k_sum[0] += simulation::k_generation[i];
       simulation::k_sum[1] += std::pow(simulation::k_generation[i], 2);
     }

--- a/tests/unit_tests/test_restart_keff.py
+++ b/tests/unit_tests/test_restart_keff.py
@@ -1,0 +1,67 @@
+"""Tests for resuming an eigenvalue simulation from a statepoint."""
+
+import re
+
+import numpy as np
+import pytest
+
+import openmc
+
+
+# One line is printed per generation, e.g.
+#       9/1    1.18342    1.18055 +/- 0.00287
+# capturing the batch, the generation and the running average k-effective.
+_GENERATION_LINE = re.compile(
+    r"^\s*(\d+)/(\d+)\s+[\d.]+\s+([\d.]+)\s+\+/-\s+[\d.]+\s*$", re.MULTILINE
+)
+
+
+@pytest.mark.parametrize("generations_per_batch", [1, 5])
+def test_restart_keff(run_in_tmpdir, capsys, generations_per_batch):
+    """A restarted run must resume with the correct accumulated k-effective.
+
+    ``simulation::k_generation`` holds one entry per generation rather than one
+    per batch, so the accumulation in ``restart_set_keff()`` has to be indexed
+    by generation. Indexing it by batch sums the wrong entries -- and too few of
+    them -- leaving the restarted run with a source-normalization k-effective
+    roughly a factor of ``generations_per_batch`` too low, which over-produces
+    fission sites and fills the shared fission bank.
+    """
+    model = openmc.examples.pwr_pin_cell()
+    model.settings.particles = 500
+    model.settings.inactive = 3
+    model.settings.batches = 8
+    model.settings.generations_per_batch = generations_per_batch
+
+    statepoint = model.run()
+
+    with openmc.StatePoint(statepoint) as sp:
+        assert sp.generations_per_batch == generations_per_batch
+        n_inactive = sp.n_inactive
+        n_loaded = len(sp.k_generation)
+
+    # Restart from the statepoint, asking for two more batches
+    model.settings.batches = 10
+    model.export_to_model_xml()
+    capsys.readouterr()
+    openmc.run(restart_file=statepoint)
+    output = capsys.readouterr().out
+
+    # Symptom of a low restart k-effective, asserted separately so that the
+    # failure mode is obvious
+    assert "fission bank is full" not in output
+
+    with openmc.StatePoint("statepoint.10.h5") as sp:
+        k_generation = np.asarray(sp.k_generation)
+
+    average_k = [float(m[2]) for m in _GENERATION_LINE.findall(output)]
+    assert len(average_k) == 2 * generations_per_batch
+
+    # The running average reported for each generation of the restarted run must
+    # be the mean over every active generation simulated so far, including the
+    # ones loaded from the statepoint. The comparison is exact to the precision
+    # of the printed value.
+    first_active = generations_per_batch * n_inactive
+    for i, reported in enumerate(average_k):
+        expected = k_generation[first_active:n_loaded + i + 1].mean()
+        assert reported == pytest.approx(expected, abs=1e-5)


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Fix restart k-effective accumulation when `generations_per_batch > 1`

## Description

`restart_set_keff()` in `src/state_point.cpp` mixes batch indices and generation
indices. `simulation::k_generation` contains one entry per *generation*, but the
accumulation loop runs over *batch* indices:

```cpp
for (int i = settings::n_inactive; i < simulation::restart_batch; ++i) {
  simulation::k_sum[0] += simulation::k_generation[i];
  simulation::k_sum[1] += std::pow(simulation::k_generation[i], 2);
}
int n = settings::gen_per_batch * simulation::n_realizations;
simulation::keff = simulation::k_sum[0] / n;
```

The normalization `n` is already a generation count, so the numerator and the
denominator only agree when `gen_per_batch == 1` — which is why this has gone
unnoticed. With `gen_per_batch > 1` the loop sums `restart_batch - n_inactive`
entries taken from the *inactive* part of `k_generation` and then divides by
`gen_per_batch * n_realizations`.

For the reported case (`batches = 300`, `inactive = 100`,
`generations_per_batch = 5`), the loop sums `k_generation[100:300]` — 200
generations that all fall inside the inactive region — and divides by 1000,
giving a restart `simulation::keff` of about 0.26 against a true active-batch
k-effective of about 1.3.

Two consequences:

1. `simulation::keff` normalizes fission site production, so a k-effective that
   is ~5x too low produces ~5x too many fission sites on the first restart
   generations. The shared fission bank overflows and OpenMC repeatedly emits
   `WARNING: The shared fission bank is full. Additional fission sites created
   in this generation will not be banked. Results may be non-deterministic.`
2. Less visibly, the bad `k_sum[0]` / `k_sum[1]` values are carried into
   `calculate_average_keff()`, so the mean and standard deviation reported for
   the continued active batches are computed from generations that were never
   supposed to be part of the active tally.

## Fix

Index `k_generation` by generation, consistent with `calculate_average_keff()`,
which accumulates one entry per active generation and normalizes by
`gen_per_batch * n_realizations + current_gen`:

```cpp
if (simulation::restart_batch > settings::n_inactive) {
  // k_generation has one entry per generation rather than per batch, so the
  // active portion of the array must be indexed by generation
  int i_start = settings::gen_per_batch * settings::n_inactive;
  int i_end = settings::gen_per_batch * simulation::restart_batch;
  for (int i = i_start; i < i_end; ++i) {
    simulation::k_sum[0] += simulation::k_generation[i];
    simulation::k_sum[1] += std::pow(simulation::k_generation[i], 2);
  }
  int n = settings::gen_per_batch * simulation::n_realizations;
  simulation::keff = simulation::k_sum[0] / n;
}
```

The loop now contributes exactly `gen_per_batch * (restart_batch - n_inactive)`
terms, matching the `gen_per_batch * n_realizations` denominator. The
`gen_per_batch == 1` path is bit-for-bit unchanged, so existing restart results
are unaffected.

## Reproducing

Run an eigenvalue model with `generations_per_batch = 5`, `inactive = 100`,
`batches = 300`, then restart from `statepoint.300.h5` with `batches = 500`.
Before the fix, the restart begins with a source-normalization k-effective far
from the converged value and the fission bank fills immediately; after the fix,
the restarted run picks up at the statepoint's active-batch k-effective and the
warnings disappear.

## Test

`tests/unit_tests/test_restart_keff.py` runs a short eigenvalue calculation to
batch 8, restarts from that statepoint for two more batches, and checks the
running average k-effective reported for every restarted generation against the
mean over all active generations simulated so far, taken from the restarted
run's own statepoint. The comparison is exact to the precision of the printed
value. It also asserts that no fission-bank-full warning is emitted, so the
reported symptom has its own assertion.

The test is parametrized over `generations_per_batch` of 1 and 5. The second
case fails on `develop` -- the reported average is low by about a factor of
five and the bank warning fires on every generation -- while the first guards
the unchanged single-generation path.

The obvious stronger test, asserting that a restarted run reproduces the
uninterrupted run bit-for-bit, is not currently possible:
`openmc_statepoint_load()` restores the seed and stride but not
`simulation::total_gen`, which enters the per-particle seed alongside
`overall_generation()`. A restarted run therefore draws a different random
stream than the original run would have at the same generation. Making restart
bit-reproducible would change the results of every restart run and seems worth
a separate discussion.

## Credit

Reported and diagnosed by @A_Bohemian on the OpenMC forum:
https://openmc.discourse.group/t/possible-restart-bug-with-generations-per-batch-1-fission-bank-fills-after-loading-statepoint/6456

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
