### PR TITLE
Deprecate surf_source_read in favor of a file source

### DIFF
--- a/docs/source/io_formats/settings.rst
+++ b/docs/source/io_formats/settings.rst
@@ -1329,6 +1329,13 @@ attributes/sub-elements:
 
     *Default*: ``surface_source.h5`` in current working directory
 
+.. deprecated::
+  The ``<surf_source_read>`` element is deprecated and will be removed in a
+  future release. A deprecation warning is emitted when it is present. Use a
+  file source instead, e.g. ``<source type="file" file="surface_source.h5"/>``,
+  which is equivalent but additionally supports a source strength and source
+  constraints.
+
 -------------------------------
 ``<surf_source_write>`` Element
 -------------------------------

--- a/docs/source/usersguide/settings.rst
+++ b/docs/source/usersguide/settings.rst
@@ -422,6 +422,11 @@ As an example, to write a maximum of three surface source files:::
       'max_source_files': 3
   }
 
+A surface source file is read back like any other source file, with the
+:class:`openmc.FileSource` class::
+
+  settings.source = openmc.FileSource('surface_source.h5')
+
 .. _compiled_source:
 
 Compiled Sources

--- a/include/openmc/settings.h
+++ b/include/openmc/settings.h
@@ -80,7 +80,6 @@ extern bool source_write;            //!< write source in HDF5 files?
 extern bool source_mcpl_write;       //!< write source in mcpl files?
 extern bool surf_source_write;       //!< write surface source file?
 extern bool surf_mcpl_write;         //!< write surface mcpl file?
-extern bool surf_source_read;        //!< read surface source file?
 extern bool survival_biasing;        //!< use survival biasing?
 extern bool survival_normalization;  //!< use survival normalization?
 extern bool temperature_multipole;   //!< use multipole data?

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -297,6 +297,9 @@ class Settings:
         Options for reading surface source points. Acceptable keys are:
 
         :path: Path to surface source file (str).
+
+        .. deprecated:: 0.17.0
+            Use :class:`openmc.FileSource` as a source distribution instead.
     surf_source_write : dict
         Options for writing surface source points. Acceptable keys are:
 
@@ -888,6 +891,13 @@ class Settings:
 
     @surf_source_read.setter
     def surf_source_read(self, ssr: dict):
+        warnings.warn(
+            "The surf_source_read attribute has been deprecated. Use a "
+            "FileSource as a source distribution instead, e.g. "
+            "settings.source = openmc.FileSource('surface_source.h5'), which "
+            "additionally supports a source strength and source constraints.",
+            FutureWarning, stacklevel=2
+        )
         cv.check_type('surface source reading options', ssr, Mapping)
         for key, value in ssr.items():
             cv.check_value('surface source reading key', key,

--- a/openmc/settings.py
+++ b/openmc/settings.py
@@ -893,7 +893,7 @@ class Settings:
     def surf_source_read(self, ssr: dict):
         warnings.warn(
             "The surf_source_read attribute has been deprecated. Use a "
-            "FileSource as a source distribution instead, e.g. "
+            "FileSource as a source distribution instead, i.e., "
             "settings.source = openmc.FileSource('surface_source.h5'), which "
             "additionally supports a source strength and source constraints.",
             FutureWarning, stacklevel=2

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -75,7 +75,6 @@ bool source_write {true};
 bool source_mcpl_write {false};
 bool surf_source_write {false};
 bool surf_mcpl_write {false};
-bool surf_source_read {false};
 bool survival_biasing {false};
 bool survival_normalization {false};
 bool temperature_multipole {false};
@@ -667,7 +666,12 @@ void read_settings_xml(pugi::xml_node root)
 
   // Check if the user has specified to read surface source
   if (check_for_node(root, "surf_source_read")) {
-    surf_source_read = true;
+    if (mpi::master)
+      warning("The <surf_source_read> element has been deprecated. Use a file "
+              "source instead, e.g. <source type=\"file\" "
+              "file=\"surface_source.h5\"/>, which additionally supports a "
+              "source strength and source constraints.");
+
     // Get surface source read node
     xml_node node_ssr = root.child("surf_source_read");
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -668,7 +668,7 @@ void read_settings_xml(pugi::xml_node root)
   if (check_for_node(root, "surf_source_read")) {
     if (mpi::master)
       warning("The <surf_source_read> element has been deprecated. Use a file "
-              "source instead, e.g. <source type=\"file\" "
+              "source instead, i.e., <source type=\"file\" "
               "file=\"surface_source.h5\"/>, which additionally supports a "
               "source strength and source constraints.");
 


### PR DESCRIPTION
<surf_source_read> is redundant: all it does is push a FileSource onto model::external_sources, which is exactly what <source type="file"> produces. The shorthand is also strictly less capable, since it cannot express a source strength or source constraints, and because it appends to the source list, specifying both a <source> element and <surf_source_read> silently yields an equal-strength mixture of the two rather than the one the user meant.

Deprecate the element and the corresponding Settings.surf_source_read attribute. Both keep working and emit a deprecation warning pointing at the replacement, following the <threads> element precedent in the same function; the Python setter uses FutureWarning as elsewhere in the API. Removal is left to a future release so that existing inputs do not silently fall back to the default Watt point source at the origin.

The settings::surf_source_read flag itself is removed outright rather than deprecated: nothing ever read it, so it was dead state with no observable effect. The element's behavior is unchanged and does not depend on it.




<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
