### PR TITLE
Fix zero k-effective in random ray runs with generations_per_batch > 1

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -221,6 +221,15 @@ void get_run_parameters(pugi::xml_node node_base)
     if (check_for_node(node_base, "generations_per_batch")) {
       gen_per_batch =
         std::stoi(get_node_value(node_base, "generations_per_batch"));
+
+      // The random ray solver runs a single generation per batch. The rest of
+      // the code has to see that, since overall_generation() strides by
+      // gen_per_batch while only one generation per batch is ever recorded.
+      if (gen_per_batch != 1 && solver_type == SolverType::RANDOM_RAY) {
+        warning("The 'generations_per_batch' setting does not apply to the "
+                "random ray solver and is ignored.");
+        gen_per_batch = 1;
+      }
     }
 
     // Preallocate space for keff and entropy by generation


### PR DESCRIPTION
<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

# Description
 
`generations_per_batch > 1` with the random ray solver reports a k-effective of
zero, in the output and in the statepoint:
 
```
  Bat./Gen.      k       Entropy         Average k
        1/1    0.94578    6.16247
        2/1    0.00000    0.00000
        ...
 k-effective                       = 0.00000 +/- 0.00000
```
 
Random ray runs one generation per batch and pins `current_gen` at 1, but the
requested `gen_per_batch` still strides `overall_generation()`, which indexes
`k_generation` and `entropy`. Batch 1 reads index 0; batch 2 reads index
`gen_per_batch`, past the end. `reserve()` is sized with the same setting, so
the read returns zeros instead of crashing. `calculate_average_keff()` uses the
same index, so `simulation::keff` -- the value random ray reports -- is zeroed
too.
 
This forces the setting to 1 for random ray, with a warning, where it is read.
 
Transport, flux and tallies are unaffected: the source update uses the domain's
own `k_eff_`, not `simulation::keff`. No valid input changes behavior, since
the setting never had an effect under this solver.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
