### PR TITLE
Avoid deprecated numpy array shape assignment

### DIFF
--- a/examples/custom_source/show_flux.py
+++ b/examples/custom_source/show_flux.py
@@ -4,7 +4,7 @@ import openmc
 # Get the flux from the statepoint
 with openmc.StatePoint('statepoint.10.h5') as sp:
     flux = sp.tallies[1].mean
-    flux.shape = (50, 50)
+    flux = flux.reshape(50, 50)
 
 # Plot the flux
 fig, ax = plt.subplots()

--- a/examples/parameterized_custom_source/show_flux.py
+++ b/examples/parameterized_custom_source/show_flux.py
@@ -4,7 +4,7 @@ import openmc
 # Get the flux from the statepoint
 with openmc.StatePoint('statepoint.10.h5') as sp:
     flux = sp.tallies[1].mean
-    flux.shape = (50, 50)
+    flux = flux.reshape(50, 50)
 
 # Plot the flux
 fig, ax = plt.subplots()

--- a/openmc/data/angle_distribution.py
+++ b/openmc/data/angle_distribution.py
@@ -194,8 +194,8 @@ class AngleDistribution(EqualityMixin):
                 intt = int(ace.xss[idx])
                 n_points = int(ace.xss[idx + 1])
                 # Data is given as rows of (values, PDF, CDF)
-                data = ace.xss[idx + 2:idx + 2 + 3*n_points]
-                data.shape = (3, n_points)
+                data = ace.xss[idx + 2:idx + 2 + 3*n_points].reshape(
+                    3, n_points)
 
                 mu_i = Tabular(data[0], data[1], INTERPOLATION_SCHEME[intt])
                 mu_i.c = data[2]

--- a/openmc/data/angle_distribution.py
+++ b/openmc/data/angle_distribution.py
@@ -194,8 +194,8 @@ class AngleDistribution(EqualityMixin):
                 intt = int(ace.xss[idx])
                 n_points = int(ace.xss[idx + 1])
                 # Data is given as rows of (values, PDF, CDF)
-                data = ace.xss[idx + 2:idx + 2 + 3*n_points].reshape(
-                    3, n_points)
+                data = ace.xss[idx + 2:idx + 2 + 3*n_points]
+                data = data.reshape(3, n_points)
 
                 mu_i = Tabular(data[0], data[1], INTERPOLATION_SCHEME[intt])
                 mu_i.c = data[2]

--- a/openmc/data/correlated.py
+++ b/openmc/data/correlated.py
@@ -359,8 +359,8 @@ class CorrelatedAngleEnergy(AngleEnergy):
 
             # Secondary energy distribution
             n_energy_out = int(ace.xss[idx + 1])
-            data = ace.xss[idx + 2:idx + 2 + 4*n_energy_out].copy().reshape(
-                4, n_energy_out)
+            data = ace.xss[idx + 2:idx + 2 + 4*n_energy_out].copy()
+            data = data.reshape(4, n_energy_out)
             data[0,:] *= EV_PER_MEV
 
             # Create continuous distribution
@@ -399,8 +399,8 @@ class CorrelatedAngleEnergy(AngleEnergy):
 
                     intt = int(ace.xss[idx])
                     n_cosine = int(ace.xss[idx + 1])
-                    data = ace.xss[idx + 2:idx + 2 + 3*n_cosine].reshape(
-                        3, n_cosine)
+                    data = ace.xss[idx + 2:idx + 2 + 3*n_cosine]
+                    data = data.reshape(3, n_cosine)
 
                     mu_ij = Tabular(data[0], data[1], INTERPOLATION_SCHEME[intt])
                     mu_ij.c = data[2]

--- a/openmc/data/correlated.py
+++ b/openmc/data/correlated.py
@@ -359,8 +359,8 @@ class CorrelatedAngleEnergy(AngleEnergy):
 
             # Secondary energy distribution
             n_energy_out = int(ace.xss[idx + 1])
-            data = ace.xss[idx + 2:idx + 2 + 4*n_energy_out].copy()
-            data.shape = (4, n_energy_out)
+            data = ace.xss[idx + 2:idx + 2 + 4*n_energy_out].copy().reshape(
+                4, n_energy_out)
             data[0,:] *= EV_PER_MEV
 
             # Create continuous distribution
@@ -399,8 +399,8 @@ class CorrelatedAngleEnergy(AngleEnergy):
 
                     intt = int(ace.xss[idx])
                     n_cosine = int(ace.xss[idx + 1])
-                    data = ace.xss[idx + 2:idx + 2 + 3*n_cosine]
-                    data.shape = (3, n_cosine)
+                    data = ace.xss[idx + 2:idx + 2 + 3*n_cosine].reshape(
+                        3, n_cosine)
 
                     mu_ij = Tabular(data[0], data[1], INTERPOLATION_SCHEME[intt])
                     mu_ij.c = data[2]
