### PR TITLE
Fix nonfinite comparisons in tolerant regression harness

### DIFF
--- a/tests/testing_harness.py
+++ b/tests/testing_harness.py
@@ -3,6 +3,7 @@ import filecmp
 import glob
 import h5py
 import hashlib
+import math
 import os
 import shutil
 
@@ -416,6 +417,9 @@ class TolerantPyAPITestHarness(PyAPITestHarness):
         def compare_tokens(token1, token2):
             if isfloat(token1) and isfloat(token2):
                 float1, float2 = float(token1), float(token2)
+                if not (math.isfinite(float1) and math.isfinite(float2)):
+                    # Infinities only match with the same sign; NaNs never match.
+                    return float1 == float2
                 return abs(float1 - float2) <= tolerance * max(abs(float1), abs(float2))
             else:
                 return token1 == token2

--- a/tests/testing_harness.py
+++ b/tests/testing_harness.py
@@ -417,10 +417,7 @@ class TolerantPyAPITestHarness(PyAPITestHarness):
         def compare_tokens(token1, token2):
             if isfloat(token1) and isfloat(token2):
                 float1, float2 = float(token1), float(token2)
-                if not (math.isfinite(float1) and math.isfinite(float2)):
-                    # Infinities only match with the same sign; NaNs never match.
-                    return float1 == float2
-                return abs(float1 - float2) <= tolerance * max(abs(float1), abs(float2))
+                return math.isclose(float1, float2, rel_tol=tolerance, abs_tol=0.0)
             else:
                 return token1 == token2
 

--- a/tests/unit_tests/test_testing_harness.py
+++ b/tests/unit_tests/test_testing_harness.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+import openmc
+import pytest
+
+from tests.testing_harness import TolerantPyAPITestHarness
+
+
+@pytest.fixture
+def tolerant_harness():
+    return TolerantPyAPITestHarness('statepoint.1.h5', openmc.Model())
+
+
+@pytest.mark.parametrize(('actual', 'expected', 'tolerance', 'accepted'), [
+    ('1.0', 'inf', 1e-6, False),
+    ('inf', '1.0', 1e-6, False),
+    ('-1.0', '-inf', 1e-6, False),
+    ('-inf', '-1.0', 1e-6, False),
+    ('inf', '-inf', 1e-6, False),
+    ('-inf', 'inf', 1e-6, False),
+    ('inf', 'inf', 1e-6, True),
+    ('-inf', '-inf', 1e-6, True),
+    ('+Infinity', 'inf', 1e-6, True),
+    ('-Infinity', '-inf', 1e-6, True),
+    ('nan', 'nan', 1e-6, False),
+    ('NaN', '-nan', 1e-6, False),
+    ('nan', '1.0', 1e-6, False),
+    ('1.0', 'nan', 1e-6, False),
+    ('nan', 'inf', 1e-6, False),
+    ('inf', 'nan', 1e-6, False),
+    ('1.0', '1.0000001', 1e-6, True),
+    ('1.0000001', '1.0', 1e-6, True),
+    ('1.0', '1.00001', 1e-6, False),
+    ('-1.0', '-1.0000001', 1e-6, True),
+    ('-1.0', '-1.00001', 1e-6, False),
+    ('1.0', '1.25', 0.2, True),
+    ('1.0', '1.251', 0.2, False),
+    ('1.0', '1.0', 0.0, True),
+    ('1.0', '1.0000001', 0.0, False),
+    ('0.0', '-0.0', 1e-6, True),
+    ('0.0', '5e-324', 1e-6, False),
+    ('5e-324', '5e-324', 1e-6, True),
+    ('5e-324', '1e-323', 1e-6, False),
+    ('1e308', '-1e308', 1e-6, False),
+    ('1e308', '1.0000001e308', 1e-6, True),
+])
+def test_tolerant_harness_numeric_tokens(
+        tolerant_harness, tmp_path, actual, expected, tolerance, accepted):
+    """Non-finite values must not weaken the finite relative-tolerance gate."""
+    actual_path = tmp_path / 'actual.dat'
+    expected_path = tmp_path / 'expected.dat'
+    actual_path.write_text(f'tally 1:\n{actual}\n')
+    expected_path.write_text(f'tally 1:\n{expected}\n')
+
+    assert tolerant_harness._are_files_equal(
+        actual_path, expected_path, tolerance) is accepted
+
+
+@pytest.mark.parametrize(('actual', 'expected', 'accepted'), [
+    ('', '', True),
+    ('tally 1:\n1.0\n', 'tally 1:\n1.0\n', True),
+    (' tally  1:\n 1.0 \n', 'tally 1:\n1.0\n', True),
+    ('tally 1:\n1.0\n', 'tally 2:\n1.0\n', False),
+    ('tally 1:\n1.0\n', 'Tally 1:\n1.0\n', False),
+    ('tally 1:\n1.0\n', 'tally 1:\n1.0\n2.0\n', False),
+    ('tally 1:\n1.0 2.0\n', 'tally 1:\n1.0\n', False),
+    ('tally 1:\n1.0\n', 'tally 1:\nnot-a-number\n', False),
+])
+def test_tolerant_harness_file_structure(
+        tolerant_harness, tmp_path, actual, expected, accepted):
+    """The numeric comparison must preserve text, line and token checks."""
+    actual_path = tmp_path / 'actual.dat'
+    expected_path = tmp_path / 'expected.dat'
+    actual_path.write_text(actual)
+    expected_path.write_text(expected)
+
+    assert tolerant_harness._are_files_equal(
+        actual_path, expected_path, 1e-6) is accepted
+
+
+@pytest.mark.parametrize(('actual', 'expected'), [
+    ('inf', '1.0'),
+    ('1.0', 'inf'),
+    ('-inf', 'inf'),
+    ('nan', 'nan'),
+])
+def test_tolerant_harness_rejects_and_preserves_results(
+        tolerant_harness, run_in_tmpdir, capsys, actual, expected):
+    """Rejected results must raise and retain the actual output for review."""
+    actual_text = f'tally 1:\n{actual}\n'
+    expected_text = f'tally 1:\n{expected}\n'
+    actual_path = Path('results_test.dat')
+    expected_path = Path('results_true.dat')
+    actual_path.write_text(actual_text)
+    expected_path.write_text(expected_text)
+
+    with pytest.raises(AssertionError, match='Results do not agree'):
+        tolerant_harness._compare_results()
+
+    assert not actual_path.exists()
+    assert Path('results_error.dat').read_text() == actual_text
+    assert expected_path.read_text() == expected_text
+    assert 'Result differences:' in capsys.readouterr().out
+
+
+@pytest.mark.parametrize('value', ['inf', '-inf'])
+def test_tolerant_harness_accepts_matching_infinity(
+        tolerant_harness, run_in_tmpdir, value):
+    """An infinity only matches an infinity with the same sign."""
+    text = f'tally 1:\n{value}\n'
+    Path('results_test.dat').write_text(text)
+    Path('results_true.dat').write_text(text)
+
+    tolerant_harness._compare_results()
+
+    assert Path('results_test.dat').read_text() == text
+    assert not Path('results_error.dat').exists()

