### PR TITLE
Fix header check JEFF40 TSL K V W

### DIFF
--- a/openmc/data/ace.py
+++ b/openmc/data/ace.py
@@ -116,7 +116,7 @@ def ascii_to_binary(ascii_file, binary_file):
         idx = 0
         while idx < len(lines):
             # check if it's a > 2.0.0 version header
-            if lines[idx].split()[0][1] == '.':
+            if lines[idx].split()[0][0].isdigit() and lines[idx].split()[0][1:2] == '.':
                 if lines[idx + 1].split()[3] == '3':
                     idx = idx + 3
                 else:
@@ -347,7 +347,7 @@ class Library(EqualityMixin):
             # line is empty, we are at end of file
 
             # check if it's a 2.0 style header
-            if lines[0].split()[0][1] == '.':
+            if lines[0].split()[0][0].isdigit() and lines[0].split()[0][1:2] == '.':
                 words = lines[0].split()
                 name = words[1]
                 words = lines[1].split()

--- a/openmc/data/ace.py
+++ b/openmc/data/ace.py
@@ -116,7 +116,8 @@ def ascii_to_binary(ascii_file, binary_file):
         idx = 0
         while idx < len(lines):
             # check if it's a > 2.0.0 version header
-            if lines[idx].split()[0][0].isdigit() and lines[idx].split()[0][1:2] == '.':
+            first_word = lines[idx].split()[0]
+            if first_word[0].isdigit() and first_word[1] == '.':
                 if lines[idx + 1].split()[3] == '3':
                     idx = idx + 3
                 else:
@@ -347,8 +348,8 @@ class Library(EqualityMixin):
             # line is empty, we are at end of file
 
             # check if it's a 2.0 style header
-            if lines[0].split()[0][0].isdigit() and lines[0].split()[0][1:2] == '.':
-                words = lines[0].split()
+            words = lines[0].split()
+            if words[0][0].isdigit() and words[0][1] == '.':
                 name = words[1]
                 words = lines[1].split()
                 atomic_weight_ratio = float(words[0])
@@ -358,7 +359,6 @@ class Library(EqualityMixin):
                     lines.pop(0)
                     lines.append(ace_file.readline())
             else:
-                words = lines[0].split()
                 name = words[0]
                 atomic_weight_ratio = float(words[1])
                 temperature = float(words[2])


### PR DESCRIPTION
# Description
This PR enables generate_jeff.py to produce the S(α,β) for K, V and W in the JEFF-4.0 TSL library.
- tsl_K_K
- tsl_V_V
- tsl_W_W


# Fixes
The ACE reader mistook one-letter thermal table names (k.01t, v.01t, w.01t) for a 2.0.1 version header because it only checked whether the second character of the first token is '.'. This silently dropped the K, V and W S(a,b) tables from  JEFF-4.0 libraries.
The check now requires the first character to be a digit.


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
