### PR TITLE
Build source regression plugins as CMake modules

### DIFF
--- a/docs/source/usersguide/settings.rst
+++ b/docs/source/usersguide/settings.rst
@@ -487,7 +487,7 @@ OpenMC shared library. This can be done by writing a CMakeLists.txt file:
 
    cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
    project(openmc_sources CXX)
-   add_library(source SHARED source_ring.cpp)
+   add_library(source MODULE source_ring.cpp)
    find_package(OpenMC REQUIRED HINTS <path to openmc>)
    target_link_libraries(source OpenMC::libopenmc)
 

--- a/tests/regression_tests/source_dlopen/test.py
+++ b/tests/regression_tests/source_dlopen/test.py
@@ -20,7 +20,7 @@ def compile_source(request):
         f.write(textwrap.dedent("""
             cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
             project(openmc_sources CXX)
-            add_library(source SHARED source_sampling.cpp)
+            add_library(source MODULE source_sampling.cpp)
             find_package(OpenMC REQUIRED HINTS {})
             target_link_libraries(source OpenMC::libopenmc)
             """.format(openmc_dir)))

--- a/tests/regression_tests/source_parameterized_dlopen/test.py
+++ b/tests/regression_tests/source_parameterized_dlopen/test.py
@@ -20,7 +20,7 @@ def compile_source(request):
         f.write(textwrap.dedent("""
             cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
             project(openmc_sources CXX)
-            add_library(source SHARED parameterized_source_sampling.cpp)
+            add_library(source MODULE parameterized_source_sampling.cpp)
             find_package(OpenMC REQUIRED HINTS {})
             target_link_libraries(source OpenMC::libopenmc)
             """.format(openmc_dir)))


### PR DESCRIPTION
# Description

Build the two regression-test source plugins as CMake `MODULE` libraries.

Both `source_dlopen` and `source_parameterized_dlopen` load `build/libsource.so`. On Darwin, their existing `SHARED` target produces `libsource.dylib`, so the generated filename does not match the requested path. `MODULE` produces `libsource.so` on both Linux and Darwin and matches the plugins' [dlopen-based use](https://cmake.org/cmake/help/latest/command/add_library.html#normal-libraries).

This changes only the two target declarations. Source sampling, runtime paths, and reference data are unchanged.

Related to #3820, specifically the source-plugin failures discussed alongside the broader floating-point portability work.

# Validation

Actual fixture templates, before and after:

| CMake platform | Existing SHARED target | MODULE target |
| --- | --- | --- |
| Linux | libsource.so | libsource.so |
| Darwin | libsource.dylib | libsource.so |

All eight configure/generate cases passed the expected filename assertions: two fixtures, two target types, and two platforms. Darwin validation is configure-only; native macOS execution remains for platform CI or a maintainer.

On Linux, all four plugins were compiled against the real strict-FP OpenMC library and exercised through the production `CompiledSourceWrapper` loader. All six native checks passed:

```text
base fixed source:       100 / 100 samples at 1000 eV
patched fixed source:    100 / 100 samples at 1000 eV
base parameterized:      100 / 100 samples at 1000 eV
base parameterized:      100 / 100 samples at 2500 eV
patched parameterized:   100 / 100 samples at 1000 eV
patched parameterized:   100 / 100 samples at 2500 eV
```

Each sample also matched the expected particle type, weight, origin, direction, and delayed-group value. This exercised actual loading, symbol lookup, construction, sampling, and destruction; it did not run particle transport.

The existing regression tests already exercise the corrected load path. No additional test framework or reference changes are needed. `git diff --check` passes.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the applicable style guidelines
- [x] I have validated the existing tests' plugin build and load path