--- a/tests/unit_tests/test_testing_harness.py
+++ b/tests/unit_tests/test_testing_harness.py
@@ -12,37 +12,12 @@ def tolerant_harness():
 
 
 @pytest.mark.parametrize(('actual', 'expected', 'tolerance', 'accepted'), [
-    ('1.0', 'inf', 1e-6, False),
     ('inf', '1.0', 1e-6, False),
-    ('-1.0', '-inf', 1e-6, False),
-    ('-inf', '-1.0', 1e-6, False),
-    ('inf', '-inf', 1e-6, False),
-    ('-inf', 'inf', 1e-6, False),
     ('inf', 'inf', 1e-6, True),
-    ('-inf', '-inf', 1e-6, True),
-    ('+Infinity', 'inf', 1e-6, True),
-    ('-Infinity', '-inf', 1e-6, True),
     ('nan', 'nan', 1e-6, False),
-    ('NaN', '-nan', 1e-6, False),
-    ('nan', '1.0', 1e-6, False),
-    ('1.0', 'nan', 1e-6, False),
-    ('nan', 'inf', 1e-6, False),
-    ('inf', 'nan', 1e-6, False),
-    ('1.0', '1.0000001', 1e-6, True),
-    ('1.0000001', '1.0', 1e-6, True),
     ('1.0', '1.00001', 1e-6, False),
-    ('-1.0', '-1.0000001', 1e-6, True),
-    ('-1.0', '-1.00001', 1e-6, False),
-    ('1.0', '1.25', 0.2, True),
-    ('1.0', '1.251', 0.2, False),
-    ('1.0', '1.0', 0.0, True),
-    ('1.0', '1.0000001', 0.0, False),
+    ('1000000.0', '1000000.1', 1e-6, True),
     ('0.0', '-0.0', 1e-6, True),
-    ('0.0', '5e-324', 1e-6, False),
-    ('5e-324', '5e-324', 1e-6, True),
-    ('5e-324', '1e-323', 1e-6, False),
-    ('1e308', '-1e308', 1e-6, False),
-    ('1e308', '1.0000001e308', 1e-6, True),
 ])
 def test_tolerant_harness_numeric_tokens(
         tolerant_harness, tmp_path, actual, expected, tolerance, accepted):
