### PR TITLE
Reset settings leaked across openmc_finalize()

### DIFF
--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -79,7 +79,9 @@ int openmc_finalize()
 
   // Reset global variables
   settings::assume_separate = false;
+  settings::atomic_relaxation = true;
   settings::check_overlaps = false;
+  settings::collision_track = false;
   settings::collision_track_config = CollisionTrackConfig {};
   settings::confidence_intervals = false;
   settings::create_fission_neutrons = true;
@@ -103,6 +105,8 @@ int openmc_finalize()
   settings::max_history_splits = 10'000'000;
   settings::max_tracks = 1000;
   settings::max_write_lost_particles = -1;
+  settings::n_batches = 0;
+  settings::n_max_batches = 0;
   settings::n_log_bins = 8000;
   settings::n_inactive = 0;
   settings::n_particles = -1;
@@ -130,6 +134,7 @@ int openmc_finalize()
   settings::surface_grazing_ratio = 0.5;
   settings::solver_type = SolverType::MONTE_CARLO;
   settings::source_latest = false;
+  settings::source_mcpl_write = false;
   settings::source_rejection_fraction = 0.05;
   settings::source_separate = false;
   settings::source_write = true;
@@ -137,13 +142,19 @@ int openmc_finalize()
   settings::ssw_cell_type = SSWCellType::None;
   settings::ssw_max_particles = 0;
   settings::ssw_max_files = 1;
+  settings::surf_mcpl_write = false;
+  settings::surf_source_write = false;
   settings::survival_biasing = false;
+  settings::survival_normalization = false;
   settings::temperature_default = 293.6;
   settings::temperature_method = TemperatureMethod::NEAREST;
   settings::temperature_multipole = false;
   settings::temperature_range = {0.0, 0.0};
   settings::temperature_tolerance = 10.0;
   settings::properties_file.clear();
+  settings::trace_batch = 0;
+  settings::trace_gen = 0;
+  settings::trace_particle = 0;
   settings::trigger_on = false;
   settings::trigger_predict = false;
   settings::trigger_batch_interval = 1;
@@ -155,6 +166,8 @@ int openmc_finalize()
   settings::verbosity = -1;
   settings::weight_cutoff = 0.25;
   settings::weight_survive = 1.0;
+  settings::weight_window_checkpoint_collision = true;
+  settings::weight_window_checkpoint_surface = false;
   settings::weight_windows_file.clear();
   settings::weight_windows_on = false;
   settings::write_all_tracks = false;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1368,6 +1368,7 @@ void free_memory_settings()
   settings::sourcepoint_batch.clear();
   settings::source_write_surf_id.clear();
   settings::res_scat_nuclides.clear();
+  settings::track_identifiers.clear();
   settings::ifp_delayed_group_on = false;
   settings::ifp_lifetime_on = false;
 }


### PR DESCRIPTION
openmc_finalize() restores most of the settings namespace to its defaults so that a subsequent openmc_init() in the same process starts clean, but a number of settings that are only assigned when their XML element is present were never reset, so they leaked into the next initialization.

Most consequential was surf_source_write: left true while ssw_max_particles was reset to 0, the next run reserved a zero-capacity surface source bank and then tried to write a surface_source.h5 it was never asked for. survival_normalization, atomic_relaxation and the two weight window checkpoints silently changed the physics of the following run, collision_track wrote unrequested collision track files, and source_mcpl_write and surf_mcpl_write produced unrequested MCPL output. track_identifiers was worse than a stale value: being a container that is appended to while parsing, it accumulated tracked particles across initializations.

Reset atomic_relaxation, collision_track, n_batches, n_max_batches, source_mcpl_write, surf_mcpl_write, surf_source_write, survival_normalization, trace_batch, trace_gen, trace_particle and the two weight_window_checkpoint flags in openmc_finalize(), and clear track_identifiers in free_memory_settings() alongside the other containers.

The remaining settings globals were audited against both functions and are either reset already or unconditionally assigned on every read.


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
