### PR TITLE
Broadcast tally results in chunks bounded by INT_MAX

### DIFF
--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -41,7 +41,9 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <climits>
 #include <cmath>
+#include <cstddef>
 #include <numeric>
 #include <string>
 
@@ -929,7 +931,21 @@ void broadcast_results()
     MPI_Datatype result_block;
     MPI_Type_contiguous(count_per_filter, MPI_DOUBLE, &result_block);
     MPI_Type_commit(&result_block);
-    MPI_Bcast(results.data(), shape[0], result_block, 0, mpi::intracomm);
+
+    // Aggregating per filter bin keeps the count well below 2**31 for all but
+    // the largest tallies, but the count is still an int. Broadcast in bounded
+    // chunks so that a tally with more filter bins than an int can represent
+    // is handled correctly rather than silently truncated.
+    const std::size_t n_filter_bins = shape[0];
+    constexpr std::size_t chunk_limit {INT_MAX};
+    double* data = results.data();
+    for (std::size_t offset = 0; offset < n_filter_bins;
+         offset += chunk_limit) {
+      const std::size_t chunk_size =
+        std::min(n_filter_bins - offset, chunk_limit);
+      MPI_Bcast(data + offset * count_per_filter, static_cast<int>(chunk_size),
+        result_block, 0, mpi::intracomm);
+    }
     MPI_Type_free(&result_block);
   }
 


### PR DESCRIPTION
Aggregating each filter bin into a contiguous datatype reduces the count passed to MPI_Bcast by a factor of the score and estimator dimensions, but the count is still an int. A tally with more filter bins than an int can represent therefore still fails, which is the part of #914 that remained open after the aggregation was introduced.

Broadcast in chunks no larger than INT_MAX filter bins, mirroring the approach already used for reductions in mpi::reduce_buffer. All ranks derive the loop bounds from the same tally layout, so the sequence of collective calls stays identical.

Fixes #914

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] ~~I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)~~
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works (if applicable)~~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
