### PR TITLE
Distinguish atomic and nuclear masses

### DIFF
--- a/include/openmc/atomic_mass.h
+++ b/include/openmc/atomic_mass.h
@@ -10,8 +10,10 @@
 
 namespace openmc {
 
-// Values here are from the Committee on Data for Science and Technology
-// (CODATA) 2018 recommendation (https://physics.nist.gov/cuu/Constants/).
+// The bare-particle rest masses below are from the Committee on Data for
+// Science and Technology (CODATA) 2018 recommendation
+// (https://physics.nist.gov/cuu/Constants/). The ATOMIC_MASS table declared
+// further down holds neutral atomic masses from AME2020 instead.
 
 // Physical constants
 constexpr double MASS_ELECTRON {5.48579909065e-4}; // mass of an electron in amu
@@ -48,7 +50,10 @@ double nuclear_mass_from_pdg(int32_t pdg);
 //!
 //! For light particles, the CODATA bare-particle mass is returned. Otherwise,
 //! the mass is approximated by subtracting the masses of the atomic electrons
-//! from the tabulated atomic mass. Electron binding energy is neglected.
+//! from the tabulated atomic mass. Electron binding energy is neglected. A
+//! nuclide with Z = 0 and A = 1 is the free neutron, for which the CODATA
+//! neutron mass is returned; atomic_mass() reports zero for it instead, as
+//! there is no corresponding neutral atom.
 //! Returns zero if the nuclide is invalid or its atomic mass is not tabulated.
 double nuclear_mass(int Z, int A);
 

--- a/include/openmc/atomic_mass.h
+++ b/include/openmc/atomic_mass.h
@@ -25,10 +25,24 @@ constexpr double MASS_ALPHA {4.001506179127};      // mass of an alpha in amu
 //! Neutral ground-state atomic masses in [u], indexed by nuclear PDG code
 extern const std::unordered_map<int32_t, double> ATOMIC_MASS;
 
+//! Return the neutral ground-state atomic mass for a PDG code in [u]
+//!
+//! Nuclear isomer codes are normalized to the ground state, and the proton
+//! code is treated as an alias for H-1. Returns zero if the code does not
+//! identify a nuclide or its mass is not tabulated.
+double atomic_mass_from_pdg(int32_t pdg);
+
 //! Return the neutral ground-state atomic mass of a nuclide in [u]
 //!
 //! Returns zero if the nuclide is invalid or its mass is not tabulated.
 double atomic_mass(int Z, int A);
+
+//! Return the bare-particle rest mass for a PDG code in [u]
+//!
+//! Elementary particles and light nuclei use their CODATA masses. Other
+//! nuclei are derived from the corresponding neutral atomic mass. Returns zero
+//! for a photon or if the particle mass is not available.
+double nuclear_mass_from_pdg(int32_t pdg);
 
 //! Return the nuclear mass of a nuclide in [u]
 //!

--- a/include/openmc/atomic_mass.h
+++ b/include/openmc/atomic_mass.h
@@ -17,11 +17,26 @@ namespace openmc {
 constexpr double MASS_ELECTRON {5.48579909065e-4}; // mass of an electron in amu
 constexpr double MASS_NEUTRON {1.00866491595};     // mass of a neutron in amu
 constexpr double MASS_PROTON {1.007276466621};     // mass of a proton in amu
-constexpr double MASS_DEUTRON {2.013553212745};    // mass of a deutron in amu
+constexpr double MASS_DEUTRON {2.013553212745};    // mass of a deuteron in amu
+constexpr double MASS_TRITON {3.01550071621};      // mass of a triton in amu
 constexpr double MASS_HELION {3.014932247175};     // mass of a helion in amu
 constexpr double MASS_ALPHA {4.001506179127};      // mass of an alpha in amu
 
-extern std::unordered_map<int32_t, double> ATOMIC_MASS;
+//! Neutral ground-state atomic masses in [u], indexed by nuclear PDG code
+extern const std::unordered_map<int32_t, double> ATOMIC_MASS;
+
+//! Return the neutral ground-state atomic mass of a nuclide in [u]
+//!
+//! Returns zero if the nuclide is invalid or its mass is not tabulated.
+double atomic_mass(int Z, int A);
+
+//! Return the nuclear mass of a nuclide in [u]
+//!
+//! For light particles, the CODATA bare-particle mass is returned. Otherwise,
+//! the mass is approximated by subtracting the masses of the atomic electrons
+//! from the tabulated atomic mass. Electron binding energy is neglected.
+//! Returns zero if the nuclide is invalid or its atomic mass is not tabulated.
+double nuclear_mass(int Z, int A);
 
 } // namespace openmc
 

--- a/include/openmc/particle_type.h
+++ b/include/openmc/particle_type.h
@@ -12,7 +12,6 @@
 #include <type_traits>
 
 #include "openmc/constants.h"
-#include "openmc/error.h"
 
 namespace openmc {
 
@@ -62,16 +61,8 @@ public:
   //----------------------------------------------------------------------------
   // Methods
 
-  // Get particle mass in [u]
-  double mass() const
-  {
-    int32_t p = std::abs(pdg_number_);
-    if (ATOMIC_MASS.count(p)) {
-      return ATOMIC_MASS[p];
-    } else {
-      fatal_error("Unknown mass for particle " + str());
-    }
-  }
+  //! Get the bare-particle rest mass in [u]
+  double mass() const;
 
   // Convert to string representation
   std::string str() const;

--- a/src/atomic_mass.cpp
+++ b/src/atomic_mass.cpp
@@ -1,6 +1,37 @@
 #include "openmc/atomic_mass.h"
 
+#include <cstdlib>
+
+#include "openmc/particle_type.h"
+
 namespace openmc {
+namespace {
+
+constexpr int32_t nuclear_pdg_code(int Z, int A)
+{
+  if (Z == 0 && A == 1)
+    return PDG_NEUTRON;
+  if (Z <= 0 || A <= 0 || Z > A)
+    return 0;
+  return 1000000000 + Z * 10000 + A * 10;
+}
+
+int32_t normalized_nuclear_pdg(int32_t pdg)
+{
+  pdg = std::abs(pdg);
+  if (pdg == PDG_PROTON)
+    return 1000010010;
+  if (pdg < 1000000000)
+    return 0;
+
+  // The mass table contains ground states only.
+  pdg -= pdg % 10;
+  int Z = (pdg / 10000) % 1000;
+  int A = (pdg / 10) % 1000;
+  return Z > 0 && A > 0 && Z <= A ? pdg : 0;
+}
+
+} // namespace
 
 // Neutral ground-state atomic masses in [u] from AME2020. Entries use the
 // 10-digit nuclear PDG code 100ZZZAAAI with I = 0.
@@ -3564,33 +3595,55 @@ const std::unordered_map<int32_t, double> ATOMIC_MASS = {
   {1001182950, 295.216178},
 };
 
-double atomic_mass(int Z, int A)
+double atomic_mass_from_pdg(int32_t pdg)
 {
-  if (Z <= 0 || A <= 0 || Z > A)
+  int32_t nuclide = normalized_nuclear_pdg(pdg);
+  if (nuclide == 0)
     return 0.0;
 
-  int32_t pdg = 1000000000 + Z * 10000 + A * 10;
-  auto it = ATOMIC_MASS.find(pdg);
+  auto it = ATOMIC_MASS.find(nuclide);
   return it == ATOMIC_MASS.end() ? 0.0 : it->second;
+}
+
+double atomic_mass(int Z, int A)
+{
+  return atomic_mass_from_pdg(nuclear_pdg_code(Z, A));
+}
+
+double nuclear_mass_from_pdg(int32_t pdg)
+{
+  int32_t particle = std::abs(pdg);
+  if (particle == PDG_PHOTON)
+    return 0.0;
+  if (particle == PDG_ELECTRON)
+    return MASS_ELECTRON;
+  if (particle == PDG_NEUTRON)
+    return MASS_NEUTRON;
+  if (particle == PDG_PROTON)
+    return MASS_PROTON;
+
+  int32_t nuclide = normalized_nuclear_pdg(particle);
+  if (nuclide == 1000010010)
+    return MASS_PROTON;
+  if (nuclide == PDG_DEUTERON)
+    return MASS_DEUTRON;
+  if (nuclide == PDG_TRITON)
+    return MASS_TRITON;
+  if (nuclide == 1000020030)
+    return MASS_HELION;
+  if (nuclide == PDG_ALPHA)
+    return MASS_ALPHA;
+  if (nuclide == 0)
+    return 0.0;
+
+  double mass = atomic_mass_from_pdg(nuclide);
+  int Z = (nuclide / 10000) % 1000;
+  return mass == 0.0 ? 0.0 : mass - Z * MASS_ELECTRON;
 }
 
 double nuclear_mass(int Z, int A)
 {
-  if (Z == 0 && A == 1)
-    return MASS_NEUTRON;
-  if (Z == 1 && A == 1)
-    return MASS_PROTON;
-  if (Z == 1 && A == 2)
-    return MASS_DEUTRON;
-  if (Z == 1 && A == 3)
-    return MASS_TRITON;
-  if (Z == 2 && A == 3)
-    return MASS_HELION;
-  if (Z == 2 && A == 4)
-    return MASS_ALPHA;
-
-  double mass = atomic_mass(Z, A);
-  return mass == 0.0 ? 0.0 : mass - Z * MASS_ELECTRON;
+  return nuclear_mass_from_pdg(nuclear_pdg_code(Z, A));
 }
 
 } // namespace openmc

--- a/src/atomic_mass.cpp
+++ b/src/atomic_mass.cpp
@@ -2,16 +2,14 @@
 
 namespace openmc {
 
-// Atomic masses in [u] from AME2020 and CODATA 2018
-std::unordered_map<int32_t, double> ATOMIC_MASS = {
-  {11, MASS_ELECTRON},
-  {22, 0.0},
-  {2112, MASS_NEUTRON},
-  {2212, MASS_PROTON},
-  {1000010020, MASS_DEUTRON},
-  {1000020030, MASS_HELION},
-  {1000020040, MASS_ALPHA},
+// Neutral ground-state atomic masses in [u] from AME2020. Entries use the
+// 10-digit nuclear PDG code 100ZZZAAAI with I = 0.
+const std::unordered_map<int32_t, double> ATOMIC_MASS = {
+  {1000010010, 1.007825031898},
+  {1000010020, 2.014101777844},
   {1000010030, 3.01604928132},
+  {1000020030, 3.01602932197},
+  {1000020040, 4.00260325413},
   {1000030030, 3.030775},
   {1000010040, 4.026431867},
   {1000030040, 4.027185561},
@@ -3565,5 +3563,34 @@ std::unordered_map<int32_t, double> ATOMIC_MASS = {
   {1001182940, 294.213979},
   {1001182950, 295.216178},
 };
+
+double atomic_mass(int Z, int A)
+{
+  if (Z <= 0 || A <= 0 || Z > A)
+    return 0.0;
+
+  int32_t pdg = 1000000000 + Z * 10000 + A * 10;
+  auto it = ATOMIC_MASS.find(pdg);
+  return it == ATOMIC_MASS.end() ? 0.0 : it->second;
+}
+
+double nuclear_mass(int Z, int A)
+{
+  if (Z == 0 && A == 1)
+    return MASS_NEUTRON;
+  if (Z == 1 && A == 1)
+    return MASS_PROTON;
+  if (Z == 1 && A == 2)
+    return MASS_DEUTRON;
+  if (Z == 1 && A == 3)
+    return MASS_TRITON;
+  if (Z == 2 && A == 3)
+    return MASS_HELION;
+  if (Z == 2 && A == 4)
+    return MASS_ALPHA;
+
+  double mass = atomic_mass(Z, A);
+  return mass == 0.0 ? 0.0 : mass - Z * MASS_ELECTRON;
+}
 
 } // namespace openmc

--- a/src/atomic_mass.cpp
+++ b/src/atomic_mass.cpp
@@ -16,13 +16,13 @@ constexpr int32_t nuclear_pdg_code(int Z, int A)
   return 1000000000 + Z * 10000 + A * 10;
 }
 
-int32_t normalized_nuclear_pdg(int32_t pdg)
+int32_t normalized_particle_pdg(int32_t pdg)
 {
   pdg = std::abs(pdg);
   if (pdg == PDG_PROTON)
     return 1000010010;
   if (pdg < 1000000000)
-    return 0;
+    return pdg;
 
   // The mass table contains ground states only.
   pdg -= pdg % 10;
@@ -3597,11 +3597,11 @@ const std::unordered_map<int32_t, double> ATOMIC_MASS = {
 
 double atomic_mass_from_pdg(int32_t pdg)
 {
-  int32_t nuclide = normalized_nuclear_pdg(pdg);
-  if (nuclide == 0)
+  int32_t particle = normalized_particle_pdg(pdg);
+  if (particle < 1000000000)
     return 0.0;
 
-  auto it = ATOMIC_MASS.find(nuclide);
+  auto it = ATOMIC_MASS.find(particle);
   return it == ATOMIC_MASS.end() ? 0.0 : it->second;
 }
 
@@ -3612,33 +3612,35 @@ double atomic_mass(int Z, int A)
 
 double nuclear_mass_from_pdg(int32_t pdg)
 {
-  int32_t particle = std::abs(pdg);
-  if (particle == PDG_PHOTON)
+  int32_t particle = normalized_particle_pdg(pdg);
+  switch (particle) {
+  case PDG_PHOTON:
     return 0.0;
-  if (particle == PDG_ELECTRON)
+  case PDG_ELECTRON:
     return MASS_ELECTRON;
-  if (particle == PDG_NEUTRON)
+  case PDG_NEUTRON:
     return MASS_NEUTRON;
-  if (particle == PDG_PROTON)
+  case 1000010010:
     return MASS_PROTON;
-
-  int32_t nuclide = normalized_nuclear_pdg(particle);
-  if (nuclide == 1000010010)
-    return MASS_PROTON;
-  if (nuclide == PDG_DEUTERON)
+  case PDG_DEUTERON:
     return MASS_DEUTRON;
-  if (nuclide == PDG_TRITON)
+  case PDG_TRITON:
     return MASS_TRITON;
-  if (nuclide == 1000020030)
+  case 1000020030:
     return MASS_HELION;
-  if (nuclide == PDG_ALPHA)
+  case PDG_ALPHA:
     return MASS_ALPHA;
-  if (nuclide == 0)
+  }
+
+  if (particle < 1000000000)
     return 0.0;
 
-  double mass = atomic_mass_from_pdg(nuclide);
-  int Z = (nuclide / 10000) % 1000;
-  return mass == 0.0 ? 0.0 : mass - Z * MASS_ELECTRON;
+  auto it = ATOMIC_MASS.find(particle);
+  if (it == ATOMIC_MASS.end())
+    return 0.0;
+
+  int Z = (particle / 10000) % 1000;
+  return it->second - Z * MASS_ELECTRON;
 }
 
 double nuclear_mass(int Z, int A)

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -76,6 +76,8 @@ double Particle::mass() const
   case PDG_ELECTRON:
   case PDG_POSITRON:
     return MASS_ELECTRON_EV;
+  case PDG_PHOTON:
+    return 0.0;
   default:
     return this->type().mass() * AMU_EV;
   }

--- a/src/particle_type.cpp
+++ b/src/particle_type.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cctype>
-#include <cstdlib>
 #include <stdexcept>
 
 #include "openmc/error.h"
@@ -135,25 +134,12 @@ std::string nuclide_name_from_pdg(int32_t pdg)
 
 double ParticleType::mass() const
 {
-  int32_t pdg = std::abs(pdg_number_);
-  switch (pdg) {
-  case PDG_PHOTON:
+  if (pdg_number_ == PDG_PHOTON)
     return 0.0;
-  case PDG_ELECTRON:
-    return MASS_ELECTRON;
-  case PDG_NEUTRON:
-    return MASS_NEUTRON;
-  case PDG_PROTON:
-    return MASS_PROTON;
-  }
 
-  if (pdg >= 1000000000) {
-    int Z = (pdg / 10000) % 1000;
-    int A = (pdg / 10) % 1000;
-    double mass = nuclear_mass(Z, A);
-    if (mass > 0.0)
-      return mass;
-  }
+  double mass = nuclear_mass_from_pdg(pdg_number_);
+  if (mass > 0.0)
+    return mass;
 
   fatal_error("Unknown mass for particle " + str());
 }

--- a/src/particle_type.cpp
+++ b/src/particle_type.cpp
@@ -2,8 +2,10 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
 #include <stdexcept>
 
+#include "openmc/error.h"
 #include "openmc/string_utils.h"
 
 namespace openmc {
@@ -130,6 +132,31 @@ std::string nuclide_name_from_pdg(int32_t pdg)
 //==============================================================================
 // ParticleType member function implementations
 //==============================================================================
+
+double ParticleType::mass() const
+{
+  int32_t pdg = std::abs(pdg_number_);
+  switch (pdg) {
+  case PDG_PHOTON:
+    return 0.0;
+  case PDG_ELECTRON:
+    return MASS_ELECTRON;
+  case PDG_NEUTRON:
+    return MASS_NEUTRON;
+  case PDG_PROTON:
+    return MASS_PROTON;
+  }
+
+  if (pdg >= 1000000000) {
+    int Z = (pdg / 10000) % 1000;
+    int A = (pdg / 10) % 1000;
+    double mass = nuclear_mass(Z, A);
+    if (mass > 0.0)
+      return mass;
+  }
+
+  fatal_error("Unknown mass for particle " + str());
+}
 
 ParticleType::ParticleType(std::string_view str)
 {

--- a/tests/cpp_unit_tests/CMakeLists.txt
+++ b/tests/cpp_unit_tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_NAMES
+  test_atomic_mass
   test_distribution
   test_file_utils
   test_tally

--- a/tests/cpp_unit_tests/test_atomic_mass.cpp
+++ b/tests/cpp_unit_tests/test_atomic_mass.cpp
@@ -19,6 +19,9 @@ TEST_CASE("Atomic and nuclear mass conventions")
     REQUIRE(atomic_mass(1, 3) == Approx(3.01604928132));
     REQUIRE(atomic_mass(2, 3) == Approx(3.01602932197));
     REQUIRE(atomic_mass(2, 4) == Approx(4.00260325413));
+    REQUIRE(atomic_mass_from_pdg(PDG_PROTON) == atomic_mass(1, 1));
+    REQUIRE(atomic_mass_from_pdg(1000010010) == atomic_mass(1, 1));
+    REQUIRE(atomic_mass_from_pdg(1000260561) == atomic_mass(26, 56));
   }
 
   SECTION("light nuclei have CODATA bare-particle masses")
@@ -29,6 +32,9 @@ TEST_CASE("Atomic and nuclear mass conventions")
     REQUIRE(nuclear_mass(1, 3) == MASS_TRITON);
     REQUIRE(nuclear_mass(2, 3) == MASS_HELION);
     REQUIRE(nuclear_mass(2, 4) == MASS_ALPHA);
+    REQUIRE(nuclear_mass_from_pdg(PDG_PROTON) == MASS_PROTON);
+    REQUIRE(nuclear_mass_from_pdg(1000010010) == MASS_PROTON);
+    REQUIRE(nuclear_mass_from_pdg(1000260561) == nuclear_mass(26, 56));
   }
 
   SECTION("heavier nuclear masses subtract the atomic electrons")

--- a/tests/cpp_unit_tests/test_atomic_mass.cpp
+++ b/tests/cpp_unit_tests/test_atomic_mass.cpp
@@ -14,11 +14,11 @@ TEST_CASE("Atomic and nuclear mass conventions")
 
   SECTION("light nuclides have AME2020 atomic masses")
   {
-    REQUIRE(atomic_mass(1, 1) == Approx(1.007825031898));
-    REQUIRE(atomic_mass(1, 2) == Approx(2.014101777844));
-    REQUIRE(atomic_mass(1, 3) == Approx(3.01604928132));
-    REQUIRE(atomic_mass(2, 3) == Approx(3.01602932197));
-    REQUIRE(atomic_mass(2, 4) == Approx(4.00260325413));
+    REQUIRE(atomic_mass(1, 1) == 1.007825031898);
+    REQUIRE(atomic_mass(1, 2) == 2.014101777844);
+    REQUIRE(atomic_mass(1, 3) == 3.01604928132);
+    REQUIRE(atomic_mass(2, 3) == 3.01602932197);
+    REQUIRE(atomic_mass(2, 4) == 4.00260325413);
     REQUIRE(atomic_mass_from_pdg(PDG_PROTON) == atomic_mass(1, 1));
     REQUIRE(atomic_mass_from_pdg(1000010010) == atomic_mass(1, 1));
     REQUIRE(atomic_mass_from_pdg(1000260561) == atomic_mass(26, 56));

--- a/tests/cpp_unit_tests/test_atomic_mass.cpp
+++ b/tests/cpp_unit_tests/test_atomic_mass.cpp
@@ -1,0 +1,71 @@
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include "openmc/atomic_mass.h"
+#include "openmc/constants.h"
+#include "openmc/particle.h"
+#include "openmc/particle_type.h"
+
+using Catch::Approx;
+
+TEST_CASE("Atomic and nuclear mass conventions")
+{
+  using namespace openmc;
+
+  SECTION("light nuclides have AME2020 atomic masses")
+  {
+    REQUIRE(atomic_mass(1, 1) == Approx(1.007825031898));
+    REQUIRE(atomic_mass(1, 2) == Approx(2.014101777844));
+    REQUIRE(atomic_mass(1, 3) == Approx(3.01604928132));
+    REQUIRE(atomic_mass(2, 3) == Approx(3.01602932197));
+    REQUIRE(atomic_mass(2, 4) == Approx(4.00260325413));
+  }
+
+  SECTION("light nuclei have CODATA bare-particle masses")
+  {
+    REQUIRE(nuclear_mass(0, 1) == MASS_NEUTRON);
+    REQUIRE(nuclear_mass(1, 1) == MASS_PROTON);
+    REQUIRE(nuclear_mass(1, 2) == MASS_DEUTRON);
+    REQUIRE(nuclear_mass(1, 3) == MASS_TRITON);
+    REQUIRE(nuclear_mass(2, 3) == MASS_HELION);
+    REQUIRE(nuclear_mass(2, 4) == MASS_ALPHA);
+  }
+
+  SECTION("heavier nuclear masses subtract the atomic electrons")
+  {
+    REQUIRE(
+      nuclear_mass(26, 56) == Approx(atomic_mass(26, 56) - 26 * MASS_ELECTRON));
+  }
+
+  SECTION("invalid and unavailable masses are reported as missing")
+  {
+    REQUIRE(atomic_mass(0, 1) == 0.0);
+    REQUIRE(atomic_mass(2, 1) == 0.0);
+    REQUIRE(atomic_mass(60, 300) == 0.0);
+    REQUIRE(nuclear_mass(2, 1) == 0.0);
+    REQUIRE(nuclear_mass(60, 300) == 0.0);
+  }
+}
+
+TEST_CASE("Particle masses are bare rest masses")
+{
+  using namespace openmc;
+
+  REQUIRE(ParticleType::photon().mass() == 0.0);
+  REQUIRE(ParticleType::electron().mass() == MASS_ELECTRON);
+  REQUIRE(ParticleType::positron().mass() == MASS_ELECTRON);
+  REQUIRE(ParticleType::neutron().mass() == MASS_NEUTRON);
+  REQUIRE(ParticleType::proton().mass() == MASS_PROTON);
+  REQUIRE(ParticleType::deuteron().mass() == MASS_DEUTRON);
+  REQUIRE(ParticleType::triton().mass() == MASS_TRITON);
+  REQUIRE(ParticleType::alpha().mass() == MASS_ALPHA);
+
+  // Nuclear PDG codes refer to bare nuclei. The isomer digit is intentionally
+  // ignored because ATOMIC_MASS contains ground-state masses only.
+  REQUIRE(ParticleType {26, 56}.mass() == nuclear_mass(26, 56));
+  REQUIRE(ParticleType {26, 56, 1}.mass() == nuclear_mass(26, 56));
+
+  Particle p;
+  p.type() = ParticleType {26, 56};
+  REQUIRE(p.mass() == Approx(nuclear_mass(26, 56) * AMU_EV));
+}


### PR DESCRIPTION
# Description

While working on a feature, I noticed that there is an inconsistency in our `ATOMIC_MASS` table in C++. Namely, several light isotopes use named constants like `MASS_PROTON`, `MASS_ALPHA`, etc. within the table, but those named constants represent nuclear masses (which exclude the mass of electrons), not atomic masses (which include electron mass). This PR makes the `ATOMIC_MASS` table consistently contain neutral ground-state atomic masses and adds dedicated helpers for atomic and nuclear mass lookup. `ParticleType::mass()` continues to provide the bare rest mass needed for particle kinematics, while light nuclei use their CODATA constants and heavier nuclei are derived from the corresponding atomic masses.

Note that existing inverse-velocity and time-cutoff regression tests remain unchanged because the masses of transportable neutrons, photons, electrons, and positrons are unaffected.


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have run [clang-format](https://docs.openmc.org/en/latest/devguide/styleguide.html#automatic-formatting) (version 18) on any C++ source files (if applicable)
- [x] I have followed the [style guidelines](https://docs.openmc.org/en/latest/devguide/styleguide.html#python) for Python source files (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)