@@ -445,8 +445,7 @@ class CorrelatedAngleEnergy(AngleEnergy):
             # TODO: separate out discrete lines
             n_angle = items[3]
             n_energy_out = items[5]
-            values = np.asarray(values)
-            values.shape = (n_energy_out, n_angle + 2)
+            values = np.asarray(values).reshape(n_energy_out, n_angle + 2)
 
             # Outgoing energy distribution at the i-th incoming energy
             eout_i = values[:,0]

--- a/openmc/data/energy_distribution.py
+++ b/openmc/data/energy_distribution.py
@@ -1246,8 +1246,8 @@ class ContinuousTabular(EnergyDistribution):
                 intt = 2
 
             n_energy_out = int(ace.xss[idx + 1])
-            data = ace.xss[idx + 2:idx + 2 + 3*n_energy_out].copy()
-            data.shape = (3, n_energy_out)
+            data = ace.xss[idx + 2:idx + 2 + 3*n_energy_out].copy().reshape(
+                3, n_energy_out)
             data[0,:] *= EV_PER_MEV
 
             # Create continuous distribution

--- a/openmc/data/energy_distribution.py
+++ b/openmc/data/energy_distribution.py
@@ -1246,8 +1246,8 @@ class ContinuousTabular(EnergyDistribution):
                 intt = 2
 
             n_energy_out = int(ace.xss[idx + 1])
-            data = ace.xss[idx + 2:idx + 2 + 3*n_energy_out].copy().reshape(
-                3, n_energy_out)
+            data = ace.xss[idx + 2:idx + 2 + 3*n_energy_out].copy()
+            data = data.reshape(3, n_energy_out)
             data[0,:] *= EV_PER_MEV
 
             # Create continuous distribution

--- a/openmc/data/kalbach_mann.py
+++ b/openmc/data/kalbach_mann.py
@@ -554,8 +554,8 @@ class KalbachMann(AngleEnergy):
                 intt = 2
 
             n_energy_out = int(ace.xss[idx + 1])
-            data = ace.xss[idx + 2:idx + 2 + 5*n_energy_out].copy()
-            data.shape = (5, n_energy_out)
+            data = ace.xss[idx + 2:idx + 2 + 5*n_energy_out].copy().reshape(
+                5, n_energy_out)
             data[0, :] *= EV_PER_MEV
 
             # Create continuous distribution
@@ -637,8 +637,7 @@ class KalbachMann(AngleEnergy):
             # TODO: split out discrete energies
             n_angle = items[3]
             n_energy_out = items[5]
-            values = np.asarray(values)
-            values.shape = (n_energy_out, n_angle + 2)
+            values = np.asarray(values).reshape(n_energy_out, n_angle + 2)
 
             # Outgoing energy distribution at the i-th incoming energy
             eout_i = values[:, 0]

--- a/openmc/data/kalbach_mann.py
+++ b/openmc/data/kalbach_mann.py
@@ -554,8 +554,8 @@ class KalbachMann(AngleEnergy):
                 intt = 2
 
             n_energy_out = int(ace.xss[idx + 1])
-            data = ace.xss[idx + 2:idx + 2 + 5*n_energy_out].copy().reshape(
-                5, n_energy_out)
+            data = ace.xss[idx + 2:idx + 2 + 5*n_energy_out].copy()
+            data = data.reshape(5, n_energy_out)
             data[0, :] *= EV_PER_MEV
 
             # Create continuous distribution

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -796,12 +796,13 @@ class ThermalScattering(EqualityMixin):
         if not continuous:
             n_mu = ace.nxs[3]
             idx = ace.jxs[3]
-            energy_out = ace.xss[idx:idx + n_energy * n_energy_out *
-                (n_mu + 2): n_mu + 2]*EV_PER_MEV
-            energy_out.shape = (n_energy, n_energy_out)
+            energy_out = (ace.xss[idx:idx + n_energy * n_energy_out *
+                (n_mu + 2): n_mu + 2]*EV_PER_MEV).reshape(
+                    n_energy, n_energy_out)
 
-            mu_out = ace.xss[idx:idx + n_energy * n_energy_out * (n_mu + 2)]
-            mu_out.shape = (n_energy, n_energy_out, n_mu+2)
+            mu_out = ace.xss[
+                idx:idx + n_energy * n_energy_out * (n_mu + 2)].reshape(
+                    n_energy, n_energy_out, n_mu + 2)
             mu_out = mu_out[:, :, 1:]
             skewed = (ace.nxs[7] == 1)
             distribution = IncoherentInelasticAEDiscrete(energy_out, mu_out, skewed)
@@ -923,8 +924,8 @@ class ThermalScattering(EqualityMixin):
                 n_mu = (ace.nxs[8] if mixed else ace.nxs[6]) + 1
                 assert n_mu > 0
                 idx = ace.jxs[9] if mixed else ace.jxs[6]
