### PR TITLE
Avoid NaN standard deviation from roundoff in Tally.std_dev

### DIFF
--- a/openmc/tallies.py
+++ b/openmc/tallies.py
@@ -7,6 +7,7 @@ from math import sqrt, log
 from numbers import Integral, Real
 import operator
 from pathlib import Path
+import warnings
 import lxml.etree as ET
 
 import h5py
@@ -597,8 +598,24 @@ class Tally(IDManagerMixin):
             n = self.num_realizations
             nonzero = np.abs(self.mean) > 0
             self._std_dev = np.zeros_like(self.mean)
-            self._std_dev[nonzero] = np.sqrt((self.sum_sq[nonzero]/n -
-                                              self.mean[nonzero]**2)/(n - 1))
+            if n > 1:
+                # The variance is formed from accumulated sums, so rounding can
+                # push it slightly below zero when the realizations are nearly
+                # identical (a monoenergetic, monodirectional source in a single
+                # material, for example). Taking the square root of that gives
+                # NaN, so clamp at zero as mean_stdev() in src/output.cpp does.
+                variance = (self.sum_sq[nonzero]/n -
+                            self.mean[nonzero]**2)/(n - 1)
+                self._std_dev[nonzero] = np.sqrt(np.maximum(variance, 0.0))
+            elif nonzero.any():
+                # A single realization supports no uncertainty estimate. Keep
+                # reporting it as undefined, but say so directly rather than
+                # leaving the user with a bare numpy warning from dividing by
+                # n - 1 == 0.
+                warnings.warn(
+                    'Standard deviation is undefined for a tally with a single '
+                    'realization; reporting it as NaN.')
+                self._std_dev[nonzero] = np.nan
 
             # Convert NumPy array to SciPy sparse LIL matrix
             if self.sparse:

--- a/tests/unit_tests/test_tally_std_dev.py
+++ b/tests/unit_tests/test_tally_std_dev.py
@@ -1,0 +1,81 @@
+"""Standard deviation of a tally whose realizations are nearly identical."""
+
+import warnings
+
+import numpy as np
+import pytest
+
+import openmc
+
+
+def _tally_with_sums(sum_, sum_sq, n):
+    """Build a Tally carrying given accumulated sums, bypassing statepoint I/O."""
+    tally = openmc.Tally()
+    tally._sp_filename = 'unused.h5'
+    tally._results_read = True
+    tally._num_realizations = n
+    tally._sum = np.array(sum_, dtype=float).reshape(1, 1, 1)
+    tally._sum_sq = np.array(sum_sq, dtype=float).reshape(1, 1, 1)
+    tally._shape = (1, 1, 1)
+    return tally
+
+
+def test_std_dev_negative_variance_from_roundoff():
+    """Rounding can drive sum_sq/n below mean**2; std_dev must not be NaN.
+
+    A tally whose batches all score the same value has zero variance, but it is
+    computed as a difference of accumulated sums and can land just below zero.
+    """
+    # 15 realizations of the same value; the accumulated sums land such that
+    # sum_sq/n is one ulp below mean**2. Whether a given pair of sums cancels
+    # this way depends on the exact order of operations, so the inputs are
+    # pinned rather than recomputed, and the premise is asserted below.
+    n = 15
+    sum_ = 142569.55519193487
+    sum_sq = 1355071871.175077
+    mean = np.array(sum_).reshape(1, 1, 1) / n
+    assert (np.array(sum_sq).reshape(1, 1, 1) / n - mean ** 2).ravel()[0] < 0.0
+
+    tally = _tally_with_sums(sum_, sum_sq, n)
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', RuntimeWarning)
+        std_dev = tally.std_dev
+    assert not np.isnan(std_dev).any()
+    assert std_dev.ravel()[0] == 0.0
+
+
+def test_std_dev_single_realization():
+    """One realization reports an undefined uncertainty, and says why.
+
+    The standard deviation stays NaN, as it was when 1/(n - 1) divided by zero,
+    but the user gets a statement of the problem instead of a numpy warning
+    about an invalid value.
+    """
+    tally = _tally_with_sums(3.0, 9.0, 1)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        std_dev = tally.std_dev
+
+    assert np.isnan(std_dev.ravel()[0])
+    messages = [str(w.message) for w in caught]
+    assert any('single realization' in m for m in messages), messages
+    assert not any(issubclass(w.category, RuntimeWarning) for w in caught)
+
+
+def test_std_dev_single_realization_zero_mean():
+    """Bins that never scored stay at zero, as before."""
+    tally = _tally_with_sums(0.0, 0.0, 1)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        std_dev = tally.std_dev
+    assert std_dev.ravel()[0] == 0.0
+
+
+def test_std_dev_unchanged_for_ordinary_tally():
+    """Normal statistics are untouched by the clamp."""
+    n = 5
+    values = np.array([1.0, 1.2, 0.9, 1.1, 1.3])
+    sum_, sum_sq = values.sum(), (values ** 2).sum()
+    tally = _tally_with_sums(sum_, sum_sq, n)
+    expected = np.sqrt((sum_sq / n - (sum_ / n) ** 2) / (n - 1))
+    assert tally.std_dev.ravel()[0] == pytest.approx(expected, rel=1e-12)


### PR DESCRIPTION
The batch variance is formed as sum_sq/n - mean**2, a difference of accumulated sums. When every realization scores nearly the same value the true variance is zero and rounding can leave the difference just below it, so the square root produces NaN and a RuntimeWarning. Because get_pandas_dataframe() ends with df.dropna(axis=1), a single NaN silently removes the whole "std. dev." column from the dataframe.

Clamp the variance at zero, as mean_stdev() in src/output.cpp already does and as keff_std is guarded in src/eigenvalue.cpp.

Handle a single realization separately, where n - 1 is a division by zero. The standard deviation stays NaN for bins that scored, as it was, but the user now gets a statement of the problem rather than numpy's "invalid value encountered in divide"; bins that never scored stay at zero and stay silent.



<!--
If you are a first-time contributor to OpenMC, please have a look at our
contributing guidelines:
https://github.com/openmc-dev/openmc/blob/develop/CONTRIBUTING.md
-->

Fixes #2408

# Checklist

- [x] I have performed a self-review of my own code
- [x] ~~I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)~~
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] ~~I have made corresponding changes to the documentation (if applicable)~~
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. See instructions here:
https://docs.openmc.org/en/latest/devguide/tests.html
-->