@@ -57,11 +32,7 @@ def test_tolerant_harness_numeric_tokens(
 
 
 @pytest.mark.parametrize(('actual', 'expected', 'accepted'), [
-    ('', '', True),
     ('tally 1:\n1.0\n', 'tally 1:\n1.0\n', True),
-    (' tally  1:\n 1.0 \n', 'tally 1:\n1.0\n', True),
-    ('tally 1:\n1.0\n', 'tally 2:\n1.0\n', False),
-    ('tally 1:\n1.0\n', 'Tally 1:\n1.0\n', False),
     ('tally 1:\n1.0\n', 'tally 1:\n1.0\n2.0\n', False),
     ('tally 1:\n1.0 2.0\n', 'tally 1:\n1.0\n', False),
     ('tally 1:\n1.0\n', 'tally 1:\nnot-a-number\n', False),
@@ -78,17 +49,11 @@ def test_tolerant_harness_file_structure(
         actual_path, expected_path, 1e-6) is accepted
 
 
-@pytest.mark.parametrize(('actual', 'expected'), [
-    ('inf', '1.0'),
-    ('1.0', 'inf'),
-    ('-inf', 'inf'),
-    ('nan', 'nan'),
-])
 def test_tolerant_harness_rejects_and_preserves_results(
-        tolerant_harness, run_in_tmpdir, capsys, actual, expected):
+        tolerant_harness, run_in_tmpdir, capsys):
     """Rejected results must raise and retain the actual output for review."""
-    actual_text = f'tally 1:\n{actual}\n'
-    expected_text = f'tally 1:\n{expected}\n'
+    actual_text = 'tally 1:\ninf\n'
+    expected_text = 'tally 1:\n1.0\n'
     actual_path = Path('results_test.dat')
     expected_path = Path('results_true.dat')
     actual_path.write_text(actual_text)
@@ -103,11 +68,10 @@ def test_tolerant_harness_rejects_and_preserves_results(
     assert 'Result differences:' in capsys.readouterr().out
 
 
-@pytest.mark.parametrize('value', ['inf', '-inf'])
 def test_tolerant_harness_accepts_matching_infinity(
-        tolerant_harness, run_in_tmpdir, value):
+        tolerant_harness, run_in_tmpdir):
     """An infinity only matches an infinity with the same sign."""
-    text = f'tally 1:\n{value}\n'
+    text = 'tally 1:\ninf\n'
     Path('results_test.dat').write_text(text)
     Path('results_true.dat').write_text(text)
 


### PR DESCRIPTION
## Summary

Prevent false matches involving nonfinite numeric tokens in
`TolerantPyAPITestHarness` by using
`math.isclose(float1, float2, rel_tol=tolerance, abs_tol=0.0)`.

The previous relative-tolerance expression could accept a finite value against
infinity or infinities with opposite signs (`inf <= inf`). It also rejected
matching infinities because their difference is NaN. The standard-library
comparison handles these cases: NaNs never match, and infinities only match
themselves. Text, line and token checks are unchanged. No simulation or tally
arithmetic is modified.

Updated following GuySten's review to use `math.isclose` and keep the tests
focused on harness behavior.

## Tests

The revised suite has 12 cases: six numeric comparisons, four file-structure
checks, and two integration tests covering rejection with preservation of
`results_error.dat` and acceptance of matching infinity.

- Revised code: **12 passed**.
- Same tests with the unchanged `develop` comparator substituted in memory:
  **4 failed, 8 passed**, demonstrating the defect remains covered.
- Additional local checks exercised the original 31 numeric and 8 structure
  cases, and found zero changed decisions across 50,000 seeded finite
  comparisons against the upstream comparator.
- `git diff --check` and targeted fatal-error lint passed.

```sh
READTHEDOCS=True OMP_NUM_THREADS=2 python -m pytest \
  tests/unit_tests/test_testing_harness.py -q
```

Local tests use OpenMC's existing documentation import mode to mock the
unavailable native library; the real Python comparison and file-handling
methods execute. Native particle transport was not run locally. See the PR's
Checks tab for upstream CI on the latest commit.

Related context: #3820. This fixes the nonfinite comparison defect, not the
compiler/libm portability issue.