-                mu_out = ace.xss[idx:idx + n_energy * n_mu]
-                mu_out.shape = (n_energy, n_mu)
+                mu_out = ace.xss[idx:idx + n_energy * n_mu].reshape(
+                    n_energy, n_mu)
                 incoherent_dist = IncoherentElasticAEDiscrete(mu_out)
 
             if ace.nxs[5] == 3:

--- a/openmc/data/thermal.py
+++ b/openmc/data/thermal.py
@@ -796,13 +796,12 @@ class ThermalScattering(EqualityMixin):
         if not continuous:
             n_mu = ace.nxs[3]
             idx = ace.jxs[3]
-            energy_out = (ace.xss[idx:idx + n_energy * n_energy_out *
-                (n_mu + 2): n_mu + 2]*EV_PER_MEV).reshape(
-                    n_energy, n_energy_out)
+            n_values = n_energy * n_energy_out * (n_mu + 2)
+            energy_out = ace.xss[idx:idx + n_values:n_mu + 2]*EV_PER_MEV
+            energy_out = energy_out.reshape(n_energy, n_energy_out)
 
-            mu_out = ace.xss[
-                idx:idx + n_energy * n_energy_out * (n_mu + 2)].reshape(
-                    n_energy, n_energy_out, n_mu + 2)
+            mu_out = ace.xss[idx:idx + n_values]
+            mu_out = mu_out.reshape(n_energy, n_energy_out, n_mu + 2)
             mu_out = mu_out[:, :, 1:]
             skewed = (ace.nxs[7] == 1)
             distribution = IncoherentInelasticAEDiscrete(energy_out, mu_out, skewed)
@@ -924,8 +923,8 @@ class ThermalScattering(EqualityMixin):
                 n_mu = (ace.nxs[8] if mixed else ace.nxs[6]) + 1
                 assert n_mu > 0
                 idx = ace.jxs[9] if mixed else ace.jxs[6]
-                mu_out = ace.xss[idx:idx + n_energy * n_mu].reshape(
-                    n_energy, n_mu)
+                mu_out = ace.xss[idx:idx + n_energy * n_mu]
+                mu_out = mu_out.reshape(n_energy, n_mu)
                 incoherent_dist = IncoherentElasticAEDiscrete(mu_out)
 
             if ace.nxs[5] == 3:

--- a/openmc/data/urr.py
+++ b/openmc/data/urr.py
@@ -205,8 +205,7 @@ class ProbabilityTables(EqualityMixin):
         idx += N
 
         # Get probability tables
-        table = ace.xss[idx : idx+N*6*M].copy()
-        table.shape = (N, 6, M)
+        table = ace.xss[idx : idx+N*6*M].copy().reshape(N, 6, M)
 
         # Convert units on heating numbers
         table[:,5,:] *= EV_PER_MEV

