### PR TITLE
Automatically trigger performance benchmarks on push

### DIFF
--- a/.github/workflows/trigger-performance-bench.yml
+++ b/.github/workflows/trigger-performance-bench.yml
@@ -1,0 +1,37 @@
+name: Trigger performance benchmarks
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create benchmark app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.BENCH_APP_ID }}
+          private-key: ${{ secrets.BENCH_APP_PRIVATE_KEY }}
+          owner: openmc-dev
+          repositories: openmc-performance-bench
+          permission-contents: write
+
+      - name: Trigger performance benchmarks
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OPENMC_SHA: ${{ github.sha }}
+        run: |
+          gh api \
+            --method POST \
+            repos/openmc-dev/openmc-performance-bench/dispatches \
+            --field event_type=run-perf \
+            --raw-field "client_payload[sha]=$OPENMC_SHA" \
+            --raw-field "client_payload[branch]=${{ github.ref_name }}"


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description

This adds a GitHub Actions workflow to automatically trigger the suite of [OpenMC performance benchmarks](https://github.com/openmc-dev/openmc-performance-bench) when a new commit is pushed to develop. These benchmarks live in a separate repo, which uses ASV to benchmark a specific OpenMC commit on a dedicated EC2 runner and publish the [results](https://github.com/openmc-dev/openmc-performance-bench-results) so that performance can be tracked over time.

Right now this will run on every push to develop, including things like documentation-only updates, but if we wanted to we could add path filtering to skip changes that aren't expected to affect performance.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [ ] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
