### PR TITLE
Fail loudly when a score has no implementation for the estimator or energy mode

### DIFF
--- a/src/tallies/tally.cpp
+++ b/src/tallies/tally.cpp
@@ -693,11 +693,16 @@ void Tally::set_scores(const vector<std::string>& scores)
 
   // Make sure all scores are compatible with multigroup mode.
   if (!settings::run_CE) {
-    for (auto sc : scores_)
-      if (sc > 0)
+    for (auto sc : scores_) {
+      if (sc > 0) {
         fatal_error("Cannot tally " + reaction_name(sc) +
                     " reaction rate "
                     "in multi-group mode");
+      } else if (sc == SCORE_FISS_Q_PROMPT || sc == SCORE_FISS_Q_RECOV) {
+        fatal_error("Cannot tally " + reaction_name(sc) +
+                    " in multi-group mode; kappa-fission is available instead");
+      }
+    }
   }
 
   // Make sure mesh surface tallies contain only current score.

--- a/src/tallies/tally_scoring.cpp
+++ b/src/tallies/tally_scoring.cpp
@@ -9,6 +9,7 @@
 #include "openmc/mgxs_interface.h"
 #include "openmc/nuclide.h"
 #include "openmc/photon.h"
+#include "openmc/reaction.h"
 #include "openmc/reaction_product.h"
 #include "openmc/search.h"
 #include "openmc/settings.h"
@@ -1076,6 +1077,15 @@ void score_general_ce_nonanalog(Particle& p, int i_tally, int start_index,
     default:
     default_case:
 
+      // Pseudo-scores are negative and each needs an explicit case above.
+      // Reaching the default block means this score has no implementation for
+      // this estimator, which would otherwise be silently skipped.
+      if (score_bin < 0)
+        fatal_error("Score " + reaction_name(score_bin) +
+                    " is not implemented "
+                    "for the estimator used by tally " +
+                    std::to_string(tally.id_));
+
       // The default block is really only meant for redundant neutron reactions
       // (e.g. 444, 901)
       if (!p.type().is_neutron())
@@ -1589,6 +1599,15 @@ void score_general_ce_analog(Particle& p, int i_tally, int start_index,
 
     default:
     default_case:
+
+      // Pseudo-scores are negative and each needs an explicit case above.
+      // Reaching the default block means this score has no implementation for
+      // this estimator, which would otherwise be silently skipped.
+      if (score_bin < 0)
+        fatal_error("Score " + reaction_name(score_bin) +
+                    " is not implemented "
+                    "for the estimator used by tally " +
+                    std::to_string(tally.id_));
 
       // The default block is really only meant for redundant neutron reactions
       // (e.g. 444, 901)
@@ -2300,6 +2319,13 @@ void score_general_mg(Particle& p, int i_tally, int start_index,
       break;
 
     default:
+      // Pseudo-scores are negative and each needs an explicit case above.
+      // Reaching the default block means this score has no multigroup
+      // implementation, which would otherwise be silently skipped.
+      if (score_bin < 0)
+        fatal_error("Score " + reaction_name(score_bin) +
+                    " is not implemented in multigroup mode (tally " +
+                    std::to_string(tally.id_) + ")");
       continue;
     }
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

### Description
 
Tally scores are dispatched through three switch statements — `score_general_ce_nonanalog`,
`score_general_ce_analog` and `score_general_mg`. Whether a score is actually implemented is
determined solely by whether it has a `case` label in the relevant one. Nothing connects those
switches to the validation in `Tally::set_scores`, so when a score is missing a case, the
`default` block silently skips it and the tally reports zero.
 
Enumerating the case labels shows four gaps today:
 
| score | tracklength/collision | analog | multigroup |
|---|---|---|---|
| `fission-q-prompt` | yes | yes | **missing** |
| `fission-q-recoverable` | yes | yes | **missing** |
| `ifp-*` (3 scores) | yes | **missing** | **missing** |
| `migration-area` (#3810) | yes | **missing** | yes |
 
These are reachable. `set_scores` forces IFP scores to a collision estimator, but the
`<estimator>` element is read afterwards and its analog branch overwrites the estimator
unconditionally, so `estimator='analog'` on an IFP tally yields silent zeros. The multigroup
whitelist only rejects `sc > 0` (MT reaction rates), so the negative pseudo-scores pass through
it untouched.
 
This PR does not add the missing implementations. It makes the absence loud:
 
- The `default` block in each of the three dispatch functions now raises an error when
  `score_bin < 0`. Every pseudo-score is negative and every MT reaction rate is positive, so
  the sign cleanly separates "should have had a case" from the intended MT fallthrough.
- `fission-q-prompt` / `fission-q-recoverable` are additionally rejected up front in
  multigroup mode, where `kappa-fission` is the available equivalent, so users get an early
  error with a useful suggestion rather than a late one.
This follows the pattern `validate_random_ray_inputs` and `FlatSourceDomain` already use — an
up-front whitelist plus a loud default in the scoring path.
 
Checked that the guard cannot fire on a valid configuration:
 
- The two `goto default_case` jumps come from `N_2N`/`N_3N`/`N_4N`/`N_GAMMA`/`N_P`/`N_A`, all
  positive MTs.
- `SCORE_CURRENT` and `SCORE_PULSE_HEIGHT` have no case in any of the three functions, but both
  set `type_` away from `VOLUME` in `set_scores`, and `setup_active_tallies` routes by `type_`.
  `score_surface_tally` and `score_pulse_height_tally` handle them inline without delegating.
- Random ray never reaches these functions; it has its own dispatch and its own whitelist.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