--- a/openmc/deplete/d1s.py
+++ b/openmc/deplete/d1s.py
@@ -185,7 +185,7 @@ def apply_time_correction(
     tally_std_dev = new_tally.std_dev.reshape(shape)
 
     # Apply TCF, broadcasting to the correct dimensions
-    tcf.shape = (1, -1, 1, 1, 1)
+    tcf = tcf.reshape(1, -1, 1, 1, 1)
     new_tally._mean = tally_mean * tcf
     new_tally._std_dev = tally_std_dev * tcf
 
@@ -207,8 +207,8 @@ def apply_time_correction(
         # scores)
         new_tally._sum = (tally_sum * tcf).reshape(shape)
         new_tally._sum_sq = (tally_sum_sq * (tcf*tcf)).reshape(shape)
-        new_tally._mean.shape = shape
-        new_tally._std_dev.shape = shape
+        new_tally._mean = new_tally._mean.reshape(shape)
+        new_tally._std_dev = new_tally._std_dev.reshape(shape)
 
     return new_tally
 

--- a/openmc/lattice.py
+++ b/openmc/lattice.py
@@ -969,8 +969,7 @@ class RectLattice(Lattice):
         dimension = get_elem_list(elem, 'dimension', int)
         shape = np.array(dimension, dtype=int)[::-1]
         universes = get_elem_list(elem, 'universes', int)
-        uarray = np.array([get_universe(u) for u in universes])
-        uarray.shape = shape
+        uarray = np.array([get_universe(u) for u in universes]).reshape(shape)
         lat.universes = uarray
         return lat
 

--- a/openmc/openmoc_compatible.py
+++ b/openmc/openmoc_compatible.py
@@ -619,8 +619,7 @@ def get_openmoc_lattice(openmc_lattice):
 
         # Convert 2D universes array to 3D for OpenMOC
         if len(universes.shape) == 2:
-            new_universes = universes.copy().reshape((1,) + universes.shape)
-            universes = new_universes
+            universes = universes.copy().reshape((1,) + universes.shape)
 
     # Initialize an empty array for the OpenMOC nested Universes in this Lattice
     universe_array = np.ndarray(tuple(dimension[::-1]), dtype=openmoc.Universe)

--- a/openmc/openmoc_compatible.py
+++ b/openmc/openmoc_compatible.py
@@ -619,8 +619,7 @@ def get_openmoc_lattice(openmc_lattice):
 
         # Convert 2D universes array to 3D for OpenMOC
         if len(universes.shape) == 2:
-            new_universes = universes.copy()
-            new_universes.shape = (1,) + universes.shape
+            new_universes = universes.copy().reshape((1,) + universes.shape)
             universes = new_universes
 
     # Initialize an empty array for the OpenMOC nested Universes in this Lattice

--- a/openmc/summary.py
+++ b/openmc/summary.py
@@ -176,7 +176,7 @@ class Summary:
                 if 'rotation' in group:
                     rotation = group['rotation'][()]
                     if rotation.size == 9:
-                        rotation.shape = (3, 3)
+                        rotation = rotation.reshape(3, 3)
                     cell.rotation = rotation
 
             elif fill_type == 'material':

--- a/tests/regression_tests/external_moab/test.py
+++ b/tests/regression_tests/external_moab/test.py
@@ -129,8 +129,8 @@ class ExternalMoabTest(PyAPITestHarness):
     def get_mesh_tally_data(tally):
         data = tally.get_reshaped_data(value='mean')
         std_dev = tally.get_reshaped_data(value='std_dev')
-        data.shape = (data.size, 1)
-        std_dev.shape = (std_dev.size, 1)
+        data = data.reshape(data.size, 1)
+        std_dev = std_dev.reshape(std_dev.size, 1)
         return np.sum(data, axis=1), np.sum(std_dev, axis=1)
 
     def _cleanup(self):

--- a/tests/regression_tests/external_moab/test.py
+++ b/tests/regression_tests/external_moab/test.py
@@ -129,8 +129,8 @@ class ExternalMoabTest(PyAPITestHarness):
     def get_mesh_tally_data(tally):
         data = tally.get_reshaped_data(value='mean')
         std_dev = tally.get_reshaped_data(value='std_dev')
-        data = data.reshape(data.size, 1)
-        std_dev = std_dev.reshape(std_dev.size, 1)
+        data = data.reshape(-1, 1)
+        std_dev = std_dev.reshape(-1, 1)
         return np.sum(data, axis=1), np.sum(std_dev, axis=1)
 
     def _cleanup(self):

--- a/tests/regression_tests/unstructured_mesh/test.py
+++ b/tests/regression_tests/unstructured_mesh/test.py
@@ -83,7 +83,7 @@ class UnstructuredMeshTest(PyAPITestHarness):
         if structured:
            data = data.reshape((-1, self.ELEM_PER_VOXEL))
         else:
-            data.shape = (data.size, 1)
+            data = data.reshape(data.size, 1)
         return np.sum(data, axis=1)
 
     def update_results(self):

--- a/tests/regression_tests/unstructured_mesh/test.py
+++ b/tests/regression_tests/unstructured_mesh/test.py
@@ -81,9 +81,9 @@ class UnstructuredMeshTest(PyAPITestHarness):
     def get_mesh_tally_data(self, tally, structured=False):
         data = tally.get_reshaped_data(value='mean')
         if structured:
-           data = data.reshape((-1, self.ELEM_PER_VOXEL))
+            data = data.reshape(-1, self.ELEM_PER_VOXEL)
         else:
-            data = data.reshape(data.size, 1)
+            data = data.reshape(-1, 1)
         return np.sum(data, axis=1)
 
     def update_results(self):

--- a/tests/unit_tests/test_deplete_microxs.py
+++ b/tests/unit_tests/test_deplete_microxs.py
@@ -46,7 +46,7 @@ def test_from_array():
                      [0., 0.],
                      [0., 0.1],
                      [0., 0.1]])
-    data.shape = (12, 2, 1)
+    data = data.reshape(12, 2, 1)
 
     MicroXS(data, nuclides, reactions)
     with pytest.raises(ValueError, match='Data array must be 3D'):


### PR DESCRIPTION
# Description

Numpy 2.5 emits a `DeprecationWarning` when assigning directly to an ndarray's `shape` attribute. This PR replaces direct shape assignments throughout the Python package, examples, and tests with calls to `reshape`.

# Checklist

- [x] I have performed a self-review of my own code
- [x] <s>I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)</s>
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] <s>I have made corresponding changes to the documentation (if applicable)</s>
- [x] <s>I have added tests that prove my fix is effective or that my feature works (if applicable)</s>